### PR TITLE
fix(hooks): session-start.sh の jq エラーハンドリングを追加

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -108,7 +108,7 @@ if [ ! -f "$STATE_FILE" ]; then
   exit 0
 fi
 
-ACTIVE=$(jq -r '.active // false' "$STATE_FILE")
+ACTIVE=$(jq -r '.active // false' "$STATE_FILE" 2>/dev/null) || ACTIVE=false
 if [ "$ACTIVE" != "true" ]; then
   # Clean stale compact state on startup/clear when flow is inactive (#756, #800)
   [ "$SOURCE" != "compact" ] && _cleanup_stale_compact
@@ -120,13 +120,13 @@ fi
 # hook not registered). Reset to active=false and show a soft message instead of
 # the alarming "CRITICAL: Active rite workflow detected" message.
 if [ "$SOURCE" = "startup" ]; then
-  PHASE=$(jq -r '.phase // ""' "$STATE_FILE")
-  ISSUE=$(jq -r '.issue_number // "" | tostring' "$STATE_FILE")
-  BRANCH=$(jq -r '.branch // ""' "$STATE_FILE")
+  PHASE=$(jq -r '.phase // ""' "$STATE_FILE" 2>/dev/null) || PHASE=""
+  ISSUE=$(jq -r '.issue_number // "" | tostring' "$STATE_FILE" 2>/dev/null) || ISSUE=""
+  BRANCH=$(jq -r '.branch // ""' "$STATE_FILE" 2>/dev/null) || BRANCH=""
   TMP_FILE="${STATE_FILE}.tmp.$$"
   trap 'rm -f "$TMP_FILE" 2>/dev/null' EXIT TERM INT
   if jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
-     '.active = false | .updated_at = $ts' "$STATE_FILE" > "$TMP_FILE"; then
+     '.active = false | .updated_at = $ts' "$STATE_FILE" > "$TMP_FILE" 2>/dev/null; then
     mv "$TMP_FILE" "$STATE_FILE"
   else
     rm -f "$TMP_FILE"
@@ -180,13 +180,13 @@ if [ "$SOURCE" = "compact" ] || [ "$SOURCE" = "clear" ]; then
   # Otherwise (no compact-state file, or non-blocked state), apply the same
   # defensive reset as startup to avoid false "interrupted workflow" detection.
   if [ "$SOURCE" = "clear" ] && [ "$COMPACT_TRANSITIONED" = "false" ]; then
-    PHASE=$(jq -r '.phase // ""' "$STATE_FILE")
-    ISSUE=$(jq -r '.issue_number // "" | tostring' "$STATE_FILE")
-    BRANCH=$(jq -r '.branch // ""' "$STATE_FILE")
+    PHASE=$(jq -r '.phase // ""' "$STATE_FILE" 2>/dev/null) || PHASE=""
+    ISSUE=$(jq -r '.issue_number // "" | tostring' "$STATE_FILE" 2>/dev/null) || ISSUE=""
+    BRANCH=$(jq -r '.branch // ""' "$STATE_FILE" 2>/dev/null) || BRANCH=""
     TMP_CLEAR_FILE="${STATE_FILE}.tmp.$$"
     trap 'rm -f "$TMP_CLEAR_FILE" 2>/dev/null' EXIT TERM INT
     if jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
-       '.active = false | .updated_at = $ts' "$STATE_FILE" > "$TMP_CLEAR_FILE"; then
+       '.active = false | .updated_at = $ts' "$STATE_FILE" > "$TMP_CLEAR_FILE" 2>/dev/null; then
       mv "$TMP_CLEAR_FILE" "$STATE_FILE"
     else
       rm -f "$TMP_CLEAR_FILE"


### PR DESCRIPTION
## 概要

`/clear` 実行時に「SessionStart:clear hook error」が発生する問題を修正。

`session-start.sh` 内の `jq` コマンドが `.rite-flow-state` ファイルの読み込みに失敗した際、
エラー出力が stderr に流れてフック全体がエラー終了していた。
すべての `jq` 呼び出しに `2>/dev/null` と `|| VARIABLE=default` のフォールバックを追加し、
jq パースエラー時も安全にデフォルト値で処理を継続するようにした。

## 変更内容

- `jq -r` 呼び出し（6箇所）に `2>/dev/null` を追加し stderr 出力を抑制
- `|| VARIABLE=default` パターンでパースエラー時のフォールバック値を設定
- `jq` によるファイル更新処理（2箇所）の stderr も同様に抑制

## 対象ファイル

| ファイル | 変更 |
|---------|------|
| `plugins/rite/hooks/session-start.sh` | jq エラーハンドリング追加 |

## 関連 Issue

Closes #18

## テスト計画

- [x] `/clear` 実行時にエラーが発生しないことを確認
- [x] `.rite-flow-state` が存在しない場合も正常動作
- [x] `.rite-flow-state` が不正な JSON の場合もフォールバックで正常終了
- [x] 既存の startup/compact パスに影響がないことを確認
