### PR TITLE
refactor(hooks): stop-guard.sh のサブシェル最適化

### DIFF
--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -32,9 +32,10 @@ log_diag() {
   # Ring buffer: truncate to last 50 lines (mapfile avoids wc -l subshell)
   if [ -f "$diag_file" ]; then
     local -a _lines
-    mapfile -t _lines < "$diag_file" 2>/dev/null
+    mapfile -t _lines < "$diag_file" 2>/dev/null || true
     if [ "${#_lines[@]}" -gt 50 ]; then
-      printf '%s\n' "${_lines[@]: -50}" > "$diag_file" 2>/dev/null || true
+      local _tmp_diag="${diag_file}.tmp.$$"
+      printf '%s\n' "${_lines[@]: -50}" > "$_tmp_diag" 2>/dev/null && mv "$_tmp_diag" "$diag_file" 2>/dev/null || { rm -f "$_tmp_diag" 2>/dev/null; true; }
     fi
   fi
 }
@@ -113,6 +114,11 @@ parse_iso8601_to_epoch() {
   # Try macOS date -j -f (strip colon from timezone offset: +09:00 -> +0900)
   local ts_nocolon
   # Strip colon from timezone offset: +09:00 -> +0900 (bash parameter expansion avoids sed subshell)
+  # e.g. ts="2026-03-04T00:04:17+09:00"
+  #   ${ts%:*}  -> "2026-03-04T00:04:17+09"  (remove shortest suffix matching :*)
+  #   ${ts##*:} -> "00"                       (remove longest prefix matching *:)
+  #   result    -> "2026-03-04T00:04:17+0900"
+  # Requires: ts has already passed the regex validation above (line 102)
   ts_nocolon="${ts%:*}${ts##*:}"
   if epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$ts_nocolon" +%s 2>/dev/null); then
     echo "$epoch"


### PR DESCRIPTION
## 概要

stop-guard.sh 内の3箇所のサブシェル生成を最適化し、hook 実行時のプロセス生成コストを削減。

Closes #24

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/stop-guard.sh` | 3箇所のサブシェル最適化 |

### 最適化詳細

1. **`echo "$INPUT" | jq` → here-string `jq ... <<< "$INPUT"`** (L12)
   - パイプによるサブシェル生成を削減
2. **`log_diag` 内の `$(wc -l ...)` → `mapfile` + `printf`** (L29-36)
   - 毎回の `wc -l` サブシェル生成を bash ビルトインに置換
   - リングバッファの `tail` 外部コマンドも `printf` で置換
3. **`echo "$ts" | sed` → bash パラメータ展開** (L111)
   - タイムゾーンオフセットのコロン除去を `${ts%:*}${ts##*:}` で実現

## 背景

PR #23 のレビュー指摘（パフォーマンス専門家）で検出されたサブシェル生成を別 Issue として対応。

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## テスト計画

- [ ] stop-guard.sh が正常に動作すること（active workflow のブロック確認）
- [ ] `log_diag` のリングバッファが50行で正しく切り詰められること
- [ ] `parse_iso8601_to_epoch` が各種タイムゾーンオフセットを正しくパースすること
