### PR TITLE
fix(test): TC-028 の呼び出しパターンと stdout 検証を TC-029 に統一

### DIFF
--- a/plugins/rite/hooks/tests/stop-guard.test.sh
+++ b/plugins/rite/hooks/tests/stop-guard.test.sh
@@ -680,8 +680,8 @@ create_state_file "$dir028" "{\"active\": true, \"updated_at\": \"$now_ts028\", 
 # Clear any existing diag log
 rm -f "$dir028/.rite-stop-guard-diag.log"
 input="{\"stop_hook_active\": false, \"cwd\": \"$dir028\"}"
-echo "$input" | bash "$GUARD" 2>/dev/null && rc=0 || rc=$?
-if [ $rc -eq 2 ]; then
+output=$(run_guard "$input") && rc=0 || rc=$?
+if [ $rc -eq 2 ] && [ -z "$output" ]; then
   diag_file="$dir028/.rite-stop-guard-diag.log"
   if [ -f "$diag_file" ] && grep -q "EXIT:2" "$diag_file"; then
     pass "exit 2 パスで診断ログに EXIT:2 が記録された（AC-3）"
@@ -689,7 +689,7 @@ if [ $rc -eq 2 ]; then
     fail "exit 2 だが診断ログに EXIT:2 が記録されていない（ファイル存在: $([ -f "$diag_file" ] && echo yes || echo no)）"
   fi
 else
-  fail "exit=$rc（期待: exit 2）"
+  fail "exit=$rc, output='$output'（期待: exit 2, stdout 空）"
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

TC-028 の呼び出しパターンと stdout 検証を TC-029 に統一し、テスト品質を改善する。

Closes #25

## 変更内容

- TC-028: direct bash 実行 (`echo "$input" | bash "$GUARD"`) を `run_guard` ヘルパーに変更
- TC-028: exit code のみの検証に stdout 空検証 (`[ -z "$output" ]`) を追加
- TC-028: fail 分岐に `output='$output'` を追加（TC-029 と同じ形式に統一）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/tests/stop-guard.test.sh` | TC-028 のテストパターン統一（3行変更） |

## テスト結果

全 29 テストケース PASS（変更後に実行確認済み）

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## チェックリスト

- [x] TC-028 が `run_guard` ヘルパーを使用
- [x] TC-028 が stdout 検証を実施
- [x] TC-028 の fail 分岐が TC-029 と同じ形式
- [x] 全テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
