### PR TITLE
refactor(hooks): pre-compact.sh の echo|jq パイプを here-string に統一

### DIFF
--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # missing the state file won't exist and the hook exits at the -f check below.
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(jq -r '.cwd // empty' <<< "$INPUT")
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi


### PR DESCRIPTION
## 概要

pre-compact.sh の `echo "$INPUT" | jq` パイプパターンを `jq <<< "$INPUT"` here-string に統一。
stop-guard.sh で既に最適化済みのパターンに合わせ、フック間の一貫性を確保する。

Closes #34

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/pre-compact.sh` | L11: `echo "$INPUT" \| jq` → `jq <<< "$INPUT"` |

## 背景

- PR #33 のレビュー指摘（差分範囲外）で検出された一貫性の問題
- stop-guard.sh (L13) では既に here-string パターンを使用済み
- サブシェル生成を1つ削減し、わずかなパフォーマンス改善

## テスト計画

- [ ] pre-compact.sh が正常に動作することを確認（compact 発生時に .rite-compact-state が正しく書き込まれる）
- [ ] CWD の解析が正しく行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
