### PR TITLE
refactor(hooks): stop-guard.sh の grep -A20 固定値を awk セクション抽出に改善

### DIFF
--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -167,7 +167,8 @@ IFS=$'\t' read -r PHASE NEXT ISSUE PR ERROR_COUNT < <(jq -r '[(.phase // "unknow
 THRESHOLD=3
 RITE_CONFIG="$STATE_ROOT/rite-config.yml"
 if [ -f "$RITE_CONFIG" ]; then
-  cfg_val=$(grep -A20 '^safety:' "$RITE_CONFIG" 2>/dev/null | grep 'repeated_failure_threshold' | head -1 | sed 's/.*:[[:space:]]*//' | tr -d '[:space:]' 2>/dev/null || echo "")
+  # awk: ^safety: セクション内を動的に抽出（次のトップレベルキーまで）
+  cfg_val=$(awk '/^safety:/{f=1;next} f && /^[^[:space:]]/{exit} f && /repeated_failure_threshold/' "$RITE_CONFIG" 2>/dev/null | head -1 | sed 's/.*:[[:space:]]*//' | tr -d '[:space:]' 2>/dev/null || echo "")
   if [[ "$cfg_val" =~ ^[0-9]+$ ]]; then
     THRESHOLD="$cfg_val"
   fi


### PR DESCRIPTION
## 概要

`stop-guard.sh` の `grep -A20` による固定行数の YAML セクション抽出を、`awk` による動的セクション抽出に改善。

## 変更内容

- `grep -A20 '^safety:'` を `awk '/^safety:/{f=1;next} f && /^[^[:space:]]/{exit} f && /repeated_failure_threshold/'` に置換
- `safety:` セクションの行数に依存しない堅牢な実装に改善
- 下流パイプライン（`head -1 | sed | tr`）は変更なし

## 関連 Issue

Closes #35

## 変更ファイル

| ファイル | 状態 |
|---------|------|
| `plugins/rite/hooks/stop-guard.sh` | 変更 |

## テスト

- 既存テスト全 29 件合格（TC-019, TC-022, TC-023 がこの箇所のテスト）

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
