### PR TITLE
fix(hooks): stop-guard.sh の trap に EXIT シグナルを追加

### DIFF
--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -29,13 +29,14 @@ log_debug() {
 # .gitignore の *.log で自動除外済み
 log_diag() {
   local diag_file="$STATE_ROOT/.rite-stop-guard-diag.log"
+  local _tmp_diag=""
+  trap '[ -n "$_tmp_diag" ] && rm -f "$_tmp_diag" 2>/dev/null; true' RETURN
   echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $1" >> "$diag_file" 2>/dev/null || true
   # Ring buffer: truncate to last 50 lines (mapfile avoids wc -l subshell)
   if [ -f "$diag_file" ]; then
     local -a _lines
     mapfile -t _lines < "$diag_file" 2>/dev/null || true
     if [ "${#_lines[@]}" -gt 50 ]; then
-      local _tmp_diag
       # fallback to PID-based name if mktemp fails (e.g., disk full, permission denied)
       _tmp_diag=$(mktemp "${diag_file}.XXXXXX" 2>/dev/null) || _tmp_diag="${diag_file}.tmp.$$"
       printf '%s\n' "${_lines[@]: -50}" > "$_tmp_diag" 2>/dev/null && mv "$_tmp_diag" "$diag_file" 2>/dev/null || { rm -f "$_tmp_diag" 2>/dev/null; true; }
@@ -193,7 +194,7 @@ fi
 # Atomically increment error_count before blocking.
 # If the write fails (disk full, permissions), skip silently — the primary goal is protection.
 TMP_STATE=$(mktemp "${STATE_FILE}.XXXXXX" 2>/dev/null) || TMP_STATE="${STATE_FILE}.tmp.$$"
-trap 'rm -f "$TMP_STATE" 2>/dev/null' TERM INT
+trap 'rm -f "$TMP_STATE" 2>/dev/null' EXIT TERM INT
 if jq --argjson cnt "$((ERROR_COUNT + 1))" '.error_count = $cnt' "$STATE_FILE" > "$TMP_STATE" 2>/dev/null; then
   mv "$TMP_STATE" "$STATE_FILE" 2>/dev/null || rm -f "$TMP_STATE"
 else


### PR DESCRIPTION
## 概要

stop-guard.sh の一時ファイルクリーンアップを改善する。

- TMP_STATE 用 trap に EXIT シグナルを追加（他のフックスクリプトと統一）
- log_diag 関数内の `_tmp_diag` に RETURN trap を追加（シグナル割り込み時のクリーンアップを保証）

## 変更内容

### 1. TMP_STATE trap の改善 (L196)

`TERM INT` のみだった trap に `EXIT` を追加。正常終了時にも一時ファイルが確実にクリーンアップされる。
他のフックスクリプト（session-end.sh, session-start.sh, cleanup-work-memory.sh）と同じ `EXIT TERM INT` パターンに統一。

### 2. log_diag 関数の _tmp_diag trap 追加

`_tmp_diag` 変数を関数スコープで初期化し、RETURN trap を設定。
mktemp と printf/mv の間でシグナルが割り込んだ場合でも、関数終了時に一時ファイルが確実に削除される。

## 関連 Issue

Closes #39

## テスト計画

- [ ] stop-guard.sh が正常に動作すること（hook 経由で実行確認）
- [ ] 一時ファイルが残らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
