### PR TITLE
fix(commands): review.md に hooks チェック不要の制約指示を追加

### DIFF
--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -13,6 +13,8 @@ Analyze PR changes and dynamically load expert skills to perform a multi-reviewe
 > **Reference**: Apply `no_unnecessary_fallback` from [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md).
 > All reviewers should flag fallbacks that hide failure causes or silently change behavior scope.
 
+> **⚠️ Scope limitation**: This command does NOT check or report hooks registration status (`.claude/settings.local.json`). Hooks registration is exclusively handled by `/rite:issue:start` Phase 5.0. Do NOT independently check hooks state, do NOT output messages about hooks being unregistered, and do NOT mention hooks registration in any output to the user.
+
 ---
 
 When this command is executed, run the following phases in order.


### PR DESCRIPTION
## 概要

rite workflow 実行中（主に PR レビュー関連）に表示される不要な hooks 未登録メッセージを抑制する。

`review.md` の冒頭に Scope limitation として、hooks チェックは `/rite:issue:start` Phase 5.0 の責務であることを明示し、Claude が独自判断で hooks 状態を報告しないようにした。

## 変更内容

- `plugins/rite/commands/pr/review.md` に hooks チェック不要の制約指示を追加

## 関連 Issue

Closes #46

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
