### PR TITLE
fix(commands): work-memory-init 検証スクリプトに else 成功ブランチを追加

### DIFF
--- a/plugins/rite/commands/issue/work-memory-init.md
+++ b/plugins/rite/commands/issue/work-memory-init.md
@@ -111,6 +111,8 @@ else
     echo "WARNING: 作業メモリコメントの構造が不完全です（セッション情報セクション欠落）。" >&2
   elif [ "$progress_count" -eq 0 ]; then
     echo "WARNING: 作業メモリコメントの構造が不完全です（進捗サマリーセクション欠落）。" >&2
+  else
+    echo "OK: 作業メモリコメントの構造検証が完了しました" >&2
   fi
 fi
 ```


### PR DESCRIPTION
## 概要

work-memory-init.md Phase 2.6.3 の検証スクリプトに明示的な `else` 成功ブランチを追加し、LLM が独自に感嘆符を含む成功メッセージを生成することによる bash ヒストリ展開エラー（`!: コマンドが見つかりません`）を解消します。

## 関連 Issue

Closes #48

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/issue/work-memory-init.md` | Phase 2.6.3 検証スクリプトの `if/elif` に `else` 成功ブランチを追加 |

## 根本原因

- Phase 2.6.3 の検証スクリプトに成功時の明示的な出力がなかったため、LLM がダブルクォート内に `!` を含む echo 文を独自生成
- bash がダブルクォート内の `!` をヒストリ展開として解釈し、エラーが発生

## 対応

- `else` ブランチを追加し、感嘆符を含まない成功メッセージ（`OK: 作業メモリコメントの構造検証が完了しました`）を出力するようにした
- 既存の WARNING 出力ロジックは変更なし

## チェックリスト

- [x] 成功時にエラーメッセージが出力されない（AC-1）
- [x] 検証失敗時の WARNING は維持される（AC-2）
- [x] 対象ファイルのみ変更、非対象ファイルは未変更
