### PR TITLE
chore(changelog): リブランド表記を削除

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -18,7 +18,7 @@ Rite Workflow の主要な変更を記録します。
 
 ### 追加
 
-- Rite Workflow 初回リリース（Zen Workflow からリブランド）
+- Rite Workflow 初回リリース
 - Claude Code 用 Issue ドリブン開発ワークフロー
 - マルチレビュアー PR レビューシステム（討論フェーズ付き）
 - スプリント計画・チーム実行

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release of Rite Workflow (rebranded from Zen Workflow)
+- Initial release of Rite Workflow
 - Issue-driven development workflow for Claude Code
 - Multi-reviewer PR review system with debate phase
 - Sprint planning and team execution


### PR DESCRIPTION
## 概要

CHANGELOG.ja.md および CHANGELOG.md の v0.1.0 エントリからリブランド表記（Zen Workflow）を削除します。

Closes #52

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `CHANGELOG.ja.md` | 「Rite Workflow 初回リリース（Zen Workflow からリブランド）」→「Rite Workflow 初回リリース」 |
| `CHANGELOG.md` | 「Initial release of Rite Workflow (rebranded from Zen Workflow)」→「Initial release of Rite Workflow」 |

## チェックリスト

- [x] CHANGELOG.ja.md から「（Zen Workflow からリブランド）」が削除されている
- [x] CHANGELOG.md から「(rebranded from Zen Workflow)」が削除されている
- [x] 他の行に変更がないこと
