### PR TITLE
chore: v0.1.3 リリース準備

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rite",
       "source": "./plugins/rite",
       "description": "Universal Issue-driven development workflow for Claude Code",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": { "name": "B16B1RD" },
       "license": "MIT"
     }


### PR DESCRIPTION
## 概要

develop ブランチの最新変更を v0.1.3 としてリリースするため、marketplace.json の version を `0.1.2` → `0.1.3` に更新。

Closes #63

## 変更内容

| ファイル | 変更 |
|---------|------|
| `.claude-plugin/marketplace.json` | version を `0.1.2` → `0.1.3` に更新 |

## 未完了の Issue チェック項目

以下のチェック項目は PR マージ後の後続作業で対応予定です:

- [ ] develop → main への PR が作成・マージ済み
- [ ] Git タグ `v0.1.3` が作成済み
- [ ] GitHub Release が作成済み
- [ ] 既存機能に退行がないこと

## チェックリスト

- [x] marketplace.json の version が `0.1.3` に更新済み
- [x] Conventional Commits 形式のコミットメッセージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
