### PR TITLE
feat: プラグインアップデート時の hooks 自動検知・通知

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -727,6 +727,20 @@ Missing or non-executable scripts will be skipped at runtime.
 
 ---
 
+### 4.5.5 Record Installed Version
+
+Write the current plugin version to a marker file for update detection by `session-start.sh`:
+
+```bash
+PLUGIN_JSON="{hooks_dir}/../.claude-plugin/plugin.json"
+VERSION=$(jq -r '.version' "$PLUGIN_JSON" 2>/dev/null)
+if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+  echo "$VERSION" > "{state_root}/.rite-initialized-version"
+fi
+```
+
+---
+
 ## Phase 4.6: Work Memory Directory Setup
 
 Create the local work memory directory:
@@ -740,7 +754,7 @@ Add `.rite-work-memory/` and `.rite-compact-state*` to `.gitignore` if not alrea
 
 ```bash
 # Check and add entries if missing
-for entry in ".rite-work-memory/" ".rite-compact-state" ".rite-compact-state.lockdir/" ".rite-compact-state.tmp.*"; do
+for entry in ".rite-work-memory/" ".rite-compact-state" ".rite-compact-state.lockdir/" ".rite-compact-state.tmp.*" ".rite-initialized-version"; do
   if ! grep -qF "$entry" .gitignore 2>/dev/null; then
     echo "$entry" >> .gitignore
   fi

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -442,6 +442,15 @@ chmod +x {plugin_root}/hooks/stop-guard.sh {plugin_root}/hooks/pre-compact.sh {p
 
 If `chmod` fails, display `⚠️ Hook scripts may not be executable. Flow may require manual continuation after sub-skill returns.` If hook registration fails (e.g., file permission error), display the same warning and continue — 🚨 Mandatory After instructions provide textual fallback.
 
+**Step 5**: Update version marker after hook registration:
+
+```bash
+VERSION=$(jq -r '.version' "{plugin_root}/.claude-plugin/plugin.json" 2>/dev/null)
+if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+  echo "$VERSION" > "$STATE_ROOT/.rite-initialized-version"
+fi
+```
+
 ### 5.1 Implementation
 
 Run [Preflight Protocol](#preflight-protocol) before starting implementation.

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -102,6 +102,33 @@ if [ "$SOURCE" = "startup" ]; then
   fi
 fi
 
+# --- Plugin version check on startup ---
+if [ "$SOURCE" = "startup" ]; then
+  _version_file="$STATE_ROOT/.rite-initialized-version"
+  if [ -f "$_version_file" ]; then
+    _installed_ver=$(cat "$_version_file" 2>/dev/null | tr -d '[:space:]')
+    _plugin_json="$SCRIPT_DIR/../.claude-plugin/plugin.json"
+    _current_ver=$(jq -r '.version // empty' "$_plugin_json" 2>/dev/null)
+    if [ -n "$_installed_ver" ] && [ -n "$_current_ver" ] && [ "$_installed_ver" != "$_current_ver" ]; then
+      # i18n: read language from rite-config.yml (same awk pattern as stop-guard.sh)
+      _lang="en"
+      _rite_config="$STATE_ROOT/rite-config.yml"
+      if [ -f "$_rite_config" ]; then
+        _cfg_lang=$(awk '/^language:/{print $2}' "$_rite_config" 2>/dev/null | tr -d '[:space:]')
+        [ -n "$_cfg_lang" ] && _lang="$_cfg_lang"
+      fi
+      case "$_lang" in
+        ja)
+          echo "[rite] プラグインが更新されました (v${_installed_ver} -> v${_current_ver})。/rite:init を実行して hooks を再登録してください。" >&2
+          ;;
+        *)
+          echo "[rite] Plugin updated (v${_installed_ver} -> v${_current_ver}). Run /rite:init to re-register hooks." >&2
+          ;;
+      esac
+    fi
+  fi
+fi
+
 STATE_FILE="$STATE_ROOT/.rite-flow-state"
 
 if [ ! -f "$STATE_FILE" ]; then

--- a/plugins/rite/i18n/en.yml
+++ b/plugins/rite/i18n/en.yml
@@ -957,3 +957,6 @@ messages:
   template_reset_error_action_manual_create: "Manually create templates"
   template_reset_error_action_manual_create_detail: "Manually create `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`"
 
+  # Hook version update notification
+  hook_version_updated: "Plugin updated (v{old} -> v{new}). Run /rite:init to re-register hooks."
+

--- a/plugins/rite/i18n/en/other.yml
+++ b/plugins/rite/i18n/en/other.yml
@@ -746,6 +746,9 @@ messages:
   template_reset_error_action_manual_create: "Manually create templates"
   template_reset_error_action_manual_create_detail: "Manually create `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`"
 
+  # Hook version update notification
+  hook_version_updated: "Plugin updated (v{old} -> v{new}). Run /rite:init to re-register hooks."
+
   # Resume command
   resume_current_branch: "Current branch"
   resume_option_manual_number: "Manually specify Issue number: `/rite:resume {issue_number}`"

--- a/plugins/rite/i18n/ja.yml
+++ b/plugins/rite/i18n/ja.yml
@@ -957,3 +957,6 @@ messages:
   template_reset_error_action_manual_create: "手動でテンプレートを作成"
   template_reset_error_action_manual_create_detail: ".github/ISSUE_TEMPLATE/` と `.github/PULL_REQUEST_TEMPLATE.md` を手動作成"
 
+  # Hook version update notification
+  hook_version_updated: "プラグインが更新されました (v{old} -> v{new})。/rite:init を実行して hooks を再登録してください。"
+

--- a/plugins/rite/i18n/ja/other.yml
+++ b/plugins/rite/i18n/ja/other.yml
@@ -746,6 +746,9 @@ messages:
   template_reset_error_action_manual_create: "手動でテンプレートを作成"
   template_reset_error_action_manual_create_detail: ".github/ISSUE_TEMPLATE/` と `.github/PULL_REQUEST_TEMPLATE.md` を手動作成"
 
+  # Hook version update notification
+  hook_version_updated: "プラグインが更新されました (v{old} -> v{new})。/rite:init を実行して hooks を再登録してください。"
+
   # Resume コマンド
   resume_current_branch: "現在のブランチ"
   resume_option_manual_number: "Issue 番号を手動で指定: `/rite:resume {issue_number}`"


### PR DESCRIPTION
## Summary

- セッション開始時に `.rite-initialized-version` と `plugin.json` のバージョンを比較し、差異があれば `/rite:init` の再実行を促す警告を表示
- `/rite:init` Phase 4.5.5 でバージョンマーカーファイルを書き込み、Phase 4.6 で `.gitignore` に登録
- `/rite:issue:start` Phase 5.0 Step 5 で hooks 修復後にバージョンマーカーを更新（次回 startup の警告を消す）
- i18n: `hook_version_updated` キーを ja/en の root + split ファイルに追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/session-start.sh` | バージョンチェック + i18n ブロック追加 |
| `plugins/rite/commands/init.md` | Phase 4.5.5 追加 + Phase 4.6 .gitignore 追加 |
| `plugins/rite/commands/issue/start.md` | Phase 5.0 Step 5 追加 |
| `plugins/rite/i18n/ja.yml` | `hook_version_updated` キー追加 |
| `plugins/rite/i18n/en.yml` | `hook_version_updated` キー追加 |
| `plugins/rite/i18n/ja/other.yml` | `hook_version_updated` キー追加 |
| `plugins/rite/i18n/en/other.yml` | `hook_version_updated` キー追加 |

## Test plan

- [ ] `/rite:init` 実行 → `.rite-initialized-version` が作成されることを確認
- [ ] `.rite-initialized-version` のバージョンを手動で古い値に変更 → 新しいセッション開始で警告メッセージ表示を確認
- [ ] `rite-config.yml` の `language: en` で英語メッセージ表示を確認
- [ ] `/rite:issue:start` で hooks 修復後にバージョンファイルが更新されることを確認
- [ ] 再度セッション開始 → 警告が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)