### PR TITLE
chore: v0.2.0 リリース準備（バージョン表記更新 + CHANGELOG 更新）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rite",
       "source": "./plugins/rite",
       "description": "Universal Issue-driven development workflow for Claude Code",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "author": { "name": "B16B1RD" },
       "license": "MIT"
     }

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,16 @@ Rite Workflow の主要な変更を記録します。
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に準拠し、
 [Semantic Versioning](https://semver.org/lang/ja/spec/v2.0.0.html) に従います。
 
+## [0.2.0] - 2026-03-05
+
+### 追加
+
+- セッション開始時のプラグインバージョンチェック機能 (#68)
+
+### 変更
+
+- SPEC およびコマンドドキュメント内の Zen/禅 表記を rite に置換 (#67)
+
 ## [0.1.3] - 2026-03-05
 
 ### 変更
@@ -70,6 +80,7 @@ Rite Workflow の主要な変更を記録します。
 - TDD Light モード
 - git worktree による並列実装サポート
 
+[0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Rite Workflow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-05
+
+### Added
+
+- Plugin version check on session startup (#68)
+
+### Changed
+
+- Replaced Zen/禅 references with rite in SPEC and command docs (#67)
+
 ## [0.1.3] - 2026-03-05
 
 ### Changed
@@ -70,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TDD Light mode
 - Parallel implementation with git worktree support
 
+[0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.0...v0.1.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 > Claude Code 用汎用 Issue ドリブン開発ワークフロー
 
-[![Version](https://img.shields.io/badge/version-0.1.3-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.1.3)
+[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## なぜ "Rite" なのか

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Universal Issue-Driven Development Workflow for Claude Code
 
-[![Version](https://img.shields.io/badge/version-0.1.3-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.1.3)
+[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Why "Rite"?

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -238,7 +238,7 @@ rite-workflow/
 ```json
 {
   "name": "rite",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -238,7 +238,7 @@ Plugin metadata file format:
 ```json
 {
   "name": "rite",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/plugins/rite/.claude-plugin/plugin.json
+++ b/plugins/rite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rite",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT",


### PR DESCRIPTION
## 概要

v0.2.0 リリースに向けて、リポジトリ内のすべてのバージョン表記を `0.1.3` → `0.2.0` に更新し、CHANGELOG に v0.2.0 の変更内容を追記しました。

Closes #69

## 変更内容

### バージョン表記更新 (0.1.3 → 0.2.0)
- `plugins/rite/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `docs/SPEC.md` / `docs/SPEC.ja.md`
- `README.md` / `README.ja.md`（バッジ URL）

### CHANGELOG 更新
- `CHANGELOG.md` に `## [0.2.0]` セクションを追加
- `CHANGELOG.ja.md` に `## [0.2.0]` セクションを追加
- v0.1.3 以降の変更: プラグインバージョンチェック機能 (#68)、Zen→rite リネーム (#67)

## チェックリスト

- [x] すべての対象ファイルのバージョン表記を更新
- [x] CHANGELOG が Keep a Changelog フォーマットに準拠
- [x] 対象外ファイルは変更なし
- [x] `grep "0\.1\.3"` で対象ファイルに残存なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
