### PR TITLE
fix(hooks): マーケットプレイスインストールで bash hook パスが解決できない問題を修正

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -371,7 +371,7 @@ WM_SOURCE="close" \
   WM_NEXT_ACTION="なし" \
   WM_BODY_TEXT="Issue closed." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort. The file will be deleted in Phase 5 regardless.

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -389,16 +389,18 @@ Determine the task type for Phase 0.4.1 adaptive interview depth via AskUserQues
 
 ## Delegation to Interview
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 **Pre-write** (before invoking interview sub-skill): Update `.rite-flow-state` so stop-guard can prevent interruptions:
 
 ```bash
 if [ -f ".rite-flow-state" ]; then
   # Preserve existing fields (issue_number, branch, etc.) from caller (e.g., start.md)
-  bash plugins/rite/hooks/flow-state-update.sh patch \
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
     --phase "create_interview" \
     --next "After rite:issue:create-interview returns: proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
 else
-  bash plugins/rite/hooks/flow-state-update.sh create \
+  bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_interview" --issue 0 --branch "" --loop 0 --pr 0 \
     --next "After rite:issue:create-interview returns: proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
 fi
@@ -512,11 +514,11 @@ Based on Phase 0.6 result, delegate to the appropriate sub-command.
 ```bash
 if [ -f ".rite-flow-state" ]; then
   # Preserve existing fields (issue_number, branch, etc.) from caller
-  bash plugins/rite/hooks/flow-state-update.sh patch \
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
     --phase "create_delegation" \
     --next "Wait for sub-skill (create-register or create-decompose) to output completion report (Issue URL). Issue has NOT been created yet. Do NOT stop."
 else
-  bash plugins/rite/hooks/flow-state-update.sh create \
+  bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
     --next "Wait for sub-skill (create-register or create-decompose) to output completion report (Issue URL). Issue has NOT been created yet. Do NOT stop."
 fi
@@ -550,7 +552,7 @@ Do **NOT** stop before the sub-skill (`rite:issue:create-register` or `rite:issu
 **Post-completion cleanup**: After the sub-skill outputs the completion report, deactivate flow state:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "create_completed" --issue 0 --branch "" --loop 0 --pr 0 \
   --next "none" --active false
 ```

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -13,6 +13,8 @@ Perform actual implementation work following the implementation plan approved in
 > **Reference**: Apply the Phase 5.1 checklist from [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md).
 > In particular, check `simplicity_enforcement`, `scope_discipline`, and `dead_code_hygiene`.
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 **Basic implementation flow:**
 
 1. Check current file content with Read tool
@@ -531,7 +533,7 @@ Execute in 3 stages (Bash → Read+Write → Bash). Since `trap` is only effecti
 **Step 1: Bash tool call — Fetch body and validate**
 
 ```bash
-bash plugins/rite/hooks/issue-body-safe-update.sh fetch --issue {issue_number}
+bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {issue_number}
 ```
 
 Outputs: `tmpfile_read=<path>`, `tmpfile_write=<path>`, `original_length=<n>`. If fetch fails, outputs WARNING and exits 0 (skip).
@@ -548,7 +550,7 @@ Outputs: `tmpfile_read=<path>`, `tmpfile_write=<path>`, `original_length=<n>`. I
 **Step 3: Bash tool call — Validate and apply**
 
 ```bash
-bash plugins/rite/hooks/issue-body-safe-update.sh apply --issue {issue_number} \
+bash {plugin_root}/hooks/issue-body-safe-update.sh apply --issue {issue_number} \
   --tmpfile-read "{tmpfile_read}" --tmpfile-write "{tmpfile_write}" \
   --original-length {original_length}
 ```
@@ -572,7 +574,7 @@ WM_SOURCE="implement" \
   WM_NEXT_ACTION="rite:lint を実行" \
   WM_BODY_TEXT="Post-implementation. Proceeding to lint." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning (`rite: implement: local work memory lock failed`) and continue — local work memory update is best-effort. The `.rite-flow-state` update (step 4a) is the primary state record.
@@ -671,7 +673,7 @@ Check the state of remaining child Issues with `trackedIssues` and calculate `re
    **4a**: Create state file:
 
    ```bash
-   bash plugins/rite/hooks/flow-state-update.sh create \
+   bash {plugin_root}/hooks/flow-state-update.sh create \
      --phase "phase5_lint" --issue {issue_number} --branch "{branch_name}" \
      --loop 0 --pr 0 \
      --next "After rite:lint returns: [lint:success/skipped]->Phase 5.2.1 (checklist). [lint:error]->fix and re-invoke. [lint:aborted]->Phase 5.6. Do NOT stop."

--- a/plugins/rite/commands/issue/implementation-plan.md
+++ b/plugins/rite/commands/issue/implementation-plan.md
@@ -13,6 +13,8 @@ This module handles Issue content analysis and implementation plan generation.
 
 > **Relationship with `create.md` Phase 0.7**: If the Issue was created via `/rite:issue:create`, a specification document (high-level design: What/Why/Where) may exist in `docs/designs/`. This module generates the **detailed implementation plan** (How/Step-by-step) that builds on that specification. Check for a linked design doc in the Issue body before starting analysis — it provides pre-validated requirements and architectural decisions that reduce redundant exploration.
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 ### 3.1 Issue Content Analysis
 
 Leverage the quality score and extracted information validated in Phase 1 to perform analysis for implementation plan generation:
@@ -261,7 +263,7 @@ WM_SOURCE="plan" \
   WM_NEXT_ACTION="実装計画に沿って作業開始" \
   WM_BODY_TEXT="Implementation plan recorded." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **Notes**:

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -175,7 +175,7 @@ Execute after Phase 1.1-1.3.
 
 ```bash
 # branch is empty here — not yet created; populated after rite:issue:branch-setup completes in Phase 2.3
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase1_5_parent" --issue {issue_number} --branch "" \
   --loop 0 --pr 0 \
   --next "After rite:issue:parent-routing returns: proceed to Phase 1.6 (child issue selection) if applicable, then Phase 2. Do NOT stop."
@@ -197,7 +197,7 @@ Do **NOT** stop after `rite:issue:parent-routing` returns. The parent routing su
 
 ```bash
 # branch is empty here — not yet created; populated after rite:issue:branch-setup completes in Phase 2.3
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase1_6_child" --issue {issue_number} --branch "" \
   --loop 0 --pr 0 \
   --next "After rite:issue:child-issue-selection returns: proceed to Phase 2 (work preparation). Do NOT stop."
@@ -247,7 +247,7 @@ Skip Phase 2.4/2.5/2.6 (no Issue number). User manually links. Phase 3+ normal.
 **Pre-write** (before invoking `rite:issue:branch-setup`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase2_branch" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "After rite:issue:branch-setup returns: proceed to Phase 2.4 (Projects Status update to In Progress). Do NOT stop."
@@ -280,7 +280,7 @@ Execute only if `iteration.enabled: true` and `iteration.auto_assign: true` in r
 **Pre-write** (before invoking `rite:issue:work-memory-init`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase2_work_memory" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "After rite:issue:work-memory-init returns: proceed to Phase 3 (implementation plan). Do NOT stop."
@@ -315,7 +315,7 @@ Do **NOT** stop after `rite:issue:work-memory-init` returns. Proceed to the next
 **Pre-write** (before invoking `rite:issue:implementation-plan`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase3_plan" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "After rite:issue:implementation-plan returns: proceed to Phase 4 (work start guidance). Do NOT stop."
@@ -469,7 +469,7 @@ Read `safety.max_implementation_rounds` from rite-config.yml (default: 20). Trac
 **Round count tracking**: When re-entering Phase 5.1, update `.rite-flow-state` atomically:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh increment --field "implementation_round"
+bash {plugin_root}/hooks/flow-state-update.sh increment --field "implementation_round"
 ```
 
 **When round count exceeds limit**:
@@ -491,7 +491,7 @@ Run [Preflight Protocol](#preflight-protocol) before invoking lint.
 **Pre-check** (defense-in-depth): Always update `.rite-flow-state` before invoking lint to ensure the stop-guard has correct phase and fresh timestamp. This unconditional write prevents stale state from causing intermittent flow stops (fixes #666):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_lint" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "After rite:lint returns: [lint:success/skipped]->Phase 5.2.1 (checklist). [lint:error]->fix and re-invoke. [lint:aborted]->Phase 5.6. Do NOT stop."
@@ -570,7 +570,7 @@ printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do ec
 **Step 1**: Update `.rite-flow-state` to post-lint phase (atomic). This second write (after the Phase 5.2 pre-check write) transitions from `phase5_lint` to `phase5_post_lint`, ensuring stop-guard routes to checklist confirmation rather than re-invoking lint:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_lint" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "Phase 5.2.1: Check Issue checklist completion. All complete->Phase 5.3 PR creation (invoke rite:pr:create). Incomplete->return to Phase 5.1 implementation. Do NOT stop."
@@ -600,7 +600,7 @@ Run [Preflight Protocol](#preflight-protocol) before creating PR.
 After 5.2.1, update `.rite-flow-state` (atomic, see 5.1 step 3):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
   --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->Phase 5.6. Do NOT stop."
@@ -633,7 +633,7 @@ Run [Preflight Protocol](#preflight-protocol) before each review cycle.
 Update `.rite-flow-state` (atomic, see 5.1 step 3):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_review" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "After rite:pr:review returns: [review:mergeable]->Phase 5.5. [review:fix-needed:{N}]->Phase 5.4.4. [review:conditional-merge/loop-limit]->Phase 5.4.4 then 5.5. Do NOT stop."
@@ -660,7 +660,7 @@ Invoke `skill: "rite:pr:review"`. Increment `loop_count`.
 **Step 1**: Update `.rite-flow-state` to post-review phase (atomic). This second write (after the Phase 5.4.1 pre-write) transitions from `phase5_review` to `phase5_post_review`, ensuring stop-guard routes to the correct next branch rather than repeatedly blocking and incrementing `error_count` (fixes #719):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_review" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "rite:pr:review completed. Check recent result pattern in context: [review:mergeable]->Phase 5.5 (ready). [review:fix-needed:{N}]->Phase 5.4.4 (fix). [review:conditional-merge/loop-limit]->Phase 5.4.4 then 5.5. Do NOT stop."
@@ -741,7 +741,7 @@ fi
 Update `.rite-flow-state` (atomic):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_fix" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "After rite:pr:fix returns: [fix:pushed]+fix-needed->Phase 5.4.1. [fix:pushed]+conditional/loop-limit->Phase 5.5. [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. [fix:error]->ask user. Do NOT stop."
@@ -764,7 +764,7 @@ Invoke `skill: "rite:pr:fix"`.
 **Step 1**: Update `.rite-flow-state` to post-fix phase (atomic). This second write (after the Phase 5.4.4 pre-write) transitions from `phase5_fix` to `phase5_post_fix`, ensuring stop-guard routes to the correct next branch rather than repeatedly blocking and incrementing `error_count` (fixes #709):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_fix" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]+fix-needed->Phase 5.4.1 (re-review). [fix:pushed]+conditional/loop-limit->Phase 5.5 (ready). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. Do NOT stop."
@@ -868,7 +868,7 @@ When loop completes, confirm:
 **Step 1**: Update `.rite-flow-state` to post-ready phase (atomic). This write transitions from `phase5_post_review`/`phase5_post_fix` to `phase5_post_ready`, ensuring stop-guard routes to Status update rather than re-invoking ready (fixes #781):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_ready" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "Phase 5.5.1: Update Issue Status to In Review, then Phase 5.5.2 metrics, then Phase 5.6 completion report. Do NOT stop."
@@ -1097,7 +1097,7 @@ Present options via `AskUserQuestion`:
 **Post-completion**: Update `.rite-flow-state` `active: false` (atomic):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh create \
+bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "completed" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
   --next "none" --active false

--- a/plugins/rite/commands/issue/update.md
+++ b/plugins/rite/commands/issue/update.md
@@ -10,6 +10,8 @@ Manually update the work memory comment on an Issue
 
 ## Overview
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 This command is for **manually** updating the work memory.
 
 ### Automatic vs Manual Updates
@@ -304,7 +306,7 @@ WM_SOURCE="update" \
   WM_NEXT_ACTION="作業を継続" \
   WM_BODY_TEXT="Manual update via rite:issue:update." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -17,6 +17,8 @@ Execute the following phases in order when this command is invoked.
 
 ## Caller Context and End-to-End Flow
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 This command has two invocation cases: standalone execution and being called from the `/rite:issue:start` end-to-end flow.
 
 | Caller | Output Pattern | Subsequent Action |
@@ -430,7 +432,7 @@ Before outputting any result pattern (`[lint:success]`, `[lint:skipped]`, `[lint
 | `[lint:aborted]` | `phase5_aborted` | `品質チェック中断` | `rite:lint was aborted by user. Proceed to Phase 5.6 (completion report). Do NOT stop.` |
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh patch \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "{phase_value}" \
   --next "{next_action_value}" \
   --if-exists
@@ -453,7 +455,7 @@ WM_SOURCE="lint" \
   WM_REQUIRE_FLOW_STATE="true" \
   WM_READ_FROM_FLOW_STATE="true" \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.rite-flow-state` update above. Claude substitutes these with the actual values based on the lint result before executing.

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -24,14 +24,16 @@ When this command is executed, run the following phases in order.
 
 ## Phase 1.0: Activate Flow State
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 Activate `.rite-flow-state` so that `stop-guard.sh` blocks premature `end_turn` during cleanup phases.
 
 ```bash
 if [ -f .rite-flow-state ]; then
-  bash plugins/rite/hooks/flow-state-update.sh patch \
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
     --phase "cleanup" --next "Execute cleanup phases. Do NOT stop."
 else
-  bash plugins/rite/hooks/flow-state-update.sh create \
+  bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "cleanup" --issue 0 --branch "" --loop 0 --pr 0 \
     --next "Execute cleanup phases. Do NOT stop."
 fi

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -17,6 +17,8 @@ Execute the following phases in order when this command is invoked.
 
 ## Caller Context and End-to-End Flow
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
+
 This command can be invoked in two ways: standalone execution or from the `/rite:issue:start` end-to-end flow (via Phase 5.3).
 
 | Caller | Subsequent Action |
@@ -647,7 +649,7 @@ WM_SOURCE="create" \
   WM_NEXT_ACTION="rite:pr:review を実行" \
   WM_BODY_TEXT="PR #{pr_number} created." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1040,7 +1040,7 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 Before outputting the pattern, update `.rite-flow-state` to `phase5_post_fix` (defense-in-depth, fixes #709). This prevents stop-guard `error_count` from accumulating when the flow continues after this skill returns:
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh patch \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_post_fix" \
   --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]+fix-needed->Phase 5.4.1 (re-review). [fix:pushed]+conditional/loop-limit->Phase 5.5 (ready). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. Do NOT stop." \
   --if-exists
@@ -1060,7 +1060,7 @@ WM_SOURCE="fix" \
   WM_BODY_TEXT="Post-fix. loop_count incremented." \
   WM_LOOP_INCREMENT="true" \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -211,7 +211,7 @@ Proceed to the next phase.
 **In e2e flow**: If `.rite-flow-state` exists, update the state file and output `[ready:error]` before ending to signal the failure to the caller (`start.md` Phase 5.5):
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh patch \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_ready_error" \
   --next "rite:pr:ready failed. Ask user: retry / skip to Phase 5.6 / terminate." \
   --if-exists
@@ -236,7 +236,7 @@ WM_SOURCE="ready" \
   WM_NEXT_ACTION="レビュー待ち" \
   WM_BODY_TEXT="PR marked as ready for review." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.
@@ -452,7 +452,7 @@ Before outputting the result pattern (`[ready:completed]`) or skipping output, u
 | `[ready:completed]` | `phase5_post_ready` | `Ready処理完了` | `rite:pr:ready completed. Proceed to start.md Phase 5.5.1 (Status update to In Review), then Phase 5.5.2 (metrics), then Phase 5.6 (completion report). Do NOT stop.` |
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh patch \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_post_ready" \
   --next "rite:pr:ready completed. Proceed to start.md Phase 5.5.1 (Status update to In Review), then Phase 5.5.2 (metrics), then Phase 5.6 (completion report). Do NOT stop." \
   --if-exists
@@ -471,7 +471,7 @@ WM_SOURCE="ready" \
   WM_REQUIRE_FLOW_STATE="true" \
   WM_READ_FROM_FLOW_STATE="true" \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -386,7 +386,7 @@ Replace `- [ ] #{issue_number}` with `- [x] #{issue_number}` in the parent Issue
 **Step 1: Bash tool call -- retrieve and validate the body**
 
 ```bash
-bash plugins/rite/hooks/issue-body-safe-update.sh fetch --issue {parent_issue_number} --parent
+bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {parent_issue_number} --parent
 ```
 
 Outputs: `tmpfile_read=<path>`, `tmpfile_write=<path>`, `original_length=<n>`.
@@ -401,7 +401,7 @@ Outputs: `tmpfile_read=<path>`, `tmpfile_write=<path>`, `original_length=<n>`.
 **Step 3: Bash tool call -- validate and apply**
 
 ```bash
-bash plugins/rite/hooks/issue-body-safe-update.sh apply --issue {parent_issue_number} \
+bash {plugin_root}/hooks/issue-body-safe-update.sh apply --issue {parent_issue_number} \
   --tmpfile-read "{tmpfile_read}" --tmpfile-write "{tmpfile_write}" \
   --original-length {original_length} --parent --diff-check
 ```

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -1238,7 +1238,7 @@ WM_SOURCE="review" \
   WM_NEXT_ACTION="レビュー結果に基づき次のアクションを決定" \
   WM_BODY_TEXT="Review cycle completed." \
   WM_ISSUE_NUMBER="{issue_number}" \
-  bash plugins/rite/hooks/local-wm-update.sh 2>/dev/null || true
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.
@@ -1629,7 +1629,7 @@ Before outputting any result pattern (`[review:mergeable]`, `[review:fix-needed:
 | `[review:loop-limit:{n}]` | `phase5_post_review` | `rite:pr:review completed. Result: [review:loop-limit:{n}]. Proceed to Phase 5.4.4 (fix) then Phase 5.5. Do NOT stop.` |
 
 ```bash
-bash plugins/rite/hooks/flow-state-update.sh patch \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_post_review" \
   --next "{next_action_value}" \
   --if-exists


### PR DESCRIPTION
## 概要

コマンドファイル内のハードコードされた `bash plugins/rite/hooks/` パスを `bash {plugin_root}/hooks/` に置換し、マーケットプレイスインストール環境でも hook スクリプトが正しく実行されるようにする。

## 変更内容

### Category A（パス置換のみ・5ファイル）
- `issue/start.md`: 15箇所置換
- `pr/ready.md`: 4箇所置換
- `pr/review.md`: 2箇所置換
- `pr/fix.md`: 2箇所置換
- `issue/close.md`: 1箇所置換

### Category B（解決手順追加 + パス置換・7ファイル）
- `issue/create.md`: Plugin Path Resolution 参照追加 + 5箇所置換
- `issue/implement.md`: Plugin Path Resolution 参照追加 + 4箇所置換
- `issue/update.md`: Plugin Path Resolution 参照追加 + 1箇所置換
- `issue/implementation-plan.md`: Plugin Path Resolution 参照追加 + 1箇所置換
- `pr/cleanup.md`: Plugin Path Resolution 参照追加 + 2箇所置換
- `pr/create.md`: Plugin Path Resolution 参照追加 + 1箇所置換
- `lint.md`: Plugin Path Resolution 参照追加 + 2箇所置換

### その他
- `pr/references/archive-procedures.md`: 2箇所置換（既存解決指示あり）

## 関連 Issue

Closes #73

## テスト

- [x] Category A 全5ファイルで `bash plugins/rite/hooks/` が0件
- [x] Category B 全ファイルで Plugin Path Resolution 参照が存在
- [x] Category B 全ファイルで `bash plugins/rite/hooks/` が0件
- [x] `init.md` は変更されていない（Non-regression）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
