### PR TITLE
fix: create workflow のサブスキル間遷移で中断が発生する問題を修正

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -495,8 +495,13 @@ Interview results are mapped to Implementation Contract sections (Section 1-9) f
 
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller MUST immediately proceed to Phase 0.6 (Task Decomposition Decision).
+When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller (`create.md`) **MUST immediately** execute its 🚨 Mandatory After Interview section:
 
-**WARNING**: The Issue has NOT been created yet. No GitHub Issue exists at this point. The interview only collected information — creation happens in `create-register.md` or `create-decompose.md`. Stopping here would completely abandon the workflow with no Issue created.
+1. Update `.rite-flow-state` to `create_post_interview` phase
+2. Proceed to Phase 0.6 (Task Decomposition Decision)
+
+**WARNING**: **No GitHub Issue has been created yet.** No GitHub Issue exists at this point. The interview only collected information — creation happens in `create-register.md` or `create-decompose.md`. Stopping here would completely abandon the workflow with no Issue created.
+
+**Concrete next action for caller**: Evaluate decomposition triggers (Phase 0.6.1), then delegate to `rite:issue:create-register` (single Issue) or `rite:issue:create-decompose` (sub-Issue decomposition).
 
 **→ Return to `create.md` and proceed to Phase 0.6 now. Do NOT stop.**

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -408,11 +408,29 @@ fi
 
 Invoke `skill: "rite:issue:create-interview"`.
 
+**🚨 Immediate after interview returns**: When `rite:issue:create-interview` completes (interview finished or skipped) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Interview below.
+
 ### 🚨 Mandatory After Interview
 
-Do **NOT** stop after `rite:issue:create-interview` returns. Proceed to the next phase immediately after the sub-skill returns. The interview sub-skill only collects information — the actual Issue creation has NOT happened yet.
+> See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
 
-**→ Proceed to Phase 0.6 (Task Decomposition Decision) now. Do NOT stop.**
+Do **NOT** stop after `rite:issue:create-interview` returns. The interview sub-skill only collects information — **no GitHub Issue has been created yet**. Stopping here would completely abandon the workflow with no deliverable.
+
+**Step 1**: Update `.rite-flow-state` to post-interview phase (atomic). This write transitions from `create_interview` to `create_post_interview`, ensuring stop-guard routes to Phase 0.6 rather than re-invoking the interview:
+
+```bash
+if [ -f ".rite-flow-state" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "create_post_interview" \
+    --next "Phase 0.6: Task Decomposition Decision. Evaluate decomposition triggers, then delegate to create-register or create-decompose. Issue has NOT been created yet. Do NOT stop."
+else
+  bash {plugin_root}/hooks/flow-state-update.sh create \
+    --phase "create_post_interview" --issue 0 --branch "" --loop 0 --pr 0 \
+    --next "Phase 0.6: Task Decomposition Decision. Evaluate decomposition triggers, then delegate to create-register or create-decompose. Issue has NOT been created yet. Do NOT stop."
+fi
+```
+
+**Step 2**: **→ Proceed to Phase 0.6 (Task Decomposition Decision) now. Do NOT stop.**
 
 ---
 
@@ -545,7 +563,11 @@ Invoke `skill: "rite:issue:create-register"`.
 
 ### 🚨 Mandatory After Delegation
 
-Do **NOT** stop before the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs its completion report. The sub-command handles all remaining phases (creation, registration, completion report). Once the completion report (Issue URL) is output, the workflow is complete — no further action is needed.
+> See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
+
+Do **NOT** stop before the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs its completion report. The sub-command handles all remaining phases (creation, registration, completion report). **No GitHub Issue has been created yet** — stopping here would abandon the workflow with no deliverable.
+
+Once the completion report (Issue URL) is output, the workflow is complete — no further action is needed.
 
 **→ Wait for the sub-skill to output its Phase 3 completion report (Issue URL). Do NOT stop before that.**
 


### PR DESCRIPTION
## Summary

- `create.md` のサブスキル遷移時の継続指示を `start.md` の実績パターンに合わせて強化
- `create-interview.md` の Caller Return Protocol に具体的な次アクションを明示
- `.rite-flow-state` のポスト遷移更新を追加（defense-in-depth）

Closes #76

## Changes

### `create.md`
- Interview invoke 直後に「🚨 Immediate after interview returns」インライン注記を追加
- 「🚨 Mandatory After Interview」を番号付きステップに強化（flow-state update + 次アクション指示）
- 「🚨 Mandatory After Delegation」に明示的な警告文を追加

### `create-interview.md`
- 「🚨 Caller Return Protocol」に caller が実行すべき具体的ステップ（1. flow-state update, 2. Phase 0.6 進行）を明記
- 「Concrete next action for caller」セクションを追加

## Test plan

- [ ] Bug Fix タスクで `/rite:issue:create` を実行し、interview スキップ後に自動的に Phase 0.6 に進むことを確認 (T-01)
- [ ] Feature タスクでフルインタビュー後も正常に遷移することを確認 (T-03)
- [ ] create-register 完了後、フロー状態がクリーンアップされることを確認 (T-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)