### PR TITLE
fix(commands): サブスキル遷移でClaude停止を防ぐプロンプト強化

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -68,12 +68,18 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 
 ## Sub-skill Return Protocol (Global)
 
+> **CRITICAL — AUTOMATIC CONTINUATION REQUIREMENT**: This is the single most important rule in this document. When a sub-skill returns, you MUST continue responding in the same turn. Ending your response after a sub-skill returns is a **bug** that forces the user to type "continue" manually.
+
 This protocol applies to **every** sub-skill invocation in this document. Each 🚨 Mandatory After section enforces it at specific transition points.
 
-1. When a sub-skill outputs a result pattern and returns control, do **NOT** stop responding and do **NOT** re-invoke the same skill — it already completed.
-2. **Immediately** check the 🚨 Mandatory After section for that phase and execute the specified next action.
-3. If the stop-guard hook blocks a stop attempt (exit 2), follow the `ACTION:` instructions in its stderr message.
-4. Execute the post-return `.rite-flow-state` update specified in the 🚨 Mandatory After section, then proceed.
+**When a sub-skill outputs a result pattern (e.g., `[review:mergeable]`, `[fix:pushed]`, `[pr:created:123]`) and returns control to you:**
+
+1. **DO NOT end your response.** You are still in the middle of the e2e flow. Ending your response here is equivalent to crashing mid-workflow.
+2. **DO NOT re-invoke the completed skill.** It already finished. Re-invoking wastes time and may cause errors.
+3. **IMMEDIATELY** locate the 🚨 Mandatory After section for the current phase and execute its steps — starting with the `.rite-flow-state` update, then proceeding to the next phase.
+4. If the stop-guard hook blocks a stop attempt (exit 2), follow the `ACTION:` instructions in its stderr message.
+
+**Self-check**: After every sub-skill returns, ask yourself: "Have I output the completion report (Phase 5.6)?" If not, you are NOT done — keep going.
 
 ---
 
@@ -610,6 +616,8 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 Invoke `skill: "rite:pr:create"`.
 
+**🚨 Immediate after pr:create returns**: When `rite:pr:create` outputs a result pattern (`[pr:created:{N}]` or `[pr:create-failed]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After 5.3 below. The review-fix loop has NOT started yet — you MUST continue to Phase 5.4.
+
 **Patterns**: `[pr:created:{number}]`→extract number, proceed 5.4. `[pr:create-failed]`→5.6.
 
 ### 🚨 Mandatory After 5.3
@@ -750,6 +758,8 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 > **Data Handoff**: When invoking `rite:pr:fix`, PR number and review results are passed via work memory. Issue information from Phase 0.1 is available in work memory, avoiding redundant `gh issue view` calls.
 
 Invoke `skill: "rite:pr:fix"`.
+
+**🚨 Immediate after fix returns**: When `rite:pr:fix` outputs a result pattern (`[fix:pushed]`, `[fix:issues-created:{N}]`, `[fix:replied-only]`, or `[fix:error]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 5.4.6 🚨 After Fix below. The fix sub-skill has already updated `.rite-flow-state` to `phase5_post_fix` via its defense-in-depth mechanism (fixes #709); execute the 5.4.6 steps without delay.
 
 #### 5.4.5 Fix Patterns
 

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -321,6 +321,22 @@ if [ -f "$COMPACT_STATE" ]; then
 fi
 ```
 
+### 3.0.1 Restore Flow State Active Flag
+
+Ensure `.rite-flow-state` has `active: true` so that the stop-guard hook blocks premature stops during the resumed workflow. Without this, the stop-guard sees `active: false` (or missing state) and allows Claude to stop mid-flow (root cause of Issue #79's resume-session variant).
+
+```bash
+STATE_FILE=".rite-flow-state"
+if [ -f "$STATE_FILE" ]; then
+  TMP_STATE="${STATE_FILE}.tmp.$$"
+  jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    '.active = true | .updated_at = $ts | .error_count = 0' \
+    "$STATE_FILE" > "$TMP_STATE" && mv "$TMP_STATE" "$STATE_FILE" || rm -f "$TMP_STATE"
+fi
+```
+
+**If `.rite-flow-state` does not exist**: The invoked command (e.g., `rite:issue:start`) will create it via `flow-state-update.sh create` in its own phases, so no action is needed here.
+
 ### 3.1 Switch Branch
 
 If the current branch differs from the branch in work memory:


### PR DESCRIPTION
## 概要

`/rite:issue:start` の e2e フロー実行中、サブスキル完了後に Claude が応答を停止し、ユーザーが "continue" 入力を求められる問題を修正。

Closes #79

## 変更内容

### Sub-skill Return Protocol 強化 (`start.md`)
- **CRITICAL — AUTOMATIC CONTINUATION REQUIREMENT** blockquote を追加し、サブスキル返却後の自動遷移を最重要ルールとして明示
- 4つのルールを具体的な禁止事項（DO NOT end your response / DO NOT re-invoke）に書き換え
- Self-check（「完了報告を出力したか？」）を追加

### 欠落した「🚨 Immediate after」段落の追加 (`start.md`)
- Phase 5.3 (PR Create): `🚨 Immediate after pr:create returns` を追加
- Phase 5.4.4 (Fix): `🚨 Immediate after fix returns` を追加
- 既存の lint (5.2), review (5.4.1), ready (5.5) と同一パターンで統一

### resume 時のフロー状態復元 (`resume.md`)
- Phase 3.0.1 を追加: `.rite-flow-state` の `active: true` と `error_count: 0` をリセット
- resume セッションで stop-guard が `EXIT:0 reason=not_active` を返す問題に対処

## テスト計画

- [ ] `/rite:issue:start` の e2e フローで review→fix→ready の遷移が自動で行われることを確認
- [ ] `/rite:resume` 後のセッションでも stop-guard が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
