### PR TITLE
fix(start): エージェント委譲プロンプトに Skill ツール書式を追加

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -675,12 +675,19 @@ When context pressure is detected (tool call count > `context_optimization.agent
 2. Spawn a general-purpose Agent with the following prompt:
    ```
    Execute the review-fix loop for PR #{pr_number} (Issue #{issue_number}).
-   1. Invoke skill "rite:pr:review" with args "{pr_number}"
+
+   Use the Skill tool to invoke each skill. The exact invocation format is:
+
+   - Review: `skill: "rite:pr:review", args: "{pr_number}"`
+   - Fix: `skill: "rite:pr:fix"`
+
+   Steps:
+   1. Invoke `skill: "rite:pr:review", args: "{pr_number}"`
    2. Based on the result pattern:
       - [review:mergeable] → return "AGENT_RESULT: [review:mergeable]"
-      - [review:fix-needed:{n}] → invoke skill "rite:pr:fix", then re-review (max {max_iterations} loops)
-      - [review:conditional-merge:{n}] → invoke skill "rite:pr:fix" for blocking only, then return result
-      - [review:loop-limit:{n}] → invoke skill "rite:pr:fix" for blocking only, then return result
+      - [review:fix-needed:{n}] → invoke `skill: "rite:pr:fix"`, then re-review (max {max_iterations} loops)
+      - [review:conditional-merge:{n}] → invoke `skill: "rite:pr:fix"` for blocking only, then return result
+      - [review:loop-limit:{n}] → invoke `skill: "rite:pr:fix"` for blocking only, then return result
    3. Return final result: "AGENT_RESULT: [review:{final_result}] loop_count={n} findings={total}"
    ```
 3. Parse `AGENT_RESULT` from agent output


### PR DESCRIPTION
## 概要

Phase 5.4.0 のエージェント委譲プロンプト内で自然言語記述だった Skill 呼び出し部分に、具体的な Skill ツール呼び出し書式を追加しました。

Closes #83

## 変更内容

- `plugins/rite/commands/issue/start.md`: エージェント委譲プロンプト（Phase 5.4.0）内の `Invoke skill "rite:pr:review"` 等の自然言語記述を、`skill: "rite:pr:review", args: "{pr_number}"` 形式の具体的な Skill ツール書式に置換

## 背景

PR #82 のレビューでプロンプトエンジニアレビュアーから指摘された内容への対応です。エージェントに委譲する際のプロンプトに Skill ツールの具体的な呼び出し書式が含まれていなかったため、エージェントが正しくスキルを呼び出せない可能性がありました。

## テスト計画

- [ ] エージェント委譲プロンプトの書式が正しいことを確認
- [ ] 既存の通常フロー（5.4.1-5.4.6）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
