### PR TITLE
fix(start): エージェント委譲の AGENT_RESULT フォールバック処理を追加

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -703,7 +703,20 @@ When context pressure is detected (tool call count > `context_optimization.agent
    - **完了報告に遷移**: Skip review-fix loop and proceed to Phase 5.6 (completion report with review skipped)
    - **手動介入**: Terminate and let the user handle manually
 
-   Update `.rite-flow-state` with the chosen action before proceeding.
+   Update `.rite-flow-state` based on the chosen option:
+
+   | Option | `--phase` | `--next` |
+   |--------|-----------|----------|
+   | inline フォールバック | `phase5_review` | `Agent delegation failed. Executing 5.4.1-5.4.6 inline. Proceed to Phase 5.4.1 (review). Do NOT stop.` |
+   | 完了報告に遷移 | `phase5_aborted` | `Agent delegation failed. User chose to skip review. Proceed to Phase 5.6 (completion report). Do NOT stop.` |
+   | 手動介入 | `phase5_manual` | `Agent delegation failed. User chose manual intervention. Terminate.` |
+
+   ```bash
+   bash plugins/rite/hooks/flow-state-update.sh create \
+     --phase "{phase_value}" --issue {issue_number} --branch "{branch_name}" \
+     --loop 0 --pr {pr_number} \
+     --next "{next_action_value}"
+   ```
 
 4. Update `.rite-flow-state` with agent results (loop_count, pr_number)
 5. Continue to Phase 5.5 (Ready) based on the result


### PR DESCRIPTION
## 概要

Phase 5.4.0 のエージェント委譲フローで、エージェントが `AGENT_RESULT` パターンを返さなかった場合のフォールバック処理を追加。

- エージェントエラー・タイムアウト・予期しない出力時に3択を提示
  - inline 実行にフォールバック（推奨）
  - 完了報告に遷移
  - 手動介入

## 変更内容

- `plugins/rite/commands/issue/start.md`: Phase 5.4.0 の AGENT_RESULT パース処理（ステップ3）にフォールバックハンドリングを追加

## 関連

Closes #84

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## テスト計画

- [ ] `/rite:issue:start` の end-to-end フローでエージェント委譲が発動するシナリオで動作確認
- [ ] フォールバック時に inline 実行に正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
