### PR TITLE
fix(hooks): context-pressure.sh の python3 起動最適化と COUNTER_VAL バリデーション追加

### DIFF
--- a/plugins/rite/hooks/context-pressure.sh
+++ b/plugins/rite/hooks/context-pressure.sh
@@ -66,8 +66,9 @@ if [ "$count" -lt "$((BASE_YELLOW - 10))" ]; then
 fi
 
 # Read configurable thresholds from rite-config.yml (fallback to defaults)
+# Pre-check: skip python3 startup (~50-100ms) when config has no pressure_thresholds key (#86)
 CONFIG_FILE="$STATE_ROOT/rite-config.yml"
-if [ -f "$CONFIG_FILE" ] && command -v python3 >/dev/null 2>&1; then
+if [ -f "$CONFIG_FILE" ] && grep -q 'pressure_thresholds' "$CONFIG_FILE" && command -v python3 >/dev/null 2>&1; then
   THRESHOLDS=$(python3 -c '
 import yaml, sys
 try:

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -126,6 +126,10 @@ if acquire_wm_lock "$LOCKDIR"; then
     COUNTER_FILE="$STATE_ROOT/.rite-context-counter"
     if [ -f "$COUNTER_FILE" ]; then
       COUNTER_VAL=$(cat "$COUNTER_FILE" 2>/dev/null) || COUNTER_VAL="0"
+      # Validate: must be numeric (same pattern as context-pressure.sh #86)
+      if ! [[ "$COUNTER_VAL" =~ ^[0-9]+$ ]]; then
+        COUNTER_VAL="0"
+      fi
       TMP_FILE=$(mktemp "${FLOW_STATE}.XXXXXX" 2>/dev/null) || TMP_FILE="${FLOW_STATE}.tmp.$$"
       if jq --arg cc "$COUNTER_VAL" '.context_counter_at_compact = ($cc | tonumber)' "$FLOW_STATE" > "$TMP_FILE" 2>/dev/null; then
         mv "$TMP_FILE" "$FLOW_STATE"


### PR DESCRIPTION
## 概要

- context-pressure.sh: python3 起動前に `grep -q` で `pressure_thresholds` キーの存在を先行チェック。キーが無い場合は python3 をスキップし 50-100ms の起動コストを節約
- pre-compact.sh: COUNTER_VAL の数値バリデーション (`^[0-9]+$`) を追加。非数値が jq `tonumber` に渡されてエラーになるのを防止

## 関連 Issue

Closes #86

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/context-pressure.sh` | `grep -q 'pressure_thresholds'` による先行チェック追加 |
| `plugins/rite/hooks/pre-compact.sh` | `COUNTER_VAL` の `^[0-9]+$` バリデーション追加 |

## Known Issues
- lint 未実行（lint コマンドが検出されませんでした）

## テスト計画

- [ ] context-pressure.sh: `pressure_thresholds` が rite-config.yml に存在する場合、python3 が起動されることを確認
- [ ] context-pressure.sh: `pressure_thresholds` が rite-config.yml に存在しない場合、python3 がスキップされることを確認
- [ ] pre-compact.sh: COUNTER_VAL が数値の場合、正常に flow-state に記録されることを確認
- [ ] pre-compact.sh: COUNTER_VAL が非数値の場合、0 にフォールバックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
