### PR TITLE
docs: lint.md の不正確な参照修正と start.md の具体例追加

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -368,7 +368,7 @@ The e2e flow must minimize context consumption to complete within a single sessi
 1. **Minimize intermediate text output**: Between tool calls, output only essential status updates (1-2 lines max). Skip explanations, summaries, and guidance text that the user doesn't need during automated flow.
 2. **Trust result patterns**: When a sub-skill returns a result pattern (e.g., `[lint:success]`), do NOT re-summarize what happened. Immediately proceed to the next phase.
 3. **Avoid redundant reads**: Information from Phase 0.1 (Issue details) is retained in context. Do NOT re-fetch Issue body, title, or labels in later phases.
-4. **Batch bash operations**: Combine related bash commands into single tool calls where possible (e.g., flow-state update + work memory sync).
+4. **Batch bash operations**: Combine related bash commands into single tool calls where possible. Examples: `flow-state-update.sh create ... && WM_SOURCE=... bash local-wm-update.sh` (flow-state + work memory sync in one call), `gh api graphql ... && gh project item-edit ...` (Projects query + update in one call).
 
 **Sub-skill output expectations** (e2e flow):
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -23,7 +23,7 @@ When called from the `/rite:issue:start` end-to-end flow, minimize output to red
 | Phase 4.3 (Summary) | Full table | **Skip entirely** |
 | Phase 4.4 (Work Memory) | Full update | Full update (no change) |
 
-**Detection**: Reuse Phase 0.1 end-to-end flow determination.
+**Detection**: See [Caller Context and End-to-End Flow](#caller-context-and-end-to-end-flow) determination method below.
 
 ---
 


### PR DESCRIPTION
## 概要

lint.md と start.md の軽微なドキュメント修正。

- lint.md: 存在しない「Phase 0.1」への不正確な参照を、正しいセクション参照に修正
- start.md: 「Batch bash operations」ルールに具体的なコマンド例を追加

## 関連 Issue

Closes #87

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/lint.md` | L26: 「Reuse Phase 0.1」→ 正しいセクション参照に修正 |
| `plugins/rite/commands/issue/start.md` | L371: Batch bash operations の具体例を追加 |

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## チェックリスト

- [x] ドキュメントの参照が正確であることを確認
- [x] 既存の書式・構造を維持
