### PR TITLE
fix(pr): PR コマンドの Issue 作成時に GitHub Projects 登録を確実にする

### DIFF
--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -474,8 +474,6 @@ If 5 or more unresolved issues are detected, recommend batch processing:
 
 If "Create separate Issues and continue with PR creation" is selected, create an Issue for each unresolved problem:
 
-Create Issues using the common script (see [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md)):
-
 > **Reference**: [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md)
 
 **Note**: The heredoc below contains `{placeholder}` markers. Claude substitutes these with actual values **before** generating the bash script — they are not shell variables.
@@ -492,7 +490,7 @@ Create Issues using the common script (see [Issue Creation with Projects Integra
 |-------------|--------|---------|
 | `{projects_enabled}` | `rite-config.yml` → `github.projects.enabled` | `true` |
 | `{project_number}` | `rite-config.yml` → `github.projects.project_number` | `6` |
-| `{owner}` | `rite-config.yml` → `github.projects.owner` | `"B16B1RD"` |
+| `{owner}` | `rite-config.yml` → `github.projects.owner` | `B16B1RD` |
 | `{iteration_mode}` | `rite-config.yml` → `iteration.enabled` が `true` かつ `iteration.auto_assign` が `true` なら `"auto"`、それ以外は `"none"` | `"none"` |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) | `/home/user/.claude/plugins/rite` |
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -800,7 +800,7 @@ Generate the Issue title in the following format:
 |-------------|--------|---------|
 | `{projects_enabled}` | `rite-config.yml` → `github.projects.enabled` | `true` |
 | `{project_number}` | `rite-config.yml` → `github.projects.project_number` | `6` |
-| `{owner}` | `rite-config.yml` → `github.projects.owner` | `"B16B1RD"` |
+| `{owner}` | `rite-config.yml` → `github.projects.owner` | `B16B1RD` |
 | `{iteration_mode}` | `rite-config.yml` → `iteration.enabled` が `true` かつ `iteration.auto_assign` が `true` なら `"auto"`、それ以外は `"none"` | `"none"` |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) | `/home/user/.claude/plugins/rite` |
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -1536,7 +1536,7 @@ Create Issues directly using `gh issue create` and register them in GitHub Proje
 |-------------|--------|---------|
 | `{projects_enabled}` | `rite-config.yml` → `github.projects.enabled` | `true` |
 | `{project_number}` | `rite-config.yml` → `github.projects.project_number` | `6` |
-| `{owner}` | `rite-config.yml` → `github.projects.owner` | `"B16B1RD"` |
+| `{owner}` | `rite-config.yml` → `github.projects.owner` | `B16B1RD` |
 | `{iteration_mode}` | `rite-config.yml` → `iteration.enabled` が `true` かつ `iteration.auto_assign` が `true` なら `"auto"`、それ以外は `"none"` | `"none"` |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) | `/home/user/.claude/plugins/rite` |
 

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -113,7 +113,7 @@ projects:
     mode: "none|auto"        # Default: "none". "auto" assigns to current iteration
     field_name: "Sprint"     # Default: "Sprint"
 options:
-  source: string             # Caller identifier (pr_review|pr_fix|cleanup|lint|interactive|parent_routing|xl_decomposition)
+  source: string             # Caller identifier (pr_review|pr_fix|pr_create|cleanup|lint|interactive|parent_routing|xl_decomposition)
   non_blocking_projects: true  # Default: true. Projects failure doesn't block Issue creation
 ```
 


### PR DESCRIPTION
## 概要

PR コマンド（fix.md, review.md, create.md）の Issue 作成時に GitHub Projects 登録が確実に行われるよう修正。

## 変更内容

- **fix.md Phase 4.3.4**: プレースホルダー値ソーステーブルを追加（`rite-config.yml` の具体的パスを明記）。Projects 登録失敗時の警告表示を必須化
- **review.md Phase 7.4.2**: fix.md と同様のプレースホルダー値ソーステーブルと警告表示指示を追加
- **create.md Phase 2.5.5**: `gh issue create` 直接呼び出しを `create-issue-with-projects.sh` 経由に変更。プレースホルダー値ソーステーブル・警告表示・エラーハンドリングを追加
- **issue-create-with-projects.md**: `create.md Phase 2.5.5` を参照元に追加。caller-specific priority mapping を追加

## 関連 Issue

Closes #100

## チェックリスト

- [x] fix.md/review.md にプレースホルダー値ソース明記
- [x] create.md の `gh issue create` → `create-issue-with-projects.sh` 変更
- [x] Projects 登録失敗時の警告表示指示を全3ファイルに追加
- [x] 参照ドキュメント（issue-create-with-projects.md）更新
- [x] Non-target ファイル（create-issue-with-projects.sh）未変更
