### PR TITLE
fix(implement): 進捗サマリー・変更ファイル更新セクションをチェックリスト更新から独立化

### DIFF
--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -559,7 +559,7 @@ Replace `{tmpfile_read}`, `{tmpfile_write}`, `{original_length}` with the values
 
 Also synchronize the "Issue checklist" section in the work memory.
 
-##### 5.1.1.1.1 Work Memory Progress Summary and Changed Files Update
+#### 5.1.1.2 Work Memory Progress Summary and Changed Files Update
 
 **Execution condition**: Execute after commit and push succeed, when on a work branch with an Issue number (`issue-{n}` pattern).
 
@@ -677,7 +677,7 @@ fi
 
 **On failure**: Display WARNING and continue (non-blocking). The progress update is best-effort; `.rite-flow-state` is the primary state record.
 
-#### 5.1.1.2 Local Work Memory Update
+#### 5.1.1.3 Local Work Memory Update
 
 **Execution condition**: Execute when on a work branch with an Issue number (`issue-{n}` pattern).
 
@@ -783,7 +783,7 @@ Check the state of remaining child Issues with `trackedIssues` and calculate `re
 
 1. Parent Issue progress update (only when working on child Issue, see 5.1.2)
 2. **Update work memory** (record phase info, changed files, next steps)
-3. **Update local work memory** (`.rite-work-memory/issue-{n}.md`) — see 5.1.1.2 above
+3. **Update local work memory** (`.rite-work-memory/issue-{n}.md`) — see 5.1.1.3 above
 4. **CRITICAL: Initialize `.rite-flow-state` and invoke lint** (atomic pair - MUST execute both):
 
    > **Note**: All `.rite-flow-state` writes use `flow-state-update.sh` which handles atomic write (PID-based temp file + `mv`) internally to prevent race conditions with concurrent hook shell processes (stop-guard, pre-compact).


### PR DESCRIPTION
## 概要

作業メモリコメントの進捗サマリー・変更ファイルセクションが自動更新されないバグを修正。

## 根本原因

`implement.md` のセクション `5.1.1.1.1 Work Memory Progress Summary and Changed Files Update` が `5.1.1.1 Issue Body Checklist Update` の子セクション（`#####` レベル5）として配置されていた。

`5.1.1.1` の実行条件は「Issue body checklist was extracted and retained in Phase 3.6」であるため、チェックリストの無い Issue では `5.1.1.1` 全体がスキップされ、進捗サマリー・変更ファイルの更新ロジックも一緒にスキップされていた。

## 修正内容

- `##### 5.1.1.1.1` → `#### 5.1.1.2` に昇格（見出しレベル5→4）
- 既存の `#### 5.1.1.2 Local Work Memory Update` → `#### 5.1.1.3` にリナンバー
- "After 5.1.1 commit/push completion" セクションの参照番号を更新

これにより、進捗サマリー・変更ファイルの更新はチェックリストの有無にかかわらず常に実行される。

## 変更ファイル

- `plugins/rite/commands/issue/implement.md` - セクション構造の修正

Closes #104
