### PR TITLE
fix(fix.md): Phase 4.5 の trap 統合による一時ファイル削除漏れ修正

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -989,7 +989,7 @@ if [[ -n "$comment_id" ]]; then
     tmpfile=$(mktemp)
     files_tmp=$(mktemp)
     history_tmp=$(mktemp)
-    trap 'rm -f "$body_tmp" "$tmpfile" "$files_tmp" "$history_tmp"' EXIT
+    trap 'rm -f "$pr_body_tmp" "$body_tmp" "$tmpfile" "$files_tmp" "$history_tmp"' EXIT
     printf '%s' "$current_body" > "$body_tmp"
     printf '%s' "$changed_files_md" > "$files_tmp"
     cat > "$history_tmp" << 'HISTORY_EOF'


### PR DESCRIPTION
## 概要

fix.md Phase 4.5.2 の `trap` 設定が Phase 4.5.1 の `trap` を上書きし、`$pr_body_tmp` の一時ファイルが削除されなくなる問題を修正。

## 変更内容

- Phase 4.5.2 の trap に `$pr_body_tmp` を追加し、前段で作成された一時ファイルも確実にクリーンアップされるようにした

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/pr/fix.md` | trap 文に `$pr_body_tmp` を追加 |

## 関連 Issue

Closes #94

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
