### PR TITLE
fix(flow-state-update): patch モードで --active フラグをサポート

### DIFF
--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -136,7 +136,7 @@ case "$MODE" in
       JQ_FILTER="$JQ_FILTER | .active = (\$active_val == \"true\")"
       JQ_ARGS+=(--arg active_val "$ACTIVE")
     fi
-    if jq "${JQ_ARGS[@]}" "$JQ_FILTER" "$FLOW_STATE" > "$TMP_STATE"; then
+    if jq "${JQ_ARGS[@]}" -- "$JQ_FILTER" "$FLOW_STATE" > "$TMP_STATE"; then
       mv "$TMP_STATE" "$FLOW_STATE"
     else
       rm -f "$TMP_STATE"


### PR DESCRIPTION
## 概要

`flow-state-update.sh` の `patch` モードで `--active` フラグが無視されるバグを修正。

- `ACTIVE` のデフォルト値をセンチネル（空文字列）に変更し、明示的な指定と未指定を区別可能に
- `create` モードでは未指定時 `true` にフォールバック（既存動作維持）
- `patch` モードでは `--active` 指定時のみ `active` フィールドを更新

Closes #109

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/flow-state-update.sh` | `ACTIVE` デフォルトをセンチネルに変更、`create`/`patch` モードでの `active` 処理を修正 |

## テスト計画

- [x] AC-1: `patch --phase X --next Y --active true` で `active` が `true` に更新される
- [x] AC-2: `patch --phase X --next Y`（`--active` 未指定）で `active` が変更されない
- [x] AC-3: `create`（`--active` 未指定）で `active` が `true` になる（既存動作維持）

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
