### PR TITLE
fix(projects): 親 Issue の Status 自動更新が実行されない問題を修正

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -273,7 +273,9 @@ Do **NOT** stop after `rite:issue:branch-setup` returns. Projects status update 
 
 > **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update)
 
-Skip if `projects.enabled: false` in rite-config.yml. Otherwise: get item ID, update Status to "In Progress", auto-add if not registered. Handles: config (2.4.1), registration check (2.4.2), auto-add (2.4.3), Status field with field_ids optimization (2.4.4), Status update (2.4.5), parent Status (2.4.7).
+Skip if `projects.enabled: false` in rite-config.yml. Otherwise: get item ID, update Status to "In Progress", auto-add if not registered. Execute sub-phases in order: config (2.4.1), registration check (2.4.2), auto-add (2.4.3), Status field with field_ids optimization (2.4.4), Status update (2.4.5).
+
+**After 2.4.5 completes, always execute 2.4.7** (Parent Issue Status Update). 2.4.7.1 performs parent detection — if no parent is found, it skips silently. Do NOT skip 2.4.7 even if the current Issue was not identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents).
 
 ### 2.5 Iteration Assignment
 

--- a/plugins/rite/references/projects-integration.md
+++ b/plugins/rite/references/projects-integration.md
@@ -112,7 +112,7 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 ### 2.4.7 Parent Issue Status Update (for child Issues)
 
-**Execution condition**: Execute only when the current Issue is a child Issue of another Issue.
+**Execution condition**: Always execute 2.4.7.1 (parent detection). If a parent is found, proceed to 2.4.7.2–2.4.7.4. If no parent is found, skip silently (this is normal for standalone Issues).
 
 **Non-blocking**: All steps in 2.4.7 are non-blocking. Any failure displays a warning and continues the workflow.
 


### PR DESCRIPTION
## 概要

親子 Issue のケースで、子 Issue の作業開始時に親 Issue の Projects Status が自動的に "In Progress" に連動更新されるよう修正。

## 変更内容

- `projects-integration.md` 2.4.7 の実行条件を「子 Issue の場合のみ実行」から「常に 2.4.7.1（親検出）を実行し、親が見つかったら更新」に変更
- `start.md` Phase 2.4 に 2.4.7 の明示的実行指示を追加（Phase 0.3 は「親 Issue かどうか」を検出するもので、「子 Issue かどうか」は検出しない点を明記）

## 根本原因

1. 2.4.7 の実行条件が「子 Issue の場合のみ」だったが、Phase 2.4 時点で子 Issue かどうかを判定する仕組みがなかった
2. `start.md` Phase 2.4 の記述が簡潔すぎて、LLM が 2.4.7 を実行せずスキップしていた

Closes #115

## テスト計画

- [ ] 子 Issue で `/rite:issue:start` を実行し、親 Issue の Status が Todo → In Progress に更新されることを確認
- [ ] 親を持たない単独 Issue で `/rite:issue:start` を実行し、エラーなくスキップされることを確認
- [ ] 親 Issue が既に In Progress の場合、ステータスが変更されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
