### PR TITLE
chore(release): v0.2.2 バージョンバンプ + CHANGELOG 更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rite",
       "source": "./plugins/rite",
       "description": "Universal Issue-driven development workflow for Claude Code",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": { "name": "B16B1RD" },
       "license": "MIT"
     }

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,16 @@ Rite Workflow の主要な変更を記録します。
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に準拠し、
 [Semantic Versioning](https://semver.org/lang/ja/spec/v2.0.0.html) に従います。
 
+## [0.2.2] - 2026-03-12
+
+### 追加
+
+- マーケットプレイス版フックパスのバージョンアップ時自動更新 (#117)
+
+### 修正
+
+- 親 Issue の Projects Status 自動更新が実行されない問題を修正 (#115)
+
 ## [0.2.1] - 2026-03-12
 
 ### 追加
@@ -110,6 +120,7 @@ Rite Workflow の主要な変更を記録します。
 - TDD Light モード
 - git worktree による並列実装サポート
 
+[0.2.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.2...v0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Rite Workflow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-03-12
+
+### Added
+
+- Marketplace hook path auto-update on version upgrade (#117)
+
+### Fixed
+
+- Parent Issue Projects status auto-update not executing (#115)
+
 ## [0.2.1] - 2026-03-12
 
 ### Added
@@ -110,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TDD Light mode
 - Parallel implementation with git worktree support
 
+[0.2.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.2...v0.1.3

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 > Claude Code 用汎用 Issue ドリブン開発ワークフロー
 
-[![Version](https://img.shields.io/badge/version-0.2.1-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.1)
+[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## なぜ "Rite" なのか

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Universal Issue-Driven Development Workflow for Claude Code
 
-[![Version](https://img.shields.io/badge/version-0.2.1-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.1)
+[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Why "Rite"?

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -238,7 +238,7 @@ rite-workflow/
 ```json
 {
   "name": "rite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -238,7 +238,7 @@ Plugin metadata file format:
 ```json
 {
   "name": "rite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/plugins/rite/.claude-plugin/plugin.json
+++ b/plugins/rite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT",


### PR DESCRIPTION
## 概要

v0.2.2 リリースに向けて、バージョン番号を含む全ファイルのバージョンを 0.2.1 → 0.2.2 に更新し、CHANGELOG（日英）に v0.2.2 のリリースノートを追加。

Closes #119

## 変更内容

### バージョン更新（6ファイル）
| ファイル | 変更内容 |
|---------|---------|
| `.claude-plugin/marketplace.json` | version: 0.2.1 → 0.2.2 |
| `plugins/rite/.claude-plugin/plugin.json` | version: 0.2.1 → 0.2.2 |
| `README.md` | バッジバージョン更新 |
| `README.ja.md` | バッジバージョン更新 |
| `docs/SPEC.md` | JSON 例のバージョン更新 |
| `docs/SPEC.ja.md` | JSON 例のバージョン更新 |

### CHANGELOG 更新（2ファイル）
- `CHANGELOG.md`: v0.2.2 リリースノート追加
- `CHANGELOG.ja.md`: v0.2.2 リリースノート追加（日本語版）

### v0.2.2 の変更内容
- **追加**: マーケットプレイス版フックパスのバージョンアップ時自動更新 (#117)
- **修正**: 親 Issue の Projects Status 自動更新が実行されない問題を修正 (#115)

## Known Issues
- lint 未実行（lint コマンドが検出されませんでした）

## チェックリスト
- [x] 全対象ファイルのバージョンが 0.2.2 に更新済み
- [x] CHANGELOG.md に v0.2.2 リリースノート追加済み
- [x] CHANGELOG.ja.md に v0.2.2 リリースノート追加済み
- [x] バージョン番号以外のコードに変更なし
- [x] 日英 CHANGELOG の内容が対応
