### PR TITLE
fix(create): サブスキル返却後の自動継続を強化

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -493,6 +493,35 @@ Interview results are mapped to Implementation Contract sections (Section 1-9) f
 
 ---
 
+## Defense-in-Depth: Flow State Update (Before Return)
+
+> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+
+Before returning control to the caller, update `.rite-flow-state` to the post-interview phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+
+```bash
+if [ -f ".rite-flow-state" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "create_post_interview" \
+    --next "rite:issue:create-interview completed. Proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
+else
+  bash {plugin_root}/hooks/flow-state-update.sh create \
+    --phase "create_post_interview" --issue 0 --branch "" --loop 0 --pr 0 \
+    --next "rite:issue:create-interview completed. Proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
+fi
+```
+
+## Result Pattern Output
+
+Output the appropriate result pattern before returning:
+
+- **Interview completed**: `[interview:completed]`
+- **Interview skipped** (XS, Bug Fix, Chore): `[interview:skipped]`
+
+This pattern is consumed by the orchestrator (`create.md`) to determine the next action.
+
+---
+
 ## 🚨 Caller Return Protocol
 
 When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller (`create.md`) **MUST immediately** execute its 🚨 Mandatory After Interview section:

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -567,6 +567,34 @@ See [GraphQL Helpers](../../references/graphql-helpers.md#error-handling) for de
 
 ---
 
+## Defense-in-Depth: Flow State Update (Before Return)
+
+> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+
+Before returning control to the caller, update `.rite-flow-state` to the post-delegation phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+
+```bash
+if [ -f ".rite-flow-state" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "create_post_delegation" \
+    --next "rite:issue:create-register completed. Issue created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+else
+  bash {plugin_root}/hooks/flow-state-update.sh create \
+    --phase "create_post_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
+    --next "rite:issue:create-register completed. Issue created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+fi
+```
+
+## Result Pattern Output
+
+Output the result pattern after the completion report:
+
+- **Issue created**: `[register:created:{number}]` (where `{number}` is the created Issue number)
+
+This pattern is consumed by the orchestrator (`create.md`) to confirm Issue creation and trigger post-completion cleanup.
+
+---
+
 ## 🚨 Caller Return Protocol
 
 When this sub-skill completes (Phase 3 completion report output), the Issue creation workflow is **complete**. The Issue has been created and registered to GitHub Projects. Control returns to the caller (`create.md`), which handles any remaining cleanup (e.g., `.rite-flow-state` deactivation).

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -52,6 +52,20 @@ create.md (orchestrator)
 
 When this command is executed, follow the phases below in order.
 
+## Sub-skill Return Protocol
+
+> **Reference**: This protocol mirrors `start.md`'s [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
+
+**When a sub-skill outputs a result pattern (e.g., `[interview:completed]`, `[register:created:{N}]`) and returns control to you:**
+
+1. **DO NOT end your response.** You are still in the middle of the create flow. Ending your response here forces the user to type "continue" manually — this is a **bug**.
+2. **DO NOT re-invoke the completed skill.** It already finished.
+3. **IMMEDIATELY** locate the 🚨 Mandatory After section for the current phase and execute its steps — starting with the `.rite-flow-state` update, then proceeding to the next phase.
+
+**Self-check**: After every sub-skill returns, ask yourself: "Has the Issue been created and the completion report output?" If not, you are NOT done — keep going.
+
+**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`) updates `.rite-flow-state` to a `post_*` phase before returning. This ensures the stop-guard blocks any premature stop attempt, even if the orchestrator's 🚨 Mandatory After instructions are not executed immediately.
+
 ## Arguments
 
 | Argument | Description |
@@ -408,11 +422,13 @@ fi
 
 Invoke `skill: "rite:issue:create-interview"`.
 
-**🚨 Immediate after interview returns**: When `rite:issue:create-interview` completes (interview finished or skipped) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Interview below.
+**🚨 Immediate after interview returns**: When `rite:issue:create-interview` outputs a result pattern (`[interview:completed]` or `[interview:skipped]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Interview below. The interview sub-skill has already updated `.rite-flow-state` to `create_post_interview` via its Defense-in-Depth section; execute the 🚨 Mandatory After Interview steps without delay.
 
 ### 🚨 Mandatory After Interview
 
 > See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
+
+**Ignore** any "next steps" or standalone guidance from the interview sub-skill. **Immediately** update `.rite-flow-state` and proceed.
 
 Do **NOT** stop after `rite:issue:create-interview` returns. The interview sub-skill only collects information — **no GitHub Issue has been created yet**. Stopping here would completely abandon the workflow with no deliverable.
 
@@ -561,23 +577,25 @@ Invoke `skill: "rite:issue:create-register"`.
 | Tentative slug | Phase 0.1.3 | Always available |
 | `phases_skipped` flag | Phase 0.1.5 | Set to `"0.3-0.5"` when Phase 0.1.5 triggered early decomposition. Set to `null` otherwise |
 
+**🚨 Immediate after delegation returns**: When the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs a result pattern (`[register:created:{N}]` or decompose completion) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Delegation below. The sub-skill has already updated `.rite-flow-state` to `create_post_delegation` via its Defense-in-Depth section; execute the 🚨 Mandatory After Delegation steps without delay.
+
 ### 🚨 Mandatory After Delegation
 
 > See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
 
-Do **NOT** stop before the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs its completion report. The sub-command handles all remaining phases (creation, registration, completion report). **No GitHub Issue has been created yet** — stopping here would abandon the workflow with no deliverable.
+**Verify**: Result pattern confirmed (e.g., `[register:created:{N}]`). The Issue has been created.
 
-Once the completion report (Issue URL) is output, the workflow is complete — no further action is needed.
+Do **NOT** stop after the sub-skill returns. Post-completion cleanup (flow-state deactivation) is still pending — this is a required step to prevent the stop-guard from blocking future sessions.
 
-**→ Wait for the sub-skill to output its Phase 3 completion report (Issue URL). Do NOT stop before that.**
-
-**Post-completion cleanup**: After the sub-skill outputs the completion report, deactivate flow state:
+**Step 1**: Deactivate flow state:
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "create_completed" --issue 0 --branch "" --loop 0 --pr 0 \
   --next "none" --active false
 ```
+
+**Step 2**: The workflow is now complete. Stop is allowed after cleanup.
 
 ---
 


### PR DESCRIPTION
## 概要

`/rite:issue:create` がサブスキル（`rite:issue:create-interview`, `rite:issue:create-register`）返却後にフローが中断し、ユーザーが「continue」と入力しないと次のフェーズに進まない問題を修正。

Closes #123

## 変更内容

### `create-interview.md`
- Defense-in-Depth セクションを追加: サブスキル返却前に `.rite-flow-state` を `create_post_interview` に更新
- 結果パターン出力を追加: `[interview:completed]` / `[interview:skipped]`

### `create-register.md`
- Defense-in-Depth セクションを追加: サブスキル返却前に `.rite-flow-state` を `create_post_delegation` に更新
- 結果パターン出力を追加: `[register:created:{number}]`

### `create.md`
- Sub-skill Return Protocol セクションを追加（`start.md` の Global Protocol と同等）
- 🚨 Immediate after interview returns を強化: defense-in-depth 参照を追加
- 🚨 Mandatory After Delegation を強化: 結果パターン検証とステップ分離

## テスト計画

- [ ] `/rite:issue:create` を実行し、interview 返却後に自動的に Phase 0.6 に進行することを確認
- [ ] register 返却後に自動的に post-completion cleanup が実行されることを確認
- [ ] `stop-guard.sh` が `create_post_interview` / `create_post_delegation` フェーズで正しくブロックすることを確認
- [ ] `start.md` の既存フローに影響がないことを確認

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
