### PR TITLE
chore: v0.2.3 バージョンバンプ + CHANGELOG 更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rite",
       "source": "./plugins/rite",
       "description": "Universal Issue-driven development workflow for Claude Code",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": { "name": "B16B1RD" },
       "license": "MIT"
     }

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: release
+description: |
+  rite workflow のリリースを実行するスキル。バージョンバンプ（6ファイル）、
+  CHANGELOG 更新（英語・日本語）、develop→main マージ PR、タグ作成、
+  GitHub Release 作成までを一気通貫で行う。
+  「リリース」「release」「バージョンアップ」「version bump」「CHANGELOG」
+  「タグ作成」「GitHub Release」といったキーワードで発動する。
+  リリース作業を行いたいとき、新しいバージョンを公開したいときに使うこと。
+---
+
+# Rite Workflow Release
+
+rite workflow のリリースを4フェーズで実行する。各フェーズでユーザーの確認を挟みながら進める。
+
+---
+
+## Phase 1: リリース情報の確認
+
+### 1.1 現在のバージョン確認
+
+```bash
+current_version=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+echo "Current version: $current_version"
+```
+
+### 1.2 リリースバージョンの決定
+
+ユーザーがバージョンを指定していない場合、以下を確認して提案する：
+
+1. `git log $(git describe --tags --abbrev=0)..develop --oneline` で前回リリースからの変更を確認
+2. 変更内容から semver のバンプ種別を判定:
+   - **major**: 破壊的変更がある場合
+   - **minor**: 新機能追加がある場合
+   - **patch**: バグ修正のみの場合
+3. ユーザーに確認: `v{proposed_version} でリリースしますか？`
+
+### 1.3 リリース内容のプレビュー
+
+develop ブランチと最新タグの差分から、CHANGELOG に含めるべき変更を一覧表示する。
+
+```bash
+latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$latest_tag" ]; then
+  git log "${latest_tag}..develop" --oneline --no-merges
+fi
+```
+
+関連する Issue/PR 番号も `gh` で確認し、CHANGELOG エントリの草案を作成してユーザーに提示する。
+
+---
+
+## Phase 2: リリース準備（バージョンバンプ + CHANGELOG 更新）
+
+### 2.1 リリース準備 Issue の作成
+
+```
+タイトル: v{VERSION} リリース準備（バージョンバンプ + CHANGELOG 更新）
+ラベル: chore
+```
+
+`gh issue create` で Issue を作成し、GitHub Projects に登録する。
+
+### 2.2 ブランチ作成
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b chore/issue-{ISSUE_NUMBER}-v{VERSION_SLUG}-release-prep
+```
+
+`{VERSION_SLUG}` はバージョン番号のドット(`.`)をハイフン(`-`)に置換（例: `0.3.0` → `0-3-0`）。
+
+### 2.3 バージョン番号の更新（6ファイル）
+
+以下の全ファイルでバージョン番号を更新する。過去のリリースで更新漏れが発生した教訓があるため、1つも漏らさないこと。
+
+| # | ファイル | 更新箇所 |
+|---|---------|---------|
+| 1 | `.claude-plugin/marketplace.json` | `"version": "{VERSION}"` |
+| 2 | `plugins/rite/.claude-plugin/plugin.json` | `"version": "{VERSION}"` |
+| 3 | `README.md` | バッジ URL 内のバージョン表記（`version-{VERSION}-blue` と `tag/v{VERSION}` の2箇所） |
+| 4 | `README.ja.md` | 同上 |
+| 5 | `docs/SPEC.md` | JSON 例の `"version": "{VERSION}"` |
+| 6 | `docs/SPEC.ja.md` | JSON 例の `"version": "{VERSION}"` |
+
+**検証**: 更新後に漏れがないか確認する:
+
+```bash
+grep -rn "{OLD_VERSION}" .claude-plugin/ plugins/rite/.claude-plugin/ README.md README.ja.md docs/SPEC.md docs/SPEC.ja.md
+```
+
+出力が空であれば OK。
+
+### 2.4 CHANGELOG 更新（2ファイル）
+
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 形式で、英語版と日本語版を更新する。
+
+#### CHANGELOG.md（英語）
+
+既存の最新セクションの上に新セクションを挿入:
+
+```markdown
+## [{VERSION}] - {YYYY-MM-DD}
+
+### Added
+
+- {feature description} (#{issue_number})
+
+### Fixed
+
+- {fix description} (#{issue_number})
+
+### Changed
+
+- {change description} (#{issue_number})
+```
+
+カテゴリ（Added/Fixed/Changed/Removed）は該当するもののみ。ファイル末尾の比較リンクも追加:
+
+```markdown
+[{VERSION}]: https://github.com/B16B1RD/cc-rite-workflow/compare/v{PREV_VERSION}...v{VERSION}
+```
+
+#### CHANGELOG.ja.md（日本語）
+
+同じ構造で日本語版も更新。カテゴリ名は `追加` / `修正` / `変更` / `削除`。
+
+### 2.5 コミット・PR 作成・マージ
+
+```bash
+git add -A
+git commit -m "chore: v{VERSION} バージョンバンプ + CHANGELOG 更新"
+git push -u origin HEAD
+```
+
+develop に向けて PR を作成:
+
+```bash
+gh pr create \
+  --base develop \
+  --title "chore: v{VERSION} バージョンバンプ + CHANGELOG 更新" \
+  --body "Closes #{PREP_ISSUE_NUMBER}"
+```
+
+ユーザーに PR 確認を促し、承認後にマージ:
+
+```bash
+gh pr merge --merge
+```
+
+---
+
+## Phase 3: リリース実行（develop → main マージ + GitHub Release）
+
+Phase 2 の PR が develop にマージされた後に実行する。
+
+### 3.1 リリース実行 Issue の作成
+
+```
+タイトル: v{VERSION} リリース（develop→main マージ、タグ作成、GitHub Release）
+ラベル: chore
+```
+
+### 3.2 develop → main マージ PR
+
+**必ずタグ作成・GitHub Release 作成の前に行う。** v0.2.2 で main マージを忘れたまま GitHub Release を作成し、後から修正が必要になった教訓がある。順序を間違えると、Release のタグが main の古いコミットを指してしまう。
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+```bash
+gh pr create \
+  --base main \
+  --head develop \
+  --title "release: v{VERSION}" \
+  --body "Merge develop into main for v{VERSION} release. Closes #{RELEASE_ISSUE_NUMBER}"
+```
+
+ユーザー確認後にマージ:
+
+```bash
+gh pr merge --merge
+```
+
+### 3.3 タグ作成 + GitHub Release
+
+main が最新であることを確認してから実行:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+CHANGELOG.md から該当バージョンのセクションを抽出してリリースノートに使用:
+
+```bash
+gh release create "v{VERSION}" \
+  --title "v{VERSION}" \
+  --notes-file <(sed -n '/^## \[{VERSION}\]/,/^## \[/{ /^## \[{VERSION}\]/d; /^## \[/d; p; }' CHANGELOG.md) \
+  --target main
+```
+
+### 3.4 リリース実行 Issue のクローズ
+
+PR マージで自動クローズされなければ手動でクローズ。
+
+### 3.5 develop ブランチに戻る
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+---
+
+## Phase 4: リリース後の確認
+
+### 4.1 検証チェックリスト
+
+| # | 確認項目 | コマンド |
+|---|---------|---------|
+| 1 | GitHub Release が公開されている | `gh release view v{VERSION}` |
+| 2 | main に最新コードが反映されている | `git log main --oneline -1` |
+| 3 | タグが正しいコミットを指している | `git log v{VERSION} --oneline -1` |
+
+### 4.2 結果報告
+
+```
+[release:success] v{VERSION} released successfully
+- GitHub Release: https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v{VERSION}
+- Issues closed: #{PREP_ISSUE_NUMBER}, #{RELEASE_ISSUE_NUMBER}
+```
+
+---
+
+## エラーハンドリング
+
+| 状況 | 対応 |
+|------|------|
+| バージョン番号の更新漏れ | grep で検出し、追加コミットで修正 |
+| CHANGELOG の形式不備 | 既存エントリのパターンに合わせて修正 |
+| main マージ前に Release を作成してしまった | Release を削除 → main マージ → Release 再作成 |
+| PR マージ衝突 | 衝突を解消してから再試行 |
+
+## 中断時の再開
+
+どのフェーズで中断しても、以下で状態を確認して再開できる:
+
+```bash
+# 現在のバージョン
+jq -r '.plugins[0].version' .claude-plugin/marketplace.json
+
+# リリース関連の open Issue
+gh issue list --search "リリース" --state open
+
+# main と develop の差分
+git log main..develop --oneline
+
+# 既存の GitHub Release
+gh release list --limit 5
+```

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,12 @@ Rite Workflow の主要な変更を記録します。
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に準拠し、
 [Semantic Versioning](https://semver.org/lang/ja/spec/v2.0.0.html) に従います。
 
+## [0.2.3] - 2026-03-13
+
+### 修正
+
+- create ワークフローのサブスキル返却後の自動継続を強化 (#125)
+
 ## [0.2.2] - 2026-03-12
 
 ### 追加
@@ -120,6 +126,7 @@ Rite Workflow の主要な変更を記録します。
 - TDD Light モード
 - git worktree による並列実装サポート
 
+[0.2.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Rite Workflow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-03-13
+
+### Fixed
+
+- Reinforced auto-continuation after sub-skill return in create workflow (#125)
+
 ## [0.2.2] - 2026-03-12
 
 ### Added
@@ -120,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TDD Light mode
 - Parallel implementation with git worktree support
 
+[0.2.3]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.1.3...v0.2.0

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 > Claude Code 用汎用 Issue ドリブン開発ワークフロー
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.2)
+[![Version](https://img.shields.io/badge/version-0.2.3-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## なぜ "Rite" なのか

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Universal Issue-Driven Development Workflow for Claude Code
 
-[![Version](https://img.shields.io/badge/version-0.2.2-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.2)
+[![Version](https://img.shields.io/badge/version-0.2.3-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.2.3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Why "Rite"?

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -238,7 +238,7 @@ rite-workflow/
 ```json
 {
   "name": "rite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -238,7 +238,7 @@ Plugin metadata file format:
 ```json
 {
   "name": "rite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"

--- a/plugins/rite/.claude-plugin/plugin.json
+++ b/plugins/rite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT",


### PR DESCRIPTION
## Summary

- 6ファイルのバージョンバンプ (0.2.2 → 0.2.3)
- CHANGELOG.md / CHANGELOG.ja.md に v0.2.3 セクション追加
- リリーススキル (.claude/skills/release/SKILL.md) 追加

Closes #129