### PR TITLE
refactor(issue): Defense-in-Depth パターンの順序明確化と冗長性解消

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -511,9 +511,7 @@ else
 fi
 ```
 
-## Result Pattern Output
-
-Output the appropriate result pattern before returning:
+After the flow-state update above, output the appropriate result pattern:
 
 - **Interview completed**: `[interview:completed]`
 - **Interview skipped** (XS, Bug Fix, Chore): `[interview:skipped]`
@@ -526,8 +524,7 @@ This pattern is consumed by the orchestrator (`create.md`) to determine the next
 
 When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller (`create.md`) **MUST immediately** execute its 🚨 Mandatory After Interview section:
 
-1. Update `.rite-flow-state` to `create_post_interview` phase
-2. Proceed to Phase 0.6 (Task Decomposition Decision)
+1. Proceed to Phase 0.6 (Task Decomposition Decision)
 
 **WARNING**: **No GitHub Issue has been created yet.** No GitHub Issue exists at this point. The interview only collected information — creation happens in `create-register.md` or `create-decompose.md`. Stopping here would completely abandon the workflow with no Issue created.
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -428,23 +428,11 @@ Invoke `skill: "rite:issue:create-interview"`.
 
 > See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
 
-**Ignore** any "next steps" or standalone guidance from the interview sub-skill. **Immediately** update `.rite-flow-state` and proceed.
+**Ignore** any "next steps" or standalone guidance from the interview sub-skill. **Immediately** proceed to the next phase.
 
 Do **NOT** stop after `rite:issue:create-interview` returns. The interview sub-skill only collects information — **no GitHub Issue has been created yet**. Stopping here would completely abandon the workflow with no deliverable.
 
-**Step 1**: Update `.rite-flow-state` to post-interview phase (atomic). This write transitions from `create_interview` to `create_post_interview`, ensuring stop-guard routes to Phase 0.6 rather than re-invoking the interview:
-
-```bash
-if [ -f ".rite-flow-state" ]; then
-  bash {plugin_root}/hooks/flow-state-update.sh patch \
-    --phase "create_post_interview" \
-    --next "Phase 0.6: Task Decomposition Decision. Evaluate decomposition triggers, then delegate to create-register or create-decompose. Issue has NOT been created yet. Do NOT stop."
-else
-  bash {plugin_root}/hooks/flow-state-update.sh create \
-    --phase "create_post_interview" --issue 0 --branch "" --loop 0 --pr 0 \
-    --next "Phase 0.6: Task Decomposition Decision. Evaluate decomposition triggers, then delegate to create-register or create-decompose. Issue has NOT been created yet. Do NOT stop."
-fi
-```
+**Step 1**: The interview sub-skill has already updated `.rite-flow-state` to `create_post_interview` via its Defense-in-Depth section. No additional flow-state write is needed here (eliminating the redundant double write).
 
 **Step 2**: **→ Proceed to Phase 0.6 (Task Decomposition Decision) now. Do NOT stop.**
 


### PR DESCRIPTION
## 概要

`create-interview.md` と `create.md` の Defense-in-Depth パターンにおいて、実行順序の明確化と冗長な flow-state 二重書き込みの解消を行う。

## 変更内容

### `create-interview.md`
- Defense-in-Depth セクション内に「After the flow-state update above, output the appropriate result pattern:」を追加し、flow-state 更新と Result Pattern 出力の実行順序を明示
- 独立していた `## Result Pattern Output` セクションを Defense-in-Depth セクションに統合
- Caller Return Protocol から冗長な手順（flow-state 更新）を削除

### `create.md`
- 🚨 Mandatory After Interview の Step 1 から冗長な flow-state 書き込みコードブロックを除去
- サブスキル側の Defense-in-Depth で既に `create_post_interview` に更新済みであることを明記

## 関連 Issue

Closes #126

## 参考

- `lint.md` Phase 4.0 の「Before outputting any result pattern, update .rite-flow-state」パターンに準拠
- PR #125 のレビュー指摘対応

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## テスト計画

- [ ] `create-interview.md` の Defense-in-Depth → Result Pattern の順序が明示されていることを確認
- [ ] `create.md` の Mandatory After Interview に冗長な flow-state 書き込みがないことを確認
- [ ] 既存の `/rite:issue:create` ワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
