### PR TITLE
fix(issue): create-decompose.md に Defense-in-Depth パターンを適用

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -612,9 +612,37 @@ Phase 0.8 terminates based on the user's selection in the decomposition result c
 
 ---
 
+## Defense-in-Depth: Flow State Update (Before Return)
+
+> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+
+Before returning control to the caller, update `.rite-flow-state` to the post-delegation phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+
+**Condition**: Execute only on the **Normal path** (sub-Issues created via Phase 0.9). On the **Delegation path** (cancelled and delegated to `create-register`), `create-register.md` handles its own Defense-in-Depth — do NOT execute this section.
+
+```bash
+if [ -f ".rite-flow-state" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "create_post_delegation" \
+    --next "rite:issue:create-decompose completed. Sub-Issues created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+else
+  bash {plugin_root}/hooks/flow-state-update.sh create \
+    --phase "create_post_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
+    --next "rite:issue:create-decompose completed. Sub-Issues created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+fi
+```
+
+After the flow-state update above, output the appropriate result pattern:
+
+- **Decomposition completed**: `[decompose:completed:{count}]` (where `{count}` is the number of sub-Issues created)
+
+This pattern is consumed by the orchestrator (`create.md`) to confirm sub-Issue creation and trigger post-completion cleanup.
+
+---
+
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes, the caller (`create.md`) should NOT take any additional action. Completion occurs via one of the following paths:
+When this sub-skill completes, the caller (`create.md`) should NOT take any additional action beyond flow-state deactivation. Completion occurs via one of the following paths:
 
-- **Normal path** (sub-Issues created via Phase 0.9): The completion report has already been output by this sub-skill.
-- **Delegation path** (cancelled and delegated to `create-register`): The completion report will be output by `create-register`. This sub-skill is NOT terminal in this path — `create-register` takes over and completes the workflow.
+- **Normal path** (sub-Issues created via Phase 0.9): The completion report has already been output by this sub-skill. The Defense-in-Depth section above has updated `.rite-flow-state` to `create_post_delegation`.
+- **Delegation path** (cancelled and delegated to `create-register`): The completion report will be output by `create-register`. This sub-skill is NOT terminal in this path — `create-register` takes over and completes the workflow (including its own Defense-in-Depth).

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -565,13 +565,13 @@ Invoke `skill: "rite:issue:create-register"`.
 | Tentative slug | Phase 0.1.3 | Always available |
 | `phases_skipped` flag | Phase 0.1.5 | Set to `"0.3-0.5"` when Phase 0.1.5 triggered early decomposition. Set to `null` otherwise |
 
-**🚨 Immediate after delegation returns**: When the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs a result pattern (`[register:created:{N}]` or decompose completion) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Delegation below. The sub-skill has already updated `.rite-flow-state` to `create_post_delegation` via its Defense-in-Depth section; execute the 🚨 Mandatory After Delegation steps without delay.
+**🚨 Immediate after delegation returns**: When the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs a result pattern (`[register:created:{N}]` or `[decompose:completed:{N}]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Delegation below. The sub-skill has already updated `.rite-flow-state` to `create_post_delegation` via its Defense-in-Depth section; execute the 🚨 Mandatory After Delegation steps without delay.
 
 ### 🚨 Mandatory After Delegation
 
 > See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
 
-**Verify**: Result pattern confirmed (e.g., `[register:created:{N}]`). The Issue has been created.
+**Verify**: Result pattern confirmed (e.g., `[register:created:{N}]` or `[decompose:completed:{N}]`). The Issue(s) have been created.
 
 Do **NOT** stop after the sub-skill returns. Post-completion cleanup (flow-state deactivation) is still pending — this is a required step to prevent the stop-guard from blocking future sessions.
 


### PR DESCRIPTION
## 概要

`create-decompose.md` に Defense-in-Depth セクションと Result Pattern Output を追加し、`create-interview.md` / `create-register.md` と同等の自動継続メカニズムを適用する。

## 変更内容

### `create-decompose.md`
- Defense-in-Depth セクションを追加（`create_post_delegation` フェーズ、Normal path のみ）
- Result Pattern Output (`[decompose:completed:{count}]`) を Defense-in-Depth セクション内に統合（Issue #126 で確立した順序明示パターンに準拠）
- Caller Return Protocol を更新（Defense-in-Depth への言及を追加、両パスの説明を補強）

### `create.md`
- `🚨 Immediate after delegation returns` の曖昧な "decompose completion" を具体的なパターン `[decompose:completed:{N}]` に修正
- `🚨 Mandatory After Delegation` の Verify 行を更新（両パターンを明記）

## 関連 Issue

Closes #127

## 参考

- `create-register.md` の Defense-in-Depth セクション（同一の `create_post_delegation` フェーズ）
- `create-interview.md` の順序明示パターン（Issue #126 で確立）
- PR #125 のレビュー指摘対応

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## テスト計画

- [ ] `create-decompose.md` に Defense-in-Depth セクションが追加されていることを確認
- [ ] Normal path / Delegation path の条件分岐が正しいことを確認
- [ ] `create.md` のパターン文字列が `[decompose:completed:{N}]` に統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
