### PR TITLE
docs(issue): create サブスキルのプロンプト品質改善

### DIFF
--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -589,7 +589,7 @@ fi
 
 Output the result pattern after the completion report:
 
-- **Issue created**: `[register:created:{number}]` (where `{number}` is the created Issue number)
+- **Issue created**: `[register:created:{number}]` (where `{number}` is the `$issue_number` from Phase 2.2 — the actual GitHub Issue number returned by `gh issue create`)
 
 This pattern is consumed by the orchestrator (`create.md`) to confirm Issue creation and trigger post-completion cleanup.
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -54,17 +54,11 @@ When this command is executed, follow the phases below in order.
 
 ## Sub-skill Return Protocol
 
-> **Reference**: This protocol mirrors `start.md`'s [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
-
-**When a sub-skill outputs a result pattern (e.g., `[interview:completed]`, `[register:created:{N}]`) and returns control to you:**
-
-1. **DO NOT end your response.** You are still in the middle of the create flow. Ending your response here forces the user to type "continue" manually — this is a **bug**.
-2. **DO NOT re-invoke the completed skill.** It already finished.
-3. **IMMEDIATELY** locate the 🚨 Mandatory After section for the current phase and execute its steps — starting with the `.rite-flow-state` update, then proceeding to the next phase.
+> **Reference**: See `start.md` [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the full protocol. The same rules apply here — DO NOT end your response after a sub-skill returns, DO NOT re-invoke the completed skill, and IMMEDIATELY proceed to the 🚨 Mandatory After section.
 
 **Self-check**: After every sub-skill returns, ask yourself: "Has the Issue been created and the completion report output?" If not, you are NOT done — keep going.
 
-**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`) updates `.rite-flow-state` to a `post_*` phase before returning. This ensures the stop-guard blocks any premature stop attempt, even if the orchestrator's 🚨 Mandatory After instructions are not executed immediately.
+**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`, `create-decompose.md`) updates `.rite-flow-state` to a `post_*` phase before returning. This ensures the stop-guard blocks any premature stop attempt, even if the orchestrator's 🚨 Mandatory After instructions are not executed immediately.
 
 ## Arguments
 


### PR DESCRIPTION
## 概要

`create-register.md` と `create.md` のプロンプト品質を改善する軽微な修正。

## 変更内容

### `create-register.md`
- Result Pattern `[register:created:{number}]` の `{number}` が `$issue_number`（Phase 2.2 で取得）であることを明示

### `create.md`
- Sub-skill Return Protocol を `start.md` の Global 参照方式に簡素化（冗長な3ステップの繰り返しを参照リンクに置換）
- Defense-in-depth リストに `create-decompose.md` を追加（Issue #127 で追加された Defense-in-Depth を反映）

## 関連 Issue

Closes #128

## 参考

- PR #125 のレビュー指摘対応

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
