### PR TITLE
feat(commit): Contextual Commits 設定追加とリファレンスドキュメント作成 (#145)

### DIFF
--- a/docs/designs/contextual-commits-integration.md
+++ b/docs/designs/contextual-commits-integration.md
@@ -1,0 +1,119 @@
+# Contextual Commits を rite workflow に統合
+
+<!-- Section ID: SPEC-OVERVIEW -->
+## 概要
+
+[Contextual Commits](https://github.com/berserkdisruptors/contextual-commits) の5種のアクションライン（intent/decision/rejected/constraint/learned）をコミット body に構造化埋め込みし、git 履歴自体を意思決定の永続記録にする。加えて `/rite:issue:recall` コマンドで過去の決定事項を検索可能にする。
+
+<!-- Section ID: SPEC-BACKGROUND -->
+## 背景・目的
+
+rite workflow は Conventional Commits でコミットメッセージを生成しているが、body は自由記述で構造化されていない。セッション中の意思決定（作業メモリの `決定事項・メモ`、`計画逸脱ログ`）は Issue 終了後に参照されなくなり、過去の判断理由が失われる。
+
+AIコーディングセッションは3つのアウトプットを生む:
+1. **コード変更** — git に保存される
+2. **意思決定** — セッション終了で消失
+3. **理解・知見** — セッション終了で消失
+
+セッション価値の2/3が失われる問題を、コミットメッセージという既存インフラだけで解決する。
+
+## 要件
+
+<!-- Section ID: SPEC-REQ-FUNC -->
+### 機能要件
+
+1. **コミット body へのアクションライン自動生成**: `implement.md` と `pr/fix.md` のコミット生成時に、作業メモリ・Issue本文・diff から構造化アクションラインを生成
+2. **`/rite:issue:recall` コマンド**: コンテキストコミット履歴から決定事項を検索
+   - 引数なし: 現在ブランチの全アクションライン要約
+   - scope 指定: 全履歴から scope でフィルタ（prefix マッチ）
+   - action(scope) 指定: 全履歴から action+scope でフィルタ
+3. **設定によるオプトアウト**: `commit.contextual: false` で従来の自由記述 body に戻せる
+4. **team-execute 対応**: 並列実行時のコミットにもアクションラインを生成
+
+<!-- Section ID: SPEC-REQ-NFR -->
+### 非機能要件
+
+1. **Conventional Commits 互換性**: subject line は変更なし。commitlint / semantic-release が正常動作すること
+2. **コミットボディの肥大化防止**: アクションライン最大10行
+3. **再現性**: 生成ソースは作業メモリ(SoT) > Issue本文 > diff > 会話コンテキスト(補助)の優先度
+4. **i18n 対応**: アクションタイプは英語固定、description は language 設定に従う
+
+<!-- Section ID: SPEC-TECH-DECISIONS -->
+## 技術的決定事項
+
+| 論点 | 決定 | 理由 |
+|------|------|------|
+| アクションタイプの言語 | 英語固定（description は language 設定に従う） | type/scope と同じ扱い |
+| デフォルト値 | `commit.contextual: true` | 追加コストなし、価値は常にある |
+| 切り捨て優先度 | intent を最優先保持。超過時は learned → constraint → rejected → decision → intent の順で切り捨て | intent は「なぜ」の核であり最も重要 |
+| 生成ソース | 作業メモリ + diff + Issue本文（会話コンテキストは補助） | /clear 後の再現性を確保 |
+| コミット対象コマンド | `implement.md` + `pr/fix.md` | review-fix は判断が濃くアクションラインの価値が高い |
+| recall の位置づけ | 独立コマンド（resume 統合は将来 Phase 2） | まず独立運用で利用パターンを見る |
+
+## アーキテクチャ
+
+<!-- Section ID: SPEC-ARCH-COMPONENTS -->
+### コンポーネント構成
+
+| コンポーネント | 役割 | ファイル |
+|---------------|------|---------|
+| **設定** | `commit.contextual` フラグ管理 | `rite-config.yml`, `templates/config/rite-config.yml` |
+| **リファレンス** | アクションライン仕様・マッピングテーブル定義 | `references/contextual-commits.md` (新規) |
+| **コミット生成（実装）** | implement フローのコミット body 拡張 | `commands/issue/implement.md` |
+| **コミット生成（修正）** | review-fix フローのコミット body 拡張 | `commands/pr/fix.md` |
+| **recall コマンド** | git 履歴からアクションライン検索 | `commands/issue/recall.md` (新規) |
+| **スキルルーティング** | recall のキーワード検出・ルーティング | `skills/rite-workflow/SKILL.md` |
+| **並列実行対応** | team-execute のコミットテンプレート拡張 | `commands/sprint/team-execute.md` |
+| **i18n** | recall コマンド用メッセージ | `i18n/{ja,en}/issue.yml` |
+
+<!-- Section ID: SPEC-ARCH-DATAFLOW -->
+### データフロー
+
+```
+コミット生成時:
+  作業メモリ (決定事項・メモ, 計画逸脱ログ, 要確認事項)
+  + Issue 本文 (仕様詳細, 技術的決定事項)
+  + diff (明確な技術選択)
+  + 会話コンテキスト (補助: 実装中の発見)
+    ↓ マッピングテーブル
+  アクションライン生成 (intent/decision/rejected/constraint/learned)
+    ↓ 10行上限フィルタリング
+  コミット body に埋め込み
+
+recall 検索時:
+  git log → アクションライン抽出 → scope/type 別グループ化 → 表示
+```
+
+## 実装ガイドライン
+
+<!-- Section ID: SPEC-IMPL-FILES -->
+### 変更が必要なファイル/領域
+
+| ファイル | 変更種別 | 変更内容 |
+|---------|---------|---------|
+| `rite-config.yml` | 修正 | `commit.contextual: true` 追加 |
+| `plugins/rite/templates/config/rite-config.yml` | 修正 | `commit.contextual: true` 追加 |
+| `plugins/rite/skills/rite-workflow/references/contextual-commits.md` | 新規 | リファレンスドキュメント |
+| `plugins/rite/commands/issue/implement.md` | 修正 | Phase 5.1.1 コミット body 生成拡張 |
+| `plugins/rite/commands/pr/fix.md` | 修正 | コミット body 生成拡張 |
+| `plugins/rite/commands/issue/recall.md` | 新規 | recall コマンド |
+| `plugins/rite/skills/rite-workflow/SKILL.md` | 修正 | ルーティング追加 |
+| `plugins/rite/commands/sprint/team-execute.md` | 修正 | コミットテンプレート拡張 |
+| `plugins/rite/i18n/ja/issue.yml` | 修正 | メッセージキー追加 |
+| `plugins/rite/i18n/en/issue.yml` | 修正 | メッセージキー追加 |
+
+<!-- Section ID: SPEC-IMPL-CONSIDERATIONS -->
+### 考慮事項
+
+1. **作業メモリの `決定事項・メモ` がフリーフォーマット**: Claude がコミット時に自然言語メモからアクションタイプを推論する必要がある
+2. **recall の git log パース性能**: 大規模リポジトリでは `git log --all` が遅くなる可能性。`--since` や `--max-count` で制限
+3. **既存コミットとの後方互換性**: contextual 設定を有効にする前のコミットにはアクションラインがない。recall は「ない場合は無視」の設計
+4. **ライセンス**: contextual-commits は MIT License。独自リファレンスドキュメントを書くため問題なし。帰属表示 `Based on Contextual Commits (MIT License)` を記載
+
+<!-- Section ID: SPEC-OUT-OF-SCOPE -->
+## スコープ外
+
+1. **`resume.md` へのコンテキストコミット復元統合** — Phase 2 として将来対応。まず recall を独立運用
+2. **lint でのコンテキストコミット形式検証** — Claude が生成するためタイポリスクが低い
+3. **`commit.contextual_types` による選択的タイプフィルタ** — 初期実装では全5タイプ生成
+4. **commitlint プラグイン** — 既存ツールチェーンへの影響がないため不要

--- a/plugins/rite/skills/rite-workflow/references/contextual-commits.md
+++ b/plugins/rite/skills/rite-workflow/references/contextual-commits.md
@@ -1,0 +1,152 @@
+# Contextual Commits Reference
+
+Based on [Contextual Commits](https://github.com/berserkdisruptors/contextual-commits) (MIT License).
+
+Conventional Commits の subject line を維持したまま、コミット body に構造化されたアクションラインを埋め込み、意思決定の永続記録を git 履歴に残す。
+
+## Configuration
+
+`rite-config.yml` の `commit.contextual` で有効/無効を切り替える:
+
+```yaml
+commit:
+  style: conventional
+  contextual: true    # true (default) | false
+```
+
+`false` の場合、既存の自由記述 body フォーマットを維持する。
+
+## Action Line Format
+
+```
+{action-type}({scope}): {description}
+```
+
+- **action-type**: 英語固定（以下5種のいずれか）
+- **scope**: 小文字英数字とハイフン。プロジェクト内で一貫した語彙を使う
+- **description**: `rite-config.yml` の `language` 設定に従う（`ja`: 日本語、`en`: 英語、`auto`: ユーザー入力言語に合わせる）
+
+## Action Types
+
+| Type | Captures | When to Use |
+|------|----------|-------------|
+| `intent(scope)` | ユーザーの意図・目的 | 動機が subject line から明らかでない場合。大半の feature/refactor で使用 |
+| `decision(scope)` | 選択した手法と理由 | 代替案が存在し、選択理由がある場合 |
+| `rejected(scope)` | 却下した代替案と理由 | 代替案を検討して却下した場合。**必ず理由を含める** |
+| `constraint(scope)` | 実装を制約した条件 | 非自明な制限が実装に影響した場合 |
+| `learned(scope)` | 実装中に発見した知見 | API の癖、ドキュメントにない挙動、パフォーマンス特性など |
+
+## Examples
+
+### language: ja
+
+```
+feat(auth): Google OAuth プロバイダーを実装
+
+intent(auth): ソーシャルログイン対応、まず Google から
+decision(oauth): passport.js を選択（マルチプロバイダー対応の柔軟性）
+rejected(oauth): auth0-sdk — セッションモデルが redis store と非互換
+constraint(callback): /api/auth/callback/:provider パターンに従う必要あり
+learned(passport-google): refresh token には明示的な offline_access scope が必要
+```
+
+### language: en
+
+```
+feat(auth): implement Google OAuth provider
+
+intent(auth): social login starting with Google, then GitHub and Apple
+decision(oauth): passport.js over auth0-sdk for multi-provider flexibility
+rejected(oauth): auth0-sdk — locks into their session model, incompatible with redis store
+constraint(callback): must follow /api/auth/callback/:provider pattern
+learned(passport-google): requires explicit offline_access scope for refresh tokens
+```
+
+### Trivial commit (no action lines needed)
+
+```
+fix(typo): correct variable name in auth handler
+```
+
+## Generation Source Priority
+
+アクションラインの生成元と優先度:
+
+| Priority | Source | Reliability | Usage |
+|----------|--------|-------------|-------|
+| 1 | **作業メモリ** (SoT) | 高 | `決定事項・メモ`、`計画逸脱ログ`、`要確認事項` から抽出 |
+| 2 | **Issue 本文** | 高 | 仕様詳細、技術的決定事項、受入条件から intent/constraint を抽出 |
+| 3 | **diff** | 中 | 明確な技術選択が見える場合のみ `decision` を推論 |
+| 4 | **会話コンテキスト** (補助) | 低 | 上記で不足する場合のみ、実装中の発見を `learned` として追加 |
+
+**重要**: 会話コンテキストは `/clear` 後に消失するため、再現性が低い。作業メモリと Issue 本文を主な生成元とする。
+
+## Work Memory → Action Line Mapping
+
+| Work Memory Section | → Action Type | Mapping Rule |
+|---------------------|---------------|--------------|
+| Issue title/description | `intent(scope)` | Issue の目的・動機を反映 |
+| `決定事項・メモ` の判断記録 | `decision(scope)` | 選択した手法と理由 |
+| `決定事項・メモ` の却下記録 | `rejected(scope)` | 検討して却下した代替案（理由必須） |
+| `計画逸脱ログ` の「変更」行 | `decision(scope)` | 計画から変更した理由 |
+| `計画逸脱ログ` の「スキップ」行 | `rejected(scope)` | 不要と判断した理由 |
+| `要確認事項` の解決済み項目 `[x]` | `constraint(scope)` / `learned(scope)` | 確認の結果判明した制約や知見 |
+| diff から明確な技術選択が見える | `decision(scope)` | 新依存追加、ライブラリ切替など |
+
+## Review-Fix Commit Mapping (pr/fix.md)
+
+レビュー修正コミットでは、以下の追加マッピングを使用:
+
+| Source | → Action Type |
+|--------|---------------|
+| レビュー指摘の対応方針 | `decision(scope)` |
+| 対応しなかった指摘とその理由 | `rejected(scope)` |
+| 対応中に発見した制約 | `constraint(scope)` |
+| 対応中の発見事項 | `learned(scope)` |
+
+## Scope Derivation Rules
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | コミットの subject line scope | `feat(auth)` → scope = `auth` |
+| 2 | アクションが関わるサブコンポーネント | `decision(oauth-library)` |
+| 3 | Issue の主要スコープ | Issue title に含まれるドメイン |
+
+scope はプロジェクト内で一貫させる。`auth` を使ったら次のコミットで `authentication` にしない。
+
+## Output Rules
+
+### Minimum Output
+
+- **Trivial な変更**（typo fix、依存バンプ、フォーマット）: アクションライン不要
+- **Non-trivial な変更**: 最低1つの `intent` を含める
+
+### Maximum Output
+
+- **10行上限**（ガードレール）
+- 超過時の切り捨て優先度（先に切り捨てるものから順）:
+  1. `learned` — 知見は有用だが最も補助的
+  2. `constraint` — 制約は diff から推測可能な場合がある
+  3. `rejected` — 却下理由は高価値だが intent/decision より後
+  4. `decision` — 選択は diff から部分的に推測可能
+  5. `intent` — **最優先保持**（「なぜ」の核）
+
+### Signal Quality Rule
+
+- diff が示す情報を繰り返さない
+- エビデンスのない fabrication は禁止（特に `intent`、`rejected`、`constraint`、`learned`）
+- 会話コンテキストがない場合、diff から推論可能な `decision` のみ許可
+
+## Queryability
+
+アクションラインは `git log --grep` で検索可能:
+
+```bash
+# auth に関する全 rejected を検索
+git log --all --grep="rejected(auth" --format="%s%n%b" | grep "^rejected(auth"
+
+# 特定 scope の全アクションラインを検索
+git log --all --grep="(oauth" --format="%s%n%b" | grep -E "^(intent|decision|rejected|constraint|learned)\(oauth"
+```
+
+`/rite:issue:recall` コマンドがこの検索を構造化して提供する。

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -81,6 +81,7 @@ branch:
 commit:
   style: conventional  # conventional | free
   enforce: false
+  contextual: true     # Contextual Commits action lines in commit body (true | false)
 
 # Build/test/lint commands (null = auto-detect)
 commands:

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -58,6 +58,7 @@ branch:
 commit:
   style: conventional
   enforce: true
+  contextual: true    # Contextual Commits action lines in commit body
 
 # Build/test/lint commands
 commands:


### PR DESCRIPTION
## 概要

[Contextual Commits](https://github.com/berserkdisruptors/contextual-commits) の設定オプションを追加し、アクションライン仕様のリファレンスドキュメントを作成する。

Closes #145

## 変更内容

- `rite-config.yml` に `commit.contextual: true` を追加
- `plugins/rite/templates/config/rite-config.yml` に `commit.contextual: true` を追加
- `plugins/rite/skills/rite-workflow/references/contextual-commits.md` を新規作成
  - 5種のアクションタイプ定義と例（日本語/英語）
  - 作業メモリ → アクションラインのマッピングテーブル
  - scope 導出ルール、最小/最大出力ルール
  - 帰属表示: `Based on Contextual Commits (MIT License)`
- `docs/designs/contextual-commits-integration.md` 設計ドキュメント追加

## 親 Issue

#144 - feat: Contextual Commits を rite workflow に統合

## チェックリスト

- [x] `rite-config.yml` に `commit.contextual: true` 追加
- [x] `templates/config/rite-config.yml` に `commit.contextual: true` 追加
- [x] `references/contextual-commits.md` 新規作成
- [x] マッピングテーブルの完成度確認
