### PR TITLE
feat(commit): implement.md のコミット body に Contextual Commits アクションライン生成を追加

### DIFF
--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -495,9 +495,47 @@ Generated based on Issue title and implementation content:
 
 Follow the `language` setting in `rite-config.yml` (`auto`: detect user input language, `ja`: Japanese, `en`: English). For `auto`, determine by presence of Japanese characters (hiragana, katakana, kanji). type/scope are always in English.
 
-**Commit body (recommended):**
+**Commit body:**
 
-Include the reason for the change ("why") in the commit body (lines after the first line). This improves git history readability and traceability.
+> **Reference**: [Contextual Commits Reference](../../skills/rite-workflow/references/contextual-commits.md) for action line specification, mapping tables, output rules, and scope derivation.
+
+Check `commit.contextual` in `rite-config.yml` to determine the commit body format.
+
+**When `commit.contextual: true` (default):**
+
+Generate structured action lines in the commit body following the Contextual Commits format. This embeds decision records directly in git history.
+
+- Leave a blank line between the description line and the action lines
+- Can be omitted for trivial changes (typo fixes, formatting, dependency bumps, etc.)
+
+**Generation procedure:**
+
+1. **Read work memory**: Extract from `決定事項・メモ`, `計画逸脱ログ`, `要確認事項` sections (Priority 1 — highest reliability)
+2. **Extract from Issue body**: Derive `intent` from Issue purpose/motivation, `constraint` from acceptance criteria and technical restrictions (Priority 2)
+3. **Infer from diff**: When the diff shows clear technical choices (new dependencies, library switches, API design), infer `decision` (Priority 3 — use only when evident)
+4. **Apply mapping table**: Map each extracted item to action types using the [Work Memory → Action Line Mapping](../../skills/rite-workflow/references/contextual-commits.md#work-memory--action-line-mapping) table
+5. **Filter to 10-line limit**: If action lines exceed 10, trim in order: `learned` → `constraint` → `rejected` → `decision` → `intent` (intent is preserved last as the core "why")
+
+**Output rules:**
+- Action type names are always in English (`intent`, `decision`, `rejected`, `constraint`, `learned`)
+- Description follows the `language` setting in `rite-config.yml`
+- Do not repeat information already visible in the diff
+- Do not fabricate action lines without evidence from work memory, Issue body, or diff
+- Conversation context is supplementary only (Priority 4 — lowest, lost after `/clear`)
+
+**Example (language: ja):**
+
+```
+feat(commit): implement.md のコミット body に Contextual Commits を追加
+
+intent(commit): コミット履歴に意思決定の永続記録を埋め込み、セッション消失後も判断理由を参照可能にする
+decision(format): Conventional Commits の subject line を維持し body のみ拡張（既存ツールチェーンとの互換性）
+constraint(body): アクションライン最大10行（コミットメッセージの肥大化防止）
+```
+
+**When `commit.contextual: false`:**
+
+Use free-form commit body. Include the reason for the change ("why") in the commit body.
 
 - Leave a blank line between the description line and the body
 - Write in free-form — no specific prefix or template required


### PR DESCRIPTION
## 概要

`implement.md` Phase 5.1.1 のコミット body セクションを拡張し、`commit.contextual` 設定に基づく Contextual Commits アクションライン生成に対応。

## 関連 Issue

Closes #146

## 変更内容

- `plugins/rite/commands/issue/implement.md` の Phase 5.1.1 "Commit body" セクションを置換
  - `commit.contextual: true` 時: 構造化アクションライン生成（5ステップの生成手順、出力ルール、例示）
  - `commit.contextual: false` 時: 既存の自由記述 body を維持
  - リファレンスドキュメント（`contextual-commits.md`）への参照を追加

## チェックリスト

- [x] Phase 5.1.1 の commit body セクションを拡張
- [x] `commit.contextual` 設定の条件分岐を追加
- [x] リファレンスドキュメントへの参照を追加
- [x] 生成手順を明確に記述
- [x] `commit.contextual: false` 時のフォールバック確認
