### PR TITLE
feat(issue): /rite:issue:recall コマンドを新設しコンテキストコミット履歴の検索を可能にする

### DIFF
--- a/plugins/rite/commands/issue/recall.md
+++ b/plugins/rite/commands/issue/recall.md
@@ -1,0 +1,211 @@
+---
+description: コンテキストコミット履歴から過去の決定事項を検索
+---
+
+# /rite:issue:recall
+
+コンテキストコミット履歴からアクションラインを検索・表示する。
+
+---
+
+## Contract
+
+**Input**: 引数なし、`{scope}`、または `{action}({scope})`
+**Output**: アクションラインのグループ化された検索結果
+
+---
+
+## Arguments
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| (なし) | 現在ブランチの全アクションライン要約 | `/rite:issue:recall` |
+| `{scope}` | 全履歴から scope でフィルタ | `/rite:issue:recall auth` |
+| `{action}({scope})` | 全履歴から action+scope でフィルタ | `/rite:issue:recall decision(oauth)` |
+
+---
+
+When this command is executed, run the following phases in order.
+
+## Phase 1: Configuration Check
+
+### 1.1 Read Configuration
+
+Read `rite-config.yml` with the Read tool and check `commit.contextual`:
+
+- `true` or not set -> proceed
+- `false` -> display `{i18n:issue_recall_disabled}` and terminate
+
+### 1.2 Base Branch
+
+Read `branch.base` from `rite-config.yml` (default: `main`). Used in Phase 2.1 for current branch range.
+
+---
+
+## Phase 2: Argument Parsing
+
+Parse the user-provided argument to determine the search mode:
+
+### 2.1 Pattern Detection
+
+```
+入力: (空)
+  → mode = "branch"
+  → git_range = "{base_branch}..HEAD"
+
+入力: "{action}({scope})" にマッチ (例: "decision(oauth)")
+  → mode = "action_scope"
+  → action = マッチした action type
+  → scope = マッチした scope
+  → Validate action ∈ {intent, decision, rejected, constraint, learned}
+  → Invalid action → display "{i18n:issue_recall_invalid_action}" and terminate
+
+入力: その他の文字列 (例: "auth")
+  → mode = "scope"
+  → scope = 入力文字列
+```
+
+---
+
+## Phase 3: Git Log Search
+
+### 3.1 Execute Search
+
+Based on the mode determined in Phase 2:
+
+**mode = "branch" (現在ブランチ)**:
+
+```bash
+git log {base_branch}..HEAD --format="%H%n%s%n%ai%n%b---COMMIT_END---"
+```
+
+**mode = "scope"**:
+
+```bash
+git log --all --grep="({scope}" --format="%H%n%s%n%ai%n%b---COMMIT_END---" --max-count=100
+```
+
+**mode = "action_scope"**:
+
+```bash
+git log --all --grep="{action}({scope}" --format="%H%n%s%n%ai%n%b---COMMIT_END---" --max-count=100
+```
+
+### 3.2 Empty Result Handling
+
+If no commits are found:
+
+```
+{i18n:issue_recall_no_results}
+```
+
+Display guidance based on mode:
+- **branch**: `{i18n:issue_recall_no_results_branch_hint}`
+- **scope/action_scope**: `{i18n:issue_recall_no_results_scope_hint}`
+
+Terminate.
+
+---
+
+## Phase 4: Action Line Extraction
+
+### 4.1 Parse Commits
+
+For each commit in the git log output, extract:
+- `hash`: commit SHA (short, first 7 chars)
+- `subject`: commit subject line
+- `date`: commit date
+- `body`: commit body
+
+### 4.2 Extract Action Lines
+
+From each commit body, extract lines matching the action line pattern:
+
+```
+Pattern: /^(intent|decision|rejected|constraint|learned)\([^)]+\): .+$/gm
+```
+
+For each matched line, parse:
+- `action`: action type (intent/decision/rejected/constraint/learned)
+- `scope`: scope value within parentheses
+- `description`: description after `: `
+
+### 4.3 Filter by Mode
+
+- **mode = "branch"**: Keep all extracted action lines
+- **mode = "scope"**: Keep only lines where scope starts with the specified scope (prefix match)
+- **mode = "action_scope"**: Keep only lines where action and scope match
+
+---
+
+## Phase 5: Result Formatting
+
+### 5.1 Group by Scope
+
+Group the extracted action lines by scope:
+
+```markdown
+## 🔍 コンテキストコミット検索結果
+
+**検索条件**: {search_description}
+**検索範囲**: {range_description}
+**結果**: {total_count} 件のアクションライン（{commit_count} コミット）
+
+### scope: {scope_1}
+
+| Type | Description | Commit | Date |
+|------|-------------|--------|------|
+| `intent` | {description} | {hash} {subject} | {date} |
+| `decision` | {description} | {hash} {subject} | {date} |
+
+### scope: {scope_2}
+
+| Type | Description | Commit | Date |
+|------|-------------|--------|------|
+| `rejected` | {description} | {hash} {subject} | {date} |
+```
+
+### 5.2 Search Description
+
+| Mode | Description |
+|------|-------------|
+| branch | `現在ブランチ ({branch_name}) の全アクションライン` |
+| scope | `全履歴から scope "{scope}" を検索` |
+| action_scope | `全履歴から {action}({scope}) を検索` |
+
+### 5.3 Summary Statistics
+
+After the grouped results, display a summary:
+
+```markdown
+### サマリー
+
+| Action Type | Count |
+|-------------|-------|
+| intent | {count} |
+| decision | {count} |
+| rejected | {count} |
+| constraint | {count} |
+| learned | {count} |
+```
+
+### 5.4 Large Result Handling
+
+If total action lines exceed 50:
+
+```
+{i18n:issue_recall_large_result}
+```
+
+Suggest narrowing with a more specific scope or action type filter.
+
+---
+
+## Error Handling
+
+| Error | Response |
+|-------|----------|
+| Not in a git repository | `{i18n:issue_recall_error_not_git}` |
+| Base branch not found (mode=branch) | `{i18n:issue_recall_error_no_base_branch}` |
+| No commits in range | Phase 3.2 empty result handling |
+| Git command failure | Display error and terminate |

--- a/plugins/rite/i18n/en/issue.yml
+++ b/plugins/rite/i18n/en/issue.yml
@@ -184,3 +184,13 @@ messages:
   issue_list_filter_sprint: "Sprint: {sprint_name}"
   issue_list_filter_backlog: "Backlog"
   issue_list_iteration: "Iteration"
+
+  # Issue Recall command
+  issue_recall_disabled: "Contextual Commits is disabled (commit.contextual: false). Enable it in rite-config.yml"
+  issue_recall_invalid_action: "Invalid action type. Valid values: intent, decision, rejected, constraint, learned"
+  issue_recall_no_results: "No action lines found"
+  issue_recall_no_results_branch_hint: "No contextual commits on current branch. Set commit.contextual: true to include action lines in commits"
+  issue_recall_no_results_scope_hint: "No action lines match the specified scope. Try broadening the scope or use /rite:issue:recall for all results"
+  issue_recall_large_result: "Results exceed 50 entries. Filter with a more specific scope or action type"
+  issue_recall_error_not_git: "Please run inside a Git repository"
+  issue_recall_error_no_base_branch: "Base branch {branch} not found. Check branch.base in rite-config.yml"

--- a/plugins/rite/i18n/ja/issue.yml
+++ b/plugins/rite/i18n/ja/issue.yml
@@ -184,3 +184,13 @@ messages:
   issue_list_filter_sprint: "スプリント: {sprint_name}"
   issue_list_filter_backlog: "バックログ"
   issue_list_iteration: "Iteration"
+
+  # Issue Recall コマンド
+  issue_recall_disabled: "Contextual Commits が無効です（commit.contextual: false）。rite-config.yml で有効にしてください"
+  issue_recall_invalid_action: "無効なアクションタイプです。有効な値: intent, decision, rejected, constraint, learned"
+  issue_recall_no_results: "アクションラインが見つかりませんでした"
+  issue_recall_no_results_branch_hint: "現在のブランチにはコンテキストコミットがありません。コミットにアクションラインを含めるには commit.contextual: true を設定してください"
+  issue_recall_no_results_scope_hint: "指定した scope に一致するアクションラインがありません。scope を広げるか、/rite:issue:recall で全件検索してください"
+  issue_recall_large_result: "結果が 50 件を超えています。より具体的な scope またはアクションタイプでフィルタしてください"
+  issue_recall_error_not_git: "Git リポジトリ内で実行してください"
+  issue_recall_error_no_base_branch: "ベースブランチ {branch} が見つかりません。rite-config.yml の branch.base を確認してください"

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -22,6 +22,7 @@ This skill provides context for rite workflow operations.
 - branch, commit
 - GitHub Projects
 - review, lint
+- recall, 決定事項検索, コンテキスト, なぜ
 
 ## Context
 
@@ -69,6 +70,7 @@ Detect current state from:
 | Long session (30+ minutes elapsed) | `/rite:issue:update` |
 | Sprint with Todo Issues available | `/rite:sprint:execute` to run Issues sequentially |
 | Sprint with multiple independent Issues | `/rite:sprint:team-execute` to run Issues in parallel with worktrees |
+| Want to recall past decisions or context | `/rite:issue:recall` or `/rite:issue:recall {scope}` |
 
 ## Question Management
 


### PR DESCRIPTION
## 概要

`/rite:issue:recall` コマンドを新設し、コンテキストコミット履歴から過去の決定事項を検索可能にする。

Closes #148

## 変更内容

- `plugins/rite/commands/issue/recall.md` — recall コマンド実行手順書を新規作成
  - 3パターンの引数解析（ブランチ全件/scope フィルタ/action+scope フィルタ）
  - Git Log 検索、アクションライン抽出、scope 別グループ化フォーマット
- `plugins/rite/skills/rite-workflow/SKILL.md` — recall 関連キーワードと Suggested Actions 追加
- `plugins/rite/i18n/ja/issue.yml` — recall コマンド用メッセージキー追加
- `plugins/rite/i18n/en/issue.yml` — recall コマンド用メッセージキー（英語）追加

## テスト計画

- [ ] `/rite:issue:recall` を引数なしで実行し、現在ブランチのアクションラインが表示されることを確認
- [ ] `/rite:issue:recall auth` で scope フィルタが動作することを確認
- [ ] `/rite:issue:recall decision(oauth)` で action+scope フィルタが動作することを確認
- [ ] `commit.contextual: false` 設定時に無効メッセージが表示されることを確認

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
