### PR TITLE
fix(start): review → fix ループの分岐指示を命令形条件分岐に書き換え

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -839,8 +839,8 @@ fi
 |----------------|--------|
 | `[review:mergeable]` | **→ Proceed to Phase 5.5** (Ready for Review). Skip fix entirely. |
 | `[review:fix-needed:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4). After it returns, proceed to 🚨 After Fix (5.4.6). |
-| `[review:conditional-merge:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4) for blocking issues only. After it returns, proceed to 🚨 After Fix (5.4.6), then Phase 5.5. |
-| `[review:loop-limit:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4) for blocking issues only (convert remaining to Issues). After it returns, proceed to 🚨 After Fix (5.4.6), then Phase 5.5. |
+| `[review:conditional-merge:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4) for non-blocking issues. After it returns, proceed to 🚨 After Fix (5.4.6), then Phase 5.5. |
+| `[review:loop-limit:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4) for remaining issues (convert to Issues where appropriate). After it returns, proceed to 🚨 After Fix (5.4.6), then Phase 5.5. |
 
 > **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。
 


### PR DESCRIPTION
## 概要

`start.md` Phase 5.4.3 Step 3 と Phase 5.4.6 Step 3 が「→ Execute 5.4.x branch now」という曖昧な間接参照だったため、LLM が正しいスキルを呼び出せず Edit ツールで直接修正してしまう問題を修正。

## 変更内容

- Phase 5.4.3 Step 3: レビュー結果パターン別の具体的アクション表（テーブル形式）に書き換え
- Phase 5.4.6 Step 3: fix 結果＋先行レビュー結果の組み合わせ別アクション表に書き換え
- 両箇所に Edit/Bash ツールでの直接修正を禁止する指示を追加

## 関連 Issue

Closes #163

## チェックリスト

- [x] Phase 5.4.3 Step 3 が具体的な条件分岐（パターン→アクション）を記述している
- [x] Phase 5.4.6 Step 3 が具体的な条件分岐を記述している
- [x] 「Edit ツールで直接修正するな」という禁止指示が含まれている

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
