### PR TITLE
fix(issue): create 完了時の出力順序を改善し次のステップを末尾に移動

### DIFF
--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -515,10 +515,6 @@ Projects 設定:
 - Priority: {priority}
 - Complexity: {complexity}
 - Iteration: {iteration_name または "バックログ"}  <!-- Iteration 有効時のみ表示 -->
-
-次のステップ:
-1. `/rite:issue:start {number}` で作業を開始
-2. 作業完了後 `/rite:pr:create` で PR 作成
 ```
 
 ---

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -577,7 +577,17 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "none" --active false
 ```
 
-**Step 2**: The workflow is now complete. Stop is allowed after cleanup.
+**Step 2**: Output the next steps as the final message. This ensures "次のステップ" appears after all internal processing (flow-state deactivation) is complete:
+
+```
+次のステップ:
+1. `/rite:issue:start {number}` で作業を開始
+2. 作業完了後 `/rite:pr:create` で PR 作成
+```
+
+Where `{number}` is the Issue number extracted from the sub-skill's result pattern (`[register:created:{N}]` or `[decompose:completed:{N}]`).
+
+**Step 3**: The workflow is now complete. Stop is allowed after cleanup.
 
 ---
 


### PR DESCRIPTION
## 概要

`/rite:issue:create` 完了時の出力順序を改善し、「次のステップ」が全処理完了後の最終出力として表示されるように変更。

## 変更内容

### `create-register.md`
- Phase 3 完了報告テンプレートから「次のステップ」セクションを除去

### `create.md`
- Mandatory After Delegation の Step 2 に「次のステップ」を最終出力として追加（flow-state deactivation 後）
- 既存の Step 2 を Step 3 にリナンバリング

## 関連 Issue

Closes #168

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
