### PR TITLE
feat(hooks): session ownership ヘルパーと flow-state 上書き保護 (#175)

### DIFF
--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -36,6 +36,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source session ownership helper for stale detection in create mode
+source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+
 # Resolve repository root
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$(pwd)" 2>/dev/null) || STATE_ROOT="$(pwd)"
 FLOW_STATE="$STATE_ROOT/.rite-flow-state"
@@ -53,6 +56,7 @@ NEXT=""
 ACTIVE=""
 IF_EXISTS=false
 FIELD=""
+SESSION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +69,7 @@ while [[ $# -gt 0 ]]; do
     --active)   ACTIVE="$2"; shift 2 ;;
     --if-exists) IF_EXISTS=true; shift ;;
     --field)    FIELD="$2"; shift 2 ;;
+    --session)  SESSION="$2"; shift 2 ;;
     *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -110,6 +115,27 @@ case "$MODE" in
     if [[ -z "$ACTIVE" ]]; then
       ACTIVE="true"
     fi
+    # Session ownership: overwrite protection for active state owned by another session
+    if [[ -n "$SESSION" && -f "$FLOW_STATE" ]]; then
+      _existing_active=$(jq -r '.active // false' "$FLOW_STATE" 2>/dev/null) || _existing_active="false"
+      if [[ "$_existing_active" == "true" ]]; then
+        _existing_sid=$(get_state_session_id "$FLOW_STATE" 2>/dev/null) || _existing_sid=""
+        if [[ -n "$_existing_sid" && "$_existing_sid" != "$SESSION" ]]; then
+          # Different session owns the state — check staleness
+          _updated_at=$(jq -r '.updated_at // empty' "$FLOW_STATE" 2>/dev/null) || _updated_at=""
+          if [[ -n "$_updated_at" ]]; then
+            _state_epoch=$(parse_iso8601_to_epoch "$_updated_at" 2>/dev/null) || _state_epoch=0
+            _now_epoch=$(date +%s)
+            _diff=$((_now_epoch - _state_epoch))
+            if [[ "$_diff" -le 7200 ]]; then
+              echo "ERROR: 別のワークフローが進行中です（2時間以内に更新）。" >&2
+              echo "INFO: 上書きするには先に /rite:resume で所有権を移転するか、2時間待ってください。" >&2
+              exit 1
+            fi
+          fi
+        fi
+      fi
+    fi
     if jq -n \
       --argjson active "$ACTIVE" \
       --argjson issue "$ISSUE" \
@@ -119,7 +145,8 @@ case "$MODE" in
       --argjson pr "$PR" \
       --arg next "$NEXT" \
       --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
-      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, loop_count: $loop, pr_number: $pr, next_action: $next, updated_at: $ts, last_synced_phase: ""}' \
+      --arg sid "$SESSION" \
+      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, loop_count: $loop, pr_number: $pr, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
       > "$TMP_STATE"; then
       mv "$TMP_STATE" "$FLOW_STATE"
     else

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# rite workflow - Session Ownership Helper Library
+# Common functions for session_id extraction and ownership checks.
+# Sourced by hooks that need to verify flow state ownership.
+#
+# Functions:
+#   extract_session_id <hook_json>  - Extract session_id from hook JSON payload
+#   get_state_session_id <file>     - Get session_id from .rite-flow-state
+#   check_session_ownership <hook_json> <state_file> - Check if state belongs to current session
+#   parse_iso8601_to_epoch <timestamp> - Convert ISO 8601 timestamp to epoch seconds
+#
+# Usage:
+#   source "$SCRIPT_DIR/session-ownership.sh"
+#   ownership=$(check_session_ownership "$INPUT" "$STATE_FILE")
+#   # ownership: "own" | "legacy" | "other" | "stale"
+
+# Extract session_id from hook JSON payload
+# Args: $1 = hook JSON string (from stdin of the hook)
+# Output: session_id string, or empty string if not found
+extract_session_id() {
+  local hook_json="$1"
+  local sid
+  sid=$(echo "$hook_json" | jq -r '.session_id // empty' 2>/dev/null) || sid=""
+  echo "$sid"
+}
+
+# Get session_id from .rite-flow-state file
+# Args: $1 = path to .rite-flow-state
+# Output: session_id string, or empty string if not found/file missing
+get_state_session_id() {
+  local state_file="$1"
+  local sid
+  if [ ! -f "$state_file" ]; then
+    echo ""
+    return 0
+  fi
+  sid=$(jq -r '.session_id // empty' "$state_file" 2>/dev/null) || sid=""
+  echo "$sid"
+}
+
+# Check session ownership of .rite-flow-state
+# Args: $1 = hook JSON string, $2 = path to .rite-flow-state
+# Output: "own" (same session), "legacy" (no session_id in state),
+#         "other" (different session, within stale threshold),
+#         "stale" (different session, beyond stale threshold)
+# Exit code: always 0
+#
+# Decision matrix:
+#   hook session_id empty  → "own" (backward compat: can't determine, assume own)
+#   state session_id empty → "legacy" (pre-session-ownership state, treat as own)
+#   hook == state          → "own"
+#   hook != state:
+#     updated_at > 2h ago  → "stale" (safe to overwrite)
+#     updated_at <= 2h ago → "other" (active session, do not overwrite)
+check_session_ownership() {
+  local hook_json="$1"
+  local state_file="$2"
+
+  local hook_sid
+  hook_sid=$(extract_session_id "$hook_json")
+
+  # If we can't determine our own session_id, assume ownership (backward compat)
+  if [ -z "$hook_sid" ]; then
+    echo "own"
+    return 0
+  fi
+
+  local state_sid
+  state_sid=$(get_state_session_id "$state_file")
+
+  # No session_id in state = legacy state (pre-session-ownership)
+  if [ -z "$state_sid" ]; then
+    echo "legacy"
+    return 0
+  fi
+
+  # Same session
+  if [ "$hook_sid" = "$state_sid" ]; then
+    echo "own"
+    return 0
+  fi
+
+  # Different session — check staleness via updated_at
+  local updated_at
+  updated_at=$(jq -r '.updated_at // empty' "$state_file" 2>/dev/null) || updated_at=""
+
+  if [ -z "$updated_at" ]; then
+    # No timestamp = treat as stale (safe to overwrite)
+    echo "stale"
+    return 0
+  fi
+
+  local state_epoch now_epoch diff_seconds
+  state_epoch=$(parse_iso8601_to_epoch "$updated_at")
+  now_epoch=$(date +%s)
+  diff_seconds=$((now_epoch - state_epoch))
+
+  # Stale threshold: 2 hours (7200 seconds)
+  if [ "$diff_seconds" -gt 7200 ]; then
+    echo "stale"
+  else
+    echo "other"
+  fi
+  return 0
+}
+
+# Parse ISO 8601 timestamp to epoch seconds
+# Moved from stop-guard.sh L83-114 to share across hooks.
+# Args: $1 = ISO 8601 timestamp (e.g., "2026-03-16T05:00:00+00:00")
+# Output: epoch seconds, or 0 on parse failure
+parse_iso8601_to_epoch() {
+  local ts="$1"
+  local epoch
+  # Validate ISO 8601 format before passing to date
+  # Supports both +HH:MM/-HH:MM offsets and Z suffix (UTC)
+  if ! [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then
+    echo 0
+    return 0
+  fi
+  # Normalize Z suffix to +00:00 for consistent parsing
+  ts="${ts/%Z/+00:00}"
+  # Try GNU date -d first (Linux)
+  if epoch=$(date -d "$ts" +%s 2>/dev/null); then
+    echo "$epoch"
+    return 0
+  fi
+  # Try macOS date -j -f (strip colon from timezone offset: +09:00 -> +0900)
+  local ts_nocolon
+  ts_nocolon="${ts%:*}${ts##*:}"
+  if epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$ts_nocolon" +%s 2>/dev/null); then
+    echo "$epoch"
+    return 0
+  fi
+  # Fallback: return 0 (will be treated as stale)
+  echo 0
+}

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -76,42 +77,7 @@ if [ "$ACTIVE" != "true" ]; then
   exit 0
 fi
 
-# Parse ISO 8601 timestamp to epoch seconds (GNU/macOS compatible)
-# NOTE: jq's fromdate only supports Z suffix (UTC), not timezone offsets (+HH:MM).
-# Since .rite-flow-state uses +00:00 offset (set by pre-compact.sh), we must use date(1)
-# to parse the timestamp correctly on both GNU (Linux) and BSD (macOS) systems.
-parse_iso8601_to_epoch() {
-  local ts="$1"
-  local epoch
-  # Validate ISO 8601 format before passing to date
-  # Supports both +HH:MM/-HH:MM offsets and Z suffix (UTC)
-  if ! [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then
-    echo 0
-    return 0
-  fi
-  # Normalize Z suffix to +00:00 for consistent parsing
-  ts="${ts/%Z/+00:00}"
-  # Try GNU date -d first (Linux)
-  if epoch=$(date -d "$ts" +%s 2>/dev/null); then
-    echo "$epoch"
-    return 0
-  fi
-  # Try macOS date -j -f (strip colon from timezone offset: +09:00 -> +0900)
-  local ts_nocolon
-  # Strip colon from timezone offset: +09:00 -> +0900 (bash parameter expansion avoids sed subshell)
-  # e.g. ts="2026-03-04T00:04:17+09:00"
-  #   ${ts%:*}  -> "2026-03-04T00:04:17+09"  (remove shortest suffix matching :*)
-  #   ${ts##*:} -> "00"                       (remove longest prefix matching *:)
-  #   result    -> "2026-03-04T00:04:17+0900"
-  # Requires: ts has already passed the regex validation above (line 102)
-  ts_nocolon="${ts%:*}${ts##*:}"
-  if epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$ts_nocolon" +%s 2>/dev/null); then
-    echo "$epoch"
-    return 0
-  fi
-  # Fallback: return 0 (will be treated as stale)
-  echo 0
-}
+# parse_iso8601_to_epoch is now provided by session-ownership.sh (sourced above)
 
 # Check staleness (over 2 hours = likely abandoned; extended from 1h to accommodate
 # multi-reviewer reviews which can take 60-90 minutes, fixes #719)


### PR DESCRIPTION
## 概要

Session Ownership の基盤となる共通ヘルパーライブラリ `session-ownership.sh` を新規作成し、`flow-state-update.sh` に `--session` パラメータと上書き保護ロジックを追加。

## 変更内容

### 新規: `session-ownership.sh`
- `extract_session_id()`: hook JSON から `session_id` を抽出
- `get_state_session_id()`: `.rite-flow-state` の `session_id` を取得
- `check_session_ownership()`: 所有権チェック（own/legacy/other/stale の4状態判定）
- `parse_iso8601_to_epoch()`: `stop-guard.sh` から移動（GNU/macOS 両対応）

### 変更: `flow-state-update.sh`
- `--session` パラメータ追加（`session_id` を JSON テンプレートに含める）
- create モードで上書き保護（他セッション + 2h 以内 → エラー終了）
- patch/increment モードは変更なし（`session_id` を維持）

### 変更: `stop-guard.sh`
- `parse_iso8601_to_epoch` のインライン定義を削除
- `session-ownership.sh` を `source` で読み込む方式に変更

## 関連 Issue

Closes #175

## テスト計画

- [x] `session-ownership.sh` の関数が正しく定義されることを確認
- [x] `flow-state-update.sh` で `--session` パラメータが正しく処理されることを確認
- [x] `stop-guard.sh` が `source` 経由で `parse_iso8601_to_epoch` を使用できることを確認
- [x] 後方互換性: `--session` 未指定時は空文字列で動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
