### PR TITLE
feat(hooks): wm-sync, pre-compact, context-pressure に session ownership 対応を追加 (#178)

### DIFF
--- a/plugins/rite/hooks/context-pressure.sh
+++ b/plugins/rite/hooks/context-pressure.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
@@ -37,6 +38,11 @@ fi
 
 # Only track during active workflows
 [ "$FLOW_ACTIVE" = "true" ] || exit 0
+
+# Session ownership check (#173): skip counter operations for other session's state
+# to prevent non-atomic read-modify-write counter corruption across concurrent sessions
+_ownership=$(check_session_ownership "$INPUT" "$FLOW_STATE" 2>/dev/null) || _ownership="own"
+[ "$_ownership" != "other" ] || exit 0
 
 COUNTER_FILE="$STATE_ROOT/.rite-context-counter"
 

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 
 # Recursion guard
 [ -z "${RITE_WM_HOOK_ACTIVE:-}" ] || exit 0
@@ -29,6 +30,9 @@ _flow_data=$(jq -r '[(.active // false | tostring), (.issue_number // "" | tostr
 IFS=$'\t' read -r _active issue_number _phase _last_synced_phase <<< "$_flow_data"
 [ "$_active" = "true" ] || exit 0
 [ -n "$issue_number" ] || exit 0
+# Session ownership check (#173): skip sync for other session's state
+_ownership=$(check_session_ownership "$INPUT" "$FLOW_STATE" 2>/dev/null) || _ownership="own"
+[ "$_ownership" != "other" ] || exit 0
 # Defense-in-depth: don't recreate WM for completed workflows (#776)
 [ "$_phase" != "completed" ] || exit 0
 [ "$_phase" != "cleanup" ] || exit 0

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -37,6 +38,15 @@ cleanup() {
 source "$SCRIPT_DIR/work-memory-update.sh"
 
 trap cleanup EXIT TERM INT
+
+# Session ownership check (#173): skip state updates for other session's state.
+# Must run before lock to avoid holding the lock while doing nothing.
+if [ -f "$FLOW_STATE" ]; then
+  _ownership=$(check_session_ownership "$INPUT" "$FLOW_STATE" 2>/dev/null) || _ownership="own"
+  if [ "$_ownership" = "other" ]; then
+    exit 0
+  fi
+fi
 
 # --- All state updates inside lock ---
 if acquire_wm_lock "$LOCKDIR"; then


### PR DESCRIPTION
## 概要

`post-tool-wm-sync.sh`、`pre-compact.sh`、`context-pressure.sh` に session ownership チェックを追加し、複数 Claude Code インスタンスが同一リポジトリで並行作業する際の state 相互干渉を防止する。

## 変更内容

### post-tool-wm-sync.sh
- `session-ownership.sh` を source して共通ヘルパーを利用
- `active == true` チェック後に `check_session_ownership()` で所有権を確認
- 他セッションの state → 作業メモリ同期をスキップ (exit 0)

### pre-compact.sh
- `session-ownership.sh` を source して共通ヘルパーを利用
- lock 取得前に `check_session_ownership()` で所有権を確認
- 他セッションの state → timestamp 更新と work memory 保存をスキップ (exit 0)

### context-pressure.sh
- `session-ownership.sh` を source して共通ヘルパーを利用
- `FLOW_ACTIVE == true` チェック後に所有権チェック追加
- 他セッションの state → カウンタ操作をスキップ（非アトミック read-modify-write の競合防止）

## 関連 Issue

Closes #178

親 Issue: #173 - Session Ownership: .rite-flow-state 複数インスタンス競合対策

## チェックリスト

- [x] 実装完了
- [x] session-ownership.sh の共通関数を使用（#175 で作成済み）
- [x] session-end.sh / stop-guard.sh の参考実装パターンに準拠（#177）
- [x] 後方互換性を維持（session_id 不明時は "own" 扱い）
