### PR TITLE
feat(commands): 全コマンドファイルに --session {session_id} を追加 + resume.md 所有権移転 (#179)

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -628,6 +628,7 @@ if [ -f ".rite-flow-state" ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_post_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "rite:issue:create-decompose completed. Sub-Issues created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
 fi
 ```

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -507,6 +507,7 @@ if [ -f ".rite-flow-state" ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_post_interview" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "rite:issue:create-interview completed. Proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
 fi
 ```

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -577,6 +577,7 @@ if [ -f ".rite-flow-state" ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_post_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "rite:issue:create-register completed. Issue created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
 fi
 ```

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -410,6 +410,7 @@ if [ -f ".rite-flow-state" ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_interview" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "After rite:issue:create-interview returns: proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
 fi
 ```
@@ -536,6 +537,7 @@ if [ -f ".rite-flow-state" ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "create_delegation" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "Wait for sub-skill (create-register or create-decompose) to output completion report (Issue URL). Issue has NOT been created yet. Do NOT stop."
 fi
 ```
@@ -574,6 +576,7 @@ Do **NOT** stop after the sub-skill returns. Post-completion cleanup (flow-state
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "create_completed" --issue 0 --branch "" --loop 0 --pr 0 \
+  --session {session_id} \
   --next "none" --active false
 ```
 

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -778,6 +778,7 @@ Check the state of remaining child Issues with `trackedIssues` and calculate `re
    bash {plugin_root}/hooks/flow-state-update.sh create \
      --phase "phase5_lint" --issue {issue_number} --branch "{branch_name}" \
      --loop 0 --pr 0 \
+     --session {session_id} \
      --next "After rite:lint returns: [lint:success/skipped]->Phase 5.2.1 (checklist). [lint:error]->fix and re-invoke. [lint:aborted]->Phase 5.6. Do NOT stop."
    ```
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -184,6 +184,7 @@ Execute after Phase 1.1-1.3.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase1_5_parent" --issue {issue_number} --branch "" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:issue:parent-routing returns: proceed to Phase 1.6 (child issue selection) if applicable, then Phase 2. Do NOT stop."
 ```
 
@@ -206,6 +207,7 @@ Do **NOT** stop after `rite:issue:parent-routing` returns. The parent routing su
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase1_6_child" --issue {issue_number} --branch "" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:issue:child-issue-selection returns: proceed to Phase 2 (work preparation). Do NOT stop."
 ```
 
@@ -267,6 +269,7 @@ Skip Phase 2.4/2.5/2.6 (no Issue number). User manually links. Phase 3+ normal.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase2_branch" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:issue:branch-setup returns: proceed to Phase 2.4 (Projects Status update to In Progress). Do NOT stop."
 ```
 
@@ -302,6 +305,7 @@ Execute only if `iteration.enabled: true` and `iteration.auto_assign: true` in r
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase2_work_memory" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:issue:work-memory-init returns: proceed to Phase 3 (implementation plan). Do NOT stop."
 ```
 
@@ -337,6 +341,7 @@ Do **NOT** stop after `rite:issue:work-memory-init` returns. Proceed to the next
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase3_plan" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:issue:implementation-plan returns: proceed to Phase 4 (work start guidance). Do NOT stop."
 ```
 
@@ -536,6 +541,7 @@ Run [Preflight Protocol](#preflight-protocol) before invoking lint.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_lint" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:lint returns: [lint:success/skipped]->Phase 5.2.1 (checklist). [lint:error]->fix and re-invoke. [lint:aborted]->Phase 5.6. Do NOT stop."
 ```
 
@@ -615,6 +621,7 @@ printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do ec
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_lint" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "Phase 5.2.1: Check Issue checklist completion. All complete->Phase 5.3 PR creation (invoke rite:pr:create). Incomplete->return to Phase 5.1 implementation. Do NOT stop."
 ```
 
@@ -731,6 +738,7 @@ After 5.2.1, update `.rite-flow-state` (atomic, see 5.1 step 3):
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
   --loop 0 --pr 0 \
+  --session {session_id} \
   --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->Phase 5.6. Do NOT stop."
 ```
 
@@ -814,6 +822,7 @@ When context pressure is detected (tool call count > `context_optimization.agent
    bash plugins/rite/hooks/flow-state-update.sh create \
      --phase "{phase_value}" --issue {issue_number} --branch "{branch_name}" \
      --loop 0 --pr {pr_number} \
+     --session {session_id} \
      --next "{next_action_value}"
    ```
 
@@ -832,6 +841,7 @@ Update `.rite-flow-state` (atomic, see 5.1 step 3):
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_review" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "After rite:pr:review returns: [review:mergeable]->Phase 5.5. [review:fix-needed:{N}]->Phase 5.4.4. [review:conditional-merge/loop-limit]->Phase 5.4.4 then 5.5. Do NOT stop."
 ```
 
@@ -859,6 +869,7 @@ Invoke `skill: "rite:pr:review"`. Increment `loop_count`.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_review" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "rite:pr:review completed. Check recent result pattern in context: [review:mergeable]->Phase 5.5 (ready). [review:fix-needed:{N}]->Phase 5.4.4 (fix). [review:conditional-merge/loop-limit]->Phase 5.4.4 then 5.5. Do NOT stop."
 ```
 
@@ -949,6 +960,7 @@ Update `.rite-flow-state` (atomic):
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_fix" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "After rite:pr:fix returns: [fix:pushed]+fix-needed->Phase 5.4.1. [fix:pushed]+conditional/loop-limit->Phase 5.5. [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. [fix:error]->ask user. Do NOT stop."
 ```
 
@@ -974,6 +986,7 @@ Invoke `skill: "rite:pr:fix"`.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_fix" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]+fix-needed->Phase 5.4.1 (re-review). [fix:pushed]+conditional/loop-limit->Phase 5.5 (ready). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. Do NOT stop."
 ```
 
@@ -1088,6 +1101,7 @@ When loop completes, confirm:
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_ready" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "Phase 5.5.1: Update Issue Status to In Review, then Phase 5.5.2 metrics, then Phase 5.6 completion report. Do NOT stop."
 ```
 
@@ -1317,6 +1331,7 @@ Present options via `AskUserQuestion`:
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "completed" --issue {issue_number} --branch "{branch_name}" \
   --loop {loop_count} --pr {pr_number} \
+  --session {session_id} \
   --next "none" --active false
 ```
 

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -35,6 +35,7 @@ if [ -f .rite-flow-state ]; then
 else
   bash {plugin_root}/hooks/flow-state-update.sh create \
     --phase "cleanup" --issue 0 --branch "" --loop 0 --pr 0 \
+    --session {session_id} \
     --next "Execute cleanup phases. Do NOT stop."
 fi
 ```

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -321,8 +321,8 @@ Ensure `.rite-flow-state` has `active: true` so that the stop-guard hook blocks 
 STATE_FILE=".rite-flow-state"
 if [ -f "$STATE_FILE" ]; then
   TMP_STATE="${STATE_FILE}.tmp.$$"
-  jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    '.active = true | .updated_at = $ts | .error_count = 0' \
+  jq --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg sid "{session_id}" \
+    '.active = true | .updated_at = $ts | .error_count = 0 | .session_id = $sid' \
     "$STATE_FILE" > "$TMP_STATE" && mv "$TMP_STATE" "$STATE_FILE" || rm -f "$TMP_STATE"
 fi
 ```


### PR DESCRIPTION
## 概要

全コマンドファイルの `flow-state-update.sh create` 呼び出しに `--session {session_id}` パラメータを追加し、`resume.md` に所有権移転ロジックを実装する。これにより、session ownership 機能の最終ステップとして、コマンド実行時に `.rite-flow-state` にセッション ID が記録され、複数インスタンス間の state 競合を防止する。

## 変更内容

### コマンドファイル (7ファイル, 23箇所)
- `start.md`: 15箇所の `flow-state-update.sh create` に `--session {session_id}` 追加
- `create.md`: 3箇所に追加
- `create-register.md`, `create-decompose.md`, `create-interview.md`, `implement.md`, `cleanup.md`: 各1箇所に追加

### resume.md: 所有権移転
- jq 操作に `--arg sid "{session_id}"` を追加
- 再開時に新セッションの `session_id` で `.rite-flow-state` の所有権を移転

## 関連 Issue

Closes #179

親 Issue: #173 - Session Ownership: .rite-flow-state 複数インスタンス競合対策

## チェックリスト

- [x] 全 `flow-state-update.sh create` 呼び出しに `--session` 追加
- [x] `resume.md` の所有権移転ロジック実装
- [x] `patch`/`increment` モードは変更なし（設計通り）
