### PR TITLE
docs(references): gh-cli-commands.md に git branch --list の DO NOT 警告を追加

### DIFF
--- a/plugins/rite/references/gh-cli-commands.md
+++ b/plugins/rite/references/gh-cli-commands.md
@@ -252,12 +252,27 @@ gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
 
 ### Check Branch
 
+> **DO NOT** use exit code (`&&`, `||`, `$?`) to determine branch existence. `git branch --list` always returns exit code 0 regardless of whether a match is found. Check the **output** instead (non-empty = exists).
+
 ```bash
 # Current branch
 git branch --show-current
 
-# Check remote branch
-git branch -r --list "origin/{branch_name}"
+# Check local branch existence (check OUTPUT, not exit code)
+local_match=$(git branch --list "{branch_name}")
+if [ -n "$local_match" ]; then
+  echo "BRANCH_EXISTS"
+else
+  echo "BRANCH_NOT_FOUND"
+fi
+
+# Check remote branch existence (check OUTPUT, not exit code)
+remote_match=$(git branch -r --list "origin/{branch_name}")
+if [ -n "$remote_match" ]; then
+  echo "REMOTE_EXISTS"
+else
+  echo "REMOTE_NOT_FOUND"
+fi
 ```
 
 ### Push


### PR DESCRIPTION
## 概要

`plugins/rite/references/gh-cli-commands.md` の "Check Branch" セクションに `git branch --list` の exit code 使用禁止の DO NOT 警告と、出力チェックによる正しいブランチ存在確認パターンを追加。

Closes #181

## 変更内容

- `gh-cli-commands.md` の "Check Branch" セクションに DO NOT 警告（blockquote 形式）を追加
- ローカルブランチとリモートブランチの存在確認に出力チェック（`[ -n "$local_match" ]`）を使用する正しいパターンを追加
- `start.md` および `branch-setup.md` の既存警告と一貫したフォーマットを使用

## 背景

PR #180 のレビューで、リファレンスファイルに `git branch --list` の exit code 使用禁止警告が未反映であることが指摘された。`git branch --list` は一致の有無にかかわらず常に exit code 0 を返すため、exit code で判定すると誤動作する。

## テスト計画

- [ ] `gh-cli-commands.md` の Check Branch セクションに DO NOT 警告が正しく追加されていることを確認
- [ ] コード例が `start.md` および `branch-setup.md` の既存パターンと一貫していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
