### PR TITLE
fix(flow-state): deactivation で patch 方式を使用し session ownership エラーを解消

### DIFF
--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -574,9 +574,8 @@ Do **NOT** stop after the sub-skill returns. Post-completion cleanup (flow-state
 **Step 1**: Deactivate flow state:
 
 ```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "create_completed" --issue 0 --branch "" --loop 0 --pr 0 \
-  --session {session_id} \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "create_completed" \
   --next "none" --active false
 ```
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1328,10 +1328,8 @@ Present options via `AskUserQuestion`:
 **Post-completion**: Update `.rite-flow-state` `active: false` (atomic):
 
 ```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "completed" --issue {issue_number} --branch "{branch_name}" \
-  --loop {loop_count} --pr {pr_number} \
-  --session {session_id} \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "completed" \
   --next "none" --active false
 ```
 


### PR DESCRIPTION
## 概要

`create.md` と `start.md` の deactivation ステップ（`--active false`）で `flow-state-update.sh create` を使用していたため、Bash ツール呼び出しごとに PID が変わり session ownership エラーが発生していた。`patch` 方式に変更し、既存の session_id を保持したまま active フラグを更新する。

## 関連 Issue

Closes #195

## 変更内容

- `commands/issue/create.md` L576-580: deactivation を `create --session {session_id}` から `patch --active false` に変更
- `commands/issue/start.md` L1330-1336: 同上

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
