### PR TITLE
refactor(hooks): hooks/hooks.json ネイティブ方式を追加し二重実行ガードを設置

### DIFF
--- a/plugins/rite/hooks/context-pressure.sh
+++ b/plugins/rite/hooks/context-pressure.sh
@@ -10,6 +10,10 @@
 # - RED: Critical warning + flow split recommendation
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_CTXPRESSURE:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_CTXPRESSURE=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/hooks.json
+++ b/plugins/rite/hooks/hooks.json
@@ -1,0 +1,88 @@
+{
+  "description": "rite workflow hooks - Issue-driven development lifecycle management",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/stop-guard.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-compact.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-bash-guard.sh"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-wm-sync.sh",
+            "timeout": 30
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/context-pressure.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -4,6 +4,10 @@
 # stdout is injected into the model's context, enabling automatic workflow continuation.
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_POSTCOMPACT:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_POSTCOMPACT=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -5,6 +5,10 @@
 # Fires after every Bash tool use; quick-exits in most cases.
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_POSTTOOL:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_POSTTOOL=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -4,6 +4,10 @@
 # compact itself cannot be prevented; this hook records state for safe resumption.
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_PRECOMPACT:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_PRECOMPACT=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -13,6 +13,10 @@
 #   stdout JSON with permissionDecision: "deny" — block
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_PRETOOL:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_PRETOOL=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -3,6 +3,10 @@
 # Saves final state when session ends
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_SESSIONEND:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_SESSIONEND=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -3,6 +3,10 @@
 # Re-injects flow state after compact or resume
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_SESSIONSTART:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_SESSIONSTART=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -n "${RITE_DEBUG:-}" ]; then

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -3,6 +3,10 @@
 # Prevents Claude from stopping during an active rite workflow
 set -euo pipefail
 
+# Double-execution guard (hooks.json + settings.local.json migration)
+[ -z "${_RITE_HOOK_RUNNING_STOP:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_STOP=1
+
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true


### PR DESCRIPTION
## 概要

Hook パス管理を settings.local.json の絶対パス方式から Claude Code ネイティブの hooks/hooks.json + ${CLAUDE_PLUGIN_ROOT} 方式へ移行。マーケットプレイス更新時のデッドロック問題を根本解決する。

本 PR は PR1（hooks.json 追加 + 二重実行ガード）。PR2（hook-preamble.sh 廃止 + init.md 改修 + session-start.sh 簡素化）は後続で対応。

## 関連 Issue

Refs #194

## 変更内容

- `plugins/rite/hooks/hooks.json` を新規作成（8 hook エントリをネイティブ形式で定義）
- 全 8 hook スクリプトに二重実行ガードを追加（`_RITE_HOOK_RUNNING_*` 環境変数）
- gh api を使用する hook に `timeout: 30` を設定

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
- init.md Phase 4.5 の改修は PR2 で対応予定

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
