### PR TITLE
fix(e2e): レビュアー確認・Ready 確認の AskUserQuestion をスキップ不可に

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1072,7 +1072,9 @@ fi
 
 ### 5.5 Ready for Review
 
-When loop completes, confirm:
+> **⚠️ MANDATORY**: The following `AskUserQuestion` confirmation MUST be executed. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review.
+
+When loop completes, confirm via `AskUserQuestion`:
 
 ```
 レビューが完了しました（一気通貫フロー）

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -156,6 +156,8 @@ End processing.
 
 ### 2.1 Confirm with User
 
+> **⚠️ MANDATORY**: This `AskUserQuestion` confirmation MUST be executed even within the `/rite:issue:start` end-to-end flow. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review.
+
 Confirm using `AskUserQuestion`:
 
 ```

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -505,6 +505,8 @@ When the reviewer count reaches 4 or more, recommend splitting the review execut
 
 ### 3.3 Confirm Reviewers
 
+> **⚠️ MANDATORY**: This `AskUserQuestion` confirmation MUST be executed even within the `/rite:issue:start` end-to-end flow. Do NOT skip this step for context optimization or any other reason. The user must always confirm the reviewer configuration before review execution begins.
+
 Confirm the reviewer configuration with `AskUserQuestion` (fallback: see Phase 1.4 note):
 
 ```


### PR DESCRIPTION
## 概要

e2e フロー内でレビュアー確認（review.md Phase 3.3）と Ready for review 確認（ready.md Phase 2.1、start.md Phase 5.5）の AskUserQuestion がスキップされる問題を修正。各箇所に MANDATORY 注記を追加し、context 最適化等の理由でスキップしてはならないことを明示。

## 関連 Issue

Closes #198

## 変更内容

- `review.md` Phase 3.3: レビュアー確認 AskUserQuestion に MANDATORY 注記追加
- `ready.md` Phase 2.1: Ready 確認 AskUserQuestion に MANDATORY 注記追加
- `start.md` Phase 5.5: Ready 確認に MANDATORY 注記追加 + テンプレート文言を「confirm via AskUserQuestion」に明確化

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
