### PR TITLE
fix(hooks): startup/clear 時に他セッションの active 状態をリセットしない問題を修正

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -232,6 +232,7 @@ fi
 # Shared by startup and clear blocks. Resets active=false and shows a soft message.
 # Always proceeds with reset regardless of session ownership (#206).
 # Note: This function always terminates via exit 0 — it never returns to the caller.
+# When issue_number is empty (e.g., state file has no issue), exits silently without message.
 _reset_active_state() {
   local _phase _issue _branch
   _phase=$(jq -r '.phase // ""' "$STATE_FILE" 2>/dev/null) || _phase=""


### PR DESCRIPTION
## 概要

`session-start.sh` の startup/clear ブロックで `_ownership = "other"` 時の early exit を削除し、常に `active=false` にリセットするように修正。

## 背景

`session-end.sh` が発火しないまま Claude Code セッションが終了すると、`.rite-flow-state` が `active: true` + 旧 `session_id` のまま残る。新セッション起動時に `session-start.sh` が「他セッションの状態だから触らない」と判断して silent exit してしまい、`flow-state-update.sh create` の 2h ロックに引っかかってワークフローを開始できない。

## 変更内容

- startup ブロック（L244-248）: `_cleanup_stale_compact; exit 0` を削除し、RITE_DEBUG 条件付きログに置換
- clear ブロック（L280-284）: 同様の変更

## 変更しないもの

- `flow-state-update.sh` の create モード 2h ガード（セカンダリ保護として維持）
- `session-end.sh` の "other" ガード（他セッションの状態を deactivate すべきでない）
- `session-ownership.sh` の判定ロジック

## 関連 Issue

Closes #206

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）

## テスト方法

1. `.rite-flow-state` を `active: true`, `session_id: "old_session"`, `updated_at` を現在時刻に設定
2. 新しい Claude Code セッションを起動
3. `session-start.sh` が状態を `active: false` にリセットすることを確認
4. `/rite:issue:start` がロックエラーなしで実行できることを確認
