### PR TITLE
fix(commands): Issue コメントの作業メモリバックアップ同期を修正

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -943,57 +943,15 @@ WM_SOURCE="review" \
 
 **Step 2.5**: Sync local work memory to Issue comment (backup):
 
-> **Reference**: Apply [Work Memory Update Safety Patterns](../../references/gh-cli-patterns.md#work-memory-update-safety-patterns).
+> **Reference**: Uses `issue-comment-wm-sync.sh` which handles owner/repo resolution internally, backup creation, safety checks, and PATCH atomically (#204).
 
 ```bash
-# ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること
 # ⚠️ このパターンは 5.4.6 (After Fix) と同一構造。変更時は両方を更新すること
-comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
-comment_id=$(echo "$comment_data" | jq -r '.id // empty')
-current_body=$(echo "$comment_data" | jq -r '.body // empty')
-
-if [ -z "$comment_id" ]; then
-  echo "WARNING: Work memory comment not found. Skipping backup sync." >&2
-else
-  backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
-  printf '%s' "$current_body" > "$backup_file"
-  original_length=$(printf '%s' "$current_body" | wc -c)
-
-  # Update session info fields only (Python-based; sed/awk 使用禁止)
-  tmpfile=$(mktemp)
-  body_tmp=$(mktemp)
-  trap 'rm -f "$tmpfile" "$body_tmp"' EXIT
-  printf '%s' "$current_body" > "$body_tmp"
-  python3 -c '
-import sys, re
-body_path, out_path = sys.argv[1], sys.argv[2]
-phase, phase_detail, timestamp = sys.argv[3], sys.argv[4], sys.argv[5]
-with open(body_path, "r") as f:
-    body = f.read()
-body = re.sub(r"^(- \*\*最終更新\*\*: ).*", rf"\g<1>{timestamp}", body, count=1, flags=re.MULTILINE)
-body = re.sub(r"^(- \*\*フェーズ\*\*: ).*", rf"\g<1>{phase}", body, count=1, flags=re.MULTILINE)
-body = re.sub(r"^(- \*\*フェーズ詳細\*\*: ).*", rf"\g<1>{phase_detail}", body, count=1, flags=re.MULTILINE)
-with open(out_path, "w") as f:
-    f.write(body)
-' "$body_tmp" "$tmpfile" "phase5_post_review" "レビュー完了" "$(date -u +'%Y-%m-%dT%H:%M:%S+00:00')"
-
-  # Safety checks before PATCH (includes 50% body length comparison; see gh-cli-patterns.md)
-  if [ ! -s "$tmpfile" ] || [[ "$(wc -c < "$tmpfile")" -lt 10 ]]; then
-    echo "WARNING: Updated body is empty. Skipping backup sync. Backup: $backup_file" >&2
-  elif grep -q '📜 rite 作業メモリ' "$tmpfile"; then
-    updated_length=$(wc -c < "$tmpfile")
-    if [[ "${updated_length:-0}" -lt $(( ${original_length:-1} / 2 )) ]]; then
-      echo "WARNING: Updated body < 50% of original. Skipping. Backup: $backup_file" >&2
-    else
-      jq -n --rawfile body "$tmpfile" '{"body": $body}' | \
-        gh api repos/{owner}/{repo}/issues/comments/"$comment_id" -X PATCH --input - > /dev/null 2>&1 || \
-        echo "WARNING: Issue comment backup sync failed (non-blocking)." >&2
-    fi
-  else
-    echo "WARNING: Updated body missing header. Skipping. Backup: $backup_file" >&2
-  fi
-fi
+bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform update-phase \
+  --phase "phase5_post_review" --phase-detail "レビュー完了" \
+  2>/dev/null || true
 ```
 
 **Step 3**: Based on the review result pattern from `rite:pr:review`, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly — always invoke the appropriate Skill tool.
@@ -1057,57 +1015,15 @@ WM_SOURCE="fix" \
 
 **Step 2.5**: Sync local work memory to Issue comment (backup):
 
-> **Reference**: Apply [Work Memory Update Safety Patterns](../../references/gh-cli-patterns.md#work-memory-update-safety-patterns).
+> **Reference**: Uses `issue-comment-wm-sync.sh` which handles owner/repo resolution internally, backup creation, safety checks, and PATCH atomically (#204).
 
 ```bash
-# ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること
 # ⚠️ このパターンは 5.4.3 (After Review) と同一構造。変更時は両方を更新すること
-comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
-comment_id=$(echo "$comment_data" | jq -r '.id // empty')
-current_body=$(echo "$comment_data" | jq -r '.body // empty')
-
-if [ -z "$comment_id" ]; then
-  echo "WARNING: Work memory comment not found. Skipping backup sync." >&2
-else
-  backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
-  printf '%s' "$current_body" > "$backup_file"
-  original_length=$(printf '%s' "$current_body" | wc -c)
-
-  # Update session info fields only (Python-based; sed/awk 使用禁止)
-  tmpfile=$(mktemp)
-  body_tmp=$(mktemp)
-  trap 'rm -f "$tmpfile" "$body_tmp"' EXIT
-  printf '%s' "$current_body" > "$body_tmp"
-  python3 -c '
-import sys, re
-body_path, out_path = sys.argv[1], sys.argv[2]
-phase, phase_detail, timestamp = sys.argv[3], sys.argv[4], sys.argv[5]
-with open(body_path, "r") as f:
-    body = f.read()
-body = re.sub(r"^(- \*\*最終更新\*\*: ).*", rf"\g<1>{timestamp}", body, count=1, flags=re.MULTILINE)
-body = re.sub(r"^(- \*\*フェーズ\*\*: ).*", rf"\g<1>{phase}", body, count=1, flags=re.MULTILINE)
-body = re.sub(r"^(- \*\*フェーズ詳細\*\*: ).*", rf"\g<1>{phase_detail}", body, count=1, flags=re.MULTILINE)
-with open(out_path, "w") as f:
-    f.write(body)
-' "$body_tmp" "$tmpfile" "phase5_post_fix" "修正完了" "$(date -u +'%Y-%m-%dT%H:%M:%S+00:00')"
-
-  # Safety checks before PATCH (includes 50% body length comparison; see gh-cli-patterns.md)
-  if [ ! -s "$tmpfile" ] || [[ "$(wc -c < "$tmpfile")" -lt 10 ]]; then
-    echo "WARNING: Updated body is empty. Skipping backup sync. Backup: $backup_file" >&2
-  elif grep -q '📜 rite 作業メモリ' "$tmpfile"; then
-    updated_length=$(wc -c < "$tmpfile")
-    if [[ "${updated_length:-0}" -lt $(( ${original_length:-1} / 2 )) ]]; then
-      echo "WARNING: Updated body < 50% of original. Skipping. Backup: $backup_file" >&2
-    else
-      jq -n --rawfile body "$tmpfile" '{"body": $body}' | \
-        gh api repos/{owner}/{repo}/issues/comments/"$comment_id" -X PATCH --input - > /dev/null 2>&1 || \
-        echo "WARNING: Issue comment backup sync failed (non-blocking)." >&2
-    fi
-  else
-    echo "WARNING: Updated body missing header. Skipping. Backup: $backup_file" >&2
-  fi
-fi
+bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform update-phase \
+  --phase "phase5_post_fix" --phase-detail "修正完了" \
+  2>/dev/null || true
 ```
 
 **Step 3**: Based on the fix result pattern from `rite:pr:fix` **and** the preceding review result pattern, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly — always invoke the appropriate Skill tool.


### PR DESCRIPTION
## 概要

Issue コメントの作業メモリ（📜 rite 作業メモリ）が phase 変化時に更新されないデグレードを修正。

`start.md` の Phase 5.4.3 (After Review) と Phase 5.4.6 (After Fix) にある手動バックアップ同期ブロック（50行超のインライン bash + Python regex + gh api PATCH）を、`issue-comment-wm-sync.sh update --transform update-phase` 呼び出しに置換。スクリプトは owner/repo を内部で動的解決するため、プレースホルダー解決の不確実性を排除。

## 関連 Issue

Closes #204

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/issue/start.md` | Phase 5.4.3 Step 2.5 と Phase 5.4.6 Step 2.5 の手動ブロックを `issue-comment-wm-sync.sh` 呼び出しに置換 |

## チェックリスト

- [x] 作業メモリが phase 変化時に更新される
- [x] 既存のコメント構造が維持される
- [x] 既存機能にリグレッションなし
