### PR TITLE
fix(init): settings.json の既存 hooks 競合検出を追加

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -510,7 +510,37 @@ echo "LATEST:${LATEST_VERSION:-unknown}"
   claude plugin update rite
 ```
 
-Continue to Phase 4.5.1 in all cases.
+Continue to Phase 4.5.0.1.
+
+### 4.5.0.1 Check for Conflicting Hooks in settings.json
+
+Read `.claude/settings.json` (the project-level, non-local settings file) and check for hooks that may conflict with rite hooks.
+
+**Purpose**: Claude Code executes hooks from both `.claude/settings.json` and `.claude/settings.local.json`. If non-rite hooks exist in `settings.json` for the same events that rite registers (e.g., SessionStart, SessionEnd, PreCompact), they will be executed alongside rite hooks, causing duplicate execution. This check warns the user about such conflicts.
+
+**Check procedure**:
+
+1. Read `.claude/settings.json` with the Read tool. If the file does not exist or has no `.hooks` section (empty `{}` or missing), skip this sub-phase entirely and proceed to Phase 4.5.1.
+2. For each hook event in `.hooks`, examine all `.hooks.{EventName}[*].hooks[*].command` values.
+3. **Exclude** commands containing `rite/hooks/` (these are rite's own hooks, which may be registered here in older installations).
+4. Collect remaining (non-rite) hook commands as **conflicting hooks**.
+
+**If conflicting hooks are found**, display:
+```
+⚠️ .claude/settings.json に既存の hooks が検出されました:
+| Hook Event | Command |
+|------------|---------|
+| {event}    | {command} |
+
+rite は .claude/settings.local.json で hooks を管理します。
+settings.json の hooks は rite hooks と二重実行されます。
+
+→ settings.json の hooks セクションを `"hooks": {}` に変更することを推奨します。
+```
+
+**If no conflicting hooks are found**, no output is displayed.
+
+**Important**: This check is **advisory only**. Do not modify `.claude/settings.json` automatically. Do not block init execution regardless of the result. Continue to Phase 4.5.1 in all cases.
 
 ### 4.5.1 Check Existing Hook Configuration
 


### PR DESCRIPTION
## 概要

`/rite:init` の Phase 4.5.1 が `.claude/settings.local.json` のみを検査し、`.claude/settings.json` の既存 hooks を一切チェックしていなかったため、rite hooks と旧 hooks が二重実行される問題を修正。

Phase 4.5.0 と 4.5.1 の間に新サブフェーズ 4.5.0.1 を追加し、settings.json の非 rite hooks を検出して警告を表示する。

## 変更内容

- `init.md` に Phase 4.5.0.1（settings.json 既存 hooks 競合チェック）を追加
- Phase 4.5.0 末尾の遷移リンクを `Continue to Phase 4.5.0.1.` に更新
- advisory only（自動削除しない、init をブロックしない）

## 関連 Issue

Closes #229

## 変更ファイル

- `plugins/rite/commands/init.md` - 変更

## チェックリスト

- [x] settings.json の .hooks セクションを読み取り、非 rite hooks を検出
- [x] 非 rite hooks 存在時に警告テーブルを表示
- [x] advisory only（init をブロックしない）
- [x] settings.json を自動変更しない
- [x] Phase 4.5.1 以降の既存フローに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
