### PR TITLE
fix(hooks): マーケットプレイス環境で /clear 時の SessionStart hook エラーを修正

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -40,8 +40,8 @@ if [[ "$SCRIPT_DIR" != *"/.claude/plugins/cache/"* ]] && command -v jq &>/dev/nu
   fi
 fi
 
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"' 2>/dev/null) || SOURCE="startup"
 
 # Extract session_id from hook JSON payload (#173)
 SESSION_ID=$(extract_session_id "$INPUT" 2>/dev/null) || SESSION_ID=""


### PR DESCRIPTION
## 概要

マーケットプレイス経由でインストールした環境で `/clear` 実行時に "SessionStart:clear hook error" が発生する問題を修正。

## 変更内容

`session-start.sh` の CWD/SOURCE 抽出における `jq` パイプに `2>/dev/null` と `|| fallback` を追加。

### 根本原因

`set -euo pipefail` 環境で `echo "$INPUT" | jq ...` を実行する際、`INPUT` が空文字列の場合に `jq` がパースエラー（exit 5）を返し、`pipefail` によりスクリプト全体が異常終了していた。hooks.json と settings.local.json の二重登録時に、2つ目のフック実行で stdin が空になるケースで発生。

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/session-start.sh` | L43-44 に `2>/dev/null \|\| fallback` を追加 |

## 関連 Issue

Closes #235

Extends: #18

## チェックリスト

- [x] MUST 要件を実装済み
- [x] AC-1: マーケットプレイス環境での /clear 正常動作
- [x] AC-2: ローカル開発環境での /clear 非退行
- [x] 既存機能への退行なし

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
