### PR TITLE
feat(workflow): Sprint Contract — 実装ステップごとの検証基準追加

### DIFF
--- a/docs/designs/harness-design-improvements.md
+++ b/docs/designs/harness-design-improvements.md
@@ -1,12 +1,21 @@
 # Anthropic ハーネス設計記事の知見を rite workflow に取り入れる
 
+## 実装ステータス
+
+| # | 改善領域 | ステータス | Issue |
+|---|---------|-----------|-------|
+| 1 | Sprint Contract（検証基準） | ✅ 実装済み | #256 |
+| 2 | Evaluator キャリブレーション（Few-shot 例） | ⬜ 未着手 | #257 |
+| 3 | Post-Step Quality Gate（セルフチェック） | ⬜ 未着手 | #258 |
+| 4 | コンテキストリセット戦略強化 | ⬜ 未着手 | #259 |
+
 <!-- Section ID: SPEC-OVERVIEW -->
 ## 概要
 
-Anthropic Engineering ブログ記事 "Harness design for long-running application development" (2026-03-24) の知見を分析し、rite workflow に適用可能な改善を実装する。記事は GAN にインスピレーションを得た Generator-Evaluator パターンを軸に、長時間実行エージェントの設計原則を解説している。
+Anthropic Engineering ブログ記事 "[Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps)" (2026-03-24) の知見を分析し、rite workflow に適用可能な改善を実装する。記事は GAN にインスピレーションを得た Generator-Evaluator パターンを軸に、長時間実行エージェントの設計原則を解説している。
 
 対象となる改善は 4 領域:
-1. Sprint Contract（実装ステップごとの検証基準）
+1. Sprint Contract（実装ステップごとの検証基準）— **実装済み**
 2. Evaluator キャリブレーション（Few-shot 例追加）
 3. Post-Step Quality Gate（実装後セルフチェック）
 4. コンテキストリセット戦略強化
@@ -26,7 +35,7 @@ rite workflow は既に Generator-Evaluator 分離、ファイルベース通信
 <!-- Section ID: SPEC-REQ-FUNC -->
 ### 機能要件
 
-1. **Sprint Contract**: `implementation-plan.md` の依存グラフテーブルに `検証基準` 列を追加し、`implement.md` の 5.1.0.5 Adaptive Re-evaluation でステップ完了前に検証基準を Read/Grep/Bash で確認する
+1. **Sprint Contract** ✅: `implementation-plan.md` の依存グラフテーブルに `検証基準` 列を追加し、`implement.md` の 5.1.0.5 Adaptive Re-evaluation でステップ完了前に検証基準を Read/Grep/Bash で確認する（#256 で実装済み）
 2. **Few-shot Evaluator Calibration**: 全レビュアー共通の Few-shot 例集（`finding-examples.md`）を作成し、良い指摘例・報告すべきでない例・ボーダーライン例を提供する。`SKILL.md` に懐疑的トーン設定を追加する
 3. **Post-Step Quality Gate**: 5.1.0.5 内にスコープ逸脱・リグレッション懸念・仕様整合の軽量セルフチェックを追加する
 4. **Context Reset Strategy**: ORANGE 閾値到達時に `/clear` + `/rite:resume` を推奨するメッセージに変更し、work memory の自動最新化を追加する
@@ -54,14 +63,14 @@ rite workflow は既に Generator-Evaluator 分離、ファイルベース通信
 <!-- Section ID: SPEC-ARCH-COMPONENTS -->
 ### コンポーネント構成
 
-| コンポーネント | 改善 | 役割 |
-|--------------|------|------|
-| `commands/issue/implementation-plan.md` | 1 | 依存グラフテンプレートに検証基準列を追加 |
-| `commands/issue/implement.md` | 1, 3 | 5.1.0.5 に検証ステップと Post-Step Quality Gate を追加 |
-| `skills/reviewers/references/finding-examples.md` | 2 | Few-shot 例集（新規作成） |
-| `skills/reviewers/SKILL.md` | 2 | 懐疑的トーン設定 + finding-examples.md 参照追加 |
-| `hooks/context-pressure.sh` | 4 | ORANGE 閾値メッセージ強化 |
-| `commands/resume.md` | 4 | 単一 Issue 実装途中リジューム強化 |
+| コンポーネント | 改善 | 役割 | ステータス |
+|--------------|------|------|-----------|
+| `plugins/rite/commands/issue/implementation-plan.md` | 1 | 依存グラフテンプレートに検証基準列を追加 | ✅ 実装済み |
+| `plugins/rite/commands/issue/implement.md` | 1, 3 | 5.1.0.5 に検証ステップを追加（改善1）、Post-Step Quality Gate を追加（改善3） | 改善1: ✅ / 改善3: ⬜ |
+| `plugins/rite/skills/reviewers/references/finding-examples.md` | 2 | Few-shot 例集（新規作成） | ⬜ 未着手 |
+| `plugins/rite/skills/reviewers/SKILL.md` | 2 | 懐疑的トーン設定 + finding-examples.md 参照追加 | ⬜ 未着手 |
+| `plugins/rite/hooks/context-pressure.sh` | 4 | ORANGE 閾値メッセージ強化 | ⬜ 未着手 |
+| `plugins/rite/commands/resume.md` | 4 | 単一 Issue 実装途中リジューム強化 | ⬜ 未着手 |
 
 <!-- Section ID: SPEC-ARCH-DATAFLOW -->
 ### データフロー

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -293,6 +293,7 @@ After completing each implementation step, re-evaluate the remaining steps befor
    | Pattern presence | `Grep` tool |
    | Test passage | `Bash` tool (run test command) |
    | Config value | `Read` or `Grep` tool |
+   | Line count / structure | `Read` tool + count |
 
    **When criteria is met**: Proceed to step 2 (mark complete).
 
@@ -300,6 +301,7 @@ After completing each implementation step, re-evaluate the remaining steps befor
    - Re-attempt the implementation to satisfy the criteria
    - If the criteria itself is incorrect (implementation approach changed), record the deviation in work memory's "計画逸脱ログ" section and update the criteria before marking complete
    - Do NOT mark the step as complete until the (original or updated) criteria is verified
+   - **Escalation**: If 2 re-attempts fail to satisfy the criteria, use `AskUserQuestion` to ask the user whether to (a) continue retrying, (b) update the criteria, or (c) skip verification and mark complete with a deviation log entry
 
    **When no `検証基準` column exists** (legacy plans or skipped plans): Skip this verification step and proceed to step 2 directly.
 

--- a/plugins/rite/commands/issue/implementation-plan.md
+++ b/plugins/rite/commands/issue/implementation-plan.md
@@ -299,7 +299,7 @@ WM_SOURCE="plan" \
 
 This section is executed **during Phase 5.1** (not during Phase 3) when the bottleneck detection in [5.1.0.5](./implement.md) triggers step re-decomposition. It defines how re-decomposed sub-steps are integrated back into the implementation plan and work memory.
 
-**Trigger**: Invoked from `implement.md` 5.1.0.5 step 5 (Bottleneck detection) when a threshold is exceeded and the step is re-decomposed into sub-steps.
+**Trigger**: Invoked from `implement.md` 5.1.0.5 step 6 (Bottleneck detection) when a threshold is exceeded and the step is re-decomposed into sub-steps.
 
 #### Plan Update Procedure
 
@@ -316,14 +316,14 @@ Update the "実装計画" section in work memory to reflect the re-decomposition
 ```markdown
 ### 実装計画（更新済み）
 
-| Step | 内容 | depends_on | 並列グループ | 状態 |
-|------|------|------------|-------------|------|
-| S1 | {step_1} | — | A | ✅ |
-| S2 | {step_2} | — | A | ✅ |
-| ~~S3~~ | ~~{original_step_3}~~ | S1 | B | ⚠️ 再分解 |
-| S3.1 | {sub_step_1} | S1 | B' | ⬜ |
-| S3.2 | {sub_step_2} | S3.1 | B' | ⬜ |
-| S4 | {step_4} | S3.2 | C | 🔒 |
+| Step | 内容 | depends_on | 並列グループ | 状態 | 検証基準 |
+|------|------|------------|-------------|------|---------|
+| S1 | {step_1} | — | A | ✅ | {criteria_1} |
+| S2 | {step_2} | — | A | ✅ | {criteria_2} |
+| ~~S3~~ | ~~{original_step_3}~~ | S1 | B | ⚠️ 再分解 | ~~{criteria_3}~~ |
+| S3.1 | {sub_step_1} | S1 | B' | ⬜ | {sub_criteria_1} |
+| S3.2 | {sub_step_2} | S3.1 | B' | ⬜ | {sub_criteria_2} |
+| S4 | {step_4} | S3.2 | C | 🔒 | {criteria_4} |
 ```
 
 **Note**: The re-decomposition is also recorded in the "ボトルネック検出ログ" section (see [bottleneck-detection.md](../../references/bottleneck-detection.md#work-memory-recording-format)).


### PR DESCRIPTION
## 概要

Anthropic ハーネス設計記事の Sprint Contract 知見に基づき、実装ステップごとの検証基準を追加。
コーディング前に「何をもって完了とするか」を定義し、Adaptive Re-evaluation で機械的に検証する仕組みを導入。

Closes #256

## 変更内容

- `implementation-plan.md`: Phase 3.3 依存グラフテーブルに `検証基準` 列を追加
- `implementation-plan.md`: 検証基準の記述ガイドライン (Phase 3.2.2) を新設
- `implement.md`: 5.1.0.5 Adaptive Re-evaluation に検証基準チェックステップを追加（手順 1）
- `docs/designs/harness-design-improvements.md`: 親 Issue #255 の設計ドキュメント

## チェックリスト

- [x] 実装完了
- [x] lint 実行（スキップ: Markdown プロジェクト）
- [x] 設計ドキュメント更新
