### PR TITLE
feat(implement): Post-Step Quality Gate — 実装後セルフチェック追加

### DIFF
--- a/docs/designs/harness-design-improvements.md
+++ b/docs/designs/harness-design-improvements.md
@@ -17,7 +17,7 @@ Anthropic Engineering ブログ記事 "[Harness design for long-running applicat
 対象となる改善は 4 領域:
 1. Sprint Contract（実装ステップごとの検証基準）— **実装済み**
 2. Evaluator キャリブレーション（Few-shot 例追加）
-3. Post-Step Quality Gate（実装後セルフチェック）
+3. Post-Step Quality Gate（実装後セルフチェック）— **実装済み**
 4. コンテキストリセット戦略強化
 
 <!-- Section ID: SPEC-BACKGROUND -->

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -309,12 +309,14 @@ After completing each implementation step, re-evaluate the remaining steps befor
 
    After verifying completion criteria (or skipping verification), perform a lightweight self-check on the just-completed step using the immediately available work context. This gate catches scope drift, regression risks, and specification misalignment early — before they compound across subsequent steps.
 
+   **Relationship with parallel implementation**: When a parallel batch completes multiple steps simultaneously, run the Quality Gate for each step in the batch individually, using each step's specific work context.
+
    **Check items**:
 
    | # | Check | Question | Trigger |
    |---|-------|----------|---------|
    | 1 | **Scope drift** | Did you modify files not listed in the implementation plan? | Edited files outside the plan's "変更対象ファイル" |
-   | 2 | **Regression concern** | If shared/common code was changed, are you aware of the impact scope? | Modified files imported/referenced by 3+ other files |
+   | 2 | **Regression concern** | If shared/common code was changed, are you aware of the impact scope? | Modified a shared utility, configuration, or common module file that you observed being referenced by other files during this implementation session |
    | 3 | **Specification alignment** | Is the change consistent with the Issue's What/Why? | Change purpose diverges from the Issue description |
 
    **Evaluation**: For each check, assess pass/flag based on the work context already in memory (files edited, step description, Issue body). Do NOT invoke Read, Grep, Bash, or any other tool — this is a mental evaluation only.
@@ -322,10 +324,11 @@ After completing each implementation step, re-evaluate the remaining steps befor
    **When all checks pass**: Proceed to step 3 (mark complete). No output needed.
 
    **When any check is flagged**:
-   - Record the flagged item(s) in work memory's "計画逸脱ログ" section with the format:
+   - Record the flagged item(s) in work memory's "計画逸脱ログ" section using the existing table format (consistent with step 6's plan deviation recording):
      ```
-     - [Quality Gate] Step S{n}: {check_name} — {brief description of the concern}
+     | {next_number} | S{n} | QG | {check_name}: {brief description} | — | — |
      ```
+     Where `逸脱種別` is `QG` (Quality Gate). `影響範囲` and `代替ステップ` are `—` (not applicable for informational flags).
    - **Continue execution** (do NOT stop or ask the user). The Quality Gate is informational — it logs concerns for later review but does not block progress.
    - Proceed to step 3 (mark complete).
 


### PR DESCRIPTION
## 概要

`implement.md` の Adaptive Re-evaluation (5.1.0.5) 内に Post-Step Quality Gate（軽量セルフチェック）を追加。実装ステップ完了後に、ツール呼び出し不要のメンタルチェックで以下の3項目を評価する:

1. **スコープ逸脱**: 計画外のファイルを変更していないか
2. **リグレッション懸念**: 共有コードを変更した場合、影響範囲を認識しているか
3. **仕様との整合**: Issue の What/Why に沿った変更か

## 関連 Issue

Closes #258

親 Issue: #255 (feat: Anthropic ハーネス設計記事の知見を rite workflow に取り入れる)

## 変更内容

- `plugins/rite/commands/issue/implement.md`: 5.1.0.5 の step 1（検証基準チェック）と旧 step 2（完了マーク）の間に新 step 2（Post-Step Quality Gate）を挿入。既存 steps を 3-7 にリナンバリング
- `docs/designs/harness-design-improvements.md`: 改善3（Post-Step Quality Gate）のステータスを「✅ 実装済み」に更新

## 設計判断

- Quality Gate はツール呼び出し不要のメンタルチェック（直前の作業コンテキストから判断、10秒以内）
- 逸脱検知時は計画逸脱ログに記録して続行（ブロッキングではない）
- Anthropic Engineering ブログ記事 "Harness design for long-running application development" の知見に基づく

## チェックリスト

- [x] 実装完了
- [x] テスト追加/更新（Markdown ドキュメント変更のため自動テスト対象外）
- [x] ドキュメント更新
