### PR TITLE
fix(common-principles): deprecated commit.style 参照を削除

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/common-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/common-principles.md
@@ -100,7 +100,6 @@ Defaults are determined in 2 tiers:
 | Item | Project Config | Fallback Value |
 |------|---------------|----------------|
 | Base branch | `rite-config.yml` `branch.base` | `main` |
-| Commit style | `rite-config.yml` `commit.style` | `conventional` |
 | Priority | `rite-config.yml` `github.projects.fields.priority` | `Medium` |
 | Complexity | `rite-config.yml` `github.projects.fields.complexity` | `M` |
 | Decomposition threshold | `rite-config.yml` `issue.auto_decompose_threshold` | `M` |
@@ -112,9 +111,6 @@ Defaults are determined in 2 tiers:
 ```text
 ❌ 「どのブランチから作成しますか？」
    → rite-config.yml の branch.base を参照
-
-❌ 「コミットメッセージのスタイルはどうしますか？」
-   → rite-config.yml の commit.style を参照
 
 ❌ 「Priority はどれにしますか？」
    → デフォルト Medium を適用


### PR DESCRIPTION
## 概要

`common-principles.md` から deprecated となった `commit.style` キーへの参照を削除。

- デフォルト値テーブルの `Commit style` 行を削除
- 禁止例セクションの `commit.style` 参照例を削除

Conventional commits はハードデフォルトのため、設定キーへの参照は不要。

## 関連 Issue

Closes #286

## 変更内容

- `plugins/rite/skills/rite-workflow/references/common-principles.md` — `commit.style` 参照を2箇所削除（テーブル行 + 禁止例）

## テスト計画

- [ ] `commit.style` への参照が完全に除去されていることを確認
- [ ] テーブルの整合性が保たれていることを確認
