### PR TITLE
fix(references): error-codes.md のテンプレートパスを templates/config/ に更新

### DIFF
--- a/plugins/rite/references/error-codes.md
+++ b/plugins/rite/references/error-codes.md
@@ -481,7 +481,7 @@ Example: `[ZEN-E001] rite-config.yml not found`
 
 **Recovery Steps**:
 1. Validate YAML syntax: `yq eval . rite-config.yml`
-2. Compare with template: `{plugin_root}/templates/rite-config.yml` (resolve `{plugin_root}` per [Plugin Path Resolution](./plugin-path-resolution.md#resolution-script))
+2. Compare with template: `{plugin_root}/templates/config/rite-config.yml` (resolve `{plugin_root}` per [Plugin Path Resolution](./plugin-path-resolution.md#resolution-script))
 3. Fix syntax errors or missing fields
 4. Retry the command
 


### PR DESCRIPTION
## 概要

`plugins/rite/references/error-codes.md` 内のテンプレート config パス参照を更新。
schema_version 導入（#284）でテンプレートが `templates/config/rite-config.yml` に移動済みだったが、error-codes.md の参照が旧パスのままだった。

Closes #287

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/references/error-codes.md` | `templates/rite-config.yml` → `templates/config/rite-config.yml` に更新 |

## 関連

- 元の PR: #285
- 元の Issue: #284

## テスト計画

- [x] 旧パス `templates/rite-config.yml` が error-codes.md に存在しないことを確認
- [x] 新パス `templates/config/rite-config.yml` が正しく参照されていることを確認

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
