### PR TITLE
docs: ドキュメント内の config 例を schema_version: 2 形式に更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -104,7 +104,7 @@ Todo → In Progress → In Review → Done
 プロジェクトルートに `rite-config.yml` を作成:
 
 ```yaml
-version: "1.0"
+schema_version: 2
 
 project:
   type: webapp  # generic | webapp | library | cli | documentation

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Create   Start Work   Set Ready  Merged
 Create `rite-config.yml` in your project root:
 
 ```yaml
-version: "1.0"
+schema_version: 2
 
 project:
   type: webapp  # generic | webapp | library | cli | documentation

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,7 +12,7 @@ The configuration file should be named `rite-config.yml` and placed in:
 
 ```yaml
 # Claude Code Rite Workflow configuration file
-version: "1.0"
+schema_version: 2
 
 # Project settings
 project:
@@ -728,7 +728,7 @@ Each notification service (slack, discord, teams) can have:
 For most projects, a minimal configuration is sufficient:
 
 ```yaml
-version: "1.0"
+schema_version: 2
 
 project:
   type: webapp

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -368,7 +368,7 @@ YAML 形式を採用（可読性が高くコメント記述可能）。
 
 ```yaml
 # rite-workflow 設定ファイル
-version: "1.0"
+schema_version: 2
 
 # プロジェクト基本設定
 project:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -368,7 +368,7 @@ Uses YAML format for readability and comment support.
 
 ```yaml
 # rite-workflow configuration file
-version: "1.0"
+schema_version: 2
 
 # Project settings
 project:


### PR DESCRIPTION
## 概要

ドキュメント内の config 例で旧形式 `version: "1.0"` が残存していたものを、schema_version 導入（#284）に合わせて `schema_version: 2` に更新。

Closes #288

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `README.md` | config 例の `version: "1.0"` → `schema_version: 2` |
| `README.ja.md` | 同上 |
| `docs/CONFIGURATION.md` | 同上（2箇所） |
| `docs/SPEC.md` | 同上 |
| `docs/SPEC.ja.md` | 同上 |

## テスト計画

- [x] 全ドキュメントで `version: "1.0"` が config 例に残存しないことを grep で確認
- [x] `schema_version: 2` が正しく挿入されていることを確認

## 関連

- 元の PR: #285
- 元の Issue: #284

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
