### PR TITLE
fix(config): contextual-commits.md の deprecated commit.style コード例を削除

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/contextual-commits.md
+++ b/plugins/rite/skills/rite-workflow/references/contextual-commits.md
@@ -10,7 +10,6 @@ Conventional Commits の subject line を維持したまま、コミット body 
 
 ```yaml
 commit:
-  style: conventional
   contextual: true    # true (default) | false
 ```
 


### PR DESCRIPTION
## 概要

`contextual-commits.md` の YAML コード例から deprecated な `commit.style` 行を削除し、`commit.contextual` のみの例に統一する。

## 変更内容

- `plugins/rite/skills/rite-workflow/references/contextual-commits.md`: YAML コード例から `style: conventional` 行を削除

## 背景

schema_version 2 で `commit.style` は deprecated であり、リファレンスドキュメントのコード例もそれに合わせて更新が必要。PR #300 のレビューで検出されたスコープ外の推奨事項から作成。

## 関連 Issue

Closes #301

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
