### PR TITLE
fix: ドキュメント・テンプレートの deprecated commit.style コード例を削除

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ branch:
 #   release: "main"    # main に本番リリース
 
 commit:
-  style: conventional
+  contextual: true
 
 # オプション: スプリント/イテレーション管理
 iteration:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ branch:
   pattern: "{type}/issue-{number}-{slug}"
 
 commit:
-  style: conventional
+  contextual: true
 
 # Optional: Sprint/Iteration management
 iteration:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,8 +87,7 @@ branch:
 
 # Commit message
 commit:
-  style: conventional  # conventional | free
-  enforce: false
+  contextual: true    # Contextual Commits action lines in commit body
 
 # Build/test/lint commands
 commands:

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -442,8 +442,7 @@ branch:
 
 # コミットメッセージ
 commit:
-  style: conventional  # conventional | free
-  enforce: false  # true の場合、形式違反時に警告
+  contextual: true    # コミット本文に Contextual Commits のアクション行を含める
 
 # ビルド・テスト・リント（自動検出、または手動指定）
 commands:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -442,8 +442,7 @@ branch:
 
 # Commit message
 commit:
-  style: conventional  # conventional | free
-  enforce: false  # If true, warn on format violation
+  contextual: true    # Contextual Commits action lines in commit body
 
 # Build/test/lint (auto-detect or manual specification)
 commands:

--- a/plugins/rite/templates/project-types/cli.yml
+++ b/plugins/rite/templates/project-types/cli.yml
@@ -52,7 +52,6 @@ branch:
     refactor: "refactor"
     chore: "chore"
 
-# Commit style
+# Commit message
 commit:
-  style: conventional
-  enforce: true
+  contextual: true

--- a/plugins/rite/templates/project-types/documentation.yml
+++ b/plugins/rite/templates/project-types/documentation.yml
@@ -45,7 +45,6 @@ branch:
     restructure: "refactor"
     chore: "chore"
 
-# Commit style
+# Commit message
 commit:
-  style: conventional
-  enforce: false
+  contextual: true

--- a/plugins/rite/templates/project-types/generic.yml
+++ b/plugins/rite/templates/project-types/generic.yml
@@ -46,7 +46,6 @@ branch:
     refactor: "refactor"
     chore: "chore"
 
-# Commit style
+# Commit message
 commit:
-  style: conventional
-  enforce: false
+  contextual: true

--- a/plugins/rite/templates/project-types/library.yml
+++ b/plugins/rite/templates/project-types/library.yml
@@ -53,7 +53,6 @@ branch:
     refactor: "refactor"
     chore: "chore"
 
-# Commit style
+# Commit message
 commit:
-  style: conventional
-  enforce: true
+  contextual: true

--- a/plugins/rite/templates/project-types/webapp.yml
+++ b/plugins/rite/templates/project-types/webapp.yml
@@ -56,7 +56,6 @@ branch:
     style: "style"
     chore: "chore"
 
-# Commit style
+# Commit message
 commit:
-  style: conventional
-  enforce: true
+  contextual: true


### PR DESCRIPTION
## 概要

schema_version 2 で deprecated な `commit.style` / `commit.enforce` のコード例を、全ドキュメントおよびプロジェクトタイプテンプレートから削除し、`commit.contextual: true` に置換しました。

Closes #305

## 変更内容

### ドキュメント
- `README.md` / `README.ja.md`: `commit.style` → `commit.contextual` に置換
- `docs/CONFIGURATION.md`: `commit.style` + `commit.enforce` → `commit.contextual` に置換
- `docs/SPEC.md` / `docs/SPEC.ja.md`: 同上

### プロジェクトタイプテンプレート（5ファイル）
- `generic.yml`, `webapp.yml`, `cli.yml`, `library.yml`, `documentation.yml`
- `# Commit style` → `# Commit message`、`style` + `enforce` → `contextual: true`

## 変更対象外

- `init.md` の deprecated キー一覧（参照のみ、コード例ではない）
- `reviewer-quality-improvement.md` の過去の振り返り記録

## テスト計画

- [ ] 各ファイルで `style: conventional` が残存していないことを確認
- [ ] `rite-config.yml` の形式と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
