### PR TITLE
docs: Notification Events テーブルを notification.sh 実装と同期

### DIFF
--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -1529,11 +1529,9 @@ notifications:
 
 | イベント | 説明 |
 |---------|------|
-| `issue_created` | Issue 作成時 |
-| `issue_started` | 作業開始時 |
 | `pr_created` | PR 作成時 |
 | `pr_ready` | Ready for review 時 |
-| `review_completed` | レビュー完了時 |
+| `issue_closed` | Issue クローズ時 |
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1385,11 +1385,9 @@ notifications:
 
 | Event | Description |
 |-------|-------------|
-| `issue_created` | When Issue created |
-| `issue_started` | When work started |
 | `pr_created` | When PR created |
 | `pr_ready` | When Ready for review |
-| `review_completed` | When review completed |
+| `issue_closed` | When Issue closed |
 
 ---
 


### PR DESCRIPTION
## 概要

Notification Events テーブルを notification.sh の実装と同期。

- `issue_created`, `issue_started`, `review_completed` を削除（未実装イベント）
- `issue_closed` を追加（実装済みだがテーブル未記載）

Closes #314

## 変更ファイル

- `docs/SPEC.md` — 変更
- `docs/SPEC.ja.md` — 変更

## テスト計画

- [ ] notification.sh の実装イベント（pr_created, pr_ready, issue_closed）と SPEC テーブルが一致
