### PR TITLE
refactor(review): prompt-engineer-reviewer の検出スコープ拡張 — Content Accuracy + List Consistency + Design Logic Review

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -17,7 +17,7 @@ All reviewers MUST adopt these principles:
 2. **Changed config keys**: `Grep` for every config key that was added, removed, or renamed. Flag any file that reads the old key without a fallback.
 3. **Changed interface contracts**: If a function signature changed (parameters added/removed/reordered), `Grep` for all call sites and verify they match the new signature.
 4. **i18n key consistency**: If i18n keys were added or removed, verify both language files (e.g., `ja.yml` and `en.yml`) have matching keys.
-5. **Keyword list / enumeration consistency**: If the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, status values, phase names, tool lists), `Grep` for all other copies of the same list across the codebase. Flag any copy that does not reflect the same addition, removal, or reordering. Skip this check when the diff does not touch any list-like structure.
+5. **Keyword list / enumeration consistency**: If the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, phase names, status values, tool names), `Grep` for all other copies of the same list across the codebase. Flag any copy that does not reflect the same addition, removal, or reordering. Skip this check when the diff does not touch any list-like structure.
 
 ## Confidence Scoring
 

--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -17,6 +17,7 @@ All reviewers MUST adopt these principles:
 2. **Changed config keys**: `Grep` for every config key that was added, removed, or renamed. Flag any file that reads the old key without a fallback.
 3. **Changed interface contracts**: If a function signature changed (parameters added/removed/reordered), `Grep` for all call sites and verify they match the new signature.
 4. **i18n key consistency**: If i18n keys were added or removed, verify both language files (e.g., `ja.yml` and `en.yml`) have matching keys.
+5. **Keyword list / enumeration consistency**: If the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, status values, phase names, tool lists), `Grep` for all other copies of the same list across the codebase. Flag any copy that does not reflect the same addition, removal, or reordering. Skip this check when the diff does not touch any list-like structure.
 
 ## Confidence Scoring
 

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -56,13 +56,13 @@ For each placeholder in the file:
 
 For each technical claim in the changed file (bash behavior, tool semantics, API contracts, shell quoting rules, exit code semantics):
 - Identify the claim and the context in which it appears
-- Verify the claim against known shell/tool behavior (e.g., `local` always returns 0 under `set -e`, `grep -c` returns exit code 1 on no match). Cross-reference with existing patterns in `commands/**/*.md` via `Grep`
+- Verify the claim against known shell/tool behavior (e.g., `local` always returns 0 regardless of the command substitution's exit code, `grep -c` returns exit code 1 when 0 matches are found and exit code 2 on error). Cross-reference with existing patterns in `commands/**/*.md` via `Grep`
 - Flag claims that are incorrect or misleading, citing the actual behavior
-- Pay special attention to: `set -e` / `set -o pipefail` interaction with `local`, `$(...)` subshell exit codes, `grep -c` exit codes, `jq` null handling, and `gh api` error responses
+- When the changed file contains bash code blocks, pay special attention to: `set -e` / `set -o pipefail` interaction with `local`, `$(...)` subshell exit codes, `grep -c` exit codes. For tool-specific claims: `jq` null handling, `gh api` error responses
 
 ### Step 6: Enumeration and Keyword List Consistency
 
-When the diff modifies a keyword list, enumeration, option set, or phase/step numbering:
+When the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, phase names, status values, tool names), or phase/step numbering:
 - `Grep` for all other locations where the same list appears (other files, comments, tables, examples)
 - `Read` each location to compare the full list content
 - Flag any copy that is missing items, has extra items, or uses a different ordering than the modified version
@@ -87,11 +87,11 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 ## Confidence Calibration
 
 - **95**: A bash command uses a variable (`$comment_id`) that is defined in a previous Bash tool call but not in the same call — shell state doesn't persist between calls
-- **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd` under `set -e`, but `local` always returns 0, masking the failure — verified by known shell semantics
+- **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd`, but `local` always returns 0 (regardless of `set -e`), masking the substitution's exit code — verified by known shell semantics
 - **92**: A Detection Process added Step 6 but the corresponding `skills/reviewers/*.md` checklist has no item that maps to Step 6 findings — confirmed by `Read` of both files
 - **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
-- **90**: A keyword list in `_reviewer-base.md` has 5 items but the same list in `prompt-engineer-reviewer.md` has only 4 — confirmed by `Grep` + `Read`
-- **88**: A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
+- **90**: (hypothetical) A keyword list in one file has 5 items but the same list in another file has only 4 — confirmed by `Grep` + `Read`
+- **88**: (hypothetical) A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
 - **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
 - **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -52,7 +52,32 @@ For each placeholder in the file:
 - Verify the source actually produces the expected value
 - Check for placeholder name typos by `Grep`-ing for similar patterns
 
-### Step 5: Cross-File Impact Check
+### Step 5: Content Accuracy Verification
+
+For each technical claim in the changed file (bash behavior, tool semantics, API contracts, shell quoting rules, exit code semantics):
+- Identify the claim and the context in which it appears
+- Verify the claim against known behavior: use `Bash` to test shell semantics when possible, or cross-reference with authoritative sources
+- Flag claims that are incorrect or misleading, citing the actual behavior
+- Pay special attention to: `set -e` / `set -o pipefail` interaction with `local`, `$(...)` subshell exit codes, `grep -c` exit codes, `jq` null handling, and `gh api` error responses
+
+### Step 6: Enumeration and Keyword List Consistency
+
+When the diff modifies a keyword list, enumeration, option set, or phase/step numbering:
+- `Grep` for all other locations where the same list appears (other files, comments, tables, examples)
+- `Read` each location to compare the full list content
+- Flag any copy that is missing items, has extra items, or uses a different ordering than the modified version
+- Check that additions to a Detection Process are reflected in the corresponding checklist (e.g., `skills/reviewers/*.md`), and vice versa
+- Skip this step entirely when the diff does not touch any list-like structure
+
+### Step 7: Design and Logic Review
+
+Analyze decision tables, routing logic, and conditional branches in the changed file:
+- For each decision/routing table: verify that all valid input combinations are covered (no missing rows)
+- For each conditional branch: check that all outcomes have explicit handling (no implicit fall-through)
+- Cross-reference Detection Process steps with the corresponding checklist items: every Detection step should have at least one checklist item that surfaces its findings, and every checklist item should be discoverable by at least one Detection step
+- Verify that priority/severity ordering is consistent across examples, tables, and prose
+
+### Step 8: Cross-File Impact Check
 
 Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 - If a skill/command was renamed or its output pattern changed, `Grep` for all callers
@@ -64,6 +89,12 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 - **95**: A bash command uses a variable (`$comment_id`) that is defined in a previous Bash tool call but not in the same call — shell state doesn't persist between calls
 - **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
 - **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
+- **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd` under `set -e`, but `local` always returns 0, masking the failure — verified with `Bash`
+- **92**: A Detection Process added Step 6 but the corresponding `skills/reviewers/*.md` checklist has no item that maps to Step 6 findings — confirmed by `Read` of both files
+- **90**: A keyword list in `_reviewer-base.md` has 5 items but the same list in `prompt-engineer-reviewer.md` has only 4 — confirmed by `Grep` + `Read`
+- **88**: A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
+- **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
+- **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
 - **70**: An instruction "seems unclear" but could be interpreted correctly by a capable LLM — move to recommendations
 - **50**: Style preference for instruction wording — do NOT report
 

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -87,12 +87,12 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 ## Confidence Calibration
 
 - **95**: A bash command uses a variable (`$comment_id`) that is defined in a previous Bash tool call but not in the same call — shell state doesn't persist between calls
-- **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
-- **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd` under `set -e`, but `local` always returns 0, masking the failure — verified with `Bash`
 - **92**: A Detection Process added Step 6 but the corresponding `skills/reviewers/*.md` checklist has no item that maps to Step 6 findings — confirmed by `Read` of both files
+- **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
 - **90**: A keyword list in `_reviewer-base.md` has 5 items but the same list in `prompt-engineer-reviewer.md` has only 4 — confirmed by `Grep` + `Read`
 - **88**: A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
+- **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
 - **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
 - **70**: An instruction "seems unclear" but could be interpreted correctly by a capable LLM — move to recommendations

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -56,7 +56,7 @@ For each placeholder in the file:
 
 For each technical claim in the changed file (bash behavior, tool semantics, API contracts, shell quoting rules, exit code semantics):
 - Identify the claim and the context in which it appears
-- Verify the claim against known behavior: use `Bash` to test shell semantics when possible, or cross-reference with authoritative sources
+- Verify the claim against known shell/tool behavior (e.g., `local` always returns 0 under `set -e`, `grep -c` returns exit code 1 on no match). Cross-reference with existing patterns in `commands/**/*.md` via `Grep`
 - Flag claims that are incorrect or misleading, citing the actual behavior
 - Pay special attention to: `set -e` / `set -o pipefail` interaction with `local`, `$(...)` subshell exit codes, `grep -c` exit codes, `jq` null handling, and `gh api` error responses
 
@@ -87,7 +87,7 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 ## Confidence Calibration
 
 - **95**: A bash command uses a variable (`$comment_id`) that is defined in a previous Bash tool call but not in the same call — shell state doesn't persist between calls
-- **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd` under `set -e`, but `local` always returns 0, masking the failure — verified with `Bash`
+- **93**: A file claims `local var=$(cmd)` preserves the exit code of `cmd` under `set -e`, but `local` always returns 0, masking the failure — verified by known shell semantics
 - **92**: A Detection Process added Step 6 but the corresponding `skills/reviewers/*.md` checklist has no item that maps to Step 6 findings — confirmed by `Read` of both files
 - **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
 - **90**: A keyword list in `_reviewer-base.md` has 5 items but the same list in `prompt-engineer-reviewer.md` has only 4 — confirmed by `Grep` + `Read`

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -37,6 +37,8 @@ This skill is activated when reviewing files matching:
 - [ ] **Impossible Tasks**: Steps Claude cannot execute (missing tools, capabilities)
 - [ ] **Circular Logic**: Instructions that reference themselves or create loops
 - [ ] **Conflicting Instructions**: Contradictory steps in the same flow
+- [ ] **Inaccurate Technical Claims**: Assertions about tool behavior, shell semantics, or API contracts that contradict actual behavior (e.g., claiming `local var=$(cmd)` is safe under `set -e`)
+- [ ] **Enumeration / Keyword List Inconsistency**: A list (severity levels, phase names, status values, tool names) modified in one file but not updated in other files that duplicate or reference the same list
 
 ### Important (Should Fix)
 
@@ -45,6 +47,9 @@ This skill is activated when reviewing files matching:
 - [ ] **Phase Gaps**: Missing transitions between phases
 - [ ] **Tool Misuse**: Incorrect tool selection or parameters
 - [ ] **Assumption Leaks**: Implicit assumptions not validated
+- [ ] **Condition Table Coverage Gaps**: Decision/routing tables missing branches for valid input combinations or edge cases
+- [ ] **Detection-Checklist Misalignment**: Detection Process steps that have no corresponding checklist item, or checklist items with no detection step to surface them
+- [ ] **Stale Cross-References**: Phase numbers, step numbers, or section names referenced in text that no longer match the actual heading structure after renumbering
 
 ### Recommendations
 
@@ -98,6 +103,9 @@ Perform the following investigation before reporting findings:
 | Consistency with existing commands | Read | Check similar patterns in other `commands/*.md` files |
 | Consistency between phases | Read | Verify that referenced Phases exist within the same file |
 | Placeholder definitions | Grep | Search whether `{placeholder}` values are defined |
+| Technical claim accuracy | Bash/WebSearch | Verify bash semantics, tool behavior, or API contracts stated in instructions (e.g., `set -e` interaction with `local`) |
+| Keyword list consistency | Grep | When a list is modified, search for all other copies of the same list across the codebase |
+| Condition table completeness | Read | Verify decision/routing tables cover all valid input combinations by cross-referencing upstream producers |
 
 ### Prohibited vs Required Findings
 

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -103,7 +103,7 @@ Perform the following investigation before reporting findings:
 | Consistency with existing commands | Read | Check similar patterns in other `commands/*.md` files |
 | Consistency between phases | Read | Verify that referenced Phases exist within the same file |
 | Placeholder definitions | Grep | Search whether `{placeholder}` values are defined |
-| Technical claim accuracy | Bash/WebSearch | Verify bash semantics, tool behavior, or API contracts stated in instructions (e.g., `set -e` interaction with `local`) |
+| Technical claim accuracy | Read/Grep | Verify bash semantics and tool behavior by cross-referencing with known patterns in existing commands (e.g., `set -e` interaction with `local`) |
 | Keyword list consistency | Grep | When a list is modified, search for all other copies of the same list across the codebase |
 | Condition table completeness | Read | Verify decision/routing tables cover all valid input combinations by cross-referencing upstream producers |
 


### PR DESCRIPTION
## 概要

prompt-engineer-reviewer の Detection Process に Content Accuracy Verification / Enumeration Consistency / Design Logic Review の 3 ステップを追加し、`/rite:pr:review` の検出力を向上させる。

PR #325 で `/rite:pr:review` が 3 サイクル後に `[review:mergeable]` を宣言した後、`/verified-review` が 8 件の実質的な指摘を追加検出した問題を解消する。

## 変更内容

- `_reviewer-base.md`: Cross-File Impact Check にキーワードリスト整合性チェック（項目 5）を追加
- `prompt-engineer-reviewer.md`: Step 5 (Content Accuracy Verification) + Step 6 (Enumeration Consistency) + Step 7 (Design Logic Review) を追加、既存 Step 5 → Step 8 にリナンバー、Confidence Calibration に 6 例追加
- `prompt-engineer.md`: Critical に 2 項目、Important に 3 項目、Investigation テーブルに 3 行追加

## 関連 Issue

Closes #326

## テスト計画

- [ ] 既存 Step 1-4 が変更されていないことを確認（AC-5）
- [ ] 新 Step 5-7 が技術的主張検証、リスト整合性、条件テーブル網羅性を検出できることを確認
- [ ] 非リスト変更で新チェックがノイズを生まないことを確認（T-07）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
