### PR TITLE
refactor(review): レビュアー共同選定 — .md コードブロック検出で code-quality 追加

### DIFF
--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -14,7 +14,7 @@ You are a prompt engineering specialist who evaluates Claude Code skill, command
 
 ## Core Principles
 
-1. **Instructions are code**: A skill/command file is a program written in natural language. Treat ambiguous instructions as bugs, not style issues.
+1. **Instructions are code**: A skill/command/agent file is a program written in natural language. Treat ambiguous instructions as bugs, not style issues.
 2. **Explicit over implicit**: If a step requires context not present in the file, it will fail. Every prerequisite must be stated or referenced.
 3. **Contradiction is critical**: Two instructions that conflict will cause unpredictable behavior. Phase ordering, condition coverage, and state management must be logically consistent.
 4. **Tool availability must match instructions**: If an instruction says "use Grep to search", the agent definition must include `Grep` in its tools list. Mismatch = guaranteed failure.
@@ -80,7 +80,7 @@ Analyze decision tables, routing logic, and conditional branches in the changed 
 ### Step 8: Cross-File Impact Check
 
 Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
-- If a skill/command was renamed or its output pattern changed, `Grep` for all callers
+- If a skill/command/agent was renamed or its output pattern changed, `Grep` for all callers
 - If a phase number was reordered, verify all internal and external references
 - Check that referenced files (templates, hooks, scripts) exist via `Glob`
 

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-engineer-reviewer
-description: Reviews Claude Code skill and command definitions for prompt quality
+description: Reviews Claude Code skill, command, and agent definitions for prompt quality
 model: opus
 tools:
   - Read
@@ -10,7 +10,7 @@ tools:
 
 # Prompt Engineer Reviewer
 
-You are a prompt engineering specialist who evaluates Claude Code skill and command definitions as executable specifications, not documentation. Every instruction you review will be interpreted literally by an LLM — ambiguity, contradiction, and missing context directly cause execution failures. You think like the LLM that will execute these prompts.
+You are a prompt engineering specialist who evaluates Claude Code skill, command, and agent definitions as executable specifications, not documentation. Every instruction you review will be interpreted literally by an LLM — ambiguity, contradiction, and missing context directly cause execution failures. You think like the LLM that will execute these prompts.
 
 ## Core Principles
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -677,7 +677,7 @@ Execute parallel reviews using sub-agents (defined in the `agents/` directory) c
 | Frontend Expert | `frontend-reviewer.md` | UI components, accessibility |
 | Test Expert | `test-reviewer.md` | Test quality, coverage |
 | Dependencies Expert | `dependencies-reviewer.md` | Package management, vulnerabilities |
-| Prompt Engineer | `prompt-engineer-reviewer.md` | Skill/command definition quality |
+| Prompt Engineer | `prompt-engineer-reviewer.md` | Skill/command/agent definition quality |
 | Technical Writer | `tech-writer-reviewer.md` | Document clarity, accuracy |
 | Error Handling Expert | `error-handling-reviewer.md` | Silent failures, error propagation, catch quality |
 | Type Design Expert | `type-design-reviewer.md` | Type encapsulation, invariant expression, enforcement |

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -378,7 +378,7 @@ Match changed files against the pattern table in SKILL.md.
 Match changed files against the Available Reviewers table in `skills/reviewers/SKILL.md` (source of truth for file patterns). Each skill file's Activation section defines detailed patterns.
 
 **Pattern priority rules:**
-1. `commands/**/*.md`, `skills/**/*.md` -> Prompt Engineer (highest priority)
+1. `commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md` -> Prompt Engineer (highest priority)
 2. Other `**/*.md` -> Technical Writer
 3. If matching multiple patterns, include all matching reviewers as candidates
 
@@ -406,6 +406,12 @@ Analyze the diff content to determine if additional expertise is needed:
 **Type design keyword detection:**
 - `interface`, `type`, `enum`, `class`, `struct`, `readonly`, `generic`
 - On detection: Add Type Design Expert
+
+**Code block detection in `.md` files:**
+- When changed files include `.md` files matching Prompt Engineer patterns (`commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md`), scan the diff for fenced code blocks (` ```bash `, ` ```sh `, ` ```yaml `, ` ```python `, ` ```json `, ` ```javascript `, ` ```typescript `, or untyped ` ``` `)
+- On detection: Add Code Quality reviewer as **co-reviewer** alongside Prompt Engineer
+- **Scope**: Only diff content is scanned (not the entire file). If the diff contains at least one fenced code block opening marker, the condition is met
+- **Note**: This does not affect `.md` files outside Prompt Engineer patterns (e.g., `docs/**/*.md`). Pure documentation `.md` changes without code blocks do not trigger this rule
 
 ### 2.4 Create Reviewer Candidate List
 

--- a/plugins/rite/skills/reviewers/SKILL.md
+++ b/plugins/rite/skills/reviewers/SKILL.md
@@ -145,7 +145,7 @@ Mapping of reviewer identifiers (`reviewer_type`) to display names. Update this 
 | error-handling | エラーハンドリング専門家 | `error-handling.md` |
 | type-design | 型設計専門家 | `type-design.md` |
 
-**Note**: This table is the source of truth. `commands/pr/review.md` also references this table. The `code-quality` reviewer is used exclusively as a fallback when no other reviewers match (see "No Reviewers Match" section below and `review.md` Phase 3.2).
+**Note**: This table is the source of truth. `commands/pr/review.md` also references this table. The `code-quality` reviewer is used as a fallback when no other reviewers match (see "No Reviewers Match" section below and `review.md` Phase 3.2), and as a co-reviewer for Prompt Engineer files containing fenced code blocks (see "Code Quality co-reviewer rule" above).
 
 ## Reviewer Selection Algorithm
 

--- a/plugins/rite/skills/reviewers/SKILL.md
+++ b/plugins/rite/skills/reviewers/SKILL.md
@@ -38,7 +38,7 @@ The table below shows primary file patterns. Each skill file's Activation sectio
 | Database Expert | `database.md` | `**/db/**`, `**/models/**`, `**/migrations/**`, `**/*.sql`, `prisma/**`, `drizzle/**` |
 | Dependencies Expert | `dependencies.md` | `package.json`, `*lock*`, `requirements.txt`, `Pipfile`, `go.mod`, `Cargo.toml` |
 | Prompt Engineer | `prompt-engineer.md` | `commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md` |
-| Technical Writer | `tech-writer.md` | `**/*.md` (excluding commands/skills), `docs/**`, `README*` |
+| Technical Writer | `tech-writer.md` | `**/*.md` (excluding commands/skills/agents), `docs/**`, `README*` |
 | Error Handling Expert | `error-handling.md` | Files containing `try`, `catch`, `throw`, `Error`, `reject`, `fallback` keywords (JS/TS); `set -e`, `pipefail`, `trap`, `|| true`, `|| :`, `2>/dev/null` keywords (Bash); `**/*.sh` |
 | Type Design Expert | `type-design.md` | `**/*.ts`, `**/*.tsx`, `**/*.rs`, `**/*.go` with `interface`, `type`, `enum`, `class`, `struct` |
 

--- a/plugins/rite/skills/reviewers/SKILL.md
+++ b/plugins/rite/skills/reviewers/SKILL.md
@@ -37,12 +37,14 @@ The table below shows primary file patterns. Each skill file's Activation sectio
 | Frontend Expert | `frontend.md` | `**/*.css`, `**/*.scss`, `**/styles/**`, `**/components/**`, `*.jsx`, `*.tsx`, `*.vue` |
 | Database Expert | `database.md` | `**/db/**`, `**/models/**`, `**/migrations/**`, `**/*.sql`, `prisma/**`, `drizzle/**` |
 | Dependencies Expert | `dependencies.md` | `package.json`, `*lock*`, `requirements.txt`, `Pipfile`, `go.mod`, `Cargo.toml` |
-| Prompt Engineer | `prompt-engineer.md` | `commands/**/*.md`, `skills/**/*.md` |
+| Prompt Engineer | `prompt-engineer.md` | `commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md` |
 | Technical Writer | `tech-writer.md` | `**/*.md` (excluding commands/skills), `docs/**`, `README*` |
 | Error Handling Expert | `error-handling.md` | Files containing `try`, `catch`, `throw`, `Error`, `reject`, `fallback` keywords (JS/TS); `set -e`, `pipefail`, `trap`, `|| true`, `|| :`, `2>/dev/null` keywords (Bash); `**/*.sh` |
 | Type Design Expert | `type-design.md` | `**/*.ts`, `**/*.tsx`, `**/*.rs`, `**/*.go` with `interface`, `type`, `enum`, `class`, `struct` |
 
 **Note**: The table above shows representative patterns only. Each skill file's Activation section is the source of truth.
+
+**Code Quality co-reviewer rule**: When `.md` files matching Prompt Engineer patterns contain fenced code blocks (` ```bash `, ` ```sh `, ` ```yaml `, etc.) in the diff, Code Quality reviewer is additionally selected as a co-reviewer alongside Prompt Engineer. This ensures embedded code snippets receive code quality review.
 
 **Emoji usage policy**: Emojis are used only for the following visibility purposes. Individual skill file Findings output must not use emojis:
 - Unified report header (`📜 rite レビュー結果`)

--- a/plugins/rite/skills/reviewers/code-quality.md
+++ b/plugins/rite/skills/reviewers/code-quality.md
@@ -2,7 +2,7 @@
 name: code-quality-reviewer
 description: |
   Reviews code for quality issues (duplication, naming, error handling, structure, unnecessary fallbacks).
-  Used as fallback when no specialized reviewers match.
+  Used as fallback when no specialized reviewers match, and as co-reviewer for Prompt Engineer .md files containing code blocks.
   Focuses on maintainability, readability, and general code health.
 ---
 

--- a/plugins/rite/skills/reviewers/code-quality.md
+++ b/plugins/rite/skills/reviewers/code-quality.md
@@ -19,7 +19,10 @@ This skill is activated as a **fallback reviewer** when:
 - Files don't fit into specific categories (API, database, etc.)
 - General code changes that need quality assessment
 
-This is a catch-all reviewer that ensures all PRs receive at least one review perspective.
+Additionally, this skill is activated as a **co-reviewer** when:
+- `.md` files matching Prompt Engineer patterns (`commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md`) contain fenced code blocks in the diff (see `review.md` Phase 2.3 "Code block detection")
+
+This is a catch-all reviewer that ensures all PRs receive at least one review perspective, and a co-reviewer for prompt engineering files that embed executable code snippets.
 
 ## Expertise Areas
 

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -10,7 +10,7 @@ description: |
 
 ## Role
 
-You are a **Prompt Engineer** reviewing Claude Code skill and command definitions for prompt quality and executability.
+You are a **Prompt Engineer** reviewing Claude Code skill, command, and agent definitions for prompt quality and executability.
 
 ## Activation
 

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -1,8 +1,8 @@
 ---
 name: prompt-engineer-reviewer
 description: |
-  Reviews Claude Code skill and command definitions for prompt quality.
-  Activated for commands/**/*.md and skills/**/*.md files.
+  Reviews Claude Code skill, command, and agent definitions for prompt quality.
+  Activated for commands/**/*.md, skills/**/*.md, and agents/**/*.md files.
   Checks instruction clarity, executability, error handling, and consistency.
 ---
 
@@ -17,8 +17,9 @@ You are a **Prompt Engineer** reviewing Claude Code skill and command definition
 This skill is activated when reviewing files matching:
 - `commands/**/*.md`
 - `skills/**/*.md`
+- `agents/**/*.md`
 
-**Note**: These files are not documentation but prompt engineering artifacts that instruct Claude Code execution.
+**Note**: These files are not documentation but prompt engineering artifacts that instruct Claude Code execution. Agent definition files contain YAML frontmatter, Detection Process, and review checklists — they are executable specifications, not documentation.
 
 ## Expertise Areas
 

--- a/plugins/rite/skills/reviewers/tech-writer.md
+++ b/plugins/rite/skills/reviewers/tech-writer.md
@@ -2,7 +2,7 @@
 name: tech-writer-reviewer
 description: |
   Reviews documentation for clarity, accuracy, and completeness.
-  Activated for .md files (excluding commands/skills), docs, and README.
+  Activated for .md files (excluding commands/skills/agents), docs, and README.
   Checks technical accuracy, broken links, examples, and writing quality.
 ---
 

--- a/plugins/rite/skills/reviewers/tech-writer.md
+++ b/plugins/rite/skills/reviewers/tech-writer.md
@@ -15,12 +15,12 @@ You are a **Technical Writer** reviewing documentation for clarity, accuracy, an
 ## Activation
 
 This skill is activated when reviewing files matching:
-- `**/*.md` (excluding `commands/**/*.md` and `skills/**/*.md`)
+- `**/*.md` (excluding `commands/**/*.md`, `skills/**/*.md`, and `agents/**/*.md`)
 - `docs/**`, `documentation/**`
 - `README*`, `CHANGELOG*`, `CONTRIBUTING*`
 - `*.rst`, `*.adoc`
 
-**Note**: `commands/**/*.md` and `skills/**/*.md` are handled by the Prompt Engineer. This exclusion is managed by the pattern priority rules in [`SKILL.md`](./SKILL.md) (Prompt Engineer takes highest priority).
+**Note**: `commands/**/*.md`, `skills/**/*.md`, and `agents/**/*.md` are handled by the Prompt Engineer. This exclusion is managed by the pattern priority rules in [`SKILL.md`](./SKILL.md) (Prompt Engineer takes highest priority).
 
 ## Expertise Areas
 


### PR DESCRIPTION
## 概要

`/rite:pr:review` のレビュアー選定ロジックを拡張し、プロンプトエンジニアリング仕様ファイル（`.md` ファイル内にコードブロックを含む）に対して code-quality-reviewer を共同選定する。

Closes #329

## 変更内容

- `review.md` Phase 2.2 パターンルールに `agents/**/*.md` を追加（Prompt Engineer 最優先）
- `review.md` Phase 2.3 にコードブロック検出ルールを追加（`.md` 差分内のフェンスドコードブロック検出で code-quality を co-reviewer として追加）
- `SKILL.md` Available Reviewers テーブル更新 + Code Quality co-reviewer ルール説明追加
- `prompt-engineer.md` YAML description + Activation セクションに `agents/**/*.md` 追加
- `code-quality.md` Activation セクションに co-reviewer トリガー追加
- `tech-writer.md` 除外リストに `agents/**/*.md` 追加
- `prompt-engineer-reviewer.md` (agent) YAML description + 冒頭パラグラフに "agent definitions" 追加

## テスト計画

- [ ] `agents/**/*.md` のみの変更で Prompt Engineer が選定されること（AC-1）
- [ ] `.md` + コードブロック差分で code-quality が共同選定されること（AC-2）
- [ ] コードブロックなし `.md` 変更で code-quality が追加されないこと（AC-3）
- [ ] 既存の非 `.md` ファイルのレビュアー選定に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
