### PR TITLE
refactor(review): sole reviewer guard + Step 6 拡張 — 単一レビュアーの盲点を解消

### DIFF
--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -69,6 +69,22 @@ When the diff modifies a keyword list, enumeration, or option set (e.g., severit
 - Check that additions to a Detection Process are reflected in the corresponding checklist (e.g., `skills/reviewers/*.md`), and vice versa
 - Skip this step entirely when the diff does not touch any list-like structure
 
+**Sub-check 6a: Inverse reference consistency**
+When the diff adds or modifies file patterns (e.g., `commands/**/*.md`) or inclusion rules in a table row:
+- `Grep` for exclusion lists, `**Note**` sections, or other rows in the same table that explicitly exclude files matching the added pattern
+- `Read` each location to verify the exclusion is still valid
+- Flag when a newly added pattern overlaps with an existing exclusion in another row (e.g., adding `agents/**/*.md` to Prompt Engineer but a different reviewer's exclusion list still says "excluding agents/")
+
+**Sub-check 6b: Table column prose consistency**
+When the diff modifies a table row's descriptive text (e.g., "Change Description" or "Reason" column):
+- `Read` other rows in the same table to verify the prose style and specificity level are consistent
+- Flag when one row uses specific file paths while others use vague descriptions, or when technical terminology differs across rows describing the same concept
+
+**Sub-check 6c: Frontmatter-body scope sync**
+When the diff modifies a YAML frontmatter `description` field:
+- `Read` the file body sections (Activation, Scope, Overview) that describe the same scope
+- Flag when the frontmatter `description` claims a scope that the body does not support (e.g., frontmatter says "Reviews X and Y" but Activation section only lists patterns for X)
+
 ### Step 7: Design and Logic Review
 
 Analyze decision tables, routing logic, and conditional branches in the changed file:
@@ -95,6 +111,8 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 - **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
 - **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
+- **88**: (hypothetical) A table row adds `agents/**/*.md` to Prompt Engineer's file patterns, but another reviewer's Note section says "excluding agents/" — confirmed by `Grep` for the pattern + `Read` of the exclusion Note
+- **85**: (hypothetical) A YAML frontmatter `description` says "Reviews skill and command definitions" but the Activation section lists patterns for `commands/**/*.md`, `skills/**/*.md`, AND `agents/**/*.md` — scope mismatch confirmed by `Read`
 - **70**: An instruction "seems unclear" but could be interpreted correctly by a capable LLM — move to recommendations
 - **50**: Style preference for instruction wording — do NOT report
 

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -62,7 +62,7 @@ For each technical claim in the changed file (bash behavior, tool semantics, API
 
 ### Step 6: Enumeration and Keyword List Consistency
 
-When the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, phase names, status values, tool names), or phase/step numbering:
+When the diff modifies a keyword list, enumeration, or option set (e.g., severity levels, phase names, status values, tool names, file patterns), or phase/step numbering:
 - `Grep` for all other locations where the same list appears (other files, comments, tables, examples)
 - `Read` each location to compare the full list content
 - Flag any copy that is missing items, has extra items, or uses a different ordering than the modified version
@@ -110,9 +110,9 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 - **88**: (hypothetical) A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
 - **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
-- **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
 - **88**: (hypothetical) A table row adds `agents/**/*.md` to Prompt Engineer's file patterns, but another reviewer's Note section says "excluding agents/" — confirmed by `Grep` for the pattern + `Read` of the exclusion Note
 - **85**: (hypothetical) A YAML frontmatter `description` says "Reviews skill and command definitions" but the Activation section lists patterns for `commands/**/*.md`, `skills/**/*.md`, AND `agents/**/*.md` — scope mismatch confirmed by `Read`
+- **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
 - **70**: An instruction "seems unclear" but could be interpreted correctly by a capable LLM — move to recommendations
 - **50**: Style preference for instruction wording — do NOT report
 

--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -108,9 +108,9 @@ Follow the Cross-File Impact Check procedure defined in `_reviewer-base.md`:
 - **90**: An instruction references Phase 3.2 but the file only has Phases 1-3.1 — confirmed by `Read`
 - **90**: (hypothetical) A keyword list in one file has 5 items but the same list in another file has only 4 — confirmed by `Grep` + `Read`
 - **88**: (hypothetical) A routing table handles `[fix:pushed]` and `[fix:error]` but has no row for `[fix:replied-only]` — confirmed by `Read` of the table and the producing skill's output patterns
+- **88**: (hypothetical) A table row adds `agents/**/*.md` to Prompt Engineer's file patterns, but another reviewer's Note section says "excluding agents/" — confirmed by `Grep` for the pattern + `Read` of the exclusion Note
 - **85**: A placeholder `{issue_number}` has no documented source in the placeholder table
 - **85**: A condition table claims 3 severity levels (CRITICAL/HIGH/MEDIUM) but the referenced `severity-levels.md` defines 4 (CRITICAL/HIGH/MEDIUM/LOW) — confirmed by `Read`
-- **88**: (hypothetical) A table row adds `agents/**/*.md` to Prompt Engineer's file patterns, but another reviewer's Note section says "excluding agents/" — confirmed by `Grep` for the pattern + `Read` of the exclusion Note
 - **85**: (hypothetical) A YAML frontmatter `description` says "Reviews skill and command definitions" but the Activation section lists patterns for `commands/**/*.md`, `skills/**/*.md`, AND `agents/**/*.md` — scope mismatch confirmed by `Read`
 - **82**: An instruction says "use `grep -P`" but the project convention (confirmed by `Grep` across `commands/`) is to use `grep -E` to avoid PCRE dependency
 - **70**: An instruction "seems unclear" but could be interpreted correctly by a capable LLM — move to recommendations

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -413,6 +413,13 @@ Analyze the diff content to determine if additional expertise is needed:
 - **Scope**: Only diff content is scanned (not the entire file). If the diff contains at least one fenced code block opening marker, the condition is met
 - **Note**: This does not affect `.md` files outside Prompt Engineer patterns (e.g., `docs/**/*.md`). Pure documentation `.md` changes without code blocks do not trigger this rule
 
+**Sole reviewer guard:**
+- After all keyword detection and code block detection rules above have been applied, if exactly **1 reviewer** has been selected (any reviewer type, not limited to Prompt Engineer), automatically add Code Quality reviewer as a **co-reviewer**
+- On detection: Add Code Quality reviewer as **co-reviewer** alongside the sole reviewer
+- **Condition**: The selected reviewer count is exactly 1 after all Phase 2.3 detection rules have been applied. If 2 or more reviewers are already selected, this guard does NOT activate
+- **Rationale**: A single reviewer has blind spots that cross-file consistency checks can miss. Adding a second perspective (Code Quality as baseline reviewer) mitigates this risk, following the same pattern as `pr-review-toolkit`'s always-on `code-reviewer`
+- **Note**: If Code Quality is already the sole reviewer (selected as fallback in Phase 3.2), this guard does not add a duplicate. The guard only applies when a non-Code-Quality reviewer is the sole selection
+
 ### 2.4 Create Reviewer Candidate List
 
 **`reviewer_type` format:**

--- a/plugins/rite/skills/reviewers/SKILL.md
+++ b/plugins/rite/skills/reviewers/SKILL.md
@@ -44,7 +44,10 @@ The table below shows primary file patterns. Each skill file's Activation sectio
 
 **Note**: The table above shows representative patterns only. Each skill file's Activation section is the source of truth.
 
-**Code Quality co-reviewer rule**: When `.md` files matching Prompt Engineer patterns contain fenced code blocks (` ```bash `, ` ```sh `, ` ```yaml `, etc.) in the diff, Code Quality reviewer is additionally selected as a co-reviewer alongside Prompt Engineer. This ensures embedded code snippets receive code quality review.
+**Code Quality co-reviewer rule**: Code Quality reviewer is additionally selected as a co-reviewer in the following cases:
+
+1. **Code block co-reviewer**: When `.md` files matching Prompt Engineer patterns contain fenced code blocks (` ```bash `, ` ```sh `, ` ```yaml `, etc.) in the diff, Code Quality is added alongside Prompt Engineer. This ensures embedded code snippets receive code quality review.
+2. **Sole reviewer guard**: When exactly 1 reviewer has been selected after all Phase 2.3 detection rules, Code Quality is automatically added as a co-reviewer. This prevents single-reviewer blind spots (cross-file inconsistency, missing updates). Does not activate when 2+ reviewers are already selected, or when Code Quality is already the sole reviewer (fallback).
 
 **Emoji usage policy**: Emojis are used only for the following visibility purposes. Individual skill file Findings output must not use emojis:
 - Unified report header (`📜 rite レビュー結果`)
@@ -145,7 +148,7 @@ Mapping of reviewer identifiers (`reviewer_type`) to display names. Update this 
 | error-handling | エラーハンドリング専門家 | `error-handling.md` |
 | type-design | 型設計専門家 | `type-design.md` |
 
-**Note**: This table is the source of truth. `commands/pr/review.md` also references this table. The `code-quality` reviewer is used as a fallback when no other reviewers match (see "No Reviewers Match" section below and `review.md` Phase 3.2), and as a co-reviewer for Prompt Engineer files containing fenced code blocks (see "Code Quality co-reviewer rule" above).
+**Note**: This table is the source of truth. `commands/pr/review.md` also references this table. The `code-quality` reviewer is used as a fallback when no other reviewers match (see "No Reviewers Match" section below and `review.md` Phase 3.2), as a co-reviewer for Prompt Engineer files containing fenced code blocks, and as a sole reviewer guard co-reviewer (see "Code Quality co-reviewer rule" above).
 
 ## Reviewer Selection Algorithm
 

--- a/plugins/rite/skills/reviewers/code-quality.md
+++ b/plugins/rite/skills/reviewers/code-quality.md
@@ -2,7 +2,8 @@
 name: code-quality-reviewer
 description: |
   Reviews code for quality issues (duplication, naming, error handling, structure, unnecessary fallbacks).
-  Used as fallback when no specialized reviewers match, and as co-reviewer for Prompt Engineer .md files containing code blocks.
+  Used as fallback when no specialized reviewers match, as co-reviewer for Prompt Engineer .md files
+  containing code blocks, and as sole reviewer guard co-reviewer when exactly 1 reviewer is selected.
   Focuses on maintainability, readability, and general code health.
 ---
 

--- a/plugins/rite/skills/reviewers/code-quality.md
+++ b/plugins/rite/skills/reviewers/code-quality.md
@@ -21,8 +21,9 @@ This skill is activated as a **fallback reviewer** when:
 
 Additionally, this skill is activated as a **co-reviewer** when:
 - `.md` files matching Prompt Engineer patterns (`commands/**/*.md`, `skills/**/*.md`, `agents/**/*.md`) contain fenced code blocks in the diff (see `review.md` Phase 2.3 "Code block detection")
+- Exactly 1 reviewer has been selected after all Phase 2.3 detection rules — **sole reviewer guard** (see `review.md` Phase 2.3 "Sole reviewer guard"). Does not activate when Code Quality is already the sole reviewer (fallback case)
 
-This is a catch-all reviewer that ensures all PRs receive at least one review perspective, and a co-reviewer for prompt engineering files that embed executable code snippets.
+This is a catch-all reviewer that ensures all PRs receive at least one review perspective, and a co-reviewer that prevents single-reviewer blind spots.
 
 ## Expertise Areas
 

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -39,7 +39,9 @@ This skill is activated when reviewing files matching:
 - [ ] **Circular Logic**: Instructions that reference themselves or create loops
 - [ ] **Conflicting Instructions**: Contradictory steps in the same flow
 - [ ] **Inaccurate Technical Claims**: Assertions about tool behavior, shell semantics, or API contracts that contradict actual behavior (e.g., claiming `local var=$(cmd)` is safe under `set -e`)
-- [ ] **Enumeration / Keyword List Inconsistency**: A list (severity levels, phase names, status values, tool names) modified in one file but not updated in other files that duplicate or reference the same list
+- [ ] **Enumeration / Keyword List Inconsistency**: A list (severity levels, phase names, status values, tool names, file patterns) modified in one file but not updated in other files that duplicate or reference the same list. Includes:
+  - Inverse reference inconsistency: a newly added file pattern overlaps with an exclusion list in another table row or Note section
+  - Frontmatter-body scope mismatch: YAML `description` claims a scope not supported by the Activation/Scope sections in the body
 
 ### Important (Should Fix)
 

--- a/plugins/rite/skills/reviewers/prompt-engineer.md
+++ b/plugins/rite/skills/reviewers/prompt-engineer.md
@@ -41,6 +41,7 @@ This skill is activated when reviewing files matching:
 - [ ] **Inaccurate Technical Claims**: Assertions about tool behavior, shell semantics, or API contracts that contradict actual behavior (e.g., claiming `local var=$(cmd)` is safe under `set -e`)
 - [ ] **Enumeration / Keyword List Inconsistency**: A list (severity levels, phase names, status values, tool names, file patterns) modified in one file but not updated in other files that duplicate or reference the same list. Includes:
   - Inverse reference inconsistency: a newly added file pattern overlaps with an exclusion list in another table row or Note section
+  - Table column prose inconsistency: table rows within the same table use inconsistent prose style or specificity level
   - Frontmatter-body scope mismatch: YAML `description` claims a scope not supported by the Activation/Scope sections in the body
 
 ### Important (Should Fix)


### PR DESCRIPTION
## 概要

- レビュアーが1人のみ選定された場合に Code Quality を co-reviewer として自動追加する sole reviewer guard を追加
- Prompt Engineer Step 6 に inverse reference check / table column prose consistency / frontmatter-body sync の3つの sub-check を追加
- 関連するスキル定義・エージェント定義を一貫して更新

## 関連 Issue

Closes #332

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/pr/review.md` | Phase 2.3 末尾に Sole reviewer guard セクション追加 |
| `plugins/rite/skills/reviewers/SKILL.md` | Code Quality co-reviewer rule を番号付きリスト（3条件）に拡張 |
| `plugins/rite/agents/prompt-engineer-reviewer.md` | Step 6 に 3 sub-check 追加 + Confidence Calibration 2 例追加 |
| `plugins/rite/skills/reviewers/prompt-engineer.md` | Critical checklist の Enumeration 項目を拡張 |
| `plugins/rite/skills/reviewers/code-quality.md` | Activation の co-reviewer 条件に sole reviewer guard 追加 |

## チェックリスト

- [x] 既存の Phase 2.3 キーワード検出ルール未変更
- [x] code-quality の fallback 動作未変更
- [x] 非 `.md` ファイルのレビュアー選定に影響なし
- [x] Definition of Done 全項目完了

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
