### PR TITLE
refactor(review): Stale Cross-References の Detection Step カバレッジを追加

### DIFF
--- a/plugins/rite/agents/prompt-engineer-reviewer.md
+++ b/plugins/rite/agents/prompt-engineer-reviewer.md
@@ -92,6 +92,7 @@ Analyze decision tables, routing logic, and conditional branches in the changed 
 - For each conditional branch: check that all outcomes have explicit handling (no implicit fall-through)
 - Cross-reference Detection Process steps with the corresponding checklist items: every Detection step should have at least one checklist item that surfaces its findings, and every checklist item should be discoverable by at least one Detection step
 - Verify that priority/severity ordering is consistent across examples, tables, and prose
+- When the diff renumbers steps or phases, scan prose text within the same file for stale intra-file references (e.g., "see Step 3", "Phase 2.1 で定義された", "Step 5 above"). `Read` the full file and check that every prose reference to a step/phase number matches an actual heading. This complements Step 8's cross-file check by covering references that stay within the same file
 
 ### Step 8: Cross-File Impact Check
 


### PR DESCRIPTION
## 概要

prompt-engineer-reviewer の Detection Process Step 7 に、ファイル内 prose 参照（"see Step 3", "Phase 2.1 で定義された" 等）のリナンバー検出指示を追加。

チェックリスト項目 "Stale Cross-References" に対応する Detection Step が不在であった Detection-Checklist Misalignment を解消する。

Closes #328

## 変更内容

- `plugins/rite/agents/prompt-engineer-reviewer.md`: Step 7 (Design and Logic Review) に intra-file prose 参照の陳腐化検出 bullet を追加
  - Step 8 の cross-file チェックを補完し、同一ファイル内の参照をカバー

## テスト計画

- [ ] Step 7 の新しい bullet が正しいフォーマットで記述されていることを確認
- [ ] チェックリスト項目 "Stale Cross-References" との対応が明確であることを確認
- [ ] Step 8 との責務分離（cross-file vs intra-file）が適切であることを確認

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
