### PR TITLE
fix(hooks): フックスクリプトの jq CWD 抽出に || CWD="" フォールバックを追加

### DIFF
--- a/plugins/rite/hooks/notification.sh
+++ b/plugins/rite/hooks/notification.sh
@@ -12,7 +12,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 # realpath normalization is unnecessary and would add a portability concern.
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
     exit 0
 fi

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -15,7 +15,7 @@ source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
-SOURCE=$(jq -r '.source // "auto"' <<< "$INPUT")
+SOURCE=$(jq -r '.source // "auto"' <<< "$INPUT" 2>/dev/null) || SOURCE="auto"
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -14,7 +14,7 @@ source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT")
+CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
 SOURCE=$(jq -r '.source // "auto"' <<< "$INPUT")
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -20,7 +20,7 @@ export RITE_WM_HOOK_ACTIVE=1
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 [ -n "$CWD" ] && [ -d "$CWD" ] || exit 0
 
 # Resolve state root (git root or CWD)

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -17,7 +17,7 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # missing the state file won't exist and the hook exits at the -f check below.
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT")
+CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -18,7 +18,7 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # reaching -f; the comment describes the logical invariant, not the exit path.)
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -19,7 +19,7 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT")
+CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
 # Extract session_id from hook JSON for ownership checks and diagnostic logging (#173)
 SESSION_ID=$(extract_session_id "$INPUT" 2>/dev/null) || SESSION_ID=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then


### PR DESCRIPTION
## 概要

フックスクリプトの jq CWD 抽出行に `|| CWD=""` フォールバックと `2>/dev/null` を追加し、`set -euo pipefail` 環境で malformed JSON 入力時の silent abort を防止する。

PR #334 で `context-pressure.sh` に適用された修正パターンを残り6ファイルに波及させる。

Closes #335

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/post-tool-wm-sync.sh` | `\|\| CWD=""` を追加 |
| `plugins/rite/hooks/notification.sh` | `2>/dev/null` と `\|\| CWD=""` を追加 |
| `plugins/rite/hooks/session-end.sh` | `2>/dev/null` と `\|\| CWD=""` を追加 |
| `plugins/rite/hooks/stop-guard.sh` | `2>/dev/null` と `\|\| CWD=""` を追加 |
| `plugins/rite/hooks/pre-compact.sh` | `2>/dev/null` と `\|\| CWD=""` を追加 |
| `plugins/rite/hooks/post-compact.sh` | `2>/dev/null` と `\|\| CWD=""` を追加 |

## 参考パターン

修正後の統一パターン（`context-pressure.sh:24` と同一）:
```bash
CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
```

## テスト計画

- [ ] 各フックスクリプトが正常な JSON 入力で正しく CWD を抽出できることを確認
- [ ] malformed JSON 入力時にスクリプトが中断せず空文字にフォールバックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
