### PR TITLE
refactor(hooks): jq 呼び出し構文を echo | jq に統一

### DIFF
--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -14,8 +14,8 @@ source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
-SOURCE=$(jq -r '.source // "auto"' <<< "$INPUT" 2>/dev/null) || SOURCE="auto"
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+SOURCE=$(echo "$INPUT" | jq -r '.source // "auto"' 2>/dev/null) || SOURCE="auto"
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -17,7 +17,7 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # missing the state file won't exist and the hook exits at the -f check below.
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
   exit 0
 fi

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -19,7 +19,7 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 
-CWD=$(jq -r '.cwd // empty' <<< "$INPUT" 2>/dev/null) || CWD=""
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 # Extract session_id from hook JSON for ownership checks and diagnostic logging (#173)
 SESSION_ID=$(extract_session_id "$INPUT" 2>/dev/null) || SESSION_ID=""
 if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then


### PR DESCRIPTION
## 概要

hooks/ 配下のフックスクリプトで混在していた jq 呼び出し構文を `echo "$INPUT" | jq` パターンに統一。

### 変更内容

- `post-compact.sh`: L17-18 の `jq <<< "$INPUT"` を `echo "$INPUT" | jq` に変更（2箇所）
- `stop-guard.sh`: L22 の `jq <<< "$INPUT"` を `echo "$INPUT" | jq` に変更（1箇所）
- `pre-compact.sh`: L20 の `jq <<< "$INPUT"` を `echo "$INPUT" | jq` に変更（1箇所）

### 背景

PR #338 のレビューで検出されたスコープ外の推奨事項。`echo | jq` が多数派パターンであり、grep/置換時の見落としリスクを低減するために統一。

## 関連 Issue

Closes #339

## テスト計画

- [ ] 各フックスクリプトが正常に動作すること（`echo | jq` パターンで CWD/SOURCE が正しく抽出される）
- [ ] hooks/ 全体で `jq.*<<<` パターンが 0 件であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
