### PR TITLE
fix(hooks): pre-tool-bash-guard.sh の jq 抽出にフォールバックを追加

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -25,12 +25,12 @@ source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 INPUT=$(cat) || INPUT=""
 
 # Only inspect Bash tool calls
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
 if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
 if [ -z "$COMMAND" ]; then
   exit 0
 fi


### PR DESCRIPTION
## 概要

`pre-tool-bash-guard.sh` の `TOOL_NAME` / `COMMAND` jq 抽出行に `|| VAR=""` フォールバックを追加。PR #338 で他のフックファイルに適用された hardening パターンを波及させる。

## 変更内容

- `plugins/rite/hooks/pre-tool-bash-guard.sh` L28, L33 の jq 抽出行にフォールバックを追加

## 関連 Issue

Closes #340

## チェックリスト

- [x] 変更が既存パターン（PR #338）と一致
- [x] 他のフックファイルと構文が統一

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
