### PR TITLE
fix(skill): rite:pr:fix Skill ロード時の bash 解釈エラーを解消 (#365)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1730,7 +1730,7 @@ tmpfile=$(mktemp) || {
 # 旧実装は `cat <<'EOF' > "$tmpfile"` 単独で exit code を check していなかった。
 # 直後の `[ ! -s "$tmpfile" ]` は size 0 のみ検出するが、disk full mid-write で
 # truncated body が書き込まれた場合 (size > 0 だが body 不完全) を検出できない。
-# `if !` で wrap し、cat 自体の exit code を check する。
+# `if ! ...` で wrap し、cat 自体の exit code を check する。
 if ! cat <<'BODY_EOF' > "$tmpfile"
 ## 概要
 
@@ -1782,7 +1782,7 @@ fi
 # しかし script が exit 1 で早期終了しつつ stdout に partial JSON を出力した場合、
 # (a) `result` は非空、(b) jq で `.issue_url` が抽出可能、(c) `.project_registration` が null
 # となり、後続の `jq '.warnings[]' 2>/dev/null` が stderr suppress により jq parse error も
-# 隠蔽し silent に「warnings 0 件」と誤認する。これを防ぐため `if !` 形式で exit code を捕捉する。
+# 隠蔽し silent に「warnings 0 件」と誤認する。これを防ぐため `if ! ...` 形式で exit code を捕捉する。
 if ! result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
   --arg title "{type}: {summary}" \
   --arg body_file "$tmpfile" \
@@ -2232,7 +2232,7 @@ gh_api_err=$(mktemp /tmp/rite-fix-gh-api-comments-err-XXXXXX) || {
 # 401/403/404/timeout/5xx で failure すると `$comment_data` が空 → `$comment_id` も空 →
 # 外側の `if [[ -n "$comment_id" ]]` が false → else 分岐を持たないため全処理が silent no-op となり、
 # Phase 8.1 が `[fix:pushed]` を出力する silent regression を起こす。
-# `if !` で exit code を捕捉し、失敗時は WM_UPDATE_FAILED を emit してから soft failure として進む
+# `if ! ...` で exit code を捕捉し、失敗時は WM_UPDATE_FAILED を emit してから soft failure として進む
 # (exit 1 はしない: 既にコミット/プッシュ済みの fix を保護するため、Phase 8.1 が
 # `[fix:pushed-wm-stale]` を出力できるよう retained flag だけ set する)。
 gh_api_failed=0
@@ -2363,7 +2363,7 @@ if [[ -n "$comment_id" ]]; then
         # M-3 修正 (本 Issue #350 検証付きレビュー M-3): sed の exit code を独立 capture
         # 旧実装は `base_branch=$(... | sed ...)` で sed 失敗を「値が空」fallback に隠蔽していた。
         # sed バイナリ異常 / pipe write error / signal 中断などの IO 系失敗を「キー値空」と区別するため、
-        # sed のみを独立変数に capture し、`if !` で exit code を判定する。
+        # sed のみを独立変数に capture し、`if ! ...` で exit code を判定する。
         # 「値が空」(sed 成功 + 抽出空) は legitimate fallback として develop に降格する。
         sed_err=$(mktemp /tmp/rite-fix-base-sed-err-XXXXXX) || {
           echo "ERROR: sed_err 一時ファイルの作成に失敗" >&2
@@ -2611,7 +2611,7 @@ with open(out_path, "w") as f:
     #
     # L-3 修正 (本 Issue #350 検証付きレビュー L-3): pipefail スコープの明文化
     # 本箇所の pipefail は **PATCH pipeline (jq | gh api PATCH) 周辺のみに限定** する設計選択である。
-    # 他の `gh api` 呼び出し (Phase 4.5.2 line 2163 の `gh api .../comments` 等) は `if !` で gh api 自体の
+    # 他の `gh api` 呼び出し (Phase 4.5.2 line 2163 の `gh api .../comments` 等) は `if ! ...` で gh api 自体の
     # exit code を捕捉済みで、`--jq` filter は gh の内部処理により exit code が伝播するため独立 pipeline
     # 化していない (gh CLI 内部で `--jq` filter 失敗を gh の exit code に正しく反映する仕様、確認済み)。
     # 将来 gh CLI の `--jq` filter exit code 伝播仕様に regression が発生した場合は、defense-in-depth で


### PR DESCRIPTION
## 概要

`rite:pr:fix` Skill ツールが `fix.md` ロード時に bash 解釈エラーで失敗していた問題を修正。

## 背景

Issue #365 で報告された通り、`/rite:issue:start` の Phase 5.4.4 で `rite:pr:fix` Skill ツールを起動すると、以下のエラーで Skill ロードが失敗していた:

```
Shell command failed for pattern "!` で gh api 自体の
    # exit code を捕捉済みで、`": [stderr]
/bin/bash: 行 4: で: コマンドが見つかりません
```

PR #363 の cycle 1 では Edit ツール手動 fallback により対応していたが、e2e フローが完全にブロックされる根本問題のため恒久対応が必要だった。

## 根本原因

`fix.md` 内の **5箇所** で `` `if !` `` パターン (backtick + bang + backtick の隣接) を使用していた。Skill loader 内で何らかの shell 処理 (history expansion 含む可能性) が発火し、`!` が直後の `` ` `` と組み合わさって prose を bash コマンドとして誤実行していた。

具体例 (line 2614):
```
# 他の `gh api` 呼び出し (...) は `if !` で gh api 自体の
# exit code を捕捉済みで、`--jq` filter は ...
```

パーサが `` !` `` から次の `` ` `` (`--jq` の opening backtick) までの prose を抽出 → bash 実行 → "で" がコマンドとして解釈不能 → エラー。

## 修正内容

5 箇所すべての `` `if !` `` を `` `if ! ...` `` に置換し、`!` と closing backtick の隣接を解消する最小修正:

| Line | Before | After |
|------|--------|-------|
| 1733 | `` `if !` で wrap し`` | `` `if ! ...` で wrap し`` |
| 1785 | `` `if !` 形式で`` | `` `if ! ...` 形式で`` |
| 2235 | `` `if !` で exit code を捕捉し`` | `` `if ! ...` で exit code を捕捉し`` |
| 2366 | `` `if !` で exit code を判定する`` | `` `if ! ...` で exit code を判定する`` |
| 2614 | `` `if !` で gh api 自体の`` | `` `if ! ...` で gh api 自体の`` |

すべて bash code block 内コメントの prose 修正のみ。実際の bash 実装 (`if ! cat ...`, `if ! result=$(...)`, `if ! comment_data=$(...)` 等) は無変更。

## 修正方針の選択

Issue Decision Log の **方針1: fix.md 内の問題パターンを除去** を採用 (最優先)。

- 方針2 (pre-tool-bash-guard.sh 修正) は不要 — root cause は loader 側の prose 解釈であり、hook 経路ではない
- 方針3 (Claude Code upstream report) は不要 — rite plugin 内で fix 可能

## 検証

| AC | 検証内容 | 検証方法 | 結果 |
|----|---------|---------|------|
| AC-1 | Skill ロード成功 (Happy Path) | Read ツールで fix.md 全文読み込み (2970 行) | ✅ エラーなし |
| AC-2 | e2e flow 内での起動 (Critical Path) | 本 PR 自身の review-fix loop で `rite:pr:fix` 起動を実測 | ⏳ 本 PR の Phase 5.4 で実測予定 |
| AC-3 | 機能非破壊 (Regression Test) | Phase 1-8 reason 表 DoD 検証スクリプト | ✅ 空出力 (完全一致) |
| AC-4 | 同パターン他ファイル調査 | `grep '[^\`]!\`'` を `commands/**/*.md` と `skills/**/*.md` で実行 | ✅ ヒット 0 件 |

### DoD 検証スクリプト実行結果

```bash
$ comm -3 \
>   <(grep -oE 'WM_UPDATE_FAILED=1; reason=[a-z_][a-z_0-9]*' plugins/rite/commands/pr/fix.md \
>     | sed 's/.*reason=//' | sort -u) \
>   <(awk '/^\*\*`reason` フィールド/{...}' plugins/rite/commands/pr/fix.md \
>     | sed 's/\$.*//' | sort -u)
$ echo "exit=$?"
exit=0
```

→ 空出力で完全一致、Phase 8.1 reason 表整合性維持。

## 関連 Issue

Closes #365

## Test plan

- [x] fix.md 内 `` `if !` `` パターン: 0 件 (Grep 確認)
- [x] commands/skills 配下の同種パターン: 0 件 (Grep 確認)
- [x] Phase 8.1 reason 表 DoD 検証スクリプト pass
- [x] git diff: fix.md のみ、5 行のみ変更
- [ ] 本 PR の review-fix loop で `rite:pr:fix` Skill 起動が成功すること (本 PR 自身が AC-2 の実証)
