### PR TITLE
fix(close): 子 Issue クローズ時に親 Issue の Sub-Issues/実装フェーズを自動更新

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -465,7 +465,7 @@ bash {plugin_root}/hooks/issue-body-safe-update.sh apply \
 
 If the script exits with 0, the update succeeded (or was skipped by `--diff-check` if no changes were needed). If non-zero, display a warning and proceed to Phase 5.
 
-**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The `--parent` flag ensures errors are treated as warnings, not fatal errors. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
+**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The `--parent` flag is passed for future differentiation but currently all errors are treated as warnings by the script. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
 
 Proceed to Phase 5.
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -401,7 +401,7 @@ When a child Issue is closed, automatically update the parent Issue's body to re
 
 Extract the parent Issue number from the closing Issue's body. The `## 親 Issue` section is added by `/rite:issue:create-decompose` when creating child Issues.
 
-**Detection pattern**: Search the Issue body (retrieved in Phase 1.1) for the `## 親 Issue` section header, then extract the Issue number from the line below it:
+**Detection pattern**: Search the Issue body for the `## 親 Issue` section header, then extract the Issue number from the line below it:
 
 ```
 ## 親 Issue
@@ -409,9 +409,10 @@ Extract the parent Issue number from the closing Issue's body. The `## 親 Issue
 #{parent_number} - {parent_title}
 ```
 
-**Extraction**:
+**Extraction**: Retrieve the Issue body and extract the parent Issue number in a single bash block:
 
 ```bash
+issue_body=$(gh issue view {issue_number} --json body --jq '.body')
 parent_number=$(echo "$issue_body" | grep -A1 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 echo "parent_number=${parent_number:-none}"
 ```
@@ -424,102 +425,87 @@ echo "parent_number=${parent_number:-none}"
 
 Skip the rest of Phase 4.5 and proceed to Phase 5. This is normal behavior (AC-3), not an error.
 
-### 4.5.2 Retrieve Parent Issue Body
+### 4.5.2 Update Parent Issue Body
+
+Update the parent Issue's Sub-Issues checkbox and 実装フェーズ status using the 3-step safe update pattern via `issue-body-safe-update.sh`.
+
+> **Reference**: Uses the same safe update pattern as `implement.md` and `archive-procedures.md` — fetch/edit/apply with body shrinkage detection and diff-check idempotency.
+
+**Step 1: Fetch parent Issue body**
 
 ```bash
-parent_body=$(gh issue view {parent_number} --json body --jq '.body')
-if [ -z "$parent_body" ]; then
+fetch_result=$(bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {parent_number} --parent)
+if [ $? -ne 0 ]; then
   echo "警告: 親 Issue #{parent_number} の本文を取得できませんでした" >&2
+  # Non-blocking: proceed to Phase 5 (AC-4)
+else
+  eval "$fetch_result"
+  echo "tmpfile_read=$tmpfile_read"
+  echo "tmpfile_write=$tmpfile_write"
+  echo "original_length=$original_length"
 fi
-echo "parent_body_length=${#parent_body}"
 ```
 
 **On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4).
 
-### 4.5.3 Update Sub-Issues Checkbox
+**Step 2: Apply updates via Python** (Sub-Issues checkbox + 実装フェーズ status in a single pass)
 
-Update the checkbox for the closing Issue in the parent Issue's `## Sub-Issues` section.
-
-**Pattern**: `- [ ] #{issue_number}` → `- [x] #{issue_number}` (only the matching Issue number line)
-
-Use Python for safe replacement (avoid `sed` special character issues per gh-cli-patterns.md):
+Use the Read tool to read `$tmpfile_read` (the path from Step 1), then apply updates via Python and write to `$tmpfile_write`:
 
 ```bash
-tmpfile_parent=$(mktemp)
-trap 'rm -f "$tmpfile_parent"' EXIT
-
-gh issue view {parent_number} --json body --jq '.body' > "$tmpfile_parent"
-
 python3 -c "
-import re, sys
+import re
 
-with open('$tmpfile_parent', 'r') as f:
+tmpfile_read = '{tmpfile_read}'
+tmpfile_write = '{tmpfile_write}'
+issue_number = '{issue_number}'
+
+with open(tmpfile_read, 'r') as f:
     body = f.read()
 
-# Only replace the specific Issue number's checkbox
-# Matches: - [ ] #{issue_number} (followed by space, dash, or end of line)
+# 1. Update Sub-Issues checkbox: - [ ] #{issue_number} -> - [x] #{issue_number}
 body = re.sub(
-    r'^(- \[) (\] #' + str({issue_number}) + r'(?:\s|$))',
+    r'^(- \[) (\] #' + issue_number + r'(?:\s|$))',
     r'\g<1>x\g<2>',
     body,
     flags=re.MULTILINE
 )
 
-with open('$tmpfile_parent', 'w') as f:
-    f.write(body)
-"
-```
-
-### 4.5.4 Update Implementation Phase Status
-
-Update the status of the row corresponding to the closing Issue in the parent Issue's `## 実装フェーズ` section.
-
-**Pattern**: In the 実装フェーズ table, find the row whose `内容` column contains `#{issue_number}` or `Sub-Issue {n}` referencing this Issue, and replace `[ ] 未着手` with `[x] 完了` in that row.
-
-```bash
-python3 -c "
-import re, sys
-
-with open('$tmpfile_parent', 'r') as f:
-    body = f.read()
-
-# Find rows in the 実装フェーズ table that reference this Issue number
-# The table format is: | フェーズ | 内容 | 状態 |
-# Match lines containing #{issue_number} and replace [ ] 未着手 with [x] 完了
+# 2. Update 実装フェーズ table: find rows referencing #{issue_number} and replace status
 lines = body.split('\n')
 updated_lines = []
 for line in lines:
-    if '#${issue_number}' in line or '#{issue_number}' in line:
+    if '#' + issue_number in line:
         line = line.replace('[ ] 未着手', '[x] 完了')
     updated_lines.append(line)
-
 body = '\n'.join(updated_lines)
 
-with open('$tmpfile_parent', 'w') as f:
+with open(tmpfile_write, 'w') as f:
     f.write(body)
 "
 ```
 
-**Note**: Only rows containing a reference to `#{issue_number}` are modified. Other rows and sections remain untouched (R7).
+**Note**: Only lines containing `#{issue_number}` are modified. Other sections remain untouched (R7). The `import sys` is omitted as it is not used.
 
-### 4.5.5 Apply Parent Issue Update
-
-Apply the updated body to the parent Issue:
+**Step 3: Apply the update**
 
 ```bash
-if [ ! -s "$tmpfile_parent" ]; then
-  echo "警告: 更新後の親 Issue 本文が空です。更新をスキップします。" >&2
+bash {plugin_root}/hooks/issue-body-safe-update.sh apply \
+  --issue {parent_number} \
+  --tmpfile-read "$tmpfile_read" \
+  --tmpfile-write "$tmpfile_write" \
+  --original-length "$original_length" \
+  --parent --diff-check
+
+apply_exit=$?
+if [ "$apply_exit" -eq 0 ]; then
+  echo "親 Issue #{parent_number} の本文を更新しました（Sub-Issues / 実装フェーズ）"
 else
-  gh issue edit {parent_number} --body-file "$tmpfile_parent"
-  if [ $? -eq 0 ]; then
-    echo "親 Issue #{parent_number} の本文を更新しました（Sub-Issues / 実装フェーズ）"
-  else
-    echo "警告: 親 Issue #{parent_number} の本文更新に失敗しました" >&2
-  fi
+  echo "警告: 親 Issue #{parent_number} の本文更新に失敗しました" >&2
 fi
 ```
 
-**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The Issue close itself (Phase 4.1) has already succeeded at this point.
+**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The `--parent` flag ensures errors are treated as warnings, not fatal errors. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
 
 Proceed to Phase 5.
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -413,7 +413,7 @@ Extract the parent Issue number from the closing Issue's body. The `## 親 Issue
 
 ```bash
 issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-parent_number=$(echo "$issue_body" | grep -A1 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+parent_number=$(echo "$issue_body" | grep -A2 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 echo "parent_number=${parent_number:-none}"
 ```
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -433,59 +433,24 @@ Update the parent Issue's Sub-Issues checkbox and 実装フェーズ status usin
 
 **Step 1: Fetch parent Issue body**
 
-```bash
-fetch_result=$(bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {parent_number} --parent)
-if [ $? -ne 0 ]; then
-  echo "警告: 親 Issue #{parent_number} の本文を取得できませんでした" >&2
-  # Non-blocking: proceed to Phase 5 (AC-4)
-else
-  eval "$fetch_result"
-  echo "tmpfile_read=$tmpfile_read"
-  echo "tmpfile_write=$tmpfile_write"
-  echo "original_length=$original_length"
-fi
-```
-
-**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4).
-
-**Step 2: Apply updates via Python** (Sub-Issues checkbox + 実装フェーズ status in a single pass)
-
-Use the Read tool to read `$tmpfile_read` (the path from Step 1), then apply updates via Python and write to `$tmpfile_write`:
+Execute the fetch script directly. The LLM reads `tmpfile_read`, `tmpfile_write`, and `original_length` from the Bash tool output:
 
 ```bash
-python3 -c "
-import re
-
-tmpfile_read = '{tmpfile_read}'
-tmpfile_write = '{tmpfile_write}'
-issue_number = '{issue_number}'
-
-with open(tmpfile_read, 'r') as f:
-    body = f.read()
-
-# 1. Update Sub-Issues checkbox: - [ ] #{issue_number} -> - [x] #{issue_number}
-body = re.sub(
-    r'^(- \[) (\] #' + issue_number + r'(?:\s|$))',
-    r'\g<1>x\g<2>',
-    body,
-    flags=re.MULTILINE
-)
-
-# 2. Update 実装フェーズ table: find rows referencing #{issue_number} and replace status
-lines = body.split('\n')
-updated_lines = []
-for line in lines:
-    if '#' + issue_number in line:
-        line = line.replace('[ ] 未着手', '[x] 完了')
-    updated_lines.append(line)
-body = '\n'.join(updated_lines)
-
-with open(tmpfile_write, 'w') as f:
-    f.write(body)
-"
+bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {parent_number} --parent
 ```
 
-**Note**: Only lines containing `#{issue_number}` are modified. Other sections remain untouched (R7). The `import sys` is omitted as it is not used.
+If the output contains `tmpfile_read=`, `tmpfile_write=`, and `original_length=`, proceed to Step 2. If the script outputs only a WARNING or fails, display a warning and proceed to Phase 5 (non-blocking, AC-4).
+
+**Step 2: Apply updates via Read tool + Write tool** (Sub-Issues checkbox + 実装フェーズ status in a single pass)
+
+Read `$tmpfile_read` (the path from Step 1 output) using the Read tool. Then apply the following two replacements to the body text:
+
+1. **Sub-Issues checkbox**: Find the line matching `- [ ] #{issue_number}` and replace `- [ ]` with `- [x]` (only the specific Issue number line)
+2. **実装フェーズ table**: Find rows whose `内容` column contains `#{issue_number}` and replace `[ ] 未着手` with `[x] 完了` in those rows
+
+Write the updated body to `$tmpfile_write` (the path from Step 1 output) using the Write tool.
+
+**Note**: Only lines containing `#{issue_number}` are modified. Other sections remain untouched (R7).
 
 **Step 3: Apply the update**
 
@@ -496,14 +461,9 @@ bash {plugin_root}/hooks/issue-body-safe-update.sh apply \
   --tmpfile-write "$tmpfile_write" \
   --original-length "$original_length" \
   --parent --diff-check
-
-apply_exit=$?
-if [ "$apply_exit" -eq 0 ]; then
-  echo "親 Issue #{parent_number} の本文を更新しました（Sub-Issues / 実装フェーズ）"
-else
-  echo "警告: 親 Issue #{parent_number} の本文更新に失敗しました" >&2
-fi
 ```
+
+If the script exits with 0, the update succeeded (or was skipped by `--diff-check` if no changes were needed). If non-zero, display a warning and proceed to Phase 5.
 
 **On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The `--parent` flag ensures errors are treated as warnings, not fatal errors. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -389,6 +389,138 @@ Status: Done
 関連 PR: #{pr_number} (Merged)
 ```
 
+Proceed to Phase 4.5.
+
+---
+
+## Phase 4.5: Parent Issue Body Update
+
+When a child Issue is closed, automatically update the parent Issue's body to reflect the child's completion status.
+
+### 4.5.1 Detect Parent Issue
+
+Extract the parent Issue number from the closing Issue's body. The `## 親 Issue` section is added by `/rite:issue:create-decompose` when creating child Issues.
+
+**Detection pattern**: Search the Issue body (retrieved in Phase 1.1) for the `## 親 Issue` section header, then extract the Issue number from the line below it:
+
+```
+## 親 Issue
+
+#{parent_number} - {parent_title}
+```
+
+**Extraction**:
+
+```bash
+parent_number=$(echo "$issue_body" | grep -A1 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+echo "parent_number=${parent_number:-none}"
+```
+
+**When no parent Issue is found** (`parent_number` is empty):
+
+```
+親 Issue の参照が見つかりませんでした。親 Issue 更新をスキップします。
+```
+
+Skip the rest of Phase 4.5 and proceed to Phase 5. This is normal behavior (AC-3), not an error.
+
+### 4.5.2 Retrieve Parent Issue Body
+
+```bash
+parent_body=$(gh issue view {parent_number} --json body --jq '.body')
+if [ -z "$parent_body" ]; then
+  echo "警告: 親 Issue #{parent_number} の本文を取得できませんでした" >&2
+fi
+echo "parent_body_length=${#parent_body}"
+```
+
+**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4).
+
+### 4.5.3 Update Sub-Issues Checkbox
+
+Update the checkbox for the closing Issue in the parent Issue's `## Sub-Issues` section.
+
+**Pattern**: `- [ ] #{issue_number}` → `- [x] #{issue_number}` (only the matching Issue number line)
+
+Use Python for safe replacement (avoid `sed` special character issues per gh-cli-patterns.md):
+
+```bash
+tmpfile_parent=$(mktemp)
+trap 'rm -f "$tmpfile_parent"' EXIT
+
+gh issue view {parent_number} --json body --jq '.body' > "$tmpfile_parent"
+
+python3 -c "
+import re, sys
+
+with open('$tmpfile_parent', 'r') as f:
+    body = f.read()
+
+# Only replace the specific Issue number's checkbox
+# Matches: - [ ] #{issue_number} (followed by space, dash, or end of line)
+body = re.sub(
+    r'^(- \[) (\] #' + str({issue_number}) + r'(?:\s|$))',
+    r'\g<1>x\g<2>',
+    body,
+    flags=re.MULTILINE
+)
+
+with open('$tmpfile_parent', 'w') as f:
+    f.write(body)
+"
+```
+
+### 4.5.4 Update Implementation Phase Status
+
+Update the status of the row corresponding to the closing Issue in the parent Issue's `## 実装フェーズ` section.
+
+**Pattern**: In the 実装フェーズ table, find the row whose `内容` column contains `#{issue_number}` or `Sub-Issue {n}` referencing this Issue, and replace `[ ] 未着手` with `[x] 完了` in that row.
+
+```bash
+python3 -c "
+import re, sys
+
+with open('$tmpfile_parent', 'r') as f:
+    body = f.read()
+
+# Find rows in the 実装フェーズ table that reference this Issue number
+# The table format is: | フェーズ | 内容 | 状態 |
+# Match lines containing #{issue_number} and replace [ ] 未着手 with [x] 完了
+lines = body.split('\n')
+updated_lines = []
+for line in lines:
+    if '#${issue_number}' in line or '#{issue_number}' in line:
+        line = line.replace('[ ] 未着手', '[x] 完了')
+    updated_lines.append(line)
+
+body = '\n'.join(updated_lines)
+
+with open('$tmpfile_parent', 'w') as f:
+    f.write(body)
+"
+```
+
+**Note**: Only rows containing a reference to `#{issue_number}` are modified. Other rows and sections remain untouched (R7).
+
+### 4.5.5 Apply Parent Issue Update
+
+Apply the updated body to the parent Issue:
+
+```bash
+if [ ! -s "$tmpfile_parent" ]; then
+  echo "警告: 更新後の親 Issue 本文が空です。更新をスキップします。" >&2
+else
+  gh issue edit {parent_number} --body-file "$tmpfile_parent"
+  if [ $? -eq 0 ]; then
+    echo "親 Issue #{parent_number} の本文を更新しました（Sub-Issues / 実装フェーズ）"
+  else
+    echo "警告: 親 Issue #{parent_number} の本文更新に失敗しました" >&2
+  fi
+fi
+```
+
+**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The Issue close itself (Phase 4.1) has already succeeded at this point.
+
 Proceed to Phase 5.
 
 ---


### PR DESCRIPTION
## 概要

子 Issue クローズ時に、親 Issue の本文中にある `## Sub-Issues` セクションのチェックボックスと `## 実装フェーズ` セクションの状態列を自動的に更新する機能を追加。

Closes #381

## 変更内容

- `close.md` に Phase 4.5「親 Issue 本文更新」を追加（Phase 4.4 と Phase 5 の間に配置）
  - **4.5.1**: 子 Issue 本文の `## 親 Issue` セクションから親 Issue 番号を検出
  - **4.5.2**: 親 Issue の本文を取得
  - **4.5.3**: Sub-Issues セクションの `- [ ] #{number}` → `- [x] #{number}` 更新
  - **4.5.4**: 実装フェーズセクションの `[ ] 未着手` → `[x] 完了` 更新
  - **4.5.5**: `gh issue edit --body-file` で親 Issue 本文を適用（non-blocking エラーハンドリング）

## テスト計画

- [ ] 親 Issue を持つ子 Issue を `/rite:issue:close` でクローズし、Sub-Issues チェックボックスが更新されることを確認 (AC-1)
- [ ] 実装フェーズテーブルの状態が `[x] 完了` に更新されることを確認 (AC-2)
- [ ] 親 Issue 参照のない Issue をクローズしてもエラーが発生しないことを確認 (AC-3)
- [ ] 既存の close.md の Phase 1-4, Phase 5 が正常動作することを確認 (T-05 非退行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
