### PR TITLE
refactor(pr): bash trap+cleanup パターン 9 箇所を共通リファレンスに集約

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -303,46 +303,16 @@ body_file="/tmp/rite-fix-target-body-{pr_number}-{target_comment_id}.txt"
 author_file="/tmp/rite-fix-target-author-{pr_number}-{target_comment_id}.txt"
 skip_file="/tmp/rite-fix-target-author-skip-{pr_number}-{target_comment_id}.txt"
 
-# 統合 trap: jq_err は常に削除、ハンドオフ 3 ファイルは「Fast Path 完了 = handoff_committed=1」
-# 時のみ保護 (trap 内で条件分岐)。これにより:
-#   - 書き出し前/書き出し中の exit 1 → 4 ファイル全削除 (orphan 防止)
-#   - 全書き出し成功+post-condition pass 後 → handoff 3 ファイルは保護、jq_err のみ削除
-#   - Phase 1.5 で明示的に cleanup を実行 (Fast Path 完了経路の正常 cleanup 経路)
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: signal 別 exit code 130/143/129、race window 回避、rc=$? capture、${var:-} safety、関数契約)
 #
-# trap 対象シグナル: EXIT INT TERM HUP の 4 種類すべて
-# - EXIT: 正常終了 / exit 1 等の意図的終了
-# - INT: Ctrl+C 等の interrupt (非対話モードでも `kill -INT` で発火)
-# - TERM: 外部からの `kill -TERM` (Claude Code Bash tool timeout / sprint team-execute の親プロセス kill 等)
-# - HUP: 端末切断 / SIGHUP (hook timeout, セッション終了)
+# 本 site 固有: 2-state commit pattern (handoff_committed)
+# - handoff_committed=0 (初期値): 書き出し前/書き出し中の exit → ハンドオフ 3 ファイル全削除 (orphan 防止)
+# - handoff_committed=1 (全書き出し成功+post-condition pass 後): ハンドオフ 3 ファイルは保護、jq_err のみ削除
+# Phase 1.5 で明示的に cleanup を実行 (Fast Path 完了経路の正常 cleanup 経路)
 #
-# 重要 — INT/TERM/HUP を明示する理由 (review.md Phase 1.2.7 / Phase 2.2.1 の trap セットアップ説明と同根、ファイル間整合性):
-# bash の EXIT trap 自体は SIGTERM/SIGHUP/SIGINT のいずれでも発火する (実証 + GNU bash manual で確認済み)。
-# しかし INT/TERM/HUP の trap action が **明示的な exit を含まないと bash は signal を consume して
-# 次のコマンドへ制御を渡してしまう** (権威ある根拠: GNU bash manual "Signals" — trap action 後に
-# bash は signal を consume し制御は次のコマンドに渡る)。trap 内で `exit <code>` を呼ばないと
-# cleanup 後に bash block が残りの命令を不完全な状態で実行する silent failure になる。
-# したがって signal 別 trap は「EXIT trap が SIGTERM で発火しないから」ではなく
-# 「signal 別に明示的な exit code (130/143/129) を返して continuation を防ぐため」に必要。
-#
-# Signal 別 exit code (silent exit 0 防止):
-# SIGINT/SIGTERM/SIGHUP 受信時の `$?` は「最後に完了したコマンドの exit status」で、
-# signal 自体が 130/143/129 を set するとは限らない。`printf` 成功直後に SIGTERM が来ると
-# `rc=0` となり、上位の fix loop 制御が「正常終了」と誤判定する silent failure が起きる。
-# これを防ぐため signal 別 trap で明示的に exit 130/143/129 を返す。
-#
-# 重要 — EXIT trap の `rc=$?` capture (bash classic pitfall):
-# bash の EXIT trap が発火した時点で `$?` は元の exit status を保持するが、`_rite_fix_fastpath_cleanup`
-# 関数が実行されると関数最後のコマンド (`rm -f` または `[ ... ]` test) の戻り値で `$?` が**上書き**される。
-# したがって `trap '_rite_fix_fastpath_cleanup; exit $?' EXIT` は exit code が常に 0 (rm -f の戻り値) に
-# なる致命的バグを生む (本 bash block 内の全ての `exit 1` が silent に exit 0 に変換される)。
-# 必ず `rc=$?` で関数呼び出し**前**に元の exit code を変数に保存してから、cleanup → `exit $rc` する。
+# H-3: gh_api_err も cleanup 対象に含める (trap 未保護による silent orphan regression を防止)
 handoff_committed=0
-# 関数責務: cleanup 操作のみを実行し、exit code を変更しない (関数の戻り値は trap action 側で無視される)。
-# exit code の決定は呼び出し側の trap action (`exit $rc` / `exit 130` 等) が責任を持つ。
-# 関数内に `exit` / `return <非ゼロ>` を追加してはならない (silent exit 0 regression を誘発する)。
-#
-# H-3 修正: gh_api_err を cleanup 対象に追加 (旧実装は jq_err / body_file / author_file / skip_file の
-# 4 ファイルのみで、gh_api_err が trap 未保護だった)。`${var:-}` 形式で未定義時も silent no-op で安全。
 _rite_fix_fastpath_cleanup() {
   rm -f "${gh_api_err:-}" "${jq_err:-}"
   if [ "$handoff_committed" = "0" ]; then
@@ -1202,13 +1172,9 @@ When posting the reply:
 ```bash
 # PR レビューコメントへの返信（in_reply_to で元コメントを指定）
 # jq --rawfile で安全に JSON を生成し、gh api に渡す
-# trap は Phase 4.5.1/4.5.2/Fast Path と同型の signal 別 4 行パターンに統一
-# (signal 受信時に明示的 exit code 130/143/129 を返し silent INT/TERM/HUP continuation を防ぐ)
 #
-# 重要 — パス先行宣言 → trap 先行設定 → mktemp の順序 (Fast Path / Phase 4.5.1/4.5.2 と同じパターン):
-# mktemp を先に実行して trap を後追いで設定すると、mktemp 成功〜trap 設定間の race window で
-# SIGTERM/SIGINT が到達した場合に作成済み tmp ファイルが orphan として残る。
-# `${var:-}` は未定義時 silent no-op で安全 (他の cleanup 関数と同型)。
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code、${var:-} safety)
 tmpfile=""
 _rite_fix_phase24_cleanup() {
   rm -f "${tmpfile:-}"
@@ -1511,11 +1477,8 @@ When posting the report:
 ```bash
 # ✅ SAFE: --body-file for dynamic report content
 #
-# 重要 — パス先行宣言 → trap 先行設定 → mktemp の順序 (Fast Path / Phase 4.5.1/4.5.2 と同じパターン):
-# mktemp を先に実行して trap を後追いで設定すると、mktemp 成功〜trap 設定間の race window で
-# SIGTERM/SIGINT が到達した場合に作成済み tmp ファイルが orphan として残る。
-# bash の INT/TERM/HUP trap action は **明示的な exit を含まないと処理を継続する**ため、
-# signal 別 exit code (130/143/129) を必ず返す。
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code、${var:-} safety)
 tmpfile=""
 _rite_fix_phase42_cleanup() {
   rm -f "${tmpfile:-}"
@@ -1673,34 +1636,20 @@ Generate the Issue title in the following format:
 ```
 
 ```bash
-# 統合 cleanup 関数 + signal 別 trap 4 行パターン (Fast Path / py_exit2 / Phase 4.5.1 / Phase 4.5.2 と同型)。
-# トラップ semantics の詳細根拠 (signal 別 exit code 130/143/129 の必要性、bash の signal continuation
-# 挙動、関数内 `${var:-}` による未定義変数 silent no-op) は Fast Path 冒頭 (Phase 1.2) の Implementation
-# note と Fast Path bash block の `_rite_fix_fastpath_cleanup` 関数定義箇所周辺の
-# コメントブロック (signal 別 trap setup の根拠説明) を参照。
-# (行番号参照は drift しやすいため Phase 1.2 Fast Path bash block 内の `_rite_fix_fastpath_cleanup`
-#  関数定義を grep の起点とする)
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
 #
-# bash block 後段で warnings_jq_err を追加するため、cleanup 対象を関数にまとめて 1 つの trap で全変数を
-# カバーする。trap を再定義すると前段の `tmpfile` cleanup が上書きで失われる (silent orphan 経路)。
+# 本 site 固有: 2-state commit pattern (issue_created) — Fast Path の handoff_committed と同型
+# - issue_created=0 (初期値): cleanup は tmpfile を preserve (Issue 作成失敗時に debug 用本文を残す)
+# - issue_created=1 (gh issue create 成功後): cleanup は tmpfile を削除 (debug 不要)
 #
-# issue_created フラグ (Fast Path の `handoff_committed` と同型の 2-state commit pattern):
-#
-# 状態遷移:
-#   - issue_created=0 (初期値): cleanup は tmpfile を **preserve** する (Issue 作成失敗時に
-#     debug 用に Issue 本文を残すため)。stderr に preserved path を表示する。
-#   - issue_created=1 (gh issue create 成功後): cleanup は tmpfile を **削除** する (debug 不要)。
-#
-# Issue 作成に失敗した場合 (`gh issue create` の 5xx / rate limit / network error 等) には、
-# tmpfile を preserve することで、ユーザーが事後的に Issue 本文を検証して手動で再作成できる。
+# 短命変数も統合 trap で保護する (M-4): mktemp 成功〜直後の rm -f までの race window で
+# SIGINT/SIGTERM/SIGHUP 到達時の orphan を防ぐため、warnings_jq_err / project_reg_jq_err も
+# cleanup 対象に含める。bash block 後段で warnings_jq_err を追加するため、cleanup は関数にまとめて
+# 1 つの trap で全変数をカバーする (trap 再定義による前段 cleanup 上書き防止)。
 issue_created=0
 tmpfile=""
 warnings_jq_err=""
-# M-4 修正 (本 Issue #350 検証付きレビュー M-4): project_reg_jq_err も統合 trap で保護
-# 旧実装は「短命変数のため統合 trap には追加しない」と明示していたが、bash の signal 到達は
-# どんな短命変数でも可能 (mktemp 成功 〜 直後の rm -f までの間に SIGINT/SIGTERM/SIGHUP が到達すると
-# orphan として残る)。並列 fix セッション × race window で /tmp 累積汚染が起きるため、
-# 統合 cleanup 関数の `rm -f` 対象に追加する。defense-in-depth として `${var:-}` 形式で安全化。
 project_reg_jq_err=""
 _rite_fix_issue_create_cleanup() {
   if [ "$issue_created" = "1" ]; then
@@ -1967,15 +1916,13 @@ Identify the related Issue from the PR or branch name.
 # Phase 1.1 で --json に body を含めて取得済みのため、再取得不要
 # 保持している body フィールドから直接パターンマッチ
 #
-# 重要 — パス先行宣言 → trap 先行設定 → mktemp の順序 (Fast Path / Phase 4.5.2 と同じパターン)。
-# 順序とトラップ semantics の根拠 (race window / signal 別 exit code 130/143/129 の必要性) は
-# Fast Path Implementation note と Fast Path bash block の `_rite_fix_fastpath_cleanup` 関数定義箇所
-# 周辺のコメントブロック (signal 別 trap setup の根拠説明) を参照 (行番号 drift 防止のため anchor 参照)。
-# mktemp 失敗時の exit code を check しないと、$pr_body_tmp が空文字列になり後続の
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code、${var:-} safety)
+#
+# 本 site 固有: mktemp 失敗時の exit code を check しないと、$pr_body_tmp が空文字列になり後続の
 # `printf > ""` が silent redirection error で空ファイルを参照し、issue_number が silent empty に落ちる。
+# M-1 で 2>&1 撤廃に伴い pr_body_grep_err / branch_grep_err も独立 stderr 退避ファイルとして統合 trap で保護。
 pr_body_tmp=""
-# pr_body_grep_err / branch_grep_err も先行宣言して cleanup 対象に含める (M-1 で 2>&1 を撤廃した
-# ことに伴い、独立 stderr 退避ファイルが必要になった)。`${var:-}` は未定義時 silent no-op で安全。
 pr_body_grep_err=""
 branch_grep_err=""
 # wm_emit_done フラグ (M-4 / M-5 対応): retained flag が 1 度 emit されたら、以降の経路で
@@ -2180,16 +2127,16 @@ The work memory update performs **three operations** in a single Bash tool invoc
 # ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること（クロスプロセス変数参照を防止）
 # comment_data の取得・更新内容の生成・PATCH を分割すると変数が失われる（Issue #693, #90）
 #
-# 重要 — Phase 4.5.2 統合 trap セットアップ (本 Issue #350 検証付きレビュー H-1 / M-4 で指摘):
-# Fast Path / Phase 4.5.1 と同じ「パス先行宣言 → trap 先行設定 → mktemp」パターンを採用。
-# 旧実装は trap 設定が mktemp 群より後にあり、最初の mktemp 〜 trap 設定までの race window で
-# SIGTERM/SIGINT を受けた場合に新規 tmp ファイルが orphan として残る経路があった。
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code、${var:-} safety、関数契約)
 #
-# 統合 trap で保護する対象 (Phase 4.5.2 で作成される全一時ファイル):
+# 本 site 固有: 統合 trap で保護する対象 (Phase 4.5.2 で作成される全一時ファイル)
 # - gh_api_err: gh api の stderr 退避用 (H-1 で新設)
 # - base_branch_grep_err: rite-config.yml grep の stderr 退避用 (M-3 で新設)
 # - diff_stderr_tmp: git diff の stderr 退避用
 # - body_tmp / tmpfile / files_tmp / history_tmp: Python 入出力用
+# - pr_body_tmp: H-7 — Phase 4.5.1 と 4.5.2 が同一 Bash invocation で連結された場合の
+#   trap 上書きによる orphan を defense-in-depth として防止
 gh_api_err=""
 base_branch_grep_err=""
 diff_stderr_tmp=""
@@ -2197,15 +2144,7 @@ body_tmp=""
 tmpfile=""
 files_tmp=""
 history_tmp=""
-# H-7 修正 (本 Issue #350 検証付きレビュー H-7): pr_body_tmp を Phase 4.5.2 cleanup に含める
-# Phase 4.5.1 と Phase 4.5.2 が同一 Bash invocation で連結された場合、Phase 4.5.2 の trap が
-# Phase 4.5.1 の trap を上書きするため、Phase 4.5.1 で作成された pr_body_tmp が orphan 化する。
-# `_rite_fix_py_exit2_cleanup` (line 2361-2365) には既に pr_body_tmp が含まれているため、
-# 通常 cleanup 経路でも同様に保護する。bash block 境界を越えた変数参照は通常 unset で no-op だが、
-# 同一 invocation 連結時の defense-in-depth として明示登録する。
 pr_body_tmp=""
-# 関数責務: cleanup 操作のみを実行し、exit code を変更しない (Fast Path と同型 — `${var:-}` で
-# 未定義時は `rm -f ""` の silent no-op になる)
 _rite_fix_phase452_cleanup() {
   rm -f "${gh_api_err:-}" "${base_branch_grep_err:-}" "${diff_stderr_tmp:-}" \
         "${body_tmp:-}" "${tmpfile:-}" "${files_tmp:-}" "${history_tmp:-}" \
@@ -2548,14 +2487,14 @@ with open(out_path, "w") as f:
       echo "ERROR: Python script detected git diff failure marker and refused to PATCH work memory silently." >&2
       # tmpfile の debug 参照を提供するため、exit 前に trap から tmpfile を除外して削除を防ぐ
       # (exit 時に trap が発火して tmpfile が消えると、下記の debug 案内が嘘になる)
-      # Fast Path と同じ signal 別 trap 構造に統一: SIGINT/SIGTERM/SIGHUP 受信時も明示的 exit code を返す
+      #
+      # trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+      # (rationale: signal 別 exit code 130/143/129、関数契約、${var:-} safety)
+      #
+      # 本 site 固有: pr_body_tmp は通常 unset (別 bash invocation のスコープ変数) だが、Phase 4.5.1 と
+      # Phase 4.5.2 が誤って同一 invocation に統合された場合の defense-in-depth として cleanup 対象に含める
+      # (L-9 / H-7 同根)。tmpfile は debug 参照用に preserve する。
       _rite_fix_py_exit2_cleanup() {
-        # L-9 修正 (本 Issue #350 検証付きレビュー L-9): pr_body_tmp 参照の意図文書化
-        # `${pr_body_tmp:-}` は通常 unset (Phase 4.5.1 のスコープ変数で、Phase 4.5.2 とは別 bash invocation)
-        # のため、`rm -f ""` の silent no-op となり実害なし。defense-in-depth として残す:
-        # Phase 4.5.1 と Phase 4.5.2 が誤って同一 invocation に統合された場合 (将来の refactoring ミス)
-        # でも pr_body_tmp が cleanup されるよう保護する。`_rite_fix_phase452_cleanup` (line 2138 付近) も
-        # 同じ理由で `${pr_body_tmp:-}` を含めている (H-7 修正での一貫性)。
         rm -f "${pr_body_tmp:-}" "${body_tmp:-}" "${files_tmp:-}" "${history_tmp:-}" \
               "${diff_stderr_tmp:-}" "${gh_api_err:-}" "${base_branch_grep_err:-}"
         # tmpfile は preserved for debug

--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -1,0 +1,163 @@
+# Bash Trap + Cleanup Patterns
+
+このファイルは `plugins/rite/commands/pr/fix.md` と `review.md` の bash block で繰り返し使用される
+**signal-specific trap + cleanup function パターン**の canonical 定義と根拠を集約する。
+
+各 bash block の冒頭では、本ファイルの該当セクションへの anchor 参照を pointer コメントとして置き、
+verbose な説明は本ファイルに一元化する。将来 signal semantics を変更する際
+(例: HUP を無視する仕様に切り替え、新しい signal を追加) は、本ファイル **1 箇所のみ**を
+更新することで意図を一貫して伝達する。
+
+---
+
+## Signal-Specific Trap Template
+
+<a id="signal-specific-trap-template"></a>
+
+全 9 箇所で使用される canonical パターン:
+
+```bash
+# 1. cleanup 対象変数の先行宣言 (未定義時 silent no-op 化のため空文字列で初期化)
+tmpfile=""
+jq_err=""
+# ... 追加の cleanup 対象変数 ...
+
+# 2. cleanup 関数定義 (責務: rm -f のみ。exit/return を含めてはならない)
+_rite_<phase>_cleanup() {
+  rm -f "${tmpfile:-}" "${jq_err:-}"
+  # ... site-specific な conditional cleanup logic (例: 2-state commit pattern) ...
+}
+
+# 3. signal 別 trap (4 行): EXIT は元 exit code を保持、INT/TERM/HUP は明示的 exit code を返す
+trap 'rc=$?; _rite_<phase>_cleanup; exit $rc' EXIT
+trap '_rite_<phase>_cleanup; exit 130' INT
+trap '_rite_<phase>_cleanup; exit 143' TERM
+trap '_rite_<phase>_cleanup; exit 129' HUP
+
+# 4. この時点で trap は武装済み。mktemp や主処理はこの後に実行する。
+tmpfile=$(mktemp) || { ... ; exit 1; }
+```
+
+**Instantiation の手順**:
+
+1. cleanup 対象となる全変数を空文字列で先行宣言する (mktemp 実行前)
+2. `_rite_<phase>_cleanup` 関数内で `"${var:-}"` 形式で列挙する
+3. 4 行の trap を関数定義**直後**に設置する (mktemp 前)
+4. mktemp / 主処理を trap 武装後に実行する
+
+---
+
+## Rationale (なぜこの 4 行構造が必要か)
+
+### EXIT trap 単独では不十分な理由
+
+bash の EXIT trap は SIGTERM/SIGHUP/SIGINT のいずれでも発火する (GNU bash manual "Signals" で確認済み、
+実証済み)。しかし **INT/TERM/HUP の trap action が明示的な `exit <code>` を含まないと、
+bash は signal を consume して次のコマンドへ制御を渡してしまう** (silent continuation)。
+
+例: `_rite_fix_fastpath_cleanup; exit 130` の `exit 130` を省略すると、SIGINT 到達後に cleanup 関数が
+実行された後、bash は block 内の残りの命令 (mapfile / for / case 等) を**不完全な状態で継続実行**する。
+これは debug が極めて困難な silent failure を引き起こす。
+
+### signal 別 exit code の選定 (POSIX 慣習: 128 + signal number)
+
+| signal  | exit code | 意味                     |
+|---------|-----------|--------------------------|
+| SIGINT  | 130       | Ctrl+C / `kill -INT`     |
+| SIGTERM | 143       | `kill -TERM` (timeout 等) |
+| SIGHUP  | 129       | 端末切断 / session 終了   |
+
+SIGINT/SIGTERM/SIGHUP 受信時の `$?` は「最後に完了したコマンドの exit status」であり、signal 自体が
+130/143/129 を set するとは限らない。例えば `printf` 成功直後に SIGTERM が来ると `rc=0` となり、上位の
+fix loop 制御が「正常終了」と誤判定する silent failure が起きる。これを防ぐため signal 別 trap で
+**明示的に exit 130/143/129 を返す**。
+
+### EXIT trap の `rc=$?` capture (bash classic pitfall)
+
+bash の EXIT trap が発火した時点で `$?` は元の exit status を保持するが、`_rite_<phase>_cleanup`
+関数を実行すると関数最後のコマンド (`rm -f` または `[ ... ]` test) の戻り値で `$?` が**上書き**される。
+
+したがって `trap '_rite_<phase>_cleanup; exit $?' EXIT` は exit code が常に 0 (rm -f の戻り値) に
+なる致命的バグを生む (bash block 内の全ての `exit 1` が silent に exit 0 に変換される)。
+
+**必ず `rc=$?` で関数呼び出し前に元の exit code を変数に保存してから**、cleanup → `exit $rc` する:
+
+```bash
+trap 'rc=$?; _rite_<phase>_cleanup; exit $rc' EXIT
+```
+
+### cleanup 関数の契約 (関数内で exit/return を呼んではならない)
+
+cleanup 関数の責務は **rm -f などの cleanup 操作のみ**であり、exit code を変更してはならない。
+関数の戻り値は trap action 側で無視される (`rc=$?` で先に保存済みのため)。
+
+関数内に `exit` や `return <非ゼロ>` を追加すると、signal 別 trap が期待する exit code (130/143/129)
+を上書きして silent exit 0 regression を誘発する。
+
+### `${var:-}` 形式で未定義変数を安全化
+
+`rm -f "${var:-}"` は `var` が未定義/空文字列のときに `rm -f ""` の silent no-op となる。
+これにより、cleanup 関数が mktemp 失敗経路や早期 exit 経路で呼ばれても安全に動作する (defense-in-depth)。
+
+### パス先行宣言 → trap 先行設定 → mktemp の順序
+
+mktemp を先に実行して trap を後追いで設定すると、**mktemp 成功〜trap 設定間の race window**で
+SIGTERM/SIGINT/SIGHUP が到達した場合に作成済み tmp ファイルが orphan として残る。
+並列 fix/review セッション (sprint team-execute 等) で /tmp に累積し、wildcard glob で掃除する誘惑 →
+他セッション破壊につながる構造的リスクを生む。
+
+したがって必ず以下の順序で記述する:
+
+1. cleanup 対象変数を空文字列で先行宣言
+2. cleanup 関数定義
+3. 4 行 trap 設置
+4. mktemp 実行
+
+---
+
+## Regression History
+
+本パターンは複数回の regression を経て現在の形に収束した。以下は過去に発見されたバグと修正の履歴:
+
+- **H-3 (fix.md Fast Path)**: `gh_api_err` が cleanup 対象から漏れており trap 未保護だった。
+  `${var:-}` 形式で cleanup 関数に追加して safety を担保。
+- **M-4 (fix.md Phase 4.3.4)**: `project_reg_jq_err` が「短命変数」として統合 trap から除外されていたが、
+  mktemp 成功 〜 直後の `rm -f` までの race window で signal 到達時に orphan 化することが判明。
+  「短命だから除外してよい」という思い込みを明示的に否定し、全短命変数を統合 trap で保護する方針に変更。
+- **H-1 (fix.md Phase 4.5.2)**: trap 設定が mktemp 群より後にあり、race window が存在した。
+  「パス先行宣言 → trap 先行設定 → mktemp」パターンに統一。
+- **H-7 (fix.md Phase 4.5.2)**: Phase 4.5.1 と Phase 4.5.2 が同一 Bash invocation で連結された場合、
+  Phase 4.5.2 の trap が Phase 4.5.1 の trap を上書きするため、Phase 4.5.1 で作成された `pr_body_tmp`
+  が orphan 化していた。Phase 4.5.2 の cleanup 関数にも `${pr_body_tmp:-}` を defense-in-depth として追加。
+- **#350 H1/H3 (fix.md Phase 2.4 / Phase 4.3.4)**: mktemp 失敗経路でも retained flag を emit する
+  必要性 (bash の `exit 1` は Claude のフロー制御にならないため、Phase 8.1 の detection を補助する)。
+- **L-6/L-9 (fix.md py_exit2)**: Python script の sentinel exit code (`sys.exit(2)`) を受けた経路で
+  tmpfile を preserve しつつ他の一時ファイルは cleanup する必要があり、専用 cleanup 関数 `_rite_fix_py_exit2_cleanup`
+  を定義。pr_body_tmp 参照は通常 unset で silent no-op だが、defense-in-depth として残す。
+
+---
+
+## Instantiation Checklist
+
+新規 bash block で本パターンを利用する際の確認項目:
+
+- [ ] cleanup 対象となる全変数を mktemp 実行**前**に空文字列で初期化した
+- [ ] cleanup 関数内の全変数参照を `"${var:-}"` 形式にした
+- [ ] cleanup 関数内に `exit` / `return <非ゼロ>` を書いていない
+- [ ] 4 行 trap (`EXIT` / `INT` / `TERM` / `HUP`) を揃えて設置した
+- [ ] EXIT trap は `rc=$?` で元 exit code を先に capture している
+- [ ] INT/TERM/HUP trap は明示的な `exit 130` / `exit 143` / `exit 129` を含む
+- [ ] trap 設置は mktemp / 主処理の**前**に行っている
+
+---
+
+## Pointer Comment (各 site で使用する anchor 参照)
+
+各 bash block の冒頭では以下の形式で本ファイルを参照する:
+
+```bash
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
+```
+
+この pointer により、**9 箇所の同時更新が 1 箇所 (本ファイル) の更新に集約される**。

--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -4,9 +4,21 @@
 **signal-specific trap + cleanup function パターン**の canonical 定義と根拠を集約する。
 
 各 bash block の冒頭では、本ファイルの該当セクションへの anchor 参照を pointer コメントとして置き、
-verbose な説明は本ファイルに一元化する。将来 signal semantics を変更する際
-(例: HUP を無視する仕様に切り替え、新しい signal を追加) は、本ファイル **1 箇所のみ**を
-更新することで意図を一貫して伝達する。
+verbose な **rationale / 説明コメント**は本ファイルに一元化する。本リファクタリングで 1 箇所に
+集約されるのは **rationale / 説明文の層** のみである。
+
+> **⚠️ 重要 — コード層との境界**: 各 site の cleanup 関数本体と 4 行 trap (`EXIT`/`INT`/`TERM`/`HUP`)
+> は依然として fix.md / review.md の 9 箇所にコードとして存在する。したがって **signal 動作そのもの**
+> を変更する場合 (例: HUP を無視する仕様に切り替え、新しい signal を追加、TERM の exit code を変更)
+> は、本ファイルの rationale 更新後に **fix.md + review.md の全 9 site で 4 行 trap のコード自体を
+> 同時更新する必要がある**。本ファイル 1 箇所の更新で自動的に反映されるわけではない。
+>
+> **rationale 層で集約されること**: 説明文 / 意図 / regression history / checklist の更新は本ファイル
+> 1 箇所で完結する。保守者は「なぜこの 4 行構造なのか」を 1 箇所読むだけで把握できる。
+>
+> **コード層で集約されないこと**: 実際の bash コード (trap 行、cleanup 関数の骨格) は markdown 内の
+> 独立した bash block として 9 箇所に残っているため、コード変更は依然 9 箇所同時更新が必要。
+> drift 検出 lint の追加は Issue #353 で追跡中。
 
 ---
 
@@ -160,4 +172,7 @@ SIGTERM/SIGINT/SIGHUP が到達した場合に作成済み tmp ファイルが o
 # (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
 ```
 
-この pointer により、**9 箇所の同時更新が 1 箇所 (本ファイル) の更新に集約される**。
+この pointer により、**rationale / 説明コメントの更新は本ファイル 1 箇所に集約される** (冒頭の
+「重要 — コード層との境界」で述べた通り、4 行 trap のコード自体はこれとは別に各 site に残っている)。
+signal 動作そのものを変更する場合 (例: HUP 追加、TERM の exit code 変更) は、本ファイルの rationale
+更新後に fix.md + review.md の全 9 site の 4 行 trap を Instantiation Checklist に従って同時更新すること。

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -477,17 +477,8 @@ total_diff_lines="${total_diff_lines:-0}"
 # これを防ぐため、(1) gh pr view の stderr を一時ファイルに退避、(2) stdout を一時ファイルに保存、
 # (3) gh pr view の exit code を if で明示的に check し、(4) 成功時のみ mapfile で読み込む。
 #
-# 重要 — パス先行宣言 → trap 先行設定 → mktemp の順序 (fix.md Fast Path / Phase 4.5.1/4.5.2 と同じパターン):
-# mktemp を 2 連発した「後」に trap を設定すると、1 つ目 mktemp 成功〜 2 つ目 mktemp 完了までと、
-# 2 つ目 mktemp 完了〜 trap 設定までの極小時間窓に SIGTERM/SIGINT が到達した場合に作成済み tmp ファイルが
-# orphan として残る。並列 review 実行 (sprint team-execute 等) で /tmp に累積し、wildcard glob で
-# 掃除する誘惑 → 他セッション破壊につながる構造的リスク。
-#
-# bash の INT/TERM/HUP trap action は **明示的な exit を含まないと処理を継続する**
-# (権威ある根拠: GNU bash manual "Signals" — trap action 後に bash は signal を consume し
-#  制御は次のコマンドに渡る。trap 内で `exit <code>` を呼ばないと cleanup 後に bash block が
-#  残りの命令 (mapfile / for / case) を不完全な状態で実行してしまう silent failure になる)
-# signal 別 exit code: SIGINT=130 / SIGTERM=143 / SIGHUP=129 (POSIX 慣習: 128 + signal number)
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code 130/143/129、${var:-} safety)
 gh_files_stderr=""
 gh_files_stdout=""
 _rite_review_p127_cleanup() {
@@ -765,11 +756,8 @@ When the PR is doc-heavy, override reviewer selection to ensure documentation qu
        exit 1 ;;
    esac
 
-   # 重要 — パス先行宣言 → trap 先行設定 → mktemp の順序 (fix.md Fast Path / Phase 4.5.1/4.5.2 と同じパターン):
-   # mktemp を先に実行して trap を後追いで設定すると、mktemp 成功〜trap 設定間の極小時間窓に
-   # SIGTERM/SIGINT が到達した場合に作成済み tmp ファイルが orphan として残る race window がある。
-   # bash の INT/TERM/HUP trap action は **明示的な exit を含まないと処理を継続する**ため、
-   # signal 別 exit code (130/143/129) を必ず返す。
+   # trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+   # (rationale: 「パス先行宣言 → trap 先行設定 → mktemp」の順序、signal 別 exit code、${var:-} safety)
    git_diff_err=""
    _rite_review_p221_cleanup() {
      rm -f "${git_diff_err:-}"


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/fix.md` と `review.md` の間で 9 箇所重複していた signal-specific trap + cleanup function の verbose 説明を 1 箇所 (`references/bash-trap-patterns.md`) に集約し、各 site は anchor 参照に置き換えた。

Phase D 定量検証 (#360) の PR #384 replay で code-quality reviewer が検出した HIGH finding への対応。

## 変更内容

### 新規ファイル

- `plugins/rite/commands/pr/references/bash-trap-patterns.md`
  - Canonical signal-specific trap template (EXIT=`$rc` / INT=130 / TERM=143 / HUP=129)
  - Rationale: EXIT trap 単独では不十分な理由、signal 別 exit code の POSIX 慣習 (128+N)、`rc=$?` capture の classic pitfall、cleanup 関数契約 (exit/return 禁止)、`${var:-}` safety、「パス先行宣言 → trap 先行設定 → mktemp」順序
  - Regression history: H-3 / M-4 / H-1 / H-7 / #350 H1-H3 / L-6/L-9
  - Instantiation checklist

### 編集ファイル

- `plugins/rite/commands/pr/fix.md`: 7 箇所で pointer 化
  - Phase 1.2 Fast Path / Phase 2.4 / Phase 4.2 / Phase 4.3.4 / Phase 4.5.1 / Phase 4.5.2 / py_exit2 inline
- `plugins/rite/commands/pr/review.md`: 2 箇所で pointer 化
  - Phase 1.2.7 / Phase 2.2.1

cleanup 関数本体と 4 行 trap (`EXIT`/`INT`/`TERM`/`HUP`) は保持 (bash 動作に影響なし)。site 固有の実装意図 (2-state commit pattern の `handoff_committed` / `issue_created` 等) は各 site にコメントで残した。

## 効果

将来 signal semantics を変更する際 (例: HUP を無視する仕様に切り替え、新しい signal を追加) の 9 箇所同時更新 drift リスクを排除。`references/bash-trap-patterns.md` 1 箇所の更新で意図を一貫して伝達可能。

## 検証

| 項目 | 期待値 | 実測値 |
|------|--------|--------|
| cleanup 関数数 | 9 | fix.md 7 + review.md 2 = 9 ✅ |
| 4 行 trap 行数 | 36 (= 9 × 4) | fix.md 28 + review.md 8 = 36 ✅ |
| Pointer 参照数 | 9 | fix.md 7 + review.md 2 = 9 ✅ |

bash 動作への影響はなし (cleanup 関数本体と trap 設定は完全保持)。

## 関連

- Phase D 検証 Issue: #360
- 実測時の PR: #384 (closed)
- 結果レポート: #385
- drift 検出 lint: Issue #353 (scope 外)

## Known Issues

- lint 未実行（rite-config.yml の `commands.lint: null` のためスキップ。markdown のみの変更のため影響なし）

Closes #388
