### PR TITLE
fix(docs): review-quality-gap-closure.md に Phase 0 スナップショット注記を追加

### DIFF
--- a/docs/designs/review-quality-gap-closure.md
+++ b/docs/designs/review-quality-gap-closure.md
@@ -2,6 +2,8 @@
 
 > **位置づけ**: `docs/designs/reviewer-quality-improvement.md`（PR #285 発、agent 定義の自己完結化）の**後続改善**。本設計書は PR #350 のドッグフーディングで発見された追加課題に対応する。
 
+> **⚠️ スナップショット注記 (#387)**: 本設計書は Phase 0 調査時点（Phase A/B/C 適用前）のコードベースを前提に記述されており、「### 真の Root Cause（調査で判明）」セクションを含む本文中のコード引用・ファイル名:行番号参照（例: `plugins/rite/commands/pr/review.md:1192-1195`、`_reviewer-base.md` の `L22 ## Confidence Scoring` / `L42 ## Input`、`review.md:1237` の `subagent_type: general-purpose` 等）はすべて当時のスナップショットです。Phase A/B/C 適用後の現行コードとは行番号・構造がズレており、たとえば `_reviewer-base.md` の見出しは Phase C の `#6 Documentation i18n parity` / `#7 Pattern portability` 追加により約 9 行シフト済みで、`review.md` の reviewer 呼び出しも named subagent (`rite:{reviewer_type}-reviewer`) に移行済みです。現行仕様は `plugins/rite/commands/pr/review.md` および `plugins/rite/agents/_reviewer-base.md` 本体を直接参照してください。
+
 <!-- Section ID: SPEC-OVERVIEW -->
 ## 概要
 


### PR DESCRIPTION
## 概要

Phase D 定量検証 (#360) の PR #384 replay で tech-writer reviewer が検出した、`docs/designs/review-quality-gap-closure.md` 内の 3 箇所の stale 行番号参照（HIGH findings）を解消する。Issue #387 が推奨する対応方針 (a) を採用し、冒頭に「Phase 0 調査時点のスナップショットである」ことを明示する注記を 1 箇所追加。

## 背景

`### 真の Root Cause（調査で判明）` セクションの以下の参照が Phase A/B/C 適用後の現行コードとずれていた:

1. **L25**: `plugins/rite/commands/pr/review.md:1192-1195` の Part A 抽出仕様を引用 → 現行では L1222-1237（`{shared_reviewer_principles}` extraction）
2. **L31-35**: `_reviewer-base.md` の見出し構造を `L22 ## Confidence Scoring` / `L42 ## Input` と記載 → Phase C で `#6 Documentation i18n parity` / `#7 Pattern portability` を追加した分、約 9 行シフトして **L31 / L51**
3. **L42**: `review.md:1237` で reviewer は `subagent_type: general-purpose` と記載 → Phase B (#358) で named subagent (`rite:{reviewer_type}-reviewer`) に移行済み

加えて L178 にも類似の `line 1192-1195` stale 参照があった。

## 対応方針

当該セクションは本質的に「Phase 0 調査時点の診断記録」であり、将来の Phase D/E 改修でも行番号は再 drift する。行番号個別更新ではなく **冒頭 1 箇所のスナップショット注記** を採用することで:

- 4 件の stale 参照（L25/L31-35/L42/L178）を同時に無効化
- 長期保守時の再 drift を防止
- Issue #387 の「冒頭に注記を追加するのが最も保守容易」という坂口さんの判断に合致

## 変更内容

- `docs/designs/review-quality-gap-closure.md`: L3（「位置づけ」directly after）に `> **⚠️ スナップショット注記 (#387)**: ...` を追加。注記内で `review.md` と `_reviewer-base.md` 本体を直接参照するよう誘導。

## 関連 Issue

Closes #387

### 参考

- Phase D 検証 Issue: #360
- 実測時の PR: #384 (closed)
- 結果レポート: #385
