### PR TITLE
refactor(references): Workflow Incident Emit Helper 3 file 重複の共通化

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -703,9 +703,9 @@ rm -f "$next_steps_tmp"
 
 ## Workflow Incident Emit Helper (#366)
 
-When this skill encounters internal failures that fall back to manual intervention or skipping (e.g., lint tool not found, repeated lint command failures, work memory PATCH failure), emit a workflow incident sentinel so the orchestrator (`/rite:issue:start` Phase 5.4.4.1) can detect it and auto-register an Issue.
+> **Reference**: See [workflow-incident-emit-protocol.md](../references/workflow-incident-emit-protocol.md) for the emit protocol and Sentinel Visibility Rule.
 
-**When to emit**:
+This skill emits sentinels for the following failure paths:
 
 | Failure Path | Sentinel Type | Details |
 |--------------|---------------|---------|
@@ -713,25 +713,7 @@ When this skill encounters internal failures that fall back to manual interventi
 | Lint tool not found at execution time (Phase 3) | `hook_abnormal_exit` | `rite:lint tool not found: {tool_name}` |
 | Work memory append failure in Phase 4.4 | `hook_abnormal_exit` | `rite:lint work memory append failure` |
 
-**How to emit**:
-
-```bash
-# Step 1: emit sentinel via hook script (silent capture, non-blocking via || true)
-sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
-  --type {sentinel_type} \
-  --details "{specific failure description}" \
-  --root-cause-hint "{optional hypothesis}" \
-  --pr-number 0 2>/dev/null) || true
-
-# Step 2: also echo to stderr for human-visible debugging
-[ -n "$sentinel_line" ] && echo "$sentinel_line" >&2
-```
-
-**Step 3 — Sentinel Visibility (LLM responsibility, cycle 1 review C2 fix)**: Because `lint.md` runs in `context: fork`, the bash subprocess stdout is NOT visible to the orchestrator. **The lint.md LLM MUST include the captured `sentinel_line` value verbatim in its final response message text** so Phase 5.4.4.1 in `/rite:issue:start` can detect it via context grep.
-
-`|| true` ensures non-blocking behavior — emission failure does not abort the lint flow. See `start.md` Phase 5.4.4.1 "Workflow Incident Sentinel Visibility Rule" for the full specification.
-
-> **Note**: Sentinel emission is bounded by `workflow_incident.enabled` in `rite-config.yml`. If disabled, the orchestrator simply ignores the sentinel.
+**Note**: `{pr_number}` is `0` for lint (no PR exists yet at lint time).
 
 ## Error Handling
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -2723,35 +2723,15 @@ Confidence override (policy bypass): {confidence_override_count}件{confidence_o
 
 ## Workflow Incident Emit Helper (#366)
 
-When this skill encounters internal failures that fall back to manual intervention (e.g., file modification error, commit failure, work memory PATCH failure), emit a workflow incident sentinel so the orchestrator (`/rite:issue:start` Phase 5.4.4.1) can detect it and auto-register an Issue.
+> **Reference**: See [workflow-incident-emit-protocol.md](../../references/workflow-incident-emit-protocol.md) for the emit protocol and Sentinel Visibility Rule.
 
-**When to emit**:
+This skill emits sentinels for the following failure paths:
 
 | Failure Path | Sentinel Type | Details |
 |--------------|---------------|---------|
 | File modification error in Phase 2 (Edit/Write tool returns error and fix is skipped) | `hook_abnormal_exit` | `rite:pr:fix file modification skipped: {file_path}` |
 | Work memory PATCH retry exhausted in Phase 4.5 | `hook_abnormal_exit` | `rite:pr:fix work memory PATCH failed after retries` |
 | Commit failure that cannot be auto-resolved in Phase 3.3 | `hook_abnormal_exit` | `rite:pr:fix commit failure` |
-
-**How to emit** (call this immediately before falling back to manual flow or returning a soft-failure pattern):
-
-```bash
-# Step 1: emit sentinel via hook script (silent capture, non-blocking via || true)
-sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
-  --type hook_abnormal_exit \
-  --details "{specific failure description}" \
-  --root-cause-hint "{optional hypothesis}" \
-  --pr-number {pr_number} 2>/dev/null) || true
-
-# Step 2: also echo to stderr for human-visible debugging
-[ -n "$sentinel_line" ] && echo "$sentinel_line" >&2
-```
-
-**Step 3 — Sentinel Visibility (LLM responsibility, cycle 1 review C2 fix)**: Because `fix.md` runs in `context: fork`, the bash subprocess stdout is NOT visible to the orchestrator. **The fix.md LLM MUST include the captured `sentinel_line` value verbatim in its final response message text** so Phase 5.4.4.1 in `/rite:issue:start` can detect it via context grep. Without this step, AC-5 (hook abnormal exit detection) is silently broken.
-
-`|| true` ensures non-blocking behavior — emission failure does not abort the fix flow. See `start.md` Phase 5.4.4.1 "Workflow Incident Sentinel Visibility Rule" for the full specification.
-
-> **Note**: Sentinel emission is bounded by `workflow_incident.enabled` in `rite-config.yml`. If disabled, the orchestrator simply ignores the sentinel.
 
 ## Error Handling
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -2704,35 +2704,15 @@ Post Issue list to PR comment (`mktemp` + `--body-file`). Output completion repo
 
 ## Workflow Incident Emit Helper (#366)
 
-When this skill encounters internal failures that fall back to alternative behavior (e.g., reviewer skill load failure → built-in profile fallback, comment post failure → text-only display), emit a workflow incident sentinel so the orchestrator (`/rite:issue:start` Phase 5.4.4.1) can detect it and auto-register an Issue.
+> **Reference**: See [workflow-incident-emit-protocol.md](../../references/workflow-incident-emit-protocol.md) for the emit protocol and Sentinel Visibility Rule.
 
-**When to emit**:
+This skill emits sentinels for the following failure paths:
 
 | Failure Path | Sentinel Type | Details |
 |--------------|---------------|---------|
 | Reviewer sub-agent skill load failure (fallback to built-in profile in Phase 2) | `skill_load_failure` | `rite reviewer skill load failure: {reviewer_type}` |
 | Comment post failure in Phase 6 (gh api PATCH/POST returns error) | `hook_abnormal_exit` | `rite:pr:review comment post failure` |
 | Review execution error that user chose to skip | `manual_fallback_adopted` | `rite:pr:review execution error skipped by user` |
-
-**How to emit**:
-
-```bash
-# Step 1: emit sentinel via hook script (silent capture, non-blocking via || true)
-sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
-  --type {sentinel_type} \
-  --details "{specific failure description}" \
-  --root-cause-hint "{optional hypothesis}" \
-  --pr-number {pr_number} 2>/dev/null) || true
-
-# Step 2: also echo to stderr for human-visible debugging
-[ -n "$sentinel_line" ] && echo "$sentinel_line" >&2
-```
-
-**Step 3 — Sentinel Visibility (LLM responsibility, cycle 1 review C2 fix)**: Because `review.md` runs in `context: fork`, the bash subprocess stdout is NOT visible to the orchestrator. **The review.md LLM MUST include the captured `sentinel_line` value verbatim in its final response message text** so Phase 5.4.4.1 in `/rite:issue:start` can detect it via context grep.
-
-`|| true` ensures non-blocking behavior — emission failure does not abort the review flow. See `start.md` Phase 5.4.4.1 "Workflow Incident Sentinel Visibility Rule" for the full specification.
-
-> **Note**: Sentinel emission is bounded by `workflow_incident.enabled` in `rite-config.yml`. If disabled, the orchestrator simply ignores the sentinel.
 
 ## Error Handling
 

--- a/plugins/rite/references/workflow-incident-emit-protocol.md
+++ b/plugins/rite/references/workflow-incident-emit-protocol.md
@@ -1,0 +1,54 @@
+# Workflow Incident Emit Protocol
+
+Common emit protocol for workflow incident sentinels, referenced by skill commands (`lint.md`, `fix.md`, `review.md`). Centralizes the bash snippet, Sentinel Visibility Rule, and non-blocking guarantees to prevent drift across skills.
+
+> **Reference**: See `start.md` Phase 5.4.4.1 "Workflow Incident Sentinel Visibility Rule" for the full orchestrator-side specification.
+
+## How to Emit
+
+Call this immediately before falling back to manual flow or returning a soft-failure pattern:
+
+```bash
+# Step 1: emit sentinel via hook script (silent capture, non-blocking via || true)
+sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
+  --type {sentinel_type} \
+  --details "{specific failure description}" \
+  --root-cause-hint "{optional hypothesis}" \
+  --pr-number {pr_number} 2>/dev/null) || true
+
+# Step 2: also echo to stderr for human-visible debugging
+[ -n "$sentinel_line" ] && echo "$sentinel_line" >&2
+```
+
+**Placeholder values**:
+
+| Placeholder | Source |
+|-------------|--------|
+| `{plugin_root}` | [Plugin Path Resolution](./plugin-path-resolution.md#resolution-script) |
+| `{sentinel_type}` | From the skill's "When to emit" table (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`) |
+| `{specific failure description}` | From the skill's "When to emit" table |
+| `{optional hypothesis}` | Optional root cause hint (may be empty) |
+| `{pr_number}` | Current PR number, or `0` if no PR exists yet |
+
+## Sentinel Visibility Rule (LLM Responsibility)
+
+Skills declared with `context: fork` execute Bash tool calls in an **isolated subprocess context**. The orchestrator (`/rite:issue:start`) does NOT see subprocess `stdout` directly — it only sees the **final response message** that the sub-skill LLM returns.
+
+**Therefore**: When a sub-skill emits a workflow incident sentinel via the bash snippet above, the sub-skill LLM **MUST also include the captured `sentinel_line` value verbatim in its final visible response text** (not only as bash stdout). Otherwise the orchestrator's context grep in Phase 5.4.4.1 will never see the sentinel and AC-5 (hook abnormal exit detection) becomes silently broken.
+
+**Concrete pattern**:
+
+After executing Step 1 and Step 2, the LLM must include the `sentinel_line` value in its response. Example:
+
+```
+[lint:error] — 3 errors detected
+[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=rite:lint tool not found: ruff; iteration_id=0-1775650793
+```
+
+## Non-Blocking Guarantee
+
+`|| true` ensures non-blocking behavior — emission failure does not abort the skill flow. The workflow MUST NOT halt because sentinel emission failed.
+
+## Configuration Boundary
+
+Sentinel emission is bounded by `workflow_incident.enabled` in `rite-config.yml`. If disabled (`enabled: false`), the orchestrator simply ignores the sentinel. Skills should still emit sentinels regardless of this setting — the filtering is done at the orchestrator level.

--- a/plugins/rite/references/workflow-incident-emit-protocol.md
+++ b/plugins/rite/references/workflow-incident-emit-protocol.md
@@ -25,8 +25,8 @@ sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
 | Placeholder | Source |
 |-------------|--------|
 | `{plugin_root}` | [Plugin Path Resolution](./plugin-path-resolution.md#resolution-script) |
-| `{sentinel_type}` | From the skill's "When to emit" table (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`) |
-| `{specific failure description}` | From the skill's "When to emit" table |
+| `{sentinel_type}` | From the skill's failure paths table (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`) |
+| `{specific failure description}` | From the skill's failure paths table |
 | `{optional hypothesis}` | Optional root cause hint (may be empty) |
 | `{pr_number}` | Current PR number, or `0` if no PR exists yet |
 


### PR DESCRIPTION
## 概要

`lint.md`, `fix.md`, `review.md` の `## Workflow Incident Emit Helper` セクションに verbatim 重複していた共通 emit protocol（bash snippet Step 1/2, Sentinel Visibility Rule, non-blocking 保証, configuration boundary）を `references/workflow-incident-emit-protocol.md` に抽出。各 skill には skill 固有の failure path テーブルのみを残し、共通参照に置換。

## 変更内容

- **新規**: `plugins/rite/references/workflow-incident-emit-protocol.md` — 共通 emit protocol（How to Emit, Sentinel Visibility Rule, Non-Blocking Guarantee, Configuration Boundary）
- **変更**: `plugins/rite/commands/lint.md` — Emit Helper セクションを共通参照 + skill 固有テーブルに簡素化
- **変更**: `plugins/rite/commands/pr/fix.md` — 同上
- **変更**: `plugins/rite/commands/pr/review.md` — 同上

## 関連

Closes #412

- 元 Issue: #404 (PR #370 replay 実測)
- 検出: code-quality HIGH + prompt-engineer 推奨事項 2 reviewer 合意

## テスト計画

- [ ] 各 skill の Emit Helper セクションが共通参照を含むことを確認
- [ ] 旧 "How to emit" bash snippet が commands/ 配下から除去されていることを確認
- [ ] 共通 reference ファイルが正しいセクション構造を持つことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
