### PR TITLE
chore(lint): distributed-fix-drift-check.sh usage に --all/--target 併用仕様を明記 (#374)

### DIFF
--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -47,6 +47,11 @@ Options:
   --quiet            Suppress per-finding output (still exit non-zero on drift)
   -h, --help         Show this help
 
+Combining --all and --target:
+  --all and --target can be used together. When both are specified, the
+  default target set is merged with explicitly specified targets.
+  Duplicate entries are automatically deduplicated.
+
 Exit codes:
   0  No drift detected
   1  Drift detected
@@ -76,6 +81,20 @@ cd "$REPO_ROOT" || { echo "ERROR: cannot cd to $REPO_ROOT" >&2; exit 2; }
 
 if [ "$USE_ALL" -eq 1 ]; then
   TARGETS+=("${DEFAULT_ALL_TARGETS[@]}")
+fi
+
+# Deduplicate TARGETS (preserving order)
+if [ "${#TARGETS[@]}" -gt 0 ]; then
+  declare -A _seen=()
+  declare -a _unique=()
+  for _t in "${TARGETS[@]}"; do
+    if [ -z "${_seen[$_t]+x}" ]; then
+      _seen[$_t]=1
+      _unique+=("$_t")
+    fi
+  done
+  TARGETS=("${_unique[@]}")
+  unset _seen _unique _t
 fi
 
 if [ "${#TARGETS[@]}" -eq 0 ]; then


### PR DESCRIPTION
## 概要

`distributed-fix-drift-check.sh` の usage に `--all` と `--target` の併用仕様を明記し、併用時の TARGETS 重複を自動排除するロジックを追加。

Closes #374

## 変更内容

- `usage()` に "Combining --all and --target" セクションを追加し、併用可能であること・重複が自動排除されることを明記
- `--all` 展開後に連想配列ベースの重複排除処理を追加（順序保持）

## 関連

- 元 PR: #373
- 元 Issue: #361（PR #373 cycle 3 review の LOW 指摘 follow-up）

## テスト計画

- [x] `--help` 出力に併用説明が表示されることを確認
- [x] `--all --target fix.md` で fix.md が1回のみチェックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
