### PR TITLE
refactor(lint): test script の $? キャプチャを rc=$? パターンに統一 (#377)

### DIFF
--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -43,11 +43,13 @@ assert_ge() {
 
 # --- Test 1: usage / help works ----------------------------------------------
 "$SCRIPT" --help >/dev/null 2>&1
-assert "--help exits 0" "0" "$?"
+rc=$?
+assert "--help exits 0" "0" "$rc"
 
 # --- Test 2: missing args returns error code 2 -------------------------------
 "$SCRIPT" >/dev/null 2>&1
-assert "no args exits 2" "2" "$?"
+rc=$?
+assert "no args exits 2" "2" "$rc"
 
 # Accumulating tempfile manager (trap is set once, list grows as tests add files)
 TMPFILES=()
@@ -94,7 +96,8 @@ This file contains no drift patterns.
 Some prose explaining behavior.
 EOF
 "$SCRIPT" --target "$CLEAN" >/dev/null 2>&1
-assert "synthetic clean file exits 0" "0" "$?"
+rc=$?
+assert "synthetic clean file exits 0" "0" "$rc"
 
 # --- Summary -----------------------------------------------------------------
 echo


### PR DESCRIPTION
## 概要

`test-distributed-fix-drift-check.sh` の Test 1/2/4 で直接 `$?` を `assert` に渡していたパターンを、Test 3 と同じ `rc=$?; assert ... "$rc"` パターンに統一。

将来のテスト追加時に `$?` が壊れやすい regression source を排除する。

## 変更内容

- Test 1 (`--help` テスト): `rc=$?` キャプチャ追加
- Test 2 (引数なしテスト): `rc=$?` キャプチャ追加
- Test 4 (clean file テスト): `rc=$?` キャプチャ追加

## テスト結果

全 7 テスト PASS (FAIL=0)

Closes #377

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
