### PR TITLE
refactor(lint): test script の grep -c ... || true 冗長性を削除 (#378)

### DIFF
--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -69,16 +69,16 @@ if ! git cat-file -e "${BASELINE_COMMIT}^{commit}" 2>/dev/null; then
 elif git show "${BASELINE_COMMIT}:plugins/rite/commands/pr/fix.md" > "$TMP_FIX" 2>/dev/null; then
   out=$("$SCRIPT" --target "$TMP_FIX" 2>&1)
   rc=$?
-  count=$(grep -c '^\[drift\]' <<< "$out" || true)
+  count=$(grep -c '^\[drift\]' <<< "$out")
   assert_ge "cec0140 fix.md detects drift findings" 5 "$count"
   assert "cec0140 fix.md exits 1 (drift detected)" "1" "$rc"
 
   # Pattern-3: at least one if-wrap drift in cec0140 fix.md
-  p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out" || true)
+  p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out")
   assert_ge "cec0140 fix.md Pattern-3 (if-wrap drift) detects >=1" 1 "$p3_count"
 
   # Pattern-2: reason-table drift detected
-  p2_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out" || true)
+  p2_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out")
   assert_ge "cec0140 fix.md Pattern-2 (reason-table drift) detects >=1" 1 "$p2_count"
 else
   echo "FAIL: git show failed for ${BASELINE_COMMIT}:plugins/rite/commands/pr/fix.md" >&2


### PR DESCRIPTION
## 概要

`test-distributed-fix-drift-check.sh` 内の `grep -c ... || true` パターン（3箇所）から冗長な `|| true` を削除。

`grep -c` は 0 件マッチ時でも `0` を stdout に出力するため、`set -e` 未使用環境では `|| true` は不要。

## 変更内容

- 行72: `count=$(grep -c '^\[drift\]' <<< "$out" || true)` → `count=$(grep -c '^\[drift\]' <<< "$out")`
- 行77: `p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out" || true)` → 同様
- 行82: `p2_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out" || true)` → 同様

## テスト結果

全 7 テスト pass（PASS=7 FAIL=0）

## 関連

Closes #378

- 元 PR: #373 (cycle 3 test LOW→follow-up)
- 元 Issue: #361

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
