### PR TITLE
fix(commands): context: fork を対話型コマンドから除去し e2e フローの AskUserQuestion ブロックを解消 (#436)

### DIFF
--- a/docs/BEST_PRACTICES_ALIGNMENT.md
+++ b/docs/BEST_PRACTICES_ALIGNMENT.md
@@ -65,8 +65,8 @@ Commands that display information without state changes use `context: fork`:
 | Analysis | `/rite:skill:suggest`, `/rite:investigate` | ✅ Applied | Independent analysis |
 | Read-only Display | `/rite:workflow` | ✅ Applied | Information display only |
 | Interactive | `/rite:issue:create`, `/rite:issue:start` | ❌ Not Applied | User interaction required |
-| State-changing | `/rite:pr:create`, `/rite:pr:cleanup`, `/rite:pr:ready` | ❌ Not Applied | Modifies repository state |
-| Interactive + State-changing | `/rite:pr:review`, `/rite:pr:fix`, `/rite:lint` | ❌ Not Applied | `AskUserQuestion` required in e2e flow (#436) |
+| State-changing | `/rite:pr:cleanup`, `/rite:pr:ready` | ❌ Not Applied | Modifies repository state |
+| Interactive + State-changing | `/rite:pr:review`, `/rite:pr:fix`, `/rite:lint`, `/rite:pr:create` | ❌ Not Applied | `AskUserQuestion` required in e2e flow (#436) |
 
 > **Note**: `context: fork` と `AskUserQuestion` は非互換です。`context: fork` 環境では `AskUserQuestion` がユーザーとの対話を完了できず、skill が accumulated output を返して終了します（#436）。Interactive なコマンドには `context: fork` を適用しないでください。
 

--- a/docs/BEST_PRACTICES_ALIGNMENT.md
+++ b/docs/BEST_PRACTICES_ALIGNMENT.md
@@ -62,9 +62,13 @@ Commands that display information without state changes use `context: fork`:
 | Category | Commands | context: fork | Reason |
 |----------|----------|---------------|--------|
 | Information Display | `/rite:issue:list`, `/rite:sprint:list`, `/rite:sprint:current` | ✅ Applied | Results only, no state needed |
-| Analysis | `/rite:skill:suggest` | ✅ Applied | Independent analysis |
+| Analysis | `/rite:skill:suggest`, `/rite:investigate` | ✅ Applied | Independent analysis |
+| Read-only Display | `/rite:workflow` | ✅ Applied | Information display only |
 | Interactive | `/rite:issue:create`, `/rite:issue:start` | ❌ Not Applied | User interaction required |
-| State-changing | `/rite:pr:create`, `/rite:pr:cleanup` | ❌ Not Applied | Modifies repository state |
+| State-changing | `/rite:pr:create`, `/rite:pr:cleanup`, `/rite:pr:ready` | ❌ Not Applied | Modifies repository state |
+| Interactive + State-changing | `/rite:pr:review`, `/rite:pr:fix`, `/rite:lint` | ❌ Not Applied | `AskUserQuestion` required in e2e flow (#436) |
+
+> **Note**: `context: fork` と `AskUserQuestion` は非互換です。`context: fork` 環境では `AskUserQuestion` がユーザーとの対話を完了できず、skill が accumulated output を返して終了します（#436）。Interactive なコマンドには `context: fork` を適用しないでください。
 
 ### Output Pattern Standardization
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1065,13 +1065,11 @@ Invoke `skill: "rite:pr:fix"`.
 
 > **Reference**: This section detects **workflow blockers** (Skill load failure, hook abnormal exit, manual fallback adoption) and auto-registers them as Issues to prevent silent loss. See [docs/SPEC.md](../../../../docs/SPEC.md#workflow-incident-detection) for the full specification.
 
-**Workflow Incident Sentinel Visibility Rule** (cycle 1 review C2 fix; cycle 2 review M-NEW1 fix — pr/create.md 追加):
+**Workflow Incident Sentinel Visibility Rule** (cycle 1 review C2 fix; cycle 2 review M-NEW1 fix — pr/create.md 追加; #436 fix — inline 実行に移行):
 
-Sub-skills declared with `context: fork` (`lint.md`, `pr/create.md`, `pr/fix.md`, `pr/review.md`) execute Bash tool calls in an **isolated subprocess context**. The orchestrator (`/rite:issue:start`, this file) does NOT see those subprocess `stdout` directly — it only sees the **final response message** that the sub-skill LLM returns.
+Sub-skills (`lint.md`, `pr/create.md`, `pr/fix.md`, `pr/review.md`) execute inline within the orchestrator's conversation context (previously these used forked execution which caused `AskUserQuestion` to fail in e2e flow — see #436). Bash tool call stdout from these sub-skills is directly visible in the orchestrator's conversation context.
 
-Note: `pr/create.md` does not currently emit workflow incident sentinels internally, but is listed here for completeness — if a Workflow Incident Emit Helper section is added to `pr/create.md` in the future, the same Visibility Rule applies.
-
-Therefore, when a sub-skill emits a workflow incident sentinel via `bash workflow-incident-emit.sh`, the sub-skill **MUST also include the emitted sentinel line as part of its final visible response text** (not only as bash stdout). Otherwise the orchestrator's context grep in this phase will never see the sentinel and AC-5 (hook abnormal exit detection) becomes silently broken.
+As a **defensive practice**, sub-skills SHOULD still include emitted sentinel lines in their final visible response text. This ensures sentinel detection remains robust even if execution context changes in the future.
 
 **Concrete pattern for sub-skills** (used in `fix.md` / `review.md` / `lint.md` Workflow Incident Emit Helper sections):
 
@@ -1086,16 +1084,16 @@ sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
 [ -n "$sentinel_line" ] && echo "$sentinel_line" >&2
 ```
 
-**Step 3 (LLM responsibility)**: The sub-skill LLM must then include the captured `sentinel_line` value (if non-empty) **verbatim in its final response message text**, e.g.:
+**Step 3 (LLM responsibility — defensive practice)**: The sub-skill LLM should include the captured `sentinel_line` value (if non-empty) **verbatim in its final response message text** as a defensive measure, e.g.:
 
 ```
 [lint:error] — 3 errors detected
 [CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=rite:lint tool not found: ruff; iteration_id=0-1775650793
 ```
 
-This way, when control returns to `/rite:issue:start`, the sentinel becomes part of the conversation context and Phase 5.4.4.1's grep can find it.
+Since sub-skills now execute inline, the sentinel is already part of the orchestrator's conversation context via bash stdout. The explicit inclusion in response text is a defense-in-depth measure.
 
-**Orchestrator-direct emit** (Phase 5.2 lint:aborted, Phase 5.3 pr:create-failed, Phase 5.4.4 fix:error, Phase 5.5 ready:error): The orchestrator runs the bash command itself (not inside a fork), so the sentinel stdout is already part of the orchestrator's conversation context. Still, the orchestrator MUST include the sentinel line in its response text for clarity and for self-detection in subsequent context grep iterations.
+**Orchestrator-direct emit** (Phase 5.2 lint:aborted, Phase 5.3 pr:create-failed, Phase 5.4.4 fix:error, Phase 5.5 ready:error): The orchestrator runs the bash command itself, so the sentinel stdout is already part of the orchestrator's conversation context. Still, the orchestrator MUST include the sentinel line in its response text for clarity and for self-detection in subsequent context grep iterations.
 
 ---
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -1,6 +1,5 @@
 ---
 description: 品質チェックを実行
-context: fork
 ---
 
 # /rite:lint

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -1,6 +1,5 @@
 ---
 description: ドラフト Pull Request を作成
-context: fork
 ---
 
 # /rite:pr:create

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1,6 +1,5 @@
 ---
 description: レビュー指摘への対応を支援
-context: fork
 ---
 
 # /rite:pr:fix

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -1,6 +1,5 @@
 ---
 description: マルチレビュアー PR レビューを実行
-context: fork
 ---
 
 # /rite:pr:review

--- a/plugins/rite/references/workflow-incident-emit-protocol.md
+++ b/plugins/rite/references/workflow-incident-emit-protocol.md
@@ -30,15 +30,15 @@ sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
 | `{optional hypothesis}` | Optional root cause hint (may be empty) |
 | `{pr_number}` | Current PR number, or `0` if no PR exists yet |
 
-## Sentinel Visibility Rule (LLM Responsibility)
+## Sentinel Visibility Rule (LLM Responsibility — Defensive Practice)
 
-Skills declared with `context: fork` execute Bash tool calls in an **isolated subprocess context**. The orchestrator (`/rite:issue:start`) does NOT see subprocess `stdout` directly — it only sees the **final response message** that the sub-skill LLM returns.
+Sub-skills (`lint.md`, `pr/create.md`, `pr/fix.md`, `pr/review.md`) execute inline within the orchestrator's conversation context. Bash tool call stdout is directly visible to the orchestrator, so sentinel lines emitted via the bash snippet above are automatically part of the conversation context.
 
-**Therefore**: When a sub-skill emits a workflow incident sentinel via the bash snippet above, the sub-skill LLM **MUST also include the captured `sentinel_line` value verbatim in its final visible response text** (not only as bash stdout). Otherwise the orchestrator's context grep in Phase 5.4.4.1 will never see the sentinel and AC-5 (hook abnormal exit detection) becomes silently broken.
+As a **defensive practice**, sub-skills SHOULD still include the captured `sentinel_line` value verbatim in their final visible response text. This ensures sentinel detection remains robust even if execution context changes in the future.
 
 **Concrete pattern**:
 
-After executing Step 1 and Step 2, the LLM must include the `sentinel_line` value in its response. Example:
+After executing Step 1 and Step 2, the LLM should include the `sentinel_line` value in its response as a defense-in-depth measure. Example:
 
 ```
 [lint:error] — 3 errors detected


### PR DESCRIPTION
## 概要

`context: fork` が設定されたインタラクティブコマンド（`review.md`, `create.md`, `fix.md`, `lint.md`）が、e2e フロー中の `AskUserQuestion` でブロックされる問題を修正。fork 環境ではユーザー入力を受け取れないため、skill がオプションテキストを返して終了していた。

## 関連 Issue

Closes #436

## 変更内容

- `review.md`, `create.md`, `fix.md`, `lint.md` の frontmatter から `context: fork` を除去
- `start.md` の Sentinel Visibility Rule を inline 実行前提に書き換え
- `workflow-incident-emit-protocol.md` の fork 前提説明を inline 実行に更新
- `BEST_PRACTICES_ALIGNMENT.md` のテーブルを実態に合わせて更新

## チェックリスト

- [x] 4コマンドの frontmatter から `context: fork` を除去
- [x] read-only コマンドの `context: fork` は維持
- [x] Sentinel Visibility Rule を inline 実行に更新
- [x] ドキュメントを実態に合わせて更新

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
