### PR TITLE
refactor(pipeline): pipefail + 早期終了下の printf|grep パターンを here-string 化し SIGPIPE false positive を予防 (#398)

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -413,7 +413,9 @@ Extract the parent Issue number from the closing Issue's body. The `## 親 Issue
 
 ```bash
 issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-parent_number=$(echo "$issue_body" | grep -A2 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+# SIGPIPE 防止 (#398): issue_body が大きい場合、echo | grep | head -1 で
+# head の早期終了により echo に SIGPIPE が届く。here-string で subprocess を排除。
+parent_number=$(grep -A2 '^## 親 Issue' <<< "$issue_body" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 echo "parent_number=${parent_number:-none}"
 ```
 

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -289,7 +289,12 @@ Detect unchecked checkboxes (`- [ ]`) in the "Progress" section of the work memo
 # sed: 「### 進捗」から次の「### 」までの範囲を抽出
 # grep: 未完了チェックボックス（- [ ]）を検出
 # head -10: 表示量を制限（大量のタスクがある場合の可読性確保）
-incomplete_tasks=$(echo "$comment_body" | sed -n '/### 進捗/,/### /p' | grep -E '^\s*- \[ \]' | head -10)
+#
+# SIGPIPE 防止 (#398): `echo "$comment_body" | sed | grep | head -10` の pipeline では
+# comment_body が pipe buffer (64KB) を超えると head -10 の早期終了で echo に SIGPIPE が届く。
+# here-string `<<<` で echo subprocess を排除し、sed が一時ファイルから読むため SIGPIPE 経路がない。
+progress_section=$(sed -n '/### 進捗/,/### /p' <<< "$comment_body")
+incomplete_tasks=$(grep -E '^\s*- \[ \]' <<< "$progress_section" | head -10)
 ```
 
 **Note**: `sed -n '/### 進捗/,/### /p'` works correctly even when the progress section is at the end of the file (no subsequent `### ` section). In that case, the range from `### 進捗` to EOF is extracted.

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -407,13 +407,15 @@ fi
 # (1) literal `/pull/` / `/issues/` を直書きして括弧グループ内のバリエーションを減らす
 # (2) pr_number 自体が数字のみであることを事前に validate (Phase 1.0 で normalize 済みだが defense-in-depth)
 # これにより将来 pr_number に他の文字が混入する拡張がなされた場合の silent false positive を防ぐ
-if ! printf '%s' "{pr_number}" | grep -qE '^[0-9]+$'; then
+# SIGPIPE 防止 (#398): printf | grep パターンを here-string に置換。
+if ! grep -qE '^[0-9]+$' <<< "{pr_number}"; then
   echo "エラー: pr_number が数字以外を含んでいます: '{pr_number}'" >&2
   echo "  Phase 1.0 で正規化された pr_number は数字のみのはずですが、何らかの経路で異常値が混入しました" >&2
   echo "[CONTEXT] FASTPATH_FETCH_FAILED=1; reason=issue_number_not_found" >&2
   exit 1
 fi
-if ! printf '%s' "$comment_issue_url" | grep -qE "/(pull|issues)/{pr_number}$"; then
+# SIGPIPE 防止 (#398): printf | grep パターンを here-string に置換。
+if ! grep -qE "/(pull|issues)/{pr_number}$" <<< "$comment_issue_url"; then
   echo "エラー: コメント #{target_comment_id} は PR #{pr_number} に属していません (silent misclassification 検出)" >&2
   echo "  実際の所属: $comment_issue_url" >&2
   echo "  期待値: /pull/{pr_number} または /issues/{pr_number} で終わる URL" >&2

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -126,8 +126,10 @@ case "$_phase" in
     _impl_status="✅ 完了"
     _test_status="⬜ 未着手"
     _doc_status="⬜ 未着手"
-    echo "$_diff_files" | grep -qE '\.(test|spec)\.|test_|tests/' 2>/dev/null && _test_status="✅ 完了"
-    echo "$_diff_files" | grep -qE '(docs/.*\.md|README\.md|CHANGELOG\.md|API\.md)' 2>/dev/null && _doc_status="✅ 完了"
+    # SIGPIPE 防止 (#398): echo | grep -qE パターンを here-string に置換。
+    # _diff_files が大きい場合、grep -q の早期終了で echo に SIGPIPE が届く経路を排除。
+    grep -qE '\.(test|spec)\.|test_|tests/' <<< "$_diff_files" 2>/dev/null && _test_status="✅ 完了"
+    grep -qE '(docs/.*\.md|README\.md|CHANGELOG\.md|API\.md)' <<< "$_diff_files" 2>/dev/null && _doc_status="✅ 完了"
 
     "$SCRIPT_DIR/issue-comment-wm-sync.sh" update \
       --issue "$issue_number" \

--- a/plugins/rite/references/bash-defensive-patterns.md
+++ b/plugins/rite/references/bash-defensive-patterns.md
@@ -4,7 +4,7 @@ A collection of defensive Bash patterns to prevent recurring syntax errors in ri
 
 > **CRITICAL: All Bash code in command templates MUST use the defensive patterns defined in this document.**
 >
-> These patterns prevent the 4 most common runtime errors observed in rite workflow execution.
+> These patterns prevent the 5 most common runtime errors observed in rite workflow execution.
 >
 > **Applies to**: All command templates under `commands/` that contain Bash code blocks
 
@@ -17,6 +17,7 @@ A collection of defensive Bash patterns to prevent recurring syntax errors in ri
 - [Pattern 2: grep Variable Expansion](#pattern-2-grep-variable-expansion)
 - [Pattern 3: Python Inline Scripts with Japanese](#pattern-3-python-inline-scripts-with-japanese)
 - [Pattern 4: Directory Pre-creation](#pattern-4-directory-pre-creation)
+- [Pattern 5: SIGPIPE Prevention in Pipelines](#pattern-5-sigpipe-prevention-in-pipelines)
 - [Quick Checklist for Template Authors](#quick-checklist-for-template-authors)
 
 ---
@@ -29,6 +30,7 @@ A collection of defensive Bash patterns to prevent recurring syntax errors in ri
 | 2 | `grep: 無効なオプション -- ' '` | Unquoted variable passed to grep | `grep -- "$pattern"` + `|| true` |
 | 3 | `SyntaxError: unterminated string literal` | Japanese strings in inline Python script (`python3 -c`) | File-based argument passing |
 | 4 | `そのようなファイルやディレクトリはありません` | Missing directory before file write | `mkdir -p` before write |
+| 5 | SIGPIPE / exit code 141 | `echo`/`printf` pipe to early-terminating `head`/`grep -m`/`grep -q` under `pipefail` | Here-string `<<<` instead of pipe |
 
 ---
 

--- a/plugins/rite/references/bash-defensive-patterns.md
+++ b/plugins/rite/references/bash-defensive-patterns.md
@@ -209,6 +209,56 @@ printf '%s' "$backup" > /tmp/rite-backups/wm-backup.md
 
 ---
 
+## Pattern 5: SIGPIPE Prevention in Pipelines
+
+### Vulnerable Pattern
+
+```bash
+# echo/printf が upstream (writer)、grep/head が downstream (reader) の pipeline
+incomplete_tasks=$(echo "$comment_body" | sed -n '/### 進捗/,/### /p' | grep -E '^\s*- \[ \]' | head -10)
+parent_number=$(echo "$issue_body" | grep -A2 '^## 親 Issue' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+ISSUE_NUMBER=$(printf '%s\n' "$ISSUE_URL" | grep -oE '[0-9]+$' || true)
+```
+
+**Failure mode**: `pipefail` 有効時、`head -N` / `grep -m 1` / `grep -q` が早期終了すると downstream の reader が閉じる。upstream の `echo` / `printf` がまだ書き込み中の場合（変数の内容が pipe buffer 64KB を超えるとき）、SIGPIPE (rc=141) が upstream に届き、pipeline 全体の exit code が 141 になる。`|| true` で吸収しても SIGPIPE と「マッチなし」が区別できない。
+
+### Defensive Pattern
+
+```bash
+# here-string `<<<` で echo/printf subprocess を排除
+# bash は here-string を一時ファイル経由で grep に渡すため、
+# grep の早期終了で SIGPIPE を受ける書き込みプロセスが存在しない
+progress_section=$(sed -n '/### 進捗/,/### /p' <<< "$comment_body")
+incomplete_tasks=$(grep -E '^\s*- \[ \]' <<< "$progress_section" | head -10)
+
+parent_number=$(grep -A2 '^## 親 Issue' <<< "$issue_body" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+
+ISSUE_NUMBER=$(grep -oE '[0-9]+$' <<< "$ISSUE_URL" || true)
+```
+
+**Key changes**:
+1. `echo "$var" | cmd` → `cmd <<< "$var"` — echo subprocess を排除し SIGPIPE 経路を断つ
+2. 複合 pipeline (`sed | grep | head`) は段階分割: まず `sed <<< "$var"` で範囲抽出、次に `grep <<< "$section"` でフィルタ
+3. `grep -q` / `grep -m 1` のような早期終了 flag と組み合わせる場合は特に重要
+
+### When NOT to Convert
+
+以下のパターンは SIGPIPE リスクがないため変換不要:
+
+| パターン | 理由 |
+|---------|------|
+| `echo "$var" \| grep -c` | `grep -c` は全入力を消費（早期終了しない） |
+| `echo "$var" \| sort -u \| grep -v` | `sort` が全入力をバッファリング |
+| `echo "$small_var" \| grep` (`$small_var` < 64KB 確定) | pipe buffer 内で echo が完了 |
+| テストコード内の `echo "$output" \| grep -q` | テスト出力は通常小さい |
+
+### Reference
+
+- PR #396 / Issue #389: 初回修正（`review.md` の `printf | grep -m 1` → `<<<`）
+- Issue #398: 横断調査による残存パターンの一括修正
+
+---
+
 ## Quick Checklist for Template Authors
 
 Before adding Bash code to a command template, verify:
@@ -219,3 +269,4 @@ Before adding Bash code to a command template, verify:
 - [ ] Python inline scripts use file-based argument passing (no shell variable embedding)
 - [ ] All file writes are preceded by `mkdir -p` for the target directory
 - [ ] All variables in `[ ]` or `[[ ]]` are double-quoted
+- [ ] Pipelines with early-termination (`head`, `grep -m`, `grep -q`) use here-string `<<<` instead of `echo`/`printf` pipe

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -156,7 +156,9 @@ ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>"$GH_ERR_FILE") || {
   exit 1
 }
 
-ISSUE_NUMBER=$(printf '%s\n' "$ISSUE_URL" | grep -oE '[0-9]+$' || true)
+# SIGPIPE 防止 (#398): printf | grep パターンを here-string に置換。
+# ISSUE_URL は短い文字列だが、pipefail 下での一貫性のため統一。
+ISSUE_NUMBER=$(grep -oE '[0-9]+$' <<< "$ISSUE_URL" || true)
 
 if [ -z "$ISSUE_NUMBER" ]; then
   add_warning "Could not extract issue number from URL"


### PR DESCRIPTION
## 概要

pipefail 有効下で `echo/printf | grep` + 早期終了（`head -N`, `grep -m 1`, `grep -q`）の組み合わせにより SIGPIPE false positive (rc=141) が発生する可能性のあるパターンを横断調査し、here-string `<<<` に置換。

PR #396 で修正した `review.md` の同種パターンが他ファイルに残存していたため一括修正。

## 変更内容

- `cleanup.md`: `echo "$comment_body" | sed | grep | head -10` → `sed <<< "$comment_body"` + `grep <<< "$progress_section"`
- `close.md`: `echo "$issue_body" | grep | head -1` → `grep <<< "$issue_body"`
- `create-issue-with-projects.sh`: `printf "$ISSUE_URL" | grep` → `grep <<< "$ISSUE_URL"`
- `fix.md`: `printf | grep -qE` (2箇所) → `grep -qE <<<`
- `post-tool-wm-sync.sh`: `echo | grep -qE` (2箇所) → `grep -qE <<<`
- `bash-defensive-patterns.md`: Pattern 5 (SIGPIPE Prevention in Pipelines) セクションを追加

## 関連 Issue

Closes #398

## テスト計画

- [ ] 変更対象ファイルの bash block が構文的に正しいこと
- [ ] drift check が pass すること (`distributed-fix-drift-check.sh --all`)
- [ ] `bash-defensive-patterns.md` に SIGPIPE パターンが記載されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
