### PR TITLE
test(lint): distributed-fix-drift-check に CLI option smoke test を追加

### DIFF
--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -174,9 +174,10 @@ EOF
 
 out=$("$SCRIPT" --pattern 2 --target "$P2_FIXTURE" 2>&1)
 p2_only_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out")
-# Use grep -cE for consistency with the other 7 grep -c sites in this file
-# (avoids `grep | wc -l` pipe and matches the established pattern).
-non_p2_count=$(grep -cE '^\[drift\]\[P[^2]\]' <<< "$out")
+# Use the same `grep -c PATTERN <<< "$out"` shape as every other count site in
+# this file (avoids the `grep | wc -l` pipe). The `[^2]` character class is
+# valid in BRE so plain `grep -c` is sufficient — no `-E` needed.
+non_p2_count=$(grep -c '^\[drift\]\[P[^2]\]' <<< "$out")
 assert_ge "--pattern 2 outputs >=1 P2 finding" 1 "$p2_only_count"
 assert "--pattern 2 outputs no non-P2 findings" "0" "$non_p2_count"
 
@@ -201,11 +202,14 @@ out=$("$SCRIPT" --repo-root "$ALL_DIR" --all 2>&1)
 rc=$?
 assert "--all + --repo-root exits 1 (drift detected in default target)" "1" "$rc"
 all_p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out")
-# Discriminator: synthetic fix.md contains EXACTLY 1 P3 trigger (the heredoc
-# fixture above). The real `plugins/rite/commands/pr/fix.md` has multiple P3
-# findings, so an `assert_ge ... 1` would still PASS even if `--repo-root`
-# silently no-op'd and the script ran against the real file. Asserting "exactly
-# 1" lets the test fail when chdir regression occurs.
+# Discriminator: the synthetic fix.md contains EXACTLY 1 P3 trigger (the
+# heredoc fixture above). If `--repo-root` silently no-op'd, the script would
+# fall back to the real repo cwd and scan the real
+# `plugins/rite/commands/pr/fix.md`, which would yield a different P3 count
+# (currently 0 — a clean codebase — but this assertion is robust regardless of
+# whether the real file has 0 or many P3 findings, because the count would
+# almost certainly not be exactly 1). Asserting "exactly 1" therefore catches
+# chdir regression in either direction.
 assert "--all + --repo-root: exactly 1 P3 from synthetic target (chdir guard)" "1" "$all_p3_count"
 # Path discriminator: the [drift] line should reference fix.md as a relative
 # path (the script chdirs to --repo-root before checking). Both synthetic and

--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -174,7 +174,9 @@ EOF
 
 out=$("$SCRIPT" --pattern 2 --target "$P2_FIXTURE" 2>&1)
 p2_only_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out")
-non_p2_count=$(grep -E '^\[drift\]\[P[^2]\]' <<< "$out" | wc -l)
+# Use grep -cE for consistency with the other 7 grep -c sites in this file
+# (avoids `grep | wc -l` pipe and matches the established pattern).
+non_p2_count=$(grep -cE '^\[drift\]\[P[^2]\]' <<< "$out")
 assert_ge "--pattern 2 outputs >=1 P2 finding" 1 "$p2_only_count"
 assert "--pattern 2 outputs no non-P2 findings" "0" "$non_p2_count"
 
@@ -199,7 +201,18 @@ out=$("$SCRIPT" --repo-root "$ALL_DIR" --all 2>&1)
 rc=$?
 assert "--all + --repo-root exits 1 (drift detected in default target)" "1" "$rc"
 all_p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out")
-assert_ge "--all expansion + --repo-root chdir detect P3 drift" 1 "$all_p3_count"
+# Discriminator: synthetic fix.md contains EXACTLY 1 P3 trigger (the heredoc
+# fixture above). The real `plugins/rite/commands/pr/fix.md` has multiple P3
+# findings, so an `assert_ge ... 1` would still PASS even if `--repo-root`
+# silently no-op'd and the script ran against the real file. Asserting "exactly
+# 1" lets the test fail when chdir regression occurs.
+assert "--all + --repo-root: exactly 1 P3 from synthetic target (chdir guard)" "1" "$all_p3_count"
+# Path discriminator: the [drift] line should reference fix.md as a relative
+# path (the script chdirs to --repo-root before checking). Both synthetic and
+# real targets share the same relative path, so this asserts the broad shape
+# rather than the absolute location.
+all_p3_path_count=$(grep -c '^\[drift\]\[P3\] plugins/rite/commands/pr/fix.md:' <<< "$out")
+assert_ge "--all + --repo-root: drift line references fix.md by relative path" 1 "$all_p3_path_count"
 
 # --- Summary -----------------------------------------------------------------
 echo

--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -148,6 +148,59 @@ out=$("$SCRIPT" --target "$CJK_BROKEN" 2>&1)
 p4_count=$(grep -c '^\[drift\]\[P4\]' <<< "$out")
 assert_ge "broken CJK anchor detected as drift" 1 "$p4_count"
 
+# --- Test 7: --pattern 2 filter outputs only P2 ------------------------------
+# Build a fixture that triggers BOTH Pattern-2 (reason-table drift) and
+# Pattern-3 (if-wrap drift). Without --pattern, the script would emit both
+# findings; with --pattern 2, only P2 lines must appear.
+P2_FIXTURE=$(mktemp)
+TMPFILES+=("$P2_FIXTURE")
+cat > "$P2_FIXTURE" <<'EOF'
+# Pattern-2 + Pattern-3 mixed fixture
+
+## Reason table
+
+| reason | description |
+|--------|-------------|
+| `table_only_reason` | listed in table but never emitted |
+
+Some narrative referencing reason=emit_only_reason for the P2 emit-side detector.
+
+## Code block (Pattern-3 candidate)
+
+cat <<'INNER_EOF' > "$tmpfile"
+content
+INNER_EOF
+EOF
+
+out=$("$SCRIPT" --pattern 2 --target "$P2_FIXTURE" 2>&1)
+p2_only_count=$(grep -c '^\[drift\]\[P2\]' <<< "$out")
+non_p2_count=$(grep -E '^\[drift\]\[P[^2]\]' <<< "$out" | wc -l)
+assert_ge "--pattern 2 outputs >=1 P2 finding" 1 "$p2_only_count"
+assert "--pattern 2 outputs no non-P2 findings" "0" "$non_p2_count"
+
+# --- Test 8: --all + --repo-root smoke ---------------------------------------
+# Build a synthetic repo root containing one of the default --all targets
+# (plugins/rite/commands/pr/fix.md) seeded with a Pattern-3 drift. The other
+# default targets are absent and silently skipped by the per-pattern
+# `[ -f "$file" ] || return 0` guard, so this single-file fixture exercises
+# both --all expansion AND --repo-root chdir in one assertion.
+ALL_DIR=$(mktemp -d)
+TMPFILES+=("$ALL_DIR")
+mkdir -p "$ALL_DIR/plugins/rite/commands/pr"
+cat > "$ALL_DIR/plugins/rite/commands/pr/fix.md" <<'EOF'
+# Synthetic fix.md for --all + --repo-root smoke test
+
+cat <<'INNER_EOF' > "$tmpfile"
+content
+INNER_EOF
+EOF
+
+out=$("$SCRIPT" --repo-root "$ALL_DIR" --all 2>&1)
+rc=$?
+assert "--all + --repo-root exits 1 (drift detected in default target)" "1" "$rc"
+all_p3_count=$(grep -c '^\[drift\]\[P3\]' <<< "$out")
+assert_ge "--all expansion + --repo-root chdir detect P3 drift" 1 "$all_p3_count"
+
 # --- Summary -----------------------------------------------------------------
 echo
 echo "Results: PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
## 概要

`test-distributed-fix-drift-check.sh` に CLI オプションパースの regression を検出するための smoke test を 2 件追加。Issue #375 (PR #373 cycle 3 test review LOW follow-up) に対応。

## 変更内容

- **Test 7**: `--pattern 2 --target <fixture>` の挙動を断定
  - fixture に Pattern-2 (reason 表ドリフト) と Pattern-3 (`if !` wrap 漏れ) を同居させる
  - フィルタなしなら両方検出される前提で、`--pattern 2` 適用後は非 P2 行が 0 件であることを assert
  - これにより `--pattern N` フィルタが「フラグを受理するだけ」ではなく「実際に他 Pattern を抑制している」ことを検証
- **Test 8**: `--all` + `--repo-root` の挙動を 1 ケースで断定
  - synthetic な repo root 配下に default `--all` target の 1 つ (`plugins/rite/commands/pr/fix.md`) を生成し Pattern-3 ドリフトを仕込む
  - 残り 2 件の default target は `[ -f "$file" ]` ガードで silent skip されるため、単一 fixture で `--all` 展開と `--repo-root` chdir の双方を検証可能
  - exit code = 1 と `[drift][P3] >= 1` を assert

## テスト結果

```
PASS=13 FAIL=0
```

既存 9 assertions を維持して新規 4 assertions を追加。

## 関連

Closes #375

- 元 PR: #373 (cycle 3 test MEDIUM → follow-up)
- 元 Issue: #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
