### PR TITLE
test(lint): Test 4b で reason-table を含む clean fixture を追加し P2/P5 比較ロジックを exercise (#376)

### DIFF
--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -99,6 +99,67 @@ EOF
 rc=$?
 assert "synthetic clean file exits 0" "0" "$rc"
 
+# --- Test 4b: clean fixture WITH reason-table validates P2/P5 comparison ----
+# Test 4 above uses prose-only content. Without a reason-table or eval-table
+# parenthesized list, Pattern-2/5 detectors hit their early-return guards
+# (`[ -z "$table_reasons" ] && return 0` at distributed-fix-drift-check.sh:179
+# and `[ -z "$table_words" ] && return 0` at line 279). The exit-0 assertion
+# in Test 4 therefore proves only "no detector ran on the comparison branch" —
+# a false negative for the actual comm-based comparison logic.
+#
+# This test adds a fixture that DOES contain a reason-table and a Pattern-5
+# parenthesized list, with `reason=...` emits matching the table 1:1.  The
+# detectors must execute their comm comparisons and emit zero findings.
+CLEAN_TABLE=$(mktemp)
+TMPFILES+=("$CLEAN_TABLE")
+cat > "$CLEAN_TABLE" <<'EOF'
+# Clean fixture with reason-table
+
+## Reason table (Pattern-2)
+
+| reason | description |
+|--------|-------------|
+| `reason_alpha` | first reason |
+| `reason_beta`  | second reason |
+| `reason_gamma` | third reason |
+
+## Narrative emits (matches table 1:1)
+
+The following emits exercise the comparison logic without producing drift:
+
+- We emit reason=reason_alpha for case A.
+- We emit reason=reason_beta  for case B.
+- We emit reason=reason_gamma for case C.
+
+## Eval-table parenthesized list (Pattern-5)
+
+Order: ( `reason_alpha` / `reason_beta` / `reason_gamma` ) — all entries
+match the same set of emits above, so Pattern-5's comm comparison must
+return empty.
+EOF
+
+# Full run: assert exit 0 AND zero P2/P5 findings on the comparison-active path.
+out=$("$SCRIPT" --target "$CLEAN_TABLE" 2>&1)
+rc=$?
+assert "clean fixture with reason-table exits 0" "0" "$rc"
+
+p2_clean=$(grep -c '^\[drift\]\[P2\]' <<< "$out")
+assert "clean fixture with reason-table: 0 P2 drift" "0" "$p2_clean"
+
+p5_clean=$(grep -c '^\[drift\]\[P5\]' <<< "$out")
+assert "clean fixture with reason-table: 0 P5 drift" "0" "$p5_clean"
+
+# Per-pattern run: discriminator that the comparison ran rather than
+# early-returning. The fixture above guarantees both `table_reasons` and
+# `table_words` are non-empty, so neither detector can short-circuit.
+"$SCRIPT" --pattern 2 --target "$CLEAN_TABLE" >/dev/null 2>&1
+rc=$?
+assert "clean fixture --pattern 2 exits 0 (P2 comparison active)" "0" "$rc"
+
+"$SCRIPT" --pattern 5 --target "$CLEAN_TABLE" >/dev/null 2>&1
+rc=$?
+assert "clean fixture --pattern 5 exits 0 (P5 comparison active)" "0" "$rc"
+
 # --- Test 5: CJK anchors resolve correctly (Pattern 4 end-to-end) ------------
 # Use a temp directory so reference files can use relative paths for Pattern 4.
 CJK_DIR=$(mktemp -d)


### PR DESCRIPTION
## 概要

Issue #376 の対応。PR #373 cycle 3 test review LOW の follow-up。

`distributed-fix-drift-check.sh` の Test 4 (synthetic clean file) は prose のみで構成されており、Pattern-2 / Pattern-5 の早期 return ガード (`[ -z "$table_reasons" ] && return 0` / `[ -z "$table_words" ] && return 0`) に吸収されてしまう。結果として既存の "exits 0" assert は「detector が comm 比較ロジックを実行した上で 0 drift」ではなく「detector が何も見なかった」を保証していたため、検出器側のリグレッションを取りこぼす false negative リスクがあった。

本 PR では Test 4b を追加し、reason-table + matching emit + Pattern-5 parenthesized list を含む fixture で comm 比較ロジックを実際に exercise した上での clean 判定を多重に保証する。

## 変更内容

`plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh` に Test 4b を追加:

- **fixture**: reason-table (3 reasons: `reason_alpha` / `reason_beta` / `reason_gamma`) + 1:1 で対応する `reason=...` emit + Pattern-5 用の `( \`reason_alpha\` / \`reason_beta\` / \`reason_gamma\` )` parenthesized list
- **assertions** (5 件):
  1. フル run で exit 0
  2. `[drift][P2]` カウント == 0
  3. `[drift][P5]` カウント == 0
  4. `--pattern 2` 単独で exit 0 (P2 comparison が早期 return せず実行されたことの discriminator)
  5. `--pattern 5` 単独で exit 0 (同上)

既存の Test 4 (prose-only fixture) は非リグレッションのため残置。

## 関連 Issue

Closes #376

関連:
- 元 PR: #373 (cycle 3 test LOW→follow-up)
- 元 Issue: #361

## テスト結果

```
$ bash plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
...
PASS: clean fixture with reason-table exits 0
PASS: clean fixture with reason-table: 0 P2 drift
PASS: clean fixture with reason-table: 0 P5 drift
PASS: clean fixture --pattern 2 exits 0 (P2 comparison active)
PASS: clean fixture --pattern 5 exits 0 (P5 comparison active)
...
Results: PASS=19 FAIL=0
```

既存 14 件 + 新規 5 件 = 19 件 すべて PASS。distributed-fix-drift-check (`--all`) も 0 drift で clean。

## チェックリスト

- [x] reason-table と emit が一致する fixture を追加 (AC #1)
- [x] 「table あり × drift 無し」経路で exit 0 となることをアサート (AC #2)
- [x] false negative 検証の網羅性向上 (AC #3)
- [x] 既存テスト非リグレッション確認 (PASS=19 FAIL=0)
