### PR TITLE
feat(lint): backtick 隣接 bang パターン検出 lint を commands/skills 配下に追加

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -463,7 +463,7 @@ fi
 
 ### 3.6 Plugin-specific Checks (Bang-Backtick Adjacency Detection)
 
-Execute the bang-backtick check script to detect Skill loader triggering patterns (backtick + bang adjacency) in `commands/**/*.md` and `skills/**/*.md`. This is the static lint counterpart to Issue #365 / PR #367 where inline-code bang adjacency broke Skill loading via bash history expansion. See the script header comment at `plugins/rite/hooks/scripts/bang-backtick-check.sh` for concrete detection patterns.
+Execute the bang-backtick check script to detect Skill loader triggering patterns (backtick + bang adjacency) in **`plugins/rite/commands/**/*.md`** and **`plugins/rite/skills/**/*.md`** (plugin-scoped; the script walks the rite plugin tree specifically and does not scan repository-root `commands/` or `skills/` directories that may belong to other plugins). This is the static lint counterpart to Issue #365 / PR #367 where inline-code bang adjacency broke Skill loading via bash history expansion. See the script header comment at `plugins/rite/hooks/scripts/bang-backtick-check.sh` for concrete detection patterns.
 
 **Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
 
@@ -570,14 +570,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {drift_output}
 ```
 
-**Bang-backtick warning appendix** (both standalone and E2E): When `bang_backtick_status` is `warning`, append findings after the lint result output:
+**Bang-backtick warning appendix** (both standalone and E2E): When `bang_backtick_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Both statuses use the same appendix so that invocation failures (exit code 2) are never silently dropped — addressing the observability gap that the same appendix rule fixes in Phase 3.5 drift check (Issue #369 prompt-engineer L-2):
 
 ```
-⚠️ Bang-backtick check: {bang_backtick_finding_count} findings detected (warning, non-blocking)
+⚠️ Bang-backtick check: {bang_backtick_finding_count} findings detected ({bang_backtick_status}, non-blocking)
 {bang_backtick_output}
 ```
 
-These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift or bang-backtick warnings.
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift or bang-backtick warnings/invocation errors.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 
@@ -660,7 +660,7 @@ Analyze the error content and present fix suggestions when possible:
 > **{i18n:lint_standalone_note}**: {i18n:lint_standalone_note_detail}
 ```
 
-**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`.
+**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -570,7 +570,7 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {drift_output}
 ```
 
-**Bang-backtick warning appendix** (both standalone and E2E): When `bang_backtick_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Both statuses use the same appendix so that invocation failures (exit code 2) are never silently dropped — addressing the observability gap that the same appendix rule fixes in Phase 3.5 drift check (Issue #369 prompt-engineer L-2):
+**Bang-backtick warning appendix** (both standalone and E2E): When `bang_backtick_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Both statuses use the same appendix so that invocation failures (exit code 2) are never silently dropped. **Note**: Phase 3.5 drift check has the same observability gap (appendix fires only on `warning`, not `error`), but fixing drift check is **out of scope for this PR** — it is tracked as a follow-up item. The asymmetry here is intentional for this PR's narrow scope:
 
 ```
 ⚠️ Bang-backtick check: {bang_backtick_finding_count} findings detected ({bang_backtick_status}, non-blocking)
@@ -660,7 +660,7 @@ Analyze the error content and present fix suggestions when possible:
 > **{i18n:lint_standalone_note}**: {i18n:lint_standalone_note_detail}
 ```
 
-**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped.
+**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. **Asymmetry note**: The `{i18n:lint_drift_check}` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -461,6 +461,41 @@ fi
 - `drift_finding_count`: Extract from `drift_output` by matching the line `==> Total drift findings: N` (regex: `/Total drift findings: (\d+)/`). If no match found, default to 0
 - `drift_output`: Script output (truncated if >50 lines)
 
+### 3.6 Plugin-specific Checks (Bang-Backtick Adjacency Detection)
+
+Execute the bang-backtick check script to detect Skill loader triggering patterns (backtick + bang adjacency) in `commands/**/*.md` and `skills/**/*.md`. This is the static lint counterpart to Issue #365 / PR #367 where inline-code bang adjacency broke Skill loading via bash history expansion. See the script header comment at `plugins/rite/hooks/scripts/bang-backtick-check.sh` for concrete detection patterns.
+
+**Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
+
+**Skip condition**: Script file does not exist (e.g., marketplace install without hooks/scripts directory).
+
+**Execution:**
+
+```bash
+if [ -f {plugin_root}/hooks/scripts/bang-backtick-check.sh ]; then
+  bang_backtick_output=$(bash {plugin_root}/hooks/scripts/bang-backtick-check.sh --all 2>&1)
+  bang_backtick_exit_code=$?
+else
+  bang_backtick_exit_code=-1  # script not found
+fi
+```
+
+**Result handling:**
+
+| Exit Code | `bang_backtick_status` | Action |
+|-----------|------------------------|--------|
+| 0 | `success` | No bang-backtick adjacency — continue to Phase 4 |
+| 1 | `warning` | Pattern detected — record as **warning** (does NOT cause `[lint:error]`). Display findings but allow flow to continue |
+| 2 | `error` | Invocation error — record as warning, display error message |
+| -1 | `skipped` | Script not found — skip silently |
+
+**Important**: Bang-backtick detection results are treated as **warnings**, not errors — same policy as Phase 3.5 drift check. A finding does NOT change the overall lint result pattern (`[lint:success]` remains `[lint:success]`). Reason: existing checks stay non-blocking during staged rollout, and Skill loader triggering is a correctness issue that should be fixed promptly but not gate CI until coverage is validated.
+
+**Record bang-backtick results** for Phase 4 reporting:
+- `bang_backtick_status`: `success` / `warning` / `error` / `skipped`
+- `bang_backtick_finding_count`: Extract from `bang_backtick_output` by matching the line `==> Total bang-backtick findings: N` (regex: `/Total bang-backtick findings: (\d+)/`). If no match found, default to 0
+- `bang_backtick_output`: Script output (truncated if >50 lines)
+
 ---
 
 ## Phase 4: Report Results
@@ -535,7 +570,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {drift_output}
 ```
 
-This appendix does NOT change the result pattern — `[lint:success]` remains the pattern even with drift warnings.
+**Bang-backtick warning appendix** (both standalone and E2E): When `bang_backtick_status` is `warning`, append findings after the lint result output:
+
+```
+⚠️ Bang-backtick check: {bang_backtick_finding_count} findings detected (warning, non-blocking)
+{bang_backtick_output}
+```
+
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift or bang-backtick warnings.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 
@@ -607,6 +649,7 @@ Analyze the error content and present fix suggestions when possible:
 | {i18n:lint_warnings} | {warning_count} |
 | {i18n:lint_test} | {test_status} ({test_error_count} failures) |
 | {i18n:lint_drift_check} | {drift_status} ({drift_finding_count} findings) |
+| Bang-backtick check | {bang_backtick_status} ({bang_backtick_finding_count} findings) |
 | {i18n:lint_duration} | {duration} |
 
 {i18n:lint_next_steps}:
@@ -617,7 +660,7 @@ Analyze the error content and present fix suggestions when possible:
 > **{i18n:lint_standalone_note}**: {i18n:lint_standalone_note_detail}
 ```
 
-**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row.
+**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -130,7 +130,14 @@ trap 'rm -f "$FINDINGS_FILE"' EXIT
 # to FINDINGS_FILE so the outer loop can count and print at the end.
 check_file() {
   local file="$1"
-  [ -f "$file" ] || return 0
+  # Non-existent targets must be reported as diagnostics — a silent `return 0` gives
+  # users false confidence when a typo'd `--target` path is passed (Issue #369 code-quality
+  # cycle 2 L-NEW1). The `--all` path is unaffected because find(1) never produces
+  # missing entries.
+  if [ ! -f "$file" ]; then
+    echo "WARNING: target not found: $file" >&2
+    return 0
+  fi
   awk -v F="$file" '
     {
       line = $0

--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -55,7 +55,10 @@ Options:
   --all              Scan plugins/rite/commands/**/*.md and plugins/rite/skills/**/*.md
   --target FILE      Check FILE (repeatable). Path relative to repo root.
   --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
-  --quiet            Suppress per-finding output (still exit non-zero on detection)
+  --quiet            Suppress progress/summary log lines on stderr (per-finding
+                     output on stdout is preserved; still exits non-zero on
+                     detection). Use for CI log noise reduction while keeping
+                     findings machine-readable.
   -h, --help         Show this help
 
 Exit codes:

--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -1,20 +1,39 @@
 #!/usr/bin/env bash
 # bang-backtick-check.sh
 #
-# Detect bang-backtick adjacent patterns in commands/**/*.md and skills/**/*.md
-# that can trigger Skill loader history expansion and break Skill loading
-# (Issue #365 / PR #367 — `if !` pattern caused /rite:pr:fix Skill load failure).
+# Detect bang-backtick adjacent patterns in plugins/rite/commands/**/*.md and
+# plugins/rite/skills/**/*.md that can trigger Skill loader history expansion and
+# break Skill loading (Issue #365 / PR #367 — backtick+bang adjacency in inline
+# code caused /rite:pr:fix Skill load failure).
 #
-# Detected patterns (both must be inline code, i.e. enclosed in single backticks):
-#   P1: closing-backtick-preceded-by-space-bang  — regex: ` [^`]* !`
-#       Example: `if !`  (the Issue #365 triggering pattern)
-#   P2: opening-backtick-followed-by-bang        — regex: `![alnum/space]
-#       Example: `!foo`, `! cmd`
+# Detected patterns (both are matched within a single Markdown inline code span,
+# i.e. text enclosed by paired single backticks). **All occurrences on a single
+# line are reported** — the scanner uses a while-match loop, so multiple triggers
+# on the same line never silently collapse to one finding.
 #
-# These patterns were chosen conservatively to produce zero false positives
-# on the existing commands/skills tree (verified at creation time).
-# Innocent patterns like `//!` (Rustdoc), `![...](...)` (Markdown image), and
-# `!\[...\]` (regex literals) are NOT matched.
+#   P1: closing-backtick-preceded-by-space-bang
+#       regex: ` [^`]* !`
+#       semantics: inline code where the character right before the closing
+#                  backtick is literal "space + bang" (tab and other whitespace
+#                  are NOT matched — this is the exact shape that broke fix.md
+#                  in Issue #365).
+#       Example that matches:    backtick-if-space-bang-backtick   (the #365 pattern)
+#       Example that does NOT:   backtick-if-space-bang-space-cmd-backtick
+#                                  (bang is not adjacent to closing backtick)
+#
+#   P2: opening-backtick-followed-by-bang
+#       regex: `![alnum or single ASCII space]
+#       semantics: inline code where the character right after the opening
+#                  backtick is literal bang, followed by an alphanumeric or a
+#                  single ASCII space (captures bash history-expansion shapes
+#                  like "bang+word" while intentionally excluding the Markdown
+#                  image-reference shape "bang+backslash-bracket").
+#
+# These patterns were chosen conservatively to produce zero false positives on
+# the existing commands/skills tree (verified at creation time on 70 files).
+# Innocent patterns such as Rustdoc inner doc `slash-slash-bang`, Markdown image
+# `bang-bracket-alt-paren-url`, regex literal `bang-backslash-bracket`, and
+# bash negation `if-space-bang-space-cmd` are intentionally NOT matched.
 #
 # Usage:
 #   bang-backtick-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
@@ -33,7 +52,7 @@ usage() {
 Usage: bang-backtick-check.sh [options]
 
 Options:
-  --all              Scan commands/**/*.md and skills/**/*.md under plugins/rite
+  --all              Scan plugins/rite/commands/**/*.md and plugins/rite/skills/**/*.md
   --target FILE      Check FILE (repeatable). Path relative to repo root.
   --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
   --quiet            Suppress per-finding output (still exit non-zero on detection)
@@ -47,7 +66,6 @@ EOF
 }
 
 log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*" >&2; }
-out() { printf '%s\n' "$*"; }
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -65,10 +83,33 @@ if [ -z "$REPO_ROOT" ]; then
 fi
 cd "$REPO_ROOT" || { echo "ERROR: cannot cd to $REPO_ROOT" >&2; exit 2; }
 
+# Resolve --all target list. Explicitly check that at least one of the scan
+# directories exists so marketplace-install environments (where hooks/scripts
+# lives in a different tree than the plugin commands/) get a clear diagnostic
+# instead of the generic "no targets specified" fallback.
 if [ "$USE_ALL" -eq 1 ]; then
+  commands_dir="plugins/rite/commands"
+  skills_dir="plugins/rite/skills"
+  found_any_dir=0
+  if [ -d "$commands_dir" ]; then
+    found_any_dir=1
+  else
+    echo "WARNING: $commands_dir not found under $REPO_ROOT (skipped)" >&2
+  fi
+  if [ -d "$skills_dir" ]; then
+    found_any_dir=1
+  else
+    echo "WARNING: $skills_dir not found under $REPO_ROOT (skipped)" >&2
+  fi
+  if [ "$found_any_dir" -eq 0 ]; then
+    echo "ERROR: --all requested but neither $commands_dir nor $skills_dir exist under $REPO_ROOT" >&2
+    echo "  Likely cause: this script was invoked outside the rite plugin repo (e.g. marketplace install)" >&2
+    echo "  Recovery: run from the rite plugin source tree, or pass --target FILE explicitly" >&2
+    exit 2
+  fi
   while IFS= read -r f; do
     TARGETS+=("$f")
-  done < <(find plugins/rite/commands plugins/rite/skills -type f -name '*.md' 2>/dev/null | sort)
+  done < <(find "$commands_dir" "$skills_dir" -type f -name '*.md' 2>/dev/null | sort)
 fi
 
 if [ "${#TARGETS[@]}" -eq 0 ]; then
@@ -77,48 +118,42 @@ if [ "${#TARGETS[@]}" -eq 0 ]; then
   exit 2
 fi
 
-FINDING_COUNT_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
-trap 'rm -f "$FINDING_COUNT_FILE"' EXIT
-echo 0 > "$FINDING_COUNT_FILE"
-
-report() {
-  # report PATTERN FILE LINE MESSAGE
-  local pattern="$1" file="$2" line="$3" msg="$4"
-  out "[bang-backtick][P${pattern}] ${file}:${line}: ${msg}"
-  local n
-  n=$(<"$FINDING_COUNT_FILE")
-  echo $((n + 1)) > "$FINDING_COUNT_FILE"
-}
+FINDINGS_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
+trap 'rm -f "$FINDINGS_FILE"' EXIT
 
 # ----- Scan one file for both patterns ---------------------------------------
+#
+# Uses awk's `while (match(...))` idiom so that multiple triggers on a single
+# line are all reported (fixes per-line undercounting bug — Issue #369 code-quality
+# H-1). Each P1/P2 occurrence emits a dedicated finding line, eliminating the
+# post-processing case dispatch the previous revision needed. Append directly
+# to FINDINGS_FILE so the outer loop can count and print at the end.
 check_file() {
   local file="$1"
   [ -f "$file" ] || return 0
-  # P1: ` [^`]* !`  — inline code whose last char is `!` preceded by a space
-  # P2: `!          — inline code whose first char after the opening backtick is `!`
-  #                   followed by alnum or space (avoids `!\[` regex literals)
   awk -v F="$file" '
     {
-      line_no = NR
       line = $0
-      # Pattern 1: space+! immediately before closing backtick inside inline code
-      # Match: `...space!`  (must be preceded by opening backtick)
-      if (match(line, /`[^`]* !`/)) {
-        print "P1|" line_no "|closing backtick preceded by space+!"
+      # P1: space+! immediately before a closing backtick inside inline code.
+      # Loop with substr/match to capture every occurrence on the same line.
+      pos = 1
+      while (pos <= length(line)) {
+        sub_s = substr(line, pos)
+        if (!match(sub_s, /`[^`]* !`/)) break
+        print "[bang-backtick][P1] " F ":" NR ": closing backtick preceded by space+!"
+        pos = pos + RSTART + RLENGTH - 1
       }
-      # Pattern 2: opening backtick immediately followed by ! (then alnum or space)
-      # `!foo` / `! cmd` are matched; `!\[...\]` is NOT (next char is backslash)
-      if (match(line, /`![[:alnum:] ]/)) {
-        print "P2|" line_no "|opening backtick followed by ! + word/space"
+      # P2: opening backtick immediately followed by ! + alnum/space.
+      # Same multi-match loop.
+      pos = 1
+      while (pos <= length(line)) {
+        sub_s = substr(line, pos)
+        if (!match(sub_s, /`![[:alnum:] ]/)) break
+        print "[bang-backtick][P2] " F ":" NR ": opening backtick followed by ! + word/space"
+        pos = pos + RSTART + RLENGTH - 1
       }
     }
-  ' "$file" | while IFS='|' read -r pat ln msg; do
-    [ -z "$pat" ] && continue
-    case "$pat" in
-      P1) report 1 "$file" "$ln" "$msg" ;;
-      P2) report 2 "$file" "$ln" "$msg" ;;
-    esac
-  done
+  ' "$file" >> "$FINDINGS_FILE"
 }
 
 log "Scanning ${#TARGETS[@]} file(s)..."
@@ -126,7 +161,12 @@ for t in "${TARGETS[@]}"; do
   check_file "$t"
 done
 
-total=$(<"$FINDING_COUNT_FILE")
+if [ -s "$FINDINGS_FILE" ]; then
+  cat "$FINDINGS_FILE"
+  total=$(wc -l < "$FINDINGS_FILE")
+else
+  total=0
+fi
 log "==> Total bang-backtick findings: ${total}"
 
 if [ "$total" -gt 0 ]; then

--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# bang-backtick-check.sh
+#
+# Detect bang-backtick adjacent patterns in commands/**/*.md and skills/**/*.md
+# that can trigger Skill loader history expansion and break Skill loading
+# (Issue #365 / PR #367 — `if !` pattern caused /rite:pr:fix Skill load failure).
+#
+# Detected patterns (both must be inline code, i.e. enclosed in single backticks):
+#   P1: closing-backtick-preceded-by-space-bang  — regex: ` [^`]* !`
+#       Example: `if !`  (the Issue #365 triggering pattern)
+#   P2: opening-backtick-followed-by-bang        — regex: `![alnum/space]
+#       Example: `!foo`, `! cmd`
+#
+# These patterns were chosen conservatively to produce zero false positives
+# on the existing commands/skills tree (verified at creation time).
+# Innocent patterns like `//!` (Rustdoc), `![...](...)` (Markdown image), and
+# `!\[...\]` (regex literals) are NOT matched.
+#
+# Usage:
+#   bang-backtick-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
+#
+# Exit codes: 0 = clean, 1 = pattern detected, 2 = invocation error.
+
+set -uo pipefail
+
+REPO_ROOT=""
+QUIET=0
+declare -a TARGETS=()
+USE_ALL=0
+
+usage() {
+  cat <<'EOF'
+Usage: bang-backtick-check.sh [options]
+
+Options:
+  --all              Scan commands/**/*.md and skills/**/*.md under plugins/rite
+  --target FILE      Check FILE (repeatable). Path relative to repo root.
+  --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
+  --quiet            Suppress per-finding output (still exit non-zero on detection)
+  -h, --help         Show this help
+
+Exit codes:
+  0  No bang-backtick adjacency detected
+  1  Pattern detected
+  2  Invocation error (bad args, missing files)
+EOF
+}
+
+log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*" >&2; }
+out() { printf '%s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) USE_ALL=1; shift ;;
+    --target) TARGETS+=("$2"); shift 2 ;;
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to $REPO_ROOT" >&2; exit 2; }
+
+if [ "$USE_ALL" -eq 1 ]; then
+  while IFS= read -r f; do
+    TARGETS+=("$f")
+  done < <(find plugins/rite/commands plugins/rite/skills -type f -name '*.md' 2>/dev/null | sort)
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "ERROR: no targets specified (use --all or --target FILE)" >&2
+  usage >&2
+  exit 2
+fi
+
+FINDING_COUNT_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
+trap 'rm -f "$FINDING_COUNT_FILE"' EXIT
+echo 0 > "$FINDING_COUNT_FILE"
+
+report() {
+  # report PATTERN FILE LINE MESSAGE
+  local pattern="$1" file="$2" line="$3" msg="$4"
+  out "[bang-backtick][P${pattern}] ${file}:${line}: ${msg}"
+  local n
+  n=$(<"$FINDING_COUNT_FILE")
+  echo $((n + 1)) > "$FINDING_COUNT_FILE"
+}
+
+# ----- Scan one file for both patterns ---------------------------------------
+check_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  # P1: ` [^`]* !`  — inline code whose last char is `!` preceded by a space
+  # P2: `!          — inline code whose first char after the opening backtick is `!`
+  #                   followed by alnum or space (avoids `!\[` regex literals)
+  awk -v F="$file" '
+    {
+      line_no = NR
+      line = $0
+      # Pattern 1: space+! immediately before closing backtick inside inline code
+      # Match: `...space!`  (must be preceded by opening backtick)
+      if (match(line, /`[^`]* !`/)) {
+        print "P1|" line_no "|closing backtick preceded by space+!"
+      }
+      # Pattern 2: opening backtick immediately followed by ! (then alnum or space)
+      # `!foo` / `! cmd` are matched; `!\[...\]` is NOT (next char is backslash)
+      if (match(line, /`![[:alnum:] ]/)) {
+        print "P2|" line_no "|opening backtick followed by ! + word/space"
+      }
+    }
+  ' "$file" | while IFS='|' read -r pat ln msg; do
+    [ -z "$pat" ] && continue
+    case "$pat" in
+      P1) report 1 "$file" "$ln" "$msg" ;;
+      P2) report 2 "$file" "$ln" "$msg" ;;
+    esac
+  done
+}
+
+log "Scanning ${#TARGETS[@]} file(s)..."
+for t in "${TARGETS[@]}"; do
+  check_file "$t"
+done
+
+total=$(<"$FINDING_COUNT_FILE")
+log "==> Total bang-backtick findings: ${total}"
+
+if [ "$total" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
@@ -111,9 +111,12 @@ EOF
 out=$("$SCRIPT" --target "$FIXTURE_P1" 2>&1)
 rc=$?
 assert "P1 fixture exits 1 (detected)" "1" "$rc"
-p1_count=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
+# grep -c exits 1 when zero matches; under `set -uo pipefail` (no `-e`) that never
+# aborts the script, so the previous `|| true` was pure noise. Remove it throughout
+# to keep the test body signal-to-noise high (Issue #369 code-quality cycle 2 L-NEW2).
+p1_count=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out")
 assert_ge "P1 fixture detects >=2 P1 findings" 2 "$p1_count"
-p2_in_p1=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
+p2_in_p1=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out")
 assert "P1 fixture does NOT bleed into P2 (p2_count == 0)" "0" "$p2_in_p1"
 
 # --- Test 5: P1 multi-trigger on a single line (H-1 regression guard) --------
@@ -128,8 +131,15 @@ EOF
 out=$("$SCRIPT" --target "$FIXTURE_P1_MULTI" 2>&1)
 rc=$?
 assert "P1 multi-trigger fixture exits 1" "1" "$rc"
-p1_multi=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
-assert_ge "P1 multi-trigger reports all 3 hits (not undercounted)" 3 "$p1_multi"
+p1_multi=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out")
+# Strict equality (not `-ge 3`) so over-counting regressions — e.g. a scanner rewrite
+# that accidentally double-emits the same match, or widens P1 to fire on overlapping
+# substrings — are caught as well (Issue #369 test cycle 2 L-NEW3).
+assert "P1 multi-trigger reports exactly 3 hits" "3" "$p1_multi"
+# Bleed-check: P2 must not fire on P1-only input, even on multi-trigger lines.
+# This pins the regex's class isolation against future widening (L-NEW4).
+p2_in_p1_multi=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out")
+assert "P1 multi-trigger does NOT bleed into P2" "0" "$p2_in_p1_multi"
 
 # --- Test 6: P2 fixture triggers P2 only (bleed-check) ----------------------
 FIXTURE_P2=$(mktemp_md)
@@ -144,9 +154,9 @@ EOF
 out=$("$SCRIPT" --target "$FIXTURE_P2" 2>&1)
 rc=$?
 assert "P2 fixture exits 1 (detected)" "1" "$rc"
-p2_count=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
+p2_count=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out")
 assert_ge "P2 fixture detects >=2 P2 findings" 2 "$p2_count"
-p1_in_p2=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
+p1_in_p2=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out")
 assert "P2 fixture does NOT bleed into P1 (p1_count == 0)" "0" "$p1_in_p2"
 
 # --- Test 7: P2 multi-trigger on a single line (H-1 regression guard) --------
@@ -161,8 +171,10 @@ EOF
 out=$("$SCRIPT" --target "$FIXTURE_P2_MULTI" 2>&1)
 rc=$?
 assert "P2 multi-trigger fixture exits 1" "1" "$rc"
-p2_multi=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
-assert_ge "P2 multi-trigger reports all 3 hits (not undercounted)" 3 "$p2_multi"
+p2_multi=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out")
+assert "P2 multi-trigger reports exactly 3 hits" "3" "$p2_multi"
+p1_in_p2_multi=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out")
+assert "P2 multi-trigger does NOT bleed into P1" "0" "$p1_in_p2_multi"
 
 # --- Test 8: tab+! is NOT matched (pins the "space-only" semantics) ----------
 # Pinning this intentionally excluded boundary prevents future regex widening

--- a/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
 # Smoke + validation tests for bang-backtick-check.sh
 #
+# Requires bash 4.4+ for safe expansion of empty arrays under `set -u`
+# (specifically, `"${ARRAY[@]}"` with an empty ARRAY must not trigger "unbound
+# variable"). The explicit version guard below fails fast on older bash rather
+# than producing cryptic errors mid-run.
+#
 # Validates:
 #   1. --help exits 0
 #   2. Missing args exits 2
 #   3. Repo-wide --all scan is clean (AC-3: false positive zero)
-#   4. Fixture with `if !` pattern is detected (AC-4, P1)
-#   5. Fixture with `!foo` pattern is detected (AC-4, P2)
-#   6. Fixture with innocent patterns (`//!`, `![...](...)`, `!\[...\]`) is clean
+#   4. P1 fixture with `if !` triggers detection (AC-4) AND bleed-check: P2 must be 0
+#   5. P1 multi-trigger on a single line reports N findings (Issue #369 H-1 regression)
+#   6. P2 fixture with `!foo` triggers detection (AC-4) AND bleed-check: P1 must be 0
+#   7. P2 multi-trigger on a single line reports N findings (Issue #369 H-1 regression)
+#   8. Boundary: tab+! is NOT matched (the P1 regex is literal space, not `[[:space:]]`)
+#   9. Boundary: double-space+! IS matched (the P1 regex is `space+!`, which matches
+#      the last space in " "+"!")
+#  10. Innocent patterns stay clean: Rustdoc `//!`, Markdown image `![alt](url)`,
+#      regex literal `!\[...\]`, bash negation `x != y`, `if ! cmd`, AND a fenced
+#      code block containing `if !` (scanner is per-line, so block context does not
+#      change semantics, but pinning the behavior prevents future regex widening)
 
 set -uo pipefail
+
+# --- bash version guard -----------------------------------------------------
+# bash 4.4 introduced the fix for expanding empty arrays under `set -u`. We rely
+# on `"${TMPFILES[@]}"` being safe even before any pushes have occurred, so hard-
+# fail older bash to avoid surprising mid-run "unbound variable" errors.
+if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 4) )); then
+  echo "FAIL: bash 4.4+ required (detected ${BASH_VERSION})" >&2
+  exit 2
+fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SCRIPT="$REPO_ROOT/plugins/rite/hooks/scripts/bang-backtick-check.sh"
@@ -33,8 +55,33 @@ assert() {
   fi
 }
 
+assert_ge() {
+  local desc="$1" min="$2" actual="$3"
+  if [ "$actual" -ge "$min" ]; then
+    echo "PASS: $desc ($actual >= $min)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc — expected>=$min actual=$actual" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- portable mktemp wrapper ------------------------------------------------
+# GNU coreutils `mktemp --suffix=.md` is not portable to BSD mktemp (macOS).
+# Fall back to plain `mktemp` + rename when the suffix form fails.
+mktemp_md() {
+  local base
+  if base=$(mktemp --suffix=.md 2>/dev/null); then
+    printf '%s' "$base"
+    return 0
+  fi
+  base=$(mktemp)
+  mv "$base" "${base}.md"
+  printf '%s' "${base}.md"
+}
+
 TMPFILES=()
-trap 'rm -f "${TMPFILES[@]}"' EXIT
+trap 'rm -rf "${TMPFILES[@]}"' EXIT
 
 # --- Test 1: --help exits 0 --------------------------------------------------
 "$SCRIPT" --help >/dev/null 2>&1
@@ -51,8 +98,8 @@ assert "no args exits 2" "2" "$rc"
 rc=$?
 assert "repo-wide --all exits 0 (no false positives)" "0" "$rc"
 
-# --- Test 4: fixture with `if !` triggers P1 detection (AC-4) ---------------
-FIXTURE_P1=$(mktemp --suffix=.md)
+# --- Test 4: P1 fixture triggers P1 only (bleed-check) ----------------------
+FIXTURE_P1=$(mktemp_md)
 TMPFILES+=("$FIXTURE_P1")
 cat > "$FIXTURE_P1" << 'EOF'
 # Fixture: P1 pattern
@@ -65,16 +112,27 @@ out=$("$SCRIPT" --target "$FIXTURE_P1" 2>&1)
 rc=$?
 assert "P1 fixture exits 1 (detected)" "1" "$rc"
 p1_count=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
-if [ "$p1_count" -ge 2 ]; then
-  echo "PASS: P1 fixture detects >=2 findings ($p1_count)"
-  PASS=$((PASS + 1))
-else
-  echo "FAIL: P1 fixture expected >=2 findings, got $p1_count" >&2
-  FAIL=$((FAIL + 1))
-fi
+assert_ge "P1 fixture detects >=2 P1 findings" 2 "$p1_count"
+p2_in_p1=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
+assert "P1 fixture does NOT bleed into P2 (p2_count == 0)" "0" "$p2_in_p1"
 
-# --- Test 5: fixture with `!foo` triggers P2 detection (AC-4) ---------------
-FIXTURE_P2=$(mktemp --suffix=.md)
+# --- Test 5: P1 multi-trigger on a single line (H-1 regression guard) --------
+FIXTURE_P1_MULTI=$(mktemp_md)
+TMPFILES+=("$FIXTURE_P1_MULTI")
+cat > "$FIXTURE_P1_MULTI" << 'EOF'
+# Fixture: three P1 hits on one line
+
+Triple trigger: `if !` and `grep !` and `exit !` live together.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_P1_MULTI" 2>&1)
+rc=$?
+assert "P1 multi-trigger fixture exits 1" "1" "$rc"
+p1_multi=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
+assert_ge "P1 multi-trigger reports all 3 hits (not undercounted)" 3 "$p1_multi"
+
+# --- Test 6: P2 fixture triggers P2 only (bleed-check) ----------------------
+FIXTURE_P2=$(mktemp_md)
 TMPFILES+=("$FIXTURE_P2")
 cat > "$FIXTURE_P2" << 'EOF'
 # Fixture: P2 pattern
@@ -87,16 +145,52 @@ out=$("$SCRIPT" --target "$FIXTURE_P2" 2>&1)
 rc=$?
 assert "P2 fixture exits 1 (detected)" "1" "$rc"
 p2_count=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
-if [ "$p2_count" -ge 2 ]; then
-  echo "PASS: P2 fixture detects >=2 findings ($p2_count)"
-  PASS=$((PASS + 1))
-else
-  echo "FAIL: P2 fixture expected >=2 findings, got $p2_count" >&2
-  FAIL=$((FAIL + 1))
-fi
+assert_ge "P2 fixture detects >=2 P2 findings" 2 "$p2_count"
+p1_in_p2=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
+assert "P2 fixture does NOT bleed into P1 (p1_count == 0)" "0" "$p1_in_p2"
 
-# --- Test 6: innocent patterns remain clean ----------------------------------
-FIXTURE_CLEAN=$(mktemp --suffix=.md)
+# --- Test 7: P2 multi-trigger on a single line (H-1 regression guard) --------
+FIXTURE_P2_MULTI=$(mktemp_md)
+TMPFILES+=("$FIXTURE_P2_MULTI")
+cat > "$FIXTURE_P2_MULTI" << 'EOF'
+# Fixture: three P2 hits on one line
+
+Triple trigger: `!foo` and `!bar` and `!baz` all on one line.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_P2_MULTI" 2>&1)
+rc=$?
+assert "P2 multi-trigger fixture exits 1" "1" "$rc"
+p2_multi=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
+assert_ge "P2 multi-trigger reports all 3 hits (not undercounted)" 3 "$p2_multi"
+
+# --- Test 8: tab+! is NOT matched (pins the "space-only" semantics) ----------
+# Pinning this intentionally excluded boundary prevents future regex widening
+# (e.g. changing space to `[[:space:]]`) from silently bleeding detection into
+# tab-delimited inline code.
+FIXTURE_TAB=$(mktemp_md)
+TMPFILES+=("$FIXTURE_TAB")
+printf '# Fixture: tab before bang\n\nThis line has `if\t!` with a tab, not a space.\n' > "$FIXTURE_TAB"
+
+out=$("$SCRIPT" --target "$FIXTURE_TAB" 2>&1)
+rc=$?
+assert "tab+! fixture exits 0 (tab is NOT treated as space)" "0" "$rc"
+
+# --- Test 9: double-space+! IS matched (the last space satisfies "space+!") --
+FIXTURE_DOUBLE_SPACE=$(mktemp_md)
+TMPFILES+=("$FIXTURE_DOUBLE_SPACE")
+cat > "$FIXTURE_DOUBLE_SPACE" << 'EOF'
+# Fixture: double space before bang
+
+This line has `if  !` with two spaces before the bang.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_DOUBLE_SPACE" 2>&1)
+rc=$?
+assert "double-space+! fixture exits 1 (last space matches)" "1" "$rc"
+
+# --- Test 10: innocent patterns remain clean (includes fenced code block) ----
+FIXTURE_CLEAN=$(mktemp_md)
 TMPFILES+=("$FIXTURE_CLEAN")
 cat > "$FIXTURE_CLEAN" << 'EOF'
 # Fixture: innocent patterns (should NOT trigger)
@@ -106,11 +200,26 @@ Markdown image: `![alt](url)`.
 Regex literal: `!\[[^\]]*\]`.
 Negation in code: `x != y`.
 Trailing bang with content: `if ! cmd`.
+
+Next, a fenced code block containing a bash negation (scanner runs per-line,
+so the block is NOT re-entered into inline-code semantics):
+
+```bash
+if ! cmd
+then
+  echo "fallback"
+fi
+```
+
+The fenced block above contains bash negation but does not match the scanner
+regex because it is outside inline-code context (no opening/closing backtick
+on the same line). Pinning this confirms future regex tweaks do not start
+silently flagging fenced code blocks.
 EOF
 
 out=$("$SCRIPT" --target "$FIXTURE_CLEAN" 2>&1)
 rc=$?
-assert "innocent fixture exits 0 (no false positives)" "0" "$rc"
+assert "innocent fixture (including fenced block) exits 0" "0" "$rc"
 
 # --- Summary -----------------------------------------------------------------
 echo ""

--- a/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Smoke + validation tests for bang-backtick-check.sh
+#
+# Validates:
+#   1. --help exits 0
+#   2. Missing args exits 2
+#   3. Repo-wide --all scan is clean (AC-3: false positive zero)
+#   4. Fixture with `if !` pattern is detected (AC-4, P1)
+#   5. Fixture with `!foo` pattern is detected (AC-4, P2)
+#   6. Fixture with innocent patterns (`//!`, `![...](...)`, `!\[...\]`) is clean
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/plugins/rite/hooks/scripts/bang-backtick-check.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT not executable" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc — expected=$expected actual=$actual" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPFILES=()
+trap 'rm -f "${TMPFILES[@]}"' EXIT
+
+# --- Test 1: --help exits 0 --------------------------------------------------
+"$SCRIPT" --help >/dev/null 2>&1
+rc=$?
+assert "--help exits 0" "0" "$rc"
+
+# --- Test 2: no args exits 2 -------------------------------------------------
+"$SCRIPT" >/dev/null 2>&1
+rc=$?
+assert "no args exits 2" "2" "$rc"
+
+# --- Test 3: repo --all is clean (AC-3 false positive zero) ------------------
+"$SCRIPT" --all --quiet >/dev/null 2>&1
+rc=$?
+assert "repo-wide --all exits 0 (no false positives)" "0" "$rc"
+
+# --- Test 4: fixture with `if !` triggers P1 detection (AC-4) ---------------
+FIXTURE_P1=$(mktemp --suffix=.md)
+TMPFILES+=("$FIXTURE_P1")
+cat > "$FIXTURE_P1" << 'EOF'
+# Fixture: P1 pattern
+
+This line contains `if !` which is the Issue #365 triggering pattern.
+Another one: check `grep !` usage.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_P1" 2>&1)
+rc=$?
+assert "P1 fixture exits 1 (detected)" "1" "$rc"
+p1_count=$(grep -c '^\[bang-backtick\]\[P1\]' <<< "$out" || true)
+if [ "$p1_count" -ge 2 ]; then
+  echo "PASS: P1 fixture detects >=2 findings ($p1_count)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: P1 fixture expected >=2 findings, got $p1_count" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Test 5: fixture with `!foo` triggers P2 detection (AC-4) ---------------
+FIXTURE_P2=$(mktemp --suffix=.md)
+TMPFILES+=("$FIXTURE_P2")
+cat > "$FIXTURE_P2" << 'EOF'
+# Fixture: P2 pattern
+
+Use `!foo` history expansion.
+Or `! cmd` negated.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_P2" 2>&1)
+rc=$?
+assert "P2 fixture exits 1 (detected)" "1" "$rc"
+p2_count=$(grep -c '^\[bang-backtick\]\[P2\]' <<< "$out" || true)
+if [ "$p2_count" -ge 2 ]; then
+  echo "PASS: P2 fixture detects >=2 findings ($p2_count)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: P2 fixture expected >=2 findings, got $p2_count" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Test 6: innocent patterns remain clean ----------------------------------
+FIXTURE_CLEAN=$(mktemp --suffix=.md)
+TMPFILES+=("$FIXTURE_CLEAN")
+cat > "$FIXTURE_CLEAN" << 'EOF'
+# Fixture: innocent patterns (should NOT trigger)
+
+Rustdoc inner: `//!` comment.
+Markdown image: `![alt](url)`.
+Regex literal: `!\[[^\]]*\]`.
+Negation in code: `x != y`.
+Trailing bang with content: `if ! cmd`.
+EOF
+
+out=$("$SCRIPT" --target "$FIXTURE_CLEAN" 2>&1)
+rc=$?
+assert "innocent fixture exits 0 (no false positives)" "0" "$rc"
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+echo "==> PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 概要

Skill loader の bash history expansion 経路を triggering する「backtick + bang 隣接パターン」を `commands/**/*.md` および `skills/**/*.md` に対して機械的に検出する静的 lint を追加する。Issue #365 / PR #367 で対処した問題の根本対策として、Out of Scope に分離していた将来課題を消化するもの。

## 変更内容

- `plugins/rite/hooks/scripts/bang-backtick-check.sh` (新規)
  - awk ベースの検出スクリプト。`distributed-fix-drift-check.sh` と同じ CLI 構造 (`--all`, `--target`, `--quiet`, exit 0/1/2)
  - P1: 閉じ backtick 直前が space + ! (Issue #365 の triggering パターン)
  - P2: 開始 backtick 直後が ! + alnum/space (history expansion)
  - 既存 commands/skills 70 ファイルで false positive 0 件を確認
- `plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh` (新規)
  - 8 テストケース (--help / no args / repo-wide / P1 fixture / P2 fixture / innocent patterns)
  - innocent patterns (Rustdoc, Markdown image, regex literal) が検出されないことを確認
- `plugins/rite/commands/lint.md` Phase 3.6 として組み込み
  - Phase 3.5 drift check と同じ warning/non-blocking 設計 (段階導入)
  - Phase 4.1 success appendix、Phase 4.3 summary table に bang-backtick 行を追加

## 採用案

**案 C (rite:lint 組み込み)** を採用:
- dogfooding: rite plugin の品質チェックに自分自身の lint を使う
- 既存 Phase 3.5 drift check と一貫した設計
- マーケットプレイスインストール環境でもスクリプト不在時は自動スキップ

## 関連

- Closes #369
- Refs: Issue #365 (triggering incident), PR #367 (最小修正)

## テスト計画

- [x] `bash plugins/rite/hooks/scripts/bang-backtick-check.sh --all` が exit 0 (false positive 0)
- [x] `bash plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh` が全 PASS (8/8)
- [x] 意図的 fixture で P1/P2 を検出 (AC-4)
- [x] innocent patterns (`//!`, `![...](...)`, `!\[...\]`) は検出されない
