### PR TITLE
fix(create): sub-skill 復帰後の停止問題と完了表示の不明瞭さを修正 (#444)

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -612,37 +612,42 @@ Phase 0.8 terminates based on the user's selection in the decomposition result c
 
 ---
 
-## Defense-in-Depth: Flow State Update (Before Return)
+## Phase 1.0: Terminal Completion (Normal Path Only)
 
-> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+> **Design decision** (Issue #444, D-01): This sub-skill handles flow-state deactivation, next-step output, and completion marker internally on the **Normal path** (sub-Issues created via Phase 0.9). On the **Delegation path** (cancelled and delegated to `create-register`), `create-register.md` handles its own Terminal Completion — do NOT execute this section.
 
-Before returning control to the caller, update `.rite-flow-state` to the post-delegation phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+**Condition**: Execute only on the **Normal path**.
 
-**Condition**: Execute only on the **Normal path** (sub-Issues created via Phase 0.9). On the **Delegation path** (cancelled and delegated to `create-register`), `create-register.md` handles its own Defense-in-Depth — do NOT execute this section.
+### 1.0.1 Flow State Deactivation
+
+After Phase 0.9.6 (Completion Report), deactivate the flow state:
 
 ```bash
 if [ -f ".rite-flow-state" ]; then
   bash {plugin_root}/hooks/flow-state-update.sh patch \
-    --phase "create_post_delegation" \
-    --next "rite:issue:create-decompose completed. Sub-Issues created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
-else
-  bash {plugin_root}/hooks/flow-state-update.sh create \
-    --phase "create_post_delegation" --issue 0 --branch "" --pr 0 \
-    --next "rite:issue:create-decompose completed. Sub-Issues created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+    --phase "create_completed" \
+    --next "none" --active false
 fi
 ```
 
-After the flow-state update above, output the appropriate result pattern:
+### 1.0.2 Completion Marker
 
-- **Decomposition completed**: `[decompose:completed:{count}]` (where `{count}` is the number of sub-Issues created)
+Output the completion marker as the **absolute last line**:
 
-This pattern is consumed by the orchestrator (`create.md`) to confirm sub-Issue creation and trigger post-completion cleanup.
+- **Decomposition completed**: `[create:completed:{first_sub_issue_number}]`
+
+Where `{first_sub_issue_number}` is the first sub-Issue number (the recommended starting point from Phase 0.9.6's 次のステップ).
+
+**Output rules**:
+1. `[create:completed:{N}]` MUST be the last line of output — no text after it
+2. Do **NOT** output narrative text like `→ create.md に戻ります` — it is not actionable and creates a natural stopping point for the LLM
+3. The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth only
 
 ---
 
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes, the caller (`create.md`) should NOT take any additional action beyond flow-state deactivation. Completion occurs via one of the following paths:
+Completion occurs via one of the following paths:
 
-- **Normal path** (sub-Issues created via Phase 0.9): The completion report has already been output by this sub-skill. The Defense-in-Depth section above has updated `.rite-flow-state` to `create_post_delegation`.
-- **Delegation path** (cancelled and delegated to `create-register`): The completion report will be output by `create-register`. This sub-skill is NOT terminal in this path — `create-register` takes over and completes the workflow (including its own Defense-in-Depth).
+- **Normal path** (sub-Issues created via Phase 0.9): This sub-skill is terminal. Issue creation workflow is **fully complete** — flow-state deactivated, next steps displayed, completion marker output. The caller (`create.md`) MAY execute its 🚨 Mandatory After Delegation as defense-in-depth (idempotent).
+- **Delegation path** (cancelled and delegated to `create-register`): `create-register.md` is the terminal sub-skill. It handles its own Terminal Completion (Phase 4) including flow-state deactivation and `[create:completed:{N}]` marker.

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -522,12 +522,11 @@ This pattern is consumed by the orchestrator (`create.md`) to determine the next
 
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller (`create.md`) **MUST immediately** execute its 🚨 Mandatory After Interview section:
+When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller **MUST immediately** execute its 🚨 Mandatory After Interview section — proceeding to Phase 0.6 (Task Decomposition Decision) in the **same response turn**.
 
-1. Proceed to Phase 0.6 (Task Decomposition Decision)
+**WARNING**: **No GitHub Issue has been created yet.** Stopping here abandons the workflow with no deliverable.
 
-**WARNING**: **No GitHub Issue has been created yet.** No GitHub Issue exists at this point. The interview only collected information — creation happens in `create-register.md` or `create-decompose.md`. Stopping here would completely abandon the workflow with no Issue created.
-
-**Concrete next action for caller**: Evaluate decomposition triggers (Phase 0.6.1), then delegate to `rite:issue:create-register` (single Issue) or `rite:issue:create-decompose` (sub-Issue decomposition).
-
-**→ Return to `create.md` and proceed to Phase 0.6 now. Do NOT stop.**
+**Output rules**:
+1. Output the result pattern (`[interview:completed]` or `[interview:skipped]`) as the **last line** of this sub-skill's output
+2. Do **NOT** output any narrative text (e.g., `→ Return to create.md`) after the result pattern — it creates a natural stopping point for the LLM
+3. The caller reads the result pattern and immediately continues to Phase 0.6

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -563,34 +563,55 @@ See [GraphQL Helpers](../../references/graphql-helpers.md#error-handling) for de
 
 ---
 
-## Defense-in-Depth: Flow State Update (Before Return)
+## Phase 4: Terminal Completion
 
-> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+> **Design decision** (Issue #444, D-01): This sub-skill is a terminal sub-skill — it handles flow-state deactivation, next-step output, and completion marker internally. The caller (`create.md`) retains the same steps as defense-in-depth but is no longer the primary path for these actions. This prevents the workflow from stalling when the orchestrator fails to continue after sub-skill return.
 
-Before returning control to the caller, update `.rite-flow-state` to the post-delegation phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+### 4.1 Flow State Deactivation
+
+After Phase 3 (Completion Report), deactivate the flow state:
 
 ```bash
 if [ -f ".rite-flow-state" ]; then
   bash {plugin_root}/hooks/flow-state-update.sh patch \
-    --phase "create_post_delegation" \
-    --next "rite:issue:create-register completed. Issue created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
-else
-  bash {plugin_root}/hooks/flow-state-update.sh create \
-    --phase "create_post_delegation" --issue 0 --branch "" --pr 0 \
-    --next "rite:issue:create-register completed. Issue created. Caller should execute post-completion cleanup (flow-state deactivation). Do NOT stop."
+    --phase "create_completed" \
+    --next "none" --active false
 fi
 ```
 
-## Result Pattern Output
+### 4.2 Next Steps Output
 
-Output the result pattern after the completion report:
+Output the next steps as the final user-facing message before the completion marker:
 
-- **Issue created**: `[register:created:{number}]` (where `{number}` is the `$issue_number` from Phase 2.2 — the actual GitHub Issue number returned by `gh issue create`)
+```
+次のステップ:
+1. `/rite:issue:start {issue_number}` で作業を開始
+2. 作業完了後 `/rite:pr:create` で PR 作成
+```
 
-This pattern is consumed by the orchestrator (`create.md`) to confirm Issue creation and trigger post-completion cleanup.
+Where `{issue_number}` is the Issue number from Phase 2.2.
+
+### 4.3 Completion Marker
+
+Output the completion marker as the **absolute last line**:
+
+- **Issue created**: `[create:completed:{issue_number}]`
+
+This marker signals to both the orchestrator (`create.md`) and the user that the workflow is fully complete (Issue created, Projects registered, flow-state deactivated, next steps displayed).
+
+**Output rules**:
+1. `[create:completed:{N}]` MUST be the last line of output — no text after it
+2. Do **NOT** output narrative text like `→ create.md に戻ります` — it is not actionable and creates a natural stopping point for the LLM
+3. The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth only
 
 ---
 
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes (Phase 3 completion report output), the Issue creation workflow is **complete**. The Issue has been created and registered to GitHub Projects. Control returns to the caller (`create.md`), which handles any remaining cleanup (e.g., `.rite-flow-state` deactivation).
+When this sub-skill completes (Phase 4 terminal completion), the Issue creation workflow is **fully complete**:
+- Issue created and registered to GitHub Projects ✅
+- `.rite-flow-state` deactivated (`active: false`) ✅
+- Next steps displayed to user ✅
+- Completion marker `[create:completed:{N}]` output ✅
+
+The caller (`create.md`) MAY execute its 🚨 Mandatory After Delegation section as defense-in-depth (idempotent — re-deactivating an already-deactivated flow state and re-outputting next steps is harmless).

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -60,7 +60,7 @@ When this command is executed, follow the phases below in order.
 
 **Completion marker convention** (Issue #444): The unified completion marker for the entire `/rite:issue:create` workflow is `[create:completed:{N}]`. Terminal sub-skills (`create-register.md`, `create-decompose.md`) output this marker as their absolute last line after handling flow-state deactivation and next-step display internally (Terminal Completion pattern). The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth.
 
-**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`, `create-decompose.md`) updates `.rite-flow-state` to a `post_*` phase before returning. Terminal sub-skills additionally deactivate the flow state (`active: false`) and output the completion marker. This ensures the workflow completes even if the orchestrator fails to continue after sub-skill return.
+**Defense-in-depth**: `create-interview.md` updates `.rite-flow-state` to a `post_*` phase (`create_post_interview`) before returning. Terminal sub-skills (`create-register.md`, `create-decompose.md`) set `create_completed` with `active: false` and output the completion marker directly. This ensures the workflow completes even if the orchestrator fails to continue after sub-skill return.
 
 ## Arguments
 
@@ -571,7 +571,7 @@ Invoke `skill: "rite:issue:create-register"`.
 
 **🚨 Immediate after delegation returns**: When the sub-skill outputs a result pattern (`[create:completed:{N}]`) and returns control, verify that the workflow completed successfully.
 
-> **Note on result patterns** (Issue #444): Terminal sub-skills (`create-register`, `create-decompose`) now output `[create:completed:{N}]` as the unified completion marker. The sub-skill handles flow-state deactivation, next-step output, and completion marker internally (Terminal Completion pattern). The legacy patterns `[register:created:{N}]` and `[decompose:completed:{N}]` are still output before the completion marker for backward compatibility.
+> **Note on result patterns** (Issue #444): Terminal sub-skills (`create-register`, `create-decompose`) now output `[create:completed:{N}]` as the unified completion marker. The sub-skill handles flow-state deactivation, next-step output, and completion marker internally (Terminal Completion pattern). The legacy patterns `[register:created:{N}]` and `[decompose:completed:{N}]` have been replaced and are no longer output.
 
 ### 🚨 Mandatory After Delegation (Defense-in-Depth)
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -35,8 +35,8 @@ This command orchestrates the Issue creation flow by delegating to specialized s
 ```
 create.md (orchestrator)
 ├── create-interview.md   ← Phase 0.4.1 + 0.5 (Adaptive Interview)
-├── create-decompose.md   ← Phase 0.7 + 0.8 + 0.9 (Spec + Decompose + Bulk Create)
-└── create-register.md    ← Phase 1 + 2 + 3 (Classify + Confirm + Create Single Issue)
+├── create-decompose.md   ← Phase 0.7 + 0.8 + 0.9 + 1.0 (Spec + Decompose + Bulk Create + Terminal Completion)
+└── create-register.md    ← Phase 1 + 2 + 3 + 4 (Classify + Confirm + Create Single Issue + Terminal Completion)
 ```
 
 ---

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -56,9 +56,11 @@ When this command is executed, follow the phases below in order.
 
 > **Reference**: See `start.md` [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the full protocol. The same rules apply here — DO NOT end your response after a sub-skill returns, DO NOT re-invoke the completed skill, and IMMEDIATELY proceed to the 🚨 Mandatory After section.
 
-**Self-check**: After every sub-skill returns, ask yourself: "Has the Issue been created and the completion report output?" If not, you are NOT done — keep going.
+**Self-check**: After every sub-skill returns, ask yourself: "Has `[create:completed:{N}]` been output?" If not, you are NOT done — keep going.
 
-**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`, `create-decompose.md`) updates `.rite-flow-state` to a `post_*` phase before returning. This ensures the stop-guard blocks any premature stop attempt, even if the orchestrator's 🚨 Mandatory After instructions are not executed immediately.
+**Completion marker convention** (Issue #444): The unified completion marker for the entire `/rite:issue:create` workflow is `[create:completed:{N}]`. Terminal sub-skills (`create-register.md`, `create-decompose.md`) output this marker as their absolute last line after handling flow-state deactivation and next-step display internally (Terminal Completion pattern). The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth.
+
+**Defense-in-depth**: Each sub-skill (`create-interview.md`, `create-register.md`, `create-decompose.md`) updates `.rite-flow-state` to a `post_*` phase before returning. Terminal sub-skills additionally deactivate the flow state (`active: false`) and output the completion marker. This ensures the workflow completes even if the orchestrator fails to continue after sub-skill return.
 
 ## Arguments
 
@@ -567,19 +569,19 @@ Invoke `skill: "rite:issue:create-register"`.
 | Tentative slug | Phase 0.1.3 | Always available |
 | `phases_skipped` flag | Phase 0.1.5 | Set to `"0.3-0.5"` when Phase 0.1.5 triggered early decomposition. Set to `null` otherwise |
 
-**🚨 Immediate after delegation returns**: When the sub-skill (`rite:issue:create-register` or `rite:issue:create-decompose`) outputs a result pattern (`[register:created:{N}]` or `[decompose:completed:{N}]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 🚨 Mandatory After Delegation below. The sub-skill has already updated `.rite-flow-state` to `create_post_delegation` via its Defense-in-Depth section; execute the 🚨 Mandatory After Delegation steps without delay.
+**🚨 Immediate after delegation returns**: When the sub-skill outputs a result pattern (`[create:completed:{N}]`) and returns control, verify that the workflow completed successfully.
 
-### 🚨 Mandatory After Delegation
+> **Note on result patterns** (Issue #444): Terminal sub-skills (`create-register`, `create-decompose`) now output `[create:completed:{N}]` as the unified completion marker. The sub-skill handles flow-state deactivation, next-step output, and completion marker internally (Terminal Completion pattern). The legacy patterns `[register:created:{N}]` and `[decompose:completed:{N}]` are still output before the completion marker for backward compatibility.
+
+### 🚨 Mandatory After Delegation (Defense-in-Depth)
 
 > See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
 
-> **CRITICAL — AUTOMATIC CONTINUATION REQUIREMENT**: This is the single most important instruction at this transition point. When `rite:issue:create-register` or `rite:issue:create-decompose` returns a result pattern, you MUST continue responding in the same turn. Ending your response here is a **bug** that forces the user to type "continue" manually.
+> **Defense-in-depth only** (Issue #444): Terminal sub-skills now handle flow-state deactivation and next-step output internally via their Terminal Completion phase. This 🚨 Mandatory After section is retained as a **safety net** — it re-executes the same steps idempotently. If the sub-skill's Terminal Completion executed correctly, these steps are no-ops.
 
-**Verify**: Result pattern confirmed (e.g., `[register:created:{N}]` or `[decompose:completed:{N}]`). The Issue(s) have been created.
+**Self-check**: Has `[create:completed:{N}]` been output? If yes, the sub-skill's Terminal Completion succeeded — execute Steps 1-3 as defense-in-depth (idempotent). If no (sub-skill returned without the completion marker), these steps are **critical** and must execute.
 
-Do **NOT** stop after the sub-skill returns. Post-completion cleanup (flow-state deactivation) is still pending — this is a required step to prevent the stop-guard from blocking future sessions.
-
-**Step 1**: Update `.rite-flow-state` to post-delegation phase (atomic). The sub-skill has already written `create_post_delegation` via its Defense-in-Depth section; this second write updates the `next_action` message and refreshes the timestamp, ensuring stop-guard routes correctly:
+**Step 1**: Update `.rite-flow-state` to post-delegation phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -587,7 +589,7 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
   --next "Sub-skill completed. Deactivate flow state and output next steps. Do NOT stop."
 ```
 
-**Step 2**: Deactivate flow state:
+**Step 2**: Deactivate flow state (idempotent — safe to re-execute if already deactivated by sub-skill):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -595,7 +597,7 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
   --next "none" --active false
 ```
 
-**Step 3**: Output the next steps as the final message. This ensures "次のステップ" appears after all internal processing (flow-state deactivation) is complete:
+**Step 3**: Output the next steps (idempotent — if already output by sub-skill, this is a duplicate that the user can safely ignore):
 
 ```
 次のステップ:
@@ -603,7 +605,7 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 2. 作業完了後 `/rite:pr:create` で PR 作成
 ```
 
-Where `{number}` is the Issue number extracted from the sub-skill's result pattern (`[register:created:{N}]` or `[decompose:completed:{N}]`).
+Where `{number}` is the Issue number extracted from the sub-skill's result pattern.
 
 **Step 4**: The workflow is now complete. Stop is allowed after cleanup.
 


### PR DESCRIPTION
## 概要

`/rite:issue:create` のフロー制御における 2 つの不具合を修正:

1. **Bug1**: sub-skill (`create-interview`, `create-register`, `create-decompose`) から復帰後に orchestrator が停止し、手動 "continue" が必要だった問題
2. **Bug2**: 最終出力が `→ create.md に戻ります。` で終わり、次のステップと flow-state deactivate が欠落していた問題

## 変更内容

### Terminal Completion パターンの導入 (Option B+C)

terminal sub-skill (`create-register`, `create-decompose`) が以下を内部で完結:
- flow-state deactivation (`active: false`)
- 次のステップ出力
- 完了マーカー `[create:completed:{N}]`

orchestrator (`create.md`) の Mandatory After Delegation は defense-in-depth として保持（冪等）。

### 各ファイルの変更

| ファイル | 変更 |
|---------|------|
| `create-interview.md` | `→ Return to create.md` ナレーション廃止、result pattern 後テキスト出力禁止を明示 |
| `create-register.md` | Phase 4 Terminal Completion セクション追加 |
| `create-decompose.md` | Phase 1.0 Terminal Completion セクション追加 |
| `create.md` | Mandatory After Delegation を defense-in-depth 化、`[create:completed:{N}]` 規約文書化 |

## 関連 Issue

Closes #444

## テスト計画

- [ ] `/rite:issue:create` を BugFix タスクで実行し、手動 continue なしに完了することを確認
- [ ] `/rite:issue:create` を Feature タスクで実行し、interview → register の自動継続を確認
- [ ] 最終出力に `[create:completed:{N}]` マーカーと「次のステップ」が含まれることを確認
- [ ] `.rite-flow-state` が完了時に `active: false` になることを確認
- [ ] 既存の Issue 作成フロー（Projects 連携等）が非回帰であることを確認

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
