### PR TITLE
fix(review): re-review 時のスコープ縮退を禁止するガードレール追加 (#464)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4524,7 +4524,7 @@ Before outputting the pattern, update `.rite-flow-state` to `phase5_post_fix` (d
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_post_fix" \
-  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (FULL re-review — スコープ縮退禁止、/rite:pr:review と同等のフルレビューを実行). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (work memory was not updated, manual intervention recommended). [fix:issues-created]->Phase 5.4.1 (FULL re-review). [fix:replied-only]->Phase 5.5. Do NOT stop." \
+  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (FULL re-review — スコープ縮退禁止、/rite:pr:review と同等のフルレビューを実行). [fix:pushed-wm-stale]->Phase 5.4.1 (FULL re-review after AskUserQuestion — スコープ縮退禁止) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:issues-created]->Phase 5.4.1 (FULL re-review — スコープ縮退禁止、/rite:pr:review と同等のフルレビューを実行). [fix:replied-only]->Phase 5.5. Do NOT stop." \
   --if-exists
 ```
 
@@ -4691,7 +4691,7 @@ Phase 4.5.1 または Phase 4.5.2 の bash block が stdout に `[CONTEXT] WM_UP
 - Do **NOT** invoke `rite:pr:review` via the Skill tool
 - Return control to the caller (`/rite:issue:start`)
 - The caller determines the next action based on this output pattern
-- **re-review は必ずフルレビューで実行すること**: caller が `[fix:pushed]` / `[fix:issues-created]` を受けて re-review を実行する際、スコープ縮退（「前回指摘の修正確認のみ」「コンテキスト効率のため範囲限定」等）は一切禁止。`/rite:pr:review` と完全に同等のフルレビューを実行し、全レビュアーをサブエージェントで並列起動すること
+- **re-review は必ずフルレビューで実行すること**: caller が `[fix:pushed]` / `[fix:pushed-wm-stale]` / `[fix:issues-created]` を受けて re-review を実行する際、スコープ縮退（「前回指摘の修正確認のみ」「コンテキスト効率のため範囲限定」等）は一切禁止。`/rite:pr:review` と完全に同等のフルレビューを実行し、全レビュアーをサブエージェントで並列起動すること
 
 **Confidence override tempfile cleanup** (silent orphan 防止):
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4463,9 +4463,11 @@ Confidence override (policy bypass): {confidence_override_count}件{confidence_o
 | `レビューソース: {review_source} (...)` | Provenance of the review findings consumed by this fix run | Phase 1.2.0 Priority chain で決定された `review_source` 値 (verified-review cycle 9 I-1 対応、schema.md Priority 1 emit 義務の provenance 契約を Phase 4.6 で履行)。展開ルールは Phase 4.5.3 の `{review_source}` / `{review_source_path_display}` 表を参照 |
 
 **Note**: The review-fix loop of `/rite:issue:start` checks the content of this completion report to determine the next action:
-- `プッシュ: 完了` -> Execute re-review (verify fix content)
-- `別 Issue 作成: N件` (N >= 1) -> Execute re-review (confirm skipped findings are managed)
+- `プッシュ: 完了` -> Execute full re-review (`/rite:pr:review` と同等のフルレビュー — スコープ縮退禁止)
+- `別 Issue 作成: N件` (N >= 1) -> Execute full re-review (`/rite:pr:review` と同等のフルレビュー — スコープ縮退禁止)
 - `プッシュ: 未実行` and `別 Issue 作成: 0件` and `全指摘 == 対応指摘` -> Proceed to completion report (all addressed via replies)
+
+> **⚠️ re-review 時のスコープ縮退禁止**: caller (`/rite:issue:start`) が re-review を実行する際、「前回指摘の修正確認に絞る」「コンテキスト効率のためスコープを限定する」等の理由でレビュー範囲を縮退させてはならない。re-review は常に初回 `/rite:pr:review` と完全に同等のフルレビューとして実行し、全レビュアーをサブエージェントで並列起動すること。
 
 ---
 
@@ -4522,7 +4524,7 @@ Before outputting the pattern, update `.rite-flow-state` to `phase5_post_fix` (d
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase5_post_fix" \
-  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (re-review). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (work memory was not updated, manual intervention recommended). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. Do NOT stop." \
+  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (FULL re-review — スコープ縮退禁止、/rite:pr:review と同等のフルレビューを実行). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (work memory was not updated, manual intervention recommended). [fix:issues-created]->Phase 5.4.1 (FULL re-review). [fix:replied-only]->Phase 5.5. Do NOT stop." \
   --if-exists
 ```
 
@@ -4689,6 +4691,7 @@ Phase 4.5.1 または Phase 4.5.2 の bash block が stdout に `[CONTEXT] WM_UP
 - Do **NOT** invoke `rite:pr:review` via the Skill tool
 - Return control to the caller (`/rite:issue:start`)
 - The caller determines the next action based on this output pattern
+- **re-review は必ずフルレビューで実行すること**: caller が `[fix:pushed]` / `[fix:issues-created]` を受けて re-review を実行する際、スコープ縮退（「前回指摘の修正確認のみ」「コンテキスト効率のため範囲限定」等）は一切禁止。`/rite:pr:review` と完全に同等のフルレビューを実行し、全レビュアーをサブエージェントで並列起動すること
 
 **Confidence override tempfile cleanup** (silent orphan 防止):
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -44,6 +44,16 @@ When called from the `/rite:issue:start` end-to-end flow, Phase 4 (sub-agent exe
 
 > **⚠️ Scope limitation**: This command does NOT check or report hooks registration status (`.claude/settings.local.json`). Hooks registration is exclusively handled by `/rite:issue:start` Phase 5.0. Do NOT independently check hooks state, do NOT output messages about hooks being unregistered, and do NOT mention hooks registration in any output to the user.
 
+> **⚠️ Anti-Degradation Guardrail — レビュー品質縮退の絶対禁止**:
+> このコマンドは、呼び出し回数・コンテキスト残量・前回レビュー結果の有無に**一切関係なく**、常にフルレビューを実行しなければならない。以下の行為は明示的に禁止する:
+>
+> - **スコープ縮退の禁止**: 「コンテキスト効率のため前回指摘の修正確認に絞る」「差分が小さいため確認のみ」等の理由でレビュー範囲を狭めること
+> - **レビュアー数の削減禁止**: 「2回目以降だから1人で十分」等の理由で選定済みレビュアーを減らすこと
+> - **Verification mode への暗黙フォールバック禁止**: `verification_mode: false`（デフォルト）のとき、verification mode 相当の動作（前回指摘の修正確認 + リグレッションチェックのみ）を行うこと
+> - **品質とコンテキスト効率のトレードオフ禁止**: レビュー品質はコンテキスト最適化より**常に**優先される。コンテキスト圧迫を理由にレビュー品質を犠牲にすることは本末転倒であり、許容しない
+>
+> re-review（fix 後の再レビュー）は初回レビューと**完全に同等**の品質で実行すること。全レビュアーをサブエージェントで並列起動し、PR 全体の差分を対象にフルレビューを行う。
+
 ---
 
 When this command is executed, run the following phases in order.


### PR DESCRIPTION
## 概要

re-review 実行時に AI が「コンテキスト効率」等の理由でレビュースコープを勝手に縮退させる動作を防止するガードレールを追加。

- review.md に Anti-Degradation Guardrail セクションを追加（スコープ縮退・レビュアー数削減・暗黙 verification mode フォールバックの禁止を明文化）
- fix.md Phase 8 の re-review 関連 3 箇所にスコープ縮退禁止の明示的指示を追加

Closes #464

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/pr/review.md` | Anti-Degradation Guardrail セクション追加（レビュー品質縮退の絶対禁止） |
| `plugins/rite/commands/pr/fix.md` | Phase 8 re-review 指示の強化（3 箇所: completion report note, flow-state-update --next, Important セクション） |

## テスト計画

- [ ] fix.md Phase 8 にスコープ縮退禁止の指示文が存在することを確認（Grep）
- [ ] review.md に Anti-Degradation Guardrail が存在することを確認（Grep）
- [ ] verification_mode: true 時の既存ロジックが破壊されていないことを確認
- [ ] Non-target ファイル（rite-config.yml, fix.md Phase 1-7）が未変更であることを確認

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
