### PR TITLE
docs(fix): Phase 8.1 「条件 2 以降」を renumbering 後の実態に合わせる (#452)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4612,7 +4612,7 @@ Then, based on the Phase 4.6 completion report content **and the WM_UPDATE_FAILE
 
 **`[CONTEXT] WM_UPDATE_FAILED=1` の検出方法** (Claude による retain と再注入):
 
-Phase 4.5.1 または Phase 4.5.2 の bash block が stdout に `[CONTEXT] WM_UPDATE_FAILED=1; reason=...; ...` を出力した場合、Claude は会話履歴からこの行を検索し、検出された場合は本 phase の Output Pattern 評価で `[fix:pushed-wm-stale]` を採用する。検出されなかった場合は通常の評価順序 (条件 2 以降) に従う。
+Phase 4.5.1 または Phase 4.5.2 の bash block が stdout に `[CONTEXT] WM_UPDATE_FAILED=1; reason=...; ...` を出力した場合、Claude は会話履歴からこの行を検索し、検出された場合は本 phase の Output Pattern 評価で `[fix:pushed-wm-stale]` を採用する。検出されなかった場合は通常の評価順序 (WM_UPDATE_FAILED 以降の条件) に従う。
 
 **`reason` フィールドの取りうる値** (Phase 4.5.1 / 4.5.2 で発火する経路の網羅):
 


### PR DESCRIPTION
## 概要

PR #450 で Phase 8.1 テーブルの row 1 に `FIX_FALLBACK_FAILED` が追加された結果、`WM_UPDATE_FAILED` が row 3 に移動し、「条件 2 以降」が誤記述となっていた問題を修正。

row 番号依存を避け「WM_UPDATE_FAILED 以降の条件」という抽象表現に統一することで、将来の renumbering による drift を防止する。

## 変更内容

- `plugins/rite/commands/pr/fix.md:4615`: 「通常の評価順序 (条件 2 以降)」→「通常の評価順序 (WM_UPDATE_FAILED 以降の条件)」

## 関連 Issue

Closes #452

## 関連

- 元の PR: #450
- 関連 Issue: #443, #451

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
