### PR TITLE
fix(workflow): start.md 足場なし Phase の silent skip 恒久対策 (#490)

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -44,7 +44,7 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 > Stopping between phases leaves the workflow in an inconsistent state (e.g., branch created but no PR), requiring manual recovery via `/rite:resume`.
 > **CRITICAL**: After every sub-skill invocation returns, **immediately** proceed to the next phase. Do NOT stop, do NOT re-invoke the completed skill.
 >
-> This table lists phases with sub-skill invocations or key decision points. Phases not listed (2.4 Projects Status, 2.5 Iteration, 5.0 Stop Hook, 5.5.1 Status Update, 5.5.2 Metrics, 5.7 Parent Completion) execute inline without stopping.
+> Every phase in the flow is subject to the Pre-write + Mandatory After scaffolding contract (#490). There is no "inline without stopping" path — every transition is tracked via `.rite-flow-state` and verified by the stop-guard phase-transition whitelist (`plugins/rite/hooks/phase-transition-whitelist.sh`).
 
 | Phase | Sub-skill Invoked | Next Phase | Stop Allowed? |
 |-------|-------------------|------------|---------------|
@@ -53,16 +53,22 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 | 1.5 (Parent Routing) | `rite:issue:parent-routing` | 1.6 or 2 | **No** |
 | 1.6 (Child Selection) | `rite:issue:child-issue-selection` | 2 | **No** |
 | 2.3 (Branch) | `rite:issue:branch-setup` | 2.4 | **No** |
+| 2.4 (Projects Status) | — | 2.5 or 2.6 | **No** |
+| 2.5 (Iteration) | — | 2.6 | **No** |
 | 2.6 (Work Memory) | `rite:issue:work-memory-init` | 3 | **No** |
 | 3 (Plan) | `rite:issue:implementation-plan` | 4 | **No** |
 | 4 (Guidance) | — | 5 or terminate | Yes (user choice) |
+| 5.0 (Stop Hook) | — | 5.1 | **No** |
 | 5.1 (Implement) | — | 5.2 (lint) | **No** |
 | 5.2 (Lint) | `rite:lint` | 5.2.1 | **No** |
 | 5.3 (PR) | `rite:pr:create` | 5.4 | **No** |
 | 5.4.1 (Review) | `rite:pr:review` | 5.4.3→5.4.4 or 5.5 | **No** |
 | 5.4.4 (Fix) | `rite:pr:fix` | 5.4.6→5.4.1 or 5.5 | **No** |
 | 5.5 (Ready) | `rite:pr:ready` | 5.5.0.1→5.5.1 | **No** |
+| 5.5.1 (Status In Review) | — | 5.5.2 | **No** |
+| 5.5.2 (Metrics) | — | 5.6 | **No** |
 | 5.6 (Report) | — | 5.7 or end | Yes |
+| 5.7 (Parent Completion) | — | end | Yes |
 
 ---
 
@@ -315,17 +321,116 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 ### 2.4 GitHub Projects Status Update
 
+**Pre-write** (before executing Projects Status update): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase2_projects" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Execute Phase 2.4 (Projects Status → In Progress). Skipping to Phase 2.5/2.6/3 without running Projects update is PROHIBITED. Do NOT stop."
+```
+
 > **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update)
 
-Skip if `projects.enabled: false` in rite-config.yml. Otherwise: get item ID, update Status to "In Progress", auto-add if not registered. Execute sub-phases in order: config (2.4.1), registration check (2.4.2), auto-add (2.4.3), Status field with field_ids optimization (2.4.4), Status update (2.4.5).
+Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the following inline procedure (extracted from the Module for determinism — do NOT silently skip).
 
-**After 2.4.5 completes, always execute 2.4.7** (Parent Issue Status Update). 2.4.7.1 performs parent detection — if no parent is found, it skips silently. Do NOT skip 2.4.7 even if the current Issue was not identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents).
+**Step 1** — Read config:
+
+```bash
+projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
+project_number=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    project_number:/{print $2; exit}' rite-config.yml 2>/dev/null)
+project_owner=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    owner:/{gsub(/"/,"",$2); print $2; exit}' rite-config.yml 2>/dev/null)
+if [ "$projects_enabled" != "true" ]; then
+  echo "Projects disabled — skipping Phase 2.4"
+  SKIP_2_4=1
+fi
+```
+
+If `SKIP_2_4=1`, jump directly to the Mandatory After 2.4 section.
+
+**Step 2** — Retrieve Issue's project item ID and project GraphQL id:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 10) { nodes { id project { id number } } }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
+```
+
+Find the node whose `project.number` matches `{project_number}`. Extract `{item_id}` and `{project_id}`. If `projectItems.nodes` is empty, auto-add the Issue to the Project via `gh project item-add {project_number} --owner {owner} --url <issue_url>` and re-query.
+
+**Step 3** — Retrieve Status field + "In Progress" option id:
+
+```bash
+gh project field-list {project_number} --owner {owner} --format json
+```
+
+Find field `name == "Status"`. Extract `{status_field_id}` (field `id`) and `{in_progress_option_id}` (option with `name == "In Progress"`). If `github.projects.field_ids.status` is set in rite-config.yml, prefer that value.
+
+**Step 4** — Update Status:
+
+```bash
+gh project item-edit --project-id {project_id} --id {item_id} --field-id {status_field_id} --single-select-option-id {in_progress_option_id}
+```
+
+On failure, display warning and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
+
+**Step 5** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). Query trackedInIssues for the current Issue, and if a parent is found, update the parent's Status to "In Progress" using the same Step 2-4 logic against the parent issue number. If no parent is found, skip silently.
+
+#### 🚨 Mandatory After 2.4
+
+> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+
+Do **NOT** stop after the Projects Status update. Phase 2.5 (Iteration) and 2.6 (Work Memory) are still pending.
+
+**Step 1**: Update `.rite-flow-state` to post-projects phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase2_post_projects" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Phase 2.4 completed. Proceed to Phase 2.5 (Iteration) if iteration.enabled, else Phase 2.6 (Work Memory). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 2.5 now** (or Phase 2.6 if iteration is disabled).
 
 ### 2.5 Iteration Assignment
 
+**Pre-write** (before executing Iteration assignment):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase2_iteration" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Execute Phase 2.5 (Iteration assignment). Skipping to Phase 2.6/3 without running Iteration assignment is PROHIBITED when iteration.enabled. Do NOT stop."
+```
+
 > **Module**: [Projects Integration](../../references/projects-integration.md#25-iteration-assignment-optional)
 
-Execute only if `iteration.enabled: true` and `iteration.auto_assign: true` in rite-config.yml. Skip if `projects.enabled: false`. Handles: field info (2.5.1), current determination (2.5.2), assignment (2.5.3), result/warning (2.5.4).
+**Skip conditions** — if any of the following are true, skip the Module procedure and go directly to Mandatory After 2.5:
+
+- `projects.enabled: false` in rite-config.yml
+- `iteration.enabled: false` in rite-config.yml
+- `iteration.auto_assign: false` in rite-config.yml
+
+Otherwise, execute the Module procedure: field info (2.5.1), current iteration determination (2.5.2), assignment (2.5.3), result/warning (2.5.4). On any failure, display warning and continue (non-blocking).
+
+#### 🚨 Mandatory After 2.5
+
+**Step 1**: Update `.rite-flow-state` to post-iteration phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase2_post_iteration" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Phase 2.5 completed (or skipped). Proceed to Phase 2.6 (Work Memory initialization). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 2.6 now**.
 
 ### 2.6 Work Memory Initialization
 
@@ -372,6 +477,17 @@ fi
 **Step 3**: Do **NOT** stop after `rite:issue:work-memory-init` returns. **→ Proceed to Phase 3 now**.
 
 ## Phase 3: Implementation Plan
+
+**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the previous phase is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase.
+
+```bash
+prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
+if [ "$prev" != "phase2_post_work_memory" ] && [ "$prev" != "phase3_post_plan" ]; then
+  echo "ERROR: Phase 3 pre-condition failed. previous_phase=$prev (expected: phase2_post_work_memory)" >&2
+  echo "ACTION: Return to the missing Phase 2 step (2.4 Projects / 2.5 Iteration / 2.6 Work Memory) and execute its Pre-write + main procedure + Mandatory After before entering Phase 3." >&2
+  exit 1
+fi
+```
 
 **Pre-write** (before invoking `rite:issue:implementation-plan`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
@@ -482,6 +598,15 @@ Invocation: `skill: "rite:lint"` or `skill: "rite:pr:review", args: "67"`
 
 ### 5.0 Stop Hook Verification
 
+**Pre-write** (before executing stop-hook verification):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_stop_hook" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Execute Phase 5.0 (Stop Hook Verification). Skipping to Phase 5.1/5.2 without verifying the stop-guard hook is PROHIBITED. Do NOT stop."
+```
+
 Before entering the end-to-end flow, verify that the stop-guard hook is active to prevent flow interruptions when sub-skills return.
 
 **Step 1**: Resolve `{plugin_root}` (if not already resolved in Phase 4.1) per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script).
@@ -551,6 +676,19 @@ echo "workflow_incident_enabled=$workflow_incident_enabled"
 Retain `workflow_incident_enabled` in conversation context. Phase 5.4.4.1 reads this value and skips its entire processing if `false`.
 
 > **Note on non-blocking / dedupe behavior**: The implementation always behaves as non-blocking (registration failure does not halt the workflow) and deduplicates incidents per session (same type is only prompted once). Only `enabled` is a configurable key.
+
+#### 🚨 Mandatory After 5.0
+
+**Step 1**: Update `.rite-flow-state` to post-stop-hook phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_stop_hook" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "Phase 5.0 completed (stop-guard verified, workflow_incident_enabled cached). Proceed to Phase 5.1 (Implementation). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 5.1 now**.
 
 ### 5.1 Implementation
 
@@ -1445,6 +1583,26 @@ WM_SOURCE="ready" \
 
 #### 5.5.1 Update Issue Status to "In Review"
 
+**Pre-condition check** (#490 AC-5): Verify that Phase 5.5 (Ready) completed. Previous phase must be `phase5_post_ready`:
+
+```bash
+prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
+if [ "$prev" != "phase5_post_ready" ]; then
+  echo "ERROR: Phase 5.5.1 pre-condition failed. previous_phase=$prev (expected: phase5_post_ready)" >&2
+  echo "ACTION: Return to Phase 5.5 (Ready for Review) and execute its Pre-write + rite:pr:ready invocation + Mandatory After 5.5 before entering Phase 5.5.1." >&2
+  exit 1
+fi
+```
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_status_in_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.5.1 (Issue Status → In Review). Skipping to Phase 5.5.2/5.6 without running the Status update is PROHIBITED. Do NOT stop."
+```
+
 **Owner**: `/rite:issue:start` (defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow).
 
 **Note**: Uses `gh project field-list` CLI (consistent with [Projects Integration](../../references/projects-integration.md)). This differs from `ready.md` Phase 4 which uses GraphQL — an intentional design choice documented there.
@@ -1498,11 +1656,31 @@ If `github.projects.field_ids.status` is set in rite-config.yml, use that value 
 gh project item-edit --project-id {project_id} --id {item_id} --field-id {status_field_id} --single-select-option-id {in_review_option_id}
 ```
 
-On failure, display warning and continue to 5.6 (non-blocking).
+On failure, display warning and continue to Mandatory After 5.5.1 (non-blocking).
 
-**→ Proceed to 5.5.2**.
+#### 🚨 Mandatory After 5.5.1
+
+**Step 1**: Update `.rite-flow-state` to post-status-in-review phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_status_in_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Phase 5.5.1 completed (Issue Status → In Review). Proceed to Phase 5.5.2 (Metrics Recording). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 5.5.2 now**.
 
 ### 5.5.2 Metrics Recording
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_metrics" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.5.2 (Metrics Recording). Skipping to Phase 5.6 without running metrics is PROHIBITED. Do NOT stop."
+```
 
 > **Reference**: [Execution Metrics](../../references/execution-metrics.md)
 
@@ -1646,7 +1824,18 @@ Present options via `AskUserQuestion`:
 - 中止（作業メモリに状態保存）→ Phase 5.6
 - 手動介入（ユーザーが直接対応）→ terminate
 
-**→ Proceed to 5.6**.
+#### 🚨 Mandatory After 5.5.2
+
+**Step 1**: Update `.rite-flow-state` to post-metrics phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_metrics" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Phase 5.5.2 completed (metrics recorded). Proceed to Phase 5.6 (Completion Report). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 5.6 now**.
 
 **Post-completion**: Update `.rite-flow-state` `active: false` (atomic):
 
@@ -1666,6 +1855,26 @@ rm -rf .rite-compact-state.lockdir 2>/dev/null || true
 **Note**: This cleanup is non-blocking. Failure to delete is silently ignored.
 
 ### 5.6 Completion Report
+
+**Pre-condition check** (#490 AC-5): Verify that Phase 5.5.1 and 5.5.2 completed. Previous phase must be `phase5_post_metrics`:
+
+```bash
+prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
+if [ "$prev" != "phase5_post_metrics" ] && [ "$prev" != "phase5_post_status_in_review" ]; then
+  echo "ERROR: Phase 5.6 pre-condition failed. previous_phase=$prev (expected: phase5_post_metrics)" >&2
+  echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
+  exit 1
+fi
+```
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_completion" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.6 (Completion Report). Proceed to Phase 5.7 (Parent Issue Completion) if applicable, else end. Do NOT stop."
+```
 
 > See [completion-report.md](./completion-report.md) for the full procedure (template read, placeholder substitution, output cases, self-verification, and inline fallbacks).
 
@@ -1702,6 +1911,15 @@ After the standard completion report sections, append a "未処理 incident" sec
 ### 5.7 Parent Issue Completion
 
 **Condition**: Parent identified in Phase 1.6/2.4.7. Execute after 5.6.
+
+**Pre-write** (only when a parent was identified — otherwise skip directly to terminate):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_parent_completion" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.7 (Parent Issue Completion). Ending the workflow without processing the parent is PROHIBITED when a parent was identified. Do NOT stop."
+```
 
 #### 5.7.1 Child Check
 
@@ -1775,6 +1993,19 @@ gh issue close {parent_issue_number}
 #### 5.7.3 Next Child
 
 Display remaining children, guide `/rite:issue:start`. No auto-start.
+
+#### 🚨 Mandatory After 5.7
+
+**Step 1**: Update `.rite-flow-state` to post-parent-completion phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_parent_completion" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} --active false \
+  --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
+```
+
+**Step 2**: Workflow terminates normally.
 
 ## Interruption/Resumption
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -45,6 +45,8 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 > **CRITICAL**: After every sub-skill invocation returns, **immediately** proceed to the next phase. Do NOT stop, do NOT re-invoke the completed skill.
 >
 > Every phase in the flow is subject to the Pre-write + Mandatory After scaffolding contract (#490). There is no "inline without stopping" path — every transition is tracked via `.rite-flow-state` and verified by the stop-guard phase-transition whitelist (`plugins/rite/hooks/phase-transition-whitelist.sh`).
+>
+> The "Stop Allowed?" column marks whether the **user** may cancel at that phase (e.g., Phase 4 Guidance where the user chooses to work later, Phase 5.6/5.7 where the workflow naturally terminates). Even for "Yes" rows, the scaffolding contract still applies — the user's stop action must be explicit, not a silent skip by the LLM.
 
 | Phase | Sub-skill Invoked | Next Phase | Stop Allowed? |
 |-------|-------------------|------------|---------------|
@@ -332,21 +334,29 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 > **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update)
 
-Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the following inline procedure (extracted from the Module for determinism — do NOT silently skip).
+Execute the following inline procedure (extracted from the Module for determinism — do NOT silently skip).
 
-**Step 1** — Read config:
+**Step 1** — Read config and emit a skip marker on stdout (the LLM reads the marker, not a bash variable; shell state does not persist across Bash tool invocations):
 
 ```bash
 projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
 project_number=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    project_number:/{print $2; exit}' rite-config.yml 2>/dev/null)
 project_owner=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    owner:/{gsub(/"/,"",$2); print $2; exit}' rite-config.yml 2>/dev/null)
 if [ "$projects_enabled" != "true" ]; then
-  echo "Projects disabled — skipping Phase 2.4"
-  SKIP_2_4=1
+  echo "[CONTEXT] PHASE_2_4_STATE=skip; reason=projects_disabled"
+else
+  echo "[CONTEXT] PHASE_2_4_STATE=execute; project_number=$project_number owner=$project_owner"
 fi
 ```
 
-If `SKIP_2_4=1`, jump directly to the Mandatory After 2.4 section.
+**LLM routing rule** (prompt-engineer CRITICAL — Bash tool shell state does not persist): the LLM reads the `[CONTEXT] PHASE_2_4_STATE=` marker from the bash block's stdout in the conversation context:
+
+| `PHASE_2_4_STATE` value | LLM action |
+|------------------------|-----------|
+| `skip` | Skip Steps 2-5 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the whitelist transition `phase2_post_branch → phase2_projects → phase2_post_projects` stays valid (the skip is recorded, not silent). |
+| `execute` | Proceed to Step 2-5 using the emitted `project_number` / `owner` values. |
+
+Do NOT rely on a bash variable (`SKIP_2_4=1`) that persists only within a single Bash tool call — each `echo`/`gh api` in the following steps is a separate invocation and the variable is lost. The `[CONTEXT]` marker travels via the conversation context and is authoritative.
 
 **Step 2** — Retrieve Issue's project item ID and project GraphQL id:
 
@@ -478,16 +488,20 @@ fi
 
 ## Phase 3: Implementation Plan
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the previous phase is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase.
+**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the previous phase is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase. `phase3_post_plan` is additionally accepted only for `/rite:resume` re-entry after Phase 3 already completed (not for normal first-entry).
 
 ```bash
 prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
+# Accept phase3_post_plan only for /rite:resume re-entry (plan already completed in a prior session).
 if [ "$prev" != "phase2_post_work_memory" ] && [ "$prev" != "phase3_post_plan" ]; then
   echo "ERROR: Phase 3 pre-condition failed. previous_phase=$prev (expected: phase2_post_work_memory)" >&2
   echo "ACTION: Return to the missing Phase 2 step (2.4 Projects / 2.5 Iteration / 2.6 Work Memory) and execute its Pre-write + main procedure + Mandatory After before entering Phase 3." >&2
+  echo "⚠️ LLM MUST NOT proceed to Phase 3 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1
 fi
 ```
+
+> **Enforcement note**: bash `exit 1` does NOT halt the LLM from proceeding. On ERROR output, the LLM MUST recognise the failure text and return to the named phase. Do NOT silently continue to the Pre-write below.
 
 **Pre-write** (before invoking `rite:issue:implementation-plan`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
@@ -1590,9 +1604,12 @@ prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
 if [ "$prev" != "phase5_post_ready" ]; then
   echo "ERROR: Phase 5.5.1 pre-condition failed. previous_phase=$prev (expected: phase5_post_ready)" >&2
   echo "ACTION: Return to Phase 5.5 (Ready for Review) and execute its Pre-write + rite:pr:ready invocation + Mandatory After 5.5 before entering Phase 5.5.1." >&2
+  echo "⚠️ LLM MUST NOT proceed to Phase 5.5.1 Pre-write below. Re-invoke Phase 5.5 first." >&2
   exit 1
 fi
 ```
+
+> **Enforcement note**: bash `exit 1` does NOT halt the LLM. On ERROR, the LLM MUST recognise the failure and return to Phase 5.5 rather than proceeding.
 
 **Pre-write**:
 
@@ -1837,35 +1854,25 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 **Step 2**: **→ Proceed to Phase 5.6 now**.
 
-**Post-completion**: Update `.rite-flow-state` `active: false` (atomic):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh patch \
-  --phase "completed" \
-  --next "none" --active false
-```
-
-**After flow state update (regardless of success/failure)**: Clean up `.rite-compact-state` to prevent stale blocked state from affecting the next session (#756):
-
-```bash
-rm -f .rite-compact-state 2>/dev/null || true
-rm -rf .rite-compact-state.lockdir 2>/dev/null || true
-```
-
-**Note**: This cleanup is non-blocking. Failure to delete is silently ignored.
+> **Note on workflow termination**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed here, between Mandatory After 5.5.2 and Phase 5.6. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition (prompt-engineer + devops CRITICAL). The terminal state update now runs at the end of Phase 5.7 (or immediately after Phase 5.6 when no parent exists) — see the "Workflow Termination" block there.
 
 ### 5.6 Completion Report
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 5.5.1 and 5.5.2 completed. Previous phase must be `phase5_post_metrics`:
+**Pre-condition check** (#490 AC-5): Verify that both Phase 5.5.1 (Status) and 5.5.2 (Metrics) completed. Previous phase must be `phase5_post_metrics` — the earlier `phase5_post_status_in_review` alternative was removed because it let Metrics silently skip (AC-5 violation, prompt-engineer + code-quality CRITICAL).
+
+If `metrics.enabled: false` in rite-config.yml, Phase 5.5.2 must still write the `phase5_post_metrics` marker (the phase body may short-circuit after the Pre-write, but the Mandatory After block must run unconditionally).
 
 ```bash
 prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
-if [ "$prev" != "phase5_post_metrics" ] && [ "$prev" != "phase5_post_status_in_review" ]; then
+if [ "$prev" != "phase5_post_metrics" ]; then
   echo "ERROR: Phase 5.6 pre-condition failed. previous_phase=$prev (expected: phase5_post_metrics)" >&2
   echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
+  echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1
 fi
 ```
+
+> **Enforcement note** (prompt-engineer HIGH): bash `exit 1` does NOT stop the LLM from proceeding to the Pre-write block below. On ERROR, the LLM MUST recognise the failure text in stderr and return to the missing phase. Do NOT silently continue. The stop-guard whitelist will also reject `phase5_post_status_in_review → phase5_completion` as a defense-in-depth layer.
 
 **Pre-write**:
 
@@ -2005,7 +2012,30 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
 ```
 
-**Step 2**: Workflow terminates normally.
+**Step 2**: Workflow terminates normally. Proceed to the "Workflow Termination" block below.
+
+### Workflow Termination
+
+> **Placement**: This block runs **after** Phase 5.7 completes **or after Phase 5.6** when no parent Issue was identified in Phase 1.6 / 2.4.7 (the Phase 5.7 skip branch). Both paths converge here so the terminal `phase="completed", active: false` state is set exactly once, with `previous_phase` pointing at a whitelist-valid source (`phase5_post_parent_completion` or `phase5_completion`).
+
+**Parent-skip routing** (prompt-engineer HIGH — Phase 5.7 skip branch missing termination): When no parent Issue was identified, Phase 5.7 is skipped entirely. In that case, jump from the end of Phase 5.6 directly to this block (bypassing 5.7.1-5.7.3 and Mandatory After 5.7) — do **not** leave the workflow in `phase5_completion, active: true`, which would cause the next stop attempt to block indefinitely.
+
+**Step 1**: Update `.rite-flow-state` to the terminal state (patch mode, preserves `previous_phase`):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "completed" \
+  --next "none" --active false
+```
+
+**Step 2**: Clean up `.rite-compact-state` to prevent stale blocked state from affecting the next session (#756):
+
+```bash
+rm -f .rite-compact-state 2>/dev/null || true
+rm -rf .rite-compact-state.lockdir 2>/dev/null || true
+```
+
+**Note**: This cleanup is non-blocking. Failure to delete is silently ignored.
 
 ## Interruption/Resumption
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -44,9 +44,9 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 > Stopping between phases leaves the workflow in an inconsistent state (e.g., branch created but no PR), requiring manual recovery via `/rite:resume`.
 > **CRITICAL**: After every sub-skill invocation returns, **immediately** proceed to the next phase. Do NOT stop, do NOT re-invoke the completed skill.
 >
-> Every phase in the flow is subject to the Pre-write + Mandatory After scaffolding contract (#490). There is no "inline without stopping" path — every transition is tracked via `.rite-flow-state` and verified by the stop-guard phase-transition whitelist (`plugins/rite/hooks/phase-transition-whitelist.sh`).
+> Every phase that writes to `.rite-flow-state` is subject to the Pre-write + Mandatory After scaffolding contract (#490). Phases that only read state (0.x Detection, 1 Quality, 2.1/2.2 Branch-pattern detection, 4 User Guidance, 5.6.1 Incident Reporting, etc.) do not write markers and are therefore excluded from whitelist verification — they run inline and their transitions are verified indirectly by the surrounding write-phases. Every state-writing transition is tracked via `.rite-flow-state` and verified by the stop-guard phase-transition whitelist (`plugins/rite/hooks/phase-transition-whitelist.sh`).
 >
-> The "Stop Allowed?" column marks whether the **user** may cancel at that phase (e.g., Phase 4 Guidance where the user chooses to work later, Phase 5.6/5.7 where the workflow naturally terminates). Even for "Yes" rows, the scaffolding contract still applies — the user's stop action must be explicit, not a silent skip by the LLM.
+> The "Stop Allowed?" column marks whether the **user** may cancel at that phase (e.g., Phase 4 Guidance where the user chooses to work later, Phase 5.6/5.7 where the workflow naturally terminates after the completion handoff is displayed). Even for "Yes" rows, the scaffolding contract still applies — the user's stop action must be explicit, not a silent skip by the LLM.
 
 | Phase | Sub-skill Invoked | Next Phase | Stop Allowed? |
 |-------|-------------------|------------|---------------|
@@ -353,7 +353,7 @@ fi
 
 | `PHASE_2_4_STATE` value | LLM action |
 |------------------------|-----------|
-| `skip` | Skip Steps 2-5 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the whitelist transition `phase2_post_branch → phase2_projects → phase2_post_projects` stays valid (the skip is recorded, not silent). |
+| `skip` | Skip Steps 2-5 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the two whitelist transitions (`phase2_post_branch → phase2_projects` and `phase2_projects → phase2_post_projects`) stay valid (the skip is recorded, not silent). |
 | `execute` | Proceed to Step 2-5 using the emitted `project_number` / `owner` values. |
 
 Do NOT rely on a bash variable (`SKIP_2_4=1`) that persists only within a single Bash tool call — each `echo`/`gh api` in the following steps is a separate invocation and the variable is lost. The `[CONTEXT]` marker travels via the conversation context and is authoritative.
@@ -488,13 +488,15 @@ fi
 
 ## Phase 3: Implementation Plan
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the previous phase is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase. `phase3_post_plan` is additionally accepted only for `/rite:resume` re-entry after Phase 3 already completed (not for normal first-entry).
+**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the current `.phase` in `.rite-flow-state` is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase. `phase3_post_plan` is additionally accepted only for `/rite:resume` re-entry after Phase 3 already completed (not for normal first-entry).
+
+> **⚠️ Why `.phase`, not `.previous_phase`**: `flow-state-update.sh` `create` mode assigns the outgoing `.phase` value to `.previous_phase` (see `hooks/flow-state-update.sh` create branch). Therefore the **expected post-phase marker** appears in `.phase`, and `.previous_phase` holds the *predecessor*. Checking `.previous_phase` here would always compare against the phase *one step behind* the expected marker and would ERROR on every normal entry (prompt-engineer cycle-3 CRITICAL).
 
 ```bash
-prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
+curr=$(jq -r '.phase // ""' .rite-flow-state 2>/dev/null)
 # Accept phase3_post_plan only for /rite:resume re-entry (plan already completed in a prior session).
-if [ "$prev" != "phase2_post_work_memory" ] && [ "$prev" != "phase3_post_plan" ]; then
-  echo "ERROR: Phase 3 pre-condition failed. previous_phase=$prev (expected: phase2_post_work_memory)" >&2
+if [ "$curr" != "phase2_post_work_memory" ] && [ "$curr" != "phase3_post_plan" ]; then
+  echo "ERROR: Phase 3 pre-condition failed. .phase=$curr (expected: phase2_post_work_memory)" >&2
   echo "ACTION: Return to the missing Phase 2 step (2.4 Projects / 2.5 Iteration / 2.6 Work Memory) and execute its Pre-write + main procedure + Mandatory After before entering Phase 3." >&2
   echo "⚠️ LLM MUST NOT proceed to Phase 3 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1
@@ -1597,12 +1599,12 @@ WM_SOURCE="ready" \
 
 #### 5.5.1 Update Issue Status to "In Review"
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 5.5 (Ready) completed. Previous phase must be `phase5_post_ready`:
+**Pre-condition check** (#490 AC-5): Verify that Phase 5.5 (Ready) completed. The current `.phase` in `.rite-flow-state` must be `phase5_post_ready` (the Mandatory After 5.5 marker). See the "Why `.phase`, not `.previous_phase`" explanation in Phase 3 pre-condition above.
 
 ```bash
-prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
-if [ "$prev" != "phase5_post_ready" ]; then
-  echo "ERROR: Phase 5.5.1 pre-condition failed. previous_phase=$prev (expected: phase5_post_ready)" >&2
+curr=$(jq -r '.phase // ""' .rite-flow-state 2>/dev/null)
+if [ "$curr" != "phase5_post_ready" ]; then
+  echo "ERROR: Phase 5.5.1 pre-condition failed. .phase=$curr (expected: phase5_post_ready)" >&2
   echo "ACTION: Return to Phase 5.5 (Ready for Review) and execute its Pre-write + rite:pr:ready invocation + Mandatory After 5.5 before entering Phase 5.5.1." >&2
   echo "⚠️ LLM MUST NOT proceed to Phase 5.5.1 Pre-write below. Re-invoke Phase 5.5 first." >&2
   exit 1
@@ -1858,14 +1860,14 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 > **Historical note (informational only — no action required)**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed between Mandatory After 5.5.2 and this heading. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition (prompt-engineer + devops CRITICAL, fixed in cycle 1). The terminal state update now runs at the end of Phase 5.7 or, when no parent is identified, immediately after this Phase 5.6 — see the "Workflow Termination" block below. This note is purely historical context for future maintainers and contains no executable instructions.
 
-**Pre-condition check** (#490 AC-5): Verify that both Phase 5.5.1 (Status) and 5.5.2 (Metrics) completed. Previous phase must be `phase5_post_metrics` — the earlier `phase5_post_status_in_review` alternative was removed because it let Metrics silently skip (AC-5 violation, prompt-engineer + code-quality CRITICAL).
+**Pre-condition check** (#490 AC-5): Verify that both Phase 5.5.1 (Status) and 5.5.2 (Metrics) completed. The current `.phase` in `.rite-flow-state` must be `phase5_post_metrics` — the earlier `phase5_post_status_in_review` alternative was removed because it let Metrics silently skip (AC-5 violation, prompt-engineer + code-quality CRITICAL). See the "Why `.phase`, not `.previous_phase`" explanation in Phase 3 pre-condition above.
 
-If `metrics.enabled: false` in rite-config.yml, Phase 5.5.2 must still write the `phase5_post_metrics` marker (the phase body may short-circuit after the Pre-write, but the Mandatory After block must run unconditionally).
+If `metrics.enabled: false` in rite-config.yml, Phase 5.5.2 must still write the `phase5_post_metrics` marker (the phase body may short-circuit Steps 1-5 below, but the Mandatory After block must run unconditionally — see Phase 5.5.2 Skip Steps note).
 
 ```bash
-prev=$(jq -r '.previous_phase // ""' .rite-flow-state 2>/dev/null)
-if [ "$prev" != "phase5_post_metrics" ]; then
-  echo "ERROR: Phase 5.6 pre-condition failed. previous_phase=$prev (expected: phase5_post_metrics)" >&2
+curr=$(jq -r '.phase // ""' .rite-flow-state 2>/dev/null)
+if [ "$curr" != "phase5_post_metrics" ]; then
+  echo "ERROR: Phase 5.6 pre-condition failed. .phase=$curr (expected: phase5_post_metrics)" >&2
   echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
   echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -69,8 +69,8 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 | 5.5 (Ready) | `rite:pr:ready` | 5.5.0.1→5.5.1 | **No** |
 | 5.5.1 (Status In Review) | — | 5.5.2 | **No** |
 | 5.5.2 (Metrics) | — | 5.6 | **No** |
-| 5.6 (Report) | — | 5.7 or end | Yes |
-| 5.7 (Parent Completion) | — | end | Yes |
+| 5.6 (Report) | — | 5.7 or Workflow Termination | Yes (only after completion handoff is displayed) |
+| 5.7 (Parent Completion) | — | Workflow Termination | Yes (only after completion handoff is displayed) |
 
 ---
 
@@ -115,6 +115,7 @@ This protocol applies to **every** sub-skill invocation in this document. Each �
 | `{status_field_id}` | `github.projects.field_ids.status` in `rite-config.yml`, or `gh project field-list` |
 | `{in_review_option_id}` | `gh project field-list` ("In Review" option) |
 | `{done_option_id}` | `gh project field-list` ("Done" option) |
+| `{parent_issue_number}` | Phase 1.6 (child-issue-selection) or Phase 2.4 Step 5 (parent lookup) result; retained in conversation context. Used only in Phase 5.7 and Workflow Termination routing |
 
 ---
 
@@ -391,7 +392,7 @@ On failure, display warning and continue (non-blocking). The scaffolding-failure
 
 **Step 5** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). Query trackedInIssues for the current Issue, and if a parent is found, update the parent's Status to "In Progress" using the same Step 2-4 logic against the parent issue number. If no parent is found, skip silently.
 
-#### 🚨 Mandatory After 2.4
+### 🚨 Mandatory After 2.4
 
 > See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
 
@@ -429,7 +430,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 Otherwise, execute the Module procedure: field info (2.5.1), current iteration determination (2.5.2), assignment (2.5.3), result/warning (2.5.4). On any failure, display warning and continue (non-blocking).
 
-#### 🚨 Mandatory After 2.5
+### 🚨 Mandatory After 2.5
 
 **Step 1**: Update `.rite-flow-state` to post-iteration phase:
 
@@ -693,7 +694,7 @@ Retain `workflow_incident_enabled` in conversation context. Phase 5.4.4.1 reads 
 
 > **Note on non-blocking / dedupe behavior**: The implementation always behaves as non-blocking (registration failure does not halt the workflow) and deduplicates incidents per session (same type is only prompted once). Only `enabled` is a configurable key.
 
-#### 🚨 Mandatory After 5.0
+### 🚨 Mandatory After 5.0
 
 **Step 1**: Update `.rite-flow-state` to post-stop-hook phase:
 
@@ -1677,7 +1678,7 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 On failure, display warning and continue to Mandatory After 5.5.1 (non-blocking).
 
-#### 🚨 Mandatory After 5.5.1
+### 🚨 Mandatory After 5.5.1
 
 **Step 1**: Update `.rite-flow-state` to post-status-in-review phase:
 
@@ -1703,7 +1704,9 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 > **Reference**: [Execution Metrics](../../references/execution-metrics.md)
 
-Skip if `metrics.enabled: false` in rite-config.yml. Otherwise:
+**Skip Steps note** (referenced by Phase 5.6 pre-condition): When `metrics.enabled: false` in rite-config.yml, skip Steps 1-5 below **but unconditionally execute Mandatory After 5.5.2**. The `phase5_post_metrics` marker is required for Phase 5.6 pre-condition to pass. Skipping the Mandatory After would leave `.phase = phase5_post_status_in_review` and trip the Phase 5.6 ERROR gate (prompt-engineer cycle-4 HIGH / code-quality cycle-4 MEDIUM).
+
+Otherwise:
 
 **Step 1**: Collect metrics from the current workflow execution:
 
@@ -1843,7 +1846,7 @@ Present options via `AskUserQuestion`:
 - 中止（作業メモリに状態保存）→ Phase 5.6
 - 手動介入（ユーザーが直接対応）→ terminate
 
-#### 🚨 Mandatory After 5.5.2
+### 🚨 Mandatory After 5.5.2
 
 **Step 1**: Update `.rite-flow-state` to post-metrics phase:
 
@@ -1882,7 +1885,7 @@ fi
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_completion" --issue {issue_number} --branch "{branch_name}" \
   --pr {pr_number} \
-  --next "Execute Phase 5.6 (Completion Report). Proceed to Phase 5.7 (Parent Issue Completion) if applicable, else end. Do NOT stop."
+  --next "Execute Phase 5.6 (Completion Report). If parent_issue_number was retained in conversation context (from Phase 1.6 / 2.4.7), proceed to Phase 5.7. Otherwise jump directly to the Workflow Termination block (bypass 5.7). Do NOT stop."
 ```
 
 > See [completion-report.md](./completion-report.md) for the full procedure (template read, placeholder substitution, output cases, self-verification, and inline fallbacks).
@@ -2003,7 +2006,7 @@ gh issue close {parent_issue_number}
 
 Display remaining children, guide `/rite:issue:start`. No auto-start.
 
-#### 🚨 Mandatory After 5.7
+### 🚨 Mandatory After 5.7
 
 **Step 1**: Update `.rite-flow-state` to post-parent-completion phase. Use **patch mode** — patch preserves `previous_phase` automatically from the outgoing `.phase` field, whereas `create` mode would overwrite the entire state and risk tripping the session-ownership check (prompt-engineer cycle-2 MEDIUM #5):
 
@@ -2042,7 +2045,7 @@ rm -rf .rite-compact-state.lockdir 2>/dev/null || true
 
 **Retention**: Branch (Git), work memory (Issue comment), Status (Projects), plan (work memory).
 
-**Resume** via `/rite:issue:start {number}`: Phase 2.2 detects branch. "Switch"→skip 2.3/2.4/2.6→Phase 3 (show plan)→continue from work memory.
+**Resume** via `/rite:issue:start {number}`: Phase 2.2 detects branch. "Switch"→skip 2.3/2.4/2.5/2.6→Phase 3 (show plan)→continue from work memory. On resume, the Phase 3 pre-condition accepts `.phase=phase3_post_plan` (already-completed plan) in addition to `phase2_post_work_memory` — the `phase3_post_plan → phase3_plan` whitelist entry covers the retry edge.
 
 **If PR exists**: After 2.2, check `gh pr list --head {branch_name}`. OPEN→`rite:pr:review`, MERGED→`rite:pr:cleanup`, CLOSED→confirm (reopen/new/cancel).
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -406,7 +406,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Phase 2.4 completed. Proceed to Phase 2.5 (Iteration) if iteration.enabled, else Phase 2.6 (Work Memory). Do NOT stop."
 ```
 
-**Step 2**: **→ Proceed to Phase 2.5 now** (or Phase 2.6 if iteration is disabled).
+**Step 2**: **→ Proceed to Phase 2.5 now**. Phase 2.5 handles its own skip conditions internally (iteration disabled / projects disabled) — do NOT skip Phase 2.5 at this level (prompt-engineer cycle-2 MEDIUM #3). The Phase 2.5 Pre-write + Mandatory After blocks always run so `phase2_post_iteration` is recorded even when the assignment body is skipped.
 
 ### 2.5 Iteration Assignment
 
@@ -1854,9 +1854,9 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 **Step 2**: **→ Proceed to Phase 5.6 now**.
 
-> **Note on workflow termination**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed here, between Mandatory After 5.5.2 and Phase 5.6. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition (prompt-engineer + devops CRITICAL). The terminal state update now runs at the end of Phase 5.7 (or immediately after Phase 5.6 when no parent exists) — see the "Workflow Termination" block there.
-
 ### 5.6 Completion Report
+
+> **Historical note (informational only — no action required)**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed between Mandatory After 5.5.2 and this heading. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition (prompt-engineer + devops CRITICAL, fixed in cycle 1). The terminal state update now runs at the end of Phase 5.7 or, when no parent is identified, immediately after this Phase 5.6 — see the "Workflow Termination" block below. This note is purely historical context for future maintainers and contains no executable instructions.
 
 **Pre-condition check** (#490 AC-5): Verify that both Phase 5.5.1 (Status) and 5.5.2 (Metrics) completed. Previous phase must be `phase5_post_metrics` — the earlier `phase5_post_status_in_review` alternative was removed because it let Metrics silently skip (AC-5 violation, prompt-engineer + code-quality CRITICAL).
 
@@ -1872,7 +1872,7 @@ if [ "$prev" != "phase5_post_metrics" ]; then
 fi
 ```
 
-> **Enforcement note** (prompt-engineer HIGH): bash `exit 1` does NOT stop the LLM from proceeding to the Pre-write block below. On ERROR, the LLM MUST recognise the failure text in stderr and return to the missing phase. Do NOT silently continue. The stop-guard whitelist will also reject `phase5_post_status_in_review → phase5_completion` as a defense-in-depth layer.
+> **Enforcement note** (prompt-engineer HIGH): bash `exit 1` does NOT stop the LLM from proceeding to the Pre-write block below. On ERROR, the LLM MUST recognise the failure text in stderr and return to the missing phase. Do NOT silently continue. The stop-guard whitelist (`["phase5_post_metrics"]="phase5_completion"`) will also reject any other source (e.g., `phase5_post_ready`, `phase5_post_status_in_review`) as a defense-in-depth layer.
 
 **Pre-write**:
 
@@ -2003,12 +2003,11 @@ Display remaining children, guide `/rite:issue:start`. No auto-start.
 
 #### 🚨 Mandatory After 5.7
 
-**Step 1**: Update `.rite-flow-state` to post-parent-completion phase:
+**Step 1**: Update `.rite-flow-state` to post-parent-completion phase. Use **patch mode** — patch preserves `previous_phase` automatically from the outgoing `.phase` field, whereas `create` mode would overwrite the entire state and risk tripping the session-ownership check (prompt-engineer cycle-2 MEDIUM #5):
 
 ```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_parent_completion" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} --active false \
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "phase5_post_parent_completion" --active false \
   --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
 ```
 

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -142,16 +142,24 @@ case "$MODE" in
         fi
       fi
     fi
+    # Capture previous phase for whitelist-based transition verification (#490).
+    # When the existing state file is absent or malformed, previous_phase is "" —
+    # stop-guard treats empty previous_phase as "workflow start" (always valid).
+    PREV_PHASE=""
+    if [[ -f "$FLOW_STATE" ]]; then
+      PREV_PHASE=$(jq -r '.phase // ""' "$FLOW_STATE" 2>/dev/null) || PREV_PHASE=""
+    fi
     if jq -n \
       --argjson active "$ACTIVE" \
       --argjson issue "$ISSUE" \
       --arg branch "$BRANCH" \
       --arg phase "$PHASE" \
+      --arg prev_phase "$PREV_PHASE" \
       --argjson pr "$PR" \
       --arg next "$NEXT" \
       --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
       --arg sid "$SESSION" \
-      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, pr_number: $pr, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
+      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
       > "$TMP_STATE"; then
       mv "$TMP_STATE" "$FLOW_STATE"
     else
@@ -161,8 +169,10 @@ case "$MODE" in
     fi
     ;;
   patch)
-    # Build jq filter: always update phase, timestamp, next_action; conditionally update active
-    JQ_FILTER='.phase = $phase | .updated_at = $ts | .next_action = $next | .error_count = 0'
+    # Build jq filter: always update phase, timestamp, next_action; conditionally update active.
+    # Also capture the outgoing phase into previous_phase so stop-guard can verify the
+    # transition whitelist (#490). Use the pre-update .phase value as previous_phase.
+    JQ_FILTER='.previous_phase = (.phase // "") | .phase = $phase | .updated_at = $ts | .next_action = $next | .error_count = 0'
     JQ_ARGS=(--arg phase "$PHASE" --arg ts "$(date -u +'%Y-%m-%dT%H:%M:%S+00:00')" --arg next "$NEXT")
     if [[ -n "$ACTIVE" ]]; then
       JQ_FILTER="$JQ_FILTER | .active = (\$active_val == \"true\")"

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -143,11 +143,32 @@ case "$MODE" in
       fi
     fi
     # Capture previous phase for whitelist-based transition verification (#490).
-    # When the existing state file is absent or malformed, previous_phase is "" —
-    # stop-guard treats empty previous_phase as "workflow start" (always valid).
+    # When the state file is absent, previous_phase is "" (legitimate cold start).
+    # When the file exists but is corrupt, fail-fast — silently treating corruption
+    # as a cold start would erase the prior phase and effectively bypass the
+    # whitelist for the next transition (error-handling CRITICAL #2).
     PREV_PHASE=""
     if [[ -f "$FLOW_STATE" ]]; then
-      PREV_PHASE=$(jq -r '.phase // ""' "$FLOW_STATE" 2>/dev/null) || PREV_PHASE=""
+      if [[ ! -s "$FLOW_STATE" ]]; then
+        echo "ERROR: .rite-flow-state exists but is empty ($FLOW_STATE)" >&2
+        echo "  previous_phase cannot be preserved; failing fast to avoid silent cold-start." >&2
+        echo "  対処: .rite-flow-state を /rite:resume で復旧するか、既存ファイルを削除してから再度 /rite:issue:start を実行" >&2
+        exit 1
+      fi
+      # Validate JSON parse; distinguish "missing .phase" (acceptable → "") from
+      # "jq parse error" (corrupt state, must not silently fall back).
+      _jq_err=$(mktemp 2>/dev/null) || _jq_err=""
+      if PREV_PHASE=$(jq -r '.phase // ""' "$FLOW_STATE" 2>"${_jq_err:-/dev/null}"); then
+        : # jq ok
+      else
+        echo "ERROR: .rite-flow-state parse failed ($FLOW_STATE)" >&2
+        [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | sed 's/^/  /' >&2
+        echo "  previous_phase cannot be preserved; failing fast to avoid silent cold-start." >&2
+        echo "  対処: 既存の .rite-flow-state を確認し、必要なら /rite:resume で復旧してください" >&2
+        [ -n "$_jq_err" ] && rm -f "$_jq_err"
+        exit 1
+      fi
+      [ -n "$_jq_err" ] && rm -f "$_jq_err"
     fi
     if jq -n \
       --argjson active "$ACTIVE" \

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -24,6 +24,15 @@
 [ -n "${_RITE_PHASE_TRANSITION_LOADED:-}" ] && return 0
 _RITE_PHASE_TRANSITION_LOADED=1
 
+# Bash 4.2+ required for `declare -gA`. Older bash (e.g., macOS default 3.2)
+# would abort with a syntax error on the associative-array literal below, and the
+# stop-guard source would silently fail-open. Bail out gracefully so that
+# stop-guard can detect the missing `rite_phase_transition_allowed` function and
+# log a diagnostic instead of silently disabling the whitelist.
+if ((BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2))); then
+  return 0
+fi
+
 # Baked-in whitelist. Each entry maps a phase to the phases it may transition to.
 # Empty string ("") is accepted as a synthetic "workflow start" predecessor for
 # any phase, since /rite:issue:start begins with no prior state.
@@ -45,8 +54,10 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   ["phase2_post_work_memory"]="phase3_plan"
 
   # Phase 3: implementation plan
+  # Phase 5.0 (Stop Hook Verification) is mandatory — transition MUST go through phase5_stop_hook.
+  # Do NOT allow direct phase3_post_plan → phase5_lint (would silently skip Stop Hook verification).
   ["phase3_plan"]="phase3_post_plan"
-  ["phase3_post_plan"]="phase5_stop_hook phase5_lint"
+  ["phase3_post_plan"]="phase5_stop_hook"
 
   # Phase 5.0: stop-hook verification
   ["phase5_stop_hook"]="phase5_post_stop_hook"
@@ -61,23 +72,40 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   ["phase5_post_pr"]="phase5_review"
 
   # Phase 5.4: review-fix loop
+  # `rite:pr:ready` defense-in-depth directly writes phase5_post_ready from phase5_post_review /
+  # phase5_post_fix, bypassing phase5_ready. Allow that transition to avoid invalid-transition
+  # blocks on the mergeable path (devops-reviewer CRITICAL #1).
   ["phase5_review"]="phase5_post_review"
-  ["phase5_post_review"]="phase5_fix phase5_ready"
+  ["phase5_post_review"]="phase5_fix phase5_ready phase5_post_ready phase5_ready_error"
   ["phase5_fix"]="phase5_post_fix"
-  ["phase5_post_fix"]="phase5_review phase5_ready"
+  ["phase5_post_fix"]="phase5_review phase5_ready phase5_post_ready phase5_ready_error"
 
   # Phase 5.5: ready → status → metrics → completion
-  ["phase5_ready"]="phase5_post_ready"
+  # phase5_ready_error is a terminal error state emitted by ready.md Phase 4.5 when skill errors
+  # (devops-reviewer HIGH #5). Allow error → post_ready and error → completed transitions so the
+  # workflow can recover via user choice (retry / manual / terminate).
+  ["phase5_ready"]="phase5_post_ready phase5_ready_error"
+  ["phase5_ready_error"]="phase5_post_ready completed"
   ["phase5_post_ready"]="phase5_status_in_review"
   ["phase5_status_in_review"]="phase5_post_status_in_review"
   ["phase5_post_status_in_review"]="phase5_metrics"
   ["phase5_metrics"]="phase5_post_metrics"
-  ["phase5_post_metrics"]="phase5_completion"
+  ["phase5_post_metrics"]="phase5_completion completed"
 
   # Phase 5.6 / 5.7: completion + parent completion
+  # "completed" is a terminal state reachable from multiple phases (post_metrics, completion,
+  # parent_completion, post_parent_completion). The Post-completion block historically patched
+  # phase="completed" directly after phase5_post_metrics, so we accept the direct transition
+  # (prompt-engineer + devops CRITICAL #2).
   ["phase5_completion"]="phase5_parent_completion completed"
   ["phase5_parent_completion"]="phase5_post_parent_completion"
   ["phase5_post_parent_completion"]="completed"
+
+  # Terminal: "completed" MAY re-enter phase5_completion only in /rite:resume scenarios.
+  # Under normal flow, transitions out of "completed" are rejected by rite_phase_transition_allowed
+  # (terminal state). The empty-value listing below keeps the name known as a source for
+  # rite_phase_is_known().
+  ["completed"]=""
 )
 
 # Load override map from rite-config.yml if present.
@@ -96,13 +124,22 @@ _rite_load_whitelist_overrides() {
   #         phase_a:
   #           - phase_b
   #           - phase_c
-  local block
+  #
+  # Trailing `# comment` and `#` column-0 comments are both tolerated
+  # (regex ends with optional `#.*` to match full-line or inline comments).
+  #
+  # Error visibility: awk errors (permission denied, disk I/O, malformed invocation)
+  # are sent to stderr. Previously suppressed with `2>/dev/null`, which silently
+  # hid override misconfiguration from users — the opposite of #490's intent
+  # (error-handling-reviewer CRITICAL).
+  local block awk_err
+  awk_err=$(mktemp /tmp/rite-phase-transition-awk-err-XXXXXX 2>/dev/null) || awk_err=""
   block=$(awk '
     BEGIN { in_hooks=0; in_sg=0; in_pt=0; pt_indent=-1 }
-    /^hooks:[[:space:]]*$/ { in_hooks=1; next }
+    /^hooks:[[:space:]]*(#.*)?$/ { in_hooks=1; next }
     in_hooks && /^[a-zA-Z]/ { in_hooks=0; in_sg=0; in_pt=0 }
-    in_hooks && /^[[:space:]]+stop_guard:[[:space:]]*$/ { in_sg=1; next }
-    in_sg && /^[[:space:]]+phase_transitions:[[:space:]]*$/ {
+    in_hooks && /^[[:space:]]+stop_guard:[[:space:]]*(#.*)?$/ { in_sg=1; next }
+    in_sg && /^[[:space:]]+phase_transitions:[[:space:]]*(#.*)?$/ {
       in_pt=1
       match($0, /^[[:space:]]+/)
       pt_indent=RLENGTH
@@ -116,7 +153,17 @@ _rite_load_whitelist_overrides() {
       if (line_indent <= pt_indent) { in_pt=0; next }
       print
     }
-  ' "$config_file" 2>/dev/null)
+  ' "$config_file" 2>"${awk_err:-/dev/null}")
+  local awk_rc=$?
+
+  if [ "$awk_rc" -ne 0 ]; then
+    echo "WARNING: rite-config.yml override parse (awk) failed (rc=$awk_rc): $config_file" >&2
+    if [ -n "$awk_err" ] && [ -s "$awk_err" ]; then
+      head -3 "$awk_err" | sed 's/^/  /' >&2
+    fi
+    echo "  対処: rite-config.yml の権限 / awk バイナリを確認してください" >&2
+  fi
+  [ -n "$awk_err" ] && rm -f "$awk_err"
 
   [ -z "$block" ] && return 0
 
@@ -131,9 +178,14 @@ _rite_load_whitelist_overrides() {
     local trimmed="${line#"${line%%[![:space:]]*}"}"
     [ -z "$trimmed" ] && continue
 
-    if [[ "$trimmed" =~ ^-\  ]]; then
-      # Block list entry: "- value"
-      local val="${trimmed#- }"
+    # Ignore pure comment lines
+    [[ "$trimmed" =~ ^# ]] && continue
+
+    # Block list entry: "- value" — use [[:space:]]+ to tolerate tab and multiple spaces
+    # (prompt-engineer IMPORTANT R #2).
+    if [[ "$trimmed" =~ ^-[[:space:]]+ ]]; then
+      local val="${trimmed#-}"
+      val="${val#"${val%%[![:space:]]*}"}"
       val="${val%%#*}"
       val="${val//[[:space:]]/}"
       [ -n "$val" ] && current_targets="${current_targets:+$current_targets }$val"
@@ -147,19 +199,31 @@ _rite_load_whitelist_overrides() {
       rhs="${rhs#"${rhs%%[![:space:]]*}"}"
       current_targets=""
       # Handle inline list form:  [a, b, c]
-      if [[ "$rhs" =~ ^\[(.*)\]$ ]]; then
-        local list_body="${BASH_REMATCH[1]}"
-        list_body="${list_body//,/ }"
-        for val in $list_body; do
-          val="${val//\"/}"
-          val="${val//\'/}"
-          val="${val//[[:space:]]/}"
-          [ -n "$val" ] && current_targets="${current_targets:+$current_targets }$val"
-        done
-        _rite_merge_override_entry "$current_key" "$current_targets"
-        current_key=""
-        current_targets=""
+      # Require balanced brackets — unclosed `[a, b` silently dropped the entry
+      # and leaked into the next key (IMPORTANT R #3).
+      if [[ "$rhs" =~ ^\[ ]]; then
+        if [[ "$rhs" =~ ^\[(.*)\]$ ]]; then
+          local list_body="${BASH_REMATCH[1]}"
+          list_body="${list_body//,/ }"
+          for val in $list_body; do
+            val="${val//\"/}"
+            val="${val//\'/}"
+            val="${val//[[:space:]]/}"
+            [ -n "$val" ] && current_targets="${current_targets:+$current_targets }$val"
+          done
+          _rite_merge_override_entry "$current_key" "$current_targets"
+          current_key=""
+          current_targets=""
+        else
+          echo "WARNING: rite-config.yml override parse: unclosed inline list on '$current_key': $rhs" >&2
+          current_key=""
+          current_targets=""
+        fi
       fi
+    else
+      # Unrecognized line — emit a debug trace so users can diagnose silent drops
+      # (error-handling IMPORTANT).
+      [ -n "${RITE_DEBUG:-}" ] && echo "[rite debug] override parse skipped line: $trimmed" >&2
     fi
   done <<< "$block"
 

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -68,7 +68,10 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   ["phase5_post_lint"]="phase5_pr phase5_lint"
 
   # Phase 5.3: PR create
-  ["phase5_pr"]="phase5_post_pr"
+  # start.md Phase 5.3 Mandatory After transitions directly from phase5_pr to phase5_review
+  # (no intermediate phase5_post_pr write). Allow both the direct path and the legacy
+  # post_pr marker for backward compat (devops cycle-2 CRITICAL).
+  ["phase5_pr"]="phase5_post_pr phase5_review"
   ["phase5_post_pr"]="phase5_review"
 
   # Phase 5.4: review-fix loop
@@ -90,7 +93,10 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   ["phase5_status_in_review"]="phase5_post_status_in_review"
   ["phase5_post_status_in_review"]="phase5_metrics"
   ["phase5_metrics"]="phase5_post_metrics"
-  ["phase5_post_metrics"]="phase5_completion completed"
+  # phase5_post_metrics → phase5_completion is the single valid path. The legacy
+  # "completed" direct edge was removed after the Post-completion block moved to
+  # Workflow Termination (prompt-engineer cycle-2 MEDIUM #1).
+  ["phase5_post_metrics"]="phase5_completion"
 
   # Phase 5.6 / 5.7: completion + parent completion
   # "completed" is a terminal state reachable from multiple phases (post_metrics, completion,
@@ -162,6 +168,10 @@ _rite_load_whitelist_overrides() {
       head -3 "$awk_err" | sed 's/^/  /' >&2
     fi
     echo "  対処: rite-config.yml の権限 / awk バイナリを確認してください" >&2
+    [ -n "$awk_err" ] && rm -f "$awk_err"
+    # Return non-zero so the caller's `|| log_diag ...` handler records the
+    # failure in the diagnostic log (devops cycle-2 LOW #2).
+    return 1
   fi
   [ -n "$awk_err" ] && rm -f "$awk_err"
 

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -44,10 +44,15 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   ["phase1_6_post_child"]="phase2_branch"
 
   # Phase 2: branch → projects → iteration → work memory → plan
+  # Since cycle-3 MEDIUM #3 fix, every 2.x phase always writes its post-marker
+  # (skip is signalled via the `[CONTEXT] PHASE_2_4_STATE=skip` marker and is recorded
+  # as a whitelist-valid transition). Direct phase2_post_branch → phase2_work_memory
+  # and phase2_post_projects → phase2_work_memory paths were removed because they
+  # bypass the iteration-phase chain (prompt-engineer cycle-3 MEDIUM).
   ["phase2_branch"]="phase2_post_branch"
-  ["phase2_post_branch"]="phase2_projects phase2_work_memory"
+  ["phase2_post_branch"]="phase2_projects"
   ["phase2_projects"]="phase2_post_projects"
-  ["phase2_post_projects"]="phase2_iteration phase2_work_memory"
+  ["phase2_post_projects"]="phase2_iteration"
   ["phase2_iteration"]="phase2_post_iteration"
   ["phase2_post_iteration"]="phase2_work_memory"
   ["phase2_work_memory"]="phase2_post_work_memory"
@@ -56,8 +61,10 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # Phase 3: implementation plan
   # Phase 5.0 (Stop Hook Verification) is mandatory — transition MUST go through phase5_stop_hook.
   # Do NOT allow direct phase3_post_plan → phase5_lint (would silently skip Stop Hook verification).
+  # phase3_post_plan → phase3_plan is accepted for /rite:resume retry after plan was already
+  # completed in a prior session (code-quality cycle-3 MEDIUM).
   ["phase3_plan"]="phase3_post_plan"
-  ["phase3_post_plan"]="phase5_stop_hook"
+  ["phase3_post_plan"]="phase5_stop_hook phase3_plan"
 
   # Phase 5.0: stop-hook verification
   ["phase5_stop_hook"]="phase5_post_stop_hook"
@@ -272,11 +279,13 @@ rite_phase_transition_allowed() {
   local prev="$1"
   local next="$2"
 
-  # Terminal / cold-start cases
+  # Terminal / cold-start cases.
+  # "completed" is the /rite:issue:start terminal state. "create_completed" is written by
+  # /rite:issue:create at its end. "phase_done" was a speculative reserved name with no
+  # producer — removed per code-quality cycle-3 LOW (premature abstraction).
   [ -z "$prev" ] && return 0
   [ "$prev" = "$next" ] && return 0
   [ "$next" = "completed" ] && return 0
-  [ "$next" = "phase_done" ] && return 0
   [ "$next" = "create_completed" ] && return 0
 
   local allowed="${_RITE_PHASE_TRANSITIONS[$prev]:-}"

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# rite workflow - Phase Transition Whitelist (#490)
+#
+# Provides the canonical phase-transition graph used by stop-guard.sh and
+# other orchestration helpers to detect silent phase-skipping bugs in
+# /rite:issue:start end-to-end flow.
+#
+# This file is designed to be SOURCED, not executed directly. After sourcing:
+#   - `rite_phase_transition_allowed <prev> <next>` — returns 0 if allowed, 1 otherwise
+#   - `rite_phase_expected_next <phase>` — prints space-separated list of valid next phases
+#   - `rite_phase_is_known <phase>` — returns 0 if the phase name exists in the graph
+#
+# Overrides may be loaded from rite-config.yml under:
+#   hooks:
+#     stop_guard:
+#       phase_transitions:
+#         <phase>: [<next1>, <next2>]
+#
+# Override semantics: MERGE — listed targets are APPENDED to the baked-in
+# whitelist for that phase (allowing projects to add custom transitions
+# without losing the defaults).
+
+# Guard against double-loading when multiple scripts source this file.
+[ -n "${_RITE_PHASE_TRANSITION_LOADED:-}" ] && return 0
+_RITE_PHASE_TRANSITION_LOADED=1
+
+# Baked-in whitelist. Each entry maps a phase to the phases it may transition to.
+# Empty string ("") is accepted as a synthetic "workflow start" predecessor for
+# any phase, since /rite:issue:start begins with no prior state.
+declare -gA _RITE_PHASE_TRANSITIONS=(
+  # Phase 1 → Phase 1.5/1.6/2
+  ["phase1_5_parent"]="phase1_5_post_parent"
+  ["phase1_5_post_parent"]="phase1_6_child phase2_branch"
+  ["phase1_6_child"]="phase1_6_post_child"
+  ["phase1_6_post_child"]="phase2_branch"
+
+  # Phase 2: branch → projects → iteration → work memory → plan
+  ["phase2_branch"]="phase2_post_branch"
+  ["phase2_post_branch"]="phase2_projects phase2_work_memory"
+  ["phase2_projects"]="phase2_post_projects"
+  ["phase2_post_projects"]="phase2_iteration phase2_work_memory"
+  ["phase2_iteration"]="phase2_post_iteration"
+  ["phase2_post_iteration"]="phase2_work_memory"
+  ["phase2_work_memory"]="phase2_post_work_memory"
+  ["phase2_post_work_memory"]="phase3_plan"
+
+  # Phase 3: implementation plan
+  ["phase3_plan"]="phase3_post_plan"
+  ["phase3_post_plan"]="phase5_stop_hook phase5_lint"
+
+  # Phase 5.0: stop-hook verification
+  ["phase5_stop_hook"]="phase5_post_stop_hook"
+  ["phase5_post_stop_hook"]="phase5_lint"
+
+  # Phase 5.1/5.2: implement + lint
+  ["phase5_lint"]="phase5_post_lint"
+  ["phase5_post_lint"]="phase5_pr phase5_lint"
+
+  # Phase 5.3: PR create
+  ["phase5_pr"]="phase5_post_pr"
+  ["phase5_post_pr"]="phase5_review"
+
+  # Phase 5.4: review-fix loop
+  ["phase5_review"]="phase5_post_review"
+  ["phase5_post_review"]="phase5_fix phase5_ready"
+  ["phase5_fix"]="phase5_post_fix"
+  ["phase5_post_fix"]="phase5_review phase5_ready"
+
+  # Phase 5.5: ready → status → metrics → completion
+  ["phase5_ready"]="phase5_post_ready"
+  ["phase5_post_ready"]="phase5_status_in_review"
+  ["phase5_status_in_review"]="phase5_post_status_in_review"
+  ["phase5_post_status_in_review"]="phase5_metrics"
+  ["phase5_metrics"]="phase5_post_metrics"
+  ["phase5_post_metrics"]="phase5_completion"
+
+  # Phase 5.6 / 5.7: completion + parent completion
+  ["phase5_completion"]="phase5_parent_completion completed"
+  ["phase5_parent_completion"]="phase5_post_parent_completion"
+  ["phase5_post_parent_completion"]="completed"
+)
+
+# Load override map from rite-config.yml if present.
+# Only called once per process via the guard flag above.
+_rite_load_whitelist_overrides() {
+  local config_file="${1:-}"
+  [ -z "$config_file" ] && return 0
+  [ ! -f "$config_file" ] && return 0
+
+  # Extract the hooks.stop_guard.phase_transitions block with awk.
+  # Supported format (subset of YAML):
+  #   hooks:
+  #     stop_guard:
+  #       phase_transitions:
+  #         phase_x: [phase_y, phase_z]
+  #         phase_a:
+  #           - phase_b
+  #           - phase_c
+  local block
+  block=$(awk '
+    BEGIN { in_hooks=0; in_sg=0; in_pt=0; pt_indent=-1 }
+    /^hooks:[[:space:]]*$/ { in_hooks=1; next }
+    in_hooks && /^[a-zA-Z]/ { in_hooks=0; in_sg=0; in_pt=0 }
+    in_hooks && /^[[:space:]]+stop_guard:[[:space:]]*$/ { in_sg=1; next }
+    in_sg && /^[[:space:]]+phase_transitions:[[:space:]]*$/ {
+      in_pt=1
+      match($0, /^[[:space:]]+/)
+      pt_indent=RLENGTH
+      next
+    }
+    in_pt {
+      # Leaving the phase_transitions block when indentation shrinks back.
+      line_indent=0
+      match($0, /^[[:space:]]*/); line_indent=RLENGTH
+      if ($0 ~ /^[[:space:]]*$/) { next }
+      if (line_indent <= pt_indent) { in_pt=0; next }
+      print
+    }
+  ' "$config_file" 2>/dev/null)
+
+  [ -z "$block" ] && return 0
+
+  # Parse the extracted block. Two sub-formats:
+  #   (1) inline list:  phase_x: [a, b, c]
+  #   (2) block list:   phase_x:\n  - a\n  - b
+  local current_key=""
+  local current_targets=""
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Strip leading whitespace
+    local trimmed="${line#"${line%%[![:space:]]*}"}"
+    [ -z "$trimmed" ] && continue
+
+    if [[ "$trimmed" =~ ^-\  ]]; then
+      # Block list entry: "- value"
+      local val="${trimmed#- }"
+      val="${val%%#*}"
+      val="${val//[[:space:]]/}"
+      [ -n "$val" ] && current_targets="${current_targets:+$current_targets }$val"
+    elif [[ "$trimmed" =~ ^([a-zA-Z0-9_]+):(.*)$ ]]; then
+      # Flush previous key
+      if [ -n "$current_key" ] && [ -n "$current_targets" ]; then
+        _rite_merge_override_entry "$current_key" "$current_targets"
+      fi
+      current_key="${BASH_REMATCH[1]}"
+      local rhs="${BASH_REMATCH[2]}"
+      rhs="${rhs#"${rhs%%[![:space:]]*}"}"
+      current_targets=""
+      # Handle inline list form:  [a, b, c]
+      if [[ "$rhs" =~ ^\[(.*)\]$ ]]; then
+        local list_body="${BASH_REMATCH[1]}"
+        list_body="${list_body//,/ }"
+        for val in $list_body; do
+          val="${val//\"/}"
+          val="${val//\'/}"
+          val="${val//[[:space:]]/}"
+          [ -n "$val" ] && current_targets="${current_targets:+$current_targets }$val"
+        done
+        _rite_merge_override_entry "$current_key" "$current_targets"
+        current_key=""
+        current_targets=""
+      fi
+    fi
+  done <<< "$block"
+
+  # Flush any trailing block list
+  if [ -n "$current_key" ] && [ -n "$current_targets" ]; then
+    _rite_merge_override_entry "$current_key" "$current_targets"
+  fi
+}
+
+_rite_merge_override_entry() {
+  local key="$1"
+  local new_targets="$2"
+  local existing="${_RITE_PHASE_TRANSITIONS[$key]:-}"
+  if [ -z "$existing" ]; then
+    _RITE_PHASE_TRANSITIONS[$key]="$new_targets"
+  else
+    # Append non-duplicate targets
+    local merged="$existing"
+    local val
+    for val in $new_targets; do
+      if ! [[ " $merged " == *" $val "* ]]; then
+        merged="$merged $val"
+      fi
+    done
+    _RITE_PHASE_TRANSITIONS[$key]="$merged"
+  fi
+}
+
+# Return 0 if `prev_phase -> next_phase` is allowed, 1 otherwise.
+# Synthetic rules:
+#   - Empty prev_phase is accepted for any known phase (workflow cold start).
+#   - Unknown prev_phase is accepted (forward-compatibility; phases added by
+#     sub-skills outside this whitelist should not cause spurious blocks).
+#   - The special phase "completed" is always a valid terminal.
+rite_phase_transition_allowed() {
+  local prev="$1"
+  local next="$2"
+
+  # Terminal / cold-start cases
+  [ -z "$prev" ] && return 0
+  [ "$prev" = "$next" ] && return 0
+  [ "$next" = "completed" ] && return 0
+  [ "$next" = "phase_done" ] && return 0
+  [ "$next" = "create_completed" ] && return 0
+
+  local allowed="${_RITE_PHASE_TRANSITIONS[$prev]:-}"
+  # Unknown prev phase → accept (forward compat)
+  [ -z "$allowed" ] && ! rite_phase_is_known "$prev" && return 0
+
+  local val
+  for val in $allowed; do
+    [ "$val" = "$next" ] && return 0
+  done
+  return 1
+}
+
+# Print the expected next phases for a given phase.
+rite_phase_expected_next() {
+  local phase="$1"
+  printf '%s\n' "${_RITE_PHASE_TRANSITIONS[$phase]:-}"
+}
+
+# Return 0 if the given phase name is defined in the whitelist as either a
+# source or a target.
+rite_phase_is_known() {
+  local phase="$1"
+  [ -n "${_RITE_PHASE_TRANSITIONS[$phase]:-}" ] && return 0
+  local key val
+  for key in "${!_RITE_PHASE_TRANSITIONS[@]}"; do
+    for val in ${_RITE_PHASE_TRANSITIONS[$key]}; do
+      [ "$val" = "$phase" ] && return 0
+    done
+  done
+  return 1
+}
+
+# Optional: auto-load overrides when RITE_CONFIG env var points to a config file.
+if [ -n "${RITE_CONFIG:-}" ]; then
+  _rite_load_whitelist_overrides "$RITE_CONFIG"
+fi

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -11,6 +11,7 @@ export _RITE_HOOK_RUNNING_STOP=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/phase-transition-whitelist.sh" 2>/dev/null || true
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -145,13 +146,27 @@ fi
 # error_count is incremented on each blocked stop; it resets to 0 on each patch-mode
 # phase transition (flow-state-update.sh, since #294), at the start of the next workflow
 # (when /rite:issue:start regenerates .rite-flow-state), or when manually reset.
-IFS=$'\t' read -r PHASE NEXT ISSUE PR ERROR_COUNT < <(jq -r '[(.phase // "unknown"), (.next_action // "unknown"), (.issue_number // 0 | tostring), (.pr_number // 0 | tostring), (.error_count // 0 | tostring)] | @tsv' "$STATE_FILE" 2>/dev/null) || {
+IFS=$'\t' read -r PHASE PREV_PHASE NEXT ISSUE PR ERROR_COUNT < <(jq -r '[(.phase // "unknown"), (.previous_phase // ""), (.next_action // "unknown"), (.issue_number // 0 | tostring), (.pr_number // 0 | tostring), (.error_count // 0 | tostring)] | @tsv' "$STATE_FILE" 2>/dev/null) || {
   PHASE="unknown"
+  PREV_PHASE=""
   NEXT="Read .rite-flow-state and continue the active workflow. Do NOT stop."
   ISSUE="0"
   PR="0"
   ERROR_COUNT="0"
 }
+
+# Phase transition whitelist verification (#490).
+# Load overrides from rite-config.yml if the helper was sourced.
+if type _rite_load_whitelist_overrides >/dev/null 2>&1 && [ -f "$STATE_ROOT/rite-config.yml" ]; then
+  _rite_load_whitelist_overrides "$STATE_ROOT/rite-config.yml" 2>/dev/null || true
+fi
+INVALID_TRANSITION=""
+if type rite_phase_transition_allowed >/dev/null 2>&1; then
+  if ! rite_phase_transition_allowed "$PREV_PHASE" "$PHASE"; then
+    EXPECTED=$(rite_phase_expected_next "$PREV_PHASE" 2>/dev/null || true)
+    INVALID_TRANSITION="prev=$PREV_PHASE curr=$PHASE expected_next=${EXPECTED:-unknown}"
+  fi
+fi
 
 # Read error threshold from rite-config.yml (safety.repeated_failure_threshold, default: 3)
 THRESHOLD=3
@@ -193,6 +208,24 @@ fi
 # Block the stop (exit 2 + stderr = Claude Code stops the end_turn and feeds stderr to assistant)
 log_debug "blocking stop (phase=$PHASE, next=$NEXT, error_count=$((ERROR_COUNT + 1))/$THRESHOLD)"
 log_diag "EXIT:2 reason=blocking phase=$PHASE issue=#$ISSUE error_count=$((ERROR_COUNT + 1))/$THRESHOLD session_id=${SESSION_ID:-unknown}"
+
+if [ -n "$INVALID_TRANSITION" ]; then
+  # Invalid phase transition detected via whitelist (#490). Surface the mismatch
+  # so the LLM re-enters the missing intermediate phase rather than pressing on.
+  log_diag "EXIT:2 reason=invalid_transition $INVALID_TRANSITION session_id=${SESSION_ID:-unknown}"
+  EXPECTED_LIST=$(rite_phase_expected_next "$PREV_PHASE" 2>/dev/null || echo "")
+  cat >&2 <<STOP_MSG
+[rite] Invalid phase transition detected — stop prevented.
+Phase: $PHASE | Previous: $PREV_PHASE | Issue: #$ISSUE | PR: #$PR
+PROBLEM: Transition $PREV_PHASE → $PHASE is not in the whitelist.
+EXPECTED NEXT FROM $PREV_PHASE: ${EXPECTED_LIST:-(unknown)}
+ACTION: Do NOT proceed with $PHASE. Return to the expected next phase above
+and execute its Pre-write + main procedure + Mandatory After block as
+defined in plugins/rite/commands/issue/start.md. Do NOT stop.
+STOP_MSG
+  exit 2
+fi
+
 cat >&2 <<STOP_MSG
 [rite] Normal operation — stop prevented.
 Phase: $PHASE | Issue: #$ISSUE | PR: #$PR

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -157,14 +157,30 @@ IFS=$'\t' read -r PHASE PREV_PHASE NEXT ISSUE PR ERROR_COUNT < <(jq -r '[(.phase
 
 # Phase transition whitelist verification (#490).
 # Load overrides from rite-config.yml if the helper was sourced.
+# Do NOT suppress stderr/exit — failure to load overrides must be visible so
+# users can diagnose why their rite-config.yml override silently did not apply
+# (error-handling HIGH — stop-guard.sh:161 2>/dev/null || true).
 if type _rite_load_whitelist_overrides >/dev/null 2>&1 && [ -f "$STATE_ROOT/rite-config.yml" ]; then
-  _rite_load_whitelist_overrides "$STATE_ROOT/rite-config.yml" 2>/dev/null || true
+  _rite_load_whitelist_overrides "$STATE_ROOT/rite-config.yml" || \
+    log_diag "override_load_failed rc=$? session_id=${SESSION_ID:-unknown}"
+fi
+# Detect cases where the whitelist helper was NOT loaded (bash < 4.2, sourcing failure,
+# etc.). Record via diag log so the silent-disabled state is recoverable
+# (devops HIGH — declare -gA incompat, error-handling HIGH — forward-compat bypass).
+if ! type rite_phase_transition_allowed >/dev/null 2>&1; then
+  log_diag "whitelist_helper_unavailable — phase transition verification disabled session_id=${SESSION_ID:-unknown}"
 fi
 INVALID_TRANSITION=""
 if type rite_phase_transition_allowed >/dev/null 2>&1; then
   if ! rite_phase_transition_allowed "$PREV_PHASE" "$PHASE"; then
     EXPECTED=$(rite_phase_expected_next "$PREV_PHASE" 2>/dev/null || true)
     INVALID_TRANSITION="prev=$PREV_PHASE curr=$PHASE expected_next=${EXPECTED:-unknown}"
+  elif [ -n "$PREV_PHASE" ] && type rite_phase_is_known >/dev/null 2>&1 && \
+       ! rite_phase_is_known "$PREV_PHASE"; then
+    # Forward-compat path was taken (prev phase not in whitelist).
+    # Record for diagnosis so typos like `phase2_post_workmemory` don't silently bypass
+    # the whitelist (error-handling HIGH — forward-compat typo silent bypass).
+    log_diag "forward_compat_accepted prev=$PREV_PHASE curr=$PHASE session_id=${SESSION_ID:-unknown}"
   fi
 fi
 
@@ -182,16 +198,30 @@ fi
 # (threshold=0 would fire immediately and never block any stops).
 [ "$THRESHOLD" -lt 1 ] && THRESHOLD=3
 
-# Allow stop when error_count has reached the threshold — the workflow is stuck in an error loop
+# Allow stop when error_count has reached the threshold — the workflow is stuck in an error loop.
+# If the underlying cause was an invalid phase transition, surface it in the message so the
+# diagnostic trail is preserved (error-handling HIGH — threshold path erases invalid_transition).
 if [ "$ERROR_COUNT" -ge "$THRESHOLD" ]; then
   log_debug "error_count=$ERROR_COUNT >= threshold=$THRESHOLD, allowing stop"
-  log_diag "EXIT:0 reason=error_threshold error_count=$ERROR_COUNT threshold=$THRESHOLD session_id=${SESSION_ID:-unknown}"
-  cat >&2 <<STOP_MSG
+  log_diag "EXIT:0 reason=error_threshold error_count=$ERROR_COUNT threshold=$THRESHOLD invalid_transition=${INVALID_TRANSITION:-none} session_id=${SESSION_ID:-unknown}"
+  if [ -n "$INVALID_TRANSITION" ]; then
+    cat >&2 <<STOP_MSG
+[rite] Error threshold reached (${ERROR_COUNT} consecutive blocked stops, threshold: ${THRESHOLD}) — stop allowed.
+Phase: $PHASE | Previous: $PREV_PHASE | Issue: #$ISSUE | PR: #$PR
+ROOT CAUSE: invalid phase transition ($INVALID_TRANSITION).
+The whitelist detected the transition as invalid on every retry, but error_count exhausted the
+threshold. The workflow is now unblocked, but the underlying phase-skip bug remains.
+Action: correct the phase marker in the failing Pre-write block, then reset
+.rite-flow-state.error_count to 0 (or re-run /rite:resume).
+STOP_MSG
+  else
+    cat >&2 <<STOP_MSG
 [rite] Error threshold reached (${ERROR_COUNT} consecutive blocked stops, threshold: ${THRESHOLD}) — stop allowed.
 Phase: $PHASE | Issue: #$ISSUE | PR: #$PR
 The workflow appears stuck in an error loop. Stopping to prevent infinite repetition.
 Reset .rite-flow-state error_count to 0 or set active to false to restore normal stop-guard behavior.
 STOP_MSG
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Fixes #490. `/rite:issue:start` の一気通貫フロー内で、足場（Pre-write + Mandatory After + インライン手順/sub-skill 委譲）が弱い Phase 群が LLM 実装時に silent に skip される実行ドリフトを構造的に防止する。

prompt engineering と hook enforcement の両層で対策:

- **start.md 足場追加**: 対象 6 Phase (2.4 / 2.5 / 5.0 / 5.5.1 / 5.5.2 / 5.7) + Phase 5.6 に Pre-write + Mandatory After セクションを統一形式で追加。Phase 2.4 は `references/projects-integration.md` の主要 bash をインライン展開し Module 参照のみを脱却
- **phase transition whitelist**: 新規 `plugins/rite/hooks/phase-transition-whitelist.sh` に canonical な遷移グラフをハードコード。`rite-config.yml` の `hooks.stop_guard.phase_transitions` で override 可能（merge セマンティクス）
- **stop-guard 検証**: `.previous_phase` → `.phase` の組を whitelist で検証し、不正な jump を検出した場合は専用メッセージで block + 期待される next phase を案内
- **flow-state-update.sh**: create/patch 両 mode で直前 phase を `previous_phase` フィールドに保持
- **後段 Phase pre-condition check**: Phase 3 / 5.5.1 / 5.6 の冒頭に `previous_phase` 検証を追加。不足 Phase を ERROR で指摘し前段に戻るよう誘導
- **L47 "inline without stopping" 表記撤廃**: Phase Flow Quick Reference に対象 6 Phase を追加し「全 Phase に足場 3 点セットが備わる」前提を文書化

## Changes

- `plugins/rite/hooks/phase-transition-whitelist.sh` — 新規。`rite_phase_transition_allowed` / `rite_phase_expected_next` / `rite_phase_is_known` を提供
- `plugins/rite/hooks/stop-guard.sh` — whitelist 検証ブロックを追加。invalid transition 時は `[rite] Invalid phase transition detected` メッセージで block
- `plugins/rite/hooks/flow-state-update.sh` — create mode で既存 `.phase` を `previous_phase` に保存、patch mode で遷移時に同期
- `plugins/rite/commands/issue/start.md` — 対象 6 Phase + Phase 5.6 への足場追加 (+516 lines)

## Test Plan

- [x] T-03 (AC-3 足場 grep 確認): `grep '#### 🚨 Mandatory After (2\.4|2\.5|5\.0|5\.5\.1|5\.5\.2|5\.7)'` が 6 ヒット
- [x] T-04 (AC-4 whitelist block): stop-guard に不正遷移 JSON を食わせて専用 block メッセージ + exit 2 を確認 (`phase2_post_branch → phase3_plan` ジャンプ、および override で許可されるケースの両方)
- [x] Plugin self-lint: drift 12 findings は既存の `pr/fix.md` / `pr/review.md` 問題でスコープ外 / bang-backtick 0 / doc-heavy 0 — 本 PR 変更ファイルは clean
- [ ] T-01/T-02/T-06 (AC-1/AC-2/AC-6 ドッグフーディング): 本 PR マージ後、次回 `/rite:issue:start` 実行時に AC-6 ドッグフーディング検証を実施（別セッション）
- [ ] T-07 (AC-7 既存 flow 非破壊): 既存の active な `.rite-flow-state` を持つ Issue で `/rite:resume` が通ることを別セッションで確認
- [ ] T-08 (AC-8 #14 リグレッション): 次回 Issue で Projects Status が In Progress に更新されることを確認

## Out of Scope

- `commands/pr/{review,fix,ready,create}.md` の内部実装（D-01 decision、未変更）
- `create.md` / `create-interview.md` の別クラスの短絡（D-05 decision、別 Issue 予定）
- ドッグフーディング AC-6 本番検証（別セッション）

## Known Issues

- `rite:lint` が既存の 12 件の distributed-fix-drift findings を検出（`pr/fix.md`: 11 件、`pr/review.md`: 1 件）。すべて本 PR 変更ファイル範囲外の既存問題のため本 PR では対応せず、別途独立した対応とする
