### PR TITLE
docs(init): /rite:init --upgrade オプションのユーザー向けドキュメントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This will:
 | Command | Description |
 |---------|-------------|
 | `/rite:init` | Initial setup wizard |
+| `/rite:init --upgrade` | Upgrade existing `rite-config.yml` to the latest schema version |
 | `/rite:getting-started` | Interactive onboarding guide |
 | `/rite:workflow` | Show workflow guide |
 | `/rite:issue:list` | List Issues |

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -51,7 +51,7 @@
 
 | コマンド | 説明 | 引数 |
 |---------|------|------|
-| `/rite:init` | 初回セットアップウィザード | なし |
+| `/rite:init` | 初回セットアップウィザード | `[--upgrade]`（既存 `rite-config.yml` のスキーマを最新版へ更新） |
 | `/rite:getting-started` | 対話型オンボーディングガイド | なし |
 | `/rite:workflow` | ワークフロー全体の案内 | なし |
 | `/rite:investigate` | 構造化コード調査 | `<トピックまたは質問>` |
@@ -498,6 +498,13 @@ language: auto  # auto | ja | en
 
 **説明:** プロジェクトへの rite ワークフロー初回セットアップ
 
+**引数:** `[--upgrade]`（省略可）
+
+| 引数 | 説明 |
+|------|------|
+| なし | 新規セットアップを実行（Phase 1〜5 を順次実行） |
+| `--upgrade` | 既存 `rite-config.yml` のスキーマを最新版へアップグレード（Phase 1〜3、5 をスキップし Phase 4.1.3 のみ実行） |
+
 **処理フロー:**
 
 #### Phase 1: 環境チェック
@@ -526,10 +533,64 @@ language: auto  # auto | ja | en
    - 既存があれば認識
    - なければ自動生成
 2. `rite-config.yml` の生成
+3. 既存 `rite-config.yml` がある場合は `schema_version` を確認し、古ければ `/rite:init --upgrade` の案内を表示
 
 #### Phase 5: 完了報告
 1. 設定サマリーの表示
 2. 次のステップの案内
+
+---
+
+#### --upgrade オプション（既存設定のスキーマ更新）
+
+**目的:** 既存プロジェクトの `rite-config.yml` を最新スキーマに追従させる。ユーザーがカスタマイズした値（`project_number`、`owner`、`branch.base`、`language` 等）は保持したまま、新しい設定セクションの追加・廃止キーの削除・`schema_version` の更新を一括適用する。
+
+**使用タイミング:**
+
+- rite workflow のバージョンアップ後、`/rite:init` または `/rite:issue:start` などの実行時に `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。` という警告が表示されたとき
+- `CHANGELOG.md` や migration-guides で新しい設定項目（例: `wiki:`、`review.debate:` 等）が追加されたことが告知されたとき
+- 既存 `rite-config.yml` の `schema_version` と、プラグイン同梱テンプレート (`plugins/rite/templates/config/rite-config.yml`) の `schema_version` が乖離しているとき
+
+**実行例:**
+
+```bash
+/rite:init --upgrade
+```
+
+**Phase 4.1.3 の処理内容（`--upgrade` 時のみ実行）:**
+
+1. **現行設定の読み込みとバージョン比較**
+   既存 `rite-config.yml` とテンプレートの `schema_version` を読み取る。両方が存在しない場合は v1 とみなす。
+2. **バックアップ作成**
+   `rite-config.yml.bak.YYYYMMDD-HHMMSS` として既存ファイルを保全する（ロールバック用）。
+3. **分岐判定**
+   - `current < latest` の場合: Step 4〜6（差分特定 → プレビュー → 承認後適用）を実施し、その後 Step 7（Phase 4.7 Wiki 初期化）へ。
+   - `current == latest` かつ `wiki:` セクション未存在の場合: バックアップ後に `wiki:` セクションをテンプレートから append し、Phase 4.7 を実行する。
+   - `current == latest` かつ `wiki:` セクション存在の場合: no-op として「設定は最新です」を表示し、Phase 4.7 に進む（既に初期化済みであれば冪等に no-op）。
+4. **差分の特定と分類**（Step 4、`current < latest` 経路のみ）
+   各キーを以下のいずれかに分類する。
+   - **User-customized value**（保持）: `project_number`、`owner`、`iteration` 系設定、`branch.base`、`language` など
+   - **Deprecated key**（削除）: `project.name`、`commit.style`、`commit.enforce`、`branch.release`、`branch.types`、`version` など
+   - **Missing section**（テンプレートからデフォルト値で追加）: `review.debate`、`review.fact_check`、`verification` など
+   - **Advanced section**（コメントアウト状態で追加）: `tdd`、`parallel`、`team`、`metrics`、`safety`、`investigate`
+   - **Unknown key**（警告付き保持）: ユーザーが独自追加したテンプレート外のキー
+5. **プレビューとユーザー承認**（Step 5）
+   廃止キー・追加セクション・保持される既存設定の一覧を提示し、`AskUserQuestion` で「適用する／キャンセル」を確認する。
+6. **適用**（Step 6）
+   承認後、`schema_version` を最新値に更新し、廃止キー削除・セクション追加（コメントアウト含む）・`wiki:` セクションの append（未存在時）を順次実行する。既存のユーザーカスタマイズ値はすべて保持される。
+7. **Phase 4.7（Wiki 初期化）の実行**（Step 7）
+   Phase 4.7 を呼び出し、既存ユーザーも Wiki 初期化済みの状態に揃える。Wiki が既に初期化済みの場合は冪等に no-op。非ブロッキングで、Phase 4.7 の失敗は `--upgrade` 全体の成否には影響しない。最後に Wiki 初期化ステータスを表示して終了する。
+
+**`schema_version` との関係:**
+
+- `rite-config.yml` 先頭の `schema_version` キーは、設定ファイルのスキーマバージョンを示す整数値（例: `schema_version: 2`）。rite workflow が後方非互換なスキーマ変更を行うたびにインクリメントされる。
+- `--upgrade` は「現行ファイルの `schema_version`」と「プラグイン同梱テンプレートの `schema_version`」を比較し、古い場合に上記の Phase 4.1.3 を実行する。
+- `schema_version` キーが存在しない古い設定ファイルは暗黙的に v1 として扱われ、`--upgrade` 経由で最新版に更新される。
+
+**Phase 5（新規セットアップの完了報告）との関係:**
+
+- `--upgrade` は Phase 1〜3 および Phase 5 の新規セットアップ完了報告をスキップする。Wiki 初期化ステータス行のみが終了時に表示される。
+- 新規プロジェクトで `/rite:init` を実行した場合の完了報告とは合流しない（`--upgrade` は既存設定の更新専用パス）。
 
 ---
 

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -503,7 +503,7 @@ language: auto  # auto | ja | en
 | 引数 | 説明 |
 |------|------|
 | なし | 新規セットアップを実行（Phase 1〜5 を順次実行） |
-| `--upgrade` | 既存 `rite-config.yml` のスキーマを最新版へアップグレード（Phase 1〜3、5 をスキップし Phase 4.1.3 のみ実行） |
+| `--upgrade` | 既存 `rite-config.yml` のスキーマを最新版へアップグレード（Phase 1〜3 と 5 をスキップし、Phase 4.1.3 を実行。Phase 4.1.3 は Step 7 で Phase 4.7 (Wiki 初期化) を呼び出すため、結果として Phase 4.1.3 + Phase 4.7 が実行される） |
 
 **処理フロー:**
 
@@ -547,8 +547,8 @@ language: auto  # auto | ja | en
 
 **使用タイミング:**
 
-- rite workflow のバージョンアップ後、`/rite:init` または `/rite:issue:start` などの実行時に `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。` という警告が表示されたとき
-- `CHANGELOG.md` や migration-guides で新しい設定項目（例: `wiki:`、`review.debate:` 等）が追加されたことが告知されたとき
+- rite workflow のバージョンアップ後、`/rite:init` 実行時や session 開始時に「rite-config.yml のスキーマが古くなっています (v{current} → v{latest})」旨の警告（末尾の行動喚起文言は呼び出し元により「`/rite:init --upgrade` でアップグレードできます」または「`/rite:init --upgrade` を実行してください」のいずれか）が表示されたとき
+- `CHANGELOG.md` や release notes から参照される migration notes（存在する場合は `docs/migration-guides/` 等）で新しい設定項目（例: `wiki:`、`review.debate:` 等）が追加されたことが告知されたとき
 - 既存 `rite-config.yml` の `schema_version` と、プラグイン同梱テンプレート (`plugins/rite/templates/config/rite-config.yml`) の `schema_version` が乖離しているとき
 
 **実行例:**

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -51,7 +51,7 @@ The command prefix `rite` was chosen for:
 
 | Command | Description | Arguments |
 |---------|-------------|-----------|
-| `/rite:init` | Initial setup wizard | None |
+| `/rite:init` | Initial setup wizard | `[--upgrade]` (upgrade existing `rite-config.yml` schema to the latest version) |
 | `/rite:getting-started` | Interactive onboarding guide | None |
 | `/rite:workflow` | Show workflow guide | None |
 | `/rite:investigate` | Structured code investigation | `<topic or question>` |
@@ -498,6 +498,13 @@ language: auto  # auto | ja | en
 
 **Description:** Initial setup of rite workflow for a project
 
+**Arguments:** `[--upgrade]` (optional)
+
+| Argument | Description |
+|----------|-------------|
+| (none) | Run fresh setup (executes Phases 1–5 sequentially) |
+| `--upgrade` | Upgrade the schema of an existing `rite-config.yml` to the latest version (skips Phases 1–3 and 5; runs only Phase 4.1.3) |
+
 **Process Flow:**
 
 #### Phase 1: Environment Check
@@ -526,10 +533,64 @@ language: auto  # auto | ja | en
    - Recognize if exists
    - Auto-generate if not
 2. Generate `rite-config.yml`
+3. If an existing `rite-config.yml` is present, check its `schema_version`; if out of date, display guidance to run `/rite:init --upgrade`
 
 #### Phase 5: Completion Report
 1. Display settings summary
 2. Guide next steps
+
+---
+
+#### --upgrade Option (Existing Configuration Schema Upgrade)
+
+**Purpose:** Bring an existing project's `rite-config.yml` up to the latest schema while preserving user-customized values (`project_number`, `owner`, `branch.base`, `language`, and so on). The upgrade applies the additions (new sections), removals (deprecated keys), and `schema_version` bump in a single confirmed batch.
+
+**When to use:**
+
+- When a warning such as `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。` appears after upgrading the rite workflow plugin and running commands like `/rite:init` or `/rite:issue:start`
+- When a new configuration section (e.g., `wiki:`, `review.debate:`) is announced in `CHANGELOG.md` or the migration-guides
+- When the `schema_version` in your `rite-config.yml` diverges from the `schema_version` in the bundled template (`plugins/rite/templates/config/rite-config.yml`)
+
+**Example:**
+
+```bash
+/rite:init --upgrade
+```
+
+**Phase 4.1.3 Behavior (runs only with `--upgrade`):**
+
+1. **Read current config and compare versions**
+   Read `schema_version` from both the existing `rite-config.yml` and the bundled template. Missing values are treated as v1.
+2. **Create a backup**
+   Copy the existing file to `rite-config.yml.bak.YYYYMMDD-HHMMSS` for rollback.
+3. **Branching**
+   - `current < latest`: Run Step 4–6 (identify changes → preview → apply after approval), then Step 7 (Phase 4.7 Wiki initialization).
+   - `current == latest` and `wiki:` section absent: After backup, append the `wiki:` block from the template and run Phase 4.7.
+   - `current == latest` and `wiki:` section present: No-op; display "configuration is up to date" and run Phase 4.7 (idempotent — no-op if Wiki is already initialized).
+4. **Identify and classify changes** (Step 4, only on the `current < latest` path)
+   Each key is classified as one of:
+   - **User-customized value** (preserve): `project_number`, `owner`, `iteration` settings, `branch.base`, `language`, etc.
+   - **Deprecated key** (remove): `project.name`, `commit.style`, `commit.enforce`, `branch.release`, `branch.types`, `version`
+   - **Missing section** (add with template defaults): `review.debate`, `review.fact_check`, `verification`, etc.
+   - **Advanced section** (add as commented-out block): `tdd`, `parallel`, `team`, `metrics`, `safety`, `investigate`
+   - **Unknown key** (preserve with warning): user-added keys not present in the template
+5. **Preview and confirm** (Step 5)
+   Display deprecated keys to be removed, sections to be added, and preserved existing settings; ask via `AskUserQuestion` to either apply or cancel.
+6. **Apply** (Step 6)
+   On approval, update `schema_version` to the latest value, remove deprecated keys, add missing sections (including commented-out Advanced sections), and append the `wiki:` section if it was absent. All user-customized values are preserved.
+7. **Run Phase 4.7 (Wiki initialization)** (Step 7)
+   Invoke Phase 4.7 to bring existing users up to the Wiki-initialized state. If Wiki is already initialized, the phase is an idempotent no-op. Phase 4.7 is non-blocking: its failure does not affect `--upgrade` success. A final Wiki status line is displayed before the command exits.
+
+**Relationship with `schema_version`:**
+
+- The `schema_version` key at the top of `rite-config.yml` is an integer that identifies the configuration schema version (e.g., `schema_version: 2`). It is incremented whenever the rite workflow introduces a backward-incompatible schema change.
+- `--upgrade` compares the `schema_version` in the current file against the one in the bundled template and runs the Phase 4.1.3 flow above when the current file is behind.
+- Configuration files without a `schema_version` key are implicitly treated as v1 and can be brought up to date via `--upgrade`.
+
+**Relationship with Phase 5 (new-install completion report):**
+
+- `--upgrade` skips Phases 1–3 and the Phase 5 new-install completion report; only the Wiki status line is displayed at the end.
+- It does not merge with the fresh-install completion report (`--upgrade` is a dedicated path for updating existing configurations).
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -503,7 +503,7 @@ language: auto  # auto | ja | en
 | Argument | Description |
 |----------|-------------|
 | (none) | Run fresh setup (executes Phases 1–5 sequentially) |
-| `--upgrade` | Upgrade the schema of an existing `rite-config.yml` to the latest version (skips Phases 1–3 and 5; runs only Phase 4.1.3) |
+| `--upgrade` | Upgrade the schema of an existing `rite-config.yml` to the latest version (skips Phases 1–3 and 5, and executes Phase 4.1.3; Phase 4.1.3 invokes Phase 4.7 (Wiki initialization) at its Step 7, so the effective execution is Phase 4.1.3 + Phase 4.7) |
 
 **Process Flow:**
 
@@ -547,9 +547,9 @@ language: auto  # auto | ja | en
 
 **When to use:**
 
-- When a warning such as `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。` appears after upgrading the rite workflow plugin and running commands like `/rite:init` or `/rite:issue:start`
-- When a new configuration section (e.g., `wiki:`, `review.debate:`) is announced in `CHANGELOG.md` or the migration-guides
-- When the `schema_version` in your `rite-config.yml` diverges from the `schema_version` in the bundled template (`plugins/rite/templates/config/rite-config.yml`)
+- When a warning that `rite-config.yml` schema is outdated appears after upgrading the rite workflow plugin and running `/rite:init` or starting a session. The exact Japanese message emitted by `/rite:init` is: `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。` The session-start hook emits a slightly different variant ending in `/rite:init --upgrade を実行してください。` ("run `/rite:init --upgrade`")
+- When release notes (`CHANGELOG.md`, or migration notes referenced from the release notes — e.g., `docs/migration-guides/` when present) announce new configuration sections (e.g., `wiki:`, `review.debate:`) that are missing from your local `rite-config.yml`
+- When the `schema_version` at the top of your `rite-config.yml` diverges from the `schema_version` in the bundled template (`plugins/rite/templates/config/rite-config.yml`)
 
 **Example:**
 

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -173,10 +173,14 @@ that case, run the upgrade variant instead of a fresh `/rite:init`:
 
 When to run it:
 
-- After updating the rite workflow plugin and seeing a warning such as
-  `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。
-  /rite:init --upgrade でアップグレードできます。`
-- When release notes (`CHANGELOG.md`, migration-guides) announce new
+- After updating the rite workflow plugin and seeing a warning that
+  `rite-config.yml` schema is outdated. The exact wording differs slightly
+  by emitter: `/rite:init` emits `rite-config.yml のスキーマが古くなっています
+  (v{current} → v{latest})。/rite:init --upgrade でアップグレードできます。`
+  and the session-start hook emits a variant ending in
+  `/rite:init --upgrade を実行してください。` Both signal the same situation
+- When release notes (`CHANGELOG.md`, or migration notes referenced from the
+  release notes — e.g., `docs/migration-guides/` when present) announce new
   configuration sections (e.g., `wiki:`, `review.debate:`) that are missing from
   your local `rite-config.yml`
 - When the `schema_version` value at the top of your `rite-config.yml` diverges
@@ -190,16 +194,20 @@ What `/rite:init --upgrade` does:
   ✓ Shows a preview of changes: deprecated keys to remove, new sections to
     add (including commented-out Advanced sections), and values that will be
     preserved (e.g., `project_number`, `owner`, `branch.base`, `language`)
-  ✓ Asks for confirmation via AskUserQuestion before applying anything
-  ✓ Appends the `wiki:` section if it is absent, so Wiki auto-initialization
-    (Phase 4.7) can run for existing projects
+  ✓ Asks for confirmation via AskUserQuestion before applying any schema
+    changes (the wiki-section append below is included in the same
+    preview/confirmation flow when the schema is also out of date; it is
+    applied without an additional prompt only when the schema is already up
+    to date and the `wiki:` section happens to be missing)
+  ✓ Appends the `wiki:` section if it is absent, so the Wiki
+    auto-initialization step of `/rite:init` can run for existing projects
   ✓ Updates `schema_version` to the latest value on success
 
 The upgrade is non-destructive: user-customized values are preserved, and a
 backup is created before any edits are made. If your configuration is already
 up to date and Wiki is already initialized, the command makes no changes to
 `rite-config.yml` itself — it still creates a timestamped backup and runs the
-Wiki auto-initialization idempotency check (Phase 4.7), then reports
+Wiki auto-initialization idempotency check of `/rite:init`, then reports
 "configuration is up to date" and exits.
 
 Check if `rite-config.yml` exists:
@@ -215,13 +223,12 @@ ls rite-config.yml 2>/dev/null || ls .claude/rite:config.yml 2>/dev/null
 
 You can skip Step 1 and proceed to Step 2.
 
-⚠ Schema may be out of date — if you see a warning such as
-  "rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。
-   /rite:init --upgrade でアップグレードできます。"
-or the top-level `schema_version` in your `rite-config.yml` differs from the
+⚠ Schema may be out of date — if you see the schema-outdated warning
+described in the "Upgrading an existing project" section above, or the
+top-level `schema_version` in your `rite-config.yml` differs from the
 bundled template in `plugins/rite/templates/config/rite-config.yml`, run
 `/rite:init --upgrade` before proceeding to Step 2 to bring the configuration
-up to date. See the "Upgrading an existing project" section above for details.
+up to date.
 ```
 
 **If it does not exist:**

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -161,6 +161,45 @@ What /rite:init configures:
 This is a one-time setup. You can reconfigure later by running /rite:init again.
 ```
 
+**Upgrading an existing project (`/rite:init --upgrade`)**
+
+If you have been using rite workflow on this project for a while, the bundled
+configuration schema may have moved ahead of your local `rite-config.yml`. In
+that case, run the upgrade variant instead of a fresh `/rite:init`:
+
+```
+/rite:init --upgrade
+```
+
+When to run it:
+
+- After updating the rite workflow plugin and seeing a warning such as
+  `rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。
+  /rite:init --upgrade でアップグレードできます。`
+- When release notes (`CHANGELOG.md`, migration-guides) announce new
+  configuration sections (e.g., `wiki:`, `review.debate:`) that are missing from
+  your local `rite-config.yml`
+- When the `schema_version` value at the top of your `rite-config.yml` diverges
+  from the bundled template in
+  `plugins/rite/templates/config/rite-config.yml`
+
+What `/rite:init --upgrade` does:
+
+  ✓ Creates a timestamped backup (`rite-config.yml.bak.YYYYMMDD-HHMMSS`)
+  ✓ Compares your current `schema_version` against the latest template version
+  ✓ Shows a preview of changes: deprecated keys to remove, new sections to
+    add (including commented-out Advanced sections), and values that will be
+    preserved (e.g., `project_number`, `owner`, `branch.base`, `language`)
+  ✓ Asks for confirmation via AskUserQuestion before applying anything
+  ✓ Appends the `wiki:` section if it is absent, so Wiki auto-initialization
+    (Phase 4.7) can run for existing projects
+  ✓ Updates `schema_version` to the latest value on success
+
+The upgrade is non-destructive: user-customized values are preserved, and a
+backup is created before any edits are made. If your configuration is already
+up to date and Wiki is already initialized, the command is an idempotent no-op
+that reports "configuration is up to date" and exits.
+
 Check if `rite-config.yml` exists:
 
 ```bash

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -195,10 +195,11 @@ What `/rite:init --upgrade` does:
     add (including commented-out Advanced sections), and values that will be
     preserved (e.g., `project_number`, `owner`, `branch.base`, `language`)
   ✓ Asks for confirmation via AskUserQuestion before applying any schema
-    changes (the wiki-section append below is included in the same
-    preview/confirmation flow when the schema is also out of date; it is
-    applied without an additional prompt only when the schema is already up
-    to date and the `wiki:` section happens to be missing)
+    changes (this single apply/cancel prompt also gates the wiki-section
+    append below when both are pending, though the `wiki:` section may not
+    be itemized separately in the preview list; when the schema is already
+    up to date and only the `wiki:` section happens to be missing, the
+    append is applied without an additional prompt)
   ✓ Appends the `wiki:` section if it is absent, so the Wiki
     auto-initialization step of `/rite:init` can run for existing projects
   ✓ Updates `schema_version` to the latest value on success
@@ -206,9 +207,10 @@ What `/rite:init --upgrade` does:
 The upgrade is non-destructive: user-customized values are preserved, and a
 backup is created before any edits are made. If your configuration is already
 up to date and Wiki is already initialized, the command makes no changes to
-`rite-config.yml` itself — it still creates a timestamped backup and runs the
-Wiki auto-initialization idempotency check of `/rite:init`, then reports
-"configuration is up to date" and exits.
+`rite-config.yml` itself — it still creates a timestamped backup, reports
+"configuration is up to date", then runs the Wiki auto-initialization
+idempotency check of `/rite:init` and displays a final Wiki status line
+before exiting.
 
 Check if `rite-config.yml` exists:
 

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -197,8 +197,10 @@ What `/rite:init --upgrade` does:
 
 The upgrade is non-destructive: user-customized values are preserved, and a
 backup is created before any edits are made. If your configuration is already
-up to date and Wiki is already initialized, the command is an idempotent no-op
-that reports "configuration is up to date" and exits.
+up to date and Wiki is already initialized, the command makes no changes to
+`rite-config.yml` itself — it still creates a timestamped backup and runs the
+Wiki auto-initialization idempotency check (Phase 4.7), then reports
+"configuration is up to date" and exits.
 
 Check if `rite-config.yml` exists:
 
@@ -212,6 +214,14 @@ ls rite-config.yml 2>/dev/null || ls .claude/rite:config.yml 2>/dev/null
 ✅ Already initialized (rite-config.yml found)
 
 You can skip Step 1 and proceed to Step 2.
+
+⚠ Schema may be out of date — if you see a warning such as
+  "rite-config.yml のスキーマが古くなっています (v{current} → v{latest})。
+   /rite:init --upgrade でアップグレードできます。"
+or the top-level `schema_version` in your `rite-config.yml` differs from the
+bundled template in `plugins/rite/templates/config/rite-config.yml`, run
+`/rite:init --upgrade` before proceeding to Step 2 to bring the configuration
+up to date. See the "Upgrading an existing project" section above for details.
 ```
 
 **If it does not exist:**


### PR DESCRIPTION
## 概要

`/rite:init --upgrade` オプションを、ユーザー向けドキュメント 4 箇所に記載した。

- 既存プロジェクトのユーザーが `rite-config.yml` のスキーマアップグレード機能を発見・理解・実行できる状態を作る
- 記載先はユーザー向けドキュメントのみ（`plugins/rite/commands/*.md` などの Claude 向け実装ファイルは変更していない）

Closes #493

## 変更内容

- `README.md`: コマンド一覧に `/rite:init --upgrade` 行を追加
- `docs/SPEC.ja.md`:
  - コマンド表に `--upgrade` オプション注記
  - `/rite:init` 仕様セクションに `--upgrade` サブセクションを追加（目的／使用タイミング／Phase 4.1.3 挙動／`schema_version` との関係／Wiki 初期化連携／実行例を自己完結した形で記述）
- `docs/SPEC.md`: SPEC.ja.md と同等の英語版追記
- `plugins/rite/commands/getting-started.md`: 「Upgrading an existing project」セクションを追加し、使用タイミング・効果・実行例を案内

## 設計メモ

- ドキュメント内容は `plugins/rite/commands/init.md` Phase 4.1.3 の実装挙動（`schema_version` 検出 → バックアップ → 差分特定 → プレビュー → 承認後適用 → Phase 4.7 Wiki 初期化）と整合させた
- SPEC は「詳細は init.md 参照」などの丸投げを避け、SPEC 単体で読み切れる情報量で記載（`feedback_documentation_quality` 遵守）

## チェックリスト

- [x] AC-1〜AC-5 すべて充足
- [x] T-01〜T-05 すべてパス（grep ベースの確認 T-01〜T-04 実施済み、T-05 整合性確認実施済み）
- [x] Target Files 以外を変更していない（`git diff --name-only` で 4 ファイルのみ確認）
- [x] `/rite:init --upgrade` の実行例が SPEC.ja.md / SPEC.md / getting-started.md に含まれる
- [x] README / SPEC.ja.md / SPEC.md / getting-started.md すべてに記載済み
- [x] `docs:` プレフィックスの Conventional Commits でコミット済み

## 動作確認

本 PR は documentation 変更のみのため、以下で確認:

- `grep -n '\-\-upgrade' README.md` → コマンド一覧にヒット
- `grep -c '\-\-upgrade' docs/SPEC.ja.md` → 13 件（コマンド表 + サブセクション）
- `grep -c '\-\-upgrade' docs/SPEC.md` → 13 件
- `grep -c '\-\-upgrade' plugins/rite/commands/getting-started.md` → 4 件
- 整合性確認: `init.md` Phase 4.1.3 の Step 1〜7 挙動と SPEC 記述が矛盾しないことを手動で照合

## Known Issues

- `/rite:lint` の Phase 3.5 drift check が 12 findings（warning, non-blocking）を報告するが、これは `plugins/rite/commands/pr/fix.md` と `review.md` に対する本 PR スコープ外の既存事象。本 PR ではこれらのファイルは変更していない。

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
