### PR TITLE
fix(create): sub-skill 委譲プロトコルを hook 層で強制 (#475)

### DIFF
--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -156,6 +156,16 @@ Projects を使用するには /rite:init を実行してください。
 
 ## Phase 0: Input Analysis and Completion
 
+> **🚫 MUST NOT — Bypass prohibition (Mode B defense, #475)** — **applies throughout all of Phase 0**.
+>
+> From this point until `[create:completed:{N}]` is output by the terminal sub-skill, the orchestrator MUST NOT:
+>
+> 1. Execute `gh issue create` via the Bash tool (blocked by `pre-tool-bash-guard.sh` hook)
+> 2. Skip the `rite:issue:create-interview` Skill invocation based on a judgment that "information is clear enough already"
+> 3. Collapse the Delegation to Interview / Phase 0.6 / Delegation Routing sections into a synthetic "create Issue" step
+>
+> Any of the above is a **protocol violation** regardless of how clearly Phase 0.1 extracted the information. The only legitimate path is: Phase 0.1 → Phase 0.3 → Phase 0.4 → Delegation to Interview → 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → terminal sub-skill. This same MUST NOT block is repeated before the Delegation to Interview section as a reminder — both occurrences have identical wording.
+
 ### 0.1 Extract Information from User Input
 
 #### EDGE-4: Short Input Handling
@@ -401,14 +411,14 @@ Determine the task type for Phase 0.4.1 adaptive interview depth via AskUserQues
 
 When Phase 0.1 already extracted What/Why/Where clearly and Phase 0.4 confirmation questions are skipped, this means **ONLY** that the user-facing confirmation dialog is skipped. It does **NOT** mean any of the following are skipped:
 
-| MUST execute even when Phase 0.4 confirmation is skipped |
-|---|
-| Phase 0.4.1 goal classification (infer task type from Phase 0.1) |
-| The "Delegation to Interview" section below (Pre-write + `rite:issue:create-interview` Skill invocation) |
-| 🚨 Mandatory After Interview |
-| Phase 0.6 (Task Decomposition Decision) |
-| Delegation Routing (Pre-write + `rite:issue:create-register` or `rite:issue:create-decompose` Skill invocation) |
-| 🚨 Mandatory After Delegation |
+| MUST execute even when Phase 0.4 confirmation is skipped | Why (enforcement layer) |
+|---|---|
+| Phase 0.4.1 goal classification (infer task type from Phase 0.1) | Required by Phase 0.5 interview scope determination |
+| Delegation to Interview section (Pre-write + `rite:issue:create-interview` Skill) | Without the `create_interview` flow-state write, stop-guard has no hook to enforce delegation |
+| 🚨 Mandatory After Interview | Updates `.rite-flow-state.phase=create_post_interview`; stop-guard keeps blocking until `create_delegation` is written below |
+| Phase 0.6 (Task Decomposition Decision) | Chooses between `create-register` (single Issue) and `create-decompose` (sub-Issues) |
+| Delegation Routing (Pre-write + terminal sub-skill Skill invocation) | Writes `create_delegation`, advancing the whitelist past `create_post_interview` |
+| 🚨 Mandatory After Delegation | Defense-in-depth for the terminal `create_completed` state |
 
 **The only legitimate way to create a GitHub Issue from this command is by invoking `rite:issue:create-register` or `rite:issue:create-decompose` as a Skill.** Calling `gh issue create` directly from the orchestrator bypasses flow-state tracking, Projects integration, and every enforcement layer — and is **blocked by `pre-tool-bash-guard.sh`** when `.rite-flow-state.phase = create_*`.
 
@@ -449,7 +459,7 @@ Invoke `skill: "rite:issue:create-interview"`.
 
 ### 🚨 Mandatory After Interview
 
-> **Enforcement**: `.rite-flow-state.phase = create_post_interview` is registered in `phase-transition-whitelist.sh`. A stop attempt at this point is blocked by `stop-guard.sh` with `invalid_transition` unless this section's Step 1 + Step 2 have been executed. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
+> **Enforcement**: `.rite-flow-state.phase` is `create_post_interview` at this point (the sub-skill wrote this via its Defense-in-Depth section). Stop-guard blocks any stop attempt while the flow-state is active — it will not unblock until `.rite-flow-state.phase` advances to `create_delegation` (via the Delegation Routing Pre-write below) or reaches `create_completed` (via the terminal sub-skill). Step 1 below refreshes the state timestamp but does NOT advance the phase on its own — the only legitimate path to a stoppable state is to continue through Phase 0.6 → Delegation Routing → terminal sub-skill. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 
 No GitHub Issue has been created yet. The interview only collects information.
 
@@ -598,9 +608,13 @@ Invoke `skill: "rite:issue:create-register"`.
 
 ### 🚨 Mandatory After Delegation (Defense-in-Depth)
 
-> **Enforcement**: Terminal sub-skills (`create-register.md`, `create-decompose.md`) write `create_completed` + `active: false` and output `[create:completed:{N}]` internally (Issue #444 Terminal Completion pattern). Steps 1-3 below are idempotent safety nets — if the sub-skill ran correctly they are no-ops. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
+> **Enforcement**: Terminal sub-skills (`create-register.md`, `create-decompose.md`) write `create_completed` + `active: false` and output `[create:completed:{N}]` internally (Issue #444 Terminal Completion pattern). See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 
-**Self-check**: Has `[create:completed:{N}]` been output? If no, Steps 1-3 are **critical** — the sub-skill failed to complete its Terminal Completion phase.
+**Self-check and branching**:
+
+1. **Has `[create:completed:{N}]` been output?**
+   - **Yes** — terminal state reached. `.rite-flow-state.phase` is already `create_completed` and `active: false`. Steps 1-3 below are **no-ops** and MUST be skipped (executing Step 1 would write `create_post_delegation` which is a retrograde transition from the terminal state).
+   - **No** — the sub-skill failed to complete its Terminal Completion phase. Steps 1-3 below are **critical** and must execute to force the workflow into the terminal state.
 
 **Step 1**: Update `.rite-flow-state` to post-delegation phase (atomic):
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -156,15 +156,17 @@ Projects を使用するには /rite:init を実行してください。
 
 ## Phase 0: Input Analysis and Completion
 
-> **🚫 MUST NOT — Bypass prohibition (Mode B defense, #475)** — **applies throughout all of Phase 0**.
+> **🚫 MUST NOT — Bypass prohibition (Mode B defense, #475)**
 >
-> From this point until `[create:completed:{N}]` is output by the terminal sub-skill, the orchestrator MUST NOT:
+> Between this point and `[create:completed:{N}]`, the orchestrator MUST NOT:
 >
 > 1. Execute `gh issue create` via the Bash tool (blocked by `pre-tool-bash-guard.sh` hook)
-> 2. Skip the `rite:issue:create-interview` Skill invocation based on a judgment that "information is clear enough already"
-> 3. Collapse the Delegation to Interview / Phase 0.6 / Delegation Routing sections into a synthetic "create Issue" step
+> 2. Skip from here directly to output without invoking `rite:issue:create-interview`
+> 3. Collapse the Delegation to Interview / Phase 0.6 / Delegation Routing sections into a single synthetic "create Issue" step
 >
-> Any of the above is a **protocol violation** regardless of how clearly Phase 0.1 extracted the information. The only legitimate path is: Phase 0.1 → Phase 0.3 → Phase 0.4 → Delegation to Interview → 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → terminal sub-skill. This same MUST NOT block is repeated before the Delegation to Interview section as a reminder — both occurrences have identical wording.
+> Any of the above is a **protocol violation** regardless of how clearly Phase 0.1 extracted the information. The only legitimate path forward is: Pre-write below → `skill: "rite:issue:create-interview"` → 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → terminal sub-skill.
+>
+> **⚠️ Drift guard**: This same block is repeated verbatim before the `## Delegation to Interview` section below. **Both occurrences MUST stay identical** — if you update one, update both. A grep-based check is the only drift detector.
 
 ### 0.1 Extract Information from User Input
 
@@ -435,6 +437,8 @@ When Phase 0.1 already extracted What/Why/Where clearly and Phase 0.4 confirmati
 > 3. Collapse the Delegation to Interview / Phase 0.6 / Delegation Routing sections into a single synthetic "create Issue" step
 >
 > Any of the above is a **protocol violation** regardless of how clearly Phase 0.1 extracted the information. The only legitimate path forward is: Pre-write below → `skill: "rite:issue:create-interview"` → 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → terminal sub-skill.
+>
+> **⚠️ Drift guard**: This same block is repeated verbatim at the start of Phase 0 above. **Both occurrences MUST stay identical** — if you update one, update both. A grep-based check is the only drift detector.
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -395,9 +395,36 @@ Determine the task type for Phase 0.4.1 adaptive interview depth via AskUserQues
 
 **Completion criteria for Phase 0.4**: See [Termination Logic > Phase 0.4 Completion Criteria](#phase-04-completion-criteria).
 
+### 0.4.2 Skip Semantics (Critical — Mode B Defense)
+
+> **⚠️ READ THIS EVERY TIME Phase 0.4 is skipped.**
+
+When Phase 0.1 already extracted What/Why/Where clearly and Phase 0.4 confirmation questions are skipped, this means **ONLY** that the user-facing confirmation dialog is skipped. It does **NOT** mean any of the following are skipped:
+
+| MUST execute even when Phase 0.4 confirmation is skipped |
+|---|
+| Phase 0.4.1 goal classification (infer task type from Phase 0.1) |
+| The "Delegation to Interview" section below (Pre-write + `rite:issue:create-interview` Skill invocation) |
+| 🚨 Mandatory After Interview |
+| Phase 0.6 (Task Decomposition Decision) |
+| Delegation Routing (Pre-write + `rite:issue:create-register` or `rite:issue:create-decompose` Skill invocation) |
+| 🚨 Mandatory After Delegation |
+
+**The only legitimate way to create a GitHub Issue from this command is by invoking `rite:issue:create-register` or `rite:issue:create-decompose` as a Skill.** Calling `gh issue create` directly from the orchestrator bypasses flow-state tracking, Projects integration, and every enforcement layer — and is **blocked by `pre-tool-bash-guard.sh`** when `.rite-flow-state.phase = create_*`.
+
 ---
 
 ## Delegation to Interview
+
+> **🚫 MUST NOT — Bypass prohibition (Mode B defense, #475)**
+>
+> Between this point and `[create:completed:{N}]`, the orchestrator MUST NOT:
+>
+> 1. Execute `gh issue create` via the Bash tool (blocked by `pre-tool-bash-guard.sh` hook)
+> 2. Skip from here directly to output without invoking `rite:issue:create-interview`
+> 3. Collapse the Delegation to Interview / Phase 0.6 / Delegation Routing sections into a single synthetic "create Issue" step
+>
+> Any of the above is a **protocol violation** regardless of how clearly Phase 0.1 extracted the information. The only legitimate path forward is: Pre-write below → `skill: "rite:issue:create-interview"` → 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → terminal sub-skill.
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) before executing bash hook commands in this file.
 
@@ -422,15 +449,11 @@ Invoke `skill: "rite:issue:create-interview"`.
 
 ### 🚨 Mandatory After Interview
 
-> See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
+> **Enforcement**: `.rite-flow-state.phase = create_post_interview` is registered in `phase-transition-whitelist.sh`. A stop attempt at this point is blocked by `stop-guard.sh` with `invalid_transition` unless this section's Step 1 + Step 2 have been executed. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 
-> **CRITICAL — AUTOMATIC CONTINUATION REQUIREMENT**: This is the single most important instruction at this transition point. When `rite:issue:create-interview` returns a result pattern, you MUST continue responding in the same turn. Ending your response here is a **bug** that forces the user to type "continue" manually. See also the delegation section below for the same pattern.
+No GitHub Issue has been created yet. The interview only collects information.
 
-**Ignore** any "next steps" or standalone guidance from the interview sub-skill. **Immediately** proceed to the next phase.
-
-Do **NOT** stop after `rite:issue:create-interview` returns. The interview sub-skill only collects information — **no GitHub Issue has been created yet**. Stopping here would completely abandon the workflow with no deliverable.
-
-**Step 1**: Update `.rite-flow-state` to post-interview phase (atomic). The sub-skill has already written `create_post_interview` via its Defense-in-Depth section; this second write updates the `next_action` message and refreshes the timestamp, ensuring stop-guard routes to the correct next phase:
+**Step 1**: Update `.rite-flow-state` to post-interview phase (atomic). The sub-skill has already written `create_post_interview` via its Defense-in-Depth section; this second write refreshes the timestamp and `next_action`:
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -575,11 +598,9 @@ Invoke `skill: "rite:issue:create-register"`.
 
 ### 🚨 Mandatory After Delegation (Defense-in-Depth)
 
-> See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the general pattern.
+> **Enforcement**: Terminal sub-skills (`create-register.md`, `create-decompose.md`) write `create_completed` + `active: false` and output `[create:completed:{N}]` internally (Issue #444 Terminal Completion pattern). Steps 1-3 below are idempotent safety nets — if the sub-skill ran correctly they are no-ops. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 
-> **Defense-in-depth only** (Issue #444): Terminal sub-skills now handle flow-state deactivation and next-step output internally via their Terminal Completion phase. This 🚨 Mandatory After section is retained as a **safety net** — it re-executes the same steps idempotently. If the sub-skill's Terminal Completion executed correctly, these steps are no-ops.
-
-**Self-check**: Has `[create:completed:{N}]` been output? If yes, the sub-skill's Terminal Completion succeeded — execute Steps 1-3 as defense-in-depth (idempotent). If no (sub-skill returned without the completion marker), these steps are **critical** and must execute.
+**Self-check**: Has `[create:completed:{N}]` been output? If no, Steps 1-3 are **critical** — the sub-skill failed to complete its Terminal Completion phase.
 
 **Step 1**: Update `.rite-flow-state` to post-delegation phase (atomic):
 

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -331,6 +331,27 @@ rite_phase_is_known() {
   return 1
 }
 
+# Return 0 if the given phase is an in-progress phase of /rite:issue:create
+# lifecycle (i.e., create_interview / create_post_interview / create_delegation /
+# create_post_delegation — NOT create_completed which is terminal).
+#
+# Single source of truth for "is the create workflow mid-delegation?" queries
+# used by pre-tool-bash-guard.sh (Pattern 5) and session-end.sh (lifecycle
+# unfinished warning). Centralizing the phase name list here prevents silent
+# drift when new create_* phases are added to _RITE_PHASE_TRANSITIONS (#501
+# code-quality review HIGH).
+rite_phase_is_create_lifecycle_in_progress() {
+  local phase="$1"
+  case "$phase" in
+    create_interview|create_post_interview|create_delegation|create_post_delegation)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Optional: auto-load overrides when RITE_CONFIG env var points to a config file.
 if [ -n "${RITE_CONFIG:-}" ]; then
   _rite_load_whitelist_overrides "$RITE_CONFIG"

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -119,6 +119,18 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # (terminal state). The empty-value listing below keeps the name known as a source for
   # rite_phase_is_known().
   ["completed"]=""
+
+  # /rite:issue:create lifecycle (#475).
+  # Orchestrator (create.md) writes create_interview → create_post_interview → create_delegation,
+  # and terminal sub-skills (create-register/create-decompose) write create_completed.
+  # Registering these in the whitelist enables stop-guard invalid-transition detection
+  # when the orchestrator silently skips sub-skill delegation (Mode B) or misroutes flow.
+  # create_completed is already treated as a universal terminal in rite_phase_transition_allowed().
+  ["create_interview"]="create_post_interview"
+  ["create_post_interview"]="create_delegation create_interview"
+  ["create_delegation"]="create_post_delegation create_completed"
+  ["create_post_delegation"]="create_completed"
+  ["create_completed"]=""
 )
 
 # Load override map from rite-config.yml if present.

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -111,25 +111,33 @@ fi
 # create_post_interview / create_delegation / create_post_delegation (i.e., create lifecycle is
 # in progress but not yet terminated by create_completed).
 #
-# Bypass prevention — CMD_CHECK normalization:
-#   Pattern 4 normalizes shell meta-characters (;, &, |, parens, backticks, $) to spaces so that
-#   `true; gh issue create` / `echo x | gh issue create` / `{gh issue create;}` all match the
-#   same `gh issue create` pattern. Pattern 5 reuses this normalization via $PADDED_ALL so that
-#   shell meta-char bypass vectors (`gh issue create;echo x`, `gh issue create|tee`,
-#   `gh issue create&`) are all caught. Backslash line continuations (`gh \\\n  issue \\\n create`)
-#   are also normalized because `\n` is replaced with space and `\` is stripped in the continuation
-#   handling below.
+# Bypass prevention — Pattern 5 normalization:
+#   Pattern 5 normalizes shell meta-characters (;, &, |, parens, braces, backticks, $, quotes) to
+#   spaces so that `true; gh issue create` / `echo x | gh issue create` / `{gh issue create;}` /
+#   `eval "gh issue create"` all match the same `gh issue create` pattern. Backslash line
+#   continuations (`gh \\\n  issue \\\n create`) are also normalized because `\n` and `\` are both
+#   replaced with space.
+#
+# ⚠️ IMPORTANT — Pattern 5 uses $COMMAND (full input) not $CMD_CHECK:
+#   Patterns 1-4 operate on $CMD_CHECK which is $COMMAND with content after the first `<<`
+#   heredoc marker stripped (to avoid false positives from heredoc body content). Pattern 5
+#   MUST NOT use CMD_CHECK because of a legitimate Mode B bypass: `cat <<EOF | sh ... gh issue
+#   create ... EOF` would be stripped to `cat ` and Pattern 5 would silently miss it. Using
+#   $COMMAND directly means heredoc bodies ARE scanned — the false positive risk (PR/Issue
+#   body text containing the literal `gh issue create`) is acceptable because (a) such text
+#   is rare in practice, and (b) the create lifecycle scope filter below limits exposure.
 #
 # Scope exclusions (allow):
 #   - no .rite-flow-state (manual gh invocation outside any workflow)
 #   - .rite-flow-state exists but active=false or phase=create_completed (lifecycle finished)
 #   - .rite-flow-state phase is not create_* (different workflow like /rite:issue:start)
-#   - gh issue subcommands other than `create` / `cre` / `crea` / `creat` prefixes
-#     (list/view/edit/close/comment/delete/pin/reopen/transfer/unpin/unlock/lock are allowed)
+#   - gh issue subcommands other than `cr` prefix (close/comment/delete/edit/list/view/etc. allowed)
+#     — gh CLI resolves `cr` unambiguously to `create` (the only `gh issue` subcommand starting
+#     with `cr`), so `cr` is the minimum unambiguous prefix and must be caught. `c` alone is
+#     ambiguous and gh CLI itself rejects it, so we do not block it here.
 if [ -z "$BLOCKED_PATTERN" ]; then
-  # Normalize CMD_CHECK: shell meta-chars → space, backslash-newline continuations → space,
-  # then collapse multiple spaces. This reuses Pattern 4's normalization approach.
-  CMD_P5="${CMD_CHECK//$'\t'/ }"
+  # Normalize $COMMAND directly (NOT $CMD_CHECK) to catch heredoc-body bypass (#501 HIGH).
+  CMD_P5="${COMMAND//$'\t'/ }"
   CMD_P5="${CMD_P5//$'\n'/ }"
   CMD_P5="${CMD_P5//$'\r'/ }"
   CMD_P5="${CMD_P5//\\/ }"
@@ -142,22 +150,24 @@ if [ -z "$BLOCKED_PATTERN" ]; then
   CMD_P5="${CMD_P5//\}/ }"
   CMD_P5="${CMD_P5//\`/ }"
   CMD_P5="${CMD_P5//\$/ }"
+  CMD_P5="${CMD_P5//\"/ }"
+  CMD_P5="${CMD_P5//\'/ }"
   while [[ "$CMD_P5" == *"  "* ]]; do
     CMD_P5="${CMD_P5//  / }"
   done
   PADDED_P5=" $CMD_P5 "
 
-  # gh subcommand prefix match: gh supports prefix shortcuts like `gh issue c` → create.
-  # However `c` alone is ambiguous (matches close/comment too), and `gh` itself resolves
-  # prefixes only when unambiguous. `create` is unambiguous from `cre` onwards (no other
-  # `issue` subcommand starts with `cre`). Match `create` / `creat` / `crea` / `cre` as
-  # trailing tokens to catch prefix shortcuts while leaving `close` / `comment` / other
-  # subcommands untouched.
-  if [[ "$PADDED_P5" =~ " gh issue "(create|creat|crea|cre)([[:space:]]|$) ]]; then
-    CWD_FROM_INPUT=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD_FROM_INPUT=""
+  # gh subcommand prefix match: gh supports prefix shortcuts when unambiguous.
+  # Among `gh issue` subcommands (close / comment / create / delete / develop / edit / list /
+  # lock / pin / reopen / status / transfer / unlock / unpin / view), only `create` starts with
+  # `cr`, so `cr` is the minimum unambiguous prefix for `create`. `c` alone is ambiguous
+  # (matches close / comment / create) and gh CLI itself rejects it, so we don't block it.
+  # Match `cr` through `create` as trailing tokens, leaving `close` / `comment` / etc. untouched.
+  if [[ "$PADDED_P5" =~ " gh issue "(create|creat|crea|cre|cr)([[:space:]]|$) ]]; then
+    CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
     STATE_ROOT_PATH=""
-    if [ -n "$CWD_FROM_INPUT" ] && [ -d "$CWD_FROM_INPUT" ]; then
-      STATE_ROOT_PATH=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD_FROM_INPUT" 2>/dev/null) || STATE_ROOT_PATH="$CWD_FROM_INPUT"
+    if [ -n "$CWD" ] && [ -d "$CWD" ]; then
+      STATE_ROOT_PATH=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT_PATH="$CWD"
     fi
     # State file lookup: if $STATE_ROOT_PATH is empty (e.g., CWD outside git repo and
     # state-path-resolve.sh failed), skip the check entirely — no state file means no

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -22,6 +22,9 @@ export _RITE_HOOK_RUNNING_PRETOOL=1
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+# Single source of truth for create_* lifecycle phase names (#501 HIGH).
+# Provides rite_phase_is_create_lifecycle_in_progress() used by Pattern 5.
+source "$SCRIPT_DIR/phase-transition-whitelist.sh" 2>/dev/null || true
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
@@ -108,26 +111,78 @@ fi
 # create_post_interview / create_delegation / create_post_delegation (i.e., create lifecycle is
 # in progress but not yet terminated by create_completed).
 #
+# Bypass prevention — CMD_CHECK normalization:
+#   Pattern 4 normalizes shell meta-characters (;, &, |, parens, backticks, $) to spaces so that
+#   `true; gh issue create` / `echo x | gh issue create` / `{gh issue create;}` all match the
+#   same `gh issue create` pattern. Pattern 5 reuses this normalization via $PADDED_ALL so that
+#   shell meta-char bypass vectors (`gh issue create;echo x`, `gh issue create|tee`,
+#   `gh issue create&`) are all caught. Backslash line continuations (`gh \\\n  issue \\\n create`)
+#   are also normalized because `\n` is replaced with space and `\` is stripped in the continuation
+#   handling below.
+#
 # Scope exclusions (allow):
 #   - no .rite-flow-state (manual gh invocation outside any workflow)
 #   - .rite-flow-state exists but active=false or phase=create_completed (lifecycle finished)
 #   - .rite-flow-state phase is not create_* (different workflow like /rite:issue:start)
-#   - gh issue subcommands other than `create` (list/view/edit/close/comment/etc.)
+#   - gh issue subcommands other than `create` / `cre` / `crea` / `creat` prefixes
+#     (list/view/edit/close/comment/delete/pin/reopen/transfer/unpin/unlock/lock are allowed)
 if [ -z "$BLOCKED_PATTERN" ]; then
-  if [[ "$CMD_CHECK" =~ gh[[:space:]]+issue[[:space:]]+create([[:space:]]|$) ]]; then
+  # Normalize CMD_CHECK: shell meta-chars → space, backslash-newline continuations → space,
+  # then collapse multiple spaces. This reuses Pattern 4's normalization approach.
+  CMD_P5="${CMD_CHECK//$'\t'/ }"
+  CMD_P5="${CMD_P5//$'\n'/ }"
+  CMD_P5="${CMD_P5//$'\r'/ }"
+  CMD_P5="${CMD_P5//\\/ }"
+  CMD_P5="${CMD_P5//;/ }"
+  CMD_P5="${CMD_P5//&/ }"
+  CMD_P5="${CMD_P5//|/ }"
+  CMD_P5="${CMD_P5//(/ }"
+  CMD_P5="${CMD_P5//)/ }"
+  CMD_P5="${CMD_P5//\{/ }"
+  CMD_P5="${CMD_P5//\}/ }"
+  CMD_P5="${CMD_P5//\`/ }"
+  CMD_P5="${CMD_P5//\$/ }"
+  while [[ "$CMD_P5" == *"  "* ]]; do
+    CMD_P5="${CMD_P5//  / }"
+  done
+  PADDED_P5=" $CMD_P5 "
+
+  # gh subcommand prefix match: gh supports prefix shortcuts like `gh issue c` → create.
+  # However `c` alone is ambiguous (matches close/comment too), and `gh` itself resolves
+  # prefixes only when unambiguous. `create` is unambiguous from `cre` onwards (no other
+  # `issue` subcommand starts with `cre`). Match `create` / `creat` / `crea` / `cre` as
+  # trailing tokens to catch prefix shortcuts while leaving `close` / `comment` / other
+  # subcommands untouched.
+  if [[ "$PADDED_P5" =~ " gh issue "(create|creat|crea|cre)([[:space:]]|$) ]]; then
     CWD_FROM_INPUT=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD_FROM_INPUT=""
     STATE_ROOT_PATH=""
     if [ -n "$CWD_FROM_INPUT" ] && [ -d "$CWD_FROM_INPUT" ]; then
       STATE_ROOT_PATH=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD_FROM_INPUT" 2>/dev/null) || STATE_ROOT_PATH="$CWD_FROM_INPUT"
     fi
-    STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
-    if [ -n "$STATE_ROOT_PATH" ] && [ -f "$STATE_FILE_PATH" ]; then
-      STATE_PHASE=$(jq -r '.phase // empty' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PHASE=""
-      STATE_ACTIVE=$(jq -r '.active // false' "$STATE_FILE_PATH" 2>/dev/null) || STATE_ACTIVE="false"
-      if [ "$STATE_ACTIVE" = "true" ] && [[ "$STATE_PHASE" == create_* ]] && [ "$STATE_PHASE" != "create_completed" ]; then
-        BLOCKED_PATTERN="create-lifecycle-direct-gh-issue"
-        BLOCKED_REASON="/rite:issue:create lifecycle 中 (phase=$STATE_PHASE) に gh issue create を直接実行することは禁止されています (#475 Mode B)."
-        BLOCKED_ALTERNATIVE="rite:issue:create-register を呼ぶべき場面です。Phase 0.6 の Delegation Routing に従い skill: \"rite:issue:create-register\" または skill: \"rite:issue:create-decompose\" を invoke してください。"
+    # State file lookup: if $STATE_ROOT_PATH is empty (e.g., CWD outside git repo and
+    # state-path-resolve.sh failed), skip the check entirely — no state file means no
+    # create lifecycle to enforce, which is the documented "allow" path.
+    if [ -n "$STATE_ROOT_PATH" ]; then
+      STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
+      if [ -f "$STATE_FILE_PATH" ]; then
+        STATE_PHASE=$(jq -r '.phase // empty' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PHASE=""
+        STATE_ACTIVE=$(jq -r '.active // false' "$STATE_FILE_PATH" 2>/dev/null) || STATE_ACTIVE="false"
+        # Use query function from phase-transition-whitelist.sh as the single source of truth
+        # for create_* lifecycle phase names. Fall back to inline glob check when the helper
+        # is unavailable (e.g., bash < 4.2 where phase-transition-whitelist.sh exits early).
+        if [ "$STATE_ACTIVE" = "true" ]; then
+          if type rite_phase_is_create_lifecycle_in_progress >/dev/null 2>&1; then
+            if rite_phase_is_create_lifecycle_in_progress "$STATE_PHASE"; then
+              BLOCKED_PATTERN="create-lifecycle-direct-gh-issue"
+            fi
+          elif [[ "$STATE_PHASE" == create_* ]] && [ "$STATE_PHASE" != "create_completed" ]; then
+            BLOCKED_PATTERN="create-lifecycle-direct-gh-issue"
+          fi
+          if [ "$BLOCKED_PATTERN" = "create-lifecycle-direct-gh-issue" ]; then
+            BLOCKED_REASON="/rite:issue:create lifecycle 中 (phase=$STATE_PHASE) に gh issue create を直接実行することは禁止されています (#475 Mode B)."
+            BLOCKED_ALTERNATIVE="rite:issue:create-register を呼ぶべき場面です。Phase 0.6 の Delegation Routing に従い skill: \"rite:issue:create-register\" または skill: \"rite:issue:create-decompose\" を invoke してください。"
+          fi
+        fi
       fi
     fi
   fi

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -99,6 +99,40 @@ if [ -z "$BLOCKED_PATTERN" ]; then
   esac
 fi
 
+# Pattern 5: gh issue create direct invocation during /rite:issue:create lifecycle (#475 Mode B).
+# The orchestrator (create.md) must delegate Issue creation to rite:issue:create-register or
+# rite:issue:create-decompose sub-skills. A direct `gh issue create` call bypasses the entire
+# sub-skill delegation protocol, flow-state tracking, and Projects integration.
+#
+# Detection: .rite-flow-state must exist AND be active AND the phase must be create_interview /
+# create_post_interview / create_delegation / create_post_delegation (i.e., create lifecycle is
+# in progress but not yet terminated by create_completed).
+#
+# Scope exclusions (allow):
+#   - no .rite-flow-state (manual gh invocation outside any workflow)
+#   - .rite-flow-state exists but active=false or phase=create_completed (lifecycle finished)
+#   - .rite-flow-state phase is not create_* (different workflow like /rite:issue:start)
+#   - gh issue subcommands other than `create` (list/view/edit/close/comment/etc.)
+if [ -z "$BLOCKED_PATTERN" ]; then
+  if [[ "$CMD_CHECK" =~ gh[[:space:]]+issue[[:space:]]+create([[:space:]]|$) ]]; then
+    CWD_FROM_INPUT=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD_FROM_INPUT=""
+    STATE_ROOT_PATH=""
+    if [ -n "$CWD_FROM_INPUT" ] && [ -d "$CWD_FROM_INPUT" ]; then
+      STATE_ROOT_PATH=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD_FROM_INPUT" 2>/dev/null) || STATE_ROOT_PATH="$CWD_FROM_INPUT"
+    fi
+    STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
+    if [ -n "$STATE_ROOT_PATH" ] && [ -f "$STATE_FILE_PATH" ]; then
+      STATE_PHASE=$(jq -r '.phase // empty' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PHASE=""
+      STATE_ACTIVE=$(jq -r '.active // false' "$STATE_FILE_PATH" 2>/dev/null) || STATE_ACTIVE="false"
+      if [ "$STATE_ACTIVE" = "true" ] && [[ "$STATE_PHASE" == create_* ]] && [ "$STATE_PHASE" != "create_completed" ]; then
+        BLOCKED_PATTERN="create-lifecycle-direct-gh-issue"
+        BLOCKED_REASON="/rite:issue:create lifecycle 中 (phase=$STATE_PHASE) に gh issue create を直接実行することは禁止されています (#475 Mode B)."
+        BLOCKED_ALTERNATIVE="rite:issue:create-register を呼ぶべき場面です。Phase 0.6 の Delegation Routing に従い skill: \"rite:issue:create-register\" または skill: \"rite:issue:create-decompose\" を invoke してください。"
+      fi
+    fi
+  fi
+fi
+
 # Pattern 4: Reviewer subagent running state-mutating git commands (Issue #442).
 # Scope: only when IS_SUBAGENT=1 (transcript_path contains "/subagents/").
 # Main-session git operations (branch switch, commit, etc. performed by

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -11,6 +11,8 @@ export _RITE_HOOK_RUNNING_SESSIONEND=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+# Single source of truth for create_* lifecycle phase names (#501 HIGH).
+source "$SCRIPT_DIR/phase-transition-whitelist.sh" 2>/dev/null || true
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -53,9 +55,21 @@ if [ -f "$STATE_FILE" ]; then
     # but not create_completed), emit a warning so the user knows the Issue was NOT
     # created and can re-run /rite:issue:create or use /rite:resume. This is
     # informational only — session-end always proceeds with deactivation.
+    # Uses rite_phase_is_create_lifecycle_in_progress() from phase-transition-whitelist.sh
+    # as the single source of truth for create_* phase names (#501 HIGH).
     _state_phase=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null) || _state_phase=""
     _state_active=$(jq -r '.active // false' "$STATE_FILE" 2>/dev/null) || _state_active="false"
-    if [ "$_state_active" = "true" ] && [[ "$_state_phase" == create_* ]] && [ "$_state_phase" != "create_completed" ]; then
+    _lifecycle_unfinished=0
+    if [ "$_state_active" = "true" ]; then
+        if type rite_phase_is_create_lifecycle_in_progress >/dev/null 2>&1; then
+            if rite_phase_is_create_lifecycle_in_progress "$_state_phase"; then
+                _lifecycle_unfinished=1
+            fi
+        elif [[ "$_state_phase" == create_* ]] && [ "$_state_phase" != "create_completed" ]; then
+            _lifecycle_unfinished=1
+        fi
+    fi
+    if [ "$_lifecycle_unfinished" = "1" ]; then
         cat >&2 <<WARN_MSG
 ⚠️  rite: /rite:issue:create lifecycle was not completed (phase=$_state_phase).
     No GitHub Issue was created. The sub-skill delegation flow

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -48,6 +48,22 @@ if [ -f "$STATE_FILE" ]; then
         exit 0
     fi
 
+    # /rite:issue:create lifecycle unfinished warning (#475 AC-9).
+    # If the session is ending while the create flow is mid-delegation (phase=create_*
+    # but not create_completed), emit a warning so the user knows the Issue was NOT
+    # created and can re-run /rite:issue:create or use /rite:resume. This is
+    # informational only — session-end always proceeds with deactivation.
+    _state_phase=$(jq -r '.phase // empty' "$STATE_FILE" 2>/dev/null) || _state_phase=""
+    _state_active=$(jq -r '.active // false' "$STATE_FILE" 2>/dev/null) || _state_active="false"
+    if [ "$_state_active" = "true" ] && [[ "$_state_phase" == create_* ]] && [ "$_state_phase" != "create_completed" ]; then
+        cat >&2 <<WARN_MSG
+⚠️  rite: /rite:issue:create lifecycle was not completed (phase=$_state_phase).
+    No GitHub Issue was created. The sub-skill delegation flow
+    (create-interview → 0.6 → create-register/create-decompose) did not reach completion.
+    Re-run /rite:issue:create or use /rite:resume to recover.
+WARN_MSG
+    fi
+
     # mktemp with PID-based fallback (consistent with stop-guard.sh)
     TMP_FILE=$(mktemp "${STATE_FILE}.XXXXXX" 2>/dev/null) || TMP_FILE="${STATE_FILE}.tmp.$$"
     # trap is inside this block: only active when STATE_FILE exists and TMP_FILE is created

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1055,7 +1055,9 @@ assert_p5_deny() {
   rm -rf "$tmpdir"
 }
 
-# Helper: assert allow (for false-positive regression)
+# Helper: assert allow (for false-positive regression).
+# Checks that permissionDecision is not "deny" (rather than rc=0 && empty output), so future
+# hook changes that emit informational stdout on allow paths don't false-fail this assertion.
 assert_p5_allow() {
   local label="$1"
   local cmd="$2"
@@ -1064,10 +1066,12 @@ assert_p5_allow() {
   local rc=0
   local out
   out=$(run_guard_with_cwd "$tmpdir" "$cmd") || rc=$?
-  if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  local decision
+  decision=$(echo "$out" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  if [ "$decision" != "deny" ]; then
     pass "$label"
   else
-    fail "$label (cmd='$cmd', rc=$rc out=$out)"
+    fail "$label (cmd='$cmd', decision=$decision out=$out)"
   fi
   rm -rf "$tmpdir"
 }
@@ -1084,8 +1088,13 @@ assert_p5_deny "TC-101 'gh issue create &' blocked (ampersand)" "gh issue create
 # TC-102: prefix shortcut 'gh issue c' → allow (ambiguous in gh CLI itself, not a real bypass)
 # gh CLI resolves `c` as ambiguous (close/comment/create) and errors out.
 # Since it never actually invokes `gh issue create`, Pattern 5 does not need to match it.
-# We start from `cre` which is unambiguous (only `create` starts with `cre` among gh issue subcommands).
+# Note: if gh CLI ever resolves `c` to a single subcommand, TC-102 must flip to deny.
 assert_p5_allow "TC-102 'gh issue c' allowed (ambiguous in gh CLI, not a real bypass)" "gh issue c --title x"
+
+# TC-102b: 2-char prefix 'gh issue cr' → deny
+# Among `gh issue` subcommands, only `create` starts with `cr`, so gh CLI resolves
+# `gh issue cr` unambiguously to `create`. This is a real bypass vector.
+assert_p5_deny "TC-102b 'gh issue cr' blocked (2-char unambiguous prefix)" "gh issue cr --title x"
 
 # TC-103: prefix shortcut 'gh issue cre' → deny
 assert_p5_deny "TC-103 'gh issue cre' blocked (prefix shortcut)" "gh issue cre --title x"
@@ -1107,6 +1116,25 @@ assert_p5_allow "TC-107 'gh issue close' allowed (full spelling, not 'create' pr
 
 # TC-108: 'gh issue comment' allowed (full spelling)
 assert_p5_allow "TC-108 'gh issue comment' allowed" "gh issue comment 123 --body x"
+
+# TC-109: heredoc-body bypass → deny (Pattern 5 uses $COMMAND directly, not $CMD_CHECK)
+# `cat <<EOF ... gh issue create ... EOF | sh` hides the command in a heredoc body.
+# Pattern 1-4 strip the heredoc via CMD_CHECK="${COMMAND%%<<*}" but Pattern 5 bypasses that
+# by operating on $COMMAND directly (#501 security review HIGH).
+assert_p5_deny "TC-109 heredoc body bypass blocked" "cat <<EOF | sh
+gh issue create --title x
+EOF"
+
+# TC-110: eval with double-quoted body → deny (quote normalization)
+assert_p5_deny "TC-110 eval \"gh issue create\" blocked (quote normalization)" 'eval "gh issue create --title x"'
+
+# TC-111: eval with single-quoted body → deny
+assert_p5_deny "TC-111 eval 'gh issue create' blocked (quote normalization)" "eval 'gh issue create --title x'"
+
+# TC-112: backslash line continuation → deny
+# `gh \<newline>  issue \<newline>  create` normalized via \n→space and \→space
+# Using $'...' ANSI-C quoting to preserve literal backslash-newline in the test input.
+assert_p5_deny "TC-112 backslash line continuation blocked" $'gh \\\n  issue \\\n  create --title x'
 
 # --------------------------------------------------------------------------
 # Summary

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -944,6 +944,20 @@ else
 fi
 rm -rf "$tmpdir"
 
+# TC-092b: gh issue create during phase=create_post_delegation (active=true) → deny
+# (fills coverage gap identified in #501 test-reviewer MEDIUM)
+echo "TC-092b: gh issue create + create_post_delegation active → deny"
+tmpdir=$(make_cwd_with_state "create_post_delegation" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-092b blocked during create_post_delegation"
+else
+  fail "TC-092b expected deny, got decision=$decision"
+fi
+rm -rf "$tmpdir"
+
 # TC-093: gh issue create with phase=create_completed → allow (lifecycle finished)
 echo "TC-093: gh issue create + create_completed → allow"
 tmpdir=$(make_cwd_with_state "create_completed" "true")
@@ -1015,6 +1029,84 @@ else
   fail "TC-098 expected allow, got rc=$rc output=$output"
 fi
 rm -rf "$tmpdir"
+
+# --------------------------------------------------------------------------
+# TC-099-108: Pattern 5 bypass vector regression tests (#501 security review)
+# --------------------------------------------------------------------------
+echo ""
+echo "=== TC-099+: Pattern 5 bypass vector blocking (#501) ==="
+
+# Helper: assert deny (for bypass tests during create_interview)
+assert_p5_deny() {
+  local label="$1"
+  local cmd="$2"
+  local tmpdir
+  tmpdir=$(make_cwd_with_state "create_interview" "true")
+  local rc=0
+  local out
+  out=$(run_guard_with_cwd "$tmpdir" "$cmd") || rc=$?
+  local decision
+  decision=$(echo "$out" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  if [ "$decision" = "deny" ]; then
+    pass "$label"
+  else
+    fail "$label (cmd='$cmd', got decision=$decision)"
+  fi
+  rm -rf "$tmpdir"
+}
+
+# Helper: assert allow (for false-positive regression)
+assert_p5_allow() {
+  local label="$1"
+  local cmd="$2"
+  local tmpdir
+  tmpdir=$(make_cwd_with_state "create_interview" "true")
+  local rc=0
+  local out
+  out=$(run_guard_with_cwd "$tmpdir" "$cmd") || rc=$?
+  if [ "$rc" = "0" ] && [ -z "$out" ]; then
+    pass "$label"
+  else
+    fail "$label (cmd='$cmd', rc=$rc out=$out)"
+  fi
+  rm -rf "$tmpdir"
+}
+
+# TC-099: semicolon boundary → deny
+assert_p5_deny "TC-099 'gh issue create;echo x' blocked (semicolon)" "gh issue create --title x;echo done"
+
+# TC-100: pipe boundary → deny
+assert_p5_deny "TC-100 'gh issue create | tee' blocked (pipe)" "gh issue create --title x|tee out"
+
+# TC-101: ampersand boundary → deny
+assert_p5_deny "TC-101 'gh issue create &' blocked (ampersand)" "gh issue create --title x &"
+
+# TC-102: prefix shortcut 'gh issue c' → allow (ambiguous in gh CLI itself, not a real bypass)
+# gh CLI resolves `c` as ambiguous (close/comment/create) and errors out.
+# Since it never actually invokes `gh issue create`, Pattern 5 does not need to match it.
+# We start from `cre` which is unambiguous (only `create` starts with `cre` among gh issue subcommands).
+assert_p5_allow "TC-102 'gh issue c' allowed (ambiguous in gh CLI, not a real bypass)" "gh issue c --title x"
+
+# TC-103: prefix shortcut 'gh issue cre' → deny
+assert_p5_deny "TC-103 'gh issue cre' blocked (prefix shortcut)" "gh issue cre --title x"
+
+# TC-104: brace group → deny (Pattern 4 normalization)
+assert_p5_deny "TC-104 '{gh issue create;}' blocked (brace group)" "{gh issue create --title x;}"
+
+# TC-105: subshell → deny
+assert_p5_deny "TC-105 '(gh issue create)' blocked (subshell)" "(gh issue create --title x)"
+
+# TC-106: env prefix → deny (not a bypass, just verify)
+assert_p5_deny "TC-106 'FOO=bar gh issue create' blocked" "FOO=bar gh issue create --title x"
+
+# TC-107: 'gh issue close' prefix 'c' ambiguity → MUST still deny because 'c' matches both
+# NOTE: This is intentional — we err on the side of blocking. 'gh issue c' is ambiguous
+# in gh CLI itself (returns "ambiguous" error), so users should not rely on it.
+# For 'gh issue close' (full spelling), the pattern does NOT match and it's allowed:
+assert_p5_allow "TC-107 'gh issue close' allowed (full spelling, not 'create' prefix)" "gh issue close 123"
+
+# TC-108: 'gh issue comment' allowed (full spelling)
+assert_p5_allow "TC-108 'gh issue comment' allowed" "gh issue comment 123 --body x"
 
 # --------------------------------------------------------------------------
 # Summary

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -863,6 +863,160 @@ echo "TC-084: subagent + '{git reset --hard HEAD;}' → deny (brace boundary)"
 assert_subagent_deny "brace group git reset blocked" "{git reset --hard HEAD;}"
 
 # --------------------------------------------------------------------------
+# TC-090〜098: Pattern 5 — gh issue create during create lifecycle (#475 Mode B)
+# --------------------------------------------------------------------------
+echo ""
+echo "=== TC-090+: Pattern 5 gh issue create lifecycle blocking (#475) ==="
+
+# Helper: run hook with explicit cwd + pre-populated .rite-flow-state
+# Args: $1=cwd_dir, $2=command, $3..=extra jq-n args (unused now)
+run_guard_with_cwd() {
+  local cwd_dir="$1"
+  local cmd="$2"
+  local rc=0
+  local output
+  output=$(jq -n --arg tn "Bash" --arg cmd "$cmd" --arg cwd "$cwd_dir" \
+    '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd}' \
+    | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  echo "$output"
+  return $rc
+}
+
+# Helper: create a tmp cwd with a .rite-flow-state file having the given phase/active.
+make_cwd_with_state() {
+  local phase="$1"
+  local active="$2"
+  local dir
+  dir=$(mktemp -d "/tmp/rite-test-475.XXXXXX")
+  cat > "$dir/.rite-flow-state" <<STATE_EOF
+{
+  "schema_version": 1,
+  "phase": "$phase",
+  "active": $active,
+  "issue_number": 0,
+  "branch": "",
+  "pr_number": 0,
+  "next_action": "test",
+  "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")",
+  "session_id": "test-session"
+}
+STATE_EOF
+  echo "$dir"
+}
+
+# TC-090: gh issue create during phase=create_interview (active=true) → deny
+echo "TC-090: gh issue create + create_interview active → deny"
+tmpdir=$(make_cwd_with_state "create_interview" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x' --body 'y'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"create-lifecycle-direct-gh-issue"* ]]; then
+  pass "TC-090 gh issue create blocked during create_interview"
+else
+  fail "TC-090 expected deny (create-lifecycle-direct-gh-issue), got decision=$decision reason=$reason"
+fi
+rm -rf "$tmpdir"
+
+# TC-091: gh issue create during phase=create_post_interview (active=true) → deny
+echo "TC-091: gh issue create + create_post_interview active → deny"
+tmpdir=$(make_cwd_with_state "create_post_interview" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-091 blocked during create_post_interview"
+else
+  fail "TC-091 expected deny, got decision=$decision"
+fi
+rm -rf "$tmpdir"
+
+# TC-092: gh issue create during phase=create_delegation (active=true) → deny
+echo "TC-092: gh issue create + create_delegation active → deny"
+tmpdir=$(make_cwd_with_state "create_delegation" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-092 blocked during create_delegation"
+else
+  fail "TC-092 expected deny, got decision=$decision"
+fi
+rm -rf "$tmpdir"
+
+# TC-093: gh issue create with phase=create_completed → allow (lifecycle finished)
+echo "TC-093: gh issue create + create_completed → allow"
+tmpdir=$(make_cwd_with_state "create_completed" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-093 allowed after create_completed"
+else
+  fail "TC-093 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# TC-094: gh issue create with active=false → allow
+echo "TC-094: gh issue create + active=false → allow"
+tmpdir=$(make_cwd_with_state "create_interview" "false")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-094 allowed when active=false"
+else
+  fail "TC-094 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# TC-095: gh issue create with phase=phase2_branch (different workflow) → allow
+echo "TC-095: gh issue create + phase2_branch → allow (different workflow)"
+tmpdir=$(make_cwd_with_state "phase2_branch" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-095 allowed during non-create workflow"
+else
+  fail "TC-095 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# TC-096: gh issue create with no .rite-flow-state → allow
+echo "TC-096: gh issue create + no .rite-flow-state → allow"
+tmpdir=$(mktemp -d "/tmp/rite-test-475.XXXXXX")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-096 allowed without state file"
+else
+  fail "TC-096 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# TC-097: gh issue list (not create) during create_interview → allow
+echo "TC-097: gh issue list + create_interview → allow (not 'create')"
+tmpdir=$(make_cwd_with_state "create_interview" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue list --state open") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-097 gh issue list allowed"
+else
+  fail "TC-097 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# TC-098: gh issue view (not create) during create_interview → allow
+echo "TC-098: gh issue view + create_interview → allow (not 'create')"
+tmpdir=$(make_cwd_with_state "create_interview" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue view 123 --json body") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-098 gh issue view allowed"
+else
+  fail "TC-098 expected allow, got rc=$rc output=$output"
+fi
+rm -rf "$tmpdir"
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -260,6 +260,60 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-475-WARN-A: create_interview lifecycle unfinished → stderr warning (#475 AC-9)
+# --------------------------------------------------------------------------
+echo "TC-475-WARN-A: create_interview active → lifecycle warning in stderr"
+dir475wa="$TEST_DIR/tc475wa"
+mkdir -p "$dir475wa"
+create_state_file "$dir475wa" '{"active": true, "phase": "create_interview", "issue_number": 0, "branch": ""}'
+run_hook "$dir475wa" >/dev/null || true
+if [ -f "${LAST_STDERR_FILE:-}" ] && grep -q "lifecycle was not completed" "$LAST_STDERR_FILE"; then
+  pass "create_interview unfinished → warning emitted"
+else
+  fail "expected lifecycle warning in stderr, got: $(cat "${LAST_STDERR_FILE:-/dev/null}" 2>/dev/null)"
+fi
+echo ""
+
+# TC-475-WARN-B: create_post_interview also emits warning
+echo "TC-475-WARN-B: create_post_interview active → lifecycle warning"
+dir475wb="$TEST_DIR/tc475wb"
+mkdir -p "$dir475wb"
+create_state_file "$dir475wb" '{"active": true, "phase": "create_post_interview", "issue_number": 0, "branch": ""}'
+run_hook "$dir475wb" >/dev/null || true
+if grep -q "lifecycle was not completed" "${LAST_STDERR_FILE:-/dev/null}"; then
+  pass "create_post_interview unfinished → warning emitted"
+else
+  fail "expected lifecycle warning in stderr"
+fi
+echo ""
+
+# TC-475-WARN-C: create_completed → NO warning (lifecycle finished)
+echo "TC-475-WARN-C: create_completed → no warning"
+dir475wc="$TEST_DIR/tc475wc"
+mkdir -p "$dir475wc"
+create_state_file "$dir475wc" '{"active": true, "phase": "create_completed", "issue_number": 0, "branch": ""}'
+run_hook "$dir475wc" >/dev/null || true
+if grep -q "lifecycle was not completed" "${LAST_STDERR_FILE:-/dev/null}"; then
+  fail "unexpected warning for create_completed"
+else
+  pass "create_completed → no warning (lifecycle finished)"
+fi
+echo ""
+
+# TC-475-WARN-D: phase5_lint (different workflow) → NO warning
+echo "TC-475-WARN-D: phase5_lint → no warning (not create lifecycle)"
+dir475wd="$TEST_DIR/tc475wd"
+mkdir -p "$dir475wd"
+create_state_file "$dir475wd" '{"active": true, "phase": "phase5_lint", "issue_number": 475, "branch": ""}'
+run_hook "$dir475wd" >/dev/null || true
+if grep -q "lifecycle was not completed" "${LAST_STDERR_FILE:-/dev/null}"; then
+  fail "unexpected warning for non-create phase"
+else
+  pass "phase5_lint → no warning"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/stop-guard.test.sh
+++ b/plugins/rite/hooks/tests/stop-guard.test.sh
@@ -719,6 +719,84 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-475-A: create_post_interview phase (active=true, fresh) → exit 2 (block)
+# #475 AC-4: stop-guard must block stop when lifecycle is mid-delegation
+# --------------------------------------------------------------------------
+echo "TC-475-A: create_post_interview active → exit 2 (block)"
+dir475a="$GUARD_TEST_DIR/tc475a"
+mkdir -p "$dir475a"
+fresh_ts=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+create_state_file "$dir475a" "{\"active\": true, \"phase\": \"create_post_interview\", \"previous_phase\": \"create_interview\", \"next_action\": \"Proceed to Phase 0.6. Do NOT stop.\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 0, \"pr_number\": 0, \"error_count\": 0, \"session_id\": \"sid-475a\"}"
+stderr_file475a="$(mktemp "$GUARD_TEST_DIR/stderr475a.XXXXXX")"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir475a\", \"session_id\": \"sid-475a\"}"
+output=$(echo "$input" | bash "$GUARD" 2>"$stderr_file475a") && rc=0 || rc=$?
+if [ $rc -eq 2 ] && grep -q "create_post_interview" "$stderr_file475a"; then
+  pass "create_post_interview active → blocked with phase in stderr"
+else
+  fail "expected exit 2 with create_post_interview in stderr, got rc=$rc stderr='$(cat "$stderr_file475a")'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-475-B: create_interview → create_post_interview transition is whitelist-valid
+# --------------------------------------------------------------------------
+echo "TC-475-B: create_interview → create_post_interview whitelist-valid"
+dir475b="$GUARD_TEST_DIR/tc475b"
+mkdir -p "$dir475b"
+create_state_file "$dir475b" "{\"active\": true, \"phase\": \"create_post_interview\", \"previous_phase\": \"create_interview\", \"next_action\": \"continue\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 0, \"pr_number\": 0, \"error_count\": 0, \"session_id\": \"sid-475b\"}"
+stderr_file475b="$(mktemp "$GUARD_TEST_DIR/stderr475b.XXXXXX")"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir475b\", \"session_id\": \"sid-475b\"}"
+output=$(echo "$input" | bash "$GUARD" 2>"$stderr_file475b") && rc=0 || rc=$?
+if [ $rc -eq 2 ] && ! grep -q "Invalid phase transition" "$stderr_file475b"; then
+  pass "create_interview→create_post_interview accepted by whitelist (no invalid_transition)"
+else
+  fail "expected exit 2 without invalid_transition, got rc=$rc stderr='$(cat "$stderr_file475b")'"
+fi
+
+# TC-475-B2: invalid transition create_interview → create_delegation (bypassing post_interview)
+echo "TC-475-B2: invalid transition create_interview → create_delegation → blocked with invalid_transition"
+dir475b2="$GUARD_TEST_DIR/tc475b2"
+mkdir -p "$dir475b2"
+create_state_file "$dir475b2" "{\"active\": true, \"phase\": \"create_delegation\", \"previous_phase\": \"create_interview\", \"next_action\": \"skipped interview post-step\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 0, \"pr_number\": 0, \"error_count\": 0, \"session_id\": \"sid-475b2\"}"
+stderr_file475b2="$(mktemp "$GUARD_TEST_DIR/stderr475b2.XXXXXX")"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir475b2\", \"session_id\": \"sid-475b2\"}"
+output=$(echo "$input" | bash "$GUARD" 2>"$stderr_file475b2") && rc=0 || rc=$?
+if [ $rc -eq 2 ] && grep -q "Invalid phase transition" "$stderr_file475b2"; then
+  pass "invalid transition create_interview→create_delegation detected"
+else
+  fail "expected exit 2 with invalid_transition, got rc=$rc stderr='$(cat "$stderr_file475b2")'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-475-C: session_id mismatch → exit 0 (stop allowed, AC-5)
+# --------------------------------------------------------------------------
+echo "TC-475-C: session_id mismatch during create_post_interview → exit 0"
+dir475c="$GUARD_TEST_DIR/tc475c"
+mkdir -p "$dir475c"
+create_state_file "$dir475c" "{\"active\": true, \"phase\": \"create_post_interview\", \"next_action\": \"continue\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 0, \"pr_number\": 0, \"session_id\": \"sid-other\"}"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir475c\", \"session_id\": \"sid-mine\"}"
+output=$(run_guard "$input") && rc=0 || rc=$?
+if [ $rc -eq 0 ]; then
+  pass "session_id mismatch → stop allowed (AC-5)"
+else
+  fail "expected exit 0, got $rc"
+fi
+
+# --------------------------------------------------------------------------
+# TC-475-D: create_completed is terminal — no block
+# --------------------------------------------------------------------------
+echo "TC-475-D: create_completed + active=false → exit 0 (terminal)"
+dir475d="$GUARD_TEST_DIR/tc475d"
+mkdir -p "$dir475d"
+create_state_file "$dir475d" "{\"active\": false, \"phase\": \"create_completed\", \"next_action\": \"none\", \"updated_at\": \"$fresh_ts\", \"session_id\": \"sid-475d\"}"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir475d\", \"session_id\": \"sid-475d\"}"
+output=$(run_guard "$input") && rc=0 || rc=$?
+if [ $rc -eq 0 ]; then
+  pass "create_completed terminal allows stop"
+else
+  fail "expected exit 0, got $rc"
+fi
+
+# --------------------------------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ $FAIL -gt 0 ]; then


### PR DESCRIPTION
## Summary

`/rite:issue:create` の sub-skill 委譲プロトコルを LLM が無視する 2 つの失敗モードを恒久対策。

- **Mode A (復帰後停止)**: `create_*` phase を `phase-transition-whitelist.sh` に登録し、stop-guard の invalid-transition 検出を有効化
- **Mode B (委譲バイパス直打ち)**: `pre-tool-bash-guard.sh` に Pattern 5 を追加し、`.rite-flow-state.phase = create_*` かつ `active=true` かつ `phase != create_completed` のとき `gh issue create` を **hook レイヤで強制 block**

過去 5 回の修正（#76, #123, #205, #216, #444）が prompt engineering 層の対症療法に留まった反省を踏まえ、本 PR は **hook レイヤの enforcement を第一防衛線** とする設計に切り替えた。

Closes #475

## Changes

### Hook layer (Mode B enforcement + 診断性向上)

| File | 変更 |
|---|---|
| `plugins/rite/hooks/phase-transition-whitelist.sh` | `create_interview → create_post_interview → create_delegation → create_completed` を `_RITE_PHASE_TRANSITIONS` に登録。forward-compat による silent accept を防止 |
| `plugins/rite/hooks/pre-tool-bash-guard.sh` | Pattern 5 追加: `gh issue create` を検出し、`.rite-flow-state` の state root を `state-path-resolve.sh` で解決したうえで phase が `create_*` かつ active=true かつ create_completed でないとき `permissionDecision: deny` を返す。`gh issue list` / `view` / `edit` は許可 |
| `plugins/rite/hooks/session-end.sh` | lifecycle 未完了警告を追加: session 終了時に phase が `create_*` で `create_completed` 未到達なら stderr に警告を出力（non-blocking、情報提供のみ） |

### Prompt layer (defense-in-depth)

| File | 変更 |
|---|---|
| `plugins/rite/commands/issue/create.md` | Phase 0.4.2 **Skip Semantics (Critical — Mode B Defense)** を新設。「confirmation skip ≠ sub-skill 委譲 skip」を literal 明記し、MUST 実行項目を表で列挙。`## Delegation to Interview` 直前に **🚫 MUST NOT — Bypass prohibition** ブロックを追加（`gh issue create` 直打ち禁止、pre-tool-bash-guard による block を明記）。`🚨 Mandatory After Interview` / `Mandatory After Delegation` を簡潔化（`continue` 促進文言を追加せず整理のみ） |

### Tests (18 cases, 3 hook test files)

| Test file | 追加ケース | 検証内容 |
|---|---|---|
| `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` | TC-090〜098 (9 cases) | Pattern 5 の全分岐: 各 `create_*` phase での deny, `create_completed` / `active=false` / 別 workflow / state 不在 / `gh issue list\|view` での allow |
| `plugins/rite/hooks/tests/stop-guard.test.sh` | TC-475-A〜D (5 cases) | `create_post_interview` block、whitelist valid/invalid transition、session_id 不一致許可、`create_completed` terminal |
| `plugins/rite/hooks/tests/session-end.test.sh` | TC-475-WARN-A〜D (4 cases) | lifecycle 未完了警告の emit / completed での suppress / 別 workflow での suppress |

Whitelist transition は source 済みスクリプトで手動検証 6 ケース全 pass。

## Decision Log: 過去 5 修正の root cause 分析（AC-12）

### Mode A (sub-skill 復帰後の停止) — 過去修正の限界

| PR / Issue | アプローチ | 限界 |
|---|---|---|
| **#76** | 自然言語指示（"continue" / "Do NOT stop"）追加 | LLM の extended thinking / turn boundary 判定を抑止できず再発 |
| **#123** | Mandatory After ブロック新設 + CRITICAL 注意書き | 文言強化の延長、ファイル肥大化の副作用 |
| **#205** | degrade 再修正 | 別 PR で巻き戻された、テストによる lock が不在 |
| **#216** | stop-guard session_id 不一致 block 修正 | session_id 問題自体は解消。但し `phase` が whitelist 未登録だと invalid-transition 検出が働かない |
| **#444** | Terminal Completion + Defense-in-Depth + `[interview:completed]` pattern | flow-state の `create_*` phase が whitelist 未登録のまま、stop-guard が forward-compat で accept |

**共通 limitation**: prompt engineering 層の対策のみで、hook 層 enforcement と phase 遷移の機械検証が欠落。

### 本 PR の克服方針

| 層 | 変更 | 過去 limitation の克服 |
|---|---|---|
| Phase graph | whitelist に create_* を登録 | forward-compat silent accept を閉塞（#444 残課題） |
| Session end | lifecycle 未完了警告 | silent loss の可視化 |
| Pre-tool hook | `gh issue create` 直打ち `permissionDecision: deny` | **permission レイヤで強制**、prompt 依存を脱却 |
| Prompt (defense-in-depth) | Skip Semantics 明記 + MUST NOT ブロック | 禁止意図の明示（強制は hook 層） |

### Mode B (新規確認) の仮説と対策対応

| 仮説 | 対応 |
|---|---|
| H6: Phase 0.4 skip の escape clause 拡大解釈 | B1 Skip Semantics で literal 否定 |
| H8: `gh issue create` permission がオープン | **A2 pre-tool-bash-guard deny で完全閉塞** |
| H9: create.md の長大さで Delegation セクション埋没 | B2 Delegation 直前に MUST NOT ブロック配置 |

### MUST NOT 遵守

- ❌ "continue" 自然言語追加 → 追加せず、既存 Mandatory After を簡潔化のみ
- ❌ session_id 検証削除 → `check_session_ownership` 経路を保持
- ❌ `[interview:completed]` 最終行契約変更 → 維持
- ❌ Phase 0.4 confirmation skip 削除 → 維持（0.4.2 で意味を明確化）
- ❌ 他コマンド（start.md, lint.md, review.md）への副作用 → なし

## Verification

### 検証済み (単体テスト)

- ✅ `pre-tool-bash-guard.test.sh`: 116 passed / 0 failed (9 new TC-090〜098 含む)
- ✅ `stop-guard.test.sh` TC-475-A〜D: 5 passed（既存 9 failures は本 PR と無関係の pre-existing）
- ✅ session-end.sh manual verification: create_interview → warning / create_completed → no warning / phase5_lint → no warning
- ✅ phase-transition-whitelist 手動検証: 6 transition 全て期待通り
- ✅ bash syntax check: 修正 3 スクリプト全て OK

### 未実施 (意図的 defer)

- ⏸ DoD#7「実機 /rite:issue:create 3 回」: 本 PR が修正する対象を呼び出す dogfooding の再帰リスクがあるため、**PR merge 前の手動検証** に委ねる。hook 層の挙動は単体テストで完全カバー。prompt 層 (B1/B2) の実効性評価は merge 後別 Issue で継続

### 未完了 checklist (Issue 側)

- [ ] 全 AC (1〜12) 検証済み: AC-1/2/3/7 は Mode A/B 実機挙動依存のため単体検証で代替
- [ ] 全テストケース (T-01〜T-13) 通過: T-04/05/06/08/09/13 は本 PR で検証済 (18 cases)、T-01/02/03/07/10/11/12 は実機依存で defer
- [ ] 実機 3 回実行: 上記 defer 理由と同じ

## Test plan

- [ ] hook 層: `bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` が 116 passed で完走
- [ ] hook 層: `bash plugins/rite/hooks/tests/stop-guard.test.sh` の TC-475-A〜D が all pass
- [ ] リグレッション: 既存 `stop-guard.test.sh` の 9 pre-existing failure が本 PR の diff 由来でないことを `git stash` で確認済
- [ ] 実機: PR merge 前に `/rite:issue:create` を Mode A (M scope) / Mode A (L scope) / Mode B (明確 description) の 3 パターンで手動実行し、継続確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
