### PR TITLE
fix(wiki): trigger 直後の /rite:wiki:ingest 自動呼び出し欠落を修復し Wiki 成長経路を復活

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -446,10 +446,32 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --content-file "$tmpfile" \
   --issue-number {issue_number} \
   --title "Issue #{issue_number} close retrospective" \
-  2>/dev/null || true
+  2>/dev/null
+trigger_exit=$?
+echo "trigger_exit=$trigger_exit"
 ```
 
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are silenced by `|| true`. Ingest failure does not block the close workflow.
+**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.4.W.2 when it is non-zero. Ingest failure does not block the close workflow.
+
+### 4.4.W.2 Wiki Ingest Invocation (Conditional)
+
+After the trigger completes, invoke `/rite:wiki:ingest` via the Skill tool so that the Raw Source written by the trigger is committed and pushed to the `wiki` branch. Without this step, the Raw Source is abandoned in the working tree and the `wiki` branch never grows (Issue #515 root cause).
+
+**Condition**: Execute only when **all** of the following are true (read from prior Phase 4.4.W stdout):
+
+- `wiki_enabled=true`
+- `auto_ingest=true`
+- `trigger_exit=0` (the trigger ran successfully — non-zero means Wiki disabled/uninitialized, so there is nothing to ingest)
+
+**When the condition is not satisfied**, skip this section silently and proceed to Phase 4.5.
+
+**When the condition is satisfied**:
+
+1. Invoke the Skill tool: `skill: "rite:wiki:ingest"` with no arguments. The ingest command auto-scans `.rite/wiki/raw/` and performs stash/checkout/commit/push to the `wiki` branch via its existing Phase 5.1 Block B implementation.
+2. **Non-blocking**: Any error returned by the Skill invocation (push failure, authentication error, LLM error, etc.) is swallowed — continue to Phase 4.5 regardless. The Raw Source remains under `.rite/wiki/raw/{type}/` and will be picked up by the next successful ingest.
+3. Do **not** pass PR/Issue number as arguments. `rite:wiki:ingest` is self-contained and discovers raw sources independently.
+
+**Rationale**: `wiki-ingest-trigger.sh` is a pure file-writing utility (see its L40-44 doc comment) and does not perform git operations. Only `rite:wiki:ingest` has the stash/checkout/commit/push sequence that persists data to the `wiki` branch. This two-step pattern preserves the responsibility boundary (trigger writes, ingest commits) while restoring the Wiki growth path.
 
 Proceed to Phase 4.5.
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4585,10 +4585,34 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --content-file "$tmpfile" \
   --pr-number {pr_number} \
   --title "PR #{pr_number} fix results" \
-  2>/dev/null || true
+  2>/dev/null
+trigger_exit=$?
+echo "trigger_exit=$trigger_exit"
 ```
 
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are silenced by `|| true`. Ingest failure does not block the fix workflow.
+**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.6.W.2 when it is non-zero. Ingest failure does not block the fix workflow.
+
+### 4.6.W.2 Wiki Ingest Invocation (Conditional)
+
+After the trigger completes, invoke `/rite:wiki:ingest` via the Skill tool so that the Raw Source written by the trigger is committed and pushed to the `wiki` branch. Without this step, the Raw Source is abandoned in the working tree and the `wiki` branch never grows (Issue #515 root cause).
+
+**Condition**: Execute only when **all** of the following are true (read from prior Phase 4.6.W stdout):
+
+- `wiki_enabled=true`
+- `auto_ingest=true`
+- `trigger_exit=0` (the trigger ran successfully — non-zero means Wiki disabled/uninitialized, so there is nothing to ingest)
+
+**When the condition is not satisfied**, skip this section silently.
+
+**When the condition is satisfied**:
+
+1. Invoke the Skill tool: `skill: "rite:wiki:ingest"` with no arguments. The ingest command auto-scans `.rite/wiki/raw/` and performs stash/checkout/commit/push to the `wiki` branch via its existing Phase 5.1 Block B implementation.
+2. **Non-blocking**: Any error returned by the Skill invocation (push failure, authentication error, LLM error, etc.) is swallowed — continue regardless. The Raw Source remains under `.rite/wiki/raw/{type}/` and will be picked up by the next successful ingest.
+3. Do **not** pass PR/Issue number as arguments. `rite:wiki:ingest` is self-contained and discovers raw sources independently.
+
+**Position rationale**: Phase 4.6.W (and therefore 4.6.W.2) runs after the review-fix loop has exited. Raw Sources written mid-loop would reflect unsettled fix state, so the placement is intentional.
+
+**Responsibility boundary**: `wiki-ingest-trigger.sh` is a pure file-writing utility (see its L40-44 doc comment) and does not perform git operations. Only `rite:wiki:ingest` has the stash/checkout/commit/push sequence that persists data to the `wiki` branch.
 
 ---
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3875,10 +3875,34 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --content-file "$tmpfile" \
   --pr-number {pr_number} \
   --title "PR #{pr_number} review results" \
-  2>/dev/null || true
+  2>/dev/null
+trigger_exit=$?
+echo "trigger_exit=$trigger_exit"
 ```
 
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are silenced by `|| true`. Ingest failure does not block the review workflow.
+**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.
+
+### 6.5.W.2 Wiki Ingest Invocation (Conditional)
+
+After the trigger completes, invoke `/rite:wiki:ingest` via the Skill tool so that the Raw Source written by the trigger is committed and pushed to the `wiki` branch. Without this step, the Raw Source is abandoned in the working tree and the `wiki` branch never grows (Issue #515 root cause).
+
+**Condition**: Execute only when **all** of the following are true (read from prior Phase 6.5.W stdout):
+
+- `wiki_enabled=true`
+- `auto_ingest=true`
+- `trigger_exit=0` (the trigger ran successfully — non-zero means Wiki disabled/uninitialized, so there is nothing to ingest)
+
+**When the condition is not satisfied**, skip this section silently and proceed to Phase 6.5.1.
+
+**When the condition is satisfied**:
+
+1. Invoke the Skill tool: `skill: "rite:wiki:ingest"` with no arguments. The ingest command auto-scans `.rite/wiki/raw/` and performs stash/checkout/commit/push to the `wiki` branch via its existing Phase 5.1 Block B implementation.
+2. **Non-blocking**: Any error returned by the Skill invocation (push failure, authentication error, LLM error, etc.) is swallowed — continue to Phase 6.5.1 regardless. The Raw Source remains under `.rite/wiki/raw/{type}/` and will be picked up by the next successful ingest.
+3. Do **not** pass PR/Issue number as arguments. `rite:wiki:ingest` is self-contained and discovers raw sources independently.
+
+**Position rationale**: This block sits after the review-fix loop has exited (the caller `/rite:issue:start` only enters Phase 6.5.W on `[review:mergeable]` or standalone execution). Raw Sources written mid-loop would reflect unsettled review state, so the placement is intentional.
+
+**Responsibility boundary**: `wiki-ingest-trigger.sh` is a pure file-writing utility (see its L40-44 doc comment) and does not perform git operations. Only `rite:wiki:ingest` has the stash/checkout/commit/push sequence that persists data to the `wiki` branch.
 
 #### 6.5.1 Next Step Branching by Invocation Source
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3882,7 +3882,7 @@ echo "trigger_exit=$trigger_exit"
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.
 
-### 6.5.W.2 Wiki Ingest Invocation (Conditional)
+#### 6.5.W.2 Wiki Ingest Invocation (Conditional)
 
 After the trigger completes, invoke `/rite:wiki:ingest` via the Skill tool so that the Raw Source written by the trigger is committed and pushed to the `wiki` branch. Without this step, the Raw Source is abandoned in the working tree and the `wiki` branch never grows (Issue #515 root cause).
 


### PR DESCRIPTION
## 概要

`/rite:pr:review` / `/rite:pr:fix` / `/rite:issue:close` の末尾 Wiki Phase で `wiki-ingest-trigger.sh` を呼んだ直後に `/rite:wiki:ingest` を Skill ツール経由で呼び出す経路を追加し、Wiki 成長経路を復活させた。

## 背景（Root Cause）

- `wiki-ingest-trigger.sh` は pure file-writing utility で git 操作を一切しない（doc コメント L40-44 で明記）
- trigger は Raw Source を `.rite/wiki/raw/{type}/` に書き出すだけ
- `wiki` ブランチへの commit & push は `/rite:wiki:ingest` Phase 5.1 Block B の責務
- しかし 3 コマンドは trigger 呼び出し直後に `/rite:wiki:ingest` を呼ばずに次 Phase に抜けていた
- 結果: Raw Source は develop ブランチ作業ツリーに放置され、`wiki` ブランチは初期化コミット `f17eba3` 1 件のまま成長しなかった

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/issue/close.md` | L443 block を `trigger_exit` capture に書き換え + 新 Phase 4.4.W.2（Skill 経由 `rite:wiki:ingest` 呼び出し） |
| `plugins/rite/commands/pr/review.md` | 同パターン + 新 Phase 6.5.W.2 |
| `plugins/rite/commands/pr/fix.md` | 同パターン + 新 Phase 4.6.W.2 |

### 新 Phase の条件式

`wiki_enabled=true` AND `auto_ingest=true` AND `trigger_exit=0` の全てを満たす場合のみ `rite:wiki:ingest` を呼び出す。trigger exit 2（Wiki 無効/未初期化）では呼ばない。Skill 呼び出しエラーは非ブロッキング（Raw Source は次回リカバリ用に保持）。

## Non-Target（責務境界保持）

- `plugins/rite/hooks/wiki-ingest-trigger.sh` — pure file-writing utility の責務を維持
- `plugins/rite/commands/wiki/ingest.md` — 既存 L657-671 の stash/checkout/commit/push 実装を再利用
- `plugins/rite/hooks/hooks.json` — wiki event hook 追加しない
- `rite-config.yml` — 現行設定のまま動作するのが正しい状態

## Acceptance Criteria

- [x] AC-1: close.md の Phase 4.4.W.2 で `rite:wiki:ingest` が条件付き呼び出される
- [x] AC-2: review.md の Phase 6.5.W.2 で同上
- [x] AC-3: fix.md の Phase 4.6.W.2 で同上
- [x] AC-4: 非ブロッキング化（`trigger_exit` capture、Skill 失敗は呑み込み）
- [x] AC-5: `auto_ingest: false` 時は silent skip（既存判定の再利用）
- [ ] AC-6: 遡及 ingest — PR マージ後の bootstrap 経路で自然収束（Decision D-04、スコープ外）
- [x] AC-7: 保存則は ingest.md 側で担保済み（未変更）

## 自己参照 bootstrap

本リポジトリは rite workflow 自体を rite workflow で開発している。本 PR のレビュー時に初めて `/rite:pr:review` 経由の Wiki 自動成長が実際に動き出す（chicken-and-egg ではなく自然収束の bootstrap 経路）。

## Known Issues（本 PR 起因ではない）

- `distributed-fix-drift-check` が既存 12 件の warning（P2/P3/P5）を検出。これは develop ブランチに既に存在する drift で、本 PR では新規 drift は追加していない（origin/develop で同じ 12 件を確認済み）。

Closes #515
