### PR TITLE
fix(workflow): 親子 Issue ステータス同期の silent skip を解消（AC-1/AC-2 充足）

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -602,44 +602,94 @@ Proceed to Phase 4.6.
 
 **Three-level nesting guard (AC / MUST NOT)**: This phase processes only the direct parent. It does NOT recurse into the parent's parent (grandparent). Three-level nesting is explicitly out of scope (see Issue #513 Section 2 Out of Scope).
 
-### 4.6.0 Idempotency Check (AC-6)
+### 4.6.0 Idempotency Check (parent-already-closed no-op)
 
 Before enumerating children, check whether the parent Issue is already closed. If so, this is a no-op invocation (the parent was previously closed — manually, by a prior auto-close run, or externally) and we must not re-prompt the user.
 
+> **Note on AC-6**: Issue #513's AC-6 as written addresses the **start** side ("parent already In Progress → no-op"). This Phase 4.6.0 applies the **same idempotency principle** to the close side (parent already CLOSED → no-op). AC-6 is not literally covering the close-side case, so we avoid citing AC-6 directly and instead describe this as "close-side idempotency, extending the AC-6 principle to the symmetric close path."
+
+Design principle (Issue #517 cycle 2 review fix): this bash block follows the same silent-failure avoidance pattern as Phase 4.6.1 — stderr is captured to a tempfile and surfaced on failure, explicit sentinels (`[CONTEXT] P460_DECISION=...`) drive LLM routing, and the retrieval-failure branch is implemented in bash (not prose only).
+
 ```bash
-parent_state=$(gh issue view {parent_number} --json state --jq '.state')
-echo "parent_state=$parent_state"
-if [ "$parent_state" = "CLOSED" ]; then
-  echo "[DEBUG] parent #{parent_number} already closed — skipping Phase 4.6 (AC-6 idempotent no-op)"
+# ============================================================================
+# Phase 4.6.0: Idempotency check (parent already closed → no-op)
+# ============================================================================
+set -uo pipefail  # strict mode (fail on undefined vars + preserve pipeline failure code)
+
+parent_number="{parent_number}"
+
+parent_state=""
+p460_err=""
+_rite_close_p460_cleanup() {
+  rm -f "${p460_err:-}"
+}
+trap 'rc=$?; _rite_close_p460_cleanup; exit $rc' EXIT
+trap '_rite_close_p460_cleanup; exit 130' INT
+trap '_rite_close_p460_cleanup; exit 143' TERM
+trap '_rite_close_p460_cleanup; exit 129' HUP
+
+# Capture stderr to tempfile (not /dev/null) so auth / network failures surface.
+# `mktemp` with no arguments respects $TMPDIR (honoring macOS /var/folders, CI overrides, etc.)
+if ! p460_err=$(mktemp 2>/dev/null); then
+  echo "[DEBUG] p460: mktemp failed — stderr from gh issue view will not be captured" >&2
+  p460_err=""
+fi
+
+if parent_state=$(gh issue view "$parent_number" --json state --jq '.state' 2>"${p460_err:-/dev/null}"); then
+  echo "parent_state=$parent_state"
+else
+  p460_rc=$?
+  parent_state=""
+  echo "[DEBUG] p460: gh issue view failed (rc=$p460_rc)" >&2
+  if [ -n "$p460_err" ] && [ -s "$p460_err" ]; then
+    head -3 "$p460_err" | sed 's/^/  p460 stderr: /' >&2
+  fi
+fi
+
+if [ -n "$p460_err" ]; then
+  rm -f "$p460_err"
+  p460_err=""
+fi
+
+# Emit branch decision sentinel (machine-readable) for LLM routing.
+if [ -z "$parent_state" ]; then
+  echo "警告: 親 Issue #${parent_number} の state 取得に失敗しました。親の自動クローズ判定をスキップします。" >&2
+  echo "[CONTEXT] P460_DECISION=skip_retrieval_failed"
+elif [ "$parent_state" = "CLOSED" ]; then
+  echo "[DEBUG] parent #${parent_number} already closed — skipping Phase 4.6 (close-side idempotency, extends AC-6 principle)"
+  echo "[CONTEXT] P460_DECISION=skip_already_closed"
+else
+  echo "[CONTEXT] P460_DECISION=proceed_to_enumeration"
 fi
 ```
 
-**When `parent_state == "CLOSED"`**: Skip the rest of Phase 4.6 (4.6.1–4.6.5) and proceed to Phase 5. This satisfies AC-6 (idempotency: re-running close on a child whose parent is already closed is a safe no-op).
+**LLM routing rule** (Claude reads the `[CONTEXT] P460_DECISION=` sentinel from the bash block's stdout):
 
-**When retrieval fails** (`parent_state` empty): Display warning and skip Phase 4.6 (non-blocking):
-
-```
-警告: 親 Issue #{parent_number} の state 取得に失敗しました。親の自動クローズ判定をスキップします。
-```
-
-Proceed to Phase 5.
-
-**When `parent_state != "CLOSED"`**: Proceed to 4.6.1.
+| `P460_DECISION` value | Next action |
+|----------------------|-------------|
+| `skip_retrieval_failed` | Warning already emitted to stderr. Skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5 (non-blocking). |
+| `skip_already_closed` | Parent is already closed — skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5. This is the close-side idempotency no-op. |
+| `proceed_to_enumeration` | Parent is open → proceed to 4.6.1. |
 
 ### 4.6.1 Enumerate Parent's Child Issues and Determine all_closed
 
 Retrieve the parent's child Issues via **two methods (OR combination, Method A → Method B fallback)**, then determine whether every child is closed. All of this is done in a **single Bash tool invocation** to avoid shell state loss between calls.
 
-**Design notes** (Issue #517 review fixes):
+**Design notes** (Issue #517 review fixes — cycles 1 + 2):
 
-- **Method A stderr is NOT suppressed**: Previous `2>/dev/null` silently downgraded auth / network / permission errors to "empty result", which is exactly the silent-skip anti-pattern Issue #513 aims to eliminate. Instead, stderr is captured to a tempfile and surfaced in debug logs when Method A fails.
-- **Method A → Method B fallback is explicit bash conditional**: Previous version relied on prose instructions and would silently overwrite Method A's result when Method B ran unconditionally. The unified bash block below branches on `jq length` of Method A's result.
-- **Method B uses a per-child loop, not an LLM-generated alias query**: Previous `{alias_query_generated_by_llm}` placeholder had no concrete example and risked unexecutable GraphQL. The deterministic per-child `gh issue view --json state` loop is simpler, fully auditable, and costs O(N) API calls for small N (parents rarely have >20 children in practice).
+- **Method A uses the `trackedIssues` field (Tasklists API), NOT the Sub-Issues API**: `trackedIssues` resolves the parent→children relationship via GitHub's Tasklists feature (which parses the body `- [ ] #N` section) — this is intentional because the repo uses `/rite:issue:create-decompose` to write body tasklists. The newer GitHub Sub-Issues API uses a separate `subIssues` field and requires the `GraphQL-Features: sub_issues` header. This block does not call `subIssues` — the header is omitted to avoid misleading the reader. See `epic-detection.md` for the `trackedIssues` vs `subIssues` distinction.
+- **Method A stderr is captured, not suppressed**: Previous `2>/dev/null` silently downgraded auth / network / permission errors to "empty result", which is the silent-skip anti-pattern Issue #513 aims to eliminate. Instead, stderr is captured to a tempfile and surfaced in debug logs on failure.
+- **Method A → Method B fallback is an explicit bash conditional**: branches on `jq length` of Method A's result rather than relying on prose.
+- **Method B uses a per-child loop, not an LLM-generated alias query**: deterministic, fully auditable, O(N) API calls for small N.
+- **`set -uo pipefail` is enabled at the block top**: strict mode (fail on undefined vars + propagate pipeline failures) adds a defense layer against silent failures introduced by future edits. `-e` is omitted to allow explicit `|| fallback` paths without unintended aborts.
+- **`mktemp` respects `$TMPDIR`**: using bare `mktemp` (no hardcoded `/tmp` path) honors macOS `/var/folders`, CI `$TMPDIR` overrides, and read-only-/tmp environments.
 
 ```bash
 # ============================================================================
 # Phase 4.6.1: Enumerate children + determine all_closed (single bash block)
 # ============================================================================
+set -uo pipefail
+
 parent_number="{parent_number}"
 owner="{owner}"
 repo="{repo}"
@@ -654,11 +704,17 @@ trap '_rite_close_p461_cleanup; exit 130' INT
 trap '_rite_close_p461_cleanup; exit 143' TERM
 trap '_rite_close_p461_cleanup; exit 129' HUP
 
-# --- Method A: Sub-Issues API (preferred) ---
+# --- Method A: Tasklists (trackedIssues) — parent→children via body tasklist ---
 # stderr is captured to tempfile (NOT suppressed) so auth / network / GraphQL errors surface.
-method_a_err=$(mktemp /tmp/rite-close-p461-method-a-err-XXXXXX) || method_a_err=""
+# Note: trackedIssues is the Tasklists feature (the body `- [ ] #N` parser); the `GraphQL-Features: sub_issues`
+# header is NOT used here because it targets the separate `subIssues` field. See epic-detection.md.
+if ! method_a_err=$(mktemp 2>/dev/null); then
+  echo "[DEBUG] p461: mktemp failed for method_a_err — method_a stderr will not be captured" >&2
+  method_a_err=""
+fi
+
 method_a_rc=0
-if method_a_raw=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
+if method_a_raw=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     issue(number: $number) {
@@ -672,29 +728,34 @@ query($owner: String!, $repo: String!, $number: Int!) {
   2>"${method_a_err:-/dev/null}"); then
   children_json="$method_a_raw"
   method_a_count=$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)
-  echo "[DEBUG] method_a succeeded: ${method_a_count} children via Sub-Issues API"
+  echo "[DEBUG] method_a succeeded: ${method_a_count} children via trackedIssues (Tasklists API)"
 else
   method_a_rc=$?
-  echo "[DEBUG] method_a failed (rc=$method_a_rc) — likely sub_issues feature not available, will try Method B"
+  echo "[DEBUG] method_a failed (rc=$method_a_rc) — Tasklists API unavailable, will try Method B"
   if [ -n "$method_a_err" ] && [ -s "$method_a_err" ]; then
     head -3 "$method_a_err" | sed 's/^/  method_a stderr: /' >&2
   fi
   children_json=""
 fi
-[ -n "$method_a_err" ] && rm -f "$method_a_err"
+if [ -n "$method_a_err" ]; then
+  rm -f "$method_a_err"
+  method_a_err=""
+fi
 
-# --- Method B: Parent body Sub-Issues tasklist (fallback) ---
-# Explicit bash conditional: only run Method B when Method A yielded empty or failed.
+# --- Method B: Parent body `## Sub-Issues` section parse (fallback) ---
+# Note: "Sub-Issues" here is the literal heading text that /rite:issue:create-decompose writes
+# into parent bodies. It is not the GitHub Sub-Issues feature. Method B only parses body markdown.
 method_a_length=$(printf '%s' "${children_json:-[]}" | jq 'length' 2>/dev/null || echo 0)
 if [ -z "$children_json" ] || [ "$method_a_length" -eq 0 ]; then
-  echo "[DEBUG] falling back to Method B (parent body tasklist parse)"
+  echo "[DEBUG] falling back to Method B (parent body '## Sub-Issues' section parse)"
   parent_body=$(gh issue view "$parent_number" --json body --jq '.body' 2>/dev/null || echo "")
   if [ -z "$parent_body" ]; then
     echo "[DEBUG] method_b: failed to fetch parent body"
     children_json="[]"
   else
-    # Extract child numbers from `- [ ] #N` / `- [x] #N` lines under `## Sub-Issues` section
-    child_numbers=$(awk '/^## Sub-Issues/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
+    # Extract child numbers from `- [ ] #N` / `- [x] #N` lines under a `## Sub-Issues` (exact) heading.
+    # The `/^## Sub-Issues$/` anchor prevents false matches against headings like `## Sub-Issues-Extended`.
+    child_numbers=$(awk '/^## Sub-Issues$/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
     echo "[DEBUG] method_b child_numbers=${child_numbers:-none}"
 
     if [ -z "$child_numbers" ]; then
@@ -707,7 +768,7 @@ if [ -z "$children_json" ] || [ "$method_a_length" -eq 0 ]; then
       for n in $child_numbers; do
         child_state=$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "")
         if [ -z "$child_state" ]; then
-          echo "[DEBUG] method_b: failed to fetch state for #$n (will treat as OPEN to block auto-close)" >&2
+          echo "[DEBUG] method_b: failed to fetch state for #$n (treating as OPEN to block auto-close — fail-closed)" >&2
           child_state="OPEN"
         fi
         if [ "$first" -eq 1 ]; then
@@ -730,8 +791,14 @@ if [ "$final_length" -eq 0 ]; then
   open_count="0"
   echo "[DEBUG] children_json is empty after both methods — cannot determine all_closed (skipping auto-close)"
 else
-  all_closed=$(printf '%s' "$children_json" | jq -r 'all(.[]; .state == "CLOSED") | tostring' 2>/dev/null || echo "false")
-  open_count=$(printf '%s' "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length' 2>/dev/null || echo "0")
+  if ! all_closed=$(printf '%s' "$children_json" | jq -r 'all(.[]; .state == "CLOSED") | tostring' 2>/dev/null); then
+    echo "[DEBUG] jq all_closed evaluation failed — treating as false (fail-closed)" >&2
+    all_closed="false"
+  fi
+  if ! open_count=$(printf '%s' "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length' 2>/dev/null); then
+    echo "[DEBUG] jq open_count evaluation failed — defaulting to 0" >&2
+    open_count="0"
+  fi
 fi
 echo "all_closed=$all_closed open_count=$open_count children_total=$final_length"
 
@@ -776,10 +843,20 @@ Skip the Status update if `github.projects.enabled: false` in `rite-config.yml`;
 
 All 4 steps run in a **single bash block** to preserve intermediate state and to guarantee the final state-inconsistency summary (Step 5) is always emitted.
 
+**Design notes** (Issue #517 review fixes — cycles 1 + 2):
+
+- **All `gh` calls capture stderr to a tempfile (not `2>/dev/null`)**: every `gh api graphql` / `gh project field-list` / `gh project item-edit` / `gh issue close` failure surfaces its first 5 stderr lines via `head -5 | sed` so the user can diagnose auth / network / permission / rate-limit / field-id mismatch root causes. This is the same pattern Phase 4.6.1 Method A uses and the pattern Phase 4.6.0 was extended to match.
+- **`set -uo pipefail`** enables strict mode against undefined variables and pipeline failure propagation. `-e` is omitted so explicit `|| fallback` handling remains intentional.
+- **`mktemp` respects `$TMPDIR`** (no `/tmp` hardcode).
+- **State inconsistency summary emits targeted recovery commands per case**: `success:field_lookup_failed` prints a `gh project field-list ...` diagnostic command (not a broken `--field-id ''` one-liner), `success:update_failed` prints the executable recovery one-liner with the actually-populated IDs, and `failed:projects_disabled` / `failed:not_registered` are classified as "Issue close failed, Status update not applicable" instead of being lumped into the catch-all "両方失敗" bucket.
+- **Placeholder source assumption**: `{projects_enabled}`, `{project_number}`, `{owner}` are substituted by the LLM from `rite-config.yml` before executing this block. `{parent_number}` and `{issue_number}` are substituted from Phase 4.5.1 and Phase 0 respectively. If any placeholder is missing, the LLM must read `rite-config.yml` before substituting.
+
 ```bash
 # ============================================================================
 # Phase 4.6.3: Parent Projects Status → Done + Issue close (unified block)
 # ============================================================================
+set -uo pipefail
+
 parent_number="{parent_number}"
 owner="{owner}"
 repo="{repo}"
@@ -794,9 +871,35 @@ parent_project_id=""
 status_field_id=""
 done_option_id=""
 
+# --- stderr capture tempfiles (one per gh call) ---
+p463_err_s1=""
+p463_err_s2=""
+p463_err_s3=""
+p463_err_s4=""
+_rite_close_p463_cleanup() {
+  rm -f "${p463_err_s1:-}" "${p463_err_s2:-}" "${p463_err_s3:-}" "${p463_err_s4:-}"
+}
+trap 'rc=$?; _rite_close_p463_cleanup; exit $rc' EXIT
+trap '_rite_close_p463_cleanup; exit 130' INT
+trap '_rite_close_p463_cleanup; exit 143' TERM
+trap '_rite_close_p463_cleanup; exit 129' HUP
+
+_mktemp_or_warn() {
+  local var_name="$1"
+  local label="$2"
+  local tmp
+  if tmp=$(mktemp 2>/dev/null); then
+    printf '%s' "$tmp"
+  else
+    echo "[DEBUG] p463 ${label}: mktemp failed — stderr from gh call will not be captured" >&2
+    printf ''
+  fi
+}
+
 # --- Step 1: Retrieve parent's project item ID and project GraphQL id ---
 if [ "$projects_enabled" = "true" ]; then
-  project_items_json=$(gh api graphql -f query='
+  p463_err_s1=$(_mktemp_or_warn "p463_err_s1" "Step 1")
+  if project_items_json=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     issue(number: $number) {
@@ -805,27 +908,47 @@ query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" 2>/dev/null) || project_items_json=""
+}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" 2>"${p463_err_s1:-/dev/null}"); then
+    :
+  else
+    p463_s1_rc=$?
+    echo "[DEBUG] p463 Step 1: gh api graphql failed (rc=$p463_s1_rc)" >&2
+    if [ -n "$p463_err_s1" ] && [ -s "$p463_err_s1" ]; then
+      head -5 "$p463_err_s1" | sed 's/^/  p463 Step 1 stderr: /' >&2
+    fi
+    project_items_json=""
+  fi
 
   if [ -n "$project_items_json" ]; then
     # Extract the node whose project.number matches {project_number}
     parent_item_id=$(printf '%s' "$project_items_json" \
-      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .id' 2>/dev/null)
+      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .id' 2>/dev/null || echo "")
     parent_project_id=$(printf '%s' "$project_items_json" \
-      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .project.id' 2>/dev/null)
+      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .project.id' 2>/dev/null || echo "")
   fi
 
   if [ -z "$parent_item_id" ] || [ -z "$parent_project_id" ]; then
-    echo "警告: 親 Issue #${parent_number} は Project #${project_number} に登録されていません。Status 更新をスキップします。" >&2
+    echo "警告: 親 Issue #${parent_number} は Project #${project_number} に登録されていません (または GraphQL 取得失敗)。Status 更新をスキップします。" >&2
     status_update_result="not_registered"
   else
-    # --- Step 2: Retrieve Status field id and "Done" option id via --jq ---
-    field_list_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null) || field_list_json=""
+    # --- Step 2: Retrieve Status field id and "Done" option id ---
+    p463_err_s2=$(_mktemp_or_warn "p463_err_s2" "Step 2")
+    if field_list_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>"${p463_err_s2:-/dev/null}"); then
+      :
+    else
+      p463_s2_rc=$?
+      echo "[DEBUG] p463 Step 2: gh project field-list failed (rc=$p463_s2_rc)" >&2
+      if [ -n "$p463_err_s2" ] && [ -s "$p463_err_s2" ]; then
+        head -5 "$p463_err_s2" | sed 's/^/  p463 Step 2 stderr: /' >&2
+      fi
+      field_list_json=""
+    fi
+
     if [ -n "$field_list_json" ]; then
       status_field_id=$(printf '%s' "$field_list_json" \
-        | jq -r '.fields[] | select(.name == "Status") | .id' 2>/dev/null)
+        | jq -r '.fields[] | select(.name == "Status") | .id' 2>/dev/null || echo "")
       done_option_id=$(printf '%s' "$field_list_json" \
-        | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id' 2>/dev/null)
+        | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id' 2>/dev/null || echo "")
     fi
 
     if [ -z "$status_field_id" ] || [ -z "$done_option_id" ]; then
@@ -833,12 +956,17 @@ query($owner: String!, $repo: String!, $number: Int!) {
       status_update_result="field_lookup_failed"
     else
       # --- Step 3: Update the Status ---
-      if gh project item-edit --project-id "$parent_project_id" --id "$parent_item_id" --field-id "$status_field_id" --single-select-option-id "$done_option_id" >/dev/null 2>&1; then
+      p463_err_s3=$(_mktemp_or_warn "p463_err_s3" "Step 3")
+      if gh project item-edit --project-id "$parent_project_id" --id "$parent_item_id" --field-id "$status_field_id" --single-select-option-id "$done_option_id" >/dev/null 2>"${p463_err_s3:-/dev/null}"; then
         status_update_result="success"
         echo "親 Issue #${parent_number} の Status を 'Done' に更新しました"
       else
+        p463_s3_rc=$?
         status_update_result="update_failed"
-        echo "警告: 親 Issue #${parent_number} の Status 更新に失敗しました。後続の gh issue close は続行します。" >&2
+        echo "警告: 親 Issue #${parent_number} の Status 更新に失敗しました (rc=$p463_s3_rc)。後続の gh issue close は続行します。" >&2
+        if [ -n "$p463_err_s3" ] && [ -s "$p463_err_s3" ]; then
+          head -5 "$p463_err_s3" | sed 's/^/  p463 Step 3 stderr: /' >&2
+        fi
       fi
     fi
   fi
@@ -847,17 +975,22 @@ else
 fi
 
 # --- Step 4: Close the parent Issue ---
-if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため、自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>&1; then
+p463_err_s4=$(_mktemp_or_warn "p463_err_s4" "Step 4")
+if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため、自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>"${p463_err_s4:-/dev/null}"; then
   issue_close_result="success"
   echo "親 Issue #${parent_number} を自動クローズしました"
 else
+  p463_s4_rc=$?
   issue_close_result="failed"
-  echo "警告: 親 Issue #${parent_number} のクローズに失敗しました。手動でクローズしてください: gh issue close ${parent_number}" >&2
+  echo "警告: 親 Issue #${parent_number} のクローズに失敗しました (rc=$p463_s4_rc)。手動でクローズしてください: gh issue close ${parent_number}" >&2
+  if [ -n "$p463_err_s4" ] && [ -s "$p463_err_s4" ]; then
+    head -5 "$p463_err_s4" | sed 's/^/  p463 Step 4 stderr: /' >&2
+  fi
 fi
 
-# --- Step 5: State inconsistency summary (MUST always emit — Issue #517 review fix) ---
-# Parent Issue と Projects Status が別エンティティのため、片方成功 / 片方失敗の state 不整合を
-# 必ずユーザーに可視化する (silent data corruption 防止)。
+# --- Step 5: State inconsistency summary (MUST always emit — silent data corruption prevention) ---
+# Parent Issue と Projects Status が別エンティティのため、片方成功 / 片方失敗の不整合を
+# 必ずユーザーに可視化する。case 分類は 4 象限 + not_applicable の 5 クラスに細分化している。
 echo ""
 echo "=== 親 Issue #${parent_number} 処理結果 ==="
 echo "  Issue close:   $issue_close_result"
@@ -867,10 +1000,17 @@ case "${issue_close_result}:${status_update_result}" in
   "success:success"|"success:projects_disabled"|"success:not_registered")
     echo "  状態: 整合性 OK"
     ;;
-  "success:update_failed"|"success:field_lookup_failed")
+  "success:update_failed")
     echo ""
     echo "⚠️  state 不整合: 親 Issue は CLOSED ですが Projects Status が Done に更新されていません。"
     echo "    復旧コマンド: gh project item-edit --project-id '$parent_project_id' --id '$parent_item_id' --field-id '$status_field_id' --single-select-option-id '$done_option_id'"
+    echo "    またはブラウザで https://github.com/${owner}/${repo}/issues/${parent_number} の Projects サイドバーから手動更新" >&2
+    ;;
+  "success:field_lookup_failed")
+    echo ""
+    echo "⚠️  state 不整合: 親 Issue は CLOSED ですが Project の Status フィールド / 'Done' オプション ID の解決に失敗したため Status は未更新です。"
+    echo "    診断コマンド: gh project field-list ${project_number} --owner ${owner} --format json"
+    echo "    (出力から 'Status' field の id と 'Done' option の id を確認し、gh project item-edit に渡してください)"
     echo "    またはブラウザで https://github.com/${owner}/${repo}/issues/${parent_number} の Projects サイドバーから手動更新" >&2
     ;;
   "failed:success")
@@ -878,9 +1018,13 @@ case "${issue_close_result}:${status_update_result}" in
     echo "⚠️  state 不整合: Projects Status は Done ですが親 Issue が OPEN のままです。"
     echo "    復旧コマンド: gh issue close ${parent_number}" >&2
     ;;
+  "failed:projects_disabled"|"failed:not_registered")
+    echo ""
+    echo "⚠️  親 Issue のクローズに失敗しました (Status 更新は対象外)。手動でクローズしてください: gh issue close ${parent_number}" >&2
+    ;;
   "failed:"*)
     echo ""
-    echo "⚠️  親 Issue の処理が失敗しました (Issue close / Status update 両方)。手動での対応が必要です: gh issue close ${parent_number}" >&2
+    echo "⚠️  親 Issue の処理が両方失敗しました (Issue close / Status update)。手動対応が必要です: gh issue close ${parent_number}" >&2
     ;;
 esac
 ```

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -483,9 +483,11 @@ When a child Issue is closed, automatically update the parent Issue's body to re
 
 ### 4.5.1 Detect Parent Issue
 
-Extract the parent Issue number from the closing Issue's body. The `## 親 Issue` section is added by `/rite:issue:create-decompose` when creating child Issues.
+Detect the parent Issue via **three methods tried in order (OR combination)**. This mirrors the 3-method detection in [`projects-integration.md` 2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) — the two sites MUST stay consistent to prevent silent-skip regressions (see Issue #513 / past incidents #115, #381, #15).
 
-**Detection pattern**: Search the Issue body for the `## 親 Issue` section header, then extract the Issue number from the line below it:
+**Method 1: `## 親 Issue` body meta (PRIMARY)**
+
+Read the closing Issue body and search for the `## 親 Issue` section written by `/rite:issue:create-decompose`.
 
 ```
 ## 親 Issue
@@ -493,23 +495,58 @@ Extract the parent Issue number from the closing Issue's body. The `## 親 Issue
 #{parent_number} - {parent_title}
 ```
 
-**Extraction**: Retrieve the Issue body and extract the parent Issue number in a single bash block:
-
 ```bash
 issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-# SIGPIPE 防止 (#398): issue_body が大きい場合、echo | grep | head -1 で
-# head の早期終了により echo に SIGPIPE が届く。here-string で subprocess を排除。
+# SIGPIPE 防止 (#398): here-string で subprocess を排除
 parent_number=$(grep -A2 '^## 親 Issue' <<< "$issue_body" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
-echo "parent_number=${parent_number:-none}"
+echo "method1_parent=${parent_number:-none}"
 ```
 
-**When no parent Issue is found** (`parent_number` is empty):
+If `parent_number` is non-empty, proceed to 4.5.2.
+
+**Method 2: Sub-Issues API (secondary)**
+
+If Method 1 returned empty, query GitHub's native Sub-Issues feature:
+
+```bash
+parent_number=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      parent { number }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F number={issue_number} \
+  --jq '.data.repository.issue.parent.number // empty')
+echo "method2_parent=${parent_number:-none}"
+```
+
+If non-empty, proceed to 4.5.2.
+
+**Method 3: Tasklist search (last resort)**
+
+If both methods failed:
+
+```bash
+parent_number=$(gh issue list --state all --search "in:body \"- [ ] #{issue_number}\" OR \"- [x] #{issue_number}\"" --json number --limit 1 --jq '.[0].number // empty')
+echo "method3_parent=${parent_number:-none}"
+```
+
+GitHub code search with `[`/`]` is unreliable, which is why this is the last resort. `--state all` (not `--state open`) because the closing Issue's parent may already be closed if someone closed it manually.
+
+**When all three methods failed (`parent_number` empty)**:
+
+```bash
+echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"
+```
+
+Display:
 
 ```
 親 Issue の参照が見つかりませんでした。親 Issue 更新をスキップします。
 ```
 
-Skip the rest of Phase 4.5 and proceed to Phase 5. This is normal behavior (AC-3), not an error.
+Skip the rest of Phase 4.5 and Phase 4.6 and proceed to Phase 5. This is normal behavior (AC-4), not an error — but the debug log above makes the skip visible so silent-skip regressions are detectable.
 
 ### 4.5.2 Update Parent Issue Body
 
@@ -551,7 +588,177 @@ bash {plugin_root}/hooks/issue-body-safe-update.sh apply \
 
 If the script exits with 0, the update succeeded (or was skipped by `--diff-check` if no changes were needed). If non-zero, display a warning and proceed to Phase 5.
 
-**On failure**: Display warning and proceed to Phase 5 (non-blocking, AC-4). The `--parent` flag is passed for future differentiation but currently all errors are treated as warnings by the script. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
+**On failure**: Display warning and proceed to Phase 4.6 (non-blocking, AC-4). The `--parent` flag is passed for future differentiation but currently all errors are treated as warnings by the script. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
+
+Proceed to Phase 4.6.
+
+---
+
+## Phase 4.6: Parent Auto-Close (All Children Completed)
+
+> **Issue #513 AC-2**: When all child Issues of the detected parent are now closed (including the just-closed one), offer to auto-close the parent. This closes the "child close → parent stays Open" silent-skip hole.
+
+**Execution condition**: Only execute when `{parent_number}` was detected in Phase 4.5.1 (any of the three methods succeeded). If no parent was detected, skip Phase 4.6 entirely and proceed to Phase 5.
+
+**Three-level nesting guard (AC / MUST NOT)**: This phase processes only the direct parent. It does NOT recurse into the parent's parent (grandparent). Three-level nesting is explicitly out of scope (see Issue #513 Section 2 Out of Scope).
+
+### 4.6.1 Enumerate Parent's Child Issues
+
+Retrieve the parent's child Issues via **two methods (OR combination)**. The methods mirror the parent-detection strategy for consistency.
+
+**Method A: Sub-Issues API (preferred)**
+
+```bash
+children_json=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      trackedIssues(first: 100) {
+        nodes { number state }
+      }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F number={parent_number} 2>/dev/null \
+  --jq '[.data.repository.issue.trackedIssues.nodes[]? | {number: .number, state: .state}]')
+echo "method_a_children=${children_json:-[]}"
+```
+
+**Method B: Parent body `## Sub-Issues` tasklist (fallback)**
+
+If Method A returns `[]` (sub-issues feature not in use in this repo), parse the parent body's Sub-Issues tasklist and resolve each referenced Issue's state:
+
+```bash
+parent_body=$(gh issue view {parent_number} --json body --jq '.body')
+# Extract child numbers from `- [ ] #N` / `- [x] #N` lines under `## Sub-Issues` section
+child_numbers=$(awk '/^## Sub-Issues/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
+echo "method_b_child_numbers=${child_numbers:-none}"
+
+# Resolve each child's state in one batch GraphQL query (if any were found)
+if [ -n "$child_numbers" ]; then
+  # Build alias query dynamically (LLM generates this based on child_numbers list)
+  # Each child: issueN: issue(number: N) { number state }
+  children_json=$(gh api graphql -f query='
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    {alias_query_generated_by_llm}
+  }
+}' -f owner="{owner}" -f repo="{repo}" --jq '[.data.repository | to_entries[] | .value | {number: .number, state: .state}]')
+fi
+```
+
+**When both methods return empty or fail**: Display warning and skip Phase 4.6 (non-blocking, AC-5 spirit applied to close side):
+
+```
+警告: 親 Issue #{parent_number} の子 Issue 一覧の取得に失敗しました。親の自動クローズをスキップします。
+```
+
+Proceed to Phase 5.
+
+### 4.6.2 All-Children-Closed Check
+
+Parse `children_json` and determine whether **every** child has `state: "CLOSED"`.
+
+```bash
+all_closed=$(echo "$children_json" | jq -r 'if length == 0 then "false" else (all(.state == "CLOSED")) | tostring end')
+open_count=$(echo "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length')
+echo "all_closed=$all_closed open_count=$open_count"
+```
+
+**When `all_closed != "true"` (some children still open)**:
+
+```bash
+echo "[DEBUG] parent #{parent_number} has ${open_count} open child(ren) — skipping auto-close"
+```
+
+Display:
+
+```
+親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。
+```
+
+Proceed to Phase 5.
+
+**When `all_closed == "true"`**: Proceed to 4.6.3.
+
+### 4.6.3 User Confirmation
+
+Confirm via `AskUserQuestion`:
+
+```
+親 Issue #{parent_number} のすべての子 Issue が完了しました。親 Issue もクローズしますか？
+
+オプション:
+- 親 Issue をクローズする（推奨）
+- 親 Issue を開いたまま終了
+```
+
+| Selection | Action |
+|-----------|--------|
+| クローズする | Proceed to 4.6.4 |
+| 開いたまま終了 | `echo "[DEBUG] user declined parent auto-close for #{parent_number}"`. Proceed to Phase 5 |
+
+### 4.6.4 Update Parent Projects Status to "Done"
+
+Skip this sub-step if `github.projects.enabled: false` in `rite-config.yml`.
+
+**Step 1**: Retrieve parent's project item ID and project ID:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 10) {
+        nodes { id project { id number } }
+      }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F number={parent_number}
+```
+
+Find the node where `project.number` matches `{project_number}`. Extract `{parent_item_id}` and `{parent_project_id}`. If `projectItems.nodes` is empty, display warning and proceed to 4.6.5 (non-blocking, AC-5):
+
+```
+警告: 親 Issue #{parent_number} は Project に登録されていません。Status 更新をスキップします。
+```
+
+**Step 2**: Retrieve Status field and "Done" option ID:
+
+```bash
+gh project field-list {project_number} --owner {owner} --format json
+```
+
+From the result, find the `name: "Status"` field. Extract `{status_field_id}` (or use `github.projects.field_ids.status` from `rite-config.yml` if configured) and `{done_option_id}` (the option whose `name` is `"Done"`).
+
+**Step 3**: Update the Status:
+
+```bash
+gh project item-edit --project-id {parent_project_id} --id {parent_item_id} --field-id {status_field_id} --single-select-option-id {done_option_id}
+```
+
+On failure, display warning and proceed to 4.6.5 (non-blocking):
+
+```
+警告: 親 Issue #{parent_number} の Status 更新に失敗しました。
+```
+
+### 4.6.5 Close the Parent Issue
+
+```bash
+gh issue close {parent_number} --comment "子 Issue がすべて完了したため、自動クローズします。（/rite:issue:close 経由、Issue #{issue_number} の close をトリガー）"
+```
+
+On failure, display warning and proceed to Phase 5:
+
+```
+警告: 親 Issue #{parent_number} のクローズに失敗しました。手動でクローズしてください。
+```
+
+On success:
+
+```
+親 Issue #{parent_number} を自動クローズしました（Status: Done）。
+```
 
 Proceed to Phase 5.
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -602,14 +602,63 @@ Proceed to Phase 4.6.
 
 **Three-level nesting guard (AC / MUST NOT)**: This phase processes only the direct parent. It does NOT recurse into the parent's parent (grandparent). Three-level nesting is explicitly out of scope (see Issue #513 Section 2 Out of Scope).
 
-### 4.6.1 Enumerate Parent's Child Issues
+### 4.6.0 Idempotency Check (AC-6)
 
-Retrieve the parent's child Issues via **two methods (OR combination)**. The methods mirror the parent-detection strategy for consistency.
-
-**Method A: Sub-Issues API (preferred)**
+Before enumerating children, check whether the parent Issue is already closed. If so, this is a no-op invocation (the parent was previously closed — manually, by a prior auto-close run, or externally) and we must not re-prompt the user.
 
 ```bash
-children_json=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
+parent_state=$(gh issue view {parent_number} --json state --jq '.state')
+echo "parent_state=$parent_state"
+if [ "$parent_state" = "CLOSED" ]; then
+  echo "[DEBUG] parent #{parent_number} already closed — skipping Phase 4.6 (AC-6 idempotent no-op)"
+fi
+```
+
+**When `parent_state == "CLOSED"`**: Skip the rest of Phase 4.6 (4.6.1–4.6.5) and proceed to Phase 5. This satisfies AC-6 (idempotency: re-running close on a child whose parent is already closed is a safe no-op).
+
+**When retrieval fails** (`parent_state` empty): Display warning and skip Phase 4.6 (non-blocking):
+
+```
+警告: 親 Issue #{parent_number} の state 取得に失敗しました。親の自動クローズ判定をスキップします。
+```
+
+Proceed to Phase 5.
+
+**When `parent_state != "CLOSED"`**: Proceed to 4.6.1.
+
+### 4.6.1 Enumerate Parent's Child Issues and Determine all_closed
+
+Retrieve the parent's child Issues via **two methods (OR combination, Method A → Method B fallback)**, then determine whether every child is closed. All of this is done in a **single Bash tool invocation** to avoid shell state loss between calls.
+
+**Design notes** (Issue #517 review fixes):
+
+- **Method A stderr is NOT suppressed**: Previous `2>/dev/null` silently downgraded auth / network / permission errors to "empty result", which is exactly the silent-skip anti-pattern Issue #513 aims to eliminate. Instead, stderr is captured to a tempfile and surfaced in debug logs when Method A fails.
+- **Method A → Method B fallback is explicit bash conditional**: Previous version relied on prose instructions and would silently overwrite Method A's result when Method B ran unconditionally. The unified bash block below branches on `jq length` of Method A's result.
+- **Method B uses a per-child loop, not an LLM-generated alias query**: Previous `{alias_query_generated_by_llm}` placeholder had no concrete example and risked unexecutable GraphQL. The deterministic per-child `gh issue view --json state` loop is simpler, fully auditable, and costs O(N) API calls for small N (parents rarely have >20 children in practice).
+
+```bash
+# ============================================================================
+# Phase 4.6.1: Enumerate children + determine all_closed (single bash block)
+# ============================================================================
+parent_number="{parent_number}"
+owner="{owner}"
+repo="{repo}"
+
+children_json=""
+method_a_err=""
+_rite_close_p461_cleanup() {
+  rm -f "${method_a_err:-}"
+}
+trap 'rc=$?; _rite_close_p461_cleanup; exit $rc' EXIT
+trap '_rite_close_p461_cleanup; exit 130' INT
+trap '_rite_close_p461_cleanup; exit 143' TERM
+trap '_rite_close_p461_cleanup; exit 129' HUP
+
+# --- Method A: Sub-Issues API (preferred) ---
+# stderr is captured to tempfile (NOT suppressed) so auth / network / GraphQL errors surface.
+method_a_err=$(mktemp /tmp/rite-close-p461-method-a-err-XXXXXX) || method_a_err=""
+method_a_rc=0
+if method_a_raw=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     issue(number: $number) {
@@ -618,69 +667,93 @@ query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}' -f owner="{owner}" -f repo="{repo}" -F number={parent_number} 2>/dev/null \
-  --jq '[.data.repository.issue.trackedIssues.nodes[]? | {number: .number, state: .state}]')
-echo "method_a_children=${children_json:-[]}"
-```
+}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" \
+  --jq '[.data.repository.issue.trackedIssues.nodes[]? | {number: .number, state: .state}]' \
+  2>"${method_a_err:-/dev/null}"); then
+  children_json="$method_a_raw"
+  method_a_count=$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)
+  echo "[DEBUG] method_a succeeded: ${method_a_count} children via Sub-Issues API"
+else
+  method_a_rc=$?
+  echo "[DEBUG] method_a failed (rc=$method_a_rc) — likely sub_issues feature not available, will try Method B"
+  if [ -n "$method_a_err" ] && [ -s "$method_a_err" ]; then
+    head -3 "$method_a_err" | sed 's/^/  method_a stderr: /' >&2
+  fi
+  children_json=""
+fi
+[ -n "$method_a_err" ] && rm -f "$method_a_err"
 
-**Method B: Parent body `## Sub-Issues` tasklist (fallback)**
+# --- Method B: Parent body Sub-Issues tasklist (fallback) ---
+# Explicit bash conditional: only run Method B when Method A yielded empty or failed.
+method_a_length=$(printf '%s' "${children_json:-[]}" | jq 'length' 2>/dev/null || echo 0)
+if [ -z "$children_json" ] || [ "$method_a_length" -eq 0 ]; then
+  echo "[DEBUG] falling back to Method B (parent body tasklist parse)"
+  parent_body=$(gh issue view "$parent_number" --json body --jq '.body' 2>/dev/null || echo "")
+  if [ -z "$parent_body" ]; then
+    echo "[DEBUG] method_b: failed to fetch parent body"
+    children_json="[]"
+  else
+    # Extract child numbers from `- [ ] #N` / `- [x] #N` lines under `## Sub-Issues` section
+    child_numbers=$(awk '/^## Sub-Issues/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
+    echo "[DEBUG] method_b child_numbers=${child_numbers:-none}"
 
-If Method A returns `[]` (sub-issues feature not in use in this repo), parse the parent body's Sub-Issues tasklist and resolve each referenced Issue's state:
+    if [ -z "$child_numbers" ]; then
+      children_json="[]"
+    else
+      # Deterministic per-child loop (O(N) API calls, N typically small).
+      # Build JSON array by iterating and appending state per child.
+      children_json="["
+      first=1
+      for n in $child_numbers; do
+        child_state=$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "")
+        if [ -z "$child_state" ]; then
+          echo "[DEBUG] method_b: failed to fetch state for #$n (will treat as OPEN to block auto-close)" >&2
+          child_state="OPEN"
+        fi
+        if [ "$first" -eq 1 ]; then
+          first=0
+        else
+          children_json+=","
+        fi
+        children_json+="{\"number\":$n,\"state\":\"$child_state\"}"
+      done
+      children_json+="]"
+    fi
+  fi
+fi
 
-```bash
-parent_body=$(gh issue view {parent_number} --json body --jq '.body')
-# Extract child numbers from `- [ ] #N` / `- [x] #N` lines under `## Sub-Issues` section
-child_numbers=$(awk '/^## Sub-Issues/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
-echo "method_b_child_numbers=${child_numbers:-none}"
+# --- all_closed determination ---
+# Empty array is treated as "cannot auto-close" (safe default — no children detected).
+final_length=$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)
+if [ "$final_length" -eq 0 ]; then
+  all_closed="false"
+  open_count="0"
+  echo "[DEBUG] children_json is empty after both methods — cannot determine all_closed (skipping auto-close)"
+else
+  all_closed=$(printf '%s' "$children_json" | jq -r 'all(.[]; .state == "CLOSED") | tostring' 2>/dev/null || echo "false")
+  open_count=$(printf '%s' "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length' 2>/dev/null || echo "0")
+fi
+echo "all_closed=$all_closed open_count=$open_count children_total=$final_length"
 
-# Resolve each child's state in one batch GraphQL query (if any were found)
-if [ -n "$child_numbers" ]; then
-  # Build alias query dynamically (LLM generates this based on child_numbers list)
-  # Each child: issueN: issue(number: N) { number state }
-  children_json=$(gh api graphql -f query='
-query($owner: String!, $repo: String!) {
-  repository(owner: $owner, name: $repo) {
-    {alias_query_generated_by_llm}
-  }
-}' -f owner="{owner}" -f repo="{repo}" --jq '[.data.repository | to_entries[] | .value | {number: .number, state: .state}]')
+# --- Branch decision sentinel for LLM routing ---
+if [ "$final_length" -eq 0 ]; then
+  echo "[CONTEXT] P461_DECISION=skip_empty_children"
+elif [ "$all_closed" = "true" ]; then
+  echo "[CONTEXT] P461_DECISION=proceed_to_confirmation"
+else
+  echo "[CONTEXT] P461_DECISION=skip_open_children; open_count=$open_count"
 fi
 ```
 
-**When both methods return empty or fail**: Display warning and skip Phase 4.6 (non-blocking, AC-5 spirit applied to close side):
+**LLM routing rule** (Claude reads the `[CONTEXT] P461_DECISION=` sentinel from the bash block's stdout):
 
-```
-警告: 親 Issue #{parent_number} の子 Issue 一覧の取得に失敗しました。親の自動クローズをスキップします。
-```
+| `P461_DECISION` value | Next action |
+|----------------------|-------------|
+| `skip_empty_children` | Display warning `親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。親の自動クローズをスキップします。` and proceed to Phase 5 (non-blocking, AC-5 spirit) |
+| `skip_open_children` | Display `親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。` and proceed to Phase 5 |
+| `proceed_to_confirmation` | Proceed to 4.6.2 (User Confirmation) |
 
-Proceed to Phase 5.
-
-### 4.6.2 All-Children-Closed Check
-
-Parse `children_json` and determine whether **every** child has `state: "CLOSED"`.
-
-```bash
-all_closed=$(echo "$children_json" | jq -r 'if length == 0 then "false" else (all(.state == "CLOSED")) | tostring end')
-open_count=$(echo "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length')
-echo "all_closed=$all_closed open_count=$open_count"
-```
-
-**When `all_closed != "true"` (some children still open)**:
-
-```bash
-echo "[DEBUG] parent #{parent_number} has ${open_count} open child(ren) — skipping auto-close"
-```
-
-Display:
-
-```
-親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。
-```
-
-Proceed to Phase 5.
-
-**When `all_closed == "true"`**: Proceed to 4.6.3.
-
-### 4.6.3 User Confirmation
+### 4.6.2 User Confirmation
 
 Confirm via `AskUserQuestion`:
 
@@ -694,17 +767,36 @@ Confirm via `AskUserQuestion`:
 
 | Selection | Action |
 |-----------|--------|
-| クローズする | Proceed to 4.6.4 |
+| クローズする | Proceed to 4.6.3 |
 | 開いたまま終了 | `echo "[DEBUG] user declined parent auto-close for #{parent_number}"`. Proceed to Phase 5 |
 
-### 4.6.4 Update Parent Projects Status to "Done"
+### 4.6.3 Update Parent Projects Status to "Done" and Close
 
-Skip this sub-step if `github.projects.enabled: false` in `rite-config.yml`.
+Skip the Status update if `github.projects.enabled: false` in `rite-config.yml`; still execute the Issue close in Step 4.
 
-**Step 1**: Retrieve parent's project item ID and project ID:
+All 4 steps run in a **single bash block** to preserve intermediate state and to guarantee the final state-inconsistency summary (Step 5) is always emitted.
 
 ```bash
-gh api graphql -f query='
+# ============================================================================
+# Phase 4.6.3: Parent Projects Status → Done + Issue close (unified block)
+# ============================================================================
+parent_number="{parent_number}"
+owner="{owner}"
+repo="{repo}"
+projects_enabled="{projects_enabled}"  # "true" or "false" from rite-config.yml
+project_number="{project_number}"      # integer from rite-config.yml
+issue_number="{issue_number}"          # the child Issue that triggered this close
+
+status_update_result="skipped"
+issue_close_result="pending"
+parent_item_id=""
+parent_project_id=""
+status_field_id=""
+done_option_id=""
+
+# --- Step 1: Retrieve parent's project item ID and project GraphQL id ---
+if [ "$projects_enabled" = "true" ]; then
+  project_items_json=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     issue(number: $number) {
@@ -713,54 +805,87 @@ query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}' -f owner="{owner}" -f repo="{repo}" -F number={parent_number}
+}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" 2>/dev/null) || project_items_json=""
+
+  if [ -n "$project_items_json" ]; then
+    # Extract the node whose project.number matches {project_number}
+    parent_item_id=$(printf '%s' "$project_items_json" \
+      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .id' 2>/dev/null)
+    parent_project_id=$(printf '%s' "$project_items_json" \
+      | jq -r --argjson pn "$project_number" '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | .project.id' 2>/dev/null)
+  fi
+
+  if [ -z "$parent_item_id" ] || [ -z "$parent_project_id" ]; then
+    echo "警告: 親 Issue #${parent_number} は Project #${project_number} に登録されていません。Status 更新をスキップします。" >&2
+    status_update_result="not_registered"
+  else
+    # --- Step 2: Retrieve Status field id and "Done" option id via --jq ---
+    field_list_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null) || field_list_json=""
+    if [ -n "$field_list_json" ]; then
+      status_field_id=$(printf '%s' "$field_list_json" \
+        | jq -r '.fields[] | select(.name == "Status") | .id' 2>/dev/null)
+      done_option_id=$(printf '%s' "$field_list_json" \
+        | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id' 2>/dev/null)
+    fi
+
+    if [ -z "$status_field_id" ] || [ -z "$done_option_id" ]; then
+      echo "警告: Status フィールドまたは 'Done' オプションの取得に失敗しました (field_id='$status_field_id' done_option_id='$done_option_id')" >&2
+      status_update_result="field_lookup_failed"
+    else
+      # --- Step 3: Update the Status ---
+      if gh project item-edit --project-id "$parent_project_id" --id "$parent_item_id" --field-id "$status_field_id" --single-select-option-id "$done_option_id" >/dev/null 2>&1; then
+        status_update_result="success"
+        echo "親 Issue #${parent_number} の Status を 'Done' に更新しました"
+      else
+        status_update_result="update_failed"
+        echo "警告: 親 Issue #${parent_number} の Status 更新に失敗しました。後続の gh issue close は続行します。" >&2
+      fi
+    fi
+  fi
+else
+  status_update_result="projects_disabled"
+fi
+
+# --- Step 4: Close the parent Issue ---
+if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため、自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>&1; then
+  issue_close_result="success"
+  echo "親 Issue #${parent_number} を自動クローズしました"
+else
+  issue_close_result="failed"
+  echo "警告: 親 Issue #${parent_number} のクローズに失敗しました。手動でクローズしてください: gh issue close ${parent_number}" >&2
+fi
+
+# --- Step 5: State inconsistency summary (MUST always emit — Issue #517 review fix) ---
+# Parent Issue と Projects Status が別エンティティのため、片方成功 / 片方失敗の state 不整合を
+# 必ずユーザーに可視化する (silent data corruption 防止)。
+echo ""
+echo "=== 親 Issue #${parent_number} 処理結果 ==="
+echo "  Issue close:   $issue_close_result"
+echo "  Status update: $status_update_result"
+
+case "${issue_close_result}:${status_update_result}" in
+  "success:success"|"success:projects_disabled"|"success:not_registered")
+    echo "  状態: 整合性 OK"
+    ;;
+  "success:update_failed"|"success:field_lookup_failed")
+    echo ""
+    echo "⚠️  state 不整合: 親 Issue は CLOSED ですが Projects Status が Done に更新されていません。"
+    echo "    復旧コマンド: gh project item-edit --project-id '$parent_project_id' --id '$parent_item_id' --field-id '$status_field_id' --single-select-option-id '$done_option_id'"
+    echo "    またはブラウザで https://github.com/${owner}/${repo}/issues/${parent_number} の Projects サイドバーから手動更新" >&2
+    ;;
+  "failed:success")
+    echo ""
+    echo "⚠️  state 不整合: Projects Status は Done ですが親 Issue が OPEN のままです。"
+    echo "    復旧コマンド: gh issue close ${parent_number}" >&2
+    ;;
+  "failed:"*)
+    echo ""
+    echo "⚠️  親 Issue の処理が失敗しました (Issue close / Status update 両方)。手動での対応が必要です: gh issue close ${parent_number}" >&2
+    ;;
+esac
 ```
 
-Find the node where `project.number` matches `{project_number}`. Extract `{parent_item_id}` and `{parent_project_id}`. If `projectItems.nodes` is empty, display warning and proceed to 4.6.5 (non-blocking, AC-5):
-
-```
-警告: 親 Issue #{parent_number} は Project に登録されていません。Status 更新をスキップします。
-```
-
-**Step 2**: Retrieve Status field and "Done" option ID:
-
-```bash
-gh project field-list {project_number} --owner {owner} --format json
-```
-
-From the result, find the `name: "Status"` field. Extract `{status_field_id}` (or use `github.projects.field_ids.status` from `rite-config.yml` if configured) and `{done_option_id}` (the option whose `name` is `"Done"`).
-
-**Step 3**: Update the Status:
-
-```bash
-gh project item-edit --project-id {parent_project_id} --id {parent_item_id} --field-id {status_field_id} --single-select-option-id {done_option_id}
-```
-
-On failure, display warning and proceed to 4.6.5 (non-blocking):
-
-```
-警告: 親 Issue #{parent_number} の Status 更新に失敗しました。
-```
-
-### 4.6.5 Close the Parent Issue
-
-```bash
-gh issue close {parent_number} --comment "子 Issue がすべて完了したため、自動クローズします。（/rite:issue:close 経由、Issue #{issue_number} の close をトリガー）"
-```
-
-On failure, display warning and proceed to Phase 5:
-
-```
-警告: 親 Issue #{parent_number} のクローズに失敗しました。手動でクローズしてください。
-```
-
-On success:
-
-```
-親 Issue #{parent_number} を自動クローズしました（Status: Done）。
-```
-
-Proceed to Phase 5.
+Proceed to Phase 5 regardless of the outcome (non-blocking, AC-5 applied to close side — the inconsistency summary above makes silent failure impossible).
 
 ---
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -618,6 +618,28 @@ set -uo pipefail  # strict mode (fail on undefined vars + preserve pipeline fail
 
 parent_number="{parent_number}"
 
+# --- Placeholder substitution sanity guard ---
+# Phase 4.6 is only reachable when Phase 4.5.1 detected a parent. If the LLM
+# routed into Phase 4.6 without substituting `{parent_number}` (e.g., skip-logic
+# bug or placeholder left literal), subsequent `gh issue view "{parent_number}"`
+# would fail with an "invalid issue number" error on stderr, and the Phase 4.6.0
+# else branch would classify it as "retrieval failed" — which is technically
+# correct but masks the true root cause (routing bug, not API failure).
+# This case statement surfaces the routing bug explicitly instead of silently
+# degrading into the retrieval-failure path.
+case "$parent_number" in
+  ''|'{parent_number}')
+    echo "[DEBUG] p460: parent_number is empty or unsubstituted literal ('$parent_number') — Phase 4.6 should not have been entered. Aborting Phase 4.6 (caller routing bug)." >&2
+    echo "[CONTEXT] P460_DECISION=skip_routing_bug"
+    exit 0
+    ;;
+  *[!0-9]*)
+    echo "[DEBUG] p460: parent_number is not numeric ('$parent_number') — Phase 4.6 should not have been entered. Aborting Phase 4.6." >&2
+    echo "[CONTEXT] P460_DECISION=skip_routing_bug"
+    exit 0
+    ;;
+esac
+
 parent_state=""
 p460_err=""
 _rite_close_p460_cleanup() {
@@ -667,6 +689,7 @@ fi
 
 | `P460_DECISION` value | Next action |
 |----------------------|-------------|
+| `skip_routing_bug` | Sanity guard fired: `parent_number` is empty, literal, or non-numeric — Phase 4.6 was entered via a routing bug. Warning emitted to stderr. Skip the rest of Phase 4.6 and proceed to Phase 5. |
 | `skip_retrieval_failed` | Warning already emitted to stderr. Skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5 (non-blocking). |
 | `skip_already_closed` | Parent is already closed — skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5. This is the close-side idempotency no-op. |
 | `proceed_to_enumeration` | Parent is open → proceed to 4.6.1. |
@@ -812,13 +835,13 @@ else
 fi
 ```
 
-**LLM routing rule** (Claude reads the `[CONTEXT] P461_DECISION=` sentinel from the bash block's stdout):
+**LLM routing rule** (Claude reads the `[CONTEXT] P461_DECISION=` sentinel from the bash block's stdout). Match by **prefix** (`skip_open_children` is emitted as `skip_open_children; open_count=N` — the `N` value is extracted from the payload and used to fill the `{open_count}` placeholder in the displayed message):
 
-| `P461_DECISION` value | Next action |
-|----------------------|-------------|
-| `skip_empty_children` | Display warning `親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。親の自動クローズをスキップします。` and proceed to Phase 5 (non-blocking, AC-5 spirit) |
-| `skip_open_children` | Display `親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。` and proceed to Phase 5 |
-| `proceed_to_confirmation` | Proceed to 4.6.2 (User Confirmation) |
+| `P461_DECISION` prefix | Payload | Next action |
+|----------------------|---------|-------------|
+| `skip_empty_children` | (none) | Display warning `親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。親の自動クローズをスキップします。` and proceed to Phase 5 (non-blocking, AC-5 spirit) |
+| `skip_open_children` | `; open_count=N` | Display `親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。` (substitute `N` for `{open_count}`) and proceed to Phase 5 |
+| `proceed_to_confirmation` | (none) | Proceed to 4.6.2 (User Confirmation) |
 
 ### 4.6.2 User Confirmation
 
@@ -885,8 +908,7 @@ trap '_rite_close_p463_cleanup; exit 143' TERM
 trap '_rite_close_p463_cleanup; exit 129' HUP
 
 _mktemp_or_warn() {
-  local var_name="$1"
-  local label="$2"
+  local label="$1"
   local tmp
   if tmp=$(mktemp 2>/dev/null); then
     printf '%s' "$tmp"
@@ -898,7 +920,7 @@ _mktemp_or_warn() {
 
 # --- Step 1: Retrieve parent's project item ID and project GraphQL id ---
 if [ "$projects_enabled" = "true" ]; then
-  p463_err_s1=$(_mktemp_or_warn "p463_err_s1" "Step 1")
+  p463_err_s1=$(_mktemp_or_warn "Step 1")
   if project_items_json=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -932,7 +954,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
     status_update_result="not_registered"
   else
     # --- Step 2: Retrieve Status field id and "Done" option id ---
-    p463_err_s2=$(_mktemp_or_warn "p463_err_s2" "Step 2")
+    p463_err_s2=$(_mktemp_or_warn "Step 2")
     if field_list_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>"${p463_err_s2:-/dev/null}"); then
       :
     else
@@ -956,7 +978,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       status_update_result="field_lookup_failed"
     else
       # --- Step 3: Update the Status ---
-      p463_err_s3=$(_mktemp_or_warn "p463_err_s3" "Step 3")
+      p463_err_s3=$(_mktemp_or_warn "Step 3")
       if gh project item-edit --project-id "$parent_project_id" --id "$parent_item_id" --field-id "$status_field_id" --single-select-option-id "$done_option_id" >/dev/null 2>"${p463_err_s3:-/dev/null}"; then
         status_update_result="success"
         echo "親 Issue #${parent_number} の Status を 'Done' に更新しました"
@@ -975,7 +997,7 @@ else
 fi
 
 # --- Step 4: Close the parent Issue ---
-p463_err_s4=$(_mktemp_or_warn "p463_err_s4" "Step 4")
+p463_err_s4=$(_mktemp_or_warn "Step 4")
 if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため、自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>"${p463_err_s4:-/dev/null}"; then
   issue_close_result="success"
   echo "親 Issue #${parent_number} を自動クローズしました"

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -390,7 +390,9 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 On failure, display warning and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
 
-**Step 5** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). Query trackedInIssues for the current Issue, and if a parent is found, update the parent's Status to "In Progress" using the same Step 2-4 logic against the parent issue number. If no parent is found, skip silently.
+**Step 5** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
+
+> **Issue #513 regression guard**: Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident: a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature.
 
 ### 🚨 Mandatory After 2.4
 

--- a/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+++ b/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
@@ -84,15 +84,18 @@ assert_file_contains "$CLOSE_MD" '\[DEBUG\] parent not detected' \
   "Silent-skip guard: explicit debug log on no-parent case (AC-4)"
 
 echo ""
-echo "[Group 3] close.md Phase 4.6: Parent Auto-Close logic (AC-2 + AC-6)"
+echo "[Group 3] close.md Phase 4.6: Parent Auto-Close logic (AC-2 + close-side idempotency)"
 assert_file_contains "$CLOSE_MD" '^##[[:space:]]+Phase[[:space:]]+4\.6' \
   "Phase 4.6 heading is present"
-# AC-6 idempotency guard: parent_state == CLOSED short-circuit
-assert_file_contains "$CLOSE_MD" 'parent_state[[:space:]]*=.*gh issue view.*parent_number.*--jq.*\.state' \
-  "AC-6 idempotency guard: parent_state check exists"
-assert_file_contains "$CLOSE_MD" 'already closed.*AC-6 idempotent' \
-  "AC-6 idempotency guard: idempotent no-op skip path exists"
-# all-children-closed check — match the jq all(.[]; ...) form with flexible whitespace
+# Close-side idempotency guard: parent_state retrieval + CLOSED short-circuit
+assert_file_contains "$CLOSE_MD" 'parent_state=.*gh issue view.*parent_number.*--jq.*\.state' \
+  "Phase 4.6.0 idempotency guard: parent_state retrieval exists"
+assert_file_contains "$CLOSE_MD" 'P460_DECISION=skip_already_closed' \
+  "Phase 4.6.0 idempotency guard: skip_already_closed sentinel exists"
+# HIGH fix (cycle 2): parent_state retrieval failure branch is in bash, not prose-only
+assert_file_contains "$CLOSE_MD" 'P460_DECISION=skip_retrieval_failed' \
+  "Phase 4.6.0 retrieval-failure branch: skip_retrieval_failed sentinel exists"
+# all-children-closed check — flexible whitespace around operators
 assert_file_contains "$CLOSE_MD" 'all_closed=.*all\([[:space:]]*\.\[\][[:space:]]*;[[:space:]]*\.state[[:space:]]*==[[:space:]]*"CLOSED"' \
   "All-children-closed check logic is present"
 assert_file_contains "$CLOSE_MD" 'gh issue close.*parent_number' \
@@ -104,15 +107,46 @@ assert_file_contains "$CLOSE_MD" 'jq -r .*projectItems\.nodes\[\].*select.*\.pro
   "Phase 4.6.3 Step 1: deterministic jq extraction for parent_item_id exists"
 assert_file_contains "$CLOSE_MD" 'jq -r .*fields\[\].*select.*name.*==.*"Status".*options\[\].*select.*name.*==.*"Done"' \
   "Phase 4.6.3 Step 2: deterministic jq extraction for done_option_id exists"
-# state-inconsistency summary (MEDIUM fix)
+# state-inconsistency summary (cycle 1 MEDIUM fix)
 assert_file_contains "$CLOSE_MD" 'state 不整合' \
   "Phase 4.6.3 Step 5: state inconsistency summary is emitted"
+# Cycle 2 MEDIUM fix: success:field_lookup_failed case is separated from success:update_failed
+# and prints a field-list diagnostic command instead of a broken one-liner with empty vars.
+assert_file_contains "$CLOSE_MD" '"success:field_lookup_failed"\)' \
+  "Phase 4.6.3 Step 5: success:field_lookup_failed is a dedicated case (not merged)"
+assert_file_contains "$CLOSE_MD" '診断コマンド: gh project field-list' \
+  "Phase 4.6.3 Step 5: field_lookup_failed case prints diagnostic command (not broken one-liner)"
+# Cycle 2 LOW fix: failed:projects_disabled / failed:not_registered are classified separately
+assert_file_contains "$CLOSE_MD" '"failed:projects_disabled"\|"failed:not_registered"\)' \
+  "Phase 4.6.3 Step 5: failed:projects_disabled/not_registered case is separated from catch-all"
 assert_file_contains "$CLOSE_MD" 'AskUserQuestion' \
   "User confirmation via AskUserQuestion (AC-2: not silent auto-close)"
-# HIGH fix: no Method A 2>/dev/null silent stderr suppression in Phase 4.6.1
-# (presence of method_a_err tempfile capture signals the fix)
+# Cycle 1 HIGH fix: Method A uses tempfile stderr capture (not 2>/dev/null)
 assert_file_contains "$CLOSE_MD" 'method_a_err=.*mktemp' \
   "Phase 4.6.1 Method A stderr capture (no silent suppression)"
+# Cycle 2 HIGH fix: Phase 4.6.3 Step 1-4 all capture stderr to tempfile (not 2>/dev/null / >/dev/null 2>&1)
+assert_file_contains "$CLOSE_MD" 'p463_err_s1.*mktemp' \
+  "Phase 4.6.3 Step 1: stderr tempfile capture (p463_err_s1)"
+assert_file_contains "$CLOSE_MD" 'p463_err_s2.*mktemp' \
+  "Phase 4.6.3 Step 2: stderr tempfile capture (p463_err_s2)"
+assert_file_contains "$CLOSE_MD" 'p463_err_s3.*mktemp' \
+  "Phase 4.6.3 Step 3: stderr tempfile capture (p463_err_s3)"
+assert_file_contains "$CLOSE_MD" 'p463_err_s4.*mktemp' \
+  "Phase 4.6.3 Step 4: stderr tempfile capture (p463_err_s4)"
+# Cycle 2 MEDIUM fix: strict mode (set -uo pipefail) in Phase 4.6.0, 4.6.1, 4.6.3 bash blocks
+assert_file_contains "$CLOSE_MD" 'Phase 4\.6\.0.*parent already closed' \
+  "Phase 4.6.0 bash block header present"
+# Cycle 2 HIGH fix: trackedIssues is labeled as Tasklists API (not Sub-Issues API)
+assert_file_contains "$CLOSE_MD" 'trackedIssues.*Tasklists' \
+  "Phase 4.6.1 Method A is correctly labeled as Tasklists API (not Sub-Issues API)"
+assert_file_not_contains "$CLOSE_MD" 'Method A: Sub-Issues API' \
+  "Regression guard: Method A mislabel 'Sub-Issues API' is removed"
+# Cycle 2 HIGH fix: stale subsection reference 4.6.1-4.6.5 is corrected to 4.6.1-4.6.3
+assert_file_not_contains "$CLOSE_MD" '4\.6\.1–4\.6\.5' \
+  "Regression guard: stale 4.6.1-4.6.5 reference is removed (actual range is 4.6.1-4.6.3)"
+# Cycle 2 MEDIUM fix: AC-6 citation is clarified as close-side extension, not literal AC-6
+assert_file_contains "$CLOSE_MD" 'close-side idempotency' \
+  "Phase 4.6.0 clarifies close-side idempotency (AC-6 applies to start side, not close side)"
 
 echo ""
 echo "[Group 4] start.md: no inline trackedInIssues simplification (Issue #513 root cause)"

--- a/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+++ b/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
@@ -23,7 +23,9 @@ assert_file_contains() {
   local file="$1"
   local pattern="$2"
   local description="$3"
-  if grep -qE "$pattern" "$file"; then
+  # Use `-e` explicitly so patterns that start with `-` (e.g. `--jq...`) are not
+  # interpreted as grep flags. `-E` must precede `-e` for extended regex.
+  if grep -qE -e "$pattern" "$file"; then
     PASS=$((PASS + 1))
     echo "  ✓ $description"
   else
@@ -37,7 +39,7 @@ assert_file_not_contains() {
   local file="$1"
   local pattern="$2"
   local description="$3"
-  if grep -qE "$pattern" "$file"; then
+  if grep -qE -e "$pattern" "$file"; then
     FAIL=$((FAIL + 1))
     FAILURES+=("$description (file: $(basename "$file"), forbidden pattern found: $pattern)")
     echo "  ✗ $description" >&2
@@ -61,9 +63,11 @@ echo ""
 echo "[Group 1] projects-integration.md 2.4.7.1: 3-method OR detection"
 assert_file_contains "$PROJECTS_INTEGRATION" '## 親 Issue' \
   "Method 1 (body meta '## 親 Issue') is present"
-assert_file_contains "$PROJECTS_INTEGRATION" 'parent \{' \
+assert_file_contains "$PROJECTS_INTEGRATION" 'parent[[:space:]]*\{[[:space:]]*number' \
   "Method 2 (Sub-Issues API 'parent { number }') is present"
-assert_file_contains "$PROJECTS_INTEGRATION" 'gh issue list --state open --search.*in:body' \
+# --state filter is intentionally context-dependent (open=start side / all=close side);
+# check for --state presence without fixing the value, plus `in:body` tasklist search marker.
+assert_file_contains "$PROJECTS_INTEGRATION" 'gh issue list[[:space:]]+--state[[:space:]]+[a-z]+[[:space:]]+--search.*in:body' \
   "Method 3 (tasklist search) is present"
 assert_file_contains "$PROJECTS_INTEGRATION" '\[DEBUG\] parent not detected' \
   "Silent-skip guard: explicit debug log on no-parent case (AC-4)"
@@ -72,25 +76,43 @@ echo ""
 echo "[Group 2] close.md Phase 4.5.1: 3-method OR detection (consistency with start)"
 assert_file_contains "$CLOSE_MD" '## 親 Issue' \
   "Method 1 (body meta '## 親 Issue') is present"
-assert_file_contains "$CLOSE_MD" 'parent \{ number \}' \
+assert_file_contains "$CLOSE_MD" 'parent[[:space:]]*\{[[:space:]]*number[[:space:]]*\}' \
   "Method 2 (Sub-Issues API 'parent { number }') is present"
-assert_file_contains "$CLOSE_MD" 'gh issue list .*--search.*in:body' \
+assert_file_contains "$CLOSE_MD" 'gh issue list[[:space:]]+--state[[:space:]]+[a-z]+.*--search.*in:body' \
   "Method 3 (tasklist search) is present"
 assert_file_contains "$CLOSE_MD" '\[DEBUG\] parent not detected' \
   "Silent-skip guard: explicit debug log on no-parent case (AC-4)"
 
 echo ""
-echo "[Group 3] close.md Phase 4.6: Parent Auto-Close logic (AC-2)"
-assert_file_contains "$CLOSE_MD" '^## Phase 4\.6: Parent Auto-Close' \
+echo "[Group 3] close.md Phase 4.6: Parent Auto-Close logic (AC-2 + AC-6)"
+assert_file_contains "$CLOSE_MD" '^##[[:space:]]+Phase[[:space:]]+4\.6' \
   "Phase 4.6 heading is present"
-assert_file_contains "$CLOSE_MD" 'all_closed=.*all\(\.state == "CLOSED"\)' \
+# AC-6 idempotency guard: parent_state == CLOSED short-circuit
+assert_file_contains "$CLOSE_MD" 'parent_state[[:space:]]*=.*gh issue view.*parent_number.*--jq.*\.state' \
+  "AC-6 idempotency guard: parent_state check exists"
+assert_file_contains "$CLOSE_MD" 'already closed.*AC-6 idempotent' \
+  "AC-6 idempotency guard: idempotent no-op skip path exists"
+# all-children-closed check — match the jq all(.[]; ...) form with flexible whitespace
+assert_file_contains "$CLOSE_MD" 'all_closed=.*all\([[:space:]]*\.\[\][[:space:]]*;[[:space:]]*\.state[[:space:]]*==[[:space:]]*"CLOSED"' \
   "All-children-closed check logic is present"
-assert_file_contains "$CLOSE_MD" 'gh issue close \{parent_number\}' \
+assert_file_contains "$CLOSE_MD" 'gh issue close.*parent_number' \
   "Parent close command is present"
 assert_file_contains "$CLOSE_MD" 'done_option_id' \
   "Projects Status -> Done update logic is present"
+# CRITICAL fix: explicit jq extraction for project item / status field / done option (determinism)
+assert_file_contains "$CLOSE_MD" 'jq -r .*projectItems\.nodes\[\].*select.*\.project\.number' \
+  "Phase 4.6.3 Step 1: deterministic jq extraction for parent_item_id exists"
+assert_file_contains "$CLOSE_MD" 'jq -r .*fields\[\].*select.*name.*==.*"Status".*options\[\].*select.*name.*==.*"Done"' \
+  "Phase 4.6.3 Step 2: deterministic jq extraction for done_option_id exists"
+# state-inconsistency summary (MEDIUM fix)
+assert_file_contains "$CLOSE_MD" 'state 不整合' \
+  "Phase 4.6.3 Step 5: state inconsistency summary is emitted"
 assert_file_contains "$CLOSE_MD" 'AskUserQuestion' \
   "User confirmation via AskUserQuestion (AC-2: not silent auto-close)"
+# HIGH fix: no Method A 2>/dev/null silent stderr suppression in Phase 4.6.1
+# (presence of method_a_err tempfile capture signals the fix)
+assert_file_contains "$CLOSE_MD" 'method_a_err=.*mktemp' \
+  "Phase 4.6.1 Method A stderr capture (no silent suppression)"
 
 echo ""
 echo "[Group 4] start.md: no inline trackedInIssues simplification (Issue #513 root cause)"

--- a/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+++ b/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
@@ -117,7 +117,7 @@ assert_file_contains "$CLOSE_MD" '"success:field_lookup_failed"\)' \
 assert_file_contains "$CLOSE_MD" '診断コマンド: gh project field-list' \
   "Phase 4.6.3 Step 5: field_lookup_failed case prints diagnostic command (not broken one-liner)"
 # Cycle 2 LOW fix: failed:projects_disabled / failed:not_registered are classified separately
-assert_file_contains "$CLOSE_MD" '"failed:projects_disabled"\|"failed:not_registered"\)' \
+assert_file_contains "$CLOSE_MD" '"failed:projects_disabled"[|]"failed:not_registered"\)' \
   "Phase 4.6.3 Step 5: failed:projects_disabled/not_registered case is separated from catch-all"
 assert_file_contains "$CLOSE_MD" 'AskUserQuestion' \
   "User confirmation via AskUserQuestion (AC-2: not silent auto-close)"
@@ -147,6 +147,18 @@ assert_file_not_contains "$CLOSE_MD" '4\.6\.1–4\.6\.5' \
 # Cycle 2 MEDIUM fix: AC-6 citation is clarified as close-side extension, not literal AC-6
 assert_file_contains "$CLOSE_MD" 'close-side idempotency' \
   "Phase 4.6.0 clarifies close-side idempotency (AC-6 applies to start side, not close side)"
+# Cycle 3 LOW fix: Phase 4.6.0 placeholder sanity guard (unsubstituted / non-numeric parent_number)
+assert_file_contains "$CLOSE_MD" 'P460_DECISION=skip_routing_bug' \
+  "Phase 4.6.0 placeholder sanity guard: skip_routing_bug sentinel exists"
+assert_file_contains "$CLOSE_MD" "''[|]'\\{parent_number\\}'" \
+  "Phase 4.6.0 placeholder sanity guard: empty-or-literal placeholder case pattern exists"
+# Cycle 3 LOW fix: _mktemp_or_warn helper takes exactly 1 arg (label), no dead var_name parameter
+assert_file_contains "$CLOSE_MD" '_mktemp_or_warn\(\) \{' \
+  "Helper _mktemp_or_warn is defined"
+assert_file_not_contains "$CLOSE_MD" 'local var_name=' \
+  "Regression guard: _mktemp_or_warn no longer takes dead var_name parameter"
+assert_file_not_contains "$CLOSE_MD" '_mktemp_or_warn "p463_err_s' \
+  "Regression guard: callers no longer pass dead var_name first arg"
 
 echo ""
 echo "[Group 4] start.md: no inline trackedInIssues simplification (Issue #513 root cause)"

--- a/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+++ b/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Static regression tests for Issue #513 parent-child Issue status sync.
+#
+# Guards against re-introduction of silent-skip patterns that caused
+# past incidents #115, #381, #15 and the #513 reopening. Verifies that
+# the three canonical files contain the 3-method OR detection and that
+# close.md has Phase 4.6 Parent Auto-Close logic.
+#
+# Usage: bash plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+PROJECTS_INTEGRATION="$REPO_ROOT/plugins/rite/references/projects-integration.md"
+CLOSE_MD="$REPO_ROOT/plugins/rite/commands/issue/close.md"
+START_MD="$REPO_ROOT/plugins/rite/commands/issue/start.md"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  local description="$3"
+  if grep -qE "$pattern" "$file"; then
+    PASS=$((PASS + 1))
+    echo "  ✓ $description"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$description (file: $(basename "$file"), pattern: $pattern)")
+    echo "  ✗ $description" >&2
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local description="$3"
+  if grep -qE "$pattern" "$file"; then
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$description (file: $(basename "$file"), forbidden pattern found: $pattern)")
+    echo "  ✗ $description" >&2
+  else
+    PASS=$((PASS + 1))
+    echo "  ✓ $description"
+  fi
+}
+
+echo "=== T-07: Parent-child sync regression guards (Issue #513) ==="
+
+# Prerequisite: all three files exist
+for f in "$PROJECTS_INTEGRATION" "$CLOSE_MD" "$START_MD"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: required file not found: $f" >&2
+    exit 1
+  fi
+done
+
+echo ""
+echo "[Group 1] projects-integration.md 2.4.7.1: 3-method OR detection"
+assert_file_contains "$PROJECTS_INTEGRATION" '## 親 Issue' \
+  "Method 1 (body meta '## 親 Issue') is present"
+assert_file_contains "$PROJECTS_INTEGRATION" 'parent \{' \
+  "Method 2 (Sub-Issues API 'parent { number }') is present"
+assert_file_contains "$PROJECTS_INTEGRATION" 'gh issue list --state open --search.*in:body' \
+  "Method 3 (tasklist search) is present"
+assert_file_contains "$PROJECTS_INTEGRATION" '\[DEBUG\] parent not detected' \
+  "Silent-skip guard: explicit debug log on no-parent case (AC-4)"
+
+echo ""
+echo "[Group 2] close.md Phase 4.5.1: 3-method OR detection (consistency with start)"
+assert_file_contains "$CLOSE_MD" '## 親 Issue' \
+  "Method 1 (body meta '## 親 Issue') is present"
+assert_file_contains "$CLOSE_MD" 'parent \{ number \}' \
+  "Method 2 (Sub-Issues API 'parent { number }') is present"
+assert_file_contains "$CLOSE_MD" 'gh issue list .*--search.*in:body' \
+  "Method 3 (tasklist search) is present"
+assert_file_contains "$CLOSE_MD" '\[DEBUG\] parent not detected' \
+  "Silent-skip guard: explicit debug log on no-parent case (AC-4)"
+
+echo ""
+echo "[Group 3] close.md Phase 4.6: Parent Auto-Close logic (AC-2)"
+assert_file_contains "$CLOSE_MD" '^## Phase 4\.6: Parent Auto-Close' \
+  "Phase 4.6 heading is present"
+assert_file_contains "$CLOSE_MD" 'all_closed=.*all\(\.state == "CLOSED"\)' \
+  "All-children-closed check logic is present"
+assert_file_contains "$CLOSE_MD" 'gh issue close \{parent_number\}' \
+  "Parent close command is present"
+assert_file_contains "$CLOSE_MD" 'done_option_id' \
+  "Projects Status -> Done update logic is present"
+assert_file_contains "$CLOSE_MD" 'AskUserQuestion' \
+  "User confirmation via AskUserQuestion (AC-2: not silent auto-close)"
+
+echo ""
+echo "[Group 4] start.md: no inline trackedInIssues simplification (Issue #513 root cause)"
+assert_file_not_contains "$START_MD" 'Query trackedInIssues for the current Issue' \
+  "Regression guard: inline 'Query trackedInIssues' simplification is removed"
+assert_file_contains "$START_MD" 'projects-integration\.md#247' \
+  "Delegation to projects-integration.md §2.4.7 is present"
+assert_file_contains "$START_MD" 'Issue #513 regression guard' \
+  "Regression guard comment is present (prevents re-introduction)"
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for msg in "${FAILURES[@]}"; do
+    echo "  - $msg"
+  done
+  exit 1
+fi
+echo "All parent-child-sync static checks passed."

--- a/plugins/rite/references/projects-integration.md
+++ b/plugins/rite/references/projects-integration.md
@@ -118,9 +118,32 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 #### 2.4.7.1 Parent Issue Detection
 
-Detect the parent Issue of the current (child) Issue. Try methods in order; use the first successful result.
+Detect the parent Issue of the current (child) Issue. **Three methods are tried in order (OR combination); the first successful result wins.** This ordering is critical: `## 親 Issue` body meta is placed PRIMARY because it is the most reliable source in repositories that use `/rite:issue:create-decompose` (which writes this section to every child), and it requires no dependency on GitHub's native Sub-Issues feature.
 
-**Method 1: Sub-Issues API (preferred)**
+> **Consistency requirement (Issue #513)**: The same 3-method OR detection MUST be used in `close.md` Phase 4.5.1. If the detection methods diverge between start and close, silent-skip regressions (e.g., the #115/#381/#15 incidents) reappear.
+
+**Method 1: `## 親 Issue` body meta (PRIMARY)**
+
+Read the current (child) Issue body and search for the `## 親 Issue` section. This section is written by `/rite:issue:create-decompose` when child Issues are created from a parent. Format:
+
+```
+## 親 Issue
+
+#{parent_number} - {parent_title}
+```
+
+```bash
+child_body=$(gh issue view {issue_number} --json body --jq '.body')
+# SIGPIPE 防止 (#398 参照): here-string で subprocess を排除
+parent_number=$(grep -A2 '^## 親 Issue' <<< "$child_body" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+echo "method1_parent=${parent_number:-none}"
+```
+
+If `parent_number` is non-empty, extract it as `{parent_issue_number}` and proceed to 2.4.7.2.
+
+**Method 2: Sub-Issues API (secondary)**
+
+If Method 1 found no parent, query GitHub's native Sub-Issues feature:
 
 ```bash
 gh api graphql -H "GraphQL-Features: sub_issues" -f query='
@@ -137,21 +160,27 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
 ```
 
-If `parent` is not null, extract `parent.number` as `{parent_issue_number}`. Proceed to 2.4.7.2.
+If `parent` is not null, extract `parent.number` as `{parent_issue_number}` and proceed to 2.4.7.2.
 
-**Method 2: Tasklist search (fallback)**
+**Method 3: Tasklist search (last resort)**
 
-If Method 1 fails (API error or `parent` is null):
+If Methods 1 and 2 both failed:
 
 ```bash
 gh issue list --state open --search "in:body \"- [ ] #{issue_number}\" OR \"- [x] #{issue_number}\"" --json number,title,state --limit 5
 ```
 
-**Note**: `--state open` is intentional — closed parent Issues do not need Status updates. The search matches both unchecked (`- [ ]`) and checked (`- [x]`) tasklist items to ensure checkbox state independence (consistent with [epic-detection.md](./epic-detection.md)). GitHub normalizes uppercase `[X]` to lowercase `[x]` in rendered markdown, so matching `[x]` alone is sufficient for the search API.
+**Note**: `--state open` is intentional — closed parent Issues do not need Status updates. The search matches both unchecked (`- [ ]`) and checked (`- [x]`) tasklist items to ensure checkbox state independence (consistent with [epic-detection.md](./epic-detection.md)). GitHub code search with `[`/`]` characters is known to be unreliable, which is why this method is the last resort.
 
-If results are non-empty, use the first result's `number` as `{parent_issue_number}`. Proceed to 2.4.7.2.
+If results are non-empty, use the first result's `number` as `{parent_issue_number}` and proceed to 2.4.7.2.
 
-**When no parent found**: Process as a standalone Issue. Display no warning (this is normal). Skip 2.4.7.2–2.4.7.4.
+**When all three methods failed (no parent found)**: This is the normal path for standalone Issues (AC-4). Emit an explicit **debug log** (not a warning) so that the skip is visible in execution traces — silent skips are prohibited by the project rule (see `feedback_review_zero_findings.md` / Issue #513 MUST requirement):
+
+```bash
+echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"
+```
+
+Then skip 2.4.7.2–2.4.7.4.
 
 #### 2.4.7.2 Retrieve Parent Issue Project Item and Current Status
 

--- a/plugins/rite/references/projects-integration.md
+++ b/plugins/rite/references/projects-integration.md
@@ -120,7 +120,7 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 Detect the parent Issue of the current (child) Issue. **Three methods are tried in order (OR combination); the first successful result wins.** This ordering is critical: `## 親 Issue` body meta is placed PRIMARY because it is the most reliable source in repositories that use `/rite:issue:create-decompose` (which writes this section to every child), and it requires no dependency on GitHub's native Sub-Issues feature.
 
-> **Consistency requirement (Issue #513)**: The same 3-method OR detection MUST be used in `close.md` Phase 4.5.1. If the detection methods diverge between start and close, silent-skip regressions (e.g., the #115/#381/#15 incidents) reappear.
+> **Consistency requirement (Issue #513)**: The same 3-method OR detection **structure** MUST be used in `close.md` Phase 4.5.1 — i.e., the same three method ordering (body meta → Sub-Issues API → tasklist search), the same OR combination semantics, and the same `[DEBUG] parent not detected` emission on total failure. **Context-dependent parameters MAY differ** between the two sites where the surrounding workflow demands it; specifically, Method 3's `--state` filter is `open` here (start side — closed parents do not need In Progress promotion) and `all` in close.md Phase 4.5.1 (close side — the closing Issue's parent may itself already be closed). These differences are intentional and are not drift. If the detection method ordering or OR semantics diverge between start and close, silent-skip regressions (e.g., the #115/#381/#15 incidents) reappear.
 
 **Method 1: `## 親 Issue` body meta (PRIMARY)**
 
@@ -150,17 +150,13 @@ gh api graphql -H "GraphQL-Features: sub_issues" -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     issue(number: $number) {
-      parent {
-        number
-        title
-        state
-      }
+      parent { number }
     }
   }
 }' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
 ```
 
-If `parent` is not null, extract `parent.number` as `{parent_issue_number}` and proceed to 2.4.7.2.
+If `parent` is not null, extract `parent.number` as `{parent_issue_number}` and proceed to 2.4.7.2. (Only `number` is requested because 2.4.7.2 re-queries the parent by number for project data, so `title`/`state` are unused here and would only create drift with `close.md` Phase 4.5.1 Method 2.)
 
 **Method 3: Tasklist search (last resort)**
 
@@ -174,7 +170,7 @@ gh issue list --state open --search "in:body \"- [ ] #{issue_number}\" OR \"- [x
 
 If results are non-empty, use the first result's `number` as `{parent_issue_number}` and proceed to 2.4.7.2.
 
-**When all three methods failed (no parent found)**: This is the normal path for standalone Issues (AC-4). Emit an explicit **debug log** (not a warning) so that the skip is visible in execution traces — silent skips are prohibited by the project rule (see `feedback_review_zero_findings.md` / Issue #513 MUST requirement):
+**When all three methods failed (no parent found)**: This is the normal path for standalone Issues (AC-4). Emit an explicit **debug log** (not a warning) so that the skip is visible in execution traces — silent skips are prohibited by Issue #513's MUST requirement ("同期失敗時は silent skip せず、明示的にログまたは warning を出力する") and the preceding incidents #115 / #381 / #15 which all stemmed from silent skips in parent-child sync:
 
 ```bash
 echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"


### PR DESCRIPTION
## 概要

Closes #513

親子 Issue のステータス同期が再発していた silent skip を解消し、AC-1（子 start → 親 Status In Progress 昇格）と AC-2（全子完了 → 親自動 Close）を充足する。過去 Issue #115 / #381 / #15 の修正意図を再導入防止する回帰検出テストも追加。

## 根本原因

| # | Severity | ファイル / 行 | 問題 |
|---|----------|--------------|------|
| 1 | CRITICAL | `plugins/rite/commands/issue/start.md:393` | Phase 2.4 Step 5 が `trackedInIssues` のみ参照する inline 簡略化。本リポジトリは GitHub ネイティブ Sub-Issues 機能を使用しておらず（親子は body tasklist + `## 親 Issue` メタで管理）、`trackedInIssues` は常に空を返すため親 Status 昇格が完全に silent skip されていた（AC-1 失敗の直接原因） |
| 2 | HIGH | `plugins/rite/commands/issue/close.md` Phase 4.5 | 親 body 更新ロジックは実装済みだが、全子完了判定 → 親 Close の処理が不在（AC-2 失敗の直接原因） |
| 3 | MEDIUM | 検出 3 情報源の不整合 | `projects-integration.md` = Sub-Issues API + tasklist search の 2 方式 / `close.md` = `## 親 Issue` body meta のみ の 1 方式。フェーズごとに検出方式が異なり、いずれか欠損時に silent skip が発生 |

## 変更内容

### 1. `references/projects-integration.md` §2.4.7.1 — 3 方式 OR 検出に統一

検出方式を 3 方式 OR（順次試行）に書き換え:

1. **Method 1 (PRIMARY)**: 子 Issue body から `## 親 Issue` セクションを読み取る。`/rite:issue:create-decompose` が書き込むメタ情報を直接参照するため、本リポジトリで最も確実に動作。
2. **Method 2**: Sub-Issues API の `parent { number }` フィールド。GitHub ネイティブ Sub-Issues 機能利用時の対応。
3. **Method 3**: `gh issue list --search "in:body ..."` によるタスクリスト検索。`[`/`]` 文字の扱いが不安定なため最終手段。

全 3 方式失敗時は `[DEBUG] parent not detected` を明示出力し、silent skip を可視化（AC-4: standalone Issue は正常フロー、ただし debug log は残す）。

### 2. `commands/issue/close.md` Phase 4.5.1 — 同じ 3 方式 OR 検出に統一

`projects-integration.md` §2.4.7.1 と同一ロジックを実装。フェーズ間の検出方式不整合を解消。

### 3. `commands/issue/close.md` Phase 4.6 — Parent Auto-Close 新規追加

新規 Phase 4.6 として以下を実装:

- **4.6.1**: 親の子 Issue 一覧取得（Method A: Sub-Issues API / Method B: 親 body `## Sub-Issues` tasklist + GraphQL batch state lookup）
- **4.6.2**: 全子 Issue の state が CLOSED かを判定
- **4.6.3**: `AskUserQuestion` でユーザー確認（無条件 auto-close は避ける）
- **4.6.4**: 親の Projects Status → Done 更新（`github.projects.enabled: false` ならスキップ、失敗は warning で継続）
- **4.6.5**: `gh issue close {parent_number}` で親 Close、失敗は warning で継続

3 階層ネスト（親の親）は処理しない（直接の親のみ、Section 2 Out of Scope 準拠）。

### 4. `commands/issue/start.md:393` — inline 簡略化を削除し delegation に置換

`trackedInIssues`-only の inline 簡略化を削除し、`projects-integration.md §2.4.7` への委譲に置換。併せて "Issue #513 regression guard" コメントを付記して再導入を防止。

### 5. `hooks/tests/parent-child-sync-static.test.sh` — 新規回帰検出テスト（T-07）

16 項目の静的 grep ベーステスト:

- **Group 1** (4): projects-integration.md に 3 方式検出 + debug log が存在
- **Group 2** (4): close.md Phase 4.5.1 に 3 方式検出 + debug log が存在
- **Group 3** (5): close.md Phase 4.6 に `## Phase 4.6`, `all_closed` 判定, `gh issue close`, `done_option_id`, `AskUserQuestion` が存在
- **Group 4** (3): start.md に inline `trackedInIssues` 簡略化が不在、delegation が存在、regression guard コメントが存在

`run-tests.sh` 経由で全テストと一緒に実行される。

## Acceptance Criteria 充足

| AC | 状態 | 充足手段 |
|----|------|---------|
| AC-1: 子 start → 親 Status In Progress | ✅ | start.md L393 delegation + projects-integration.md 2.4.7.1 の 3 方式検出 |
| AC-2: 全子 close → 親自動 Close | ✅ | close.md Phase 4.6 新規追加 |
| AC-3: 親 body Sub-Issues 同期 | ✅ | 既存 Phase 4.5.2 + Phase 4.5.1 の検出拡張で補強 |
| AC-4: 親未検出時 no-op + debug log | ✅ | projects-integration.md / close.md 双方で `[DEBUG] parent not detected` 出力 |
| AC-5: API 失敗時 warning + 非ブロック継続 | ✅ | 既存 2.4.7.5 error handling + Phase 4.6 の warning fallthrough |
| AC-6: 冪等性（既に In Progress は no-op） | ✅ | 既存 2.4.7.3 Status Condition Check で充足 |
| AC-7: #115/#381/#15 回帰検出 | ✅ | T-07 静的テスト 16 項目 |

## Test Plan

- [x] T-07 回帰検出テスト（16 項目全 pass）: `bash plugins/rite/hooks/tests/parent-child-sync-static.test.sh`
- [x] `run-tests.sh` に組み込み実行（pre-existing failures 3 件は本 PR 無関係）
- [x] `/rite:lint` プラグイン固有チェック（bang-backtick 0 / doc-heavy-patterns 0）。drift 12 件は本 PR 無関係の pre-existing
- [ ] **マージ後の手動 E2E 検証（T-01〜T-06）**: 実 GitHub API / Projects 依存のため自動化不可
  - [ ] T-01: 親 Todo + 子 Todo → `/rite:issue:start {child}` → 親 Status が In Progress に遷移
  - [ ] T-02: 親の全子 Issue を `/rite:issue:close` → 親が自動 Close される
  - [ ] T-03: 親 body Sub-Issues tasklist の `[ ]` → `[x]` 同期
  - [ ] T-04: 親子関係メタがない子での no-op 動作（debug log 出力確認）
  - [ ] T-05: 親 Status 更新 API 失敗時の warning + 非ブロック継続
  - [ ] T-06: 親が既に In Progress の状態での冪等性

## 関連

- 過去の再発 Issue: #115, #381, #15
- 実例: #502（親） - #503, #504, #505, #506（子）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
