### PR TITLE
fix(wiki): content-file パスを /tmp/rite-* prefix に変更し Wiki 成長経路を復活 (#518)

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -426,7 +426,9 @@ The retrospective content includes: Issue title, key decisions made during imple
 
 ```bash
 # {plugin_root} はリテラル値で埋め込む
-tmpfile=$(mktemp)
+# ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
+# (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
+tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trap 'rm -f "$tmpfile"' EXIT
 
 cat <<'RETRO_EOF' > "$tmpfile"
@@ -440,15 +442,20 @@ cat <<'RETRO_EOF' > "$tmpfile"
 {retrospective_summary — Issue の作業中に学んだこと、予想外の困難、有効だったアプローチを LLM が Issue body + work memory から要約して埋め込む}
 RETRO_EOF
 
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type retrospectives \
   --source-ref "issue-{issue_number}" \
   --content-file "$tmpfile" \
   --issue-number {issue_number} \
   --title "Issue #{issue_number} close retrospective" \
-  2>/dev/null
+  2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
+if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+fi
+rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.4.W.2 when it is non-zero. Ingest failure does not block the close workflow.

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -430,7 +430,8 @@ The retrospective content includes: Issue title, key decisions made during imple
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
-trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
+# rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
+trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
 
 cat <<'RETRO_EOF' > "$tmpfile"
 ## Issue Close Retrospective
@@ -453,8 +454,14 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
 if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
-  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
+  # UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  # (F-09 対応) iconv 不在環境 (Alpine 等) では LC_ALL=C tr で ASCII-only fallback
+  if command -v iconv >/dev/null 2>&1; then
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)
+  else
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | LC_ALL=C tr -cd '\11\12\15\40-\176')
+  fi
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
 fi
 ```
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -429,7 +429,8 @@ The retrospective content includes: Issue title, key decisions made during imple
 # ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
-trap 'rm -f "$tmpfile"' EXIT
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
+trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
 
 cat <<'RETRO_EOF' > "$tmpfile"
 ## Issue Close Retrospective
@@ -442,7 +443,6 @@ cat <<'RETRO_EOF' > "$tmpfile"
 {retrospective_summary — Issue の作業中に学んだこと、予想外の困難、有効だったアプローチを LLM が Issue body + work memory から要約して埋め込む}
 RETRO_EOF
 
-trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type retrospectives \
   --source-ref "issue-{issue_number}" \
@@ -452,10 +452,10 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
-if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
+  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
 fi
-rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.4.W.2 when it is non-zero. Ingest failure does not block the close workflow.

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4562,7 +4562,8 @@ The fix content includes: PR number, findings addressed, fix strategies used, an
 # ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
-trap 'rm -f "$tmpfile"' EXIT
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
+trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
 
 cat <<'FIX_EOF' > "$tmpfile"
 ## Fix Results
@@ -4581,7 +4582,6 @@ cat <<'FIX_EOF' > "$tmpfile"
 - Skipped (separate Issue): {skip_count}
 FIX_EOF
 
-trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type fixes \
   --source-ref "pr-{pr_number}" \
@@ -4591,10 +4591,10 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
-if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
+  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
 fi
-rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.6.W.2 when it is non-zero. Ingest failure does not block the fix workflow.

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4563,7 +4563,8 @@ The fix content includes: PR number, findings addressed, fix strategies used, an
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
-trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
+# rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
+trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
 
 cat <<'FIX_EOF' > "$tmpfile"
 ## Fix Results
@@ -4592,8 +4593,14 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
 if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
-  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
+  # UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  # (F-09 対応) iconv 不在環境 (Alpine 等) では LC_ALL=C tr で ASCII-only fallback
+  if command -v iconv >/dev/null 2>&1; then
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)
+  else
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | LC_ALL=C tr -cd '\11\12\15\40-\176')
+  fi
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
 fi
 ```
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4559,7 +4559,9 @@ The fix content includes: PR number, findings addressed, fix strategies used, an
 
 ```bash
 # {plugin_root} はリテラル値で埋め込む
-tmpfile=$(mktemp)
+# ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
+# (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
+tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trap 'rm -f "$tmpfile"' EXIT
 
 cat <<'FIX_EOF' > "$tmpfile"
@@ -4579,15 +4581,20 @@ cat <<'FIX_EOF' > "$tmpfile"
 - Skipped (separate Issue): {skip_count}
 FIX_EOF
 
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type fixes \
   --source-ref "pr-{pr_number}" \
   --content-file "$tmpfile" \
   --pr-number {pr_number} \
   --title "PR #{pr_number} fix results" \
-  2>/dev/null
+  2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
+if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+fi
+rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.6.W.2 when it is non-zero. Ingest failure does not block the fix workflow.

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3848,7 +3848,9 @@ The review content includes: PR number, reviewer types, finding categories, seve
 
 ```bash
 # {plugin_root} はリテラル値で埋め込む
-tmpfile=$(mktemp)
+# ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
+# (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
+tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trap 'rm -f "$tmpfile"' EXIT
 
 cat <<'REVIEW_EOF' > "$tmpfile"
@@ -3869,15 +3871,20 @@ cat <<'REVIEW_EOF' > "$tmpfile"
 - LOW: {count}
 REVIEW_EOF
 
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type reviews \
   --source-ref "pr-{pr_number}" \
   --content-file "$tmpfile" \
   --pr-number {pr_number} \
   --title "PR #{pr_number} review results" \
-  2>/dev/null
+  2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
+if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+fi
+rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3851,7 +3851,8 @@ The review content includes: PR number, reviewer types, finding categories, seve
 # ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
-trap 'rm -f "$tmpfile"' EXIT
+trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
+trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
 
 cat <<'REVIEW_EOF' > "$tmpfile"
 ## Review Results
@@ -3871,7 +3872,6 @@ cat <<'REVIEW_EOF' > "$tmpfile"
 - LOW: {count}
 REVIEW_EOF
 
-trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX)
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   --type reviews \
   --source-ref "pr-{pr_number}" \
@@ -3881,10 +3881,10 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
   2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
-if [ "$trigger_exit" -ne 0 ] && [ -s "$trigger_stderr" ]; then
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500)" >&2
+if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
+  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
 fi
-rm -f "$trigger_stderr"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3852,7 +3852,8 @@ The review content includes: PR number, reviewer types, finding categories, seve
 # (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
-trap 'rm -f "$tmpfile" "$trigger_stderr"' EXIT
+# rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
+trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
 
 cat <<'REVIEW_EOF' > "$tmpfile"
 ## Review Results
@@ -3882,8 +3883,14 @@ bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
 if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
-  # iconv -c で UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
-  echo "[CONTEXT] WIKI_TRIGGER_STDERR=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)" >&2
+  # UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
+  # (F-09 対応) iconv 不在環境 (Alpine 等) では LC_ALL=C tr で ASCII-only fallback
+  if command -v iconv >/dev/null 2>&1; then
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)
+  else
+    _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | LC_ALL=C tr -cd '\11\12\15\40-\176')
+  fi
+  echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
 fi
 ```
 

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -755,11 +755,13 @@ _rite_issue518_tmps+=("$tmp_default")
 echo "x" > "$tmp_default"
 ( cd "$dir36b" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_default" >/dev/null 2>err.log ) && rc=0 || rc=$?
 if [ $rc -eq 1 ]; then
-  # 補助 grep: 拒否理由を示すエラーメッセージが含まれていることを確認する (文言は OR で緩和)
-  if grep -qiE 'must be under|outside|not allowed|invalid path|rite' "$dir36b/err.log"; then
-    pass "mktemp default (/tmp/tmp.*) → exit 1 (pitfall detected)"
+  # 補助 grep は dead assertion を避けるため、else 分岐を fail にする (F-08 対応)。
+  # OR pattern は rite-ingest-trigger.sh の実エラー文言 (`--content-file must be under $PWD or /tmp/rite-*`)
+  # に固有な substring のみに絞る (F-10 対応: 旧 `rite` 単独 token は path 混入で誤 match しやすい)。
+  if grep -qiE 'must be under|/tmp/rite-' "$dir36b/err.log"; then
+    pass "mktemp default (/tmp/tmp.*) → exit 1 + pitfall エラー文言検出"
   else
-    pass "mktemp default → exit 1 (文言チェックはスキップ、exit code のみで pitfall 検出)"
+    fail "exit 1 は正しいが pitfall 拒否文言が stderr にない: $(cat "$dir36b/err.log")"
   fi
 else
   fail "Expected exit 1 for mktemp default, got rc=$rc, stderr=$(cat "$dir36b/err.log")"

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -688,12 +688,25 @@ echo ""
 # Phase: Issue #518 regression — /tmp/rite-* prefix と mktemp デフォルト pitfall
 # ==========================================================================
 
+# /tmp 外ファイルの明示 cleanup (review F-04: TEST_DIR 外は main cleanup() の対象外)
+# TC-036a/b は wiki-ingest-trigger.sh のパス検証が /tmp/rite-* prefix と mktemp デフォルトを
+# 正しく区別することを test するため、$TEST_DIR 内ではなく /tmp 直下にファイルを作る必要がある。
+# main trap cleanup は $TEST_DIR しか掃除しないため、個別 trap で追跡する。
+_rite_issue518_tmps=()
+_rite_issue518_cleanup() {
+  if [ ${#_rite_issue518_tmps[@]} -gt 0 ]; then
+    rm -f "${_rite_issue518_tmps[@]}"
+  fi
+}
+# main cleanup に chain する (既存 trap は cleanup() を呼ぶので、本 trap は issue518 専用ファイルのみ削除)
+trap '_rite_issue518_cleanup; cleanup' EXIT
+
 # --------------------------------------------------------------------------
-# TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (Issue #518 正常系)
+# TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (Issue #518 正常系 / PR #519 fix)
 # --------------------------------------------------------------------------
 # Issue #518: pr/review.md / pr/fix.md / issue/close.md は wiki-ingest-trigger.sh を
 # 呼ぶときに tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX) でファイル生成する必要がある。
-# この TC は /tmp/rite-* prefix でのファイルが正常に受容されることを保証する。
+# この TC は /tmp/rite-* prefix でのファイルが正常に受容され、PR #519 fix が正しく動作することを保証する。
 echo "TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (Issue #518 regression)"
 dir36a="$TEST_DIR/tc36a"
 mkdir -p "$dir36a"
@@ -703,11 +716,12 @@ wiki:
 EOF
 # Create content-file using /tmp/rite-* prefix (review.md / fix.md / close.md と同パターン)
 tmp_in_rite=$(mktemp /tmp/rite-wiki-content-XXXXXX)
+_rite_issue518_tmps+=("$tmp_in_rite")
 echo "review body" > "$tmp_in_rite"
 ( cd "$dir36a" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_in_rite" > out.log 2>err.log ) && rc=0 || rc=$?
-rm -f "$tmp_in_rite"
 if [ $rc -eq 0 ]; then
-  target_path36a=$(cat "$dir36a/out.log" | tr -d '[:space:]')
+  # review F-06: tr -d [:space:] は stdout 多行時に path を連結してしまう。先頭行のみ取る
+  target_path36a=$(head -1 "$dir36a/out.log" | tr -d '[:space:]')
   if [ -n "$target_path36a" ] && [ -f "$dir36a/$target_path36a" ]; then
     pass "/tmp/rite-* prefix content-file → exit 0 + raw file created"
   else
@@ -719,11 +733,16 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-036b: Content-file from mktemp default (/tmp/tmp.*) → exit 1 (Issue #518 pitfall)
+# TC-036b: Content-file from mktemp default → exit 1 (Issue #518 pitfall lock)
 # --------------------------------------------------------------------------
 # Issue #518 根本原因の再現テスト: `mktemp` をデフォルト引数で呼ぶと /tmp/tmp.XXXXXXX が
 # 生成され、wiki-ingest-trigger.sh のパス検証 ($PWD 配下 or /tmp/rite-* prefix) で拒否される。
-# 本 TC はこの pitfall が exit 1 で検出され、将来再発した場合に CI で気付けることを保証する。
+# 本 TC は、将来 commands/*.md が mktemp デフォルトに戻った場合に fix ループの回帰テストとして
+# exit code で pitfall を検出する。
+#
+# review F-03: 旧実装は `grep -qE 'must be under.*rite'` でエラー文言の literal に依存していたため、
+# 文言を i18n / reword した瞬間に silent fail する設計欠陥があった。assertion を 2 段階にし、
+# exit code (1) を必須 pass 条件とし、文言 grep は OR パターンで緩和する (defense-in-depth)。
 echo "TC-036b: Content-file from mktemp default → exit 1 (Issue #518 pitfall)"
 dir36b="$TEST_DIR/tc36b"
 mkdir -p "$dir36b"
@@ -732,13 +751,18 @@ wiki:
   enabled: true
 EOF
 tmp_default=$(mktemp)
+_rite_issue518_tmps+=("$tmp_default")
 echo "x" > "$tmp_default"
 ( cd "$dir36b" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_default" >/dev/null 2>err.log ) && rc=0 || rc=$?
-rm -f "$tmp_default"
-if [ $rc -eq 1 ] && grep -qE 'must be under.*rite' "$dir36b/err.log"; then
-  pass "mktemp default (/tmp/tmp.*) → exit 1 (pitfall detected)"
+if [ $rc -eq 1 ]; then
+  # 補助 grep: 拒否理由を示すエラーメッセージが含まれていることを確認する (文言は OR で緩和)
+  if grep -qiE 'must be under|outside|not allowed|invalid path|rite' "$dir36b/err.log"; then
+    pass "mktemp default (/tmp/tmp.*) → exit 1 (pitfall detected)"
+  else
+    pass "mktemp default → exit 1 (文言チェックはスキップ、exit code のみで pitfall 検出)"
+  fi
 else
-  fail "Expected exit 1 with 'must be under', got rc=$rc, stderr=$(cat "$dir36b/err.log")"
+  fail "Expected exit 1 for mktemp default, got rc=$rc, stderr=$(cat "$dir36b/err.log")"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -685,6 +685,64 @@ fi
 echo ""
 
 # ==========================================================================
+# Phase: Issue #518 regression — /tmp/rite-* prefix と mktemp デフォルト pitfall
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (Issue #518 正常系)
+# --------------------------------------------------------------------------
+# Issue #518: pr/review.md / pr/fix.md / issue/close.md は wiki-ingest-trigger.sh を
+# 呼ぶときに tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX) でファイル生成する必要がある。
+# この TC は /tmp/rite-* prefix でのファイルが正常に受容されることを保証する。
+echo "TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (Issue #518 regression)"
+dir36a="$TEST_DIR/tc36a"
+mkdir -p "$dir36a"
+cat > "$dir36a/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+# Create content-file using /tmp/rite-* prefix (review.md / fix.md / close.md と同パターン)
+tmp_in_rite=$(mktemp /tmp/rite-wiki-content-XXXXXX)
+echo "review body" > "$tmp_in_rite"
+( cd "$dir36a" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_in_rite" > out.log 2>err.log ) && rc=0 || rc=$?
+rm -f "$tmp_in_rite"
+if [ $rc -eq 0 ]; then
+  target_path36a=$(cat "$dir36a/out.log" | tr -d '[:space:]')
+  if [ -n "$target_path36a" ] && [ -f "$dir36a/$target_path36a" ]; then
+    pass "/tmp/rite-* prefix content-file → exit 0 + raw file created"
+  else
+    fail "/tmp/rite-* prefix → rc=0 but output file not found (path='$target_path36a')"
+  fi
+else
+  fail "Expected rc=0 for /tmp/rite-* prefix, got rc=$rc, stderr=$(cat "$dir36a/err.log")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-036b: Content-file from mktemp default (/tmp/tmp.*) → exit 1 (Issue #518 pitfall)
+# --------------------------------------------------------------------------
+# Issue #518 根本原因の再現テスト: `mktemp` をデフォルト引数で呼ぶと /tmp/tmp.XXXXXXX が
+# 生成され、wiki-ingest-trigger.sh のパス検証 ($PWD 配下 or /tmp/rite-* prefix) で拒否される。
+# 本 TC はこの pitfall が exit 1 で検出され、将来再発した場合に CI で気付けることを保証する。
+echo "TC-036b: Content-file from mktemp default → exit 1 (Issue #518 pitfall)"
+dir36b="$TEST_DIR/tc36b"
+mkdir -p "$dir36b"
+cat > "$dir36b/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+tmp_default=$(mktemp)
+echo "x" > "$tmp_default"
+( cd "$dir36b" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_default" >/dev/null 2>err.log ) && rc=0 || rc=$?
+rm -f "$tmp_default"
+if [ $rc -eq 1 ] && grep -qE 'must be under.*rite' "$dir36b/err.log"; then
+  pass "mktemp default (/tmp/tmp.*) → exit 1 (pitfall detected)"
+else
+  fail "Expected exit 1 with 'must be under', got rc=$rc, stderr=$(cat "$dir36b/err.log")"
+fi
+echo ""
+
+# ==========================================================================
 # Phase: オプション値なし末尾テスト (TC-037 〜 TC-039)
 # cycle 8 F-06 fix: $# -ge 2 ガードの検証
 # ==========================================================================

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -177,12 +177,15 @@ resolved_content=$(realpath -- "$CONTENT_FILE") || {
   exit 1
 }
 # F-02 fix: /tmp/* → /tmp/rite-* に制限 (exfiltration 経路の縮小)
+# F-11 fix: macOS では /tmp → /private/tmp の symlink があり、realpath 解決後は
+#   /private/tmp/rite-* が返る。同じ信頼境界 (owner-managed /tmp/rite- namespace) として
+#   allowlist に追加する。exfiltration リスク増加なし (どちらも owner-writable /tmp 直下の rite prefix)
 case "$resolved_content" in
-  "$PWD"/*|/tmp/rite-*)
-    : # allowed ($PWD 配下 or /tmp/rite-* 配下)
+  "$PWD"/*|/tmp/rite-*|/private/tmp/rite-*)
+    : # allowed ($PWD 配下 / /tmp/rite-* / /private/tmp/rite-* — 後者は macOS realpath 解決後)
     ;;
   *)
-    echo "ERROR: --content-file must be under \$PWD or /tmp/rite-*" >&2
+    echo "ERROR: --content-file must be under \$PWD or /tmp/rite-* (macOS: /private/tmp/rite-*)" >&2
     echo "  resolved path: $resolved_content" >&2
     echo "  hint: copy the file into the project directory first" >&2
     exit 1


### PR DESCRIPTION
## Summary

Issue #518 Pre-gate 実証調査 (D6-1〜D6-5) により根本原因を特定し、最小修正で解決した。

- **根本原因**: `pr/review.md` / `pr/fix.md` / `issue/close.md` 3 ファイルの `tmpfile=$(mktemp)` が `/tmp/tmp.*` を生成し、`wiki-ingest-trigger.sh` のパス検証 (`$PWD` 配下 or `/tmp/rite-*` prefix) で拒否されていた
- **Silent 化の原因**: 呼び出し側の `2>/dev/null` により ERROR メッセージが抑制
- **結果**: PR #516 merge 後も raw ディレクトリは空、wiki branch は init 1 commit のまま成長 0 件
- **修正**: 3 ファイルで `mktemp /tmp/rite-wiki-content-XXXXXX` に変更 + stderr 可視化 + 回帰テスト TC-036a/TC-036b 追加

## v4 plan への影響

`~/.claude/plans/jiggly-finding-zebra.md` (v4 plan) の hook 駆動永続化層 (PostToolUse/Stop hook + shell-only 永続化 + worktree + flock) は **過剰診断** だった。実際は 1 行レベルのバグ修正で解決可能。v5 plan の起票は不要。

v4/v3 plan のアーカイブ (H16) は別 Issue で対応。

## Changes

| File | Change |
|------|--------|
| `plugins/rite/commands/pr/review.md` | `tmpfile=$(mktemp)` → `mktemp /tmp/rite-wiki-content-XXXXXX`、`2>/dev/null` → stderr ログ化 |
| `plugins/rite/commands/pr/fix.md` | 同上 |
| `plugins/rite/commands/issue/close.md` | 同上 |
| `plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh` | TC-036a (正常系) / TC-036b (pitfall 再現) 追加 |

## Pre-gate 調査結果

詳細は Issue #518 の [コメント](https://github.com/B16B1RD/cc-rite-workflow/issues/518#issuecomment-4248189781) 参照。

- [x] D6-1: PR #516 merge 後の呼び出し痕跡確認
- [x] D6-2: trigger 発火 trace (3 ファイルで実装済み)
- [x] D6-3: Raw Source 生成有無 (未生成確認)
- [x] D6-4: 永続化失敗ポイント特定 (content-file path validation silent rejection)
- [x] D6-5: 4 仮説反証 (silent exit 確定)
- [x] H6: Context 追記完了

## Test plan

- [x] \`bash plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh\` → 45/45 PASS
- [ ] PR レビュー自体が bootstrap として動作し、マージ後に自然に wiki branch が成長することを確認
- [ ] セルフレビュー (/rite:pr:review) を走らせ raw file が生成されることを確認

## Scope out

- v4 plan (\`jiggly-finding-zebra.md\`) の archive (H16)
- v3 plan (\`melodic-discovering-riddle.md\`) の archive
- D1-D8 / H1-H19 の残項目 (Pre-gate 結果を踏まえると大半は moot)
- \`start.md\` からの \`wiki:query\` 参照強化 (H15)

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)