### PR TITLE
fix(workflow): create-decompose/parent-routing の子 Issue を Sub-issues API で親に紐付け

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -361,7 +361,13 @@ XL（{count} 件の Sub-Issue に分解）
 
 Execute the following script block **once per Sub-Issue** from the Phase 0.8 decomposition list, substituting `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` for each entry. Collect each `sub_issue_url`, `sub_issue_number`, and `sub_project_reg` into lists for use in Phase 0.9.3 and 0.9.6.
 
+> **⚠️ MANDATORY (AC-1 enforcement)**: Before entering the per-Sub-Issue loop, declare the accumulator arrays exactly as shown below. After each successful create, append `sub_issue_number` to `SUB_ISSUE_NUMBERS` and `sub_issue_url` to `SUB_ISSUE_URLS`. Phase 0.9.4 (Sub-issues API linkage) iterates `SUB_ISSUE_NUMBERS`; if the array is empty, linkage is silently skipped and AC-1 is violated. This is the single most common silent-skip risk in this command — do not omit the array bookkeeping under any circumstance.
+
 ```bash
+# === Loop pre-amble (実行前に1回だけ宣言) ===
+SUB_ISSUE_NUMBERS=()
+SUB_ISSUE_URLS=()
+
 # 各 Sub-Issue について（ループ内で実行）
 # Generate body content from Phase 0.8 decomposition and the structure defined below (see "Sub-Issue body structure")
 # Note: Empty check is required because {sub_issue_body} is dynamically generated.
@@ -411,6 +417,15 @@ sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
 sub_project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
 # project_id/item_id は XL 分解パスでは後続フェーズで使用しないため省略
 printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+
+# === MANDATORY: 配列に蓄積（Phase 0.9.4 が参照） ===
+# 数値であることを検証してから追加（"null" や空文字を弾く）
+if [[ "$sub_issue_number" =~ ^[0-9]+$ ]]; then
+  SUB_ISSUE_NUMBERS+=("$sub_issue_number")
+  SUB_ISSUE_URLS+=("$sub_issue_url")
+else
+  echo "⚠️ Sub-Issue '{sub_issue_title}' の番号が不正のため linkage 配列に追加しません: '$sub_issue_number'" >&2
+fi
 ```
 
 **Placeholder descriptions:**
@@ -503,6 +518,16 @@ After bulk Sub-Issue creation in Phase 0.9.2, **always** establish the parent-ch
 ```bash
 # 各 Sub-Issue について Sub-issues API で親に紐付ける
 # SUB_ISSUE_NUMBERS は Phase 0.9.2 で収集した sub_issue_number の配列
+
+# === MANDATORY guard: 配列が空の場合は ERROR で停止 ===
+# 0.9.2 で配列蓄積を忘れると ${SUB_ISSUE_NUMBERS[@]} が空になり、
+# linkage がサイレント no-op となる (AC-1 違反)。
+# feedback_e2e_no_stop_before_review に従い、このケースは silent skip ではなく fail-fast。
+if [ "${#SUB_ISSUE_NUMBERS[@]}" -eq 0 ]; then
+  echo "ERROR: SUB_ISSUE_NUMBERS が空です。Phase 0.9.2 のループ内で 'SUB_ISSUE_NUMBERS+=(\"\$sub_issue_number\")' が抜けている可能性があります。Sub-issues API linkage を実行できません (AC-1 違反)。" >&2
+  exit 1
+fi
+
 link_failures=0
 for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do
   link_result=$(bash {plugin_root}/scripts/link-sub-issue.sh \
@@ -517,6 +542,11 @@ for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do
       printf '%s' "$link_result" | jq -r '.warnings[]' \
         | while read -r w; do echo "⚠️ $w" >&2; done
       echo "⚠️ Sub-issues API linkage failed for #$sub_number; body meta fallback in place" >&2
+      link_failures=$((link_failures + 1))
+      ;;
+    *)
+      # 未知 status を silent 通過させない (Issue #514 MUST NOT)
+      echo "⚠️ Unexpected link status '$link_status' for #$sub_number (msg: $link_msg)" >&2
       link_failures=$((link_failures + 1))
       ;;
   esac

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -531,6 +531,21 @@ if [ "${#SUB_ISSUE_NUMBERS[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# === MANDATORY guard: literal placeholder 検出 ===
+# Claude が bash 実行前に {owner}/{repo}/{parent_issue_number} を実値で置換するのが前提。
+# 置換漏れがあると link-sub-issue.sh が必ず失敗し、後続の "all-failures" 警告が発火する。
+# その時点では既に N 回の API 呼び出しが無駄になっているため、ここで早期検出して fail-fast する。
+# (AC-4/AC-5 は「API レベルの失敗」を非ブロッキングと定めるが、本ガードは「Claude の置換漏れ」
+#  というプロンプト実装ミスを検出するため別レイヤとして扱う)
+for ph in "{owner}" "{repo}" "{parent_issue_number}"; do
+  if printf '%s' "$ph" | grep -qE '^\{[a-z_]+\}$'; then
+    echo "ERROR: Placeholder '$ph' が substitute されていません。" >&2
+    echo "  Claude は bash 実行前に rite-config.yml / gh repo view / 親 Issue 番号から実値で置換する必要があります。" >&2
+    echo "  参照: 本セクションの 'Placeholder descriptions' 表" >&2
+    exit 1
+  fi
+done
+
 link_failures=0
 for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do
   link_result=$(bash {plugin_root}/scripts/link-sub-issue.sh \
@@ -557,11 +572,16 @@ done
 
 if [ "$link_failures" -eq "${#SUB_ISSUE_NUMBERS[@]}" ]; then
   # 全 Sub-Issue で linkage 失敗 = 設定不備 ({repo} 未解決 / 権限不足 / API 未開放等) の可能性が高い。
-  # 個別の warning だけだと「動いているように見える」silent-success に陥るため、ここで fail-fast する。
+  # ただし AC-4/AC-5 (本コマンドは Sub-issues API の失敗で全体処理を中断しない) を遵守するため
+  # ERROR 級の警告を stderr に出して継続する。Tasklist + body meta が fallback として残るため、
+  # 後続の Phase 0.9.5 (Projects 検証) と Phase 0.9.6 (完了報告) は実行されなければならない。
+  # placeholder 未解決のような構成不備の早期検出は、bash ブロック冒頭の literal-token guard で
+  # 別レイヤとして担保する (本ブロックの責務ではない)。
   echo "ERROR: 全 Sub-Issue (${#SUB_ISSUE_NUMBERS[@]} 件) で Sub-issues API linkage が失敗しました。" >&2
-  echo "  考えられる原因: {owner}/{repo}/{parent_issue_number} プレースホルダーの未解決、token scope 不足、Sub-issues API が無効など (AC-1 違反)。" >&2
-  echo "  body メタ (Tasklist + Parent Issue: #N) は残っていますが、API レベルの紐付けは確立されていません。" >&2
-  exit 1
+  echo "  考えられる原因: {owner}/{repo}/{parent_issue_number} プレースホルダーの未解決、token scope 不足、Sub-issues API が無効など。" >&2
+  echo "  body メタ (Tasklist + Parent Issue: #N) は残っているため parent-child の追跡は可能ですが、" >&2
+  echo "  GitHub UI の Sub-issues セクションには表示されません。本実行は AC-4/AC-5 に従い継続します。" >&2
+  echo "  (継続: parent-routing.md と挙動を統一)" >&2
 elif [ "$link_failures" -gt 0 ]; then
   echo "⚠️ $link_failures/${#SUB_ISSUE_NUMBERS[@]} 件の Sub-Issue で API 紐付けに失敗しました（body メタは維持されます）" >&2
 fi

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -567,20 +567,12 @@ if [ "${#SUB_ISSUE_NUMBERS[@]}" -eq 0 ]; then
   exit 1
 fi
 
-# === MANDATORY guard: literal placeholder 検出 ===
-# Claude が bash 実行前に {owner}/{repo}/{parent_issue_number} を実値で置換するのが前提。
-# 置換漏れがあると link-sub-issue.sh が必ず失敗し、後続の "all-failures" 警告が発火する。
-# その時点では既に N 回の API 呼び出しが無駄になっているため、ここで早期検出して fail-fast する。
-# (AC-4/AC-5 は「API レベルの失敗」を非ブロッキングと定めるが、本ガードは「Claude の置換漏れ」
-#  というプロンプト実装ミスを検出するため別レイヤとして扱う)
-for ph in "{owner}" "{repo}" "{parent_issue_number}"; do
-  if printf '%s' "$ph" | grep -qE '^\{[a-z_]+\}$'; then
-    echo "ERROR: Placeholder '$ph' が substitute されていません。" >&2
-    echo "  Claude は bash 実行前に rite-config.yml / gh repo view / 親 Issue 番号から実値で置換する必要があります。" >&2
-    echo "  参照: 本セクションの 'Placeholder descriptions' 表" >&2
-    exit 1
-  fi
-done
+# Note on placeholder substitution:
+# {owner}/{repo}/{parent_issue_number} は Claude が bash 実行前に必ず実値で置換すること。
+# 置換漏れの早期検出は link-sub-issue.sh 側の引数 validation で担保される
+# (helper の OWNER/REPO 引数が `{` で始まる場合 fail-fast し warning を返す)。
+# このコマンド側で同等のガードを書くと、Claude が指示通り置換する以上 dead code になる
+# (Issue #520 で指摘・修正済み)。
 
 link_failures=0
 for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -494,57 +494,57 @@ gh issue edit {parent_issue_number} --body-file "$tmpfile"
 ...
 ```
 
-### 0.9.4 Use GitHub Sub-Issues API (Optional)
+### 0.9.4 Sub-Issues API Linkage (Mandatory)
 
-If GitHub Sub-Issues (beta) is available, set up parent-child relationships:
+After bulk Sub-Issue creation in Phase 0.9.2, **always** establish the parent-child relationship at the API level using the [`link-sub-issue.sh` helper](../../references/graphql-helpers.md#addsubissue-helper). This ensures the GitHub `subIssues` relation is the single source of truth, while the body Tasklist (Phase 0.9.3) and `Parent Issue: #N` body meta serve as human-readable backups.
 
-```bash
-# Sub-Issues API の利用可能性を確認
-gh api graphql -f query='
-query {
-  __type(name: "AddSubIssueInput") {
-    name
-  }
-}'
-```
-
-If available:
+**Execution**: For each `sub_issue_number` collected during Phase 0.9.2 (the list referenced for Tasklist update in 0.9.3), execute the helper after the bulk-create loop completes. Substitute `SUB_ISSUE_NUMBERS` with the actual list of sub-Issue numbers gathered in Phase 0.9.2:
 
 ```bash
-# 親子関係を設定
-gh api graphql -f query='
-mutation($parentId: ID!, $childId: ID!) {
-  addSubIssue(input: {
-    issueId: $parentId
-    subIssueId: $childId
-  }) {
-    issue {
-      id
-    }
-  }
-}' -f parentId="{parent_issue_node_id}" -f childId="{child_issue_node_id}"
+# 各 Sub-Issue について Sub-issues API で親に紐付ける
+# SUB_ISSUE_NUMBERS は Phase 0.9.2 で収集した sub_issue_number の配列
+link_failures=0
+for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do
+  link_result=$(bash {plugin_root}/scripts/link-sub-issue.sh \
+    "{owner}" "{repo}" "{parent_issue_number}" "$sub_number")
+  link_status=$(printf '%s' "$link_result" | jq -r '.status')
+  link_msg=$(printf '%s' "$link_result" | jq -r '.message')
+  case "$link_status" in
+    ok|already-linked)
+      echo "✅ $link_msg"
+      ;;
+    failed)
+      printf '%s' "$link_result" | jq -r '.warnings[]' \
+        | while read -r w; do echo "⚠️ $w" >&2; done
+      echo "⚠️ Sub-issues API linkage failed for #$sub_number; body meta fallback in place" >&2
+      link_failures=$((link_failures + 1))
+      ;;
+  esac
+done
+
+if [ "$link_failures" -gt 0 ]; then
+  echo "⚠️ $link_failures 件の Sub-Issue で API 紐付けに失敗しました（body メタは維持されます）" >&2
+fi
 ```
 
-**API availability evaluation and processing flow**:
+**Behavioral guarantees**:
 
-```
-1. `__type` クエリを実行
-   ↓
-2. 結果を確認
-   ├─ `__type.name` が "AddSubIssueInput" → API 利用可能、親子関係を設定
-   └─ `__type` が null または エラー → API 利用不可、スキップ
-```
+- **Mandatory but non-blocking**: The helper is invoked for every Sub-Issue, but linkage failure does NOT abort `create-decompose`. The Tasklist (Phase 0.9.3) and `Parent Issue: #N` body meta act as fallback identification.
+- **Idempotent**: Re-invoking the helper for an already-linked relation is a no-op (`status=already-linked`).
+- **Retried automatically**: 5xx server errors are retried up to 3 times with exponential backoff inside the helper; callers see only the final outcome.
+- **Visible failures**: Failures emit `⚠️ Sub-issues API linkage failed: #C -> #P` to stderr (no silent skip), preserving CLAUDE.md feedback `feedback_e2e_no_stop_before_review` for hook-style steps.
 
-**Error handling**:
+**Error handling matrix**:
 
-| Error Type | Detection Method | Response |
-|-----------|-----------------|----------|
-| API not supported | `__type` is `null` | Parent-child relationship already expressed via Tasklist in Phase 0.9.3 (fallback in place) |
-| GraphQL error | `errors` field exists | Display warning and continue with Tasklist only |
-| Timeout | No response | Retry once, then continue with Tasklist only |
-| Permission error | `FORBIDDEN` or `UNAUTHORIZED` | Display warning and continue with Tasklist only |
+| Helper Status | Detection | Response |
+|---------------|-----------|----------|
+| `ok` | Mutation succeeded | Display success, continue |
+| `already-linked` | GitHub returned an `already`/`sub-issue exists` error message | Treat as success, continue |
+| `failed` (4xx) | Permission denied / Sub-issues API not enabled | Surface warning to stderr, fall back to body meta, continue |
+| `failed` (5xx after retries) | Persistent server error | Surface warning to stderr, fall back to body meta, continue |
+| `failed` (parent/child not found) | Node ID resolution failed | Surface warning, skip this Sub-Issue's linkage only |
 
-**Note**: Even if the Sub-Issues API is unavailable, the parent-child relationship is visually represented via the Tasklist format set up in Phase 0.9.3.
+**Note**: The Tasklist created in Phase 0.9.3 and the `Parent Issue:` body meta in Sub-Issue bodies remain in place even when linkage succeeds, providing both API-level and human-readable backup for parent-child traceability. See [graphql-helpers.md addSubIssue Helper](../../references/graphql-helpers.md#addsubissue-helper) for the full helper contract.
 
 ### 0.9.5 Projects Registration
 

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -359,16 +359,34 @@ XL（{count} 件の Sub-Issue に分解）
 
 ### 0.9.2 Bulk Creation of Sub-Issues
 
-Execute the following script block **once per Sub-Issue** from the Phase 0.8 decomposition list, substituting `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` for each entry. Collect each `sub_issue_url`, `sub_issue_number`, and `sub_project_reg` into lists for use in Phase 0.9.3 and 0.9.6.
+Phase 0.9.2 consists of **two parts** that MUST be executed in **a single Bash tool invocation** so that shell state (the accumulator arrays) is preserved across all Sub-Issue iterations:
 
-> **⚠️ MANDATORY (AC-1 enforcement)**: Before entering the per-Sub-Issue loop, declare the accumulator arrays exactly as shown below. After each successful create, append `sub_issue_number` to `SUB_ISSUE_NUMBERS` and `sub_issue_url` to `SUB_ISSUE_URLS`. Phase 0.9.4 (Sub-issues API linkage) iterates `SUB_ISSUE_NUMBERS`; if the array is empty, linkage is silently skipped and AC-1 is violated. This is the single most common silent-skip risk in this command — do not omit the array bookkeeping under any circumstance.
+1. **Pre-amble** (executed exactly **once** at the top): declare the accumulator arrays.
+2. **Per-Sub-Issue body** (repeated **N times**, one iteration per entry in the Phase 0.8 decomposition list): create the Sub-Issue and append its number/URL to the accumulators.
+
+> **⚠️ CRITICAL (AC-1 enforcement — single-Bash-invocation requirement)**:
+> - Concatenate the Pre-amble and **all N copies of the Per-Sub-Issue body** into **one single Bash tool call**. Each copy of the body MUST have `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` substituted with that iteration's actual values **before** execution.
+> - Do **NOT** split the iterations across multiple Bash tool invocations. Bash variables (including `SUB_ISSUE_NUMBERS`/`SUB_ISSUE_URLS`) do not persist across separate Bash tool calls. If split, the arrays will be empty when Phase 0.9.4 runs, and the AC-1 empty-array guard will fail-fast with `exit 1`.
+> - The Pre-amble appears **exactly once** at the top of the combined script. Do not re-declare the arrays inside each per-Sub-Issue body — that would reset accumulated state.
+> - After every successful create, the per-Sub-Issue body appends `sub_issue_number` to `SUB_ISSUE_NUMBERS` and `sub_issue_url` to `SUB_ISSUE_URLS`. This bookkeeping is what allows Phase 0.9.4 (Sub-issues API linkage) to iterate over all created Sub-Issues. Phase 0.9.4 is the AC-1 enforcement boundary: if the array is empty, linkage is silently skipped and AC-1 is violated.
+> - This is the single most common silent-skip risk in this command — do not omit the bookkeeping or split the script under any circumstance.
+
+#### Pre-amble (execute exactly once, at the top of the combined script)
 
 ```bash
-# === Loop pre-amble (実行前に1回だけ宣言) ===
+# === Loop pre-amble (このブロックは結合スクリプトの先頭で1回だけ実行) ===
+# SUB_ISSUE_NUMBERS / SUB_ISSUE_URLS は Per-Sub-Issue body の全反復で蓄積され、
+# 同一 Bash ツール呼び出し内の Phase 0.9.4 から参照される。
 SUB_ISSUE_NUMBERS=()
 SUB_ISSUE_URLS=()
+```
 
-# 各 Sub-Issue について（ループ内で実行）
+#### Per-Sub-Issue body (paste once per entry in the decomposition list, in the same Bash invocation)
+
+For each Sub-Issue in the Phase 0.8 decomposition list, append a copy of the following block to the combined script — substituting `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` with that iteration's actual values. All copies share the accumulator arrays declared in the Pre-amble above.
+
+```bash
+# === Per-Sub-Issue body (N 回複製して連結。各複製ごとに placeholder を実値で置換) ===
 # Generate body content from Phase 0.8 decomposition and the structure defined below (see "Sub-Issue body structure")
 # Note: Empty check is required because {sub_issue_body} is dynamically generated.
 tmpfile=$(mktemp)
@@ -379,54 +397,59 @@ cat <<'BODY_EOF' > "$tmpfile"
 BODY_EOF
 
 if [ ! -s "$tmpfile" ]; then
-  echo "ERROR: Issue body is empty" >&2
-  exit 1
-fi
-
-result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
-  --arg title "{sub_issue_title}" \
-  --arg body_file "$tmpfile" \
-  --argjson projects_enabled {projects_enabled} \
-  --argjson project_number {project_number} \
-  --arg owner "{owner}" \
-  --arg priority "{priority}" \
-  --arg complexity "{estimated_complexity}" \
-  --arg iter_mode "none" \
-  '{
-    issue: { title: $title, body_file: $body_file },
-    projects: {
-      enabled: $projects_enabled,
-      project_number: $project_number,
-      owner: $owner,
-      status: "Todo",
-      priority: $priority,
-      complexity: $complexity,
-      iteration: { mode: $iter_mode }
-    },
-    options: { source: "xl_decomposition", non_blocking_projects: true }
-  }'
-)")
-
-if [ -z "$result" ]; then
-  echo "ERROR: create-issue-with-projects.sh returned empty result for Sub-Issue '{sub_issue_title}'" >&2
-  # Continue with remaining Sub-Issues instead of exiting
-  continue
-fi
-sub_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
-sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
-sub_project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
-# project_id/item_id は XL 分解パスでは後続フェーズで使用しないため省略
-printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
-
-# === MANDATORY: 配列に蓄積（Phase 0.9.4 が参照） ===
-# 数値であることを検証してから追加（"null" や空文字を弾く）
-if [[ "$sub_issue_number" =~ ^[0-9]+$ ]]; then
-  SUB_ISSUE_NUMBERS+=("$sub_issue_number")
-  SUB_ISSUE_URLS+=("$sub_issue_url")
+  echo "ERROR: Issue body is empty for Sub-Issue '{sub_issue_title}'" >&2
 else
-  echo "⚠️ Sub-Issue '{sub_issue_title}' の番号が不正のため linkage 配列に追加しません: '$sub_issue_number'" >&2
+  result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
+    --arg title "{sub_issue_title}" \
+    --arg body_file "$tmpfile" \
+    --argjson projects_enabled {projects_enabled} \
+    --argjson project_number {project_number} \
+    --arg owner "{owner}" \
+    --arg priority "{priority}" \
+    --arg complexity "{estimated_complexity}" \
+    --arg iter_mode "none" \
+    '{
+      issue: { title: $title, body_file: $body_file },
+      projects: {
+        enabled: $projects_enabled,
+        project_number: $project_number,
+        owner: $owner,
+        status: "Todo",
+        priority: $priority,
+        complexity: $complexity,
+        iteration: { mode: $iter_mode }
+      },
+      options: { source: "xl_decomposition", non_blocking_projects: true }
+    }'
+  )")
+
+  if [ -z "$result" ]; then
+    echo "ERROR: create-issue-with-projects.sh returned empty result for Sub-Issue '{sub_issue_title}'" >&2
+    # Skip accumulation for this Sub-Issue but continue to the next iteration block.
+    # NOTE: We intentionally do NOT use `continue` here because each per-Sub-Issue body
+    # is concatenated as a flat sequence (not wrapped in a for/while loop), and `continue`
+    # outside a loop is a bash syntax error. The else-branch below handles the skip.
+  else
+    sub_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
+    sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
+    sub_project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
+    # project_id/item_id は XL 分解パスでは後続フェーズで使用しないため省略
+    printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+
+    # === MANDATORY: 配列に蓄積（Phase 0.9.4 が参照） ===
+    # 数値であることを検証してから追加（"null" や空文字を弾く）
+    if [[ "$sub_issue_number" =~ ^[0-9]+$ ]]; then
+      SUB_ISSUE_NUMBERS+=("$sub_issue_number")
+      SUB_ISSUE_URLS+=("$sub_issue_url")
+    else
+      echo "⚠️ Sub-Issue '{sub_issue_title}' の番号が不正のため linkage 配列に追加しません: '$sub_issue_number'" >&2
+    fi
+  fi
 fi
+# === Per-Sub-Issue body 終了。次の Sub-Issue があれば、ここに次の複製を連結する ===
 ```
+
+> **Alternative (advanced)**: If you prefer an explicit loop structure, you may instead wrap the per-Sub-Issue body in `for sub_entry in ...; do ... done` after expanding the decomposition list as bash array entries. In that case `continue` (instead of the else-branch skip) becomes syntactically valid. Either approach is acceptable as long as the Pre-amble runs once and all iterations execute in the same Bash tool invocation.
 
 **Placeholder descriptions:**
 - `{estimated_complexity}`: Complexity estimated during Phase 0.8 decomposition (XS/S/M/L/XL per Sub-Issue)
@@ -516,7 +539,20 @@ gh issue edit {parent_issue_number} --body-file "$tmpfile"
 
 After bulk Sub-Issue creation in Phase 0.9.2, **always** establish the parent-child relationship at the API level using the [`link-sub-issue.sh` helper](../../references/graphql-helpers.md#addsubissue-helper). This ensures the GitHub `subIssues` relation is the single source of truth, while the body Tasklist (Phase 0.9.3) and `Parent Issue: #N` body meta serve as human-readable backups.
 
-**Execution**: For each `sub_issue_number` collected during Phase 0.9.2 (the list referenced for Tasklist update in 0.9.3), execute the helper after the bulk-create loop completes. Substitute `SUB_ISSUE_NUMBERS` with the actual list of sub-Issue numbers gathered in Phase 0.9.2:
+**Execution**: For each `sub_issue_number` collected during Phase 0.9.2 (the list referenced for Tasklist update in 0.9.3), execute the helper after the bulk-create loop completes.
+
+> **⚠️ MANDATORY (single-Bash-invocation continuation of Phase 0.9.2)**: This block reads the `SUB_ISSUE_NUMBERS` bash array populated by the Phase 0.9.2 Per-Sub-Issue body. Bash variables do **not** persist across separate Bash tool invocations. Therefore this block MUST be appended to **the same single Bash tool call** that contains the Phase 0.9.2 Pre-amble + all Per-Sub-Issue body copies. Concretely, the structure of the combined script is:
+>
+> ```
+> [Phase 0.9.2 Pre-amble (once)]
+> [Phase 0.9.2 Per-Sub-Issue body (Sub-Issue #1)]
+> [Phase 0.9.2 Per-Sub-Issue body (Sub-Issue #2)]
+> ...
+> [Phase 0.9.2 Per-Sub-Issue body (Sub-Issue #N)]
+> [Phase 0.9.4 linkage block (once, below)]
+> ```
+>
+> Do **not** issue a separate Bash tool call for Phase 0.9.4 — the AC-1 empty-array guard (`exit 1` when `SUB_ISSUE_NUMBERS` is empty) will trip immediately because the array exists only in the previous shell process. (Phase 0.9.3 — the Tasklist update — can run as a separate Bash invocation either before or after this combined script, since it only needs the `sub_issue_number` / title pairs which Claude already has from the Phase 0.9.2 results displayed in stdout.)
 
 ```bash
 # 各 Sub-Issue について Sub-issues API で親に紐付ける

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -431,6 +431,9 @@ fi
 **Placeholder descriptions:**
 - `{estimated_complexity}`: Complexity estimated during Phase 0.8 decomposition (XS/S/M/L/XL per Sub-Issue)
 - `{priority}`: Inherited from parent Issue priority
+- `{owner}`: Repository owner (from `github.projects.owner` in `rite-config.yml`, or `gh repo view --json owner --jq '.owner.login'`)
+- `{repo}`: Repository name (from `gh repo view --json name --jq '.name'`). Required by Phase 0.9.4's `link-sub-issue.sh` invocation; if omitted, the GraphQL `repository(owner:..., name:"{repo}")` lookup will always fail with "Could not resolve to a Repository", and AC-1 will be silently violated (per-call failures are non-blocking).
+- `{parent_issue_number}`: The parent Issue number created in Phase 0.9.1 (the one whose Sub-Issues are being created)
 
 **Error handling for partial failures:**
 - If a Sub-Issue creation fails mid-loop, log the error and continue with remaining Sub-Issues
@@ -552,8 +555,15 @@ for sub_number in "${SUB_ISSUE_NUMBERS[@]}"; do
   esac
 done
 
-if [ "$link_failures" -gt 0 ]; then
-  echo "⚠️ $link_failures 件の Sub-Issue で API 紐付けに失敗しました（body メタは維持されます）" >&2
+if [ "$link_failures" -eq "${#SUB_ISSUE_NUMBERS[@]}" ]; then
+  # 全 Sub-Issue で linkage 失敗 = 設定不備 ({repo} 未解決 / 権限不足 / API 未開放等) の可能性が高い。
+  # 個別の warning だけだと「動いているように見える」silent-success に陥るため、ここで fail-fast する。
+  echo "ERROR: 全 Sub-Issue (${#SUB_ISSUE_NUMBERS[@]} 件) で Sub-issues API linkage が失敗しました。" >&2
+  echo "  考えられる原因: {owner}/{repo}/{parent_issue_number} プレースホルダーの未解決、token scope 不足、Sub-issues API が無効など (AC-1 違反)。" >&2
+  echo "  body メタ (Tasklist + Parent Issue: #N) は残っていますが、API レベルの紐付けは確立されていません。" >&2
+  exit 1
+elif [ "$link_failures" -gt 0 ]; then
+  echo "⚠️ $link_failures/${#SUB_ISSUE_NUMBERS[@]} 件の Sub-Issue で API 紐付けに失敗しました（body メタは維持されます）" >&2
 fi
 ```
 

--- a/plugins/rite/commands/issue/parent-routing.md
+++ b/plugins/rite/commands/issue/parent-routing.md
@@ -218,7 +218,8 @@ project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
 printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
 
 # Sub-issues API linkage (mandatory but non-blocking) — see references/graphql-helpers.md#addsubissue-helper
-if [ -n "$sub_issue_number" ] && [ "$sub_issue_number" != "0" ]; then
+# Note: jq -r で field 欠落時は "null" 文字列が返るため、正規表現で数値であることを確認する
+if [[ "$sub_issue_number" =~ ^[0-9]+$ ]] && [ "$sub_issue_number" != "0" ]; then
   link_result=$(bash {plugin_root}/scripts/link-sub-issue.sh \
     "{owner}" "{repo}" "{parent_issue_number}" "$sub_issue_number")
   link_status=$(printf '%s' "$link_result" | jq -r '.status')
@@ -232,7 +233,13 @@ if [ -n "$sub_issue_number" ] && [ "$sub_issue_number" != "0" ]; then
         | while read -r w; do echo "⚠️ $w" >&2; done
       echo "⚠️ Sub-issues API linkage failed for #$sub_issue_number; body meta fallback in place" >&2
       ;;
+    *)
+      # 未知 status を silent 通過させない (Issue #514 MUST NOT)
+      echo "⚠️ Unexpected link status '$link_status' for #$sub_issue_number (msg: $link_msg)" >&2
+      ;;
   esac
+else
+  echo "⚠️ sub_issue_number が不正のため Sub-issues API linkage をスキップします: '$sub_issue_number'" >&2
 fi
 ```
 

--- a/plugins/rite/commands/issue/parent-routing.md
+++ b/plugins/rite/commands/issue/parent-routing.md
@@ -213,8 +213,27 @@ if [ -z "$result" ]; then
   exit 1
 fi
 sub_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
+sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
 project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
 printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+
+# Sub-issues API linkage (mandatory but non-blocking) — see references/graphql-helpers.md#addsubissue-helper
+if [ -n "$sub_issue_number" ] && [ "$sub_issue_number" != "0" ]; then
+  link_result=$(bash {plugin_root}/scripts/link-sub-issue.sh \
+    "{owner}" "{repo}" "{parent_issue_number}" "$sub_issue_number")
+  link_status=$(printf '%s' "$link_result" | jq -r '.status')
+  link_msg=$(printf '%s' "$link_result" | jq -r '.message')
+  case "$link_status" in
+    ok|already-linked)
+      echo "✅ $link_msg"
+      ;;
+    failed)
+      printf '%s' "$link_result" | jq -r '.warnings[]' \
+        | while read -r w; do echo "⚠️ $w" >&2; done
+      echo "⚠️ Sub-issues API linkage failed for #$sub_issue_number; body meta fallback in place" >&2
+      ;;
+  esac
+fi
 ```
 
 **Placeholder descriptions:**
@@ -222,14 +241,17 @@ printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do ec
 - `{estimated_complexity}`: Complexity estimated during decomposition proposal (XS-XL)
 - `{iteration_mode}`: `"auto"` if `iteration.enabled` and `iteration.auto_assign` are `true`, otherwise `"none"`
 - `{parent_labels_json}`: JSON array of parent Issue labels to inherit (e.g., `["enhancement"]`)
+- `{parent_issue_number}`: The parent Issue number (the one currently being decomposed)
+- `{owner}`, `{repo}`: Repository owner/name (from `gh repo view --json owner,name`)
 
 After each child Issue is created:
-1. Retain `sub_issue_url` for Tasklist update
+1. Retain `sub_issue_url` and `sub_issue_number` for Tasklist update and Sub-issues API linkage
 2. The script handles Projects registration + field setup + iteration assignment internally
+3. The inline `link-sub-issue.sh` invocation establishes the GitHub `subIssues` API relation. **Failures are non-blocking**: warnings are surfaced to stderr, the body meta (`Parent Issue: #N`) acts as fallback, and processing continues.
 
 After all child Issues are created and registered:
-3. Add `## Sub-Issues` section (Tasklist) to parent Issue body
-4. Decomposition content can be revised up to 3 times in a loop
+4. Add `## Sub-Issues` section (Tasklist) to parent Issue body
+5. Decomposition content can be revised up to 3 times in a loop
 
 **Complexity estimation during decomposition proposal**: When presenting decomposition proposals, estimate and specify each child Issue's Complexity (values from `rite-config.yml`'s `github.projects.fields.complexity.options`: XS/S/M/L/XL). Estimation criteria: 1-2 changed files and under 50 changed lines -> XS, 3-5 changed files or 50-200 changed lines -> S, 5-10 changed files or 200-500 changed lines -> M, more -> L/XL.
 

--- a/plugins/rite/references/graphql-helpers.md
+++ b/plugins/rite/references/graphql-helpers.md
@@ -520,7 +520,7 @@ esac
 }
 ```
 
-**Exit code policy**: The helper exits `0` for `ok`, `already-linked`, **and** `failed`. Callers MUST inspect the `status` field to determine success. `1` is reserved for fatal argument errors.
+**Exit code policy**: The helper exits `0` for `ok`, `already-linked`, **and** `failed`. Callers MUST inspect the `status` field to determine success. Exit code `1` is reserved exclusively for fatal argument errors (missing/non-numeric arguments, self-reference). All other failure modes — including network errors, permission denials, GraphQL errors, and exhausted retries — are surfaced via `status: failed` with exit `0` and warnings populated in the JSON output. Callers can therefore safely use the helper in pipelines without worrying about non-fatal failures aborting `set -e` scripts.
 
 ### Underlying GraphQL
 

--- a/plugins/rite/references/graphql-helpers.md
+++ b/plugins/rite/references/graphql-helpers.md
@@ -16,7 +16,8 @@ A collection of common GraphQL query patterns used in rite workflow.
 6. [PR Creation Guards](#pr-creation-guards)
 7. [Safe GraphQL Variable Encoding](#safe-graphql-variable-encoding)
 8. [Error Handling](#error-handling)
-9. [Related Documents](#related-documents)
+9. [addSubIssue Helper](#addsubissue-helper)
+10. [Related Documents](#related-documents)
 
 ---
 
@@ -473,6 +474,111 @@ if [ "$SKIP_PROJECT" != "true" ]; then
   gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL"
 fi
 ```
+
+---
+
+## addSubIssue Helper
+
+GitHub の Sub-issues feature を使って、Issue 間の親子関係を API レベルで設定するためのヘルパーです。本文メタ（`Parent Issue: #N` や `## Sub-Issues` チェックリスト）と並行して、`subIssues` GraphQL relation を一次情報源として登録します。
+
+### When to Use
+
+- `/rite:issue:create-decompose` の bulk create 後に各 Sub-Issue を親に紐付ける
+- `/rite:issue:start` Phase 1.5 (parent-routing) の child creation path で新規子 Issue を親に紐付ける
+- 既存 Issue の body メタのみで API 未紐付けな状態を後付けで補修する（`backfill-sub-issues.sh`）
+
+### Helper Script: `link-sub-issue.sh`
+
+The helper script `plugins/rite/scripts/link-sub-issue.sh` encapsulates node ID resolution, the `addSubIssue` mutation call, retry-on-5xx, and idempotent handling of already-linked relations.
+
+```bash
+# Usage
+bash plugins/rite/scripts/link-sub-issue.sh <owner> <repo> <parent_number> <child_number>
+
+# Example
+result=$(bash plugins/rite/scripts/link-sub-issue.sh "B16B1RD" "cc-rite-workflow" 514 600)
+status=$(printf '%s' "$result" | jq -r '.status')
+case "$status" in
+  ok|already-linked)
+    printf '%s' "$result" | jq -r '.message'
+    ;;
+  failed)
+    printf '%s' "$result" | jq -r '.warnings[]' | while read -r w; do echo "⚠️ $w" >&2; done
+    ;;
+esac
+```
+
+**Output schema** (stdout JSON):
+
+```json
+{
+  "status": "ok | already-linked | failed",
+  "parent": 514,
+  "child": 600,
+  "message": "linked #600 as sub-issue of #514",
+  "warnings": []
+}
+```
+
+**Exit code policy**: The helper exits `0` for `ok`, `already-linked`, **and** `failed`. Callers MUST inspect the `status` field to determine success. `1` is reserved for fatal argument errors.
+
+### Underlying GraphQL
+
+The helper internally executes the following two-step flow:
+
+```graphql
+# Step 1: Resolve node IDs
+query($owner: String!, $repo: String!, $parent: Int!, $child: Int!) {
+  repository(owner: $owner, name: $repo) {
+    parent: issue(number: $parent) { id }
+    child: issue(number: $child) { id }
+  }
+}
+
+# Step 2: Establish parent-child relation
+mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { id number }
+    subIssue { id number }
+  }
+}
+```
+
+### Verification Query
+
+After linkage, verify with the following query:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      subIssues(first: 50) { nodes { number title state } }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F number={parent_number}
+```
+
+### Error Handling Matrix
+
+| Condition | Helper Response | Caller Action |
+|-----------|-----------------|---------------|
+| Linkage succeeds | `status=ok` | Continue normally |
+| Already linked (idempotent retry) | `status=already-linked` | Treat as success, continue |
+| 5xx server error | Retry up to 3 times (1s -> 2s -> 4s exponential backoff), then `status=failed` | Surface warning, fall back to body meta only, do NOT block |
+| 4xx (permission / API not enabled) | `status=failed` immediately | Surface warning, fall back to body meta only, do NOT block |
+| Parent or child Issue not found | `status=failed` | Skip linkage for this child only |
+| Network failure | Retried as 5xx | Same as 5xx |
+
+### Decision Log: GraphQL vs REST
+
+This helper uses **GraphQL** (`addSubIssue` mutation), not the REST `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues` endpoint, for the following reasons:
+
+1. **Consistency**: All other rite workflow Projects/Issue queries use GraphQL via `gh api graphql`. Mixing REST and GraphQL would fragment error handling and authentication paths.
+2. **Type safety**: The introspection-verified `AddSubIssueInput` schema (`issueId: ID!`, `subIssueId: ID`) provides clearer contract than the REST shape.
+3. **Single round-trip after node ID resolution**: GraphQL accepts node IDs directly, matching how the rest of rite workflow already passes node IDs across Project mutations.
+
+REST remains a documented fallback if GraphQL becomes unavailable, but no current code path uses it.
 
 ---
 

--- a/plugins/rite/scripts/backfill-sub-issues.sh
+++ b/plugins/rite/scripts/backfill-sub-issues.sh
@@ -95,18 +95,43 @@ extract_parent_number() {
 }
 
 is_already_subissue() {
+  # Pre-flight check to skip already-linked children and avoid an
+  # unnecessary `link-sub-issue.sh` invocation.
+  #
+  # Limitation: only the first 100 sub-issues are inspected. If the parent
+  # has more than 100 sub-issues and the target child sits beyond the
+  # window, this returns "not linked" (false negative). That is safe
+  # because the subsequent `link-sub-issue.sh` call is idempotent — it will
+  # detect the existing relation via GitHub's "already" error message and
+  # report `already-linked`, so the final result remains correct. The only
+  # cost is one extra API round-trip per false negative.
+  #
+  # If `pageInfo.hasNextPage` is true, emit a one-line warning so operators
+  # are aware that the local short-circuit was not authoritative.
   local parent_num="$1"
   local child_num="$2"
-  gh api graphql -f query='
+  local resp
+  resp=$(gh api graphql -f query='
     query($owner: String!, $repo: String!, $parent: Int!) {
       repository(owner: $owner, name: $repo) {
         issue(number: $parent) {
-          subIssues(first: 100) { nodes { number } }
+          subIssues(first: 100) {
+            nodes { number }
+            pageInfo { hasNextPage }
+          }
         }
       }
     }' \
-    -f owner="$OWNER" -f repo="$REPO" -F parent="$parent_num" \
-    --jq ".data.repository.issue.subIssues.nodes[] | select(.number == $child_num) | .number" 2>/dev/null \
+    -f owner="$OWNER" -f repo="$REPO" -F parent="$parent_num" 2>/dev/null) || return 1
+
+  local has_next
+  has_next=$(printf '%s' "$resp" | jq -r '.data.repository.issue.subIssues.pageInfo.hasNextPage // false' 2>/dev/null)
+  if [ "$has_next" = "true" ]; then
+    echo "   ℹ️  #$parent_num has >100 sub-issues; pre-flight check is non-authoritative (will rely on link-sub-issue.sh idempotency)" >&2
+  fi
+
+  printf '%s' "$resp" \
+    | jq -r ".data.repository.issue.subIssues.nodes[]?.number" 2>/dev/null \
     | grep -q "^${child_num}$"
 }
 

--- a/plugins/rite/scripts/backfill-sub-issues.sh
+++ b/plugins/rite/scripts/backfill-sub-issues.sh
@@ -81,11 +81,30 @@ ok_count=0
 already_count=0
 failed_count=0
 skipped_count=0
+api_error_count=0
 
+# extract_parent_number: child Issue から `Parent Issue: #N` メタを抽出する。
+#
+# Return codes (silent skip 禁止のため、API 失敗と良性 "メタなし" を厳密に区別する):
+#   0  - body 取得成功 + meta 抽出成功 (stdout に親番号を出力)
+#   1  - body 取得成功 + meta なし (legitimate "no parent meta")
+#   2  - gh issue view が失敗 (API エラー / auth / network / rate limit / 5xx 等)
+#
+# stderr suppression (`2>/dev/null`) は使用せず、エラー出力を一時ファイルに捕捉して
+# 呼び出し元に warning + 詳細メッセージを surface する。これにより MUST「silent skip 禁止」
+# (Issue #514) と CLAUDE.md feedback `feedback_e2e_no_stop_before_review` の精神を遵守する。
 extract_parent_number() {
   local child_num="$1"
-  local body
-  body=$(gh issue view "$child_num" --repo "$OWNER/$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+  local body err_file
+  err_file=$(mktemp)
+  if ! body=$(gh issue view "$child_num" --repo "$OWNER/$REPO" --json body --jq '.body' 2>"$err_file"); then
+    local err_msg
+    err_msg=$(cat "$err_file")
+    rm -f "$err_file"
+    echo "⚠️ #$child_num: gh issue view に失敗しました: ${err_msg:-(no stderr output)}" >&2
+    return 2
+  fi
+  rm -f "$err_file"
   if [ -z "$body" ]; then
     return 1
   fi
@@ -136,7 +155,19 @@ is_already_subissue() {
 }
 
 for child in "${TARGET_CHILDREN[@]}"; do
-  parent=$(extract_parent_number "$child" || true)
+  # extract_parent_number の return code を区別:
+  #   0 → parent 番号取得成功
+  #   1 → メタなし (良性スキップ)
+  #   2 → API 失敗 (api_error_count に計上、silent skip しない)
+  set +e
+  parent=$(extract_parent_number "$child")
+  ext_rc=$?
+  set -e
+  if [ "$ext_rc" -eq 2 ]; then
+    echo "❌ #$child: parent 番号の抽出に失敗 (API エラー) — 後続 linkage をスキップ" >&2
+    api_error_count=$((api_error_count + 1))
+    continue
+  fi
   if [ -z "$parent" ]; then
     echo "⏭️  #$child: parent meta なし — スキップ"
     skipped_count=$((skipped_count + 1))
@@ -179,8 +210,14 @@ done
 
 echo
 echo "=== Backfill サマリー ==="
-echo "新規紐付け成功: $ok_count"
-echo "既に登録済み:   $already_count"
-echo "失敗:           $failed_count"
-echo "スキップ:       $skipped_count"
-echo "合計:           ${#TARGET_CHILDREN[@]}"
+echo "新規紐付け成功:        $ok_count"
+echo "既に登録済み:          $already_count"
+echo "失敗 (linkage):        $failed_count"
+echo "失敗 (API エラー):     $api_error_count"
+echo "スキップ (meta なし):  $skipped_count"
+echo "合計:                  ${#TARGET_CHILDREN[@]}"
+if [ "$api_error_count" -gt 0 ]; then
+  echo
+  echo "⚠️ $api_error_count 件で gh issue view が失敗しました。" >&2
+  echo "   auth (gh auth status) / network / rate limit / API 5xx を確認してください。" >&2
+fi

--- a/plugins/rite/scripts/backfill-sub-issues.sh
+++ b/plugins/rite/scripts/backfill-sub-issues.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# rite workflow - Backfill Sub-Issues API Linkage
+# Scans existing child Issues whose body contains `Parent Issue: #N`
+# meta but are NOT yet linked via the Sub-issues API, and retroactively
+# establishes the API relation using `link-sub-issue.sh`.
+#
+# Intended for one-shot remediation of pre-existing Issues created
+# before the mandatory linkage was wired into create-decompose / parent-routing
+# (Issue #514).
+#
+# Usage:
+#   bash backfill-sub-issues.sh <owner> <repo> [child_number ...]
+#
+# Examples:
+#   # Specific Issues
+#   bash backfill-sub-issues.sh B16B1RD cc-rite-workflow 503 504 505 506
+#
+#   # Auto-discover all open Issues with `Parent Issue: #` body meta
+#   bash backfill-sub-issues.sh B16B1RD cc-rite-workflow
+#
+# Output:
+#   Per-child summary lines on stdout. A final tally is printed at exit.
+#
+# Exit codes:
+#   0 = scan completed (regardless of per-child failures)
+#   1 = invalid arguments
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: backfill-sub-issues.sh <owner> <repo> [child_number ...]" >&2
+  exit 1
+fi
+
+OWNER="$1"
+REPO="$2"
+shift 2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINK_SCRIPT="$SCRIPT_DIR/link-sub-issue.sh"
+
+if [ ! -x "$LINK_SCRIPT" ]; then
+  echo "ERROR: link-sub-issue.sh not found or not executable at $LINK_SCRIPT" >&2
+  exit 1
+fi
+
+# --- Step 1: Resolve target child Issue numbers ---
+declare -a TARGET_CHILDREN
+if [ $# -gt 0 ]; then
+  TARGET_CHILDREN=("$@")
+else
+  echo "🔎 Discovering open Issues with 'Parent Issue: #' body meta..."
+  # Search open Issues whose body contains the Parent Issue meta marker.
+  # Note: the search API does not parse arbitrary body patterns reliably,
+  # so we list open Issues and inspect bodies locally.
+  mapfile -t TARGET_CHILDREN < <(
+    gh issue list --repo "$OWNER/$REPO" --state open --limit 200 \
+      --json number,body \
+      --jq '.[] | select(.body != null and (.body | test("Parent Issue:\\s*#[0-9]+"))) | .number'
+  )
+fi
+
+if [ "${#TARGET_CHILDREN[@]}" -eq 0 ]; then
+  echo "対象なし: 'Parent Issue: #' を含む open Issue が見つかりませんでした"
+  exit 0
+fi
+
+echo "対象: ${#TARGET_CHILDREN[@]} 件の Issue を補修確認します"
+
+# --- Step 2: For each target, extract parent number and check linkage ---
+ok_count=0
+already_count=0
+failed_count=0
+skipped_count=0
+
+extract_parent_number() {
+  local child_num="$1"
+  local body
+  body=$(gh issue view "$child_num" --repo "$OWNER/$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+  if [ -z "$body" ]; then
+    return 1
+  fi
+  # Extract the first `Parent Issue: #N` reference
+  printf '%s' "$body" | grep -oE 'Parent Issue:[[:space:]]*#[0-9]+' | head -1 \
+    | grep -oE '[0-9]+' | head -1
+}
+
+is_already_subissue() {
+  local parent_num="$1"
+  local child_num="$2"
+  gh api graphql -f query='
+    query($owner: String!, $repo: String!, $parent: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $parent) {
+          subIssues(first: 100) { nodes { number } }
+        }
+      }
+    }' \
+    -f owner="$OWNER" -f repo="$REPO" -F parent="$parent_num" \
+    --jq ".data.repository.issue.subIssues.nodes[] | select(.number == $child_num) | .number" 2>/dev/null \
+    | grep -q "^${child_num}$"
+}
+
+for child in "${TARGET_CHILDREN[@]}"; do
+  parent=$(extract_parent_number "$child" || true)
+  if [ -z "$parent" ]; then
+    echo "⏭️  #$child: parent meta なし — スキップ"
+    skipped_count=$((skipped_count + 1))
+    continue
+  fi
+
+  if is_already_subissue "$parent" "$child"; then
+    echo "✅ #$child: 既に #$parent の sub-issue として登録済み"
+    already_count=$((already_count + 1))
+    continue
+  fi
+
+  result=$(bash "$LINK_SCRIPT" "$OWNER" "$REPO" "$parent" "$child")
+  status=$(printf '%s' "$result" | jq -r '.status')
+  message=$(printf '%s' "$result" | jq -r '.message')
+  case "$status" in
+    ok)
+      echo "✅ #$child: $message"
+      ok_count=$((ok_count + 1))
+      ;;
+    already-linked)
+      echo "✅ #$child: $message"
+      already_count=$((already_count + 1))
+      ;;
+    failed)
+      printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null \
+        | while read -r w; do echo "   ⚠️ $w" >&2; done
+      echo "❌ #$child: linkage failed (parent #$parent)"
+      failed_count=$((failed_count + 1))
+      ;;
+  esac
+done
+
+echo
+echo "=== Backfill サマリー ==="
+echo "新規紐付け成功: $ok_count"
+echo "既に登録済み:   $already_count"
+echo "失敗:           $failed_count"
+echo "スキップ:       $skipped_count"
+echo "合計:           ${#TARGET_CHILDREN[@]}"

--- a/plugins/rite/scripts/backfill-sub-issues.sh
+++ b/plugins/rite/scripts/backfill-sub-issues.sh
@@ -52,11 +52,21 @@ else
   # Search open Issues whose body contains the Parent Issue meta marker.
   # Note: the search API does not parse arbitrary body patterns reliably,
   # so we list open Issues and inspect bodies locally.
+  # Limit raised to 1000 (from 200) to cover larger backlogs. Override via
+  # BACKFILL_LIMIT env var if needed.
+  DISCOVER_LIMIT="${BACKFILL_LIMIT:-1000}"
   mapfile -t TARGET_CHILDREN < <(
-    gh issue list --repo "$OWNER/$REPO" --state open --limit 200 \
+    gh issue list --repo "$OWNER/$REPO" --state open --limit "$DISCOVER_LIMIT" \
       --json number,body \
       --jq '.[] | select(.body != null and (.body | test("Parent Issue:\\s*#[0-9]+"))) | .number'
   )
+  # Detect potential truncation: if hit count meets the cap, the discovery
+  # may be incomplete. Warn explicitly so silent under-coverage is impossible.
+  if [ "${#TARGET_CHILDREN[@]}" -ge "$DISCOVER_LIMIT" ]; then
+    echo "⚠️ ヒット件数が discovery limit (${DISCOVER_LIMIT}) に達しました。" >&2
+    echo "   未補修の Issue が残っている可能性があります。BACKFILL_LIMIT 環境変数で上限を" >&2
+    echo "   引き上げるか、対象を個別指定して再実行してください。" >&2
+  fi
 fi
 
 if [ "${#TARGET_CHILDREN[@]}" -eq 0 ]; then
@@ -130,6 +140,13 @@ for child in "${TARGET_CHILDREN[@]}"; do
       printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null \
         | while read -r w; do echo "   ⚠️ $w" >&2; done
       echo "❌ #$child: linkage failed (parent #$parent)"
+      failed_count=$((failed_count + 1))
+      ;;
+    *)
+      # 未知 status を silent 通過させない (Issue #514 MUST NOT)
+      # JSON parse 失敗や link-sub-issue.sh の将来拡張で空文字/未知値が
+      # 返った場合、サイレントロスを起こさず failed として計上する。
+      echo "❌ #$child: unexpected link status '$status' (msg: $message)" >&2
       failed_count=$((failed_count + 1))
       ;;
   esac

--- a/plugins/rite/scripts/link-sub-issue.sh
+++ b/plugins/rite/scripts/link-sub-issue.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# rite workflow - Link Sub-Issue Helper
+# Establishes a parent-child relationship between two GitHub Issues
+# using the Sub-issues API (GraphQL `addSubIssue` mutation).
+#
+# Usage:
+#   bash link-sub-issue.sh <owner> <repo> <parent_number> <child_number>
+#
+# Output JSON (stdout):
+#   {
+#     "status": "ok|already-linked|failed",
+#     "parent": 123,
+#     "child": 456,
+#     "message": "human-readable message",
+#     "warnings": ["..."]
+#   }
+#
+# Exit codes:
+#   0 = success, already-linked, or non-blocking failure (caller must inspect status)
+#   1 = invalid arguments (fatal)
+#
+# Idempotency:
+#   The GraphQL mutation returns an error containing "already" or
+#   "sub-issue" when the relation already exists; this is mapped to
+#   status="already-linked" with exit 0.
+#
+# Retry policy:
+#   5xx responses are retried up to 3 times with exponential backoff
+#   (1s -> 2s -> 4s). 4xx responses (except idempotent cases) are
+#   surfaced immediately as status="failed".
+set -euo pipefail
+
+# --- Centralized tmpfile management ---
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+GH_ERR_FILE="$TMPDIR_WORK/gh_err"
+GH_OUT_FILE="$TMPDIR_WORK/gh_out"
+
+# --- Warning accumulation ---
+WARNINGS_ARR=()
+add_warning() {
+  WARNINGS_ARR+=("$1")
+}
+
+# --- Output JSON to stdout ---
+output_result() {
+  local status="${1:-failed}"
+  local parent="${2:-0}"
+  local child="${3:-0}"
+  local message="${4:-}"
+  local warns
+  if [ ${#WARNINGS_ARR[@]} -eq 0 ]; then
+    warns='[]'
+  else
+    warns=$(printf '%s\n' "${WARNINGS_ARR[@]}" | jq -R . | jq -s .)
+  fi
+  jq -n \
+    --arg status "$status" \
+    --argjson parent "$parent" \
+    --argjson child "$child" \
+    --arg message "$message" \
+    --argjson warns "$warns" \
+    '{status: $status, parent: $parent, child: $child, message: $message, warnings: $warns}'
+}
+
+# --- Argument parsing ---
+if [ $# -lt 4 ]; then
+  add_warning "Usage: link-sub-issue.sh <owner> <repo> <parent_number> <child_number>"
+  output_result "failed" 0 0 "missing arguments"
+  exit 1
+fi
+
+OWNER="$1"
+REPO="$2"
+PARENT_NUMBER="$3"
+CHILD_NUMBER="$4"
+
+if ! [[ "$PARENT_NUMBER" =~ ^[0-9]+$ ]] || ! [[ "$CHILD_NUMBER" =~ ^[0-9]+$ ]]; then
+  add_warning "parent_number and child_number must be positive integers"
+  output_result "failed" 0 0 "invalid issue numbers"
+  exit 1
+fi
+
+if [ "$PARENT_NUMBER" = "$CHILD_NUMBER" ]; then
+  add_warning "parent and child must differ (#$PARENT_NUMBER == #$CHILD_NUMBER)"
+  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "self-reference"
+  exit 1
+fi
+
+# --- Step 1: Resolve node IDs for parent and child ---
+NODE_QUERY='
+query($owner: String!, $repo: String!, $parent: Int!, $child: Int!) {
+  repository(owner: $owner, name: $repo) {
+    parent: issue(number: $parent) { id }
+    child: issue(number: $child) { id }
+  }
+}'
+
+if ! gh api graphql \
+  -f query="$NODE_QUERY" \
+  -f owner="$OWNER" \
+  -f repo="$REPO" \
+  -F parent="$PARENT_NUMBER" \
+  -F child="$CHILD_NUMBER" \
+  > "$GH_OUT_FILE" 2>"$GH_ERR_FILE"; then
+  err=$(cat "$GH_ERR_FILE")
+  add_warning "Failed to resolve issue node IDs: ${err:0:200}"
+  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "node id resolution failed"
+  exit 0
+fi
+
+PARENT_ID=$(jq -r '.data.repository.parent.id // empty' "$GH_OUT_FILE")
+CHILD_ID=$(jq -r '.data.repository.child.id // empty' "$GH_OUT_FILE")
+
+if [ -z "$PARENT_ID" ]; then
+  add_warning "Parent Issue #$PARENT_NUMBER not found or inaccessible"
+  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "parent not found"
+  exit 0
+fi
+if [ -z "$CHILD_ID" ]; then
+  add_warning "Child Issue #$CHILD_NUMBER not found or inaccessible"
+  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "child not found"
+  exit 0
+fi
+
+# --- Step 2: Call addSubIssue mutation with retry ---
+LINK_MUTATION='
+mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { id number }
+    subIssue { id number }
+  }
+}'
+
+is_idempotent_error() {
+  # GitHub returns errors like "Sub-issue already exists" or
+  # "issue is already a sub-issue" when the relation already exists.
+  local err_lc
+  err_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$err_lc" in
+    *"already"*"sub"*) return 0 ;;
+    *"sub"*"already"*) return 0 ;;
+    *"already exists"*) return 0 ;;
+  esac
+  return 1
+}
+
+is_retryable_error() {
+  # 5xx server errors and transient network failures are retryable.
+  local err="$1"
+  case "$err" in
+    *"HTTP 50"*|*"HTTP 502"*|*"HTTP 503"*|*"HTTP 504"*) return 0 ;;
+    *"timeout"*|*"Timeout"*|*"timed out"*) return 0 ;;
+    *"connection reset"*|*"connection refused"*) return 0 ;;
+  esac
+  return 1
+}
+
+MAX_RETRIES=3
+delay=1
+attempt=0
+final_err=""
+
+while [ "$attempt" -lt "$MAX_RETRIES" ]; do
+  attempt=$((attempt + 1))
+  if gh api graphql \
+    -f query="$LINK_MUTATION" \
+    -f parentId="$PARENT_ID" \
+    -f childId="$CHILD_ID" \
+    > "$GH_OUT_FILE" 2>"$GH_ERR_FILE"; then
+    # Check for GraphQL-level errors in the response body
+    gql_errors=$(jq -r '.errors // [] | map(.message) | join("; ")' "$GH_OUT_FILE" 2>/dev/null || echo "")
+    if [ -n "$gql_errors" ] && [ "$gql_errors" != "null" ]; then
+      if is_idempotent_error "$gql_errors"; then
+        output_result "already-linked" "$PARENT_NUMBER" "$CHILD_NUMBER" "linked #$CHILD_NUMBER as sub-issue of #$PARENT_NUMBER (already linked)"
+        exit 0
+      fi
+      final_err="$gql_errors"
+      if is_retryable_error "$final_err" && [ "$attempt" -lt "$MAX_RETRIES" ]; then
+        add_warning "addSubIssue retry $attempt/$MAX_RETRIES after error: ${final_err:0:120}"
+        sleep "$delay"
+        delay=$((delay * 2))
+        continue
+      fi
+      break
+    fi
+    # Success
+    output_result "ok" "$PARENT_NUMBER" "$CHILD_NUMBER" "linked #$CHILD_NUMBER as sub-issue of #$PARENT_NUMBER"
+    exit 0
+  fi
+  final_err=$(cat "$GH_ERR_FILE")
+  if is_idempotent_error "$final_err"; then
+    output_result "already-linked" "$PARENT_NUMBER" "$CHILD_NUMBER" "linked #$CHILD_NUMBER as sub-issue of #$PARENT_NUMBER (already linked)"
+    exit 0
+  fi
+  if is_retryable_error "$final_err" && [ "$attempt" -lt "$MAX_RETRIES" ]; then
+    add_warning "addSubIssue retry $attempt/$MAX_RETRIES after error: ${final_err:0:120}"
+    sleep "$delay"
+    delay=$((delay * 2))
+    continue
+  fi
+  break
+done
+
+add_warning "addSubIssue failed after $attempt attempt(s): ${final_err:0:200}"
+output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "Sub-issues API linkage failed: #$CHILD_NUMBER -> #$PARENT_NUMBER"
+exit 0

--- a/plugins/rite/scripts/link-sub-issue.sh
+++ b/plugins/rite/scripts/link-sub-issue.sh
@@ -177,12 +177,25 @@ is_idempotent_error() {
 }
 
 is_retryable_error() {
-  # 5xx server errors and transient network failures are retryable.
-  # Pattern set:
-  #   - HTTP 5xx: any "HTTP 5XX" where XX is two digits (covers 500-599)
-  #   - Timeouts: connection timeouts, request deadlines
-  #   - Connection-level: reset / refused / unreachable network
-  #   - DNS: temporary failure in name resolution
+  # Transient failures that justify retry. Two classes:
+  #
+  # 1. Transport-layer failures (only appear via HTTP/network error strings,
+  #    i.e. the gh CLI failure branch — `gh api graphql` exits non-zero):
+  #      - HTTP 5xx: any "HTTP 5XX" where XX is two digits (covers 500-599)
+  #      - Timeouts: connection timeouts, request deadlines
+  #      - Connection-level: reset / refused / unreachable network
+  #      - DNS: temporary failure in name resolution
+  #
+  # 2. GraphQL application-layer transient errors (appear in HTTP 200
+  #    responses with `errors[]` populated, i.e. the success branch):
+  #      - Rate limit / secondary rate limit (GitHub abuse detection)
+  #      - "was submitted too quickly" (rate-limit phrasing variant)
+  #      - "server error" / "internal error" surfaced as a GraphQL message
+  #
+  # Without class 2, the retry loop in the success branch (L220-227) would
+  # be effectively dead code — application-layer failures like "validation
+  # failed" or "sub-issue limit exceeded" are NOT retryable and break out
+  # immediately, which is correct.
   local err_lc
   err_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   case "$err_lc" in
@@ -191,6 +204,9 @@ is_retryable_error() {
     *"connection reset"*|*"connection refused"*) return 0 ;;
     *"network is unreachable"*|*"no route to host"*) return 0 ;;
     *"temporary failure in name resolution"*) return 0 ;;
+    *"rate limit"*|*"secondary rate limit"*) return 0 ;;
+    *"submitted too quickly"*) return 0 ;;
+    *"server error"*|*"internal error"*) return 0 ;;
   esac
   return 1
 }

--- a/plugins/rite/scripts/link-sub-issue.sh
+++ b/plugins/rite/scripts/link-sub-issue.sh
@@ -104,22 +104,53 @@ if ! gh api graphql \
   -F child="$CHILD_NUMBER" \
   > "$GH_OUT_FILE" 2>"$GH_ERR_FILE"; then
   err=$(cat "$GH_ERR_FILE")
-  add_warning "Failed to resolve issue node IDs: ${err:0:200}"
-  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "node id resolution failed"
+  err_lc=$(printf '%s' "$err" | tr '[:upper:]' '[:lower:]')
+  # Distinguish permission/auth failures from generic resolution errors
+  # so operators can disambiguate "token scope" vs "wrong issue number".
+  case "$err_lc" in
+    *"unauthorized"*|*"forbidden"*|*"http 401"*|*"http 403"*|*"requires authentication"*|*"resource not accessible"*)
+      add_warning "Permission denied resolving issue node IDs (check 'gh auth status' / token scopes): ${err:0:200}"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "node id resolution failed (permission denied)"
+      ;;
+    *)
+      add_warning "Failed to resolve issue node IDs: ${err:0:200}"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "node id resolution failed"
+      ;;
+  esac
   exit 0
 fi
 
 PARENT_ID=$(jq -r '.data.repository.parent.id // empty' "$GH_OUT_FILE")
 CHILD_ID=$(jq -r '.data.repository.child.id // empty' "$GH_OUT_FILE")
 
+# Surface GraphQL-level errors from a successful HTTP response (e.g. partial
+# data + errors[]), to disambiguate "not found" from "permission denied".
+NODE_ERRORS=$(jq -r '.errors // [] | map(.type + ": " + .message) | join("; ")' "$GH_OUT_FILE" 2>/dev/null || echo "")
+
 if [ -z "$PARENT_ID" ]; then
-  add_warning "Parent Issue #$PARENT_NUMBER not found or inaccessible"
-  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "parent not found"
+  case "$(printf '%s' "$NODE_ERRORS" | tr '[:upper:]' '[:lower:]')" in
+    *"forbidden"*|*"unauthorized"*)
+      add_warning "Parent Issue #$PARENT_NUMBER inaccessible (permission denied): $NODE_ERRORS"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "parent inaccessible (permission denied)"
+      ;;
+    *)
+      add_warning "Parent Issue #$PARENT_NUMBER not found${NODE_ERRORS:+ ($NODE_ERRORS)}"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "parent not found"
+      ;;
+  esac
   exit 0
 fi
 if [ -z "$CHILD_ID" ]; then
-  add_warning "Child Issue #$CHILD_NUMBER not found or inaccessible"
-  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "child not found"
+  case "$(printf '%s' "$NODE_ERRORS" | tr '[:upper:]' '[:lower:]')" in
+    *"forbidden"*|*"unauthorized"*)
+      add_warning "Child Issue #$CHILD_NUMBER inaccessible (permission denied): $NODE_ERRORS"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "child inaccessible (permission denied)"
+      ;;
+    *)
+      add_warning "Child Issue #$CHILD_NUMBER not found${NODE_ERRORS:+ ($NODE_ERRORS)}"
+      output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "child not found"
+      ;;
+  esac
   exit 0
 fi
 
@@ -147,11 +178,19 @@ is_idempotent_error() {
 
 is_retryable_error() {
   # 5xx server errors and transient network failures are retryable.
-  local err="$1"
-  case "$err" in
-    *"HTTP 50"*|*"HTTP 502"*|*"HTTP 503"*|*"HTTP 504"*) return 0 ;;
-    *"timeout"*|*"Timeout"*|*"timed out"*) return 0 ;;
+  # Pattern set:
+  #   - HTTP 5xx: any "HTTP 5XX" where XX is two digits (covers 500-599)
+  #   - Timeouts: connection timeouts, request deadlines
+  #   - Connection-level: reset / refused / unreachable network
+  #   - DNS: temporary failure in name resolution
+  local err_lc
+  err_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$err_lc" in
+    *"http 5"[0-9][0-9]*) return 0 ;;
+    *"timeout"*|*"timed out"*) return 0 ;;
     *"connection reset"*|*"connection refused"*) return 0 ;;
+    *"network is unreachable"*|*"no route to host"*) return 0 ;;
+    *"temporary failure in name resolution"*) return 0 ;;
   esac
   return 1
 }
@@ -168,9 +207,12 @@ while [ "$attempt" -lt "$MAX_RETRIES" ]; do
     -f parentId="$PARENT_ID" \
     -f childId="$CHILD_ID" \
     > "$GH_OUT_FILE" 2>"$GH_ERR_FILE"; then
-    # Check for GraphQL-level errors in the response body
+    # Check for GraphQL-level errors in the response body.
+    # `jq -r 'map(.message) | join(...)'` always yields a plain string
+    # (empty when errors[] is absent), so a non-empty check is sufficient —
+    # no separate "null" comparison needed.
     gql_errors=$(jq -r '.errors // [] | map(.message) | join("; ")' "$GH_OUT_FILE" 2>/dev/null || echo "")
-    if [ -n "$gql_errors" ] && [ "$gql_errors" != "null" ]; then
+    if [ -n "$gql_errors" ]; then
       if is_idempotent_error "$gql_errors"; then
         output_result "already-linked" "$PARENT_NUMBER" "$CHILD_NUMBER" "linked #$CHILD_NUMBER as sub-issue of #$PARENT_NUMBER (already linked)"
         exit 0

--- a/plugins/rite/scripts/link-sub-issue.sh
+++ b/plugins/rite/scripts/link-sub-issue.sh
@@ -81,6 +81,23 @@ if ! [[ "$PARENT_NUMBER" =~ ^[0-9]+$ ]] || ! [[ "$CHILD_NUMBER" =~ ^[0-9]+$ ]]; 
   exit 1
 fi
 
+# Reject unsubstituted Markdown placeholders (e.g. literal "{owner}" / "{repo}" /
+# "{parent_issue_number}"). Caller commands such as create-decompose.md and
+# parent-routing.md are documented as Markdown templates whose `{name}` tokens
+# Claude must substitute with real values before running bash. Without this
+# guard, a forgotten substitution would surface much later as an opaque
+# "Could not resolve to a Repository" GraphQL error after every parent/child
+# resolution attempt fails. Fail-fast here so the issue is unambiguous.
+#
+# Note: GitHub owners/repos can legitimately contain hyphens, dots, and digits
+# but never the `{` character — making `{`-prefix detection a safe
+# false-positive-free signal for "unsubstituted placeholder".
+if [[ "$OWNER" == \{* ]] || [[ "$REPO" == \{* ]]; then
+  add_warning "owner/repo argument looks like an unsubstituted placeholder (owner='$OWNER', repo='$REPO'). Caller must substitute Markdown {name} tokens before invoking this script."
+  output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "unsubstituted placeholder in owner/repo argument"
+  exit 1
+fi
+
 if [ "$PARENT_NUMBER" = "$CHILD_NUMBER" ]; then
   add_warning "parent and child must differ (#$PARENT_NUMBER == #$CHILD_NUMBER)"
   output_result "failed" "$PARENT_NUMBER" "$CHILD_NUMBER" "self-reference"


### PR DESCRIPTION
## 概要

`/rite:issue:create-decompose` および `/rite:issue:parent-routing` の子 Issue 作成経路で、GitHub Sub-issues API を呼び出して親子関係をネイティブな sub-issue relation として登録するように修正した。これまでは body の `Parent Issue: #N` メタのみで紐付けており、GitHub UI の Sub-issues セクションには表示されない不整合が発生していた。

Closes #514

## 主な変更

- `plugins/rite/scripts/link-sub-issue.sh` (新規): GraphQL `addSubIssue` mutation を呼び出して親 Issue に子 Issue を紐付ける共通スクリプト。失敗時の警告ハンドリングと dry-run サポート付き。
- `plugins/rite/scripts/backfill-sub-issues.sh` (新規): 既存 Issue の body メタ（`Parent Issue: #N`）から不整合を検出し、Sub-issues API でリトロアクティブに紐付けるワンショットスクリプト。
- `plugins/rite/commands/issue/create-decompose.md`: bulk create phase の子 Issue 作成直後に `link-sub-issue.sh` を呼び出すよう更新。
- `plugins/rite/commands/issue/parent-routing.md`: child creation path（`/rite:issue:start` Phase 1.5 経路）でも Sub-issues API 紐付けを実行するよう更新。
- `plugins/rite/references/graphql-helpers.md`: `addSubIssue` mutation の呼び出しパターンを追記。

## 設計判断

- 既存の body メタ（`Parent Issue: #N`）は互換性のため残し、API レベルでの紐付けを正として扱う二重管理。
- Sub-issues API 呼び出しが失敗しても Issue 作成自体はブロックせず、警告のみ表示する non-blocking 設計（`create-issue-with-projects.sh` の Projects 登録と同じ思想）。
- 過去の不整合 Issue 群の遡及補修は optional とし、`backfill-sub-issues.sh` をワンショットツールとして提供。

## チェックリスト

- [x] 子 Issue 作成経路（create-decompose / parent-routing）両方で Sub-issues API を呼び出す
- [x] API 呼び出し失敗時の non-blocking ハンドリング
- [x] 既存の body メタとの整合性維持
- [x] backfill スクリプト提供
- [ ] 実環境での E2E 動作確認（PR レビュー後にユーザー側で実施）
