### PR TITLE
fix(workflow): /rite:issue:create の sub-skill return 後の自動継続契約を 3 層で強化

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -38,12 +38,13 @@ The command prefix `rite` was chosen for:
 10. [Build/Test/Lint Auto-Detection](#buildtestlint-auto-detection)
 11. [Dynamic Reviewer Generation](#dynamic-reviewer-generation)
 12. [Workflow Incident Detection](#workflow-incident-detection)
-13. [Error Handling](#error-handling)
-14. [Migration](#migration)
-15. [Internationalization](#internationalization)
-16. [Dependencies](#dependencies)
-17. [Distribution](#distribution)
-18. [Project Types](#project-types)
+13. [Sub-skill Return Auto-Continuation Contract](#sub-skill-return-auto-continuation-contract)
+14. [Error Handling](#error-handling)
+15. [Migration](#migration)
+16. [Internationalization](#internationalization)
+17. [Dependencies](#dependencies)
+18. [Distribution](#distribution)
+19. [Project Types](#project-types)
 
 ---
 
@@ -1704,6 +1705,82 @@ Both features persist operational learnings, but their scopes are distinct:
 | **One-time platform defects** (e.g., "hook X exited abnormally in iteration Y") | Issues via `workflow_incident` auto-registration (#366) |
 
 They share no code paths.
+
+## Sub-skill Return Auto-Continuation Contract
+
+### Overview (#525)
+
+When an orchestrator command (e.g., `/rite:issue:start`, `/rite:issue:create`) invokes a sub-skill via the Skill tool and the sub-skill outputs its result pattern (e.g., `[interview:skipped]`, `[review:mergeable]`, `[create:completed:{N}]`), control returns to the orchestrator LLM. The orchestrator **MUST** continue executing the next phase in the **same response turn** — the sub-skill return is a continuation trigger, not a turn boundary.
+
+Violating this contract leaves the workflow partially executed: no Issue created, `.rite-flow-state` stuck in `active: true`, stale timestamps, and the user forced to type `continue` manually to recover. Issue #525 was filed after multiple instances of this failure in `/rite:issue:create` with the Bug Fix preset.
+
+### The three defense-in-depth layers
+
+| Layer | Mechanism | Enforced by |
+|-------|-----------|------------|
+| **1. Prompt contract** | Anti-pattern / correct-pattern examples + "same response turn" / "DO NOT stop" phrases in orchestrator documentation | `commands/issue/start.md` Sub-skill Return Protocol (Global), `commands/issue/create.md` Sub-skill Return Protocol, `plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md` |
+| **2. Flow state** | Sub-skills write `*_post_*` phase markers with `active: true` before return; `stop-guard.sh` blocks every stop attempt until the orchestrator reaches the terminal phase (`create_completed` with `active: false` for `/rite:issue:create`) | `hooks/flow-state-update.sh`, `hooks/stop-guard.sh` |
+| **3. Caller-continuation hints** | HTML comment `<!-- caller: read .rite-flow-state and continue with Phase X.Y in the SAME response turn. DO NOT stop. -->` immediately before the sub-skill's result pattern | Defense-in-Depth sections in `commands/issue/create-interview.md`, `commands/issue/create-register.md` |
+
+All three layers must be present for the contract to hold. If any layer is weakened (e.g., the HTML comment is removed, or the `same response turn` phrase is dropped from the prompt), the LLM may revert to its default "task-complete → end turn" behavior on the next failure path.
+
+### Contract specification
+
+For every Skill tool invocation within an orchestrator:
+
+1. When the sub-skill returns control (outputs its result pattern), the orchestrator LLM **MUST NOT** end its response.
+2. The orchestrator **MUST NOT** re-invoke the completed sub-skill.
+3. The orchestrator **MUST** execute its 🚨 Mandatory After section for the current phase, beginning with the `.rite-flow-state` update, then proceeding to the next phase — all in the same response turn.
+4. If `stop-guard.sh` blocks a stop attempt (exit 2), the orchestrator **MUST** follow the `ACTION:` instructions in the hook's stderr message, not retry the stop.
+
+The contract ends only when the orchestrator's terminal completion marker has been output:
+
+| Orchestrator | Terminal marker |
+|-------------|----------------|
+| `/rite:issue:start` | Phase 5.6 completion report + Workflow Termination block |
+| `/rite:issue:create` | `[create:completed:{N}]` as the absolute last line |
+
+### Phase-aware stop-guard hints (#525)
+
+When `stop-guard.sh` blocks a stop attempt with an active `.rite-flow-state`, the blocking message now includes phase-specific continuation hints for `/rite:issue:create` paths:
+
+| Active phase | Hint content |
+|-------------|-------------|
+| `create_post_interview` | "Sub-skill rite:issue:create-interview returned. The return tag is a CONTINUATION TRIGGER, not a turn boundary. Immediately run Phase 0.6 → Delegation Routing Pre-write → invoke rite:issue:create-register in the SAME response turn." |
+| `create_delegation` | "Delegation sub-skill is in-flight. When it returns `[create:completed:{N}]`, run Mandatory After Delegation self-check in the SAME response turn. DO NOT stop before the completion marker is output." |
+
+These hints are **best-effort**: they only fire when a stop attempt is actually blocked, so they act as a backstop for the prompt contract rather than a primary enforcement mechanism. The primary path is the prompt contract (Layer 1).
+
+### Optional sentinel: `auto_continuation_failed` (MAY)
+
+When the contract is violated in practice — i.e., the user types `continue` to recover — the orchestrator **MAY** emit the `auto_continuation_failed` sentinel via `plugins/rite/hooks/workflow-incident-emit.sh` so the incident is auto-registered as an Issue via Phase 5.4.4.1 (Workflow Incident Detection).
+
+This sentinel is classified as **MAY** rather than **MUST** because:
+
+1. The detection heuristic (recognising a `continue`-recovery as a contract violation) has false-positive risk — users may type `continue` for reasons unrelated to auto-continuation (e.g., resuming after a legitimate user-initiated pause).
+2. Implementation is scoped to a follow-up PR (#525 Decision Log D-02) to avoid bloating the main fix.
+
+Sentinel format (when implemented):
+
+```
+[CONTEXT] WORKFLOW_INCIDENT=1; type=auto_continuation_failed; details=<details>; iteration_id=<pr>-<epoch>
+```
+
+The sentinel integrates with the existing Phase 5.4.4.1 detection flow (same as `skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`) — no new dispatch code is required in the orchestrator.
+
+### Acceptance criteria
+
+| AC | Description |
+|----|-------------|
+| AC-1 | bug fix preset で `/rite:issue:create` が end-to-end で `[create:completed:{N}]` まで自動完了する（利用者の `continue` 介入なし） |
+| AC-2 | M complexity 以上で interview 完了後に同 turn 内で `create-register` が発火する |
+| AC-3 | `create.md` の Sub-skill Return Protocol セクションに "anti-pattern" / "correct-pattern" / "same response turn" / "DO NOT stop" の 4 phrase が全て含まれる |
+| AC-4 | `auto_continuation_failed` sentinel 実装時、Phase 5.4.4.1 detection で観測可能（MAY — 本 Issue スコープ外） |
+| AC-5 | Terminal Completion pattern (`[create:completed:{N}]` + `.rite-flow-state active: false`) が引き続き動作する (non-regression) |
+
+### Relationship to Workflow Incident Detection
+
+Phase 5.4.4.1 (Workflow Incident Detection) treats contract violations as one sentinel type among six (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`, and the optional `auto_continuation_failed`). All six share the same detection → AskUserQuestion → Issue registration flow via `create-issue-with-projects.sh`.
 
 ## Error Handling
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1720,7 +1720,7 @@ Violating this contract leaves the workflow partially executed: no Issue created
 |-------|-----------|------------|
 | **1. Prompt contract** | Anti-pattern / correct-pattern examples + "same response turn" / "DO NOT stop" phrases in orchestrator documentation | `commands/issue/start.md` Sub-skill Return Protocol (Global), `commands/issue/create.md` Sub-skill Return Protocol, `plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md` |
 | **2. Flow state** | Sub-skills write `*_post_*` phase markers with `active: true` before return; `stop-guard.sh` blocks every stop attempt until the orchestrator reaches the terminal phase (`create_completed` with `active: false` for `/rite:issue:create`) | `hooks/flow-state-update.sh`, `hooks/stop-guard.sh` |
-| **3. Caller-continuation hints** | HTML comment `<!-- caller: read .rite-flow-state and continue with Phase X.Y in the SAME response turn. DO NOT stop. -->` immediately before the sub-skill's result pattern | Defense-in-Depth sections in `commands/issue/create-interview.md`, `commands/issue/create-register.md` |
+| **3. Caller-continuation hints** | HTML comment `<!-- caller: read .rite-flow-state and continue with Phase X.Y in the SAME response turn. DO NOT stop. -->` immediately before the sub-skill's result pattern. The HTML comment is visible to the LLM via conversation context but does NOT render in Markdown output. | Defense-in-Depth sections in `commands/issue/create-interview.md`, `commands/issue/create-register.md`, `commands/issue/create-decompose.md` |
 
 All three layers must be present for the contract to hold. If any layer is weakened (e.g., the HTML comment is removed, or the `same response turn` phrase is dropped from the prompt), the LLM may revert to its default "task-complete → end turn" behavior on the next failure path.
 
@@ -1746,8 +1746,9 @@ When `stop-guard.sh` blocks a stop attempt with an active `.rite-flow-state`, th
 
 | Active phase | Hint content |
 |-------------|-------------|
-| `create_post_interview` | "Sub-skill rite:issue:create-interview returned. The return tag is a CONTINUATION TRIGGER, not a turn boundary. Immediately run Phase 0.6 → Delegation Routing Pre-write → invoke rite:issue:create-register in the SAME response turn." |
+| `create_post_interview` | "Sub-skill rite:issue:create-interview returned. The return tag is a CONTINUATION TRIGGER, not a turn boundary. Immediately run Phase 0.6 → Delegation Routing Pre-write → invoke rite:issue:create-register (or create-decompose) in the SAME response turn." |
 | `create_delegation` | "Delegation sub-skill is in-flight. When it returns `[create:completed:{N}]`, run Mandatory After Delegation self-check in the SAME response turn. DO NOT stop before the completion marker is output." |
+| `create_post_delegation` | "Terminal sub-skill returned without `[create:completed:{N}]` (defense-in-depth path). Run Mandatory After Delegation Step 2 (deactivate flow state) and Step 3 (output next-steps) in the SAME response turn to force the workflow into the terminal state." |
 
 These hints are **best-effort**: they only fire when a stop attempt is actually blocked, so they act as a backstop for the prompt contract rather than a primary enforcement mechanism. The primary path is the prompt contract (Layer 1).
 
@@ -1766,7 +1767,7 @@ Sentinel format (when implemented):
 [CONTEXT] WORKFLOW_INCIDENT=1; type=auto_continuation_failed; details=<details>; iteration_id=<pr>-<epoch>
 ```
 
-The sentinel integrates with the existing Phase 5.4.4.1 detection flow (same as `skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`) — no new dispatch code is required in the orchestrator.
+The sentinel would integrate with the existing Phase 5.4.4.1 detection flow (same as the existing five sentinel types: `skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`) — no new dispatch code is required in the orchestrator. Note: the `type` enum in the "Workflow Incident Detection" section above remains five-valued until `auto_continuation_failed` is implemented.
 
 ### Acceptance criteria
 
@@ -1780,7 +1781,7 @@ The sentinel integrates with the existing Phase 5.4.4.1 detection flow (same as 
 
 ### Relationship to Workflow Incident Detection
 
-Phase 5.4.4.1 (Workflow Incident Detection) treats contract violations as one sentinel type among six (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`, and the optional `auto_continuation_failed`). All six share the same detection → AskUserQuestion → Issue registration flow via `create-issue-with-projects.sh`.
+Phase 5.4.4.1 (Workflow Incident Detection) currently treats five sentinel types as contract violations (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped`, `wiki_ingest_failed`). The optional `auto_continuation_failed` sentinel (MAY, scoped to a follow-up PR — see Decision Log D-02 in Issue #525) would integrate via the same flow when implemented; until then, the `type` enum remains five-valued. All sentinel types share the same detection → AskUserQuestion → Issue registration flow via `create-issue-with-projects.sh`.
 
 ## Error Handling
 

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -709,6 +709,8 @@ Phase 0.8 terminates based on the user's selection in the decomposition result c
 
 ## Phase 1.0: Terminal Completion (Normal Path Only)
 
+<!-- caller: this sub-skill is terminal on the Normal path. Phase 1.0.2 outputs [create:completed:{N}] as the absolute last line and deactivates .rite-flow-state. The orchestrator's 🚨 Mandatory After Delegation section MUST run in the SAME response turn as a defense-in-depth no-op (Step 1/2 skipped when marker present). DO NOT stop before the orchestrator's self-check completes. -->
+
 > **Design decision** (Issue #444, D-01): This sub-skill handles flow-state deactivation, next-step output, and completion marker internally on the **Normal path** (sub-Issues created via Phase 0.9). On the **Delegation path** (cancelled and delegated to `create-register`), `create-register.md` handles its own Terminal Completion — do NOT execute this section.
 
 **Condition**: Execute only on the **Normal path**.

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -511,16 +511,28 @@ else
 fi
 ```
 
-After the flow-state update above, output the appropriate result pattern. Emit the caller-continuation comment **immediately before** the result pattern so it appears in the orchestrator's conversation context:
+After the flow-state update above, output the appropriate result pattern. Emit the caller-continuation comment **immediately before** the result pattern. The comment and the result pattern MUST be the last two non-empty lines of this sub-skill's output, in this order:
+
+**Output format example (interview skipped)**:
 
 ```
 <!-- caller: read .rite-flow-state and continue with Phase 0.6 (Task Decomposition Decision) in the SAME response turn. DO NOT stop. No GitHub Issue has been created yet. -->
+[interview:skipped]
 ```
+
+**Output format example (interview completed)**:
+
+```
+<!-- caller: read .rite-flow-state and continue with Phase 0.6 (Task Decomposition Decision) in the SAME response turn. DO NOT stop. No GitHub Issue has been created yet. -->
+[interview:completed]
+```
+
+Result patterns:
 
 - **Interview completed**: `[interview:completed]`
 - **Interview skipped** (XS, Bug Fix, Chore): `[interview:skipped]`
 
-This pattern is consumed by the orchestrator (`create.md`) to determine the next action. The HTML comment is a hint for the caller LLM (does not render in Markdown output).
+This pattern is consumed by the orchestrator (`create.md`) to determine the next action. The HTML comment is a hint for the caller LLM (does not render in Markdown output but is visible in the conversation context that the caller LLM reads).
 
 ---
 

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -511,12 +511,16 @@ else
 fi
 ```
 
-After the flow-state update above, output the appropriate result pattern:
+After the flow-state update above, output the appropriate result pattern. Emit the caller-continuation comment **immediately before** the result pattern so it appears in the orchestrator's conversation context:
+
+```
+<!-- caller: read .rite-flow-state and continue with Phase 0.6 (Task Decomposition Decision) in the SAME response turn. DO NOT stop. No GitHub Issue has been created yet. -->
+```
 
 - **Interview completed**: `[interview:completed]`
 - **Interview skipped** (XS, Bug Fix, Chore): `[interview:skipped]`
 
-This pattern is consumed by the orchestrator (`create.md`) to determine the next action.
+This pattern is consumed by the orchestrator (`create.md`) to determine the next action. The HTML comment is a hint for the caller LLM (does not render in Markdown output).
 
 ---
 

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -565,6 +565,8 @@ See [GraphQL Helpers](../../references/graphql-helpers.md#error-handling) for de
 
 ## Phase 4: Terminal Completion
 
+<!-- caller: this sub-skill is terminal. Phase 4 outputs [create:completed:{N}] as the absolute last line and deactivates .rite-flow-state. The orchestrator's 🚨 Mandatory After Delegation section MUST run in the SAME response turn as a defense-in-depth no-op (Step 1/2 skipped when marker present). DO NOT stop before the orchestrator's self-check completes. -->
+
 > **Design decision** (Issue #444, D-01): This sub-skill is a terminal sub-skill — it handles flow-state deactivation, next-step output, and completion marker internally. The caller (`create.md`) retains the same steps as defense-in-depth but is no longer the primary path for these actions. This prevents the workflow from stalling when the orchestrator fails to continue after sub-skill return.
 
 ### 4.1 Flow State Deactivation

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -77,7 +77,7 @@ This is a **bug**. The return tag is NOT a turn boundary — it is a hand-off si
 [CORRECT]
 <Skill rite:issue:create-interview returns>
 <LLM output: "[interview:skipped]">
-<In the SAME response turn, LLM IMMEDIATELY:>
+<In the same response turn, LLM IMMEDIATELY:>
   1. Runs the Pre-write bash for Phase 0.6 / Delegation Routing
   2. Evaluates Phase 0.6 triggers
   3. Runs the Delegation Routing Pre-write bash
@@ -86,9 +86,16 @@ This is a **bug**. The return tag is NOT a turn boundary — it is a hand-off si
   6. Runs Mandatory After Delegation self-check
 ```
 
-**Rule**: Treat `[interview:skipped]` / `[interview:completed]` / `[decompose:*]` as **continuation triggers**, not as stopping points. The **only** valid stop in this workflow is after `[create:completed:{N}]` is output AND the next-steps text has been displayed.
+**Rule**: Treat `[interview:skipped]` / `[interview:completed]` as **continuation triggers**, not as stopping points. Both terminal sub-skills (`create-register`, `create-decompose`) output `[create:completed:{N}]` as the unified completion marker. The **only** valid stop in this workflow is after the next-steps text has been displayed AND `[create:completed:{N}]` is output as the absolute last line (the terminal sub-skill emits them in this order — see `create-register.md` Phase 4.2/4.3 and `create-decompose.md` Phase 1.0.2).
 
-> **Contract phrases (AC-3, Issue #525)**: The anti-pattern / correct-pattern contract above uses these exact phrases: `anti-pattern`, `correct-pattern`, `same response turn`, `DO NOT stop`. These phrases are grep-verified as part of the AC-3 static check — do not rewrite them away.
+> **Contract phrases (AC-3, Issue #525)**: The anti-pattern / correct-pattern contract above uses these exact phrases: `anti-pattern`, `correct-pattern`, `same response turn`, `DO NOT stop`. These phrases are grep-verified as part of the AC-3 static check — do not rewrite them away. Manual verification command:
+>
+> ```bash
+> for p in "anti-pattern" "correct-pattern" "same response turn" "DO NOT stop"; do
+>   grep -c "$p" plugins/rite/commands/issue/create.md
+> done
+> # Expected: all 4 counts >= 1
+> ```
 
 **Completion marker convention** (Issue #444): The unified completion marker for the entire `/rite:issue:create` workflow is `[create:completed:{N}]`. Terminal sub-skills (`create-register.md`, `create-decompose.md`) output this marker as their absolute last line after handling flow-state deactivation and next-step display internally (Terminal Completion pattern). The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth.
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -54,9 +54,41 @@ When this command is executed, follow the phases below in order.
 
 ## Sub-skill Return Protocol
 
-> **Reference**: See `start.md` [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) for the full protocol. The same rules apply here — DO NOT end your response after a sub-skill returns, DO NOT re-invoke the completed skill, and IMMEDIATELY proceed to the 🚨 Mandatory After section.
+> **Reference**: See `start.md` [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global) and the global reference `plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md` for the full contract. The same rules apply here — DO NOT end your response after a sub-skill returns, DO NOT re-invoke the completed skill, and IMMEDIATELY proceed to the 🚨 Mandatory After section in the **same response turn**.
 
 **Self-check**: After every sub-skill returns, ask yourself: "Has `[create:completed:{N}]` been output?" If not, you are NOT done — keep going.
+
+### Anti-pattern (what NOT to do)
+
+When `rite:issue:create-interview` returns `[interview:skipped]` or `[interview:completed]`:
+
+```
+[WRONG]
+<Skill rite:issue:create-interview returns>
+<LLM output: "[interview:skipped]">
+<LLM ends turn. User sees "Cooked for 2m 0s" and must type `continue` manually.>
+```
+
+This is a **bug**. The return tag is NOT a turn boundary — it is a hand-off signal. Ending the turn here abandons the workflow mid-flight with no Issue created.
+
+### Correct-pattern (what to do)
+
+```
+[CORRECT]
+<Skill rite:issue:create-interview returns>
+<LLM output: "[interview:skipped]">
+<In the SAME response turn, LLM IMMEDIATELY:>
+  1. Runs the Pre-write bash for Phase 0.6 / Delegation Routing
+  2. Evaluates Phase 0.6 triggers
+  3. Runs the Delegation Routing Pre-write bash
+  4. Invokes skill: "rite:issue:create-register" (or create-decompose)
+  5. Waits for [create:completed:{N}]
+  6. Runs Mandatory After Delegation self-check
+```
+
+**Rule**: Treat `[interview:skipped]` / `[interview:completed]` / `[decompose:*]` as **continuation triggers**, not as stopping points. The **only** valid stop in this workflow is after `[create:completed:{N}]` is output AND the next-steps text has been displayed.
+
+> **Contract phrases (AC-3, Issue #525)**: The anti-pattern / correct-pattern contract above uses these exact phrases: `anti-pattern`, `correct-pattern`, `same response turn`, `DO NOT stop`. These phrases are grep-verified as part of the AC-3 static check — do not rewrite them away.
 
 **Completion marker convention** (Issue #444): The unified completion marker for the entire `/rite:issue:create` workflow is `[create:completed:{N}]`. Terminal sub-skills (`create-register.md`, `create-decompose.md`) output this marker as their absolute last line after handling flow-state deactivation and next-step display internally (Terminal Completion pattern). The orchestrator's 🚨 Mandatory After Delegation section serves as defense-in-depth.
 
@@ -463,6 +495,8 @@ Invoke `skill: "rite:issue:create-interview"`.
 
 ### 🚨 Mandatory After Interview
 
+> **⚠️ 同 turn 内で必ず実行すること (MUST execute in the SAME response turn)**: `rite:issue:create-interview` の return 直後、**応答を終了せずに** 以下の Step 1-2 を即座に実行する。`[interview:*]` return tag は turn 境界ではなく継続トリガである。turn を閉じた場合、ユーザーの `continue` 介入なしに workflow が停止し、Issue は作成されない (本 Issue #525 の再発条件)。
+
 > **Enforcement**: `.rite-flow-state.phase` is `create_post_interview` at this point (the sub-skill wrote this via its Defense-in-Depth section). Stop-guard blocks any stop attempt while the flow-state is active — it will not unblock until `.rite-flow-state.phase` advances to `create_delegation` (via the Delegation Routing Pre-write below) or reaches `create_completed` (via the terminal sub-skill). Step 1 below refreshes the state timestamp but does NOT advance the phase on its own — the only legitimate path to a stoppable state is to continue through Phase 0.6 → Delegation Routing → terminal sub-skill. See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 
 No GitHub Issue has been created yet. The interview only collects information.
@@ -611,6 +645,8 @@ Invoke `skill: "rite:issue:create-register"`.
 > **Note on result patterns** (Issue #444): Terminal sub-skills (`create-register`, `create-decompose`) now output `[create:completed:{N}]` as the unified completion marker. The sub-skill handles flow-state deactivation, next-step output, and completion marker internally (Terminal Completion pattern). The legacy patterns `[register:created:{N}]` and `[decompose:completed:{N}]` have been replaced and are no longer output.
 
 ### 🚨 Mandatory After Delegation (Defense-in-Depth)
+
+> **⚠️ 同 turn 内で必ず実行すること (MUST execute in the SAME response turn)**: delegation sub-skill の return 直後、**応答を終了せずに** 以下の self-check と Step 1-3 を即座に実行する。Terminal sub-skill は通常 `[create:completed:{N}]` を出力して完了するが、万一出力が欠落した場合は本セクションが唯一のリカバリ経路である。
 
 > **Enforcement**: Terminal sub-skills (`create-register.md`, `create-decompose.md`) write `create_completed` + `active: false` and output `[create:completed:{N}]` internally (Issue #444 Terminal Completion pattern). See start.md [Sub-skill Return Protocol (Global)](./start.md#sub-skill-return-protocol-global).
 

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -269,6 +269,9 @@ case "$PHASE" in
   create_delegation)
     CREATE_HINT="HINT: Delegation sub-skill is in-flight. When it returns [create:completed:{N}], run Mandatory After Delegation self-check (Step 1/2 are no-ops if marker present) in the SAME response turn. DO NOT stop before the completion marker is output."
     ;;
+  create_post_delegation)
+    CREATE_HINT="HINT: Terminal sub-skill returned without [create:completed:{N}] (defense-in-depth path). Run Mandatory After Delegation Step 2 (deactivate flow state) and Step 3 (output next-steps) in the SAME response turn to force the workflow into the terminal state."
+    ;;
 esac
 
 if [ -n "$CREATE_HINT" ]; then

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -256,10 +256,35 @@ STOP_MSG
   exit 2
 fi
 
-cat >&2 <<STOP_MSG
+# Best-effort hint for /rite:issue:create sub-skill return phases (#525).
+# When the LLM stops implicitly after a sub-skill return (e.g., right after
+# [interview:skipped] / [interview:completed] / [create:completed:{N}]),
+# surface a phase-specific continuation hint so the next prompt re-entry
+# makes the correct continuation obvious.
+CREATE_HINT=""
+case "$PHASE" in
+  create_post_interview)
+    CREATE_HINT="HINT: Sub-skill rite:issue:create-interview returned. The return tag is a CONTINUATION TRIGGER, not a turn boundary. Immediately run Phase 0.6 (Task Decomposition Decision) → Delegation Routing Pre-write → invoke rite:issue:create-register (or create-decompose) in the SAME response turn. No GitHub Issue has been created yet."
+    ;;
+  create_delegation)
+    CREATE_HINT="HINT: Delegation sub-skill is in-flight. When it returns [create:completed:{N}], run Mandatory After Delegation self-check (Step 1/2 are no-ops if marker present) in the SAME response turn. DO NOT stop before the completion marker is output."
+    ;;
+esac
+
+if [ -n "$CREATE_HINT" ]; then
+  cat >&2 <<STOP_MSG
+[rite] Normal operation — stop prevented.
+Phase: $PHASE | Issue: #$ISSUE | PR: #$PR
+ACTION: $NEXT
+$CREATE_HINT
+Do NOT re-invoke any completed skill. Do NOT stop.
+STOP_MSG
+else
+  cat >&2 <<STOP_MSG
 [rite] Normal operation — stop prevented.
 Phase: $PHASE | Issue: #$ISSUE | PR: #$PR
 ACTION: $NEXT
 Do NOT re-invoke any completed skill. Do NOT stop.
 STOP_MSG
+fi
 exit 2

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -117,6 +117,12 @@ See [references/phase-mapping.md](./references/phase-mapping.md) for phase list.
 
 See [references/work-memory-format.md](./references/work-memory-format.md) for work memory format.
 
+## Sub-skill Return Auto-Continuation Contract
+
+When an orchestrator command (e.g., `/rite:issue:start`, `/rite:issue:create`) invokes a sub-skill via the Skill tool, the LLM **MUST** continue in the same response turn after the sub-skill returns. The return tag is a continuation trigger, not a turn boundary — stopping prematurely abandons the workflow before the terminal completion marker is output.
+
+See [references/sub-skill-return-protocol.md](./references/sub-skill-return-protocol.md) for the full contract, anti-pattern / correct-pattern examples, and the three defense-in-depth layers (prompt / flow-state / caller-continuation hint). The canonical specification lives in `docs/SPEC.md` "Sub-skill Return Auto-Continuation Contract" section.
+
 ## AI Coding Principles (Summary)
 
 Avoid common AI coding failure patterns: surface assumptions, manage confusion, push back when warranted, enforce simplicity, maintain scope discipline, clean dead code, plan inline, address all discovered issues, and keep documentation in sync with specification changes (`documentation_consistency`) — when the implementation changes user-visible behavior, update related README / docs / CLAUDE.md / plugin .md files in the same PR rather than deferring to a follow-up Issue.

--- a/plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md
+++ b/plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md
@@ -6,6 +6,8 @@
 
 When Claude Code invokes a Skill tool and the sub-skill outputs its result pattern (e.g., `[interview:skipped]`, `[review:mergeable]`, `[fix:pushed]`), control returns to the orchestrator LLM in the same response turn. The orchestrator's natural inclination — trained by general assistant behavior — is to treat the sub-skill's completion as a task boundary and end the turn.
 
+> **Scope note**: The example patterns above are drawn from `/rite:issue:create` and `/rite:pr:*` orchestrators. This contract applies to **all** sub-skill returns, but Issue #525 specifically addresses the `/rite:issue:create` failure mode (`[interview:skipped]` turn-end bug). Other orchestrators that already survive the failure mode in practice inherit the same contract as a safety invariant.
+
 **This is a bug.** The sub-skill return is a hand-off signal, not a turn boundary. Ending the turn at this point forces the user to type `continue` manually, which:
 
 1. Breaks the "single-command end-to-end" experience that orchestrator commands promise
@@ -33,6 +35,8 @@ Ask yourself: **"Has the orchestrator's terminal completion marker been output y
 | Other `/rite:*` commands | Check the command's "Output" / "Terminal Completion" section | Match the explicit contract there |
 
 If the marker has **not** been output, you are NOT done — keep going in the same turn.
+
+> **⚠️ Duplication note**: The anti-pattern / correct-pattern blocks below are **intentionally duplicated** with `commands/issue/create.md` Sub-skill Return Protocol section. The canonical source is `docs/SPEC.md` "Sub-skill Return Auto-Continuation Contract". When modifying either copy, **always update both files and SPEC.md together** to prevent drift. A future refactor may consolidate via @include.
 
 ## Anti-pattern (what NOT to do)
 
@@ -67,15 +71,15 @@ The contract is enforced at three layers. Violating any one layer is a bug:
 
 | Layer | Mechanism | File |
 |-------|-----------|------|
-| 1. Prompt contract | Anti-pattern / correct-pattern + "same response turn" warnings | `commands/**/*.md` orchestrator sections |
+| 1. Prompt contract | Anti-pattern / correct-pattern + "same response turn" warnings | `commands/issue/start.md` (Sub-skill Return Protocol Global), `commands/issue/create.md` (Sub-skill Return Protocol), this reference |
 | 2. Flow state | Sub-skills write `*_post_*` phases + `active: true` before return; stop-guard blocks stop attempts until terminal state | `hooks/flow-state-update.sh` + `hooks/stop-guard.sh` |
-| 3. Caller-continuation hints | HTML comment `<!-- caller: ... -->` immediately before the sub-skill's result pattern | Defense-in-Depth sections in sub-skill `.md` files |
+| 3. Caller-continuation hints | HTML comment `<!-- caller: ... -->` immediately before the sub-skill's result pattern | Defense-in-Depth sections in `commands/issue/create-interview.md`, `commands/issue/create-register.md`, `commands/issue/create-decompose.md` |
 
 When all three layers are present, the LLM receives the continuation signal from three independent sources: the prompt itself, the stop-guard's blocking message, and the inline HTML comment in the sub-skill output.
 
 ## Relationship to Workflow Incident Detection
 
-When the contract is violated in practice — the user types `continue` to recover — the orchestrator MAY emit the `auto_continuation_failed` sentinel via `plugins/rite/hooks/workflow-incident-emit.sh` so the incident is auto-registered as an Issue via Phase 5.4.4.1. This is an **optional** (MAY) enforcement: the detection heuristic has false-positive risk and is out of scope for Issue #525 MUST requirements. See `docs/SPEC.md` "Sub-skill Return Auto-Continuation Contract" section for the full specification.
+When the contract is violated in practice — the user types `continue` to recover — the orchestrator MAY emit the `auto_continuation_failed` sentinel via `plugins/rite/hooks/workflow-incident-emit.sh` so the incident is auto-registered as an Issue via Phase 5.4.4.1. This is an **optional observability sentinel** (MAY) — it does not enforce the contract but records violations for later diagnosis. The detection heuristic has false-positive risk and is out of scope for Issue #525 MUST requirements. The 3 layers above are the actual enforcement; the sentinel is observability. See `docs/SPEC.md` "Sub-skill Return Auto-Continuation Contract" section for the full specification.
 
 ## References
 
@@ -84,4 +88,5 @@ When the contract is violated in practice — the user types `continue` to recov
 - `commands/issue/create.md` — Sub-skill Return Protocol + anti/correct-pattern examples
 - `commands/issue/create-interview.md` — Defense-in-Depth + caller continuation comment
 - `commands/issue/create-register.md` — Terminal Completion + caller continuation comment
-- `hooks/stop-guard.sh` — Phase-aware continuation hints for `create_post_interview` / `create_delegation`
+- `commands/issue/create-decompose.md` — Terminal Completion (Normal path) + caller continuation comment
+- `hooks/stop-guard.sh` — Phase-aware continuation hints for `create_post_interview` / `create_delegation` / `create_post_delegation`

--- a/plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md
+++ b/plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md
@@ -1,0 +1,87 @@
+# Sub-skill Return Auto-Continuation Contract
+
+> **Scope**: This reference defines the **global** contract for how an orchestrator command (e.g., `/rite:issue:start`, `/rite:issue:create`) must handle control when a Skill tool invocation returns. It applies to **every** sub-skill return in the rite workflow.
+
+## Why this contract exists
+
+When Claude Code invokes a Skill tool and the sub-skill outputs its result pattern (e.g., `[interview:skipped]`, `[review:mergeable]`, `[fix:pushed]`), control returns to the orchestrator LLM in the same response turn. The orchestrator's natural inclination — trained by general assistant behavior — is to treat the sub-skill's completion as a task boundary and end the turn.
+
+**This is a bug.** The sub-skill return is a hand-off signal, not a turn boundary. Ending the turn at this point forces the user to type `continue` manually, which:
+
+1. Breaks the "single-command end-to-end" experience that orchestrator commands promise
+2. Causes workflow state to decay (stale timestamps, compact-state drift)
+3. May silently skip mandatory defense-in-depth steps (e.g., flow-state patches, Issue-comment backups)
+4. In terminal sub-skills, may leave `.rite-flow-state` in an `active: true` state indefinitely
+
+## The contract
+
+**When a sub-skill tool invocation returns control to the orchestrator:**
+
+1. **DO NOT end your response.** You are still in the middle of the orchestrator's phase flow.
+2. **DO NOT re-invoke the completed skill.** It already finished — re-invoking wastes context and may corrupt state.
+3. **IMMEDIATELY** execute the orchestrator's 🚨 Mandatory After section for the current phase, starting with the `.rite-flow-state` update, then proceeding to the next phase — **in the same response turn**.
+4. If the stop-guard hook blocks a stop attempt (exit 2), follow the `ACTION:` instructions in its stderr message instead of retrying the stop.
+
+## Self-check after every sub-skill return
+
+Ask yourself: **"Has the orchestrator's terminal completion marker been output yet?"**
+
+| Orchestrator | Terminal marker | When contract ends |
+|-------------|----------------|-------------------|
+| `/rite:issue:start` | Phase 5.6 completion report + Workflow Termination block | After the completion report text is displayed |
+| `/rite:issue:create` | `[create:completed:{N}]` + next-steps text | After `[create:completed:{N}]` is the absolute last line |
+| Other `/rite:*` commands | Check the command's "Output" / "Terminal Completion" section | Match the explicit contract there |
+
+If the marker has **not** been output, you are NOT done — keep going in the same turn.
+
+## Anti-pattern (what NOT to do)
+
+```
+[WRONG]
+<Skill rite:issue:create-interview returns>
+<LLM output: "[interview:skipped]">
+<LLM ends turn. User sees "Cooked for 2m 0s" and must type `continue`.>
+```
+
+This abandons the workflow with no Issue created and no flow-state cleanup.
+
+## Correct-pattern (what to do)
+
+```
+[CORRECT]
+<Skill rite:issue:create-interview returns>
+<LLM output: "[interview:skipped]">
+<In the SAME response turn, LLM IMMEDIATELY:>
+  1. Runs Pre-write bash for Phase 0.6
+  2. Evaluates Phase 0.6 triggers
+  3. Runs Delegation Routing Pre-write bash
+  4. Invokes skill: "rite:issue:create-register"
+  5. Waits for [create:completed:{N}]
+  6. Runs Mandatory After Delegation self-check
+<Orchestrator terminal completion reached. Turn may end.>
+```
+
+## Defense-in-depth layers
+
+The contract is enforced at three layers. Violating any one layer is a bug:
+
+| Layer | Mechanism | File |
+|-------|-----------|------|
+| 1. Prompt contract | Anti-pattern / correct-pattern + "same response turn" warnings | `commands/**/*.md` orchestrator sections |
+| 2. Flow state | Sub-skills write `*_post_*` phases + `active: true` before return; stop-guard blocks stop attempts until terminal state | `hooks/flow-state-update.sh` + `hooks/stop-guard.sh` |
+| 3. Caller-continuation hints | HTML comment `<!-- caller: ... -->` immediately before the sub-skill's result pattern | Defense-in-Depth sections in sub-skill `.md` files |
+
+When all three layers are present, the LLM receives the continuation signal from three independent sources: the prompt itself, the stop-guard's blocking message, and the inline HTML comment in the sub-skill output.
+
+## Relationship to Workflow Incident Detection
+
+When the contract is violated in practice — the user types `continue` to recover — the orchestrator MAY emit the `auto_continuation_failed` sentinel via `plugins/rite/hooks/workflow-incident-emit.sh` so the incident is auto-registered as an Issue via Phase 5.4.4.1. This is an **optional** (MAY) enforcement: the detection heuristic has false-positive risk and is out of scope for Issue #525 MUST requirements. See `docs/SPEC.md` "Sub-skill Return Auto-Continuation Contract" section for the full specification.
+
+## References
+
+- `docs/SPEC.md` — "Sub-skill Return Auto-Continuation Contract" (canonical specification)
+- `commands/issue/start.md` — Sub-skill Return Protocol (Global) section
+- `commands/issue/create.md` — Sub-skill Return Protocol + anti/correct-pattern examples
+- `commands/issue/create-interview.md` — Defense-in-Depth + caller continuation comment
+- `commands/issue/create-register.md` — Terminal Completion + caller continuation comment
+- `hooks/stop-guard.sh` — Phase-aware continuation hints for `create_post_interview` / `create_delegation`


### PR DESCRIPTION
## 概要

`/rite:issue:create` の orchestrator が sub-skill (`rite:issue:create-interview` / `rite:issue:create-register`) の return tag を turn 境界と誤認して LLM が応答を終了し、利用者が `continue` を入力しないと workflow が停止する問題 (Issue #525) を修正します。

## 変更内容

### 3 層の防御機構

| 層 | 機構 | 変更ファイル |
|---|------|-------------|
| 1. Prompt 契約 | anti-pattern / correct-pattern 例示 + "same response turn" / "DO NOT stop" 強調 | `plugins/rite/commands/issue/create.md` |
| 2. Stop-guard hint | `create_post_interview` / `create_delegation` phase 用 phase-specific continuation hint | `plugins/rite/hooks/stop-guard.sh` |
| 3. Caller-continuation comment | result pattern 直前の `<!-- caller: ... -->` HTML コメント | `plugins/rite/commands/issue/create-interview.md` + `create-register.md` |

### Global protocol ドキュメント化

- `plugins/rite/skills/rite-workflow/references/sub-skill-return-protocol.md` (新規): global 契約本文を明文化し、3 層の役割分担と anti/correct-pattern 例示を記載
- `plugins/rite/skills/rite-workflow/SKILL.md`: 新 reference へのリンクを追加
- `docs/SPEC.md`: "Sub-skill Return Auto-Continuation Contract" セクション追加、ToC 更新、AC-1〜AC-5 と optional `auto_continuation_failed` sentinel (MAY) を規定

## 関連 Issue

Closes #525

## チェックリスト

- [x] create.md に anti-pattern / correct-pattern 例示追加 (AC-3)
- [x] Mandatory After Interview / Delegation に同 turn 内実行警告追加
- [x] create-interview.md / create-register.md に caller 継続誘導コメント追加
- [x] stop-guard.sh phase-specific hint 追加
- [x] sub-skill-return-protocol.md 新規作成
- [x] SKILL.md からリンク追加
- [x] docs/SPEC.md にセクション追加 + ToC 更新
- [x] AC-3 4 phrase grep pass
- [x] 既存 Terminal Completion pattern / result pattern を変更していない (AC-5 non-regression)

## テスト計画

| ID | Description | Status |
|----|-------------|--------|
| T-03 | create.md に 4 phrase (`anti-pattern`, `correct-pattern`, `same response turn`, `DO NOT stop`) が存在 | ✅ grep で検証済み |
| T-04 | create-interview.md / create-register.md に `<!-- caller: ... -->` が存在 | ✅ grep で検証済み |
| T-06 | Terminal Completion pattern 非後退 | ✅ 未変更 |
| T-07 | result pattern テキスト非後退 | ✅ 未変更 |
| T-01 | bug fix preset で `/rite:issue:create` E2E 自動完了 | 🔄 新セッションで手動検証必要 |
| T-02 | M complexity で interview 後自動継続 | 🔄 新セッションで手動検証必要 |

## Known Issues

- AC-4 (`auto_continuation_failed` sentinel) は MAY (Decision Log D-02) のため本 PR スコープ外。将来 PR で別途実装。
- lint 実行時に pr/fix.md / pr/review.md の drift findings (16 件) と wiki growth warning (1 件) を検出したが、いずれも本 PR で未変更のファイル起因のため scope 外。
