### PR TITLE
docs(implement): parallel 分岐 false 経路を新設ゲート経由に明記 (#487)

### DIFF
--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -207,7 +207,7 @@ Analyze the "files to change" from the implementation plan (Phase 3) and determi
 
 ```
 parallel.enabled を確認
-├─ false → 通常の順次実装（5.1.0 をスキップ、5.1.1 へ）
+├─ false → 5.1.0.1-5.1.0.4 parallel implementation はスキップ、5.1.0.5 Adaptive Re-evaluation / 5.1.0.6 Test Verification Gate / 5.1.0.6.1 Acceptance Criteria Check / 5.1.0.7 Documentation Impact Investigation を経て 5.1.1 へ
 └─ true → 複雑度を確認
     ├─ XS/S → 通常の順次実装
     └─ M 以上 → 独立タスクを分析


### PR DESCRIPTION
## Summary

- `plugins/rite/commands/issue/implement.md:210` の parallel 分岐フローで「`false` → 5.1.0 をスキップ、5.1.1 へ」という記述を改め、`5.1.0.1-5.1.0.4` の parallel subsection のみをスキップし、`5.1.0.5` Adaptive Re-evaluation / `5.1.0.6` Test Verification Gate / `5.1.0.6.1` Acceptance Criteria Check / `5.1.0.7` Documentation Impact Investigation を経由して `5.1.1` Commit に到達する経路であることを明示した
- 文字通り読むと重要なゲートをすべてバイパスする指示に解釈される余地があったため、Issue #487 の修正方針に沿って書き換え

Closes #487

## Test plan

- [ ] 修正後の L210 が parallel subsection のみをスキップする旨を明示していることを目視確認
- [ ] 同ファイル内の他の遷移記述（L469 など）と語彙が整合していることを確認