### PR TITLE
refactor(issue-start): Projects Status 更新を projects-status-update.sh に集約 (#496)

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -328,7 +328,11 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 2.4 (Projects Status → In Progress). Skipping to Phase 2.5/2.6/3 without running Projects update is PROHIBITED. Do NOT stop."
 ```
 
-> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh` — see Issue #496 for the refactor rationale.
+> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh`, which is the single source of truth for Projects Status updates across Phase 2.4, 5.5.1, and 5.7.2.
+<!-- Refactor origin: Issue #496 / PR #531 — do not re-inline Step 2-3 below. -->
+<!-- projects-integration.md §2.4 documents the underlying API calls for reference. -->
+
+
 
 **Step 1** — Read config and emit a skip marker on stdout (the LLM reads the marker, not a bash variable; shell state does not persist across Bash tool invocations):
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -109,13 +109,8 @@ This protocol applies to **every** sub-skill invocation in this document. Each �
 | `{fallback_branch}` | Phase 2.3.2.3 only (`main` preferred, else default branch) |
 | `{default_branch}` | `gh repo view --json defaultBranchRef` (Phase 2.3.2.3 only) |
 | `{project_number}` | `github.projects.project_number` in `rite-config.yml` |
-| `{project_id}` | GraphQL query result (`projectV2.id`). Obtained once, reused |
-| `{item_id}` | GraphQL query result (node matching child Issue number) |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) |
-| `{status_field_id}` | `github.projects.field_ids.status` in `rite-config.yml`, or `gh project field-list` |
-| `{in_review_option_id}` | `gh project field-list` ("In Review" option) |
-| `{done_option_id}` | `gh project field-list` ("Done" option) |
-| `{parent_issue_number}` | Phase 1.6 (child-issue-selection) or Phase 2.4 Step 5 (parent lookup) result; retained in conversation context. Used only in Phase 5.7 and Workflow Termination routing |
+| `{parent_issue_number}` | Phase 1.6 (child-issue-selection) or Phase 2.4 Step 3 (parent lookup via 2.4.7) result; retained in conversation context. Used only in Phase 5.7 and Workflow Termination routing |
 
 ---
 
@@ -333,9 +328,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 2.4 (Projects Status → In Progress). Skipping to Phase 2.5/2.6/3 without running Projects update is PROHIBITED. Do NOT stop."
 ```
 
-> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update)
-
-Execute the following inline procedure (extracted from the Module for determinism — do NOT silently skip).
+> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh` — see Issue #496 for the refactor rationale.
 
 **Step 1** — Read config and emit a skip marker on stdout (the LLM reads the marker, not a bash variable; shell state does not persist across Bash tool invocations):
 
@@ -354,43 +347,33 @@ fi
 
 | `PHASE_2_4_STATE` value | LLM action |
 |------------------------|-----------|
-| `skip` | Skip Steps 2-5 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the two whitelist transitions (`phase2_post_branch → phase2_projects` and `phase2_projects → phase2_post_projects`) stay valid (the skip is recorded, not silent). |
-| `execute` | Proceed to Step 2-5 using the emitted `project_number` / `owner` values. |
+| `skip` | Skip Step 2 and Step 3 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the two whitelist transitions (`phase2_post_branch → phase2_projects` and `phase2_projects → phase2_post_projects`) stay valid (the skip is recorded, not silent). |
+| `execute` | Proceed to Step 2-3 using the emitted `project_number` / `owner` values. |
 
 Do NOT rely on a bash variable (`SKIP_2_4=1`) that persists only within a single Bash tool call — each `echo`/`gh api` in the following steps is a separate invocation and the variable is lost. The `[CONTEXT]` marker travels via the conversation context and is authoritative.
 
-**Step 2** — Retrieve Issue's project item ID and project GraphQL id:
+**Step 2** — Update Issue Status to "In Progress" via the shared script:
 
 ```bash
-gh api graphql -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    issue(number: $number) {
-      projectItems(first: 10) { nodes { id project { id number } } }
-    }
-  }
-}' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "In Progress" \
+  --argjson auto_add true \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
 ```
 
-Find the node whose `project.number` matches `{project_number}`. Extract `{item_id}` and `{project_id}`. If `projectItems.nodes` is empty, auto-add the Issue to the Project via `gh project item-add {project_number} --owner {owner} --url <issue_url>` and re-query.
+The script executes: GraphQL `projectItems` query → auto-add if not registered → `field-list` retrieval → Status `item-edit`. Inspect its stdout JSON:
 
-**Step 3** — Retrieve Status field + "In Progress" option id:
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` or `"failed"` → display `.warnings[]` and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
 
-```bash
-gh project field-list {project_number} --owner {owner} --format json
-```
+The script is the single source of truth for Projects Status updates. See [projects-integration.md §2.4.2-2.4.5](../../references/projects-integration.md#242-check-issue-project-registration-status) for API-level documentation.
 
-Find field `name == "Status"`. Extract `{status_field_id}` (field `id`) and `{in_progress_option_id}` (option with `name == "In Progress"`). If `github.projects.field_ids.status` is set in rite-config.yml, prefer that value.
-
-**Step 4** — Update Status:
-
-```bash
-gh project item-edit --project-id {project_id} --id {item_id} --field-id {status_field_id} --single-select-option-id {in_progress_option_id}
-```
-
-On failure, display warning and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
-
-**Step 5** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
+**Step 3** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
 
 > **Issue #513 regression guard**: Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident: a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature.
 
@@ -1645,58 +1628,31 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 **Owner**: `/rite:issue:start` (defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow).
 
-**Note**: Uses `gh project field-list` CLI (consistent with [Projects Integration](../../references/projects-integration.md)). This differs from `ready.md` Phase 4 which uses GraphQL — an intentional design choice documented there.
+**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`. This differs from `ready.md` Phase 4 which uses a direct GraphQL mutation — an intentional design choice documented there.
 
-Skip if `projects.enabled: false` in rite-config.yml. Otherwise:
-
-**Step 1**: Retrieve Issue's project item ID. `{owner}` and `{repo}` are obtained before Phase 0.1 (see Placeholder Legend). Reuse `{project_number}` from rite-config.yml:
+Skip if `projects.enabled: false` in rite-config.yml. Otherwise invoke the shared script to transition the Issue Status to **In Review**:
 
 ```bash
-gh api graphql -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    issue(number: $number) {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project { id, number }
-        }
-      }
-    }
-  }
-}' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "In Review" \
+  --argjson auto_add false \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
 ```
 
-Find the node where `project.number` matches `{project_number}`. Extract `{item_id}` (node `id`) and `{project_id}` (node `project.id`).
+`auto_add: false` because at this point the Issue is already registered in the Project (Phase 2.4 auto-added it if missing).
 
-**When `projectItems.nodes` is empty** (Issue not registered in Project):
+Inspect the script's stdout JSON:
 
-```
-警告: Issue #{issue_number} は Project に登録されていません
-Status 更新をスキップします
-```
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking).
+- `.result == "failed"` → display `.warnings[]` and continue (non-blocking).
 
-Display warning and proceed to 5.6 (non-blocking).
-
-**Step 2**: Retrieve Status field "In Review" option ID:
-
-```bash
-gh project field-list {project_number} --owner {owner} --format json
-```
-
-From the result, find the field with `name` "Status". Extract:
-- `{status_field_id}`: the field's `id`
-- `{in_review_option_id}`: the `id` of the option with `name` "In Review"
-
-If `github.projects.field_ids.status` is set in rite-config.yml, use that value as `{status_field_id}` instead.
-
-**Step 3**: Update Status:
-
-```bash
-gh project item-edit --project-id {project_id} --id {item_id} --field-id {status_field_id} --single-select-option-id {in_review_option_id}
-```
-
-On failure, display warning and continue to Mandatory After 5.5.1 (non-blocking).
+See [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) for the underlying API calls.
 
 ### 🚨 Mandatory After 5.5.1
 
@@ -2031,60 +1987,29 @@ Use [Basic Query](../../references/epic-detection.md#basic-query). All `CLOSED`�
 
 Confirm via `AskUserQuestion`. If "No", display message and proceed to 5.7.3 (no auto-close). If yes, update Projects Status to "Done" and then close the Issue.
 
-Skip Steps 1-3 if `projects.enabled: false` in rite-config.yml. Otherwise:
+Skip Step 1 if `projects.enabled: false` in rite-config.yml. Otherwise:
 
-**Step 1**: Retrieve parent Issue's project item ID. `{owner}` and `{repo}` are obtained before Phase 0.1 (see Placeholder Legend). Reuse `{project_number}` from rite-config.yml:
-
-```bash
-gh api graphql -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    issue(number: $number) {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project { id, number }
-        }
-      }
-    }
-  }
-}' -f owner="{owner}" -f repo="{repo}" -F number={parent_issue_number}
-```
-
-Find the node where `project.number` matches `{project_number}`. Extract `{item_id}` (node `id`) and `{project_id}` (node `project.id`).
-
-**When `projectItems.nodes` is empty** (parent Issue not registered in Project):
-
-```
-警告: Issue #{parent_issue_number} は Project に登録されていません
-Status 更新をスキップします
-```
-
-Display warning and proceed to Step 4 (non-blocking).
-
-**Step 2**: Retrieve Status field "Done" option ID:
+**Step 1**: Update parent Issue Status to "Done" via the shared script:
 
 ```bash
-gh project field-list {project_number} --owner {owner} --format json
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {parent_issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "Done" \
+  --argjson auto_add false \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
 ```
 
-From the result, find the field with `name` "Status". Extract:
-- `{status_field_id}`: the field's `id`
-- `{done_option_id}`: the `id` of the option with `name` "Done"
+Inspect the script's stdout JSON:
 
-If `github.projects.field_ids.status` is set in rite-config.yml, use that value as `{status_field_id}` instead.
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` → display `警告: Issue #{parent_issue_number} は Project に登録されていません` and proceed to Step 2 (non-blocking).
+- `.result == "failed"` → display `.warnings[]` and proceed to Step 2 (non-blocking).
 
-**When "Done" option is not found**: Display warning and proceed to Step 4 (non-blocking).
-
-**Step 3**: Update Status:
-
-```bash
-gh project item-edit --project-id {project_id} --id {item_id} --field-id {status_field_id} --single-select-option-id {done_option_id}
-```
-
-On failure, display warning and continue to Step 4 (non-blocking).
-
-**Step 4**: Close the parent Issue:
+**Step 2**: Close the parent Issue:
 
 ```bash
 gh issue close {parent_issue_number}

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -328,9 +328,8 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 2.4 (Projects Status → In Progress). Skipping to Phase 2.5/2.6/3 without running Projects update is PROHIBITED. Do NOT stop."
 ```
 
-> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh`, which is the single source of truth for Projects Status updates across Phase 2.4, 5.5.1, and 5.7.2.
-<!-- Refactor origin: Issue #496 / PR #531 — do not re-inline Step 2-3 below. -->
-<!-- projects-integration.md §2.4 documents the underlying API calls for reference. -->
+> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh`, which is the single source of truth for Projects Status updates across Phase 2.4, 5.5.1, and 5.7.2. `projects-integration.md` §2.4 documents the underlying API calls for reference and debugging, but callers MUST NOT re-inline those bash blocks here — always delegate to the script.
+<!-- Refactor origin: Issue #496 / PR #531. Do not re-inline Step 2-3. -->
 
 
 

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -371,9 +371,10 @@ github:
 
 **Note**: This file (ready.md) uses GraphQL instead of `gh project field-list`.
 
-**Differences from other command files (close.md, start.md, cleanup.md):**
-- Other files: Use the `gh project field-list` CLI command (adequate when retrieving field lists only)
-- This file: Uses GraphQL (an intentional design decision for the following reasons)
+**Differences from other command files:**
+- `close.md` / `cleanup.md`: Use the `gh project field-list` CLI command directly (adequate when retrieving field lists only)
+- `start.md` (Phase 2.4 / 5.5.1 / 5.7.2): Delegates Projects Status updates to `plugins/rite/scripts/projects-status-update.sh`, which internally uses `gh project field-list` + `gh project item-edit` (see Issue #496 / PR #531 for the refactor)
+- This file (ready.md): Uses GraphQL (an intentional design decision for the following reasons)
 
 **Reasons for using GraphQL:**
 - Both field ID and option ID can be fetched in a single query

--- a/plugins/rite/references/projects-integration.md
+++ b/plugins/rite/references/projects-integration.md
@@ -11,6 +11,8 @@ This module handles GitHub Projects integration including Status updates and Ite
 Retrieve the Project item ID and update Status to "In Progress".
 **Automatically add the Issue to the Project if it is not registered.**
 
+> **Runtime execution**: Callers (`commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2) invoke `plugins/rite/scripts/projects-status-update.sh`, which is the single source of truth for Projects Status updates. The bash examples in §2.4.2 – §2.4.5 below document the underlying API calls for reference and debugging. Do NOT reproduce them inline in new commands — delegate to the script instead (see Issue #496 for the refactor rationale).
+
 ### 2.4.1 Configuration Retrieval
 
 Retrieve Projects configuration from `rite-config.yml`:

--- a/plugins/rite/scripts/projects-status-update.sh
+++ b/plugins/rite/scripts/projects-status-update.sh
@@ -127,7 +127,12 @@ if [ -z "$STATUS_NAME" ]; then
   exit 1
 fi
 
-# Helper: emit non-blocking failure and exit according to NON_BLOCKING mode.
+# Helper: emit a terminal failure result and exit.
+# NOTE: fail_nb ALWAYS exits — it never returns to the caller. This is intentional:
+# all failure paths should emit exactly one JSON result and terminate. Callers rely
+# on this behavior (they are not wrapped in `if fail_nb ...; then` guards).
+# When NON_BLOCKING=true, exit code is 0 so orchestrators can continue the workflow
+# and inspect `.result` in the stdout JSON. When false, exit code is 1 for fail-fast.
 fail_nb() {
   local result="$1"
   local item_id="${2:-}"
@@ -139,6 +144,15 @@ fail_nb() {
     exit 0
   fi
   exit 1
+}
+
+# Helper: read gh stderr file into a warning, handling the empty/missing case.
+gh_err_msg() {
+  if [ -s "$GH_ERR_FILE" ]; then
+    cat "$GH_ERR_FILE"
+  else
+    printf '(no stderr captured — gh may have exited before writing)'
+  fi
 }
 
 # --- Step A: Retrieve Issue's project item ID and project GraphQL id ---
@@ -163,7 +177,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 
 GQL_RESULT=$(query_project_items) || {
-  add_warning "GraphQL projectItems query failed: $(cat "$GH_ERR_FILE")"
+  add_warning "GraphQL projectItems query failed: $(gh_err_msg)"
   fail_nb "failed"
 }
 
@@ -177,7 +191,7 @@ fi
 # Find node whose project.number matches PROJECT_NUMBER.
 find_matching_node() {
   printf '%s\n' "$GQL_RESULT" | jq -r --argjson pn "$PROJECT_NUMBER" \
-    '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | "\(.id)|\(.project.id)"' | head -1
+    '[.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn)][0] | if . == null then "" else "\(.id)|\(.project.id)" end'
 }
 
 NODE_LINE=$(find_matching_node)
@@ -195,14 +209,18 @@ if [ -z "$NODE_LINE" ]; then
     fail_nb "failed"
   fi
 
-  if ! gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL" --format json >"$TMPDIR_WORK/add_out" 2>"$GH_ERR_FILE"; then
-    add_warning "gh project item-add failed: $(cat "$GH_ERR_FILE")"
+  # We discard item-add stdout here because the following re-query is required
+  # anyway to obtain project.id (item-add --format json returns only the item id,
+  # not the parent project id). See create-issue-with-projects.sh for a variant
+  # that captures item-add stdout as a fallback.
+  if ! gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL" --format json >/dev/null 2>"$GH_ERR_FILE"; then
+    add_warning "gh project item-add failed: $(gh_err_msg)"
     fail_nb "failed"
   fi
 
-  # Re-query to obtain project.id (item-add --format json returns only item id, not project id).
+  # Re-query to obtain project.id.
   GQL_RESULT=$(query_project_items) || {
-    add_warning "GraphQL re-query after auto-add failed: $(cat "$GH_ERR_FILE")"
+    add_warning "GraphQL re-query after auto-add failed: $(gh_err_msg)"
     fail_nb "failed"
   }
   NODE_LINE=$(find_matching_node)
@@ -223,12 +241,12 @@ fi
 # If status_field_id_hint is provided, we still need to fetch options (field_ids
 # optimization only skips field ID extraction, not option ID).
 FIELD_LIST_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json 2>"$GH_ERR_FILE") || {
-  add_warning "gh project field-list failed: $(cat "$GH_ERR_FILE")"
+  add_warning "gh project field-list failed: $(gh_err_msg)"
   fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
 }
 
 # `gh project field-list` returns {fields: [...]} — find the Status field.
-STATUS_NODE=$(printf '%s\n' "$FIELD_LIST_JSON" | jq -c '.fields[] | select(.name == "Status")' | head -1)
+STATUS_NODE=$(printf '%s\n' "$FIELD_LIST_JSON" | jq -c '[.fields[] | select(.name == "Status")][0] // empty')
 if [ -z "$STATUS_NODE" ]; then
   add_warning "Status field not found in project #$PROJECT_NUMBER"
   fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
@@ -244,7 +262,7 @@ if [ -z "$STATUS_FIELD_ID" ]; then
   fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
 fi
 
-OPTION_ID=$(printf '%s\n' "$STATUS_NODE" | jq -r --arg sn "$STATUS_NAME" '.options[] | select(.name == $sn) | .id' | head -1)
+OPTION_ID=$(printf '%s\n' "$STATUS_NODE" | jq -r --arg sn "$STATUS_NAME" '[.options[] | select(.name == $sn)][0].id // empty')
 if [ -z "$OPTION_ID" ]; then
   add_warning "Status option '$STATUS_NAME' not found in Status field"
   fail_nb "failed" "$ITEM_ID" "$PROJECT_ID" "$STATUS_FIELD_ID"
@@ -256,7 +274,7 @@ if ! gh project item-edit \
     --id "$ITEM_ID" \
     --field-id "$STATUS_FIELD_ID" \
     --single-select-option-id "$OPTION_ID" >/dev/null 2>"$GH_ERR_FILE"; then
-  add_warning "gh project item-edit failed: $(cat "$GH_ERR_FILE")"
+  add_warning "gh project item-edit failed: $(gh_err_msg)"
   fail_nb "failed" "$ITEM_ID" "$PROJECT_ID" "$STATUS_FIELD_ID" "$OPTION_ID"
 fi
 

--- a/plugins/rite/scripts/projects-status-update.sh
+++ b/plugins/rite/scripts/projects-status-update.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# rite workflow - Projects Status Update
+# Common core script for updating a GitHub Issue's Status field in GitHub Projects.
+#
+# Extracted from:
+#   - commands/issue/start.md Phase 2.4 Step 2-4 (Status -> In Progress)
+#   - commands/issue/start.md Phase 5.5.1 (Status -> In Review)
+#   - commands/issue/start.md Phase 5.7.2 (parent Issue Status -> Done)
+#   - references/projects-integration.md §2.4.2-2.4.5
+#
+# Usage:
+#   bash projects-status-update.sh '<json_args>'
+#
+# Input JSON schema:
+#   {
+#     "issue_number": 496,
+#     "owner": "B16B1RD",
+#     "repo": "cc-rite-workflow",
+#     "project_number": 6,
+#     "status_name": "In Progress",           # required: Todo|In Progress|In Review|Done|...
+#     "status_field_id_hint": "PVTSSF_...",   # optional: skip field ID discovery if provided
+#     "auto_add": true,                        # default: true — add Issue to Project if missing
+#     "non_blocking": true                     # default: true — warnings + exit 0 on API failure
+#   }
+#
+# Output JSON (stdout):
+#   {
+#     "result": "updated|skipped_not_in_project|failed",
+#     "item_id": "PVTI_...",
+#     "project_id": "PVT_...",
+#     "status_field_id": "PVTSSF_...",
+#     "option_id": "...",
+#     "warnings": []
+#   }
+#
+# Exit codes:
+#   0 = success OR non-blocking failure (caller must inspect .result)
+#   1 = fatal (JSON parse error, missing required fields, non_blocking=false API failure)
+set -euo pipefail
+
+# --- Centralized tmpfile management ---
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+GH_ERR_FILE="$TMPDIR_WORK/gh_err"
+
+# --- Warning accumulation ---
+WARNINGS_ARR=()
+add_warning() {
+  WARNINGS_ARR+=("$1")
+}
+
+# --- Helper: output JSON result to stdout ---
+output_result() {
+  local result="${1:-failed}"
+  local item_id="${2:-}"
+  local project_id="${3:-}"
+  local status_field_id="${4:-}"
+  local option_id="${5:-}"
+  local warns
+  if [ ${#WARNINGS_ARR[@]} -eq 0 ]; then
+    warns='[]'
+  else
+    warns=$(printf '%s\n' "${WARNINGS_ARR[@]}" | jq -R . | jq -s .)
+  fi
+  jq -n \
+    --arg result "$result" \
+    --arg item_id "$item_id" \
+    --arg project_id "$project_id" \
+    --arg status_field_id "$status_field_id" \
+    --arg option_id "$option_id" \
+    --argjson warns "$warns" \
+    '{result: $result, item_id: $item_id, project_id: $project_id, status_field_id: $status_field_id, option_id: $option_id, warnings: $warns}'
+}
+
+# --- Argument parsing ---
+if [ $# -lt 1 ]; then
+  add_warning "No JSON argument provided"
+  output_result "failed"
+  exit 1
+fi
+
+INPUT_JSON="$1"
+
+# Validate JSON parseability before eval'ing extracted fields.
+if ! printf '%s\n' "$INPUT_JSON" | jq -e . >/dev/null 2>&1; then
+  add_warning "Invalid JSON argument"
+  output_result "failed"
+  exit 1
+fi
+
+# Extract all fields in one jq invocation.
+eval "$(printf '%s\n' "$INPUT_JSON" | jq -r '
+  @sh "ISSUE_NUMBER=\(.issue_number // 0)",
+  @sh "OWNER=\(.owner // "")",
+  @sh "REPO=\(.repo // "")",
+  @sh "PROJECT_NUMBER=\(.project_number // 0)",
+  @sh "STATUS_NAME=\(.status_name // "")",
+  @sh "STATUS_FIELD_ID_HINT=\(.status_field_id_hint // "")",
+  @sh "AUTO_ADD=\(if .auto_add == false then false else true end)",
+  @sh "NON_BLOCKING=\(if .non_blocking == false then false else true end)"
+')"
+
+# --- Validation ---
+if [ "$ISSUE_NUMBER" -eq 0 ]; then
+  add_warning "issue_number is required"
+  output_result "failed"
+  exit 1
+fi
+if [ -z "$OWNER" ]; then
+  add_warning "owner is required"
+  output_result "failed"
+  exit 1
+fi
+if [ -z "$REPO" ]; then
+  add_warning "repo is required"
+  output_result "failed"
+  exit 1
+fi
+if [ "$PROJECT_NUMBER" -eq 0 ]; then
+  add_warning "project_number is required"
+  output_result "failed"
+  exit 1
+fi
+if [ -z "$STATUS_NAME" ]; then
+  add_warning "status_name is required"
+  output_result "failed"
+  exit 1
+fi
+
+# Helper: emit non-blocking failure and exit according to NON_BLOCKING mode.
+fail_nb() {
+  local result="$1"
+  local item_id="${2:-}"
+  local project_id="${3:-}"
+  local status_field_id="${4:-}"
+  local option_id="${5:-}"
+  output_result "$result" "$item_id" "$project_id" "$status_field_id" "$option_id"
+  if [ "$NON_BLOCKING" = "true" ]; then
+    exit 0
+  fi
+  exit 1
+}
+
+# --- Step A: Retrieve Issue's project item ID and project GraphQL id ---
+query_project_items() {
+  gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      url
+      projectItems(first: 10) {
+        nodes {
+          id
+          project {
+            id
+            number
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f repo="$REPO" -F number="$ISSUE_NUMBER" 2>"$GH_ERR_FILE"
+}
+
+GQL_RESULT=$(query_project_items) || {
+  add_warning "GraphQL projectItems query failed: $(cat "$GH_ERR_FILE")"
+  fail_nb "failed"
+}
+
+# Check that the issue node exists (null means issue not found in repo).
+ISSUE_EXISTS=$(printf '%s\n' "$GQL_RESULT" | jq -r '.data.repository.issue // empty')
+if [ -z "$ISSUE_EXISTS" ]; then
+  add_warning "Issue #$ISSUE_NUMBER not found in $OWNER/$REPO"
+  fail_nb "failed"
+fi
+
+# Find node whose project.number matches PROJECT_NUMBER.
+find_matching_node() {
+  printf '%s\n' "$GQL_RESULT" | jq -r --argjson pn "$PROJECT_NUMBER" \
+    '.data.repository.issue.projectItems.nodes[] | select(.project.number == $pn) | "\(.id)|\(.project.id)"' | head -1
+}
+
+NODE_LINE=$(find_matching_node)
+
+# --- Step B: Auto-add if not registered ---
+if [ -z "$NODE_LINE" ]; then
+  if [ "$AUTO_ADD" != "true" ]; then
+    add_warning "Issue #$ISSUE_NUMBER is not registered in project #$PROJECT_NUMBER (auto_add disabled)"
+    fail_nb "skipped_not_in_project"
+  fi
+
+  ISSUE_URL=$(printf '%s\n' "$GQL_RESULT" | jq -r '.data.repository.issue.url // empty')
+  if [ -z "$ISSUE_URL" ]; then
+    add_warning "Could not determine issue URL for auto-add"
+    fail_nb "failed"
+  fi
+
+  if ! gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL" --format json >"$TMPDIR_WORK/add_out" 2>"$GH_ERR_FILE"; then
+    add_warning "gh project item-add failed: $(cat "$GH_ERR_FILE")"
+    fail_nb "failed"
+  fi
+
+  # Re-query to obtain project.id (item-add --format json returns only item id, not project id).
+  GQL_RESULT=$(query_project_items) || {
+    add_warning "GraphQL re-query after auto-add failed: $(cat "$GH_ERR_FILE")"
+    fail_nb "failed"
+  }
+  NODE_LINE=$(find_matching_node)
+  if [ -z "$NODE_LINE" ]; then
+    add_warning "Auto-add succeeded but project item not found in re-query"
+    fail_nb "failed"
+  fi
+fi
+
+ITEM_ID="${NODE_LINE%%|*}"
+PROJECT_ID="${NODE_LINE##*|}"
+if [ -z "$ITEM_ID" ] || [ -z "$PROJECT_ID" ]; then
+  add_warning "Failed to parse item_id / project_id from GraphQL result"
+  fail_nb "failed"
+fi
+
+# --- Step C: Retrieve Status field + option id ---
+# If status_field_id_hint is provided, we still need to fetch options (field_ids
+# optimization only skips field ID extraction, not option ID).
+FIELD_LIST_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json 2>"$GH_ERR_FILE") || {
+  add_warning "gh project field-list failed: $(cat "$GH_ERR_FILE")"
+  fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
+}
+
+# `gh project field-list` returns {fields: [...]} — find the Status field.
+STATUS_NODE=$(printf '%s\n' "$FIELD_LIST_JSON" | jq -c '.fields[] | select(.name == "Status")' | head -1)
+if [ -z "$STATUS_NODE" ]; then
+  add_warning "Status field not found in project #$PROJECT_NUMBER"
+  fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
+fi
+
+if [ -n "$STATUS_FIELD_ID_HINT" ]; then
+  STATUS_FIELD_ID="$STATUS_FIELD_ID_HINT"
+else
+  STATUS_FIELD_ID=$(printf '%s\n' "$STATUS_NODE" | jq -r '.id // empty')
+fi
+if [ -z "$STATUS_FIELD_ID" ]; then
+  add_warning "Could not determine Status field id"
+  fail_nb "failed" "$ITEM_ID" "$PROJECT_ID"
+fi
+
+OPTION_ID=$(printf '%s\n' "$STATUS_NODE" | jq -r --arg sn "$STATUS_NAME" '.options[] | select(.name == $sn) | .id' | head -1)
+if [ -z "$OPTION_ID" ]; then
+  add_warning "Status option '$STATUS_NAME' not found in Status field"
+  fail_nb "failed" "$ITEM_ID" "$PROJECT_ID" "$STATUS_FIELD_ID"
+fi
+
+# --- Step D: Update Status ---
+if ! gh project item-edit \
+    --project-id "$PROJECT_ID" \
+    --id "$ITEM_ID" \
+    --field-id "$STATUS_FIELD_ID" \
+    --single-select-option-id "$OPTION_ID" >/dev/null 2>"$GH_ERR_FILE"; then
+  add_warning "gh project item-edit failed: $(cat "$GH_ERR_FILE")"
+  fail_nb "failed" "$ITEM_ID" "$PROJECT_ID" "$STATUS_FIELD_ID" "$OPTION_ID"
+fi
+
+output_result "updated" "$ITEM_ID" "$PROJECT_ID" "$STATUS_FIELD_ID" "$OPTION_ID"
+exit 0

--- a/plugins/rite/scripts/projects-status-update.sh
+++ b/plugins/rite/scripts/projects-status-update.sh
@@ -2,8 +2,9 @@
 # rite workflow - Projects Status Update
 # Common core script for updating a GitHub Issue's Status field in GitHub Projects.
 #
-# Extracted from:
-#   - commands/issue/start.md Phase 2.4 Step 2-4 (Status -> In Progress)
+# Extracted from (Issue #496 / PR #531):
+#   - commands/issue/start.md Phase 2.4 Step 2 (Status -> In Progress;
+#     the post-refactor Step 2 consolidates the pre-refactor Step 2-4 triple)
 #   - commands/issue/start.md Phase 5.5.1 (Status -> In Review)
 #   - commands/issue/start.md Phase 5.7.2 (parent Issue Status -> Done)
 #   - references/projects-integration.md §2.4.2-2.4.5

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Mock gh CLI for testing create-issue-with-projects.sh
+# Mock gh CLI for testing create-issue-with-projects.sh AND projects-status-update.sh
 # This script intercepts gh commands and returns predefined responses.
 #
 # Usage:
@@ -7,7 +7,7 @@
 #   The test harness prepends the directory containing this script to PATH
 #   so that `gh` resolves here instead of the real binary.
 #
-# Scenarios:
+# Scenarios (create-issue-with-projects.sh):
 #   "success"              - All commands succeed (default)
 #   "issue_create_fail"    - gh issue create fails
 #   "project_add_fail"     - gh project item-add fails
@@ -20,6 +20,23 @@
 #   "no_current_iteration" - GraphQL includes iteration field but only future iterations
 #   "no_project_id"        - GraphQL returns null project ID
 #   "url_parse_fail"       - gh issue create returns non-URL string (no trailing number)
+#
+# Scenarios (projects-status-update.sh):
+#   "psu_success"              - Issue in project, Status updated
+#   "psu_issue_not_found"      - repository.issue returns null
+#   "psu_not_in_project"       - projectItems.nodes is empty (no auto_add)
+#   "psu_auto_add_then_ok"     - First query empty, item-add succeeds, re-query finds item
+#   "psu_auto_add_fail"        - item-add fails
+#   "psu_auto_add_requery_empty" - item-add succeeds but re-query still empty
+#   "psu_field_list_fail"      - gh project field-list fails
+#   "psu_no_status_field"      - field-list returns no Status field
+#   "psu_no_status_option"     - Status field exists but requested option name missing
+#   "psu_item_edit_fail"       - gh project item-edit fails
+#
+# The projects-status-update.sh script uses a different GraphQL shape
+# (`data.repository.issue.projectItems`) than create-issue-with-projects.sh
+# (`data.{user|organization}.projectV2`), so this mock detects the query shape
+# via the `repository(owner:` token in the query string and branches accordingly.
 set -euo pipefail
 
 SCENARIO="${MOCK_GH_SCENARIO:-success}"
@@ -56,8 +73,40 @@ case "$1" in
 
   project)
     case "$2" in
+      field-list)
+        # New: `gh project field-list PROJECT_NUMBER --owner OWNER --format json`
+        # Used by projects-status-update.sh to resolve Status field + option ids.
+        if [ "$SCENARIO" = "psu_field_list_fail" ]; then
+          echo "error: failed to list project fields" >&2
+          exit 1
+        fi
+        if [ "$SCENARIO" = "psu_no_status_field" ]; then
+          cat <<'FLJSON'
+{"fields": [{"id": "FIELD_PRIORITY", "name": "Priority", "options": [{"id": "OPT_P_HIGH", "name": "High"}]}]}
+FLJSON
+          exit 0
+        fi
+        if [ "$SCENARIO" = "psu_no_status_option" ]; then
+          cat <<'FLJSON'
+{"fields": [{"id": "FIELD_STATUS", "name": "Status", "options": [{"id": "OPT_TODO", "name": "Todo"}]}]}
+FLJSON
+          exit 0
+        fi
+        cat <<'FLJSON'
+{
+  "fields": [
+    {"id": "FIELD_STATUS", "name": "Status", "options": [
+      {"id": "OPT_TODO", "name": "Todo"},
+      {"id": "OPT_INPROGRESS", "name": "In Progress"},
+      {"id": "OPT_INREVIEW", "name": "In Review"},
+      {"id": "OPT_DONE", "name": "Done"}
+    ]}
+  ]
+}
+FLJSON
+        ;;
       item-add)
-        if [ "$SCENARIO" = "project_add_fail" ]; then
+        if [ "$SCENARIO" = "project_add_fail" ] || [ "$SCENARIO" = "psu_auto_add_fail" ]; then
           echo "error: failed to add item to project" >&2
           exit 1
         fi
@@ -82,7 +131,7 @@ ITEMJSON
         fi
         ;;
       item-edit)
-        if [ "$SCENARIO" = "field_edit_fail" ]; then
+        if [ "$SCENARIO" = "field_edit_fail" ] || [ "$SCENARIO" = "psu_item_edit_fail" ]; then
           echo "error: failed to edit project item" >&2
           exit 1
         fi
@@ -134,12 +183,18 @@ ITEMJSON
           exit 1
         fi
 
-        # Detect mutation vs query (for iteration assignment)
-        # Note: query arg may have leading newline (e.g., query=\nmutation...)
+        # Detect query shape: projects-status-update.sh queries `repository(owner:`
+        # while create-issue-with-projects.sh queries `user|organization(login:`.
+        is_repository_query=false
         is_mutation=false
         for arg in "$@"; do
-          if [[ "$arg" == query=* ]] && [[ "$arg" == *mutation* ]]; then
-            is_mutation=true
+          if [[ "$arg" == query=* ]]; then
+            if [[ "$arg" == *"repository(owner:"* ]]; then
+              is_repository_query=true
+            fi
+            if [[ "$arg" == *mutation* ]]; then
+              is_mutation=true
+            fi
             break
           fi
         done
@@ -147,6 +202,47 @@ ITEMJSON
         if [ "$is_mutation" = true ]; then
           # No stdout output for mutations (only exit code matters to caller)
           exit 0
+        fi
+
+        # --- projects-status-update.sh path ---
+        if [ "$is_repository_query" = true ]; then
+          # Determine scenario-dependent response shape.
+          case "$SCENARIO" in
+            psu_issue_not_found)
+              printf '{"data":{"repository":{"issue":null}}}\n'
+              exit 0
+              ;;
+            psu_not_in_project|psu_auto_add_requery_empty|psu_auto_add_fail)
+              # All scenarios where the initial query returns no project items.
+              # - psu_not_in_project: auto_add=false, script stops
+              # - psu_auto_add_fail: auto_add=true, script tries item-add which then fails
+              # - psu_auto_add_requery_empty: auto_add=true, item-add succeeds, re-query empty
+              printf '{"data":{"repository":{"issue":{"url":"https://github.com/test-owner/test-repo/issues/%s","projectItems":{"nodes":[]}}}}}\n' "$MOCK_ISSUE_NUMBER"
+              exit 0
+              ;;
+            psu_auto_add_then_ok)
+              # State machine: first call returns empty, subsequent calls return item.
+              # Use a fixed-name file in MOCK_GH_STATE_DIR (do NOT include $$ —
+              # mock-gh.sh's own PID differs between the two gh invocations).
+              state_dir="${MOCK_GH_STATE_DIR:-/tmp}"
+              state_file="$state_dir/psu_autoadd_count"
+              if [ -f "$state_file" ]; then
+                printf '{"data":{"repository":{"issue":{"url":"https://github.com/test-owner/test-repo/issues/%s","projectItems":{"nodes":[{"id":"%s","project":{"id":"%s","number":6}}]}}}}}\n' "$MOCK_ISSUE_NUMBER" "$MOCK_ITEM_ID" "$MOCK_PROJECT_ID"
+              else
+                echo "1" > "$state_file"
+                printf '{"data":{"repository":{"issue":{"url":"https://github.com/test-owner/test-repo/issues/%s","projectItems":{"nodes":[]}}}}}\n' "$MOCK_ISSUE_NUMBER"
+              fi
+              exit 0
+              ;;
+            psu_success|psu_field_list_fail|psu_no_status_field|psu_no_status_option|psu_item_edit_fail)
+              printf '{"data":{"repository":{"issue":{"url":"https://github.com/test-owner/test-repo/issues/%s","projectItems":{"nodes":[{"id":"%s","project":{"id":"%s","number":6}}]}}}}}\n' "$MOCK_ISSUE_NUMBER" "$MOCK_ITEM_ID" "$MOCK_PROJECT_ID"
+              exit 0
+              ;;
+            *)
+              printf '{"data":{"repository":{"issue":{"url":"https://github.com/test-owner/test-repo/issues/%s","projectItems":{"nodes":[{"id":"%s","project":{"id":"%s","number":6}}]}}}}}\n' "$MOCK_ISSUE_NUMBER" "$MOCK_ITEM_ID" "$MOCK_PROJECT_ID"
+              exit 0
+              ;;
+          esac
         fi
 
         # Determine GQL root based on owner type

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -208,8 +208,17 @@ ITEMJSON
         if [ "$is_repository_query" = true ]; then
           # Determine scenario-dependent response shape.
           case "$SCENARIO" in
+            psu_graphql_fail)
+              echo "error: GraphQL projectItems query failed" >&2
+              exit 1
+              ;;
             psu_issue_not_found)
               printf '{"data":{"repository":{"issue":null}}}\n'
+              exit 0
+              ;;
+            psu_issue_url_null)
+              # projectItems empty AND url is null → auto_add branch cannot proceed
+              printf '{"data":{"repository":{"issue":{"url":null,"projectItems":{"nodes":[]}}}}}\n'
               exit 0
               ;;
             psu_not_in_project|psu_auto_add_requery_empty|psu_auto_add_fail)

--- a/plugins/rite/scripts/tests/projects-status-update.test.sh
+++ b/plugins/rite/scripts/tests/projects-status-update.test.sh
@@ -241,6 +241,21 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-015a: auto-add succeeds but re-query still empty → failed
+# (guards the scripts/projects-status-update.sh "Auto-add succeeded but project
+# item not found in re-query" branch from regression)
+# --------------------------------------------------------------------------
+echo "TC-015a: auto-add + re-query empty → failed"
+run_script "$(build_json 42 'In Progress' true)" psu_auto_add_requery_empty
+if [ "$LAST_RC" = "0" ] \
+   && [ "$(json_field '.result')" = "failed" ] \
+   && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("Auto-add succeeded but project item not found in re-query"))) | length >= 1' >/dev/null; then
+  pass "auto-add re-query empty captured"
+else
+  fail "TC-015a unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
 # TC-015: Missing issue_number → exit 1
 # --------------------------------------------------------------------------
 echo "TC-015: Missing issue_number → exit 1"

--- a/plugins/rite/scripts/tests/projects-status-update.test.sh
+++ b/plugins/rite/scripts/tests/projects-status-update.test.sh
@@ -30,6 +30,8 @@ fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
 # Helper: run the target script with mock gh and given JSON args.
 # Each call uses a fresh MOCK_GH_STATE_DIR so state-machine scenarios
 # (e.g., psu_auto_add_then_ok) do not leak between test cases.
+# stderr is redirected to a separate file (NOT merged into stdout) so JSON
+# parsing assertions on $LAST_OUTPUT are not corrupted by incidental warnings.
 run_script() {
   local json_args="$1"
   local scenario="${2:-psu_success}"
@@ -45,6 +47,19 @@ run_script() {
     PATH="$MOCK_BIN_DIR:$PATH" \
     bash "$TARGET" "$json_args" 2>"$TEST_DIR/last_stderr"
   ) || rc=$?
+  LAST_OUTPUT="$output"
+  LAST_RC=$rc
+  return 0
+}
+
+# Validation helper: run script with no scenario / mock setup (validation
+# branch exits before any `gh` call). stderr is isolated to avoid polluting
+# the JSON stdout capture.
+run_validation() {
+  local args=("$@")
+  local rc=0
+  local output
+  output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" "${args[@]}" 2>"$TEST_DIR/last_stderr") || rc=$?
   LAST_OUTPUT="$output"
   LAST_RC=$rc
   return 0
@@ -79,36 +94,60 @@ echo ""
 # TC-001: No arguments → exit 1
 # --------------------------------------------------------------------------
 echo "TC-001: No arguments → exit 1"
-rc=0
-output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" 2>&1) || rc=$?
-if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.result == "failed"' >/dev/null; then
+run_validation
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.result == "failed"' >/dev/null; then
   pass "No args → exit 1 with failed result"
 else
-  fail "Expected exit 1 with failed result, got rc=$rc output=$output"
+  fail "Expected exit 1 with failed result, got rc=$LAST_RC output=$LAST_OUTPUT"
 fi
 
 # --------------------------------------------------------------------------
 # TC-002: Invalid JSON → exit 1
 # --------------------------------------------------------------------------
 echo "TC-002: Invalid JSON → exit 1"
-rc=0
-output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" "not-json" 2>&1) || rc=$?
-if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "Invalid JSON argument")) | length == 1' >/dev/null; then
+run_validation "not-json"
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "Invalid JSON argument")) | length == 1' >/dev/null; then
   pass "Invalid JSON → exit 1"
 else
-  fail "Expected exit 1 with 'Invalid JSON argument' warning, got rc=$rc output=$output"
+  fail "Expected exit 1 with 'Invalid JSON argument' warning, got rc=$LAST_RC output=$LAST_OUTPUT"
 fi
 
 # --------------------------------------------------------------------------
 # TC-003: Missing required field (owner) → exit 1
 # --------------------------------------------------------------------------
 echo "TC-003: Missing owner → exit 1"
-rc=0
-output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" '{"issue_number": 42, "repo": "test-repo", "project_number": 6, "status_name": "Todo"}' 2>&1) || rc=$?
-if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "owner is required")) | length == 1' >/dev/null; then
+run_validation '{"issue_number": 42, "repo": "test-repo", "project_number": 6, "status_name": "Todo"}'
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "owner is required")) | length == 1' >/dev/null; then
   pass "Missing owner → exit 1"
 else
-  fail "Expected exit 1 with 'owner is required', got rc=$rc output=$output"
+  fail "Expected exit 1 with 'owner is required', got rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-003a/b/c: Missing remaining required fields → exit 1
+# --------------------------------------------------------------------------
+echo "TC-003a: Missing repo → exit 1"
+run_validation '{"issue_number": 42, "owner": "x", "project_number": 6, "status_name": "Todo"}'
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "repo is required")) | length == 1' >/dev/null; then
+  pass "Missing repo → exit 1"
+else
+  fail "TC-003a unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+echo "TC-003b: Missing project_number → exit 1"
+run_validation '{"issue_number": 42, "owner": "x", "repo": "y", "status_name": "Todo"}'
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "project_number is required")) | length == 1' >/dev/null; then
+  pass "Missing project_number → exit 1"
+else
+  fail "TC-003b unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+echo "TC-003c: Missing status_name → exit 1"
+run_validation '{"issue_number": 42, "owner": "x", "repo": "y", "project_number": 6}'
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "status_name is required")) | length == 1' >/dev/null; then
+  pass "Missing status_name → exit 1"
+else
+  fail "TC-003c unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
 fi
 
 # --------------------------------------------------------------------------
@@ -241,30 +280,56 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# TC-015a: auto-add succeeds but re-query still empty → failed
+# TC-015: Missing issue_number → exit 1
+# --------------------------------------------------------------------------
+echo "TC-015: Missing issue_number → exit 1"
+run_validation '{"owner": "x", "repo": "y", "project_number": 1, "status_name": "Todo"}'
+if [ "$LAST_RC" = "1" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. == "issue_number is required")) | length == 1' >/dev/null; then
+  pass "Missing issue_number → exit 1"
+else
+  fail "TC-015 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-016: Initial GraphQL projectItems query fails → failed
+# --------------------------------------------------------------------------
+echo "TC-016: GraphQL query failure → failed"
+run_script "$(build_json 42 'Todo')" psu_graphql_fail
+if [ "$LAST_RC" = "0" ] \
+   && [ "$(json_field '.result')" = "failed" ] \
+   && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("projectItems query failed"))) | length >= 1' >/dev/null; then
+  pass "GraphQL query failure captured"
+else
+  fail "TC-016 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-017: auto-add succeeds but re-query still empty → failed
 # (guards the scripts/projects-status-update.sh "Auto-add succeeded but project
 # item not found in re-query" branch from regression)
 # --------------------------------------------------------------------------
-echo "TC-015a: auto-add + re-query empty → failed"
+echo "TC-017: auto-add + re-query empty → failed"
 run_script "$(build_json 42 'In Progress' true)" psu_auto_add_requery_empty
 if [ "$LAST_RC" = "0" ] \
    && [ "$(json_field '.result')" = "failed" ] \
    && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("Auto-add succeeded but project item not found in re-query"))) | length >= 1' >/dev/null; then
   pass "auto-add re-query empty captured"
 else
-  fail "TC-015a unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+  fail "TC-017 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
 fi
 
 # --------------------------------------------------------------------------
-# TC-015: Missing issue_number → exit 1
+# TC-018: Issue URL is null when auto_add=true → failed
+# (guards the "Could not determine issue URL for auto-add" branch)
 # --------------------------------------------------------------------------
-echo "TC-015: Missing issue_number → exit 1"
-rc=0
-output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" '{"owner": "x", "repo": "y", "project_number": 1, "status_name": "Todo"}' 2>&1) || rc=$?
-if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "issue_number is required")) | length == 1' >/dev/null; then
-  pass "Missing issue_number → exit 1"
+echo "TC-018: auto_add=true + issue.url=null → failed"
+run_script "$(build_json 42 'Todo' true)" psu_issue_url_null
+if [ "$LAST_RC" = "0" ] \
+   && [ "$(json_field '.result')" = "failed" ] \
+   && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("Could not determine issue URL"))) | length >= 1' >/dev/null; then
+  pass "issue URL null captured"
 else
-  fail "TC-015 unexpected: rc=$rc output=$output"
+  fail "TC-018 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
 fi
 
 echo ""

--- a/plugins/rite/scripts/tests/projects-status-update.test.sh
+++ b/plugins/rite/scripts/tests/projects-status-update.test.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# Tests for projects-status-update.sh
+# Usage: bash plugins/rite/scripts/tests/projects-status-update.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/../projects-status-update.sh"
+MOCK_DIR="$SCRIPT_DIR"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+MOCK_BIN_DIR="$TEST_DIR/mock-bin"
+mkdir -p "$MOCK_BIN_DIR"
+ln -s "$MOCK_DIR/mock-gh.sh" "$MOCK_BIN_DIR/gh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# Helper: run the target script with mock gh and given JSON args.
+# Each call uses a fresh MOCK_GH_STATE_DIR so state-machine scenarios
+# (e.g., psu_auto_add_then_ok) do not leak between test cases.
+run_script() {
+  local json_args="$1"
+  local scenario="${2:-psu_success}"
+  local issue_number="${3:-42}"
+  local state_dir
+  state_dir=$(mktemp -d "$TEST_DIR/mockstate.XXXXXX")
+  local rc=0
+  local output
+  output=$(
+    MOCK_GH_SCENARIO="$scenario" \
+    MOCK_ISSUE_NUMBER="$issue_number" \
+    MOCK_GH_STATE_DIR="$state_dir" \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    bash "$TARGET" "$json_args" 2>"$TEST_DIR/last_stderr"
+  ) || rc=$?
+  LAST_OUTPUT="$output"
+  LAST_RC=$rc
+  return 0
+}
+
+json_field() {
+  printf '%s\n' "$LAST_OUTPUT" | jq -r "$1"
+}
+
+# Build a standard input JSON document.
+build_json() {
+  local issue="${1:-42}"
+  local status="${2:-In Progress}"
+  local auto_add="${3:-true}"
+  local non_blocking="${4:-true}"
+  local project_number="${5:-6}"
+  jq -n \
+    --argjson issue "$issue" \
+    --arg owner "test-owner" \
+    --arg repo "test-repo" \
+    --argjson project_number "$project_number" \
+    --arg status "$status" \
+    --argjson auto_add "$auto_add" \
+    --argjson non_blocking "$non_blocking" \
+    '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}'
+}
+
+echo "=== projects-status-update.sh tests ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-001: No arguments → exit 1
+# --------------------------------------------------------------------------
+echo "TC-001: No arguments → exit 1"
+rc=0
+output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" 2>&1) || rc=$?
+if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.result == "failed"' >/dev/null; then
+  pass "No args → exit 1 with failed result"
+else
+  fail "Expected exit 1 with failed result, got rc=$rc output=$output"
+fi
+
+# --------------------------------------------------------------------------
+# TC-002: Invalid JSON → exit 1
+# --------------------------------------------------------------------------
+echo "TC-002: Invalid JSON → exit 1"
+rc=0
+output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" "not-json" 2>&1) || rc=$?
+if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "Invalid JSON argument")) | length == 1' >/dev/null; then
+  pass "Invalid JSON → exit 1"
+else
+  fail "Expected exit 1 with 'Invalid JSON argument' warning, got rc=$rc output=$output"
+fi
+
+# --------------------------------------------------------------------------
+# TC-003: Missing required field (owner) → exit 1
+# --------------------------------------------------------------------------
+echo "TC-003: Missing owner → exit 1"
+rc=0
+output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" '{"issue_number": 42, "repo": "test-repo", "project_number": 6, "status_name": "Todo"}' 2>&1) || rc=$?
+if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "owner is required")) | length == 1' >/dev/null; then
+  pass "Missing owner → exit 1"
+else
+  fail "Expected exit 1 with 'owner is required', got rc=$rc output=$output"
+fi
+
+# --------------------------------------------------------------------------
+# TC-004: Basic success path → result=updated
+# --------------------------------------------------------------------------
+echo "TC-004: Basic success → updated"
+run_script "$(build_json 42 'In Progress')" psu_success
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "updated" ] && [ "$(json_field '.item_id')" = "PVTI_mock456" ] && [ "$(json_field '.option_id')" = "OPT_INPROGRESS" ]; then
+  pass "Basic success: result=updated, item_id+option_id set"
+else
+  fail "TC-004 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-005: Not in project + auto_add=true → auto-add then updated
+# --------------------------------------------------------------------------
+echo "TC-005: Auto-add + re-query success"
+run_script "$(build_json 42 'In Progress' true)" psu_auto_add_then_ok
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "updated" ]; then
+  pass "Auto-add path: updated after re-query"
+else
+  fail "TC-005 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-006: Not in project + auto_add=false → skipped_not_in_project
+# --------------------------------------------------------------------------
+echo "TC-006: Not in project + auto_add=false → skipped"
+run_script "$(build_json 42 'Todo' false)" psu_not_in_project
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "skipped_not_in_project" ]; then
+  pass "skipped_not_in_project returned, exit 0"
+else
+  fail "TC-006 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-007: Issue not found → failed (non_blocking=true, exit 0)
+# --------------------------------------------------------------------------
+echo "TC-007: Issue not found → failed+exit 0"
+run_script "$(build_json 42 'Todo' true true)" psu_issue_not_found
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "failed" ]; then
+  pass "Issue not found → failed, non-blocking exit 0"
+else
+  fail "TC-007 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-008: item-add failure → failed
+# --------------------------------------------------------------------------
+echo "TC-008: item-add failure → failed"
+run_script "$(build_json 42 'Todo' true)" psu_auto_add_fail
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "failed" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("item-add failed"))) | length >= 1' >/dev/null; then
+  pass "item-add failure captured in warnings"
+else
+  fail "TC-008 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-009: field-list failure → failed
+# --------------------------------------------------------------------------
+echo "TC-009: field-list failure → failed"
+run_script "$(build_json 42 'Todo')" psu_field_list_fail
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "failed" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("field-list failed"))) | length >= 1' >/dev/null; then
+  pass "field-list failure captured in warnings"
+else
+  fail "TC-009 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-010: Status field missing → failed
+# --------------------------------------------------------------------------
+echo "TC-010: Status field missing → failed"
+run_script "$(build_json 42 'Todo')" psu_no_status_field
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "failed" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e '.warnings | map(select(. | test("Status field not found"))) | length >= 1' >/dev/null; then
+  pass "Status field missing captured"
+else
+  fail "TC-010 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-011: Status option not found → failed
+# --------------------------------------------------------------------------
+echo "TC-011: Status option 'Archive' not found → failed"
+run_script "$(build_json 42 'Archive')" psu_no_status_option
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "failed" ] && printf '%s\n' "$LAST_OUTPUT" | jq -e ".warnings | map(select(. | test(\"Status option 'Archive' not found\"))) | length >= 1" >/dev/null; then
+  pass "Unknown Status option captured"
+else
+  fail "TC-011 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-012: item-edit failure → failed, fields partially populated
+# --------------------------------------------------------------------------
+echo "TC-012: item-edit failure → failed with item_id/project_id"
+run_script "$(build_json 42 'In Progress')" psu_item_edit_fail
+if [ "$LAST_RC" = "0" ] \
+   && [ "$(json_field '.result')" = "failed" ] \
+   && [ "$(json_field '.item_id')" = "PVTI_mock456" ] \
+   && [ "$(json_field '.project_id')" = "PVT_mock123" ] \
+   && [ "$(json_field '.status_field_id')" = "FIELD_STATUS" ] \
+   && [ "$(json_field '.option_id')" = "OPT_INPROGRESS" ]; then
+  pass "item-edit failure returns partial identifiers"
+else
+  fail "TC-012 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-013: non_blocking=false + item-edit failure → exit 1
+# --------------------------------------------------------------------------
+echo "TC-013: non_blocking=false + failure → exit 1"
+run_script "$(build_json 42 'In Progress' true false)" psu_item_edit_fail
+if [ "$LAST_RC" = "1" ] && [ "$(json_field '.result')" = "failed" ]; then
+  pass "non_blocking=false correctly returns exit 1"
+else
+  fail "TC-013 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-014: status_field_id_hint provided → skips field id extraction but still
+#         resolves option id from field-list
+# --------------------------------------------------------------------------
+echo "TC-014: status_field_id_hint honored"
+json=$(jq -n --arg owner "test-owner" --arg repo "test-repo" --arg status "In Progress" --arg hint "PVTSSF_hinted" \
+  '{issue_number:42, owner:$owner, repo:$repo, project_number:6, status_name:$status, status_field_id_hint:$hint, auto_add:true, non_blocking:true}')
+run_script "$json" psu_success
+if [ "$LAST_RC" = "0" ] && [ "$(json_field '.result')" = "updated" ] && [ "$(json_field '.status_field_id')" = "PVTSSF_hinted" ]; then
+  pass "status_field_id_hint preserved in output"
+else
+  fail "TC-014 unexpected: rc=$LAST_RC output=$LAST_OUTPUT"
+fi
+
+# --------------------------------------------------------------------------
+# TC-015: Missing issue_number → exit 1
+# --------------------------------------------------------------------------
+echo "TC-015: Missing issue_number → exit 1"
+rc=0
+output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" '{"owner": "x", "repo": "y", "project_number": 1, "status_name": "Todo"}' 2>&1) || rc=$?
+if [ "$rc" = "1" ] && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "issue_number is required")) | length == 1' >/dev/null; then
+  pass "Missing issue_number → exit 1"
+else
+  fail "TC-015 unexpected: rc=$rc output=$output"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
## Summary

- `plugins/rite/scripts/projects-status-update.sh` を新規追加し、`commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2 に散在していた Projects Status 更新手順を一元化
- Phase 2.4 Step 1 の `PHASE_2_4_STATE` marker は維持 (cycle 1 で追加された determinism / silent skip 防止の核) し、Step 2-4 のみ script 呼び出しに置換
- `projects-integration.md` §2.4 に「runtime は script が single source of truth」である旨の注記を追加。§2.4.2-2.4.5 の bash 例は API リファレンスとして維持
- 未参照になった Placeholder Legend (`{item_id}`, `{project_id}`, `{status_field_id}`, `{in_review_option_id}`, `{done_option_id}`) を削除

## 背景

Issue #496 で code-quality reviewer が cycle 1-4 にわたり継続指摘していた drift リスク。Phase 2.4 inline と `projects-integration.md` §2.4.2-2.4.5 がほぼ完全に重複し、GitHub Projects API 変更時に片方のみ更新される危険があった。さらに start.md 内には同種の Status 更新コードが 3 箇所 (In Progress / In Review / Done) に散在していた。

ユーザー選択は **Option B' (共通 shell script 化)** — 構造的に重複を排除し、メモリ `avoid-orchestrator-multistep-contract` (複数 bash invocation 跨ぎの契約を prose で書かず shell script に逃がす) とも整合。

## 設計

### `plugins/rite/scripts/projects-status-update.sh`

**Input JSON:**
\`\`\`json
{
  "issue_number": 496,
  "owner": "B16B1RD",
  "repo": "cc-rite-workflow",
  "project_number": 6,
  "status_name": "In Progress",
  "status_field_id_hint": "PVTSSF_...",
  "auto_add": true,
  "non_blocking": true
}
\`\`\`

**Output JSON:**
\`\`\`json
{
  "result": "updated|skipped_not_in_project|failed",
  "item_id": "PVTI_...",
  "project_id": "PVT_...",
  "status_field_id": "PVTSSF_...",
  "option_id": "...",
  "warnings": []
}
\`\`\`

- `set -euo pipefail` + centralized tmpfile + EXIT trap (既存 `create-issue-with-projects.sh` のパターンを踏襲)
- Step A: GraphQL `projectItems` query → project.number マッチする node 抽出
- Step B: 該当なし AND `auto_add=true` → `gh project item-add` → re-query
- Step C: `gh project field-list` → Status field / option 解決 (`status_field_id_hint` 指定時は field id 解決をスキップ)
- Step D: `gh project item-edit` 実行
- `non_blocking=true` (default) のときは API エラーでも `result: \"failed\"` + `warnings[]` を返し exit 0

### 呼び出し側 refactor

| 箇所 | 旧 | 新 |
|-----|----|----|
| Phase 2.4 Step 2-4 | `gh api graphql` + `gh project field-list` + `gh project item-edit` の 3 段 inline | script 呼び出し 1 回 (`status_name: \"In Progress\"`, `auto_add: true`) |
| Phase 5.5.1 | 同じ 3 段 inline | script 呼び出し 1 回 (`status_name: \"In Review\"`, `auto_add: false`) |
| Phase 5.7.2 | 同じ 3 段 inline | script 呼び出し 1 回 (`status_name: \"Done\"`, `auto_add: false`) |

Phase 2.4 Step 5 (Phase 2.4.7 への delegation) は **#513 regression guard で固定** されているため無変更。単に Step 3 にリナンバーしただけ。

## スコープ外

- Phase 2.4.7 の parent Issue 検出ロジック (3-method OR) — `#513 regression guard` 固定、別関心事
- `ready.md` Phase 4 の GraphQL mutation 経路 — 設計意図的分離 (start.md line 1631 の note 参照)

## Dry-run 実証 (実機)

本 PR の branch 上で本リポジトリ Issue #496 / project #6 を対象に直接実行:

**Case A — existing issue, status_name=Todo, auto_add=false:**
\`\`\`json
{\"result\": \"updated\", \"item_id\": \"PVTI_lAHOAA1CPM4BQeHmzgp3I7w\", \"project_id\": \"PVT_kwHOAA1CPM4BQeHm\", \"status_field_id\": \"PVTSSF_lAHOAA1CPM4BQeHmzg-lInQ\", \"option_id\": \"36fa0b2f\", \"warnings\": []}
\`\`\`
(option_id 36fa0b2f は Issue body の Todo optionId と一致 — 旧実装と同じ API 結果)

**Case B — non-existent issue #999999, non_blocking=true:**
\`\`\`json
{\"result\": \"failed\", ..., \"warnings\": [\"GraphQL projectItems query failed: gh: Could not resolve to an Issue with the number of 999999.\"]}
\`\`\`
exit 0 (non-blocking 契約準拠)

**Case C — project_number mismatch (99), auto_add=false:**
\`\`\`json
{\"result\": \"skipped_not_in_project\", ..., \"warnings\": [\"Issue #496 is not registered in project #99 (auto_add disabled)\"]}
\`\`\`
exit 0

**Case D — missing required field (owner):** exit 1 + warning
**Case E — non_blocking=false + invalid issue:** exit 1 + warning

## Test plan

- [x] bash -n syntax check pass
- [x] 5 cases (A-E) dry-run 実証済み (実機 Issue #496 / project #6)
- [x] start.md 内の `gh project item-edit` / `gh project field-list` / `projectItems(first...)` が Phase 2.4/5.5.1/5.7.2 本体から消えたことを grep で確認
- [x] Phase 2.4 Step 1 の `PHASE_2_4_STATE` marker は保持 (silent skip 再発防止)
- [ ] e2e: 本 PR を別 Issue で `/rite:issue:start` 経由で通過させる (次 Issue 実施時に自動検証)

Closes #496