### PR TITLE
fix(workflow): Phase 5.7.2 の gh issue close を /rite:issue:close Skill 呼び出しに置換 (#534)

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -2012,13 +2012,41 @@ Inspect the script's stdout JSON:
 - `.result == "skipped_not_in_project"` → display `警告: Issue #{parent_issue_number} は Project に登録されていません` and proceed to Step 2 (non-blocking).
 - `.result == "failed"` → display `.warnings[]` and proceed to Step 2 (non-blocking).
 
-**Step 2**: Close the parent Issue:
+**Step 2**: Close the parent Issue via `/rite:issue:close` Skill invocation.
+
+> **Why Skill invoke (not `gh issue close`)**: `close.md` Phase 4.4.W.2 で Wiki raw source の蓄積（`wiki-ingest-commit.sh`）が発火する。直接 `gh issue close` を実行すると close.md を経由しないため、Wiki 経路が 100% silent skip になる（Issue #532 / #534 で修正）。
+
+**Pre-write** (before invoking `rite:issue:close`): Update `.rite-flow-state` so stop-guard can resume flow if interrupted:
 
 ```bash
-gh issue close {parent_issue_number}
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_parent_close" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "After rite:issue:close returns: proceed to 🚨 Mandatory After 5.7.2, then 5.7.3 (Next Child). Do NOT stop."
 ```
 
-**→ Proceed to 5.7.3** (display remaining children if any).
+Invoke `skill: "rite:issue:close", args: "{parent_issue_number}"`.
+
+> **Note**: `close.md` receives `{parent_issue_number}` as its `{issue_number}` argument. Phase 4.1 executes `gh issue close`, Phase 4.4.W triggers Wiki ingest. The close.md `AskUserQuestion` (Phase 3) will present options to the user — since the user already confirmed "Close parent Issue" in Phase 5.7.2's own `AskUserQuestion`, they should select the manual close option when prompted by close.md.
+
+> **Note**: `close.md` does NOT output a machine-readable result pattern (unlike `[review:mergeable]` etc.). When it returns control, immediately proceed to 🚨 Mandatory After 5.7.2.
+
+### 🚨 Mandatory After 5.7.2
+
+> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+
+Do **NOT** stop after `rite:issue:close` returns. Phase 5.7.3 (Next Child) and Workflow Termination are still pending.
+
+**Step 1**: Update `.rite-flow-state` to post-parent-close phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_parent_close" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "rite:issue:close completed. Proceed to 5.7.3 (Next Child display). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to 5.7.3** (display remaining children if any).
 
 #### 5.7.3 Next Child
 

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -105,13 +105,17 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # Workflow Termination (prompt-engineer cycle-2 MEDIUM #1).
   ["phase5_post_metrics"]="phase5_completion"
 
-  # Phase 5.6 / 5.7: completion + parent completion
+  # Phase 5.6 / 5.7: completion + parent completion + parent close (via rite:issue:close)
   # "completed" is a terminal state reachable from multiple phases (post_metrics, completion,
   # parent_completion, post_parent_completion). The Post-completion block historically patched
   # phase="completed" directly after phase5_post_metrics, so we accept the direct transition
   # (prompt-engineer + devops CRITICAL #2).
+  # Phase 5.7.2 now invokes rite:issue:close as a sub-skill (Issue #534), adding
+  # phase5_parent_close / phase5_post_parent_close to the transition chain.
   ["phase5_completion"]="phase5_parent_completion completed"
-  ["phase5_parent_completion"]="phase5_post_parent_completion"
+  ["phase5_parent_completion"]="phase5_parent_close phase5_post_parent_completion"
+  ["phase5_parent_close"]="phase5_post_parent_close"
+  ["phase5_post_parent_close"]="phase5_post_parent_completion"
   ["phase5_post_parent_completion"]="completed"
 
   # Terminal: "completed" MAY re-enter phase5_completion only in /rite:resume scenarios.


### PR DESCRIPTION
## 概要

`start.md` Phase 5.7.2 (Auto-Close) で `gh issue close {parent_issue_number}` を直接実行していた箇所を、`Skill: rite:issue:close` の呼び出しに置換する。

これにより `close.md` Phase 4.4.W.2（raw 蓄積経路）が実ワークフローで発火するようになる。

## 変更内容

- `plugins/rite/commands/issue/start.md` Phase 5.7.2 Step 2: `gh issue close` 直接実行を削除し、`skill: "rite:issue:close"` の Skill invoke に置換
- Pre-write (`phase5_parent_close`) / 🚨 Mandatory After 5.7.2 (`phase5_post_parent_close`) セクションを追加
- `plugins/rite/hooks/phase-transition-whitelist.sh` に `phase5_parent_close` → `phase5_post_parent_close` 遷移を追加

## 背景

親 Issue クローズ経路で `gh issue close` を直接実行していたため、`close.md` を経由せず Wiki raw source 蓄積経路（Phase 4.4.W.2）が 100% silent skip していた。Issue #532（Wiki 機能が実ワークフローで発火しない問題の根本修正）の Phase 1-A として修正。

## 未完了の Issue チェック項目

- [ ] 手動 E2E で issue close + raw 蓄積発火を確認

この項目は PR マージ前の手動検証で対応予定です。

## テスト計画

- [ ] Phase 5.7.2 で `/rite:issue:close` が invoke されることを手動 E2E で確認
- [ ] 親 Issue が実際に closed になることを確認
- [ ] `close.md` Phase 4.4.W.2 で `wiki-ingest-commit.sh` が発火することを確認
- [ ] wiki branch に raw source が commit されることを確認

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
