### PR TITLE
fix(wiki): review.md / fix.md の Phase 8 に W Phase completion gate を追加 (#535)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4852,6 +4852,39 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 | 2 | Work memory contains `コマンド: /rite:issue:start` AND (`フェーズ: 実装作業中` OR `フェーズ: 品質検証`) | Within loop → Execute Phase 8 |
 | 3 | Otherwise (user directly input `/rite:pr:fix`) | Standalone execution → Skip Phase 8 |
 
+### 8.0.1 W Phase Completion Gate (Defense-in-Depth, #535)
+
+> **Purpose**: Prevent the LLM from outputting a result pattern (`[fix:pushed]` / `[fix:replied-only]` / etc.) without having executed Phase 4.6.W (Wiki Ingest). If Phase 4.6.W was executed, at least one `[CONTEXT] WIKI_INGEST_` sentinel MUST be present in the conversation context (emitted by Phase 4.6.W Step 1 skip path, Step 3 failure path, or Phase 4.6.W.2 success/failure paths). The complete absence of any sentinel indicates the LLM skipped Phase 4.6.W entirely.
+
+**Condition**: Execute only when `.rite-flow-state` exists (indicating e2e flow) AND `wiki.enabled: true` in `rite-config.yml`. When wiki is disabled, W Phase is legitimately skipped (no sentinel expected) — pass the gate unconditionally.
+
+**Check**: Search the conversation context for any of the following sentinel patterns:
+
+- `[CONTEXT] WIKI_INGEST_DONE=1`
+- `[CONTEXT] WIKI_INGEST_SKIPPED=1`
+- `[CONTEXT] WIKI_INGEST_FAILED=1`
+- `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1`
+
+**Routing**:
+
+| Condition | Action |
+|-----------|--------|
+| At least one `WIKI_INGEST_` sentinel found | Gate passes — proceed to Phase 8.1 |
+| No sentinel found AND `wiki.enabled: true` | **ERROR**: W Phase was skipped. Execute the ACTION below |
+| No sentinel found AND `wiki.enabled: false` | Gate passes — wiki disabled, no sentinel expected |
+
+**On ERROR** (no sentinel found, wiki enabled):
+
+```
+ERROR: Phase 8.0.1 W Phase completion gate failed.
+No [CONTEXT] WIKI_INGEST_* sentinel found in conversation context.
+This means Phase 4.6.W (Wiki Ingest Trigger) was NOT executed.
+ACTION: Return to Phase 4.6.W and execute the Wiki Ingest Trigger before outputting the result pattern. Do NOT proceed to Phase 8.1 without a WIKI_INGEST_* sentinel.
+⚠️ LLM MUST NOT output [fix:pushed] or any other result pattern until Phase 4.6.W has been executed.
+```
+
+> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 4.6.W. The stop-guard whitelist provides a defense-in-depth layer by rejecting the `phase5_post_fix` transition if W Phase markers are absent from the expected flow.
+
 ### 8.1 Output Pattern (Return Control to Caller)
 
 Before outputting the pattern, update `.rite-flow-state` to `phase5_post_fix` (defense-in-depth, fixes #709). This prevents stop-guard `error_count` from accumulating when the flow continues after this skill returns:

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4852,7 +4852,7 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 | 2 | Work memory contains `コマンド: /rite:issue:start` AND (`フェーズ: 実装作業中` OR `フェーズ: 品質検証`) | Within loop → Execute Phase 8 |
 | 3 | Otherwise (user directly input `/rite:pr:fix`) | Standalone execution → Skip Phase 8 |
 
-### 8.0.1 W Phase Completion Gate (Defense-in-Depth, #535)
+### 8.0 W Phase Completion Gate (Defense-in-Depth, #535)
 
 > **Purpose**: Prevent the LLM from outputting a result pattern (`[fix:pushed]` / `[fix:replied-only]` / etc.) without having executed Phase 4.6.W (Wiki Ingest). If Phase 4.6.W was executed, at least one `[CONTEXT] WIKI_INGEST_` sentinel MUST be present in the conversation context (emitted by Phase 4.6.W Step 1 skip path, Step 3 failure path, or Phase 4.6.W.2 success/failure paths). The complete absence of any sentinel indicates the LLM skipped Phase 4.6.W entirely.
 
@@ -4876,14 +4876,14 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 **On ERROR** (no sentinel found, wiki enabled):
 
 ```
-ERROR: Phase 8.0.1 W Phase completion gate failed.
+ERROR: Phase 8.0 W Phase completion gate failed.
 No [CONTEXT] WIKI_INGEST_* sentinel found in conversation context.
 This means Phase 4.6.W (Wiki Ingest Trigger) was NOT executed.
 ACTION: Return to Phase 4.6.W and execute the Wiki Ingest Trigger before outputting the result pattern. Do NOT proceed to Phase 8.1 without a WIKI_INGEST_* sentinel.
 ⚠️ LLM MUST NOT output [fix:pushed] or any other result pattern until Phase 4.6.W has been executed.
 ```
 
-> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 4.6.W. The stop-guard whitelist provides a defense-in-depth layer by rejecting the `phase5_post_fix` transition if W Phase markers are absent from the expected flow.
+> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 4.6.W. Note that the stop-guard whitelist (`phase-transition-whitelist.sh`) validates phase name transitions only and does NOT check for W Phase sentinel presence. This gate is therefore the **sole** defense layer against W Phase skip.
 
 ### 8.1 Output Pattern (Return Control to Caller)
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4412,6 +4412,39 @@ Replace `{next_action_value}` with the value from the table above based on the r
 
 **Note on `error_count`**: `flow-state-update.sh` patch mode preserves all existing fields not explicitly set — only `phase`, `updated_at`, and `next_action` are changed (consistent with `lint.md` Phase 4.0 and `fix.md` Phase 8.1). The count is effectively reset when `/rite:issue:start` writes a new complete object via `jq -n` at the next phase transition.
 
+### 8.0.1 W Phase Completion Gate (Defense-in-Depth, #535)
+
+> **Purpose**: Prevent the LLM from outputting a result pattern (`[review:mergeable]` / `[review:fix-needed:{n}]`) without having executed Phase 6.5.W (Wiki Ingest). If Phase 6.5.W was executed, at least one `[CONTEXT] WIKI_INGEST_` sentinel MUST be present in the conversation context (emitted by Phase 6.5.W Step 1 skip path, Step 3 failure path, or Phase 6.5.W.2 success/failure paths). The complete absence of any sentinel indicates the LLM skipped Phase 6.5.W entirely.
+
+**Condition**: Execute only when `.rite-flow-state` exists (indicating e2e flow) AND `wiki.enabled: true` in `rite-config.yml`. When wiki is disabled, W Phase is legitimately skipped (no sentinel expected) — pass the gate unconditionally.
+
+**Check**: Search the conversation context for any of the following sentinel patterns:
+
+- `[CONTEXT] WIKI_INGEST_DONE=1`
+- `[CONTEXT] WIKI_INGEST_SKIPPED=1`
+- `[CONTEXT] WIKI_INGEST_FAILED=1`
+- `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1`
+
+**Routing**:
+
+| Condition | Action |
+|-----------|--------|
+| At least one `WIKI_INGEST_` sentinel found | Gate passes — proceed to Phase 8.1 |
+| No sentinel found AND `wiki.enabled: true` | **ERROR**: W Phase was skipped. Execute the ACTION below |
+| No sentinel found AND `wiki.enabled: false` | Gate passes — wiki disabled, no sentinel expected |
+
+**On ERROR** (no sentinel found, wiki enabled):
+
+```
+ERROR: Phase 8.0.1 W Phase completion gate failed.
+No [CONTEXT] WIKI_INGEST_* sentinel found in conversation context.
+This means Phase 6.5.W (Wiki Ingest Trigger) was NOT executed.
+ACTION: Return to Phase 6.5.W and execute the Wiki Ingest Trigger before outputting the result pattern. Do NOT proceed to Phase 8.1 without a WIKI_INGEST_* sentinel.
+⚠️ LLM MUST NOT output [review:mergeable] or [review:fix-needed:{n}] until Phase 6.5.W has been executed.
+```
+
+> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 6.5.W. The stop-guard whitelist provides a defense-in-depth layer by rejecting the `phase5_post_review` transition if W Phase markers are absent from the expected flow.
+
 ### 8.1 Output Pattern (Return Control to Caller)
 
 Based on the Phase 6 review results, output the corresponding machine-readable pattern:

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4443,7 +4443,7 @@ ACTION: Return to Phase 6.5.W and execute the Wiki Ingest Trigger before outputt
 ⚠️ LLM MUST NOT output [review:mergeable] or [review:fix-needed:{n}] until Phase 6.5.W has been executed.
 ```
 
-> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 6.5.W. The stop-guard whitelist provides a defense-in-depth layer by rejecting the `phase5_post_review` transition if W Phase markers are absent from the expected flow.
+> **Enforcement note**: This gate is a prose instruction — `exit 1` in bash does NOT halt the LLM. The LLM MUST recognise the ERROR text and return to Phase 6.5.W. Note that the stop-guard whitelist (`phase-transition-whitelist.sh`) validates phase name transitions only and does NOT check for W Phase sentinel presence. This gate is therefore the **sole** defense layer against W Phase skip.
 
 ### 8.1 Output Pattern (Return Control to Caller)
 


### PR DESCRIPTION
## 概要

`pr/review.md` Phase 8 および `pr/fix.md` Phase 8 に W Phase completion gate（defense-in-depth）を追加。

LLM が Phase 6.5.W / 4.6.W（Wiki Ingest Trigger + Raw Commit）をスキップして output pattern を出力するのを防止する。会話コンテキスト内の `[CONTEXT] WIKI_INGEST_*` センチネルの存在を検証し、不在時は W Phase への復帰を強制する。

## 変更内容

- `plugins/rite/commands/pr/review.md` — Phase 8.0.1 W Phase Completion Gate を追加
- `plugins/rite/commands/pr/fix.md` — Phase 8.0.1 W Phase Completion Gate を追加（review.md と対称構造）

## 設計

### 根本原因

Phase 6.5.W / 4.6.W は Phase 8（output pattern）の前に正しく配置されているが、Phase 8 に「W Phase が実行されたか」を検証するゲートがなかった。LLM が W Phase をスキップした場合、何のチェックもなく output pattern を出力していた。

### 修正アプローチ

Phase 8 output pattern 出力前に、会話コンテキスト内の `[CONTEXT] WIKI_INGEST_*` センチネル（DONE / SKIPPED / FAILED / PUSH_FAILED）の存在を検証する pre-condition check を追加。センチネルが不在かつ `wiki.enabled: true` の場合、ERROR を出力して W Phase への復帰を強制する。

### 対象センチネル

| センチネル | 発生パス |
|-----------|---------|
| `WIKI_INGEST_DONE=1` | trigger 成功 → commit 成功 |
| `WIKI_INGEST_SKIPPED=1` | config disabled / auto_ingest_off / commit_branch_missing |
| `WIKI_INGEST_FAILED=1` | trigger 失敗 / commit 失敗 |
| `WIKI_INGEST_PUSH_FAILED=1` | commit 成功、push 失敗 |

## 関連 Issue

Closes #535

## 親 Issue

#532 - Wiki 機能が実ワークフローで発火しない問題の根本修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)
