### PR TITLE
feat(wiki): wiki-growth-check.sh に PR↔raw 対応検知を追加 (#536)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -814,6 +814,7 @@ Settings for the Experience Wiki — an LLM-driven project knowledge base that p
 | `auto_query` | boolean | `true` | Automatically run `/rite:wiki:query` at the start of Issue work and at review/fix/implement phases to inject relevant heuristics into the conversation context |
 | `auto_lint` | boolean | `true` | Automatically run `/rite:wiki:lint --auto` after each ingest to detect contradictions, staleness, orphans, missing cross-refs, and broken links |
 | `growth_check.threshold_prs` | integer | `5` | Issue #524 layer 3 (lint growth check) — `/rite:lint` Phase 3.8 emits a non-blocking warning when this many merged PRs accumulate on the development base branch since the last commit on `branch_name` (signalling that Phase X.X.W may be silently skipped). Increase to relax the check; setting it to a very large number effectively disables the lint warning while preserving layers 1-2 |
+| `growth_check.pr_raw_threshold` | integer | `3` | Issue #536 — warn when this many of the last `threshold_prs` merged PRs have no corresponding raw source on the wiki branch. Detects regressions where PRs are merged but Phase X.X.W never fires. Override at runtime with `--pr-raw-threshold N` |
 
 **Example (opt out completely):**
 
@@ -840,6 +841,7 @@ wiki:
   enabled: true
   growth_check:
     threshold_prs: 20   # warn only after 20 PRs have accumulated since the last wiki commit
+    pr_raw_threshold: 5  # warn if 5+ of last 20 PRs have no raw source (Issue #536)
 ```
 
 **Related commands:** `/rite:wiki:init` (one-time setup), `/rite:wiki:ingest`, `/rite:wiki:query`, `/rite:wiki:lint`.

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -17,13 +17,15 @@
 #   - layer 2: workflow-incident-emit.sh の wiki_ingest_skipped / wiki_ingest_failed sentinel
 #
 # Usage:
-#   wiki-growth-check.sh [--repo-root DIR] [--quiet] [--threshold N] [-h|--help]
+#   wiki-growth-check.sh [--repo-root DIR] [--quiet] [--threshold N]
+#                        [--pr-raw-threshold N] [-h|--help]
 #
 # Options:
-#   --repo-root DIR   Repository root (default: git rev-parse --show-toplevel)
-#   --quiet           Suppress informational output (still emits findings line)
-#   --threshold N     Override threshold from rite-config.yml (testing/dry-run)
-#   -h, --help        Show this help
+#   --repo-root DIR        Repository root (default: git rev-parse --show-toplevel)
+#   --quiet                Suppress informational output (still emits findings line)
+#   --threshold N          Override growth-stall threshold from rite-config.yml
+#   --pr-raw-threshold N   Override PR↔raw correspondence threshold (Issue #536)
+#   -h, --help             Show this help
 #
 # Exit codes (drift-check と同一の非ブロッキング契約):
 #   0  Wiki growth healthy (or wiki branch absent / wiki disabled — skip silently)
@@ -286,6 +288,8 @@ if [ "$merged_count" -ge "$threshold" ]; then
   echo "==> Wiki growth stall detected: $merged_count merged PRs on '$base_branch' since last '$wiki_branch' commit ($last_wiki) — no raw sources ingested (threshold: $threshold)"
   echo "==> Hint: Phase X.X.W (Wiki Ingest Trigger) may be silently skipped in review/fix/close. Check WIKI_INGEST_DONE / WIKI_INGEST_SKIPPED / WIKI_INGEST_FAILED context lines."
   findings=$((findings + 1))
+else
+  log_info "wiki-growth-check: growth-stall: healthy ($merged_count merged PRs since last '$wiki_branch' commit, threshold: $threshold)"
 fi
 
 # --- PR ↔ raw source correspondence check (Issue #536) ---
@@ -318,18 +322,29 @@ check_pr_raw_correspondence() {
 
   # Get the last `threshold` merged PRs (reuse existing threshold for the window size)
   local recent_prs_json recent_pr_numbers
+  local gh_pr_err
+  gh_pr_err=$(mktemp /tmp/rite-wiki-growth-pr-err-XXXXXX 2>/dev/null) || gh_pr_err=""
   recent_prs_json=$(gh pr list \
     --state merged \
     --base "$base_branch" \
     --json number \
-    --limit "$threshold" 2>/dev/null) || {
-    log_info "wiki-growth-check: pr-raw-correspondence: gh pr list failed, skipping"
+    --limit "$threshold" 2>"${gh_pr_err:-/dev/null}") || {
+    echo "WARNING: wiki-growth-check: pr-raw-correspondence: gh pr list failed, skipping" >&2
+    [ -n "$gh_pr_err" ] && [ -s "$gh_pr_err" ] && head -3 "$gh_pr_err" | sed 's/^/  /' >&2
+    [ -n "$gh_pr_err" ] && rm -f "$gh_pr_err"
     return 0
   }
-  recent_pr_numbers=$(printf '%s' "$recent_prs_json" | jq -r '.[].number' 2>/dev/null) || {
-    log_info "wiki-growth-check: pr-raw-correspondence: jq parse failed, skipping"
+  [ -n "$gh_pr_err" ] && rm -f "$gh_pr_err"
+
+  local jq_pr_err
+  jq_pr_err=$(mktemp /tmp/rite-wiki-growth-jq-err-XXXXXX 2>/dev/null) || jq_pr_err=""
+  recent_pr_numbers=$(printf '%s' "$recent_prs_json" | jq -r '.[].number' 2>"${jq_pr_err:-/dev/null}") || {
+    echo "WARNING: wiki-growth-check: pr-raw-correspondence: jq parse failed, skipping" >&2
+    [ -n "$jq_pr_err" ] && [ -s "$jq_pr_err" ] && head -3 "$jq_pr_err" | sed 's/^/  /' >&2
+    [ -n "$jq_pr_err" ] && rm -f "$jq_pr_err"
     return 0
   }
+  [ -n "$jq_pr_err" ] && rm -f "$jq_pr_err"
 
   if [ -z "$recent_pr_numbers" ]; then
     log_info "wiki-growth-check: pr-raw-correspondence: no recent merged PRs found"

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -54,17 +54,20 @@ trap '_rite_wiki_growth_cleanup; exit 129' HUP
 REPO_ROOT=""
 QUIET=0
 THRESHOLD_OVERRIDE=""
+PR_RAW_THRESHOLD_OVERRIDE=""
 
 usage() {
   cat <<'EOF'
 Usage: wiki-growth-check.sh [options]
 
 Options:
-  --repo-root DIR   Repository root (default: git rev-parse --show-toplevel)
-  --quiet           Suppress informational output
-  --threshold N     Override threshold (default: read from rite-config.yml,
-                    fallback 5 when wiki.growth_check.threshold_prs is absent)
-  -h, --help        Show this help
+  --repo-root DIR          Repository root (default: git rev-parse --show-toplevel)
+  --quiet                  Suppress informational output
+  --threshold N            Override growth-stall threshold (default: read from
+                           rite-config.yml, fallback 5)
+  --pr-raw-threshold N     Override PR↔raw correspondence threshold (default:
+                           read from rite-config.yml, fallback 3) (Issue #536)
+  -h, --help               Show this help
 
 Exit codes:
   0  No growth stall (or wiki disabled / wiki branch absent — skip silently)
@@ -75,10 +78,11 @@ EOF
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo-root)  REPO_ROOT="$2"; shift 2 ;;
-    --quiet)      QUIET=1; shift ;;
-    --threshold)  THRESHOLD_OVERRIDE="$2"; shift 2 ;;
-    -h|--help)    usage; exit 0 ;;
+    --repo-root)           REPO_ROOT="$2"; shift 2 ;;
+    --quiet)               QUIET=1; shift ;;
+    --threshold)           THRESHOLD_OVERRIDE="$2"; shift 2 ;;
+    --pr-raw-threshold)    PR_RAW_THRESHOLD_OVERRIDE="$2"; shift 2 ;;
+    -h|--help)             usage; exit 0 ;;
     *) echo "ERROR: Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
@@ -275,14 +279,107 @@ if [ -z "$merged_count" ] || ! [[ "$merged_count" =~ ^[0-9]+$ ]]; then
 fi
 [ -n "$jq_err" ] && rm -f "$jq_err"
 
-# --- Decision ---
+# --- Decision: growth stall check (existing) ---
+findings=0
+
 if [ "$merged_count" -ge "$threshold" ]; then
   echo "==> Wiki growth stall detected: $merged_count merged PRs on '$base_branch' since last '$wiki_branch' commit ($last_wiki) — no raw sources ingested (threshold: $threshold)"
   echo "==> Hint: Phase X.X.W (Wiki Ingest Trigger) may be silently skipped in review/fix/close. Check WIKI_INGEST_DONE / WIKI_INGEST_SKIPPED / WIKI_INGEST_FAILED context lines."
-  echo "==> Total wiki-growth-check findings: 1"
-  exit 1
+  findings=$((findings + 1))
 fi
 
-log_info "wiki-growth-check: healthy ($merged_count merged PRs since last '$wiki_branch' commit, threshold: $threshold)"
-echo "==> Total wiki-growth-check findings: 0"
+# --- PR ↔ raw source correspondence check (Issue #536) ---
+# For each of the last N merged PRs, check whether at least one raw source
+# file exists on the wiki branch with a matching `pr-{number}` in its name.
+# This detects regressions where PRs are merged but Phase X.X.W never fires,
+# even when the wiki branch is otherwise receiving commits from other sources.
+
+check_pr_raw_correspondence() {
+  # Read pr_raw_threshold: CLI override > rite-config.yml > default 3
+  local pr_raw_thresh
+  if [ -n "$PR_RAW_THRESHOLD_OVERRIDE" ]; then
+    pr_raw_thresh="$PR_RAW_THRESHOLD_OVERRIDE"
+  else
+    pr_raw_thresh=$(printf '%s\n' "$wiki_section" \
+    | awk '
+      /^[[:space:]]+growth_check:/ { in_gc=1; gc_indent=match($0, /[^[:space:]]/); next }
+      in_gc {
+        if ($0 ~ /^[[:space:]]*$/) next
+        cur_indent=match($0, /[^[:space:]]/)
+        if (cur_indent <= gc_indent) { in_gc=0; next }
+        if ($0 ~ /^[[:space:]]+pr_raw_threshold:/) { print; exit }
+      }
+    ' \
+    | sed 's/[[:space:]]#.*//' | sed 's/.*pr_raw_threshold:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+  fi
+  if [ -z "$pr_raw_thresh" ] || ! [[ "$pr_raw_thresh" =~ ^[0-9]+$ ]] || [ "$pr_raw_thresh" -lt 1 ]; then
+    pr_raw_thresh=3
+  fi
+
+  # Get the last `threshold` merged PRs (reuse existing threshold for the window size)
+  local recent_prs_json recent_pr_numbers
+  recent_prs_json=$(gh pr list \
+    --state merged \
+    --base "$base_branch" \
+    --json number \
+    --limit "$threshold" 2>/dev/null) || {
+    log_info "wiki-growth-check: pr-raw-correspondence: gh pr list failed, skipping"
+    return 0
+  }
+  recent_pr_numbers=$(printf '%s' "$recent_prs_json" | jq -r '.[].number' 2>/dev/null) || {
+    log_info "wiki-growth-check: pr-raw-correspondence: jq parse failed, skipping"
+    return 0
+  }
+
+  if [ -z "$recent_pr_numbers" ]; then
+    log_info "wiki-growth-check: pr-raw-correspondence: no recent merged PRs found"
+    return 0
+  fi
+
+  # Get all raw source filenames from the wiki branch (local or remote)
+  local raw_files
+  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
+
+  # Extract unique PR numbers that have raw sources
+  local raw_pr_numbers
+  raw_pr_numbers=$(printf '%s\n' "$raw_files" | grep -oE 'pr-[0-9]+' | sed 's/pr-//' | sort -u)
+
+  # Count how many recent PRs have NO corresponding raw source
+  local missing_count=0
+  local missing_prs=""
+  local total_checked=0
+  while IFS= read -r pr_num; do
+    [ -z "$pr_num" ] && continue
+    total_checked=$((total_checked + 1))
+    if ! printf '%s\n' "$raw_pr_numbers" | grep -qx "$pr_num"; then
+      missing_count=$((missing_count + 1))
+      missing_prs="${missing_prs:+$missing_prs, }#$pr_num"
+    fi
+  done <<< "$recent_pr_numbers"
+
+  if [ "$total_checked" -eq 0 ]; then
+    log_info "wiki-growth-check: pr-raw-correspondence: no PRs to check"
+    return 0
+  fi
+
+  if [ "$missing_count" -ge "$pr_raw_thresh" ]; then
+    echo "==> PR↔raw correspondence gap: $missing_count of $total_checked recent merged PRs have no raw source on '$wiki_branch' (threshold: $pr_raw_thresh)"
+    echo "==> Missing PRs: $missing_prs"
+    echo "==> Hint: Phase X.X.W (Wiki Ingest Trigger) may not be firing for these PRs. Verify review.md Phase 6.5.W.2 / fix.md Phase 4.6.W.2 / close.md Phase 4.4.W.2 execution."
+    return 1
+  fi
+
+  log_info "wiki-growth-check: pr-raw-correspondence: healthy ($missing_count of $total_checked recent PRs missing raw, threshold: $pr_raw_thresh)"
+  return 0
+}
+
+if ! check_pr_raw_correspondence; then
+  findings=$((findings + 1))
+fi
+
+# --- Final result ---
+echo "==> Total wiki-growth-check findings: $findings"
+if [ "$findings" -gt 0 ]; then
+  exit 1
+fi
 exit 0

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -173,6 +173,9 @@ wiki:
     threshold_prs: 5                   # Issue #524: lint warns when this many merged PRs accumulate
                                        # since the last commit on `branch_name` with no raw-source ingest
                                        # in between (warning only — does not change [lint:success])
+    pr_raw_threshold: 3                # Issue #536: warn when this many of the last `threshold_prs`
+                                       # merged PRs have no corresponding raw source on wiki branch
+                                       # (e.g., 3 means "warn if 3+ of last 5 PRs have no raw")
 
 # Language setting
 language: ja


### PR DESCRIPTION
## 概要

`wiki-growth-check.sh` に PR↔raw source 対応検知機能を追加。直近 N 件の merged PR に対応する raw source が wiki branch に存在するかを検査し、閾値超過時に警告を出力する。

Closes #536

## 変更内容

- `wiki-growth-check.sh` に `check_pr_raw_correspondence` 関数を追加
  - `gh pr list` で直近の merged PR 番号を取得
  - `git ls-tree` で wiki branch の raw source ファイルから PR 番号を抽出
  - 対応なし件数が `pr_raw_threshold` 以上で警告出力
- `--pr-raw-threshold N` CLI オプションを追加（テスト時の override 用）
- `rite-config.yml` に `wiki.growth_check.pr_raw_threshold` 設定を追加（default: 3）
- 既存の growth stall check と findings を合算し、最終行で統一出力

## テスト計画

- [x] `--threshold 5 --pr-raw-threshold 3`: 3/5 PR に raw なし → 警告出力を確認
- [x] `--pr-raw-threshold 100`: 閾値超過せず → exit 0、findings 0
- [x] `--pr-raw-threshold 3` (= missing count): 境界条件で警告発生を確認
- [x] `--pr-raw-threshold 4` (> missing count): 境界条件で healthy を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
