### PR TITLE
feat(wiki): wiki-growth-check.sh を総合 health check に拡張 + SKILL.md trouble-shooting 追加 (#538)

### DIFF
--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -393,36 +393,24 @@ if ! check_pr_raw_correspondence; then
 fi
 
 # --- Comprehensive health check: raw count, page count, pending count, page stall (Issue #538) ---
+# DRY: git ls-tree for .rite/wiki/raw/ is called once in check_page_stall and
+# passed to helper functions to avoid 3x duplication of the same git ls-tree call.
 
-# Count raw source files on the wiki branch
-count_raw_sources() {
-  local raw_files raw_count
-  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
-  if [ -z "$raw_files" ]; then
-    raw_count=0
+# Count files from a pre-fetched file list (passed as $1)
+# Usage: _count_lines "$file_list"
+_count_lines() {
+  local file_list="$1"
+  if [ -z "$file_list" ]; then
+    echo 0
   else
-    raw_count=$(printf '%s\n' "$raw_files" | grep -c '.' || true)
+    printf '%s\n' "$file_list" | grep -c '.' || true
   fi
-  echo "$raw_count"
 }
 
-# Count wiki page files on the wiki branch
-count_wiki_pages() {
-  local page_files page_count
-  page_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/pages/ 2>/dev/null) || page_files=""
-  if [ -z "$page_files" ]; then
-    page_count=0
-  else
-    page_count=$(printf '%s\n' "$page_files" | grep -c '.' || true)
-  fi
-  echo "$page_count"
-}
-
-# Count raw sources with ingested: false (pending ingest)
+# Count raw sources with ingested: false from a pre-fetched raw file list (passed as $1)
 # Checks YAML frontmatter of each raw source file via git show
-count_pending_raw() {
-  local raw_files pending_count file_path file_content
-  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
+_count_pending_from_list() {
+  local raw_files="$1" pending_count file_path file_content
   pending_count=0
   if [ -n "$raw_files" ]; then
     while IFS= read -r file_path; do
@@ -441,10 +429,14 @@ count_pending_raw() {
 # This catches the blind spot where Phase X.X.W fires (raw commit works)
 # but /rite:wiki:ingest never runs (pages never generated)
 check_page_stall() {
-  local raw_count page_count pending_count
-  raw_count=$(count_raw_sources)
-  page_count=$(count_wiki_pages)
-  pending_count=$(count_pending_raw)
+  # Fetch raw and page file lists once (DRY — single git ls-tree per path)
+  local raw_files page_files raw_count page_count pending_count
+  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
+  page_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/pages/ 2>/dev/null) || page_files=""
+
+  raw_count=$(_count_lines "$raw_files")
+  page_count=$(_count_lines "$page_files")
+  pending_count=$(_count_pending_from_list "$raw_files")
 
   log_info "wiki-growth-check: health-summary: raw_sources=$raw_count pages=$page_count pending=$pending_count"
 

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -392,6 +392,89 @@ if ! check_pr_raw_correspondence; then
   findings=$((findings + 1))
 fi
 
+# --- Comprehensive health check: raw count, page count, pending count, page stall (Issue #538) ---
+
+# Count raw source files on the wiki branch
+count_raw_sources() {
+  local raw_files raw_count
+  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
+  if [ -z "$raw_files" ]; then
+    raw_count=0
+  else
+    raw_count=$(printf '%s\n' "$raw_files" | grep -c '.' || true)
+  fi
+  echo "$raw_count"
+}
+
+# Count wiki page files on the wiki branch
+count_wiki_pages() {
+  local page_files page_count
+  page_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/pages/ 2>/dev/null) || page_files=""
+  if [ -z "$page_files" ]; then
+    page_count=0
+  else
+    page_count=$(printf '%s\n' "$page_files" | grep -c '.' || true)
+  fi
+  echo "$page_count"
+}
+
+# Count raw sources with ingested: false (pending ingest)
+# Checks YAML frontmatter of each raw source file via git show
+count_pending_raw() {
+  local raw_files pending_count file_path file_content
+  raw_files=$(git ls-tree --name-only -r "$git_log_target" -- .rite/wiki/raw/ 2>/dev/null) || raw_files=""
+  pending_count=0
+  if [ -n "$raw_files" ]; then
+    while IFS= read -r file_path; do
+      [ -z "$file_path" ] && continue
+      file_content=$(git show "${git_log_target}:${file_path}" 2>/dev/null) || continue
+      # Check YAML frontmatter for ingested: false
+      if printf '%s\n' "$file_content" | head -20 | grep -qE '^ingested:[[:space:]]*(false|no)'; then
+        pending_count=$((pending_count + 1))
+      fi
+    done <<< "$raw_files"
+  fi
+  echo "$pending_count"
+}
+
+# Detect page stall: raw sources are accumulating but pages are not growing
+# This catches the blind spot where Phase X.X.W fires (raw commit works)
+# but /rite:wiki:ingest never runs (pages never generated)
+check_page_stall() {
+  local raw_count page_count pending_count
+  raw_count=$(count_raw_sources)
+  page_count=$(count_wiki_pages)
+  pending_count=$(count_pending_raw)
+
+  log_info "wiki-growth-check: health-summary: raw_sources=$raw_count pages=$page_count pending=$pending_count"
+
+  # Page stall detection: raw sources exist but zero pages
+  if [ "$raw_count" -gt 0 ] && [ "$page_count" -eq 0 ]; then
+    echo "==> Page stall detected: $raw_count raw sources on '$wiki_branch' but 0 wiki pages generated"
+    echo "==> Pending raw sources (ingested: false): $pending_count"
+    echo "==> Hint: /rite:wiki:ingest may never have run, or ingest.md failed silently. Run /rite:wiki:ingest manually to trigger page generation."
+    return 1
+  fi
+
+  # Page stall detection: many pending raw sources relative to total
+  # Threshold: if pending > 50% of total raw AND pending >= 3, flag as stall
+  if [ "$raw_count" -gt 0 ] && [ "$pending_count" -ge 3 ]; then
+    local half_raw=$(( raw_count / 2 ))
+    if [ "$pending_count" -gt "$half_raw" ]; then
+      echo "==> Page stall detected: $pending_count of $raw_count raw sources are pending (ingested: false), only $page_count pages exist"
+      echo "==> Hint: raw sources are accumulating but pages are stagnating. Run /rite:wiki:ingest to process pending raw sources."
+      return 1
+    fi
+  fi
+
+  log_info "wiki-growth-check: page-stall: healthy (raw=$raw_count, pages=$page_count, pending=$pending_count)"
+  return 0
+}
+
+if ! check_page_stall; then
+  findings=$((findings + 1))
+fi
+
 # --- Final result ---
 echo "==> Total wiki-growth-check findings: $findings"
 if [ "$findings" -gt 0 ]; then

--- a/plugins/rite/skills/wiki/SKILL.md
+++ b/plugins/rite/skills/wiki/SKILL.md
@@ -99,3 +99,56 @@ bash plugins/rite/hooks/wiki-query-inject.sh \
 - `--format full` でページ本文（YAML frontmatter 除く）まで含めて出力
 
 詳細は `wiki-query-inject.sh --help` を参照。
+
+## トラブルシューティング
+
+Wiki 機能が期待通りに動作しない場合の診断手順。
+
+### raw source が増えていない場合
+
+raw source は `/rite:pr:review`（Phase 6.5.W.2）、`/rite:pr:fix`（Phase 4.6.W.2）、`/rite:issue:close`（Phase 4.4.W.2）で自動生成されます。raw が増えていない場合:
+
+1. **wiki.enabled を確認**: `rite-config.yml` で `wiki.enabled: true` になっているか
+2. **wiki.auto_ingest を確認**: `wiki.auto_ingest: true` になっているか（`false` だと raw 蓄積のトリガーが無効化される）
+3. **wiki branch の存在を確認**: `git branch -a | grep wiki` で wiki branch が存在するか。存在しない場合は `/rite:wiki:init` を実行するか `git fetch origin wiki:wiki` を実行
+4. **Phase X.X.W の sentinel を確認**: 完了レポートの `### 📚 Wiki ingest 状況` セクションで `SKIPPED` や `FAILED` のカウントを確認
+5. **workflow incident を確認**: `[CONTEXT] WIKI_INGEST_SKIPPED=1` や `WIKI_INGEST_FAILED=1` が Phase 5.4.4.1 で検出・報告されているか
+
+### raw は増えているがページが増えない場合
+
+raw source は蓄積されているが `.rite/wiki/pages/` にページが生成されていない場合:
+
+1. **`/rite:wiki:ingest` を手動実行**: ページ統合は `/rite:wiki:ingest` で実行されます。自動発火は `/rite:pr:cleanup` の末尾 Phase で行われるため、cleanup を実行していない場合はページが生成されません
+2. **pending raw を確認**: `wiki-growth-check.sh` の出力で `pending` 数を確認。`ingested: false` のまま残っている raw source が多い場合は ingest が実行されていません
+3. **ingest のエラーログを確認**: `/rite:wiki:ingest` 実行時に LLM 解析エラーが発生していないか確認
+4. **SCHEMA.md の整合性を確認**: `.rite/wiki/SCHEMA.md` が正しくセットアップされているか。`/rite:wiki:lint` で品質チェックを実行
+
+### 手動 `/rite:wiki:ingest` の実行タイミング
+
+以下のタイミングで手動実行を推奨:
+
+- **PR cleanup 後に自動発火しなかった場合**: cleanup.md の末尾 Phase で ingest が skip された場合
+- **`wiki-growth-check.sh` が page stall を検出した場合**: `==> Page stall detected` の出力があった場合
+- **大量の pending raw source がある場合**: `pending` 数が raw 総数の 50% を超えている場合
+- **Wiki を初めて使い始める場合**: `/rite:wiki:init` 実行後、既存の raw source をページ化するため
+
+実行方法: `/rite:wiki:ingest` を Claude Code で呼び出す。
+
+### `wiki-growth-check.sh` の alarm の読み方
+
+`wiki-growth-check.sh` は `/rite:lint` から呼び出される総合 health check です。以下の alarm を出力します:
+
+| alarm | 意味 | 対処 |
+|-------|------|------|
+| `Wiki growth stall detected` | wiki branch の最終 commit 以降に N 件以上の PR がマージされたが、raw source が追加されていない | Phase X.X.W が silent skip されている。review.md / fix.md / close.md の Wiki Phase 到達を確認 |
+| `PR↔raw correspondence gap` | 直近の merged PR に対応する raw source ファイル（`pr-{number}` 名）が wiki branch に存在しない | 個別 PR の Phase X.X.W 実行を確認。`wiki-ingest-trigger.sh` / `wiki-ingest-commit.sh` のログを確認 |
+| `Page stall detected` | raw source は存在するがページ数がゼロ、または pending raw が多い | `/rite:wiki:ingest` を手動実行。cleanup 経路での自動発火が機能しているか確認 |
+
+閾値の調整は `rite-config.yml` の `wiki.growth_check` セクションで可能:
+
+```yaml
+wiki:
+  growth_check:
+    threshold_prs: 5          # growth stall の閾値（デフォルト: 5）
+    pr_raw_threshold: 3       # PR↔raw 対応の閾値（デフォルト: 3）
+```


### PR DESCRIPTION
## 概要

wiki-growth-check.sh を総合 health check に拡張し、SKILL.md にトラブルシューティング節を追加する。

## 関連 Issue

Closes #538

親 Issue: #532 - Wiki 機能が実ワークフローで発火しない問題の根本修正

## 変更内容

### wiki-growth-check.sh の総合化

- `count_raw_sources`: wiki branch の raw source 件数を把握
- `count_wiki_pages`: wiki ページ数を把握
- `count_pending_raw`: `ingested: false` の pending 数を把握
- `check_page_stall`: raw 増加 + page 停滞パターンの検知（2条件: raw>0 かつ page=0、pending が raw の50%超かつ3件以上）

### SKILL.md トラブルシューティング節

- raw source が増えていない場合の原因特定手順
- raw は増えているがページが増えない場合の原因特定手順
- 手動 `/rite:wiki:ingest` の実行タイミング
- `wiki-growth-check.sh` の alarm の読み方（テーブル形式）

## テスト結果

- 正常状態: growth-stall / pr-raw healthy、page stall 検出（raw=15, pages=0, pending=15）
- `--threshold 1`: growth-stall alarm + page stall 検出、findings=2

## チェックリスト

- [x] wiki-growth-check.sh の総合化
- [x] SKILL.md trouble-shooting 節の追加
- [x] 両パターンの alarm 発火確認
- [x] ドキュメントの review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
