### PR TITLE
refactor: parent_issue_number を .rite-flow-state に永続化

### DIFF
--- a/plugins/rite/commands/issue/child-issue-selection.md
+++ b/plugins/rite/commands/issue/child-issue-selection.md
@@ -181,9 +181,12 @@ Before returning control to the caller, update `.rite-flow-state` to the post-ch
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "phase1_6_post_child" \
+  --parent-issue {parent_issue_number} \
   --next "rite:issue:child-issue-selection completed. Proceed to Phase 2 (work preparation). Do NOT stop." \
   --if-exists
 ```
+
+> **Note**: `{parent_issue_number}` is the parent Issue number (the Issue originally passed to `/rite:issue:start`). This persists the parent-child relationship in `.rite-flow-state` so it survives context compaction (#497).
 
 After the flow-state update above, output the appropriate result pattern:
 

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -858,7 +858,18 @@ WM_SOURCE="implement" \
 
 #### 5.1.2 Parent Issue Progress Update (only when working on child Issue)
 
-**Execution condition**: Execute only when working on a child Issue selected in Phase 1.6.
+**Execution condition**: Execute only when `parent_issue_number` is non-zero. Read deterministically from `.rite-flow-state` (#497 — survives context compaction):
+
+```bash
+parent_issue_number=$(jq -r '.parent_issue_number // 0' .rite-flow-state 2>/dev/null) || parent_issue_number=0
+if [ "$parent_issue_number" -eq 0 ] 2>/dev/null; then
+  echo "[CONTEXT] PARENT_ISSUE=none — skip 5.1.2"
+else
+  echo "[CONTEXT] PARENT_ISSUE=$parent_issue_number — execute 5.1.2"
+fi
+```
+
+Skip this section when `PARENT_ISSUE=none`.
 
 **5.1.2.1 Tasklist Update**
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -110,7 +110,7 @@ This protocol applies to **every** sub-skill invocation in this document. Each �
 | `{default_branch}` | `gh repo view --json defaultBranchRef` (Phase 2.3.2.3 only) |
 | `{project_number}` | `github.projects.project_number` in `rite-config.yml` |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script) |
-| `{parent_issue_number}` | Phase 1.6 (child-issue-selection) or Phase 2.4 Step 3 (parent lookup via 2.4.7) result; retained in conversation context. Used only in Phase 5.7 and Workflow Termination routing |
+| `{parent_issue_number}` | Phase 1.6 (child-issue-selection) or Phase 2.4 Step 3 (parent lookup via 2.4.7) result; persisted in `.rite-flow-state` via `--parent-issue` option. Read via `jq -r '.parent_issue_number // 0' .rite-flow-state`. Used in Phase 5.1.2, 5.7, and Workflow Termination routing |
 
 ---
 
@@ -386,14 +386,16 @@ The script is the single source of truth for Projects Status updates. See [proje
 
 Do **NOT** stop after the Projects Status update. Phase 2.5 (Iteration) and 2.6 (Work Memory) are still pending.
 
-**Step 1**: Update `.rite-flow-state` to post-projects phase:
+**Step 1**: Update `.rite-flow-state` to post-projects phase. If Phase 2.4.7 detected a parent Issue (`{parent_issue_number}` is non-empty and non-zero), persist it via `--parent-issue` so it survives context compaction and session restarts (#497):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase2_post_projects" --issue {issue_number} --branch "{branch_name}" \
-  --pr 0 \
+  --pr 0 --parent-issue {parent_issue_number} \
   --next "Phase 2.4 completed. Proceed to Phase 2.5 (Iteration) if iteration.enabled, else Phase 2.6 (Work Memory). Do NOT stop."
 ```
+
+> **Note**: When Phase 2.4.7 detected no parent (standalone Issue), `{parent_issue_number}` is `0` (the default). The `--parent-issue 0` is harmless and explicitly records that no parent was found.
 
 **Step 2**: **→ Proceed to Phase 2.5 now**. Phase 2.5 handles its own skip conditions internally (iteration disabled / projects disabled) — do NOT skip Phase 2.5 at this level (prompt-engineer cycle-2 MEDIUM #3). The Phase 2.5 Pre-write + Mandatory After blocks always run so `phase2_post_iteration` is recorded even when the assignment body is skipped.
 
@@ -1864,7 +1866,7 @@ fi
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_completion" --issue {issue_number} --branch "{branch_name}" \
   --pr {pr_number} \
-  --next "Execute Phase 5.6 (Completion Report). If parent_issue_number was retained in conversation context (from Phase 1.6 / 2.4.7), proceed to Phase 5.7. Otherwise jump directly to the Workflow Termination block (bypass 5.7). Do NOT stop."
+  --next "Execute Phase 5.6 (Completion Report). Read parent_issue_number from .rite-flow-state; if non-zero, proceed to Phase 5.7. Otherwise jump directly to the Workflow Termination block (bypass 5.7). Do NOT stop."
 ```
 
 > See [completion-report.md](./completion-report.md) for the full procedure (template read, placeholder substitution, output cases, self-verification, and inline fallbacks).
@@ -1971,7 +1973,18 @@ echo "[CONTEXT] WIKI_LAST_COMMIT=${last_wiki_commit:-}"
 
 ### 5.7 Parent Issue Completion
 
-**Condition**: Parent identified in Phase 1.6/2.4.7. Execute after 5.6.
+**Condition**: `parent_issue_number` is non-zero in `.rite-flow-state`. Read deterministically via:
+
+```bash
+parent_issue_number=$(jq -r '.parent_issue_number // 0' .rite-flow-state 2>/dev/null) || parent_issue_number=0
+if [ "$parent_issue_number" -eq 0 ] 2>/dev/null; then
+  echo "[CONTEXT] PARENT_ISSUE=none — skip Phase 5.7, proceed to Workflow Termination"
+else
+  echo "[CONTEXT] PARENT_ISSUE=$parent_issue_number — execute Phase 5.7"
+fi
+```
+
+Execute after 5.6. When `PARENT_ISSUE=none`, skip directly to Workflow Termination block.
 
 **Pre-write** (only when a parent was identified — otherwise skip directly to terminate):
 
@@ -2068,7 +2081,7 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 
 > **Placement**: This block runs **after** Phase 5.7 completes **or after Phase 5.6** when no parent Issue was identified in Phase 1.6 / 2.4.7 (the Phase 5.7 skip branch). Both paths converge here so the terminal `phase="completed", active: false` state is set exactly once, with `previous_phase` pointing at a whitelist-valid source (`phase5_post_parent_completion` or `phase5_completion`).
 
-**Parent-skip routing** (prompt-engineer HIGH — Phase 5.7 skip branch missing termination): When no parent Issue was identified, Phase 5.7 is skipped entirely. In that case, jump from the end of Phase 5.6 directly to this block (bypassing 5.7.1-5.7.3 and Mandatory After 5.7) — do **not** leave the workflow in `phase5_completion, active: true`, which would cause the next stop attempt to block indefinitely.
+**Parent-skip routing** (prompt-engineer HIGH — Phase 5.7 skip branch missing termination): When `parent_issue_number` is `0` in `.rite-flow-state` (read via `jq -r '.parent_issue_number // 0' .rite-flow-state`), Phase 5.7 is skipped entirely. In that case, jump from the end of Phase 5.6 directly to this block (bypassing 5.7.1-5.7.3 and Mandatory After 5.7) — do **not** leave the workflow in `phase5_completion, active: true`, which would cause the next stop attempt to block indefinitely.
 
 **Step 1**: Update `.rite-flow-state` to the terminal state (patch mode, preserves `previous_phase`):
 

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -68,6 +68,7 @@ Stop here.
 - `{issue_number}`: Issue number (from argument or branch name extraction in Phase 1.1)
 - `{owner}`, `{repo}`: Repository information (obtain via `gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'`)
 - `{plugin_root}`: Plugin root directory (resolve per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script))
+- `{parent_issue_display}`: Read from `.rite-flow-state` via `jq -r '.parent_issue_number // 0'`. Display `#{N}` if non-zero, `なし` if zero or absent
 
 #### 1.2.1 Local Work Memory Check
 
@@ -261,6 +262,7 @@ Issue: #{issue_number} - {issue_title}
 {i18n:resume_phase_label}: {phase}
 {i18n:resume_phase_detail_label}: {phase_detail}
 {i18n:resume_last_updated_label}: {timestamp}
+親 Issue: {parent_issue_display}
 
 {i18n:resume_confirm_resume}
 ```

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -262,7 +262,7 @@ Issue: #{issue_number} - {issue_title}
 {i18n:resume_phase_label}: {phase}
 {i18n:resume_phase_detail_label}: {phase_detail}
 {i18n:resume_last_updated_label}: {timestamp}
-親 Issue: {parent_issue_display}
+{i18n:resume_parent_issue_label}: {parent_issue_display}
 
 {i18n:resume_confirm_resume}
 ```

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -22,6 +22,7 @@
 #   --issue          Issue number (create mode, default: 0)
 #   --branch         Branch name (create mode, default: "")
 #   --pr             PR number (create mode, default: 0)
+#   --parent-issue   Parent Issue number (create mode, default: 0; patch mode: update only if specified)
 #   --next           next_action text (required for create/patch)
 #   --active         Active flag (create mode: default true; patch mode: update only if specified)
 #   --field          Field name to increment (increment mode)
@@ -50,6 +51,7 @@ PHASE=""
 ISSUE=0
 BRANCH=""
 PR=0
+PARENT_ISSUE=0
 NEXT=""
 ACTIVE=""
 IF_EXISTS=false
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --issue)    ISSUE="$2"; shift 2 ;;
     --branch)   BRANCH="$2"; shift 2 ;;
     --pr)       PR="$2"; shift 2 ;;
+    --parent-issue) PARENT_ISSUE="$2"; shift 2 ;;
     --next)     NEXT="$2"; shift 2 ;;
     --active)   ACTIVE="$2"; shift 2 ;;
     --if-exists) IF_EXISTS=true; shift ;;
@@ -177,10 +180,11 @@ case "$MODE" in
       --arg phase "$PHASE" \
       --arg prev_phase "$PREV_PHASE" \
       --argjson pr "$PR" \
+      --argjson parent_issue "$PARENT_ISSUE" \
       --arg next "$NEXT" \
       --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
       --arg sid "$SESSION" \
-      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
+      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
       > "$TMP_STATE"; then
       mv "$TMP_STATE" "$FLOW_STATE"
     else
@@ -198,6 +202,10 @@ case "$MODE" in
     if [[ -n "$ACTIVE" ]]; then
       JQ_FILTER="$JQ_FILTER | .active = (\$active_val == \"true\")"
       JQ_ARGS+=(--arg active_val "$ACTIVE")
+    fi
+    if [[ "$PARENT_ISSUE" -ne 0 ]]; then
+      JQ_FILTER="$JQ_FILTER | .parent_issue_number = (\$parent_issue_val | tonumber)"
+      JQ_ARGS+=(--arg parent_issue_val "$PARENT_ISSUE")
     fi
     if jq "${JQ_ARGS[@]}" -- "$JQ_FILTER" "$FLOW_STATE" > "$TMP_STATE"; then
       mv "$TMP_STATE" "$FLOW_STATE"

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -172,6 +172,16 @@ case "$MODE" in
         exit 1
       fi
       [ -n "$_jq_err" ] && rm -f "$_jq_err"
+      # Preserve parent_issue_number from existing state when --parent-issue is not
+      # explicitly specified (#497). Without this, every create call that omits
+      # --parent-issue would reset parent_issue_number to 0, erasing the value
+      # persisted by Phase 2.4 Mandatory After.
+      if [[ "$PARENT_ISSUE" -eq 0 ]]; then
+        _existing_parent=$(jq -r '.parent_issue_number // 0' "$FLOW_STATE" 2>/dev/null) || _existing_parent=0
+        if [[ "$_existing_parent" =~ ^[0-9]+$ ]] && [[ "$_existing_parent" -ne 0 ]]; then
+          PARENT_ISSUE="$_existing_parent"
+        fi
+      fi
     fi
     if jq -n \
       --argjson active "$ACTIVE" \

--- a/plugins/rite/i18n/en/other.yml
+++ b/plugins/rite/i18n/en/other.yml
@@ -344,6 +344,7 @@ messages:
   resume_phase_label: "Phase"
   resume_phase_detail_label: "Phase detail"
   resume_last_updated_label: "Last updated"
+  resume_parent_issue_label: "Parent Issue"
   resume_confirm_resume: "Do you want to resume this work?"
   resume_uncommitted_changes_warning: "Warning: There are uncommitted changes on the current branch"
   resume_current_branch: "Current branch"

--- a/plugins/rite/i18n/ja/other.yml
+++ b/plugins/rite/i18n/ja/other.yml
@@ -344,6 +344,7 @@ messages:
   resume_phase_label: "フェーズ"
   resume_phase_detail_label: "フェーズ詳細"
   resume_last_updated_label: "最終更新"
+  resume_parent_issue_label: "親 Issue"
   resume_confirm_resume: "この作業を再開しますか？"
   resume_uncommitted_changes_warning: "警告: 現在のブランチにコミットされていない変更があります"
   resume_current_branch: "現在のブランチ"


### PR DESCRIPTION
## 概要

`parent_issue_number` を会話コンテキスト retention から `.rite-flow-state` への永続化に変更。context compaction や session 跨ぎでも Phase 5.7 routing が deterministic に動作するようにする。

Closes #497

## 変更内容

### `flow-state-update.sh`
- `--parent-issue` オプションを追加（create/patch 両モード対応）
- create mode: `parent_issue_number` フィールドを jq 出力に追加（デフォルト: 0）
- patch mode: `--parent-issue` 指定時のみ条件付き更新（`--active` と同パターン）

### `start.md`
- Placeholder Legend: `{parent_issue_number}` の説明を `.rite-flow-state` 経由に更新
- Mandatory After 2.4: `--parent-issue` を flow-state-update に渡すよう追記
- Phase 5.7: routing 条件を `jq -r '.parent_issue_number // 0'` に変更
- Workflow Termination: Parent-skip routing の判定も `.rite-flow-state` 経由に変更

### `child-issue-selection.md`
- Defense-in-Depth flow-state update に `--parent-issue` を渡すよう追記

### `implement.md`
- Phase 5.1.2: 実行条件を `.rite-flow-state` からの読み取りに変更

### `resume.md`
- State 復元表示に `parent_issue_number` を追加
- Placeholder legend に `{parent_issue_display}` を追記

## テスト計画

- [ ] `flow-state-update.sh create --parent-issue 42` で `.rite-flow-state` に `parent_issue_number: 42` が書き込まれることを確認
- [ ] `flow-state-update.sh patch --parent-issue 42` で既存の `.rite-flow-state` の `parent_issue_number` が更新されることを確認
- [ ] `--parent-issue` 未指定の create mode で `parent_issue_number: 0` がデフォルトとして書き込まれることを確認
- [ ] `--parent-issue` 未指定の patch mode で既存の `parent_issue_number` が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
