### PR TITLE
fix: /rite:resume と Recognized Patterns 経路の whitelist 遷移を追加 (#498)

### DIFF
--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -39,9 +39,9 @@ fi
 declare -gA _RITE_PHASE_TRANSITIONS=(
   # Phase 1 → Phase 1.5/1.6/2
   ["phase1_5_parent"]="phase1_5_post_parent"
-  ["phase1_5_post_parent"]="phase1_6_child phase2_branch"
+  ["phase1_5_post_parent"]="phase1_6_child phase2_branch phase3_plan"
   ["phase1_6_child"]="phase1_6_post_child"
-  ["phase1_6_post_child"]="phase2_branch"
+  ["phase1_6_post_child"]="phase2_branch phase3_plan"
 
   # Phase 2: branch → projects → iteration → work memory → plan
   # Since cycle-3 MEDIUM #3 fix, every 2.x phase always writes its post-marker
@@ -49,13 +49,21 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # as a whitelist-valid transition). Direct phase2_post_branch → phase2_work_memory
   # and phase2_post_projects → phase2_work_memory paths were removed because they
   # bypass the iteration-phase chain (prompt-engineer cycle-3 MEDIUM).
-  ["phase2_branch"]="phase2_post_branch"
-  ["phase2_post_branch"]="phase2_projects"
-  ["phase2_projects"]="phase2_post_projects"
-  ["phase2_post_projects"]="phase2_iteration"
-  ["phase2_iteration"]="phase2_post_iteration"
-  ["phase2_post_iteration"]="phase2_work_memory"
-  ["phase2_work_memory"]="phase2_post_work_memory"
+  #
+  # Resume/Recognized-Patterns skip edges (#498):
+  # When /rite:resume detects an existing branch (Phase 2.2) or Phase 2.2.1
+  # Recognized Patterns selects a non-Issue-numbered branch, Phases 2.3-2.6
+  # are skipped entirely. The workflow jumps directly to Phase 3 (plan), so
+  # every Phase 2 intermediate state must be allowed to transition to phase3_plan.
+  # Similarly, Phase 1.5/1.6 post-markers must reach phase3_plan when
+  # Recognized Patterns triggers before Phase 2.3.
+  ["phase2_branch"]="phase2_post_branch phase3_plan"
+  ["phase2_post_branch"]="phase2_projects phase3_plan"
+  ["phase2_projects"]="phase2_post_projects phase3_plan"
+  ["phase2_post_projects"]="phase2_iteration phase3_plan"
+  ["phase2_iteration"]="phase2_post_iteration phase3_plan"
+  ["phase2_post_iteration"]="phase2_work_memory phase3_plan"
+  ["phase2_work_memory"]="phase2_post_work_memory phase3_plan"
   ["phase2_post_work_memory"]="phase3_plan"
 
   # Phase 3: implementation plan


### PR DESCRIPTION
## 概要

`/rite:resume` と Phase 2.2.1 Recognized Patterns 経路で、`phase-transition-whitelist.sh` の遷移検証が不十分だった問題を修正。

- Resume 経路: Phase 2.2 で既存ブランチ検出 → Phase 2.3-2.6 skip → Phase 3 直行時、中間 phase から `phase3_plan` への遷移が whitelist に不在
- Recognized Patterns 経路: Phase 2.2.1 で Issue 番号なしブランチ選択 → Phase 2.4-2.6 skip 時、`phase1_5_post_parent` / `phase1_6_post_child` から `phase3_plan` への遷移が whitelist に不在

## 変更内容

- Phase 2 の全中間状態（`phase2_branch` 〜 `phase2_work_memory`）に `phase3_plan` への遷移エッジを追加
- Phase 1.5/1.6 のポストマーカー（`phase1_5_post_parent`, `phase1_6_post_child`）に `phase3_plan` への遷移エッジを追加
- 既存の遷移は非破壊（MERGE セマンティクス）

## テスト計画

- [x] Resume 経路: 全 Phase 2 中間状態 → `phase3_plan` が ALLOWED
- [x] Recognized Patterns 経路: `phase1_5_post_parent` / `phase1_6_post_child` → `phase3_plan` が ALLOWED
- [x] 既存遷移の非破壊検証: 正規フローの全遷移が引き続き ALLOWED

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
