### PR TITLE
refactor(wiki): shell scripts の shared lib 抽出 (parse_wiki_scalar / worktree-git)

### DIFF
--- a/plugins/rite/hooks/scripts/lib/wiki-config.sh
+++ b/plugins/rite/hooks/scripts/lib/wiki-config.sh
@@ -1,0 +1,92 @@
+# rite workflow - Wiki config parsing / branch name validation helpers
+#
+# Responsibility: provide the canonical implementations of
+#   - parse_wiki_scalar()        — lenient YAML reader for the `wiki:` section
+#   - validate_wiki_branch_name() — defensive branch-name validation
+# so that wiki-worktree-setup.sh / wiki-worktree-commit.sh /
+# wiki-ingest-commit.sh can share a single definition instead of keeping
+# three character-exact copies in sync manually.
+#
+# Design rationale (Issue #549): previous commits (PR #548 cycle 4 review
+# F-05 / F-06) identified that parse_wiki_scalar had drifted across the
+# three sibling scripts, creating a transcription-failure class of bugs
+# every time the `wiki.branch_name` parsing contract changed. Extracting a
+# shared lib makes future edits a one-file operation.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/wiki-config.sh"
+#   val=$(parse_wiki_scalar enabled)
+#   validate_wiki_branch_name "$wiki_branch" || exit 1
+#
+# Contract:
+#   - No side effects at source time (function definitions only).
+#   - Does NOT set `set -euo pipefail` — the caller owns that.
+#   - Assumes the working directory is the repo root and rite-config.yml
+#     exists. Callers that need to tolerate a missing config file should
+#     guard with `[[ -f rite-config.yml ]]` before calling parse_wiki_scalar.
+
+# -----------------------------------------------------------------------
+# parse_wiki_scalar KEY
+#
+# Extract the value of `wiki.<KEY>` from rite-config.yml using the same
+# lenient YAML approach as wiki-ingest-trigger.sh / ingest.md Phase 1.1
+# (awk section extraction + inline-comment strip + quote strip).
+#
+# Security note (verified-review cycle 4 LOW): key value extraction uses
+# `awk -v k=...` rather than `sed` with an interpolated `$key`. Current
+# callers pass hardcoded literal keys only, so there is no injection path
+# today, but `sed "s/.*${key}:[[:space:]]*//"` would treat sed metachars
+# in `$key` as pattern metacharacters if a future caller ever passed
+# user-controlled input. `awk -v` keeps the value in a variable binding
+# that is never re-parsed as a regex.
+# -----------------------------------------------------------------------
+parse_wiki_scalar() {
+  local key="$1"
+  local section line val
+  section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null || true)
+  [[ -z "$section" ]] && return 0
+  line=$(printf '%s\n' "$section" | awk -v k="$key" '
+    BEGIN { pat = "^[[:space:]]+" k ":" }
+    $0 ~ pat { print; exit }
+  ' 2>/dev/null || true)
+  [[ -z "$line" ]] && return 0
+  val=$(printf '%s' "$line" \
+    | sed 's/[[:space:]]#.*//' \
+    | awk -v k="$key" '{
+        sub("^[[:space:]]*" k ":[[:space:]]*", "")
+        print
+      }' \
+    | tr -d '[:space:]"'"'")
+  printf '%s' "$val"
+}
+
+# -----------------------------------------------------------------------
+# validate_wiki_branch_name BRANCH
+#
+# Reject branch names that would be unsafe to pass to `git` as a ref or
+# as the positional argument of `git -C ... add -- "$path"`. The rules
+# mirror what wiki-ingest-commit.sh MEDIUM #6 established:
+#   - non-empty
+#   - must not start with `-` (would be parsed as an option flag)
+#   - must not start with `.` (collides with hidden refs)
+#   - must not contain `..` (path traversal in `refs/heads/<name>`)
+#   - must not contain `//` (empty path segment)
+#   - must match the common ref-name alphabet [A-Za-z0-9._/-]+
+#
+# On failure emits a descriptive ERROR + allowed-syntax hint to stderr and
+# returns 1. On success returns 0 with no output. Callers typically use:
+#   validate_wiki_branch_name "$wiki_branch" || exit 1
+# -----------------------------------------------------------------------
+validate_wiki_branch_name() {
+  local branch="$1"
+  if [[ -z "$branch" ]] || [[ "$branch" == -* ]] || \
+     [[ "$branch" == .* ]] || \
+     [[ "$branch" == *..* ]] || \
+     [[ "$branch" == *//* ]] || \
+     [[ ! "$branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "ERROR: invalid wiki.branch_name '${branch}' in rite-config.yml" >&2
+    echo "  allowed: [A-Za-z0-9._/-]+, must not start with '-' / '.', must not contain '..' or '//'" >&2
+    return 1
+  fi
+  return 0
+}

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -1,0 +1,137 @@
+# rite workflow - Worktree-scoped git add/commit/push helper
+#
+# Responsibility: provide the canonical `git -C <worktree> add / commit /
+# push` flow with stderr tempfile capture, head -n 10 extraction, and
+# exit-code semantics shared by:
+#   - wiki-worktree-commit.sh  (pages/index/log commits on wiki branch)
+#   - wiki-ingest-commit.sh    (worktree fast path for raw-source ingest)
+#
+# Design rationale (Issue #549): PR #548 cycle 4 F-06 identified that the
+# add/commit/push block + error handling (stderr tempfile -> head -n 10
+# -> sed prefix) was structurally identical across the two scripts. Any
+# future enhancement (e.g. push retry with exponential backoff) would
+# require synchronous edits across both. A shared helper eliminates that
+# drift vector.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/worktree-git.sh"
+#   worktree_commit_push WORKTREE COMMIT_MSG PATH1 [PATH2 ...]
+#   rc=$?
+#   case "$rc" in
+#     0) ;;  # committed and pushed
+#     3) exit 3 ;;  # add/commit failed — error already surfaced to stderr
+#     4) push_failed=true ;;  # commit landed, push failed
+#     5) ;;  # no staged diff — caller decides policy
+#   esac
+#
+# Arguments:
+#   WORKTREE      path to the worktree (caller must have validated it)
+#   COMMIT_MSG    commit message (must not contain newline / CR — callers
+#                 that read from user input should validate first)
+#   PATH1...      pathspecs to `git add --`. At least one is required.
+#
+# Exit codes:
+#   0  success — committed and pushed
+#   2  argument error (missing worktree / commit message / pathspec)
+#   3  git add or commit failed (error details already on stderr)
+#   4  commit OK, push failed (caller should emit wiki_ingest_push_failed
+#      sentinel and decide whether to exit 4 or continue)
+#   5  no staged diff after add (no-op, caller decides skip/success)
+#
+# stdout:
+#   On exit 0 or 4: "head=<sha>; push=<ok|failed>"
+#   On exit 5:      "no-staged-diff"
+#   Otherwise:      empty (errors are on stderr)
+#
+# Contract:
+#   - Does NOT set `set -euo pipefail`. Caller owns shell options.
+#   - Uses a local trap for stderr tempfile cleanup; caller's outer trap
+#     is restored via `trap - EXIT INT TERM HUP` before return.
+#   - Caller must have ALREADY verified:
+#       * worktree exists at WORKTREE path
+#       * worktree HEAD is on the expected branch
+#       * COMMIT_MSG has been checked for newline/CR injection
+
+worktree_commit_push() {
+  local worktree="$1"
+  local commit_msg="$2"
+  shift 2 2>/dev/null || true
+
+  if [[ -z "$worktree" ]] || [[ -z "$commit_msg" ]] || [[ $# -eq 0 ]]; then
+    echo "ERROR: worktree_commit_push: WORKTREE / COMMIT_MSG / PATH... required" >&2
+    return 2
+  fi
+
+  local add_err="" commit_err="" push_err=""
+  trap 'rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"' EXIT INT TERM HUP
+  add_err=$(mktemp /tmp/rite-wtgit-add-err-XXXXXX 2>/dev/null) || add_err=""
+  commit_err=$(mktemp /tmp/rite-wtgit-commit-err-XXXXXX 2>/dev/null) || commit_err=""
+  push_err=$(mktemp /tmp/rite-wtgit-push-err-XXXXXX 2>/dev/null) || push_err=""
+
+  # Step 1: stage paths
+  if ! git -C "$worktree" add -- "$@" 2>"${add_err:-/dev/null}"; then
+    echo "ERROR: git -C '$worktree' add failed" >&2
+    [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | sed 's/^/  git: /' >&2
+    echo "  hint: index lock / path error / permission denied のいずれかを確認してください" >&2
+    rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
+    trap - EXIT INT TERM HUP
+    return 3
+  fi
+
+  # Step 2: verify staged diff is non-empty
+  set +e
+  git -C "$worktree" diff --cached --quiet 2>"${add_err:-/dev/null}"
+  local cached_rc=$?
+  set -e
+  case "$cached_rc" in
+    0)
+      echo "no-staged-diff"
+      rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
+      trap - EXIT INT TERM HUP
+      return 5
+      ;;
+    1) ;;  # staged diff present, proceed
+    *)
+      echo "ERROR: git -C '$worktree' diff --cached --quiet failed (rc=$cached_rc)" >&2
+      [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | sed 's/^/  git: /' >&2
+      rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
+      trap - EXIT INT TERM HUP
+      return 3
+      ;;
+  esac
+
+  # Step 3: commit
+  if ! git -C "$worktree" commit --quiet -m "$commit_msg" 2>"${commit_err:-/dev/null}"; then
+    echo "ERROR: git -C '$worktree' commit failed" >&2
+    [ -n "$commit_err" ] && [ -s "$commit_err" ] && head -n 10 "$commit_err" | sed 's/^/  git: /' >&2
+    echo "  hint: pre-commit hook / gpg sign / author config / permission のいずれかを確認" >&2
+    rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
+    trap - EXIT INT TERM HUP
+    return 3
+  fi
+
+  local head_sha
+  head_sha=$(git -C "$worktree" rev-parse HEAD 2>/dev/null || echo unknown)
+
+  # Step 4: push. Failure here is incident-observable (return 4) but caller
+  # owns the policy decision (continue workflow vs. hard fail).
+  local push_status="ok"
+  local branch
+  branch=$(git -C "$worktree" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+  if ! git -C "$worktree" push --quiet origin "$branch" 2>"${push_err:-/dev/null}"; then
+    push_status="failed"
+    echo "WARNING: git -C '$worktree' push origin '$branch' failed — commit is local only" >&2
+    [ -n "$push_err" ] && [ -s "$push_err" ] && head -n 10 "$push_err" | sed 's/^/  git: /' >&2
+    echo "  manual recovery: git -C '$worktree' push origin '$branch'" >&2
+  fi
+
+  echo "head=${head_sha}; push=${push_status}"
+
+  rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
+  trap - EXIT INT TERM HUP
+
+  if [[ "$push_status" == "failed" ]]; then
+    return 4
+  fi
+  return 0
+}

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -77,6 +77,97 @@
 #       * COMMIT_MSG has been checked for newline/CR injection
 #       * BRANCH matches the expected wiki.branch_name
 
+# -----------------------------------------------------------------------
+# verify_worktree_branch: confirm a worktree's HEAD is on an expected branch.
+#
+# Responsibility (cycle 3 C3-M1 fix): eliminate the duplicated rev-parse
+# --abbrev-ref HEAD verification block that previously lived in both
+# wiki-worktree-commit.sh and wiki-ingest-commit.sh. Both callers ran
+# essentially the same sequence (mktemp stderr tempfile + scope-limited
+# trap + `set +e` / `set -e` fence + rev-parse + ERROR + `head -3` + rm -f
+# + branch compare) with only the tempfile prefix differing. This helper
+# centralizes that logic so fixes propagate to both callers automatically.
+#
+# Usage:
+#   verify_worktree_branch "$worktree_path" "$wiki_branch" "wwc" "$extra_hint"
+#   # returns 0 if worktree HEAD == expected_branch
+#   # returns non-zero after emitting ERROR to stderr (caller should exit 1)
+#
+# Arguments:
+#   WORKTREE          worktree path (caller has already confirmed existence)
+#   EXPECTED_BRANCH   branch name the worktree must be on
+#   TEMPFILE_TAG      short tag (4-8 chars) for the mktemp prefix, so
+#                     concurrent runs from different callers produce
+#                     distinguishable tempfile names. Example: "wwc",
+#                     "wic-wt".
+#   EXTRA_HINT        optional extra stderr line to emit when the branch
+#                     mismatch is detected (used by ingest-commit.sh to
+#                     clarify that silent fall-through would be even more
+#                     confusing). Pass empty string to omit.
+#
+# Exit codes:
+#   0  worktree is on expected branch
+#   2  rev-parse failed (worktree corrupt / permission / git binary issue)
+#   3  worktree is on a different branch
+verify_worktree_branch() {
+  local worktree="$1"
+  local expected_branch="$2"
+  local tempfile_tag="${3:-vwb}"
+  local extra_hint="${4:-}"
+
+  local rev_parse_err=""
+  # Save caller's outer trap to avoid clobbering it.
+  local _vwb_outer_exit _vwb_outer_int _vwb_outer_term _vwb_outer_hup
+  _vwb_outer_exit=$(trap -p EXIT)
+  _vwb_outer_int=$(trap -p INT)
+  _vwb_outer_term=$(trap -p TERM)
+  _vwb_outer_hup=$(trap -p HUP)
+
+  trap 'rm -f "${rev_parse_err:-}"' EXIT INT TERM HUP
+  rev_parse_err=$(mktemp "/tmp/rite-${tempfile_tag}-revparse-err-XXXXXX" 2>/dev/null) || rev_parse_err=""
+
+  # Save caller's errexit so we can restore exactly.
+  local _vwb_errexit=0
+  case $- in *e*) _vwb_errexit=1 ;; esac
+  set +e
+  local wt_head wt_head_rc
+  wt_head=$(git -C "$worktree" rev-parse --abbrev-ref HEAD 2>"${rev_parse_err:-/dev/null}")
+  wt_head_rc=$?
+  if [[ $_vwb_errexit -eq 1 ]]; then set -e; fi
+
+  _vwb_restore_traps() {
+    if [[ -n "$_vwb_outer_exit" ]]; then eval "$_vwb_outer_exit"; else trap - EXIT; fi
+    if [[ -n "$_vwb_outer_int"  ]]; then eval "$_vwb_outer_int";  else trap - INT;  fi
+    if [[ -n "$_vwb_outer_term" ]]; then eval "$_vwb_outer_term"; else trap - TERM; fi
+    if [[ -n "$_vwb_outer_hup"  ]]; then eval "$_vwb_outer_hup";  else trap - HUP;  fi
+  }
+
+  if [ "$wt_head_rc" -ne 0 ]; then
+    echo "ERROR: git -C '$worktree' rev-parse --abbrev-ref HEAD が失敗しました (rc=$wt_head_rc)" >&2
+    if [ -n "$rev_parse_err" ] && [ -s "$rev_parse_err" ]; then
+      head -3 "$rev_parse_err" | sed 's/^/  git: /' >&2
+    fi
+    echo "  原因候補: worktree corrupt (.git file 破損) / permission denied / git binary 異常" >&2
+    echo "  対処: git worktree remove '$worktree' && bash plugins/rite/hooks/scripts/wiki-worktree-setup.sh" >&2
+    [ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
+    _vwb_restore_traps
+    return 2
+  fi
+  [ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
+  _vwb_restore_traps
+
+  if [ "$wt_head" != "$expected_branch" ]; then
+    echo "ERROR: worktree at '$worktree' is on branch '$wt_head', expected '$expected_branch'" >&2
+    echo "  hint: git -C '$worktree' checkout '$expected_branch'" >&2
+    if [ -n "$extra_hint" ]; then
+      echo "  $extra_hint" >&2
+    fi
+    return 3
+  fi
+
+  return 0
+}
+
 worktree_commit_push() {
   local worktree="$1"
   local branch="$2"
@@ -195,6 +286,10 @@ worktree_commit_push() {
   # status line — otherwise the caller sees `head=unknown; push=ok` and
   # treats it as a successful commit.
   local head_sha head_err=""
+  # cycle 3 C3-L1 fix: extend internal trap to cover head_err so SIGINT /
+  # SIGTERM / SIGHUP during the post-commit rev-parse does not leak the
+  # tempfile. Must be set BEFORE mktemp.
+  trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}" "${head_err:-}"' EXIT INT TERM HUP
   head_err=$(mktemp /tmp/rite-wtgit-head-err-XXXXXX 2>/dev/null) || head_err=""
   if head_sha=$(git -C "$worktree" rev-parse HEAD 2>"${head_err:-/dev/null}"); then
     :
@@ -221,7 +316,7 @@ worktree_commit_push() {
 
   echo "head=${head_sha}; push=${push_status}"
 
-  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}" "${head_err:-}"
   _wtgp_restore_caller_state
 
   if [[ "$push_status" == "failed" ]]; then

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -8,31 +8,35 @@
 #
 # Design rationale (Issue #549): PR #548 cycle 4 F-06 identified that the
 # add/commit/push block + error handling (stderr tempfile -> head -n 10
-# -> sed prefix) was structurally identical across the two scripts. Any
-# future enhancement (e.g. push retry with exponential backoff) would
-# require synchronous edits across both. A shared helper eliminates that
-# drift vector.
+# -> sed prefix) was structurally identical across the two scripts. A
+# shared helper removes that drift vector. PR #550 review further
+# tightened the contract so the lib does not silently toggle caller
+# shell options or clobber caller traps.
 #
 # Usage:
-#   source "$(dirname "$0")/lib/worktree-git.sh"
-#   worktree_commit_push WORKTREE COMMIT_MSG PATH1 [PATH2 ...]
+#   source "$_SCRIPT_DIR/lib/worktree-git.sh"
+#   worktree_commit_push "$worktree_path" "$wiki_branch" "$commit_msg" "$wiki_rel"
 #   rc=$?
 #   case "$rc" in
 #     0) ;;  # committed and pushed
 #     3) exit 3 ;;  # add/commit failed — error already surfaced to stderr
 #     4) push_failed=true ;;  # commit landed, push failed
-#     5) ;;  # no staged diff — caller decides policy
+#     5) ;;  # no staged diff — caller decides policy (stdout is silent)
 #   esac
 #
 # Arguments:
 #   WORKTREE      path to the worktree (caller must have validated it)
+#   BRANCH        expected branch name for the push (caller-validated;
+#                 lib does NOT re-derive via `rev-parse --abbrev-ref`
+#                 because a detached HEAD would silently fall back to
+#                 the literal "HEAD" and misclassify push failures).
 #   COMMIT_MSG    commit message (must not contain newline / CR — callers
 #                 that read from user input should validate first)
 #   PATH1...      pathspecs to `git add --`. At least one is required.
 #
 # Exit codes:
 #   0  success — committed and pushed
-#   2  argument error (missing worktree / commit message / pathspec)
+#   2  argument error (missing worktree / branch / commit message / pathspec)
 #   3  git add or commit failed (error details already on stderr)
 #   4  commit OK, push failed (caller should emit wiki_ingest_push_failed
 #      sentinel and decide whether to exit 4 or continue)
@@ -40,95 +44,156 @@
 #
 # stdout:
 #   On exit 0 or 4: "head=<sha>; push=<ok|failed>"
-#   On exit 5:      "no-staged-diff"
+#   On exit 5:      (empty — caller emits its own reason=no-staged-diff)
 #   Otherwise:      empty (errors are on stderr)
 #
 # Contract:
-#   - Does NOT set `set -euo pipefail`. Caller owns shell options.
-#   - Uses a local trap for stderr tempfile cleanup; caller's outer trap
-#     is restored via `trap - EXIT INT TERM HUP` before return.
+#   - Does NOT toggle `set -e` / `set -u` / `set -o pipefail`. The
+#     function saves the caller's `errexit` state before any `set +e`
+#     probe and restores it before return, so the caller's shell-option
+#     environment is preserved in every exit path.
+#   - Does NOT install EXIT / INT / TERM / HUP traps that persist past
+#     return. Any trap installed for internal tempfile cleanup is
+#     restored to the caller's previous trap via `trap -p` / `eval`
+#     before every return path, so the caller may install its own
+#     outer trap without surprise clobbering.
 #   - Caller must have ALREADY verified:
 #       * worktree exists at WORKTREE path
-#       * worktree HEAD is on the expected branch
+#       * worktree HEAD is on BRANCH
 #       * COMMIT_MSG has been checked for newline/CR injection
+#       * BRANCH matches the expected wiki.branch_name
 
 worktree_commit_push() {
   local worktree="$1"
-  local commit_msg="$2"
-  shift 2 2>/dev/null || true
+  local branch="$2"
+  local commit_msg="$3"
+  shift 3 || true
 
-  if [[ -z "$worktree" ]] || [[ -z "$commit_msg" ]] || [[ $# -eq 0 ]]; then
-    echo "ERROR: worktree_commit_push: WORKTREE / COMMIT_MSG / PATH... required" >&2
+  if [[ -z "$worktree" ]] || [[ -z "$branch" ]] || [[ -z "$commit_msg" ]] || [[ $# -eq 0 ]]; then
+    echo "ERROR: worktree_commit_push: WORKTREE / BRANCH / COMMIT_MSG / PATH... required" >&2
     return 2
   fi
 
-  local add_err="" commit_err="" push_err=""
-  trap 'rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"' EXIT INT TERM HUP
-  add_err=$(mktemp /tmp/rite-wtgit-add-err-XXXXXX 2>/dev/null) || add_err=""
-  commit_err=$(mktemp /tmp/rite-wtgit-commit-err-XXXXXX 2>/dev/null) || commit_err=""
-  push_err=$(mktemp /tmp/rite-wtgit-push-err-XXXXXX 2>/dev/null) || push_err=""
+  # Save caller's errexit state so we can restore it instead of force-
+  # setting `set -e` on return (contract: caller owns shell options).
+  local _wtgp_errexit=0
+  case $- in *e*) _wtgp_errexit=1 ;; esac
 
-  # Step 1: stage paths
+  # Save caller's outer traps (EXIT / INT / TERM / HUP) so we can restore
+  # them instead of clearing via `trap -`. `trap -p` output is POSIX-safe
+  # for `eval` reinput, including traps with quoted strings.
+  local _wtgp_outer_exit _wtgp_outer_int _wtgp_outer_term _wtgp_outer_hup
+  _wtgp_outer_exit=$(trap -p EXIT)
+  _wtgp_outer_int=$(trap -p INT)
+  _wtgp_outer_term=$(trap -p TERM)
+  _wtgp_outer_hup=$(trap -p HUP)
+
+  # Restore caller's errexit + outer traps; caller expects none of
+  # these to differ from their pre-call state.
+  _wtgp_restore_caller_state() {
+    # Restore traps: empty output from `trap -p` means no trap was set.
+    if [[ -n "$_wtgp_outer_exit" ]]; then eval "$_wtgp_outer_exit"; else trap - EXIT; fi
+    if [[ -n "$_wtgp_outer_int"  ]]; then eval "$_wtgp_outer_int";  else trap - INT;  fi
+    if [[ -n "$_wtgp_outer_term" ]]; then eval "$_wtgp_outer_term"; else trap - TERM; fi
+    if [[ -n "$_wtgp_outer_hup"  ]]; then eval "$_wtgp_outer_hup";  else trap - HUP;  fi
+    # Restore errexit.
+    if [[ $_wtgp_errexit -eq 1 ]]; then set -e; else set +e; fi
+  }
+
+  local add_err="" diff_err="" commit_err="" push_err=""
+  # Internal cleanup trap (EXIT only — caller's signal traps are
+  # re-applied below on any non-signal return path).
+  trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"' EXIT INT TERM HUP
+
+  # mktemp failures are surfaced to stderr (not silently swallowed) so
+  # operators can see when stderr capture is degraded to /dev/null.
+  if ! add_err=$(mktemp /tmp/rite-wtgit-add-err-XXXXXX 2>/dev/null); then
+    echo "WARNING: mktemp for worktree_commit_push add stderr capture failed — diagnostics will be lost" >&2
+    add_err=""
+  fi
+  if ! diff_err=$(mktemp /tmp/rite-wtgit-diff-err-XXXXXX 2>/dev/null); then
+    echo "WARNING: mktemp for worktree_commit_push diff stderr capture failed — diagnostics will be lost" >&2
+    diff_err=""
+  fi
+  if ! commit_err=$(mktemp /tmp/rite-wtgit-commit-err-XXXXXX 2>/dev/null); then
+    echo "WARNING: mktemp for worktree_commit_push commit stderr capture failed — diagnostics will be lost" >&2
+    commit_err=""
+  fi
+  if ! push_err=$(mktemp /tmp/rite-wtgit-push-err-XXXXXX 2>/dev/null); then
+    echo "WARNING: mktemp for worktree_commit_push push stderr capture failed — diagnostics will be lost" >&2
+    push_err=""
+  fi
+
+  # Step 1: stage paths. Quote the first pathspec in the error message
+  # to mirror the pre-refactor wiki-worktree-commit.sh format, so log
+  # greppers that anchor on `'<path>'` keep working.
+  local _first_path="$1"
   if ! git -C "$worktree" add -- "$@" 2>"${add_err:-/dev/null}"; then
-    echo "ERROR: git -C '$worktree' add failed" >&2
+    echo "ERROR: git add '$_first_path' failed in worktree '$worktree'" >&2
     [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | sed 's/^/  git: /' >&2
     echo "  hint: index lock / path error / permission denied のいずれかを確認してください" >&2
-    rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
-    trap - EXIT INT TERM HUP
+    rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+    _wtgp_restore_caller_state
     return 3
   fi
 
-  # Step 2: verify staged diff is non-empty
+  # Step 2: verify staged diff is non-empty. Use a dedicated diff_err
+  # tempfile so the add-step warnings are not mixed with diff-step
+  # errors on rc>1 — otherwise `head -n 10 "$add_err"` in the error
+  # branch would display add warnings alongside the diff failure and
+  # obscure the true root cause.
   set +e
-  git -C "$worktree" diff --cached --quiet 2>"${add_err:-/dev/null}"
+  git -C "$worktree" diff --cached --quiet 2>"${diff_err:-/dev/null}"
   local cached_rc=$?
-  set -e
+  if [[ $_wtgp_errexit -eq 1 ]]; then set -e; fi
   case "$cached_rc" in
     0)
-      echo "no-staged-diff"
-      rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
-      trap - EXIT INT TERM HUP
+      # Silent on stdout: callers emit their own `reason=no-staged-diff`
+      # status line (wiki-worktree-commit.sh / wiki-ingest-commit.sh
+      # both do this). Returning 5 is the sole signal.
+      rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+      _wtgp_restore_caller_state
       return 5
       ;;
     1) ;;  # staged diff present, proceed
     *)
-      echo "ERROR: git -C '$worktree' diff --cached --quiet failed (rc=$cached_rc)" >&2
-      [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | sed 's/^/  git: /' >&2
-      rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
-      trap - EXIT INT TERM HUP
+      echo "ERROR: git diff --cached failed in worktree '$worktree' (rc=$cached_rc)" >&2
+      [ -n "$diff_err" ] && [ -s "$diff_err" ] && head -n 10 "$diff_err" | sed 's/^/  git: /' >&2
+      rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+      _wtgp_restore_caller_state
       return 3
       ;;
   esac
 
   # Step 3: commit
   if ! git -C "$worktree" commit --quiet -m "$commit_msg" 2>"${commit_err:-/dev/null}"; then
-    echo "ERROR: git -C '$worktree' commit failed" >&2
+    echo "ERROR: git commit failed in worktree '$worktree'" >&2
     [ -n "$commit_err" ] && [ -s "$commit_err" ] && head -n 10 "$commit_err" | sed 's/^/  git: /' >&2
     echo "  hint: pre-commit hook / gpg sign / author config / permission のいずれかを確認" >&2
-    rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
-    trap - EXIT INT TERM HUP
+    rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+    _wtgp_restore_caller_state
     return 3
   fi
 
   local head_sha
   head_sha=$(git -C "$worktree" rev-parse HEAD 2>/dev/null || echo unknown)
 
-  # Step 4: push. Failure here is incident-observable (return 4) but caller
-  # owns the policy decision (continue workflow vs. hard fail).
+  # Step 4: push using the caller-supplied branch (no silent
+  # `rev-parse --abbrev-ref HEAD` fallback to literal "HEAD"). Push
+  # failure is incident-observable (return 4) but the caller owns the
+  # policy decision (continue workflow vs. hard fail).
   local push_status="ok"
-  local branch
-  branch=$(git -C "$worktree" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if ! git -C "$worktree" push --quiet origin "$branch" 2>"${push_err:-/dev/null}"; then
     push_status="failed"
-    echo "WARNING: git -C '$worktree' push origin '$branch' failed — commit is local only" >&2
+    echo "WARNING: git push origin '$branch' failed in worktree '$worktree' — commit is local only" >&2
     [ -n "$push_err" ] && [ -s "$push_err" ] && head -n 10 "$push_err" | sed 's/^/  git: /' >&2
     echo "  manual recovery: git -C '$worktree' push origin '$branch'" >&2
   fi
 
   echo "head=${head_sha}; push=${push_status}"
 
-  rm -f "${add_err:-}" "${commit_err:-}" "${push_err:-}"
-  trap - EXIT INT TERM HUP
+  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+  _wtgp_restore_caller_state
 
   if [[ "$push_status" == "failed" ]]; then
     return 4

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -57,6 +57,20 @@
 #     restored to the caller's previous trap via `trap -p` / `eval`
 #     before every return path, so the caller may install its own
 #     outer trap without surprise clobbering.
+#   - Signal-handling limitation: while this helper is executing, its
+#     internal trap OVERRIDES the caller's signal traps for EXIT / INT
+#     / TERM / HUP. Signals delivered during the helper body (e.g.
+#     user Ctrl-C while `git push` is in flight) clean up the helper's
+#     internal tempfiles only — the caller's signal-driven cleanup
+#     (e.g. stash pop on SIGINT) is NOT invoked until after the helper
+#     returns and the caller's trap is restored. Callers that need
+#     signal-safe rollback during helper execution must either wrap
+#     the helper in their own subshell or accept best-effort cleanup.
+#   - Nested function `_wtgp_restore_caller_state` leaks into the
+#     caller's global scope (bash dynamic scoping). The underscore
+#     prefix marks it as a private helper: callers MUST NOT invoke it
+#     directly from outside `worktree_commit_push`, and MUST NOT
+#     redefine a function with the same name.
 #   - Caller must have ALREADY verified:
 #       * worktree exists at WORKTREE path
 #       * worktree HEAD is on BRANCH
@@ -175,8 +189,23 @@ worktree_commit_push() {
     return 3
   fi
 
-  local head_sha
-  head_sha=$(git -C "$worktree" rev-parse HEAD 2>/dev/null || echo unknown)
+  # head_sha capture: post-commit rev-parse should normally succeed. If it
+  # fails (corrupt worktree between commit and rev-parse, extremely rare),
+  # surface a WARNING rather than silently embedding "unknown" in the
+  # status line — otherwise the caller sees `head=unknown; push=ok` and
+  # treats it as a successful commit.
+  local head_sha head_err=""
+  head_err=$(mktemp /tmp/rite-wtgit-head-err-XXXXXX 2>/dev/null) || head_err=""
+  if head_sha=$(git -C "$worktree" rev-parse HEAD 2>"${head_err:-/dev/null}"); then
+    :
+  else
+    local head_rc=$?
+    echo "WARNING: git -C '$worktree' rev-parse HEAD failed post-commit (rc=$head_rc)" >&2
+    [ -n "$head_err" ] && [ -s "$head_err" ] && head -n 5 "$head_err" | sed 's/^/  git: /' >&2
+    echo "  head SHA will be reported as 'unknown' — the commit itself succeeded but the worktree may be corrupt" >&2
+    head_sha="unknown"
+  fi
+  [ -n "$head_err" ] && rm -f "$head_err"
 
   # Step 4: push using the caller-supplied branch (no silent
   # `rev-parse --abbrev-ref HEAD` fallback to literal "HEAD"). Push

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -303,35 +303,12 @@ if [ -d "$worktree_path" ]; then
   # otherwise silently fall through to the legacy path below, which fails with
   # "fatal: '<wiki>' is already used by worktree at '...'" — masking the true
   # cause (worktree misalignment) behind a cryptic checkout error.
-  # wiki-worktree-commit.sh L213-234 uses the same capture/surface pattern; keep symmetric.
-  # cycle 5 F-01 fix: rev-parse stderr を silent 破棄せず tempfile に capture し、
-  # 失敗時に head -3 で本文を surface する (wiki-worktree-commit.sh L213-234 と対称化)。
-  wt_head=""
-  rev_parse_err=""
-  trap 'rm -f "${rev_parse_err:-}"' EXIT INT TERM HUP
-  rev_parse_err=$(mktemp /tmp/rite-wic-wt-revparse-err-XXXXXX 2>/dev/null) || rev_parse_err=""
-  set +e
-  wt_head=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>"${rev_parse_err:-/dev/null}")
-  wt_head_rc=$?
-  set -e
-  if [ "$wt_head_rc" -ne 0 ]; then
-    echo "ERROR: git -C '$worktree_path' rev-parse --abbrev-ref HEAD が失敗しました (rc=$wt_head_rc)" >&2
-    if [ -n "$rev_parse_err" ] && [ -s "$rev_parse_err" ]; then
-      head -3 "$rev_parse_err" | sed 's/^/  git: /' >&2
-    fi
-    echo "  原因候補: worktree corrupt (.git file 破損) / permission denied / git binary 異常" >&2
-    echo "  対処: git worktree remove '$worktree_path' && bash plugins/rite/hooks/scripts/wiki-worktree-setup.sh" >&2
-    [ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
-    exit 1
-  fi
-  [ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
-  trap - EXIT INT TERM HUP
-  if [ "$wt_head" != "$wiki_branch" ]; then
-    echo "ERROR: worktree at '$worktree_path' is on branch '$wt_head', expected '$wiki_branch'" >&2
-    echo "  hint: git -C '$worktree_path' checkout '$wiki_branch'" >&2
-    echo "  silent fall-through to legacy path would fail with 'already used by worktree'" >&2
-    exit 1
-  fi
+  # cycle 3 C3-M1 fix: rev-parse + stderr capture + branch compare は
+  # lib/worktree-git.sh の verify_worktree_branch() に統合済み。4th arg の extra_hint
+  # で「silent fall-through to legacy path」警告を追加して元の挙動を保持する。
+  verify_worktree_branch "$worktree_path" "$wiki_branch" "wic-wt" \
+    "silent fall-through to legacy path would fail with 'already used by worktree'" \
+    || exit 1
   # Pre-flight: validate wiki branch name (Phase 1.1 already validates but
   # defense-in-depth here since `git -C ... add -- "$path"` would silently
   # accept option-like paths if the validation were bypassed).

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -389,8 +389,15 @@ if [ -d "$worktree_path" ]; then
       # No staged diff — files already match wiki branch. Clean up dev-tree
       # duplicates so the existing drift WARNING in ingest.md does not
       # re-flag them on the next /rite:wiki:ingest run.
+      # Symmetric with the rc=0/4 branch above: rm failures are surfaced so
+      # operators can diagnose read-only FS / permission denied. Otherwise
+      # stale raw files silently re-appear as pending on the next run.
       echo "[wiki-ingest-commit] committed=0; branch=${wiki_branch}; reason=no-staged-diff (worktree path)"
-      for f in "${pending_files[@]}"; do rm -f "$f"; done
+      for f in "${pending_files[@]}"; do
+        if ! rm -f "$f"; then
+          echo "WARNING: failed to remove staged raw file from dev tree: $f (no-staged-diff path)" >&2
+        fi
+      done
       exit 0
       ;;
     *)

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -159,39 +159,16 @@ if [[ ! -f "rite-config.yml" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# rite-config.yml: wiki.enabled / wiki.branch_name / wiki.branch_strategy
-#
-# Same lenient YAML parsing approach as wiki-ingest-trigger.sh and
-# ingest.md Phase 1.1 (awk + inline-comment strip + quote strip).
+# Shared lib (Issue #549): parse_wiki_scalar / validate_wiki_branch_name /
+# worktree_commit_push. Extracted to lib/ so wiki-worktree-setup.sh /
+# wiki-worktree-commit.sh / wiki-ingest-commit.sh share a single source
+# of truth for the `wiki.branch_name` parsing contract and the worktree-
+# scoped add/commit/push flow.
 # -----------------------------------------------------------------------
-parse_wiki_scalar() {
-  # $1 = key name (e.g. "enabled" / "branch_name" / "branch_strategy")
-  #
-  # verified-review cycle 4 LOW (security/defence-in-depth): key value
-  # extraction uses awk -v rather than sed with interpolated $key. Current
-  # callers pass hardcoded literal keys only, so there is no injection
-  # path today, but sed "s/.*${key}:[[:space:]]*//" would treat sed
-  # metacharacters in $key as pattern metacharacters if a future caller
-  # ever passed user-controlled input. awk -v k=... keeps $key in a
-  # variable binding that is never re-parsed as a regex.
-  local key="$1"
-  local section line val
-  section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null || true)
-  [[ -z "$section" ]] && return 0
-  line=$(printf '%s\n' "$section" | awk -v k="$key" '
-    BEGIN { pat = "^[[:space:]]+" k ":" }
-    $0 ~ pat { print; exit }
-  ' 2>/dev/null || true)
-  [[ -z "$line" ]] && return 0
-  val=$(printf '%s' "$line" \
-    | sed 's/[[:space:]]#.*//' \
-    | awk -v k="$key" '{
-        sub("^[[:space:]]*" k ":[[:space:]]*", "")
-        print
-      }' \
-    | tr -d '[:space:]"'"'")
-  printf '%s' "$val"
-}
+# shellcheck source=lib/wiki-config.sh
+source "$(dirname "$0")/lib/wiki-config.sh"
+# shellcheck source=lib/worktree-git.sh
+source "$(dirname "$0")/lib/worktree-git.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')
@@ -205,22 +182,7 @@ esac
 wiki_branch=$(parse_wiki_scalar branch_name)
 wiki_branch="${wiki_branch:-wiki}"
 
-# MEDIUM #6 (git option injection via branch_name): validate that the
-# configured branch name is a safe git ref. Without this guard, a
-# rite-config.yml entry like `branch_name: "--upload-pack=foo"` would be
-# interpreted by subsequent `git` commands as an option flag rather than
-# a ref. We restrict to the common ref-name alphabet and forbid leading
-# dashes explicitly. Combined with the per-command `git show-ref --verify
-# refs/heads/...` style below, this is defence-in-depth.
-if [[ -z "$wiki_branch" ]] || [[ "$wiki_branch" == -* ]] || \
-   [[ "$wiki_branch" == .* ]] || \
-   [[ "$wiki_branch" == *..* ]] || \
-   [[ "$wiki_branch" == *//* ]] || \
-   [[ ! "$wiki_branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-  echo "ERROR: invalid wiki.branch_name '${wiki_branch}' in rite-config.yml" >&2
-  echo "  allowed: [A-Za-z0-9._/-]+, must not start with '-' / '.', must not contain '..' or '//'" >&2
-  exit 1
-fi
+validate_wiki_branch_name "$wiki_branch" || exit 1
 
 branch_strategy=$(parse_wiki_scalar branch_strategy)
 branch_strategy="${branch_strategy:-separate_branch}"
@@ -389,84 +351,47 @@ if [ -d "$worktree_path" ]; then
     wt_pending_paths+=(".rite/wiki/raw/${rel}")
   done
 
-  # Step W2: git add / commit / push within the worktree.
-  # cycle 4 F-01 fix: path declare → trap install → mktemp の順に並べて、
-  # mktemp 成功直後に SIGINT/SIGTERM/SIGHUP が届いた場合の orphan tmpfile を防ぐ。
-  # 同ファイルの fm_err (git fetch-merge stderr) / ref_err (git show-ref stderr) /
-  # stage_dir (legacy path の raw files staging dir) 退避用 tempfile 作成箇所と同じ
-  # canonical pattern に統一 (asymmetric fix transcription の解消)。
-  wt_add_err=""
-  wt_commit_err=""
-  wt_push_err=""
-  trap 'rm -f "${wt_add_err:-}" "${wt_commit_err:-}" "${wt_push_err:-}"' EXIT INT TERM HUP
-  wt_add_err=$(mktemp /tmp/rite-wic-wt-add-err-XXXXXX 2>/dev/null) || wt_add_err=""
-  wt_commit_err=$(mktemp /tmp/rite-wic-wt-commit-err-XXXXXX 2>/dev/null) || wt_commit_err=""
-  wt_push_err=$(mktemp /tmp/rite-wic-wt-push-err-XXXXXX 2>/dev/null) || wt_push_err=""
-
-  if ! git -C "$worktree_path" add -- "${wt_pending_paths[@]}" 2>"${wt_add_err:-/dev/null}"; then
-    echo "ERROR: git -C $worktree_path add failed for raw sources" >&2
-    [ -n "$wt_add_err" ] && [ -s "$wt_add_err" ] && head -5 "$wt_add_err" | sed 's/^/  git: /' >&2
-    exit 3
-  fi
-
-  # Confirm staged diff is non-empty (no-op early exit if files already match).
+  # Step W2: delegate the git -C "$worktree_path" add/commit/push flow to
+  # the shared helper (lib/worktree-git.sh). The helper owns stderr
+  # tempfile capture + head -n 10 extraction + exit code semantics so any
+  # future enhancement (e.g. push retry with exponential backoff) lands
+  # in one place.
   set +e
-  git -C "$worktree_path" diff --cached --quiet 2>"${wt_add_err:-/dev/null}"
-  wt_cached_rc=$?
+  wtcp_out=$(worktree_commit_push \
+    "$worktree_path" \
+    "chore(wiki): ingest ${#pending_files[@]} raw source(s) (worktree path)" \
+    "${wt_pending_paths[@]}")
+  wtcp_rc=$?
   set -e
-  case "$wt_cached_rc" in
-    0)
-      echo "[wiki-ingest-commit] committed=0; branch=${wiki_branch}; reason=no-staged-diff (worktree path)"
-      # Clean up the dev-tree raw files since they're now redundant duplicates of
-      # the worktree files (and the existing drift WARNING in ingest.md would flag
-      # them on next /rite:wiki:ingest run).
-      for f in "${pending_files[@]}"; do rm -f "$f"; done
-      rm -f "${wt_add_err:-}" "${wt_commit_err:-}" "${wt_push_err:-}"
-      trap - EXIT INT TERM HUP
+
+  case "$wtcp_rc" in
+    0|4)
+      # Success or push-failed. wtcp_out = "head=<sha>; push=<ok|failed>"
+      # Step W3: remove pending raw files from dev tree (commit succeeded).
+      for f in "${pending_files[@]}"; do
+        if ! rm -f "$f"; then
+          echo "WARNING: failed to remove staged raw file from dev tree: $f" >&2
+        fi
+      done
+      echo "[wiki-ingest-commit] committed=${#pending_files[@]}; branch=${wiki_branch}; ${wtcp_out}; via=worktree"
+      if [ "$wtcp_rc" = "4" ]; then
+        exit 4
+      fi
       exit 0
       ;;
-    1) ;;  # staged diff present, proceed
+    5)
+      # No staged diff — files already match wiki branch. Clean up dev-tree
+      # duplicates so the existing drift WARNING in ingest.md does not
+      # re-flag them on the next /rite:wiki:ingest run.
+      echo "[wiki-ingest-commit] committed=0; branch=${wiki_branch}; reason=no-staged-diff (worktree path)"
+      for f in "${pending_files[@]}"; do rm -f "$f"; done
+      exit 0
+      ;;
     *)
-      echo "ERROR: git -C $worktree_path diff --cached --quiet failed (rc=$wt_cached_rc)" >&2
-      [ -n "$wt_add_err" ] && [ -s "$wt_add_err" ] && head -5 "$wt_add_err" | sed 's/^/  git: /' >&2
+      # 3 (add/commit failure) or anything unexpected — error already on stderr
       exit 3
       ;;
   esac
-
-  if ! git -C "$worktree_path" commit -m "chore(wiki): ingest ${#pending_files[@]} raw source(s) (worktree path)" 2>"${wt_commit_err:-/dev/null}"; then
-    echo "ERROR: git -C $worktree_path commit failed" >&2
-    [ -n "$wt_commit_err" ] && [ -s "$wt_commit_err" ] && head -5 "$wt_commit_err" | sed 's/^/  git: /' >&2
-    echo "  hint: pre-commit hook / gpg sign / author config / permission のいずれかを確認" >&2
-    exit 3
-  fi
-
-  head_sha=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo unknown)
-
-  push_status="ok"
-  push_failed=false
-  if ! git -C "$worktree_path" push --quiet origin "$wiki_branch" 2>"${wt_push_err:-/dev/null}"; then
-    push_status="failed"
-    push_failed=true
-    echo "WARNING: git -C $worktree_path push origin '$wiki_branch' failed — commit is local only" >&2
-    [ -n "$wt_push_err" ] && [ -s "$wt_push_err" ] && head -5 "$wt_push_err" | sed 's/^/  git: /' >&2
-    echo "  manual recovery: git -C '$worktree_path' push origin '$wiki_branch'" >&2
-  fi
-
-  # Step W3: remove pending raw files from dev tree (commit succeeded).
-  for f in "${pending_files[@]}"; do
-    if ! rm -f "$f"; then
-      echo "WARNING: failed to remove staged raw file from dev tree: $f" >&2
-    fi
-  done
-
-  rm -f "${wt_add_err:-}" "${wt_commit_err:-}" "${wt_push_err:-}"
-  trap - EXIT INT TERM HUP
-
-  echo "[wiki-ingest-commit] committed=${#pending_files[@]}; branch=${wiki_branch}; head=${head_sha}; push=${push_status}; via=worktree"
-  if [ "$push_failed" = "true" ]; then
-    exit 4
-  fi
-  exit 0
 fi
 
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -113,6 +113,11 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   exit 1
 fi
 
+# Resolve the canonical lib path BEFORE `cd`. See wiki-worktree-setup.sh
+# for rationale — `$(dirname "$0")` after `cd` breaks under relative
+# invocation paths.
+_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
@@ -166,9 +171,9 @@ fi
 # scoped add/commit/push flow.
 # -----------------------------------------------------------------------
 # shellcheck source=lib/wiki-config.sh
-source "$(dirname "$0")/lib/wiki-config.sh"
+source "$_SCRIPT_DIR/lib/wiki-config.sh"
 # shellcheck source=lib/worktree-git.sh
-source "$(dirname "$0")/lib/worktree-git.sh"
+source "$_SCRIPT_DIR/lib/worktree-git.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')
@@ -359,6 +364,7 @@ if [ -d "$worktree_path" ]; then
   set +e
   wtcp_out=$(worktree_commit_push \
     "$worktree_path" \
+    "$wiki_branch" \
     "chore(wiki): ingest ${#pending_files[@]} raw source(s) (worktree path)" \
     "${wt_pending_paths[@]}")
   wtcp_rc=$?

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -104,6 +104,11 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   exit 1
 fi
 
+# Resolve the canonical lib path BEFORE `cd`. See wiki-worktree-setup.sh
+# for rationale — `$(dirname "$0")` after `cd` breaks under relative
+# invocation paths.
+_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
@@ -147,9 +152,9 @@ fi
 # Shared lib (Issue #549): parser/validator + worktree add/commit/push helper.
 # -----------------------------------------------------------------------
 # shellcheck source=lib/wiki-config.sh
-source "$(dirname "$0")/lib/wiki-config.sh"
+source "$_SCRIPT_DIR/lib/wiki-config.sh"
 # shellcheck source=lib/worktree-git.sh
-source "$(dirname "$0")/lib/worktree-git.sh"
+source "$_SCRIPT_DIR/lib/worktree-git.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')
@@ -308,7 +313,7 @@ fi
 # staged diff after add (no-op).
 # -----------------------------------------------------------------------
 set +e
-wtcp_out=$(worktree_commit_push "$worktree_path" "$COMMIT_MSG" "$wiki_rel")
+wtcp_out=$(worktree_commit_push "$worktree_path" "$wiki_branch" "$COMMIT_MSG" "$wiki_rel")
 wtcp_rc=$?
 set -e
 

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -144,27 +144,12 @@ if [[ ! -f "rite-config.yml" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# rite-config.yml parser (lenient, matches wiki-ingest-commit.sh)
+# Shared lib (Issue #549): parser/validator + worktree add/commit/push helper.
 # -----------------------------------------------------------------------
-parse_wiki_scalar() {
-  local key="$1"
-  local section line val
-  section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null || true)
-  [[ -z "$section" ]] && return 0
-  line=$(printf '%s\n' "$section" | awk -v k="$key" '
-    BEGIN { pat = "^[[:space:]]+" k ":" }
-    $0 ~ pat { print; exit }
-  ' 2>/dev/null || true)
-  [[ -z "$line" ]] && return 0
-  val=$(printf '%s' "$line" \
-    | sed 's/[[:space:]]#.*//' \
-    | awk -v k="$key" '{
-        sub("^[[:space:]]*" k ":[[:space:]]*", "")
-        print
-      }' \
-    | tr -d '[:space:]"'"'")
-  printf '%s' "$val"
-}
+# shellcheck source=lib/wiki-config.sh
+source "$(dirname "$0")/lib/wiki-config.sh"
+# shellcheck source=lib/worktree-git.sh
+source "$(dirname "$0")/lib/worktree-git.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')
@@ -178,20 +163,7 @@ esac
 wiki_branch=$(parse_wiki_scalar branch_name)
 wiki_branch="${wiki_branch:-wiki}"
 
-# Reject unsafe branch names (mirrors wiki-ingest-commit.sh MEDIUM #6 fix).
-# git check-ref-format 準拠のサブセット拒否 (setup.sh と対称):
-#   - 先頭が `.` (hidden ref)
-#   - `..` を含む (path traversal)
-#   - `//` を含む (refs/heads// で空セグメント)
-if [[ -z "$wiki_branch" ]] || [[ "$wiki_branch" == -* ]] || \
-   [[ "$wiki_branch" == .* ]] || \
-   [[ "$wiki_branch" == *..* ]] || \
-   [[ "$wiki_branch" == *//* ]] || \
-   [[ ! "$wiki_branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-  echo "ERROR: invalid wiki.branch_name '${wiki_branch}' in rite-config.yml" >&2
-  echo "  allowed: [A-Za-z0-9._/-]+, must not start with '-' / '.', must not contain '..' or '//'" >&2
-  exit 1
-fi
+validate_wiki_branch_name "$wiki_branch" || exit 1
 
 # -----------------------------------------------------------------------
 # Verify the worktree exists at the expected path and is on wiki_branch.
@@ -329,100 +301,33 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# Stage all changes under .rite/wiki and commit.
+# Stage all changes under .rite/wiki, commit, and push via shared helper.
+# worktree_commit_push (lib/worktree-git.sh) handles the stderr capture +
+# head -n 10 extraction pattern that was previously inlined here. Exit
+# codes: 3 = add/commit failure, 4 = commit ok / push failed, 5 = no
+# staged diff after add (no-op).
 # -----------------------------------------------------------------------
-add_idx_err=""
-trap 'rm -f "${add_idx_err:-}"' EXIT INT TERM HUP
-if ! add_idx_err=$(mktemp /tmp/rite-wwc-add-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp for add_idx_err failed — git add stderr will not be captured for diagnostics" >&2
-  add_idx_err=""
-fi
-if ! git -C "$worktree_path" add -- "$wiki_rel" >/dev/null 2>"${add_idx_err:-/dev/null}"; then
-  echo "ERROR: git add '$wiki_rel' failed in worktree" >&2
-  if [[ -n "$add_idx_err" ]] && [[ -s "$add_idx_err" ]]; then
-    head -n 10 "$add_idx_err" | sed 's/^/  git: /' >&2
-  fi
-  echo "  hint: index lock / path error / permission denied のいずれかを確認してください" >&2
-  exit 3
-fi
-[[ -n "$add_idx_err" ]] && rm -f "$add_idx_err"
-add_idx_err=""
-trap - EXIT INT TERM HUP
-
-# Re-check staged diff (the `add` may have staged zero files if everything
-# was already in the working index but matched .gitignore — defensive).
 set +e
-git -C "$worktree_path" diff --cached --quiet
-post_add_rc=$?
+wtcp_out=$(worktree_commit_push "$worktree_path" "$COMMIT_MSG" "$wiki_rel")
+wtcp_rc=$?
 set -e
-case "$post_add_rc" in
+
+case "$wtcp_rc" in
   0)
+    # "head=<sha>; push=ok"
+    echo "[wiki-worktree-commit] committed=1; branch=${wiki_branch}; ${wtcp_out}"
+    exit 0
+    ;;
+  4)
+    echo "[wiki-worktree-commit] committed=1; branch=${wiki_branch}; ${wtcp_out}"
+    exit 4
+    ;;
+  5)
     echo "[wiki-worktree-commit] committed=0; branch=${wiki_branch}; reason=no-staged-diff"
     exit 0
     ;;
-  1) ;; # staged diff present, proceed
   *)
-    echo "ERROR: git diff --cached after add failed (rc=$post_add_rc)" >&2
+    # 3 (add/commit failed) or anything unexpected — error already on stderr
     exit 3
     ;;
 esac
-
-commit_err=""
-trap 'rm -f "${commit_err:-}"' EXIT INT TERM HUP
-if ! commit_err=$(mktemp /tmp/rite-wwc-commit-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp for commit_err failed — git commit stderr will not be captured for diagnostics" >&2
-  commit_err=""
-fi
-if ! git -C "$worktree_path" commit --quiet -m "$COMMIT_MSG" 2>"${commit_err:-/dev/null}"; then
-  echo "ERROR: git commit failed in worktree" >&2
-  if [[ -n "$commit_err" ]] && [[ -s "$commit_err" ]]; then
-    head -n 10 "$commit_err" | sed 's/^/  git: /' >&2
-  fi
-  echo "  hint: pre-commit hook 失敗 / gpg sign 失敗 / author config 不在 のいずれかを確認してください" >&2
-  exit 3
-fi
-[[ -n "$commit_err" ]] && rm -f "$commit_err"
-commit_err=""
-trap - EXIT INT TERM HUP
-
-committed_sha=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo unknown)
-
-# -----------------------------------------------------------------------
-# Push with incident-observable failure semantics (exit 4).
-# Mirrors wiki-ingest-commit.sh CRITICAL #1 fix.
-# -----------------------------------------------------------------------
-push_status="ok"
-push_failed=false
-
-push_err=""
-trap 'rm -f "${push_err:-}"' EXIT INT TERM HUP
-# mktemp 失敗 (read-only /tmp / inode 枯渇 / permission denied) を silent に握り潰さず
-# WARNING で可視化する (wiki-ingest-commit.sh:559-564 の対称パターン)。
-if ! push_err=$(mktemp /tmp/rite-wwc-push-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp for push_err failed — push stderr will not be captured for diagnostics" >&2
-  echo "  hint: /tmp permission / disk space / inode exhaustion を確認してください" >&2
-  push_err=""
-fi
-
-if ! git -C "$worktree_path" push --quiet origin "$wiki_branch" 2>"${push_err:-/dev/null}"; then
-  push_status="failed"
-  push_failed=true
-  echo "WARNING: git push origin '$wiki_branch' failed — commit is local only" >&2
-  if [[ -n "$push_err" ]] && [[ -s "$push_err" ]]; then
-    head -n 10 "$push_err" | sed 's/^/  git: /' >&2
-  fi
-  echo "  manual recovery: git -C '$worktree_path' push origin '$wiki_branch'" >&2
-fi
-
-# trap action を本 push 用 push_err 削除のみに絞ってリセットすることで、将来別 trap が
-# 追加された場合に他 cleanup を巻き込まないようにする (cycle review MEDIUM #4 対応)。
-[[ -n "$push_err" ]] && rm -f "$push_err"
-push_err=""
-trap - EXIT INT TERM HUP
-
-echo "[wiki-worktree-commit] committed=1; branch=${wiki_branch}; head=${committed_sha}; push=${push_status}"
-
-if [[ "$push_failed" == "true" ]]; then
-  exit 4
-fi
-exit 0

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -185,32 +185,9 @@ fi
 # Confirm the worktree HEAD points to wiki_branch. A misaligned worktree
 # (e.g. user ran `git -C .rite/wiki-worktree checkout develop` by hand)
 # would otherwise route wiki commits onto the wrong branch.
-# stderr を tempfile に分離して、worktree corrupt / detached HEAD / branch 不在 を
-# ERROR メッセージで区別可能にする (cycle 2 MEDIUM F-13 fix)。
-rev_parse_err=""
-trap 'rm -f "${rev_parse_err:-}"' EXIT INT TERM HUP
-rev_parse_err=$(mktemp /tmp/rite-wwc-revparse-err-XXXXXX 2>/dev/null) || rev_parse_err=""
-set +e
-wt_head=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>"${rev_parse_err:-/dev/null}")
-wt_head_rc=$?
-set -e
-if [ "$wt_head_rc" -ne 0 ]; then
-  echo "ERROR: git -C '$worktree_path' rev-parse --abbrev-ref HEAD が失敗しました (rc=$wt_head_rc)" >&2
-  if [ -n "$rev_parse_err" ] && [ -s "$rev_parse_err" ]; then
-    head -3 "$rev_parse_err" | sed 's/^/  git: /' >&2
-  fi
-  echo "  原因候補: worktree corrupt (.git file 破損) / permission denied / git binary 異常" >&2
-  echo "  対処: git worktree remove '$worktree_path' && bash plugins/rite/hooks/scripts/wiki-worktree-setup.sh" >&2
-  [ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
-  exit 1
-fi
-[ -n "$rev_parse_err" ] && rm -f "$rev_parse_err"
-trap - EXIT INT TERM HUP
-if [[ "$wt_head" != "$wiki_branch" ]]; then
-  echo "ERROR: worktree at '$worktree_path' is on branch '$wt_head', expected '$wiki_branch'" >&2
-  echo "  hint: git -C '$worktree_path' checkout '$wiki_branch'" >&2
-  exit 1
-fi
+# cycle 3 C3-M1 fix: rev-parse + stderr capture + branch compare は
+# lib/worktree-git.sh の verify_worktree_branch() に統合済み。
+verify_worktree_branch "$worktree_path" "$wiki_branch" "wwc" "" || exit 1
 
 # -----------------------------------------------------------------------
 # Detect pending changes within the worktree's .rite/wiki tree.

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -51,6 +51,16 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   exit 1
 fi
 
+# Resolve the canonical lib path BEFORE `cd`. Using `$(dirname "$0")`
+# after `cd "$repo_root"` silently fails when the script is invoked via
+# a relative path (e.g. `bash ./scripts/wiki-worktree-setup.sh` from a
+# subdirectory), because `$0` stays relative and `dirname` resolves it
+# relative to the new cwd. `BASH_SOURCE[0]` + `cd -P` anchors the path
+# to the script's own file location regardless of the caller's cwd,
+# mirroring the convention used across the other hook scripts
+# (session-start.sh / stop-guard.sh / work-memory-update.sh etc.).
+_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
@@ -93,7 +103,7 @@ fi
 # rite-config.yml parser + branch name validator (shared lib, Issue #549)
 # -----------------------------------------------------------------------
 # shellcheck source=lib/wiki-config.sh
-source "$(dirname "$0")/lib/wiki-config.sh"
+source "$_SCRIPT_DIR/lib/wiki-config.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -56,9 +56,15 @@ fi
 # a relative path (e.g. `bash ./scripts/wiki-worktree-setup.sh` from a
 # subdirectory), because `$0` stays relative and `dirname` resolves it
 # relative to the new cwd. `BASH_SOURCE[0]` + `cd -P` anchors the path
-# to the script's own file location regardless of the caller's cwd,
-# mirroring the convention used across the other hook scripts
-# (session-start.sh / stop-guard.sh / work-memory-update.sh etc.).
+# to the script's own file location regardless of the caller's cwd.
+#
+# Naming convention note: sibling hook scripts (session-start.sh,
+# stop-guard.sh, work-memory-update.sh, etc.) use `SCRIPT_DIR` without
+# the underscore prefix and `cd` without `-P`. The underscore prefix
+# here marks this as a private lib-source helper (not exported for
+# external use), and `cd -P` is a defensive addition that resolves
+# symlinks to the script's physical location — both are supersets of
+# the sibling convention rather than drifts away from it.
 _SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 repo_root=$(git rev-parse --show-toplevel)

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -90,27 +90,10 @@ if [[ ! -f "rite-config.yml" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# rite-config.yml parser (lenient, matches wiki-ingest-commit.sh)
+# rite-config.yml parser + branch name validator (shared lib, Issue #549)
 # -----------------------------------------------------------------------
-parse_wiki_scalar() {
-  local key="$1"
-  local section line val
-  section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null || true)
-  [[ -z "$section" ]] && return 0
-  line=$(printf '%s\n' "$section" | awk -v k="$key" '
-    BEGIN { pat = "^[[:space:]]+" k ":" }
-    $0 ~ pat { print; exit }
-  ' 2>/dev/null || true)
-  [[ -z "$line" ]] && return 0
-  val=$(printf '%s' "$line" \
-    | sed 's/[[:space:]]#.*//' \
-    | awk -v k="$key" '{
-        sub("^[[:space:]]*" k ":[[:space:]]*", "")
-        print
-      }' \
-    | tr -d '[:space:]"'"'")
-  printf '%s' "$val"
-}
+# shellcheck source=lib/wiki-config.sh
+source "$(dirname "$0")/lib/wiki-config.sh"
 
 wiki_enabled_raw=$(parse_wiki_scalar enabled)
 wiki_enabled_norm=$(printf '%s' "$wiki_enabled_raw" | tr '[:upper:]' '[:lower:]')
@@ -124,20 +107,7 @@ esac
 wiki_branch=$(parse_wiki_scalar branch_name)
 wiki_branch="${wiki_branch:-wiki}"
 
-# Reject unsafe branch names (mirrors wiki-ingest-commit.sh MEDIUM #6 fix).
-# git check-ref-format 準拠のサブセットとして以下も明示拒否する:
-#   - 先頭が `.` (hidden ref と紛れる)
-#   - `..` を含む (path traversal リスク)
-#   - `//` を含む (refs/heads// で空セグメント)
-if [[ -z "$wiki_branch" ]] || [[ "$wiki_branch" == -* ]] || \
-   [[ "$wiki_branch" == .* ]] || \
-   [[ "$wiki_branch" == *..* ]] || \
-   [[ "$wiki_branch" == *//* ]] || \
-   [[ ! "$wiki_branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-  echo "ERROR: invalid wiki.branch_name '${wiki_branch}' in rite-config.yml" >&2
-  echo "  allowed: [A-Za-z0-9._/-]+, must not start with '-' / '.', must not contain '..' or '//'" >&2
-  exit 1
-fi
+validate_wiki_branch_name "$wiki_branch" || exit 1
 
 # -----------------------------------------------------------------------
 # Verify the wiki branch exists locally. Remote-only existence is a skip.

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -206,15 +206,17 @@ fi
 # under pipefail aborts the entire script. We split the pipeline into stages and
 # explicitly tolerate empty results so missing keys lenient-fall-through to "not false".
 #
-# Note — YAML パースロジック同期: 本ブロックの YAML パースは以下の 4 箇所に同型のロジックが存在する
-# (F-23 修正版: awk + YAML コメント除去 + クォート除去):
+# Note — YAML パースロジック同期: Issue #549 で canonical 実装が
+# `hooks/scripts/lib/wiki-config.sh` の `parse_wiki_scalar()` / `validate_wiki_branch_name()`
+# に集約された。本スクリプト / wiki-growth-check.sh / commands/wiki/ingest.md Phase 1.1 の
+# 3 箇所は lib 化対象外のまま残存しているため、lib 側の parse 契約を変更する場合は以下の
+# 残存 3 箇所と動作を同期すること:
 #   1. 本スクリプト (wiki-ingest-trigger.sh) — lenient (false/no/0 のみ reject)
-#   2. hooks/scripts/wiki-ingest-commit.sh — `parse_wiki_scalar` helper、lenient だが stderr 退避は
-#      簡素化されている (shell deterministic commit path 用、MEDIUM #8 in PR #529 で sync 範囲に追加)
-#   3. hooks/scripts/wiki-growth-check.sh — lenient (layer 3 growth stall 検出用。wiki.enabled /
-#      wiki.branch_name / wiki.growth_check.threshold_prs を参照。PR #529 cycle 2 MEDIUM で sync 範囲に追加)
-#   4. commands/wiki/ingest.md Phase 1.1 — strict 4 分岐 (page integration 用)
-# パース方式を変更する場合は 4 箇所全てを同期すること。wiki-patterns.md の reference パターンも参照先。
+#   2. hooks/scripts/wiki-growth-check.sh — lenient (layer 3 growth stall 検出用)
+#   3. commands/wiki/ingest.md Phase 1.1 — strict 4 分岐 (page integration 用)
+# lib/wiki-config.sh が canonical 定義。lib 化済みの script
+# (wiki-ingest-commit.sh / wiki-worktree-commit.sh / wiki-worktree-setup.sh) は source して
+# 同一実装を共有するため、上記 3 箇所を lib に統合する場合は別 Issue で追跡すること。
 if [[ -f "rite-config.yml" ]]; then
   # cycle 9 MEDIUM fix: sed/awk の stderr を tempfile に捕捉 (silent swallow 禁止)。
   # 旧実装 `2>/dev/null || wiki_section=""` は grep no-match だけでなく sed/awk の構文エラー /


### PR DESCRIPTION
## 概要

PR #548 cycle 4 レビューで指摘された shell scripts 間の重複 helper（F-05 `parse_wiki_scalar()` の 3-way duplication、F-06 worktree fast path の構造的 duplication）を、`plugins/rite/hooks/scripts/lib/` を新設して shared lib に集約する。

## 背景

3 scripts (`wiki-worktree-setup.sh` / `wiki-worktree-commit.sh` / `wiki-ingest-commit.sh`) で `parse_wiki_scalar()` / branch name validation regex / worktree add/commit/push エラーハンドリングブロックが character-exact な重複状態だった。ペア修正が必要になるたびに drift 事故リスクが発生する構造的問題。

## 変更内容

### 新設
- `plugins/rite/hooks/scripts/lib/wiki-config.sh`
  - `parse_wiki_scalar()` — rite-config.yml の `wiki:` セクション lenient YAML parser
  - `validate_wiki_branch_name()` — branch name 形式の defensive validation
- `plugins/rite/hooks/scripts/lib/worktree-git.sh`
  - `worktree_commit_push()` — worktree-scoped add / commit / push + stderr tempfile capture + head -n 10 抽出

### 既存 script の修正
- `wiki-worktree-setup.sh` / `wiki-worktree-commit.sh` / `wiki-ingest-commit.sh` が新 lib を `source` するよう修正
- inline 定義を削除し、`worktree_commit_push` 呼出に置換

## 効果

- 重複行数: 3 scripts 合計で **-200 lines**（270 removed / 70 added）
- 将来の push retry / exponential backoff など機能追加時の修正箇所が 1 ファイルに集約
- `wiki.branch_name` parsing 契約の single source of truth が確立

## 検証

- `bash -n` 全 scripts pass
- `wiki-worktree-setup.sh` → `status=already`
- `wiki-worktree-commit.sh --dry-run` → `reason=no-pending`
- `wiki-ingest-commit.sh --dry-run` → `reason=no-pending`
- Plugin-specific checks: bang-backtick/doc-heavy/wiki-growth 全て 0 findings
- drift check は 32 件検出されたが全て pre-existing（`commands/pr/fix.md` / `commands/pr/review.md`、本 PR 範囲外）

## 関連

Closes #549
- 元の PR: #548
- 元の Issue: #547

## Known Issues

- `/rite:lint` はコマンド未設定（`commands.lint: null`）のためスキップ。plugin-specific checks のみ実行

## Test plan

- [x] bash -n syntax check
- [x] wiki-worktree-setup.sh idempotent 動作（既存 worktree で status=already）
- [x] wiki-worktree-commit.sh / wiki-ingest-commit.sh の --dry-run が既存挙動を保つ
- [ ] /rite:wiki:ingest 実ワークフロー発火実績（マージ後、次 PR サイクルで確認）
- [ ] /rite:pr:cleanup 経由の auto-ingest が回帰しない（同上）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
