### PR TITLE
docs(wiki): 設計書 line 69 に canonical identifier missing_concept / unregistered_raw を追記

### DIFF
--- a/docs/designs/experience-heuristics-persistence-layer.md
+++ b/docs/designs/experience-heuristics-persistence-layer.md
@@ -66,7 +66,7 @@ rite ワークフロー実行時に関連経験則を自動参照し、コンテ
 | 実行方法 | タイミング | 検出対象 |
 |---------|----------|---------|
 | 自動 | Ingest 時 | 新規ページと既存ページの矛盾 |
-| 手動 | `/rite:wiki:lint` コマンド | 矛盾、陳腐化、孤児ページ、欠落概念、未登録 raw（ingest:skip 済、informational、`n_warnings` 不加算）、壊れた相互参照 |
+| 手動 | `/rite:wiki:lint` コマンド | 矛盾、陳腐化、孤児ページ、欠落概念 (`missing_concept`)、未登録 raw (`unregistered_raw`、ingest:skip 済、informational、`n_warnings` 不加算)、壊れた相互参照 |
 
 #### F5: インデックスとログ
 


### PR DESCRIPTION
## 概要

`docs/designs/experience-heuristics-persistence-layer.md:69` の narrative JA に canonical identifier `missing_concept` / `unregistered_raw` をリテラル backtick 形式で併記し、identifier 検索（`Grep "missing_concept" docs/`）で design doc もヒットするようにする。

## 背景

Issue #569 参照。README / SPEC.md / SPEC.ja.md は canonical identifier を `欠落概念 (\`missing_concept\`)` / `未登録 raw (\`unregistered_raw\`、informational — \`n_warnings\` 不加算)` 形式で記載しているが、設計書の line 69 は narrative JA のみで canonical identifier を含まなかった。

## 変更内容

- `docs/designs/experience-heuristics-persistence-layer.md:69` を README/SPEC と同じパターンに揃えた（1 行の置換）

## 検証

- `grep -n "missing_concept" docs/designs/experience-heuristics-persistence-layer.md` で該当行がヒット
- `grep -n "unregistered_raw" docs/designs/experience-heuristics-persistence-layer.md` で同行がヒット
- 他ファイル（SPEC.md / SPEC.ja.md / README.md）の canonical 表記箇所数は変更前後で同じ（drift 無し）

## 関連

Closes #569

元の PR: #564（tech-writer レビューでスコープ外推奨事項として検出）
