### PR TITLE
fix(wiki): lint Phase 6.2 awk frontmatter terminator 検出で誤抽出リスク排除 (#570)

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -1030,6 +1030,10 @@ while IFS= read -r page; do
     # post-condition: page-template.md / wiki branch の実 page の両方で `extracted >= 1` になること。
     page_refs=$(printf '%s\n' "$page_content" | awk -v diag="${awk_diag:-/dev/null}" -v page="$page" '
       /^sources:/ { in_sources=1; sources_seen++; next }
+      # Issue #570: frontmatter terminator (`---`) を明示検出。
+      # minimal frontmatter (sources: 直後に `---` で閉じる、tags:/confidence: なし) でも
+      # sources 節が確実に閉じ、body 内 YAML code block の `    ref: "..."` 誤抽出を防ぐ。
+      in_sources && /^---[[:space:]]*$/ { in_sources=0; next }
       in_sources && /^[a-zA-Z]/ { in_sources=0 }
       in_sources && /^[[:space:]]*-[[:space:]]*ref:[[:space:]]/ {
         # legacy 単行形式: `- ref: "..."` (dash と ref が同一行)


### PR DESCRIPTION
## Summary

- lint Phase 6.2 の awk に `^---[[:space:]]*$` 終端検出を追加し、minimal frontmatter (sources: 直後に `---` で閉じ、tags:/confidence: なし) でも body 内 YAML code block の `    ref: "..."` が誤抽出されないよう decisive に排除
- canonical template (L9-10 に tags:/confidence: あり) では `^[a-zA-Z]` 先行マッチで同一挙動を維持、既存挙動に regression なし
- Issue #570 で指摘された hypothetical failure mode を 1 行追加で排除（lint 側 enforce ではなく awk 側改善の代替案を採用）

## Changes

- `plugins/rite/commands/wiki/lint.md` L1033 に `in_sources && /^---[[:space:]]*$/ { in_sources=0; next }` を追加
- 変更意図を説明するコメント 3 行を追加

## Test plan

- [x] 手元で 3 パターン (canonical / minimal / legacy 単行) の awk を実行し、期待通りの抽出結果を確認
  - canonical: `raw/pr-123.md` のみ抽出（body code block 無視）
  - minimal: `raw/pr-456.md` のみ抽出（Issue #570 の誤抽出リスクが排除されることを確認）
  - legacy `- ref:` 形式: `raw/legacy.md` 抽出
- [ ] `/rite:wiki:lint` 実行で regression なし
- [ ] PR #564 の完了条件 (missing_concept=0 / unregistered_raw=0) が引き続き満たされる

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)