### PR TITLE
refactor(wiki): lint Phase 6.0 same_branch 成功経路に selective surface を追加

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -693,6 +693,11 @@ case "$branch_strategy" in
     # を防ぐ。git show 側も同じ理由で LC_ALL=C で統一 (本 PR では cat 側のみ影響あるが defense-in-depth)。
     if log_content=$(LC_ALL=C cat .rite/wiki/log.md 2>"${log_err:-/dev/null}"); then
       log_read_ok="true"
+      # selective surface pattern: cat は通常 stderr を成功経路で emit しないが、separate_branch
+      # 成功経路 (直上 git show) と対称化するため同型 surface を配置する (Issue #571)。
+      # BSD cat 等が diagnostic を emit する稀なケースで silent に warning を握りつぶさないための
+      # defense-in-depth であり、LC_ALL=C による locale 固定との併用で対称性を完成させる。
+      [ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | sed 's/^/  WARNING(cat hint): /' >&2
     else
       rc=$?
       if [ -n "$log_err" ] && [ -s "$log_err" ] && grep -qE "No such file or directory|cannot open" "$log_err"; then


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/lint.md` Phase 6.0 の `same_branch` 成功経路に、`separate_branch` 成功経路と同型の selective surface pattern を追加し、両経路の挙動を対称化します。

`separate_branch` (line 657) では `git show` 成功時でも stderr に残った ambiguous ref hint 等を `WARNING(git hint):` で可視化する selective surface が存在しましたが、`same_branch` (line 694) の `cat` 成功経路には同等の surface が欠けていました。本 PR で `WARNING(cat hint):` prefix の surface を追加し、対称化します。

## 関連 Issue

Closes #571

元 PR: #564 (code-quality レビュアーの観察：重要度なし / Observed Likelihood: Hypothetical)

## 変更内容

- `plugins/rite/commands/wiki/lint.md` (line 695 直後、+5 行)
  - `log_read_ok="true"` 直後に `[ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | sed 's/^/  WARNING(cat hint): /' >&2` を追加
  - 対称化目的と「`cat` は通常 stderr を成功経路で emit しない」旨の説明コメント (3 行) を併記

## 検証

- `grep -n "WARNING(cat hint)" plugins/rite/commands/wiki/lint.md` → `same_branch` 成功経路に 1 件マッチ（line 700）
- 既存 `WARNING(git hint)` は 2 件のまま維持（Phase 2.3 index + Phase 6.0 separate_branch）
- `cat` が diagnostic を emit する稀なケース（BSD cat 等）でのみ warning が発火するため、通常運用時の副作用なし

## 実装上の意図

- `cat` は通常 stderr を成功経路で emit しない（Issue #571 の元レビューコメント通り、実害は低い）
- ただし BSD/macOS 環境や将来的な locale 変更で silent に warning を握りつぶさないための defense-in-depth
- `LC_ALL=C` による locale 固定との併用で、`separate_branch` と完全対称の失敗許容設計を実現

## チェックリスト

- [ ] プロジェクト規約に準拠
- [ ] 影響範囲の動作確認 (grep 検証済み)
- [ ] 既存の対称性 (Phase 2.3 / Phase 6.0 separate_branch) を破壊していない

## Known Issues

- lint 未実行: rite-config.yml で `commands.lint: null`、言語ファイル未配置のため本リポジトリでは lint コマンドが検出されない既知の運用（ユーザー選択により skip）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)

## 検出された問題（別 Issue として追跡）

- #577: Phase 2.3 same_branch index 読出成功経路に selective surface を追加し対称化する (Phase 6.0 対称化の続編)
