### PR TITLE
fix(hooks): session-start.sh の session ownership 判定を通常パスに復活 (#558)

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -247,23 +247,44 @@ if [ "$ACTIVE" != "true" ]; then
   exit 0
 fi
 
-# --- Defensive reset helper (#761, #173, #206) ---
-# Shared by startup and clear blocks. Resets active=false and shows a soft message.
-# Always proceeds with reset regardless of session ownership (#206).
+# --- Defensive reset helper (#558, #761, #173, #206) ---
+# Shared by startup and clear blocks. Resets active=false on phase != completed.
+#
+# When the state is owned by another active session (check_session_ownership
+# returns "other"), skip the reset — overwriting another session's active state
+# would clobber its in-flight work memory and trip stop-guard whitelist
+# violations on its next phase transition. For "own" / "legacy" / "stale" /
+# fail-safe paths, proceed with reset (crash-recovery and backward-compat take
+# priority over multi-instance protection).
+#
+# Regression note (#558): a prior commit moved the check_session_ownership call
+# inside an RITE_DEBUG block as a "performance" optimization, silently disabling
+# multi-instance protection in normal runs. DO NOT re-enclose check_session_ownership
+# in conditional gates — it must run on every reset path so the "other" branch can fire.
+#
 # Note: This function always terminates via exit 0 — it never returns to the caller.
 # When issue_number is empty (e.g., state file has no issue), exits silently without message.
 _reset_active_state() {
-  local _phase _issue _branch
+  local _phase _issue _branch _ownership
   _phase=$(jq -r '.phase // ""' "$STATE_FILE" 2>/dev/null) || _phase=""
   _issue=$(jq -r '.issue_number // "" | tostring' "$STATE_FILE" 2>/dev/null) || _issue=""
   _branch=$(jq -r '.branch // ""' "$STATE_FILE" 2>/dev/null) || _branch=""
 
-  # Debug log for session ownership diagnostics (#206)
-  if [ -n "${RITE_DEBUG:-}" ]; then
-    local _ownership
+  # Session ownership check runs on the normal execution path (#558), not just RITE_DEBUG.
+  # Fail-safe: if the helper isn't sourced or returns non-zero, treat as "unknown"
+  # and proceed with reset — crash-recovery takes priority over multi-instance protection.
+  if command -v check_session_ownership >/dev/null 2>&1; then
     _ownership=$(check_session_ownership "$INPUT" "$STATE_FILE" 2>/dev/null) || _ownership="unknown"
-    echo "[rite] Resetting active state (ownership: $_ownership)" >&2
+  else
+    _ownership="unknown"
   fi
+
+  if [ "$_ownership" = "other" ]; then
+    [ -n "${RITE_DEBUG:-}" ] && echo "[rite] Skipping reset (state owned by other session)" >&2
+    exit 0
+  fi
+
+  [ -n "${RITE_DEBUG:-}" ] && echo "[rite] Resetting active state (ownership: $_ownership)" >&2
 
   # Atomic write: jq to temp file, then mv. No trap — explicit cleanup on failure.
   local _tmp

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -277,6 +277,7 @@ _reset_active_state() {
     _ownership=$(check_session_ownership "$INPUT" "$STATE_FILE" 2>/dev/null) || _ownership="unknown"
   else
     _ownership="unknown"
+    [ -n "${RITE_DEBUG:-}" ] && echo "[rite] ownership check unavailable (check_session_ownership not sourced)" >&2
   fi
 
   if [ "$_ownership" = "other" ]; then

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -708,6 +708,43 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-T04b (#558 / review M-EH1): check_session_ownership unavailable + RITE_DEBUG=1
+#                                 → debug log "ownership check unavailable" 出力 (AC-04 spec)
+# --------------------------------------------------------------------------
+echo "TC-T04b (#558): helper undefined + RITE_DEBUG=1 → 'ownership check unavailable' debug log"
+dirT04b="$TEST_DIR/tcT04b"
+mkdir -p "$dirT04b/sandbox/hooks"
+sandbox_hook_dir_b="$dirT04b/sandbox/hooks"
+src_hook_dir_b="$(cd "$SCRIPT_DIR/.." && pwd)"
+cp "$src_hook_dir_b/session-start.sh" "$sandbox_hook_dir_b/"
+cp "$src_hook_dir_b/hook-preamble.sh" "$sandbox_hook_dir_b/"
+cp "$src_hook_dir_b/state-path-resolve.sh" "$sandbox_hook_dir_b/"
+cat > "$sandbox_hook_dir_b/session-ownership.sh" <<'STUB_EOF'
+#!/bin/bash
+extract_session_id() { echo ""; }
+get_state_session_id() { echo ""; }
+parse_iso8601_to_epoch() { echo 0; }
+STUB_EOF
+ts_t04b=$(iso8601_now 0)
+cat > "$dirT04b/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 204, "branch": "feat/issue-204-debuglog", "phase": "implementing", "session_id": "ses-T04b-state", "updated_at": "$ts_t04b"}
+EOF
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+output=$(jq -n --arg cwd "$dirT04b" --arg src "startup" --arg sid "ses-T04b-hook" \
+  '{cwd: $cwd, source: $src, session_id: $sid}' \
+  | RITE_DEBUG=1 bash "$sandbox_hook_dir_b/session-start.sh" 2>"$LAST_STDERR_FILE") && rc=0 || rc=$?
+stderr_content=$(cat "$LAST_STDERR_FILE")
+ACTIVE_AFTER=$(jq -r '.active' "$dirT04b/.rite-flow-state" 2>/dev/null)
+if [ $rc -eq 0 ] && [ "$ACTIVE_AFTER" = "false" ] \
+   && echo "$stderr_content" | grep -q "ownership check unavailable" \
+   && echo "$stderr_content" | grep -q "check_session_ownership not sourced"; then
+  pass "TC-T04b: helper undefined + RITE_DEBUG → debug log 'ownership check unavailable' shown"
+else
+  fail "TC-T04b: expected debug log 'ownership check unavailable'; got rc=$rc, active=$ACTIVE_AFTER, stderr='$stderr_content'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # TC-T05 (#558): static grep — old comment removed (AC-05)
 # --------------------------------------------------------------------------
 echo "TC-T05 (#558): static grep — old comment 'Always proceeds with reset...' removed"

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -70,6 +70,34 @@ run_hook_with_source() {
   return $rc
 }
 
+# Helper: run session-start hook with CWD, source, and explicit session_id (#558)
+# Produces a hook JSON payload containing session_id so check_session_ownership
+# can compare against the state file's session_id.
+run_hook_with_session() {
+  local cwd="$1"
+  local source="$2"
+  local session_id="$3"
+  local rc=0
+  local output
+  LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+  output=$(jq -n --arg cwd "$cwd" --arg src "$source" --arg sid "$session_id" \
+    '{cwd: $cwd, source: $src, session_id: $sid}' \
+    | bash "$HOOK" 2>"$LAST_STDERR_FILE") || rc=$?
+  echo "$output"
+  return $rc
+}
+
+# ISO 8601 timestamp helper for state files (#558)
+# Args: $1 = offset in seconds (negative = past, default 0 = now)
+iso8601_now() {
+  local offset="${1:-0}"
+  if date -u -d "@$(( $(date +%s) + offset ))" +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null; then
+    return 0
+  fi
+  # macOS fallback
+  date -u -r "$(( $(date +%s) + offset ))" +"%Y-%m-%dT%H:%M:%S+00:00"
+}
+
 echo "=== session-start.sh tests ==="
 echo ""
 
@@ -572,6 +600,125 @@ if [ $rc -eq 0 ] && [ -z "$output" ] && [ "$ACTIVE_AFTER" = "false" ]; then
   pass "source=startup + no issue_number → silent reset (no message because ISSUE is empty)"
 else
   fail "Expected exit 0, no output, active=false. Got rc=$rc, active=$ACTIVE_AFTER, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-T01 (#558): own-session startup → reset (session_id matches)
+# --------------------------------------------------------------------------
+echo "TC-T01 (#558): own-session startup → reset proceeds"
+dirT01="$TEST_DIR/tcT01"
+mkdir -p "$dirT01"
+sid_t01="ses-T01-$(date +%s)"
+ts_t01=$(iso8601_now 0)
+cat > "$dirT01/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 200, "branch": "feat/issue-200-own", "phase": "implementing", "session_id": "$sid_t01", "updated_at": "$ts_t01"}
+EOF
+
+output=$(run_hook_with_session "$dirT01" "startup" "$sid_t01") && rc=0 || rc=$?
+ACTIVE_AFTER=$(jq -r '.active' "$dirT01/.rite-flow-state" 2>/dev/null)
+if [ $rc -eq 0 ] && [ "$ACTIVE_AFTER" = "false" ] && echo "$output" | grep -q "前回のセッション状態が残っていたためリセットしました"; then
+  pass "TC-T01: own-session → reset (active=false, message shown)"
+else
+  fail "TC-T01: expected own-session reset; got rc=$rc, active=$ACTIVE_AFTER, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-T02 (#558): other-session startup → SKIP reset (file unchanged)
+# --------------------------------------------------------------------------
+echo "TC-T02 (#558): other-session startup → reset skipped (regression guard)"
+dirT02="$TEST_DIR/tcT02"
+mkdir -p "$dirT02"
+sid_state="ses-T02-state-$(date +%s)"
+sid_hook="ses-T02-hook-$(date +%s)"
+ts_t02=$(iso8601_now 0)
+state_t02='{"active": true, "issue_number": 201, "branch": "feat/issue-201-other", "phase": "implementing", "session_id": "'"$sid_state"'", "updated_at": "'"$ts_t02"'"}'
+printf '%s' "$state_t02" > "$dirT02/.rite-flow-state"
+mtime_before=$(stat -c '%Y' "$dirT02/.rite-flow-state" 2>/dev/null || stat -f '%m' "$dirT02/.rite-flow-state")
+content_before=$(cat "$dirT02/.rite-flow-state")
+sleep 1  # ensure mtime resolution can detect a change
+
+output=$(run_hook_with_session "$dirT02" "startup" "$sid_hook") && rc=0 || rc=$?
+mtime_after=$(stat -c '%Y' "$dirT02/.rite-flow-state" 2>/dev/null || stat -f '%m' "$dirT02/.rite-flow-state")
+content_after=$(cat "$dirT02/.rite-flow-state")
+ACTIVE_AFTER=$(jq -r '.active' "$dirT02/.rite-flow-state" 2>/dev/null)
+if [ $rc -eq 0 ] && [ "$ACTIVE_AFTER" = "true" ] && [ -z "$output" ] && [ "$content_before" = "$content_after" ] && [ "$mtime_before" = "$mtime_after" ]; then
+  pass "TC-T02: other-session → file unchanged (active=true, no output, mtime preserved)"
+else
+  fail "TC-T02: expected file unchanged; got rc=$rc, active=$ACTIVE_AFTER, output='$output', mtime_before=$mtime_before mtime_after=$mtime_after, content_diff=$([ "$content_before" = "$content_after" ] && echo no || echo yes)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-T03 (#558): legacy state (no session_id) startup → reset (backward compat)
+# --------------------------------------------------------------------------
+echo "TC-T03 (#558): legacy state (no session_id) startup → reset"
+dirT03="$TEST_DIR/tcT03"
+mkdir -p "$dirT03"
+ts_t03=$(iso8601_now 0)
+cat > "$dirT03/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 202, "branch": "feat/issue-202-legacy", "phase": "implementing", "updated_at": "$ts_t03"}
+EOF
+
+output=$(run_hook_with_session "$dirT03" "startup" "ses-T03-hook") && rc=0 || rc=$?
+ACTIVE_AFTER=$(jq -r '.active' "$dirT03/.rite-flow-state" 2>/dev/null)
+if [ $rc -eq 0 ] && [ "$ACTIVE_AFTER" = "false" ] && echo "$output" | grep -q "前回のセッション状態が残っていたためリセットしました"; then
+  pass "TC-T03: legacy state → reset (active=false, message shown)"
+else
+  fail "TC-T03: expected legacy state reset; got rc=$rc, active=$ACTIVE_AFTER, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-T04 (#558): check_session_ownership unavailable → fail-safe reset
+# Sandbox: copy session-start.sh + dependencies, replace session-ownership.sh
+# with a stub that fails to define the function → command -v false → reset
+# --------------------------------------------------------------------------
+echo "TC-T04 (#558): check_session_ownership unavailable → fail-safe reset"
+dirT04="$TEST_DIR/tcT04"
+mkdir -p "$dirT04/sandbox/hooks"
+sandbox_hook_dir="$dirT04/sandbox/hooks"
+src_hook_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
+cp "$src_hook_dir/session-start.sh" "$sandbox_hook_dir/"
+cp "$src_hook_dir/hook-preamble.sh" "$sandbox_hook_dir/"
+cp "$src_hook_dir/state-path-resolve.sh" "$sandbox_hook_dir/"
+# Stub session-ownership.sh: define helpers that don't break source, but omit check_session_ownership
+cat > "$sandbox_hook_dir/session-ownership.sh" <<'STUB_EOF'
+#!/bin/bash
+# Test stub: check_session_ownership intentionally NOT defined
+extract_session_id() { echo ""; }
+get_state_session_id() { echo ""; }
+parse_iso8601_to_epoch() { echo 0; }
+STUB_EOF
+ts_t04=$(iso8601_now 0)
+cat > "$dirT04/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 203, "branch": "feat/issue-203-failsafe", "phase": "implementing", "session_id": "ses-T04-state", "updated_at": "$ts_t04"}
+EOF
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+output=$(jq -n --arg cwd "$dirT04" --arg src "startup" --arg sid "ses-T04-hook" \
+  '{cwd: $cwd, source: $src, session_id: $sid}' \
+  | bash "$sandbox_hook_dir/session-start.sh" 2>"$LAST_STDERR_FILE") && rc=0 || rc=$?
+ACTIVE_AFTER=$(jq -r '.active' "$dirT04/.rite-flow-state" 2>/dev/null)
+if [ $rc -eq 0 ] && [ "$ACTIVE_AFTER" = "false" ] && echo "$output" | grep -q "前回のセッション状態が残っていたためリセットしました"; then
+  pass "TC-T04: check_session_ownership undefined → fail-safe reset (active=false)"
+else
+  fail "TC-T04: expected fail-safe reset; got rc=$rc, active=$ACTIVE_AFTER, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-T05 (#558): static grep — old comment removed (AC-05)
+# --------------------------------------------------------------------------
+echo "TC-T05 (#558): static grep — old comment 'Always proceeds with reset...' removed"
+HOOK_FILE="$SCRIPT_DIR/../session-start.sh"
+# grep -c always prints the count to stdout (0 with exit 1 if no matches), so use || true (not || echo 0) to avoid double-printed "0".
+old_match_count=$(grep -c "Always proceeds with reset regardless of session ownership" "$HOOK_FILE" 2>/dev/null || true)
+old_match_count=${old_match_count:-0}
+if [ "$old_match_count" = "0" ]; then
+  pass "TC-T05: old comment 'Always proceeds with reset regardless of session ownership' removed (0 matches)"
+else
+  fail "TC-T05: old comment still present ($old_match_count matches in $HOOK_FILE)"
 fi
 echo ""
 


### PR DESCRIPTION
## 概要

`session-start.sh` の `_reset_active_state()` が `check_session_ownership` を `RITE_DEBUG` 条件内でしか呼ばず、**通常実行時は他セッション所有の active state を無条件 reset** していた回帰を修正する。

回帰の経緯: #206 で「他セッションの active 状態をリセットしない」方針を導入後、`2b0c2efd` の review 指摘 (LOW: performance) 対応で `check_session_ownership` 呼び出しが `RITE_DEBUG` 条件内に押し込められ、debug-only ログにしか使われなくなった。結果として multi-instance 保護 invariant が silently 失われた。

## 関連 Issue

Closes #558

Extends: #206 (回帰修正)

## 変更内容

### `plugins/rite/hooks/session-start.sh`

`_reset_active_state()` を以下のように修正:

1. `check_session_ownership` を `RITE_DEBUG` 条件外（通常パス）で呼ぶ
2. 戻り値が `"other"` の場合は reset を skip して `exit 0`
3. fail-safe: `command -v check_session_ownership` で helper 不在を検知し、未定義/失敗時は `_ownership="unknown"` にフォールバックして reset 実行（crash recovery を multi-instance 保護より優先）
4. L252 のコメントを `# Always proceeds with reset regardless of session ownership (#206).` から `# When the state is owned by another active session ... skip the reset` に修正
5. 再発防止コメントとして「performance 最適化のために `check_session_ownership` 呼び出しを条件分岐で隠さない」旨を明記

### `plugins/rite/hooks/tests/session-start.test.sh`

回帰防止テスト 5 件と test helper を追加:

| ID | Category | 検証内容 |
|----|----------|---------|
| TC-T01 | Non-regression | 自セッション所有 state (session_id 一致) → reset 実行 (active=false, message 出力) |
| TC-T02 | Happy (本修正の核心) | 他セッション所有 state (session_id 不一致 + updated_at recent) → reset スキップ (ファイル mtime / 内容維持) |
| TC-T03 | Non-regression | session_id 欠落の legacy state → reset 実行 (後方互換) |
| TC-T04 | Error | sandbox 環境で `check_session_ownership` 未定義 → fail-safe で reset 実行 |
| TC-T05 | Compat (static) | 旧コメント文字列 `Always proceeds with reset regardless of session ownership` の grep が 0 マッチ |

`run_hook_with_session` ヘルパーを追加し、hook JSON に `session_id` フィールドを含められるようにした。

## Acceptance Criteria 検証

| AC | 状態 | 検証手段 |
|----|------|---------|
| AC-01 自セッション state は reset される | ✅ | TC-T01 PASS |
| AC-02 他セッション active state は変更されない | ✅ | TC-T02 PASS (mtime + 内容両方検証) |
| AC-03 legacy state は reset される | ✅ | TC-T03 PASS |
| AC-04 fail-safe で reset 実行 | ✅ | TC-T04 PASS (sandbox で helper 削除) |
| AC-05 旧コメント文字列の grep が 0 マッチ | ✅ | TC-T05 PASS |

**DoD #4 (2 インスタンス並行起動の手動確認)**: 自動テスト T-02 がコードレベルで等価な保護を verify しているため、本 PR では automated guard で代替する方針 (Issue 中で確認済み)。

## 仕様調整 (Decision Log D-05)

Issue 4.3 では `check_session_ownership` の戻り値を `"self"` / `"other"` / `"unknown"` / `"legacy"` と記載していたが、実装は `"own"` / `"legacy"` / `"other"` / `"stale"` を返す（`session-ownership.sh` の Decision Matrix 参照）。修正コードは実装の実値に従い `"other"` のみ skip 分岐。`"own"` / `"legacy"` / `"stale"` / 未定義 / 失敗のいずれも reset 実行。

## テスト結果

```
=== session-start.sh tests ===
...
=== Results: 32 passed, 0 failed ===
```

既存 TC-001〜TC-027 (27 件) は全て非回帰、新規 TC-T01〜TC-T05 (5 件) は全て PASS。

## Known Issues (out-of-scope, pre-existing on develop)

以下は本 PR の変更範囲外、かつ develop ブランチに既存する warning。同じ commit を develop checkout して再実行し件数一致を確認済み:

- `distributed-fix-drift-check`: 32 findings (pr/fix.md / pr/review.md 等)
- `bang-backtick-check`: 1 finding (wiki/references/bash-cross-boundary-state-transfer.md:153)

これらは別 Issue で追跡すべき内容で、本 PR の scope (`session-start.sh` + そのテスト) には含めない。

## Test Plan

- [x] `bash plugins/rite/hooks/tests/session-start.test.sh` 全 PASS (32/32)
- [x] AC-01〜AC-05 を T-01〜T-05 で verify
- [x] develop checkout で warning 件数を再確認 (本 PR で増えていないこと)
- [x] 非対象ファイル (`stop-guard.sh` / `session-end.sh` / `session-ownership.sh` 本体) untouched (`git diff --stat` で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
