### PR TITLE
feat(skills): wiki SKILL.md Auto-Activation Keywords に 6 lint カテゴリを追加 (#565)

### DIFF
--- a/plugins/rite/skills/wiki/SKILL.md
+++ b/plugins/rite/skills/wiki/SKILL.md
@@ -8,7 +8,9 @@ description: |
   unregistered raw sources, and broken references, or initialize the Wiki structure.
   Activates on "wiki", "ingest", "query", "lint", "経験則", "知識ページ",
   "Wiki 蓄積", "経験則を残す", "経験則を参照", "Wiki 検索", "Wiki Lint",
-  "Wiki 品質", "wiki:init", "wiki:ingest", "wiki:query", "wiki:lint",
+  "Wiki 品質", "missing_concept", "欠落概念", "unregistered_raw",
+  "未登録 raw", "broken_refs", "壊れた相互参照",
+  "wiki:init", "wiki:ingest", "wiki:query", "wiki:lint",
   "/rite:wiki:".
 ---
 
@@ -21,7 +23,7 @@ description: |
 - wiki, Wiki, 経験則, 知識ページ
 - ingest, 蓄積, 経験則を残す
 - query, 経験則を参照, Wiki 検索
-- lint, Wiki Lint, Wiki 品質, 矛盾チェック, 陳腐化, 孤児ページ
+- lint, Wiki Lint, Wiki 品質, 矛盾チェック, 陳腐化, 孤児ページ, 欠落概念, missing_concept, 未登録 raw, unregistered_raw, 壊れた相互参照, broken_refs
 - `/rite:wiki:init`, `/rite:wiki:ingest`, `/rite:wiki:query`, `/rite:wiki:lint`
 
 ## アーキテクチャ概要


### PR DESCRIPTION
## 概要

- PR #564 で導入した 6 lint カテゴリ名（`contradictions` / `stale` / `orphans` / `missing_concept` / `unregistered_raw` / `broken_refs`）のうち、description block は更新済みだったが、`## Auto-Activation Keywords` 章は 3 カテゴリ（矛盾チェック / 陳腐化 / 孤児ページ）しかカバーしておらず drift が発生していた。
- description block の `Activates on` リストと Auto-Activation Keywords 章の両方に、欠落していた 3 カテゴリ（`missing_concept` / `欠落概念`、`unregistered_raw` / `未登録 raw`、`broken_refs` / `壊れた相互参照`）を追加し、両者の lint カテゴリ集合を完全一致させた。
- これによりユーザーが「未登録 raw」「欠落概念」「壊れた相互参照」等で query した際の skill auto-activation が確実に発火するようになる。

## 関連 Issue

Closes #565

## 変更内容

- `plugins/rite/skills/wiki/SKILL.md`
  - description block（YAML frontmatter）の `Activates on` リストに 6 キーワード追加
  - `## Auto-Activation Keywords` 章の lint 行（L24）に同 6 キーワード追加（既存の日本語キーワードは保持）

## テスト計画

- [x] lint 実行（`/rite:lint`）→ 本 PR 対象ファイルに関する drift/bang-backtick 検出なし
- [x] description block 内で 6 キーワード全件が検出される（`grep -oE '"(missing_concept|欠落概念|unregistered_raw|未登録 raw|broken_refs|壊れた相互参照)"'` で 6 件）
- [x] Auto-Activation Keywords 章で 6 キーワード全件が検出される

## 背景・レビュー指摘

元の PR: #564
レビュアー: prompt-engineer-reviewer（推奨 #4）
指摘: SKILL.md description scope drift — description は 6 カテゴリで更新済みだが、Auto-Activation Keywords は 3 カテゴリのまま

## Definition of Done

- [x] `plugins/rite/skills/wiki/SKILL.md` の Activation Keywords に 4 キーワード（`unregistered_raw` / `未登録 raw` / `欠落概念` / `missing_concept`）が含まれる
- [x] description block と Keywords の lint カテゴリ集合が一致する（drift なし）
  - DoD #2 を厳格に満たすため `broken_refs` / `壊れた相互参照` も追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
