### PR TITLE
feat(lint): /rite:lint Phase 3.9 に .gitignore health check を追加 (#567)

### DIFF
--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -1731,6 +1731,8 @@ rite workflow は `/rite:issue:start` の一気通貫実行中に発生する **
 | `manual_fallback_adopted` | ユーザーが orchestrator の `AskUserQuestion` で「手動 Edit fallback」を選択 | Orchestrator fallback prompts (Phase 5.2 lint:aborted, Phase 5.3 pr:create-failed, Phase 5.4.4 fix:error, Phase 5.5 ready:error) |
 | `wiki_ingest_skipped` (#524) | `wiki.enabled=false` または `wiki.auto_ingest=false` により Phase X.X.W (`pr/review.md` 6.5.W / `pr/fix.md` 4.6.W / `issue/close.md` 4.4.W) が Wiki ingest pipeline を skip した場合 | サブスキルが Phase X.X.W Step 1 から `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=...` status line と共に sentinel を emit |
 | `wiki_ingest_failed` (#524) | `wiki-ingest-trigger.sh` が Phase X.X.W で 0 / 2 以外の exit code で終了した場合 | サブスキルが Phase X.X.W Step 3 から `[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_{n}` status line と共に sentinel を emit |
+| `wiki_ingest_push_failed` (#555) | `wiki-ingest-commit.sh` が exit 4 で終了 — local wiki branch への commit は成功したが origin push が失敗した場合 (Phase X.X.W.2 で発生) | サブスキルが `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` status line と共に sentinel を emit |
+| `gitignore_drift` (#567) | `/rite:lint` Phase 3.9 で `.gitignore` の `.rite/wiki/` ルール (PR #564 の最終防御線) が欠落、または `same_branch` 戦略で negation エントリが欠落を検出 | `gitignore-health-check.sh` が drift 検出時に `workflow-incident-emit.sh` 経由で sentinel を emit |
 
 ### Sentinel フォーマット
 
@@ -1742,7 +1744,7 @@ rite workflow は `/rite:issue:start` の一気通貫実行中に発生する **
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|-----|------|
-| `type` | enum | 必須 | `skill_load_failure` / `hook_abnormal_exit` / `manual_fallback_adopted` / `wiki_ingest_skipped` / `wiki_ingest_failed` のいずれか (最後の 2 種は #524 で追加) |
+| `type` | enum | 必須 | `skill_load_failure` / `hook_abnormal_exit` / `manual_fallback_adopted` / `wiki_ingest_skipped` / `wiki_ingest_failed` (#524) / `wiki_ingest_push_failed` (#555) / `gitignore_drift` (#567) のいずれか |
 | `details` | string | 必須 | 1 行の incident description (semicolon は comma に置換、改行は除去) |
 | `root_cause_hint` | string | 任意 | 原因仮説 (空の場合は sentinel から省略) |
 | `iteration_id` | string | 必須 | `{pr_number}-{epoch_seconds}` 形式の追跡 ID |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1588,6 +1588,8 @@ The rite workflow auto-detects **workflow blockers** during `/rite:issue:start` 
 | `manual_fallback_adopted` | User selects "manual Edit fallback" option in any orchestrator `AskUserQuestion` | Orchestrator fallback prompts (Phase 5.2 lint:aborted, Phase 5.3 pr:create-failed, Phase 5.4.4 fix:error, Phase 5.5 ready:error) |
 | `wiki_ingest_skipped` (#524) | `wiki.enabled=false` or `wiki.auto_ingest=false` causes Phase X.X.W (`pr/review.md` 6.5.W / `pr/fix.md` 4.6.W / `issue/close.md` 4.4.W) to skip the Wiki ingest pipeline | Sub-skill emits sentinel from Phase X.X.W Step 1 along with `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=...` status line |
 | `wiki_ingest_failed` (#524) | `wiki-ingest-trigger.sh` exits with a non-zero code other than 2 (exit 2 = Wiki disabled/uninitialized = legitimate skip) during Phase X.X.W | Sub-skill emits sentinel from Phase X.X.W Step 3 along with `[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_{n}` status line |
+| `wiki_ingest_push_failed` (#555) | `wiki-ingest-commit.sh` exits 4 — commit landed locally on the wiki branch but origin push failed during Phase X.X.W.2 | Sub-skill emits sentinel along with `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` status line |
+| `gitignore_drift` (#567) | `/rite:lint` Phase 3.9 detects that the `.rite/wiki/` rule (PR #564 last-line-of-defense) is missing from `.gitignore`, OR `same_branch` strategy lacks the required negation entry | `gitignore-health-check.sh` emits sentinel via `workflow-incident-emit.sh` when drift is detected |
 
 ### Sentinel Format
 
@@ -1599,7 +1601,7 @@ The `root_cause_hint` field is **optional** and entirely omitted from the sentin
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | enum | yes | One of `skill_load_failure` / `hook_abnormal_exit` / `manual_fallback_adopted` / `wiki_ingest_skipped` / `wiki_ingest_failed` (the last two added in #524) |
+| `type` | enum | yes | One of `skill_load_failure` / `hook_abnormal_exit` / `manual_fallback_adopted` / `wiki_ingest_skipped` / `wiki_ingest_failed` (#524) / `wiki_ingest_push_failed` (#555) / `gitignore_drift` (#567) |
 | `details` | string | yes | One-line incident description (semicolons replaced by commas, newlines stripped) |
 | `root_cause_hint` | string | no | Optional cause hypothesis (omitted from sentinel if empty) |
 | `iteration_id` | string | yes | `{pr_number}-{epoch_seconds}` for traceability |

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1299,7 +1299,7 @@ Invoke `skill: "rite:pr:fix"`.
 
 #### 5.4.4.1 Workflow Incident Detection (#366, expanded by #524)
 
-> **Reference**: This section detects **workflow blockers** (Skill load failure, hook abnormal exit, manual fallback adoption, **Wiki ingest skip / failure**) and auto-registers them as Issues to prevent silent loss. See [docs/SPEC.md](../../../../docs/SPEC.md#workflow-incident-detection) for the full specification.
+> **Reference**: This section detects **workflow blockers** (Skill load failure, hook abnormal exit, manual fallback adoption, **Wiki ingest skip / failure**, **Gitignore drift**) and auto-registers them as Issues to prevent silent loss. See [docs/SPEC.md](../../../../docs/SPEC.md#workflow-incident-detection) for the full specification.
 
 **Detection scope** — recognised sentinel `type` values:
 
@@ -1311,8 +1311,9 @@ Invoke `skill: "rite:pr:fix"`.
 | `wiki_ingest_skipped` | review/fix/close Phase X.X.W when `wiki.enabled=false` / `wiki.auto_ingest=false` (#524), **OR** `wiki-ingest-commit.sh` exits 2 (wiki branch missing locally — fresh clone, #528 PR #529) | AskUserQuestion → register Issue / skip. Two sub-cases: (a) **configuration disable** (`wiki.enabled=false` / `auto_ingest=false`) is intentional — user typically skips; (b) **`commit_branch_missing`** is an operational state on fresh clones — recommended action is to run `git fetch origin wiki:wiki` or `/rite:wiki:init` and re-run the enclosing phase, rather than creating a tracking Issue |
 | `wiki_ingest_failed` | review/fix/close Phase X.X.W when `wiki-ingest-trigger.sh` exits non-zero / non-2 (#524), **OR** `wiki-ingest-commit.sh` exits non-0/2/4 (git stash/checkout/commit failure, #528 PR #529) | AskUserQuestion → register Issue / skip — recommended to register because both trigger and commit paths are supposed to be reliable |
 | `wiki_ingest_push_failed` | review/fix/close Phase X.X.W when `wiki-ingest-commit.sh` exits 4 — commit landed locally on the wiki branch but origin push failed (#528 PR #529, addresses the silent-success regression) | AskUserQuestion → register Issue / skip — recommended to **register** because the local commit is preserved but origin diverges from local. Manual recovery: `git push origin wiki` on the enclosing dev branch once connectivity / auth is restored |
+| `gitignore_drift` | `/rite:lint` Phase 3.9 when `gitignore-health-check.sh` detects that the `.rite/wiki/` rule (PR #564 last-line-of-defense) is missing from `.gitignore`, OR when `same_branch` strategy lacks the required negation entry (#567) | AskUserQuestion → register Issue / skip — recommended to **register** because a missing `.rite/wiki/` rule allows wiki-ingest-trigger.sh temporary writes to leak into develop branch PR diffs. Manual recovery: restore the `.rite/wiki/` entry (and `!.rite/wiki/` negation for `same_branch`) to `.gitignore` |
 
-The processing flow below applies uniformly to all six types — there is no per-type branching beyond the table above.
+The processing flow below applies uniformly to all seven types — there is no per-type branching beyond the table above.
 
 **Sub-case routing note for `wiki_ingest_skipped` with `reason=commit_branch_missing`**: when the sentinel `details` field or the accompanying `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=commit_branch_missing` status line indicates the operational fresh-clone sub-case, the AskUserQuestion offered here defaults to **"skip"** (no tracking Issue) and shows the recovery hint as the primary option: run `git fetch origin wiki:wiki` on the current working tree, then re-run the enclosing phase. Creating a tracking Issue for `commit_branch_missing` would be an anti-pattern because the state is transient and user-resolvable within seconds. The configuration-disable sub-case retains the existing behaviour (the prompt makes the state visible but user typically skips).
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -676,10 +676,10 @@ fi
 |-----------|---------------------------|--------|
 | 0 | `success` | `.rite/wiki/` rule healthy (or legitimate no-op: wiki disabled / `rite-config.yml` absent — script handled internally and returned 0 with `findings: 0`) — continue to Phase 4 |
 | 1 | `warning` | Drift detected — record as **warning** (does NOT cause `[lint:error]`). A `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel is also emitted on stdout so Phase 5.4.4.1 can auto-register a tracking Issue. Display findings and allow flow to continue |
-| 2 | `error` | Invocation error (not in git repo, etc.) — record as warning, display error message |
+| 2 | `error` | Invocation error (not in git repo, `git check-ignore` failure, `same_branch` 戦略で probe file 作成不能 — read-only filesystem / permission denied / disk full 等) — record as warning, display error message |
 | -1 | `skipped` | Script not found (marketplace install without `hooks/scripts/`) — skip silently |
 
-**Important**: Gitignore health check results are treated as **warnings**, not errors — same policy as Phase 3.5 / 3.6 / 3.7 / 3.8 checks. A finding does NOT change the overall lint result pattern (`[lint:success]` remains `[lint:success]`). Issue #567 explicitly mandates this non-blocking contract — the check exists to detect regression immediately while not halting merges.
+**Important**: Gitignore health check results are treated as **warnings**, not errors — same policy as Phase 0.6 / 3.5 / 3.6 / 3.7 / 3.8 checks. A finding does NOT change the overall lint result pattern (`[lint:success]` remains `[lint:success]`). Issue #567 explicitly mandates this non-blocking contract — the check exists to detect regression immediately while not halting merges.
 
 **Record gitignore health check results** for Phase 4 reporting:
 - `gitignore_health_status`: `success` / `warning` / `error` / `skipped`
@@ -788,7 +788,7 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {verify_terminal_output}
 ```
 
-**Gitignore health check appendix (Issue #567)** (both standalone and E2E): When `gitignore_health_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output. The appendix output includes both the stderr WARNING and the `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel from stdout (merged via `2>&1` at invocation) so the sentinel reaches the orchestrator's conversation context where Phase 5.4.4.1 grep detects it:
+**Gitignore health check appendix (Issue #567)** (both standalone and E2E): When `gitignore_health_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output. When status is `warning` (exit 1, drift detected), the appendix output includes both the stderr WARNING and the `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel from stdout (merged via `2>&1` at invocation) so the sentinel reaches the orchestrator's conversation context where Phase 5.4.4.1 grep detects it. When status is `error` (exit 2, invocation failure), the script exits before sentinel emit so the appendix contains only the stderr ERROR diagnostic:
 
 ```
 ⚠️ Gitignore health check: {gitignore_health_finding_count} findings detected ({gitignore_health_status}, non-blocking)

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -651,6 +651,41 @@ fi
 - `wiki_growth_finding_count`: Extract from `wiki_growth_output` by matching the line `==> Total wiki-growth-check findings: N` (regex: `/Total wiki-growth-check findings: (\d+)/`). If no match found, default to 0
 - `wiki_growth_output`: Script output (truncated if >50 lines)
 
+### 3.9 Plugin-specific Checks (Gitignore Health Check) — Issue #567
+
+Execute the gitignore health check script to detect regressions of the `.rite/wiki/` exclusion rule that PR #564 added as the last line of defense against wiki-ingest-trigger.sh silent leaks on the develop branch. If a future `.gitignore` cleanup PR removes the rule, this check surfaces the drift before the leak reaches production. See `plugins/rite/hooks/scripts/gitignore-health-check.sh` header for the strategy-aware detection contract (separate_branch uses `git check-ignore`; same_branch uses `git add --dry-run` because negation rules make `git check-ignore` non-deterministic per `.gitignore` L101-113 spec).
+
+**Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
+
+**Skip condition**: Only the script's own absence (e.g., marketplace install without `hooks/scripts/` directory) makes lint.md skip the entire Phase 3.9. All other no-op cases (`wiki.enabled=false`, `rite-config.yml` absent, wiki section absent) are handled **inside** `gitignore-health-check.sh`, which returns exit 0 with `findings: 0`.
+
+**Execution:**
+
+```bash
+if [ -f {plugin_root}/hooks/scripts/gitignore-health-check.sh ]; then
+  gitignore_health_output=$(bash {plugin_root}/hooks/scripts/gitignore-health-check.sh --quiet 2>&1)
+  gitignore_health_exit_code=$?
+else
+  gitignore_health_exit_code=-1  # script not found
+fi
+```
+
+**Result handling:**
+
+| Exit Code | `gitignore_health_status` | Action |
+|-----------|---------------------------|--------|
+| 0 | `success` | `.rite/wiki/` rule healthy (or legitimate no-op: wiki disabled / `rite-config.yml` absent — script handled internally and returned 0 with `findings: 0`) — continue to Phase 4 |
+| 1 | `warning` | Drift detected — record as **warning** (does NOT cause `[lint:error]`). A `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel is also emitted on stdout so Phase 5.4.4.1 can auto-register a tracking Issue. Display findings and allow flow to continue |
+| 2 | `error` | Invocation error (not in git repo, etc.) — record as warning, display error message |
+| -1 | `skipped` | Script not found (marketplace install without `hooks/scripts/`) — skip silently |
+
+**Important**: Gitignore health check results are treated as **warnings**, not errors — same policy as Phase 3.5 / 3.6 / 3.7 / 3.8 checks. A finding does NOT change the overall lint result pattern (`[lint:success]` remains `[lint:success]`). Issue #567 explicitly mandates this non-blocking contract — the check exists to detect regression immediately while not halting merges.
+
+**Record gitignore health check results** for Phase 4 reporting:
+- `gitignore_health_status`: `success` / `warning` / `error` / `skipped`
+- `gitignore_health_finding_count`: Extract from `gitignore_health_output` by matching the line `==> Total gitignore-health-check findings: N` (regex: `/Total gitignore-health-check findings: (\d+)/`). If no match found, default to 0
+- `gitignore_health_output`: Script output (truncated if >50 lines)
+
 ---
 
 ## Phase 4: Report Results
@@ -753,7 +788,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {verify_terminal_output}
 ```
 
-These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, or terminal-output warnings/invocation errors.
+**Gitignore health check appendix (Issue #567)** (both standalone and E2E): When `gitignore_health_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output. The appendix output includes both the stderr WARNING and the `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel from stdout (merged via `2>&1` at invocation) so the sentinel reaches the orchestrator's conversation context where Phase 5.4.4.1 grep detects it:
+
+```
+⚠️ Gitignore health check: {gitignore_health_finding_count} findings detected ({gitignore_health_status}, non-blocking)
+{gitignore_health_output}
+```
+
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, or gitignore-health warnings/invocation errors.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 
@@ -829,6 +871,7 @@ Analyze the error content and present fix suggestions when possible:
 | Doc-heavy patterns drift check | {doc_heavy_drift_status} ({doc_heavy_drift_finding_count} findings) |
 | Wiki growth check (#524) | {wiki_growth_status} ({wiki_growth_finding_count} findings) |
 | Terminal output check (#561) | {verify_terminal_status} ({verify_terminal_finding_count} findings) |
+| Gitignore health check (#567) | {gitignore_health_status} ({gitignore_health_finding_count} findings) |
 | {i18n:lint_duration} | {duration} |
 
 {i18n:lint_next_steps}:
@@ -839,7 +882,7 @@ Analyze the error content and present fix suggestions when possible:
 > **{i18n:lint_standalone_note}**: {i18n:lint_standalone_note_detail}
 ```
 
-**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Terminal output check (#561)` row follows the same policy as `Wiki growth check`: omit when `verify_terminal_status` is `skipped` (marketplace install without hooks directory), and display with `success` / `warning` / `error` otherwise. **Asymmetry note**: The `{i18n:lint_drift_check}` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. Phase 3.7 (`Doc-heavy patterns drift check`) and Phase 3.8 (`Wiki growth check`) and Phase 0.6 (`Terminal output check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
+**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Terminal output check (#561)` row follows the same policy as `Wiki growth check`: omit when `verify_terminal_status` is `skipped` (marketplace install without hooks directory), and display with `success` / `warning` / `error` otherwise. The `Gitignore health check (#567)` row follows the same policy: omit when `gitignore_health_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = healthy rule / legitimate no-op; `warning` = drift detected; `error` = invocation failure). **Asymmetry note**: The `{i18n:lint_drift_check}` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. Phase 3.7 (`Doc-heavy patterns drift check`) and Phase 3.8 (`Wiki growth check`) and Phase 0.6 (`Terminal output check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -56,17 +56,33 @@
 #
 set -uo pipefail
 
+# Resolve script directory early using POSIX-portable idiom.
+# `readlink -f` is a GNU extension unsupported by macOS BSD readlink — using it
+# would silently fall back to an empty string when coreutils is absent, and the
+# sentinel emit site (`$_SCRIPT_DIR/../workflow-incident-emit.sh`) would resolve
+# to a relative path under CWD (cd'd to REPO_ROOT later), breaking drift
+# detection silently. Peer scripts (wiki-ingest-commit.sh / wiki-worktree-*.sh)
+# all use this same `cd -P "$(dirname "${BASH_SOURCE[0]}")"` pattern.
+_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Signal-specific trap (canonical pattern from references/bash-trap-patterns.md):
 # - EXIT preserves original exit code via `rc=$?`
 # - INT/TERM/HUP exit with POSIX-conventional codes (130/143/129)
 # - Tempfiles + same_branch probe file are cleaned in all paths
+# - BSD/macOS rm portability: empty-arg guard via `[ -n "${var:-}" ] && rm -f "$var"`
+#   (some BSD rm variants emit "cannot remove ''" on empty args)
 check_ignore_err=""
 add_dry_err=""
 negation_probe=""
 _rite_gitignore_cleanup() {
-  rm -f "${check_ignore_err:-}" "${add_dry_err:-}"
+  [ -n "${check_ignore_err:-}" ] && rm -f "$check_ignore_err"
+  [ -n "${add_dry_err:-}" ] && rm -f "$add_dry_err"
   # same_branch probe file: always remove so lint runs never pollute the tree
   [ -n "${negation_probe:-}" ] && rm -f "${negation_probe}" 2>/dev/null
+  # Also remove the probe parent directories (.rite/wiki/raw/, .rite/wiki/) if this
+  # script created them and they are empty. `rmdir` fails on non-empty directories,
+  # which protects pre-existing raw source files from being unintentionally removed.
+  rmdir .rite/wiki/raw .rite/wiki 2>/dev/null || true
 }
 trap 'rc=$?; _rite_gitignore_cleanup; exit $rc' EXIT
 trap '_rite_gitignore_cleanup; exit 130' INT
@@ -205,9 +221,11 @@ parent_rule_line=""
 if [ "$check_ignore_rc" -eq 0 ]; then
   # `git check-ignore -v` output: `<source>:<line>:<pattern>\t<path>`
   # The pattern field contains `.rite/wiki/` (or a more specific subpath rule)
-  # when the parent exclusion is healthy. For separate_branch, this is the
-  # health check. For same_branch we also need layer 2 (negation verify).
-  if printf '%s' "$check_ignore_out" | grep -qE '(^|[[:space:]:]|!)\.rite/wiki/'; then
+  # when the parent exclusion is healthy. The pattern field is always preceded
+  # by a colon (`:` separator after line number) in this output format, so a
+  # minimal `:<pattern>` match is sufficient and avoids the `.rite/wiki/` path
+  # field (suffix) from producing a false positive.
+  if printf '%s' "$check_ignore_out" | grep -qE ':\.rite/wiki/'; then
     parent_rule_matched=1
     parent_rule_line="$check_ignore_out"
   fi
@@ -231,15 +249,22 @@ case "$branch_strategy" in
     # cannot deterministically verify negation. Use `git add --dry-run` with a real
     # probe file (cleaned up by trap on exit).
     negation_probe=".rite/wiki/raw/.rite-lint-negation-probe"
+    # mkdir/touch failure classified as invocation error (exit 2) so lint.md
+    # Phase 3.9 Result handling routes it to the `error` branch (recorded as
+    # warning with diagnostic message) rather than silent healthy skip (exit 0).
+    # This distinguishes "verify impossible due to env constraint" (exit 2) from
+    # "rule healthy" (exit 0), matching the header L45-L49 exit code contract.
     mkdir -p "$(dirname "$negation_probe")" 2>/dev/null || {
-      echo "WARNING: gitignore-health-check: cannot mkdir $(dirname "$negation_probe") — same_branch negation verify skipped" >&2
+      echo "ERROR: gitignore-health-check: cannot mkdir $(dirname "$negation_probe")" >&2
+      echo "  対処: read-only filesystem / permission / disk full のいずれかを確認してください" >&2
       echo "==> Total gitignore-health-check findings: 0"
-      exit 0
+      exit 2
     }
     touch "$negation_probe" 2>/dev/null || {
-      echo "WARNING: gitignore-health-check: cannot touch $negation_probe — same_branch negation verify skipped" >&2
+      echo "ERROR: gitignore-health-check: cannot touch $negation_probe" >&2
+      echo "  対処: read-only filesystem / permission / disk full のいずれかを確認してください" >&2
       echo "==> Total gitignore-health-check findings: 0"
-      exit 0
+      exit 2
     }
 
     add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
@@ -268,11 +293,10 @@ esac
 
 # --- Emit sentinel on drift ---
 if [ "$findings" -gt 0 ]; then
-  # Delegate sentinel formatting to workflow-incident-emit.sh. Resolve script path
-  # relative to this script so the script still works when invoked via absolute
-  # path from lint.md (with {plugin_root} substitution).
-  script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-  emit_script="$script_dir/../workflow-incident-emit.sh"
+  # Delegate sentinel formatting to workflow-incident-emit.sh. `$_SCRIPT_DIR`
+  # was resolved at the top of this script using the POSIX-portable
+  # `cd -P "$(dirname "${BASH_SOURCE[0]}")"` idiom (macOS BSD-compatible).
+  emit_script="$_SCRIPT_DIR/../workflow-incident-emit.sh"
   if [ -f "$emit_script" ]; then
     # Emit to stdout so the sentinel reaches the orchestrator's conversation context.
     # `|| true` preserves non-blocking contract (emit failure must not halt lint).

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# gitignore-health-check.sh
+#
+# Verify that `.gitignore` still excludes `.rite/wiki/` — the last-line-of-defense
+# rule added in PR #564 that prevents wiki-ingest-trigger.sh temporary writes from
+# silently leaking into the develop branch PR diff. If a future `.gitignore`
+# cleanup PR inadvertently removes this rule, the regression must be detected
+# immediately (Issue #567).
+#
+# Detection strategy (strategy-aware, per `.gitignore` header L101-113 spec):
+#
+#   separate_branch (default): `.rite/wiki/` must be ignored outright.
+#       Use `git check-ignore -v .rite/wiki/raw/.rite-lint-probe` with a probe
+#       path (no real file created — git evaluates the path pattern statically).
+#       A healthy state returns rc=0 and the matched pattern contains
+#       `.rite/wiki/`. Any other outcome is drift.
+#
+#   same_branch: `.rite/wiki/` exclusion must have a negation override so
+#       `git add .rite/wiki/...` works during /rite:wiki:ingest on the same
+#       branch. Per `.gitignore` spec, `git check-ignore -v` is NOT deterministic
+#       under negation rules — it can return rc=0/1 for both healthy and broken
+#       states. `git add --dry-run` is the canonical sanity check.
+#       We create a real probe file, run `git add --dry-run` on it, and verify
+#       rc=0 + stdout contains `add '...negation-probe'`. The probe is cleaned
+#       up regardless of outcome via the signal-specific trap below.
+#
+# On drift, emit a `gitignore_drift` workflow incident sentinel on stdout so
+# Phase 5.4.4.1 in start.md can auto-register a tracking Issue.
+#
+# Issue #567 — `.gitignore` silent-leak regression guard.
+# Companion to:
+#   - PR #564: added `.rite/wiki/` to `.gitignore` as last-line-of-defense
+#   - plugins/rite/hooks/workflow-incident-emit.sh: sentinel formatter
+#   - plugins/rite/commands/lint.md Phase 3.9: invocation site
+#
+# Usage:
+#   gitignore-health-check.sh [--repo-root DIR] [--quiet]
+#                             [--branch-strategy-override STRATEGY] [-h|--help]
+#
+# Options:
+#   --repo-root DIR                   Repository root (default: git rev-parse --show-toplevel)
+#   --quiet                           Suppress informational output
+#   --branch-strategy-override VAL    Override wiki.branch_strategy from rite-config.yml
+#                                     (one of: separate_branch | same_branch) — smoke test only
+#   -h, --help                        Show this help
+#
+# Exit codes (non-blocking contract, identical to drift-check / wiki-growth-check):
+#   0  Health verified (or wiki disabled / legitimate no-op — skip silently)
+#   1  Drift detected (warning — caller MUST keep [lint:success])
+#   2  Invocation error (bad args, missing repo)
+#
+# Output:
+#   Always prints `==> Total gitignore-health-check findings: N` on stdout.
+#   On drift (exit 1), additionally prints a `[CONTEXT] WORKFLOW_INCIDENT=1;
+#   type=gitignore_drift; ...` sentinel line via workflow-incident-emit.sh.
+#
+set -uo pipefail
+
+# Signal-specific trap (canonical pattern from references/bash-trap-patterns.md):
+# - EXIT preserves original exit code via `rc=$?`
+# - INT/TERM/HUP exit with POSIX-conventional codes (130/143/129)
+# - Tempfiles + same_branch probe file are cleaned in all paths
+check_ignore_err=""
+add_dry_err=""
+negation_probe=""
+_rite_gitignore_cleanup() {
+  rm -f "${check_ignore_err:-}" "${add_dry_err:-}"
+  # same_branch probe file: always remove so lint runs never pollute the tree
+  [ -n "${negation_probe:-}" ] && rm -f "${negation_probe}" 2>/dev/null
+}
+trap 'rc=$?; _rite_gitignore_cleanup; exit $rc' EXIT
+trap '_rite_gitignore_cleanup; exit 130' INT
+trap '_rite_gitignore_cleanup; exit 143' TERM
+trap '_rite_gitignore_cleanup; exit 129' HUP
+
+REPO_ROOT=""
+QUIET=0
+STRATEGY_OVERRIDE=""
+
+usage() {
+  cat <<'EOF'
+Usage: gitignore-health-check.sh [options]
+
+Options:
+  --repo-root DIR                   Repository root (default: git rev-parse --show-toplevel)
+  --quiet                           Suppress informational output
+  --branch-strategy-override VAL    Override wiki.branch_strategy (separate_branch | same_branch)
+                                    Used for smoke testing only; production runs read rite-config.yml.
+  -h, --help                        Show this help
+
+Exit codes:
+  0  Health verified (or wiki disabled / legitimate no-op)
+  1  Drift detected (warning, non-blocking)
+  2  Invocation error
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root)                 REPO_ROOT="$2"; shift 2 ;;
+    --quiet)                     QUIET=1; shift ;;
+    --branch-strategy-override)  STRATEGY_OVERRIDE="$2"; shift 2 ;;
+    -h|--help)                   usage; exit 0 ;;
+    *) echo "ERROR: Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+log_info() {
+  [ "$QUIET" -eq 0 ] && echo "$@"
+}
+
+# --- Resolve repo root ---
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "ERROR: not inside a git repository (git rev-parse --show-toplevel failed)" >&2
+    echo "==> Total gitignore-health-check findings: 0"
+    exit 2
+  }
+fi
+cd "$REPO_ROOT" || {
+  echo "ERROR: cannot cd to repo root: $REPO_ROOT" >&2
+  echo "==> Total gitignore-health-check findings: 0"
+  exit 2
+}
+
+# --- Read config ---
+config_file="rite-config.yml"
+if [ ! -f "$config_file" ]; then
+  log_info "gitignore-health-check: rite-config.yml not found, skipping (exit 0)"
+  echo "==> Total gitignore-health-check findings: 0"
+  exit 0
+fi
+
+wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' "$config_file" 2>/dev/null) || wiki_section=""
+if [ -z "$wiki_section" ]; then
+  log_info "gitignore-health-check: wiki section absent in rite-config.yml — skipping (exit 0)"
+  echo "==> Total gitignore-health-check findings: 0"
+  exit 0
+fi
+
+# wiki.enabled (opt-out default true)
+wiki_enabled=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+enabled:/ { print; exit }' \
+  | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' \
+  | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
+case "$wiki_enabled" in
+  false|no|0) wiki_enabled="false" ;;
+  true|yes|1) wiki_enabled="true" ;;
+  *)          wiki_enabled="true" ;;
+esac
+if [ "$wiki_enabled" = "false" ]; then
+  log_info "gitignore-health-check: wiki.enabled=false, skipping (exit 0)"
+  echo "==> Total gitignore-health-check findings: 0"
+  exit 0
+fi
+
+# wiki.branch_strategy (default: separate_branch)
+if [ -n "$STRATEGY_OVERRIDE" ]; then
+  branch_strategy="$STRATEGY_OVERRIDE"
+else
+  branch_strategy=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+branch_strategy:/ { print; exit }' \
+    | sed 's/[[:space:]]#.*//' | sed 's/.*branch_strategy:[[:space:]]*//' \
+    | tr -d '[:space:]"'"'"'')
+fi
+case "$branch_strategy" in
+  separate_branch|same_branch) ;;
+  "") branch_strategy="separate_branch" ;;
+  *)
+    echo "WARNING: gitignore-health-check: unknown wiki.branch_strategy '$branch_strategy' — treating as separate_branch" >&2
+    branch_strategy="separate_branch"
+    ;;
+esac
+
+# --- Layer 1: parent exclusion verify (separate_branch + same_branch 共通) ---
+# `git check-ignore -v` with a probe path that does NOT exist on disk. This is
+# the canonical way to ask git "is this path ignored by the current .gitignore?"
+# without polluting the working tree.
+probe_path=".rite/wiki/raw/.rite-lint-probe"
+check_ignore_err=$(mktemp /tmp/rite-gitignore-check-XXXXXX 2>/dev/null) || check_ignore_err=""
+if [ -z "$check_ignore_err" ]; then
+  echo "WARNING: gitignore-health-check: mktemp failed — check-ignore stderr won't be surfaced" >&2
+fi
+
+findings=0
+check_ignore_out=""
+check_ignore_rc=0
+if check_ignore_out=$(git check-ignore -v "$probe_path" 2>"${check_ignore_err:-/dev/null}"); then
+  check_ignore_rc=0
+else
+  check_ignore_rc=$?
+fi
+
+# check_ignore_rc values:
+#   0  = matched an ignore rule (or matched a negation — `!pattern` prefix on output)
+#   1  = no rule matched (path is NOT ignored)
+#   2+ = git error
+if [ "$check_ignore_rc" -ge 2 ]; then
+  echo "WARNING: gitignore-health-check: git check-ignore failed (rc=$check_ignore_rc) — skipping separate_branch verify" >&2
+  [ -n "$check_ignore_err" ] && [ -s "$check_ignore_err" ] && head -3 "$check_ignore_err" | sed 's/^/  /' >&2
+  echo "==> Total gitignore-health-check findings: 0"
+  exit 2
+fi
+
+parent_rule_matched=0
+parent_rule_line=""
+if [ "$check_ignore_rc" -eq 0 ]; then
+  # `git check-ignore -v` output: `<source>:<line>:<pattern>\t<path>`
+  # The pattern field contains `.rite/wiki/` (or a more specific subpath rule)
+  # when the parent exclusion is healthy. For separate_branch, this is the
+  # health check. For same_branch we also need layer 2 (negation verify).
+  if printf '%s' "$check_ignore_out" | grep -qE '(^|[[:space:]:]|!)\.rite/wiki/'; then
+    parent_rule_matched=1
+    parent_rule_line="$check_ignore_out"
+  fi
+fi
+
+case "$branch_strategy" in
+  separate_branch)
+    if [ "$parent_rule_matched" -eq 0 ]; then
+      echo "==> gitignore-health-check: DRIFT DETECTED (separate_branch): '.rite/wiki/' rule missing from .gitignore" >&2
+      echo "==> git check-ignore -v $probe_path returned rc=$check_ignore_rc, output: ${check_ignore_out:-<empty>}" >&2
+      echo "==> Hint: PR #564 added '.rite/wiki/' as last-line-of-defense against wiki-ingest-trigger.sh silent leaks. Restore the rule." >&2
+      findings=$((findings + 1))
+    else
+      log_info "gitignore-health-check: separate_branch layer 1 healthy — ${parent_rule_line}"
+    fi
+    ;;
+
+  same_branch)
+    # For same_branch, we also need a negation override so `git add .rite/wiki/...`
+    # works during /rite:wiki:ingest. Per .gitignore L101-113 spec, `git check-ignore`
+    # cannot deterministically verify negation. Use `git add --dry-run` with a real
+    # probe file (cleaned up by trap on exit).
+    negation_probe=".rite/wiki/raw/.rite-lint-negation-probe"
+    mkdir -p "$(dirname "$negation_probe")" 2>/dev/null || {
+      echo "WARNING: gitignore-health-check: cannot mkdir $(dirname "$negation_probe") — same_branch negation verify skipped" >&2
+      echo "==> Total gitignore-health-check findings: 0"
+      exit 0
+    }
+    touch "$negation_probe" 2>/dev/null || {
+      echo "WARNING: gitignore-health-check: cannot touch $negation_probe — same_branch negation verify skipped" >&2
+      echo "==> Total gitignore-health-check findings: 0"
+      exit 0
+    }
+
+    add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
+    add_dry_out=""
+    add_dry_rc=0
+    if add_dry_out=$(git add --dry-run -- "$negation_probe" 2>"${add_dry_err:-/dev/null}"); then
+      add_dry_rc=0
+    else
+      add_dry_rc=$?
+    fi
+
+    # Healthy negation: rc=0 + stdout like `add '.rite/wiki/raw/.rite-lint-negation-probe'`
+    # Broken negation: rc=1 + stderr contains "paths are ignored"
+    if [ "$add_dry_rc" -eq 0 ] && printf '%s' "$add_dry_out" | grep -qF "add '${negation_probe}'"; then
+      log_info "gitignore-health-check: same_branch layer 2 healthy — negation override works (git add --dry-run rc=0)"
+    else
+      echo "==> gitignore-health-check: DRIFT DETECTED (same_branch): negation override for '.rite/wiki/' missing or broken" >&2
+      echo "==> git add --dry-run $negation_probe returned rc=$add_dry_rc" >&2
+      [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ] && head -3 "$add_dry_err" | sed 's/^/  /' >&2
+      echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see .gitignore L66-75 for setup steps)." >&2
+      findings=$((findings + 1))
+    fi
+    # probe cleanup handled by trap
+    ;;
+esac
+
+# --- Emit sentinel on drift ---
+if [ "$findings" -gt 0 ]; then
+  # Delegate sentinel formatting to workflow-incident-emit.sh. Resolve script path
+  # relative to this script so the script still works when invoked via absolute
+  # path from lint.md (with {plugin_root} substitution).
+  script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+  emit_script="$script_dir/../workflow-incident-emit.sh"
+  if [ -f "$emit_script" ]; then
+    # Emit to stdout so the sentinel reaches the orchestrator's conversation context.
+    # `|| true` preserves non-blocking contract (emit failure must not halt lint).
+    bash "$emit_script" \
+      --type gitignore_drift \
+      --details "gitignore health check: .rite/wiki/ rule drift detected (strategy=$branch_strategy)" \
+      --root-cause-hint "PR may have removed .rite/wiki/ exclusion or negation from .gitignore" \
+      --pr-number 0 || true
+  else
+    echo "WARNING: gitignore-health-check: workflow-incident-emit.sh not found at $emit_script — sentinel not emitted" >&2
+  fi
+  echo "==> Total gitignore-health-check findings: $findings"
+  exit 1
+fi
+
+echo "==> Total gitignore-health-check findings: 0"
+exit 0

--- a/plugins/rite/hooks/workflow-incident-emit.sh
+++ b/plugins/rite/hooks/workflow-incident-emit.sh
@@ -18,6 +18,7 @@
 #   --type             incident type. Required. One of:
 #                        skill_load_failure | hook_abnormal_exit | manual_fallback_adopted
 #                        | wiki_ingest_skipped | wiki_ingest_failed | wiki_ingest_push_failed
+#                        | gitignore_drift
 #   --details          one-line incident description (required)
 #   --root-cause-hint  optional cause hypothesis (omitted from output if empty)
 #   --pr-number        PR number for iteration_id (defaults to 0 when not yet created)
@@ -67,8 +68,9 @@ fi
 case "$TYPE" in
   skill_load_failure|hook_abnormal_exit|manual_fallback_adopted) ;;
   wiki_ingest_skipped|wiki_ingest_failed|wiki_ingest_push_failed) ;;
+  gitignore_drift) ;;
   *)
-    echo "ERROR: Invalid --type: $TYPE (expected: skill_load_failure | hook_abnormal_exit | manual_fallback_adopted | wiki_ingest_skipped | wiki_ingest_failed | wiki_ingest_push_failed)" >&2
+    echo "ERROR: Invalid --type: $TYPE (expected: skill_load_failure | hook_abnormal_exit | manual_fallback_adopted | wiki_ingest_skipped | wiki_ingest_failed | wiki_ingest_push_failed | gitignore_drift)" >&2
     exit 1
     ;;
 esac

--- a/plugins/rite/references/workflow-incident-emit-protocol.md
+++ b/plugins/rite/references/workflow-incident-emit-protocol.md
@@ -25,7 +25,7 @@ sentinel_line=$(bash {plugin_root}/hooks/workflow-incident-emit.sh \
 | Placeholder | Source |
 |-------------|--------|
 | `{plugin_root}` | [Plugin Path Resolution](./plugin-path-resolution.md#resolution-script) |
-| `{sentinel_type}` | From the skill's failure paths table (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped` (#524), `wiki_ingest_failed` (#524), `wiki_ingest_push_failed` (#555)) |
+| `{sentinel_type}` | From the skill's failure paths table (`skill_load_failure`, `hook_abnormal_exit`, `manual_fallback_adopted`, `wiki_ingest_skipped` (#524), `wiki_ingest_failed` (#524), `wiki_ingest_push_failed` (#555), `gitignore_drift` (#567)) |
 | `{specific failure description}` | From the skill's failure paths table |
 | `{optional hypothesis}` | Optional root cause hint (may be empty) |
 | `{pr_number}` | Current PR number, or `0` if no PR exists yet |


### PR DESCRIPTION
## 概要

`/rite:lint` Phase 3.9 として `.gitignore` の `.rite/wiki/` ルール存在を verify する health check を追加し、PR #564 で導入された silent-leak 最終防御線が将来の `.gitignore` 整理 PR で誤って削除されるのを早期検知する。

## 変更内容

- **`plugins/rite/hooks/scripts/gitignore-health-check.sh`** 新規: probe path `.rite/wiki/raw/.rite-lint-probe` を `git check-ignore -v` で verify（separate_branch 戦略）。`same_branch` 戦略時は probe file を作成し `git add --dry-run` で negation entry を verify（negation 配下では `check-ignore` が非決定的なため、`.gitignore` L101-113 の仕様に準拠）。drift 検知時は `workflow-incident-emit.sh --type gitignore_drift` を delegate して sentinel を stdout emit。probe file は signal-specific trap で必ず cleanup。
- **`plugins/rite/hooks/workflow-incident-emit.sh`**: `gitignore_drift` type を case validation に追加（doc comment と error string も同期）。
- **`plugins/rite/commands/lint.md`**: Phase 3.9（新 check の invocation ブロック）、Phase 4.1 appendix、Phase 4.3 summary row を追加。既存 Phase 3.5-3.8 の非ブロッキング契約を踏襲し、exit 1 でも `[lint:success]` を維持。
- **`plugins/rite/commands/issue/start.md`**: Phase 5.4.4.1 detection scope table に `gitignore_drift` 行を追加し、sentinel → auto-register 経路と整合させる。

## 関連 Issue

Closes #567

元の PR: #564（`.rite/wiki/` last-line-of-defense 追加）

## 検証内容

手動 smoke test で 3 経路を確認:

1. **正常系（separate_branch, healthy）**: `bash gitignore-health-check.sh --quiet` → exit=0, findings=0 ✅
2. **drift 系（separate_branch, `.rite/wiki/` 欠落）**: `.gitignore` から一時退避して実行 → exit=1, `[CONTEXT] WORKFLOW_INCIDENT=1; type=gitignore_drift; ...` sentinel emit ✅
3. **drift 系（same_branch, negation 欠落）**: `--branch-strategy-override same_branch` で実行 → exit=1, sentinel emit, probe file 残留なし ✅
4. **healthy 系（same_branch + negation 一時追加）**: exit=0, findings=0, probe file 残留なし ✅

## チェックリスト（Issue #567 完了条件）

- [x] `.gitignore` の `.rite/wiki/` ルール存在を verify する health check が `/rite:lint` で実装される
- [x] ルール削除を検知した場合に non-blocking WARNING + retained flag emit
- [x] `same_branch` 戦略時の negation エントリ存在 verify も実装

## 非ブロッキング契約

本 PR の変更は既存 Phase 3.5-3.8 と同じ非ブロッキング契約（exit 1 でも `[lint:success]`）に従う。drift 検出は workflow 進行を止めず、`workflow_incident` sentinel を経由して Phase 5.4.4.1 で auto-register される。

