### PR TITLE
feat(commands): /rite:wiki:init で same_branch 戦略向け .gitignore negation を自動注入

### DIFF
--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -200,13 +200,13 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 **Edit ツール呼び出しパラメータ**:
 
 - `file_path`: `.gitignore`
-- `old_string`: 次の 1 行を exact match する（一意にマッチ）:
-  ```
-  # <<< gitignore-wiki-section-end (anchor / F-09 対応)
-  ```
-- `new_string`: **以下の 7 行を literal で指定する**（`old_string` の 1 行 + 改行 + negation ブロック 6 行）。
+- `old_string` — 以下の 1 行を exact match する（一意にマッチ）:
 
-以下のコードブロックは Markdown 表示用の参照であり、リスト項目外の top-level fenced block として配置している（リストインデント 2 スペースの混入を避けるため）:
+```
+# <<< gitignore-wiki-section-end (anchor / F-09 対応)
+```
+
+- `new_string` — 以下の 7 行を literal で指定する（`old_string` の 1 行 + 改行 + negation ブロック 6 行）:
 
 ```
 # <<< gitignore-wiki-section-end (anchor / F-09 対応)
@@ -218,7 +218,12 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 # <<< gitignore-wiki-negation-end
 ```
 
-**注意点**: (1) 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない (2) 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない (3) old_string と new_string の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く (4) 上記コードブロックは top-level fenced block として配置しているため各行の**先頭インデントは 0 スペース**。ただし Markdown レンダラや Claude が参照時に余計なインデントを認識した場合は、new_string では**行頭を `#` または `!` から直接開始する**（`  # >>> ...` のような先頭空白は含めない）
+**注意点**:
+
+1. 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない
+2. 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない
+3. `old_string` と `new_string` の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く
+4. 各行の先頭インデントは 0 スペース。Markdown レンダラや Claude が参照時に余計な先頭空白を認識した場合でも、new_string では**行頭を `#` または `!` から直接開始する**（`  # >>> ...` のような先頭空白は含めない）
 
 `!.rite/wiki/**` は glob を明示する防御的エントリで、単独では機能しない（parent exclusion が残るため）が、gitignore を消費する一部のツール (IDE の VCS integration 等) への defense-in-depth として推奨される（`.gitignore` 上部 Step 1 コメントと同じ根拠）。
 
@@ -227,12 +232,25 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 > **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` L281 付近の `grep -qF` パターン参照。
 
 ```bash
-# F-02 対応 (re-review F-02): signal-specific trap で probe ファイルの残留を防ぐ。
+# signal-specific trap で probe ファイルの残留を防ぐ
+# (canonical: plugins/rite/commands/pr/references/bash-trap-patterns.md
+#  の `#signal-specific-trap-template` anchor)。
+#
 # SIGINT/SIGTERM/SIGHUP で rm -f がスキップされ、Phase 3.1 の same_branch ブロックの
 # `git add .rite/wiki/` に probe (.negation-probe) が混入する経路を塞ぐ。
-# 関数名は bash-trap-patterns.md L140-L151 の命名規約 `_rite_<scope>_<phase>_cleanup` に準拠。
-# (Phase 3.1 の `_rite_wiki_init_cleanup` は規約確立前の旧命名維持対象 — bash-trap-patterns.md L154
-#  参照。本 Phase 1.3 は新規追加なので規約準拠の `_rite_wiki_init_phase13_cleanup` を採用。)
+# 関数名は上記 canonical の命名規約 `_rite_<scope>_<phase>_cleanup` に準拠。
+# (Phase 3.1 の `_rite_wiki_init_cleanup` は規約確立前の旧命名維持対象。本 Phase 1.3 は
+#  新規追加なので規約準拠の `_rite_wiki_init_phase13_cleanup` を採用。)
+#
+# canonical instantiation 順序 (re-review cycle 3 F-A 対応):
+#   (1) パス変数を空文字で先行宣言
+#   (2) cleanup 関数と 4 行 trap を設定
+#   (3) その後で mktemp を実行
+# これにより trap arm と mktemp の間に signal が到達しても、cleanup 関数が未定義変数
+# を参照する経路を閉じる。
+probe_mkdir_err=""
+probe_touch_err=""
+
 _rite_wiki_init_phase13_cleanup() {
   rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
 }
@@ -241,11 +259,13 @@ trap '_rite_wiki_init_phase13_cleanup; exit 130' INT
 trap '_rite_wiki_init_phase13_cleanup; exit 143' TERM
 trap '_rite_wiki_init_phase13_cleanup; exit 129' HUP
 
-# F-07 + re-review F-04 対応: mkdir / touch の失敗を明示的にハンドリング + stderr を退避。
+# mkdir / touch の失敗を明示的にハンドリング + stderr を退避。
 # permission/disk full/readonly 等で probe 作成失敗時、verification 自体を skip して
 # WARNING を表示する (non-blocking、Phase 2 へ進行)。silent に `git add --dry-run` を
 # 実行して pathspec mismatch 警告 (rc=128) を「negation 不在」と誤認することを防ぐ。
-# stderr は tempfile に退避し、失敗時に head -3 で先頭行を stderr に流す (canonical lint.md L620-L625)。
+# stderr は tempfile に退避し、失敗時に head -3 で先頭行を stderr に流す
+# (canonical: plugins/rite/hooks/scripts/gitignore-health-check.sh の probe 作成 +
+#  stderr 退避パターン参照)。
 probe_mkdir_err=$(mktemp /tmp/rite-wiki-init-p13-mkdir-err-XXXXXX 2>/dev/null) || probe_mkdir_err=""
 probe_touch_err=$(mktemp /tmp/rite-wiki-init-p13-touch-err-XXXXXX 2>/dev/null) || probe_touch_err=""
 probe_created="false"
@@ -268,9 +288,10 @@ fi
 
 if [ "$probe_created" = "true" ]; then
   # verification: rc=0 かつ stdout に canonical pattern `add '<path>'` (probe フルパス) を含めば OK
-  # F-03 対応: `grep -q "^add '"` (単純プレフィックス) では偶然 `add '...'` で始まる任意
-  # パスが出ると false positive になる。gitignore-health-check.sh L281 の canonical impl と
-  # 同じく `grep -qF "add '<probe path 全体>'"` で完全パス fixed-string match に統一する。
+  # `grep -q "^add '"` (単純プレフィックス) では偶然 `add '...'` で始まる任意パスが出ると
+  # false positive になるため、`grep -qF "add '<probe path 全体>'"` で完全パス fixed-string
+  # match に統一する (canonical: plugins/rite/hooks/scripts/gitignore-health-check.sh の
+  # `grep -qF "add '${negation_probe}'"` パターン)。
   dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>&1)
   dry_run_rc=$?
 
@@ -284,12 +305,15 @@ if [ "$probe_created" = "true" ]; then
   fi
 fi
 
-# re-review F-01 対応: 明示 rm → trap 解除 の順序に統一 (canonical: lint.md L1586-L1591)。
+# 明示 rm → trap 解除 の順序 (canonical: bash-trap-patterns.md `#signal-specific-trap-template`)。
 # 役割分離:
-#   - 明示 rm (通常パス): 正常完了時の同期 cleanup。通常経路で確実に probe を削除する
-#   - trap cleanup (signal 経路 defense-in-depth): SIGINT/SIGTERM/SIGHUP で rm に到達できなかった
-#     場合の保険。EXIT trap も rc=0 では走らないため、正常経路の一次 cleanup は明示 rm が担う
+#   - 明示 rm (通常パス): Phase 1.3.4 の処理完了時点で同期的に probe を削除。script は
+#     Phase 2 以降を継続するため、EXIT trap に delegate するだけでは処理途中の cleanup
+#     にならない (EXIT trap は script 終了時のみ発火する)。
+#   - trap cleanup (signal 経路 defense-in-depth): SIGINT/SIGTERM/SIGHUP で明示 rm に
+#     到達できなかった場合の保険として動作する。
 # 明示 rm を trap 解除より前に置くことで、rm〜trap 解除間の micro-race window を排除する。
+# trap 解除後は EXIT trap が発火しないため、script 終了時に冗長 rm が走らない。
 rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
 trap - EXIT INT TERM HUP
 ```

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -204,17 +204,21 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
   ```
   # <<< gitignore-wiki-section-end (anchor / F-09 対応)
   ```
-- `new_string`: **以下の 7 行を literal で指定**する（`old_string` の 1 行 + 改行 + negation ブロック 6 行。**コードフェンス ` ``` ` は含めない**）:
-  ```
-  # <<< gitignore-wiki-section-end (anchor / F-09 対応)
-  # >>> gitignore-wiki-negation-start (Issue #568 — same_branch 戦略用 negation 自動注入)
-  # 本プロジェクトは same_branch 戦略のため、.rite/wiki/ 配下を再包含する。
-  # verification 手順は本 .gitignore 上部の Step 1-5 コメントを参照。
-  !.rite/wiki/
-  !.rite/wiki/**
-  # <<< gitignore-wiki-negation-end
-  ```
-  **注意点**: (1) 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない (2) 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない (3) old_string と new_string の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く
+- `new_string`: **以下の 7 行を literal で指定する**（`old_string` の 1 行 + 改行 + negation ブロック 6 行）。
+
+以下のコードブロックは Markdown 表示用の参照であり、リスト項目外の top-level fenced block として配置している（リストインデント 2 スペースの混入を避けるため）:
+
+```
+# <<< gitignore-wiki-section-end (anchor / F-09 対応)
+# >>> gitignore-wiki-negation-start (Issue #568 — same_branch 戦略用 negation 自動注入)
+# 本プロジェクトは same_branch 戦略のため、.rite/wiki/ 配下を再包含する。
+# verification 手順は本 .gitignore 上部の Step 1-5 コメントを参照。
+!.rite/wiki/
+!.rite/wiki/**
+# <<< gitignore-wiki-negation-end
+```
+
+**注意点**: (1) 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない (2) 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない (3) old_string と new_string の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く (4) 上記コードブロックは top-level fenced block として配置しているため各行の**先頭インデントは 0 スペース**。ただし Markdown レンダラや Claude が参照時に余計なインデントを認識した場合は、new_string では**行頭を `#` または `!` から直接開始する**（`  # >>> ...` のような先頭空白は含めない）
 
 `!.rite/wiki/**` は glob を明示する防御的エントリで、単独では機能しない（parent exclusion が残るため）が、gitignore を消費する一部のツール (IDE の VCS integration 等) への defense-in-depth として推奨される（`.gitignore` 上部 Step 1 コメントと同じ根拠）。
 
@@ -223,27 +227,41 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 > **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` L281 付近の `grep -qF` パターン参照。
 
 ```bash
-# F-02 対応: signal-specific trap で probe ファイルの残留を防ぐ。
+# F-02 対応 (re-review F-02): signal-specific trap で probe ファイルの残留を防ぐ。
 # SIGINT/SIGTERM/SIGHUP で rm -f がスキップされ、Phase 3.1 の same_branch ブロックの
 # `git add .rite/wiki/` に probe (.negation-probe) が混入する経路を塞ぐ。
-# 既存 Phase 3.1 の _rite_wiki_init_cleanup と同パターン (canonical bash-trap-patterns.md 準拠)。
-_rite_wiki_negation_probe_cleanup() {
-  rm -f .rite/wiki/raw/.negation-probe
+# 関数名は bash-trap-patterns.md L140-L151 の命名規約 `_rite_<scope>_<phase>_cleanup` に準拠。
+# (Phase 3.1 の `_rite_wiki_init_cleanup` は規約確立前の旧命名維持対象 — bash-trap-patterns.md L154
+#  参照。本 Phase 1.3 は新規追加なので規約準拠の `_rite_wiki_init_phase13_cleanup` を採用。)
+_rite_wiki_init_phase13_cleanup() {
+  rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
 }
-trap 'rc=$?; _rite_wiki_negation_probe_cleanup; exit $rc' EXIT
-trap '_rite_wiki_negation_probe_cleanup; exit 130' INT
-trap '_rite_wiki_negation_probe_cleanup; exit 143' TERM
-trap '_rite_wiki_negation_probe_cleanup; exit 129' HUP
+trap 'rc=$?; _rite_wiki_init_phase13_cleanup; exit $rc' EXIT
+trap '_rite_wiki_init_phase13_cleanup; exit 130' INT
+trap '_rite_wiki_init_phase13_cleanup; exit 143' TERM
+trap '_rite_wiki_init_phase13_cleanup; exit 129' HUP
 
-# F-07 対応: mkdir / touch の失敗を明示的にハンドリングする。
+# F-07 + re-review F-04 対応: mkdir / touch の失敗を明示的にハンドリング + stderr を退避。
 # permission/disk full/readonly 等で probe 作成失敗時、verification 自体を skip して
 # WARNING を表示する (non-blocking、Phase 2 へ進行)。silent に `git add --dry-run` を
 # 実行して pathspec mismatch 警告 (rc=128) を「negation 不在」と誤認することを防ぐ。
+# stderr は tempfile に退避し、失敗時に head -3 で先頭行を stderr に流す (canonical lint.md L620-L625)。
+probe_mkdir_err=$(mktemp /tmp/rite-wiki-init-p13-mkdir-err-XXXXXX 2>/dev/null) || probe_mkdir_err=""
+probe_touch_err=$(mktemp /tmp/rite-wiki-init-p13-touch-err-XXXXXX 2>/dev/null) || probe_touch_err=""
 probe_created="false"
-if mkdir -p .rite/wiki/raw 2>/dev/null && touch .rite/wiki/raw/.negation-probe 2>/dev/null; then
+if mkdir -p .rite/wiki/raw 2>"${probe_mkdir_err:-/dev/null}" && \
+   touch .rite/wiki/raw/.negation-probe 2>"${probe_touch_err:-/dev/null}"; then
   probe_created="true"
 else
   echo "WARNING: negation probe の作成に失敗しました (read-only fs / permission / disk full の可能性)" >&2
+  if [ -n "$probe_mkdir_err" ] && [ -s "$probe_mkdir_err" ]; then
+    echo "  mkdir stderr (先頭 3 行):" >&2
+    head -3 "$probe_mkdir_err" | sed 's/^/    /' >&2
+  fi
+  if [ -n "$probe_touch_err" ] && [ -s "$probe_touch_err" ]; then
+    echo "  touch stderr (先頭 3 行):" >&2
+    head -3 "$probe_touch_err" | sed 's/^/    /' >&2
+  fi
   echo "  verification を skip して Phase 2 に進行します (non-blocking)" >&2
   echo "  Phase 3.1 の git add で negation が効いていなければそこで改めてエラーが出ます" >&2
 fi
@@ -266,11 +284,14 @@ if [ "$probe_created" = "true" ]; then
   fi
 fi
 
-# cleanup trap を明示解除 (正常完了時)。trap handler は probe を削除する。
-# trap - で正常完了時の early-rm と signal 中断時の trap-rm が二重にならないよう、
-# cleanup を trap 経由に一本化する。
+# re-review F-01 対応: 明示 rm → trap 解除 の順序に統一 (canonical: lint.md L1586-L1591)。
+# 役割分離:
+#   - 明示 rm (通常パス): 正常完了時の同期 cleanup。通常経路で確実に probe を削除する
+#   - trap cleanup (signal 経路 defense-in-depth): SIGINT/SIGTERM/SIGHUP で rm に到達できなかった
+#     場合の保険。EXIT trap も rc=0 では走らないため、正常経路の一次 cleanup は明示 rm が担う
+# 明示 rm を trap 解除より前に置くことで、rm〜trap 解除間の micro-race window を排除する。
+rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
 trap - EXIT INT TERM HUP
-rm -f .rite/wiki/raw/.negation-probe
 ```
 
 **成功時**: `✅ .gitignore に negation エントリを追記しました` を追加で表示し Phase 2 へ。

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -116,7 +116,7 @@ PR #564 で `.rite/wiki/` が `.gitignore` に追加されたため、`same_bran
 
 **Skip 条件** (idempotent):
 
-- `.gitignore` に既に `^!\.rite/wiki/[[:space:]]*$` に match する行が存在する → 既に注入済みのため silent skip（末尾 whitespace 許容）
+- `.gitignore` に既に `^!\.rite/wiki/[[:space:]]*$` に match する行が存在する → 既に注入済みのため idempotent skip。LLM 分岐テーブル (`already_negated` 行) で `✅ .gitignore に既に negation エントリが存在します（idempotent skip）` メッセージを表示してから Phase 2 へ進む（rebase シナリオで「既に注入済み」をユーザーに通知し信頼性を確保）。末尾 whitespace 許容
 
 #### 1.3.1 事前検査
 
@@ -139,7 +139,7 @@ elif ! grep -qE '^\.rite/wiki/[[:space:]]*$' .gitignore; then
 elif grep -qE '^!\.rite/wiki/[[:space:]]*$' .gitignore; then
   state="skip"
   reason="already_negated"
-elif ! grep -qF '# <<< gitignore-wiki-section-end' .gitignore; then
+elif ! grep -qF '# <<< gitignore-wiki-section-end (anchor / F-09 対応)' .gitignore; then
   # PR #586 F-01 対応: Phase 1.3.3 Edit ツールが hardcode する anchor が不在の場合、
   # Edit が `old_string not found` で hard fail するため、early skip + 手動追記案内に分岐する。
   # 本 anchor は rite-workflow 自己開発 repo の .gitignore L131 のみに存在し、consumer project には
@@ -148,6 +148,14 @@ elif ! grep -qF '# <<< gitignore-wiki-section-end' .gitignore; then
   # 追加した .gitignore は条件 1-3 を満たすが anchor を持たないため、本条件で fall-back する。
   # grep -qF (fixed-string match) を使うのは anchor コメント文字列に regex メタ文字 (括弧) が
   # 含まれるため (`(anchor / F-09 対応)`)。
+  #
+  # PR #586 F-04 (cycle 5) 対応: cycle 4 で grep の検索文字列を anchor の prefix のみ
+  # (`# <<< gitignore-wiki-section-end`) で書いていたが、Phase 1.3.3 Edit ツールの old_string は
+  # suffix 込みの exact 文字列 (`# <<< gitignore-wiki-section-end (anchor / F-09 対応)`) を要求する。
+  # consumer が anchor の suffix を独自編集 (例: `# <<< gitignore-wiki-section-end (custom note)`)
+  # している場合、検出 grep は通過するが Edit が hard fail する strictness 差を残していた。
+  # cycle 6 で grep の検索文字列を Edit と同一の exact 文字列に統一し、検出と Edit の strictness
+  # を完全一致させる (consumer の anchor fork 編集ケースもこの elif で skip される)。
   state="skip"
   reason="anchor_absent"
 else
@@ -308,15 +316,25 @@ if [ "$probe_created" = "true" ]; then
   # `grep -qF "add '${negation_probe}'"` パターン)。
   #
   # PR #586 F-02 対応: stderr を独立 tempfile に退避し stdout に merge しない。
-  # 同一ファイル内 L555 のプロジェクト規約「2>&1 は付けない: 構造化 stdout と WARNING stderr
+  # 同一ファイル内 Phase 3.5.1 のプロジェクト規約「2>&1 は付けない: 構造化 stdout と WARNING stderr
   # の分離を維持する」に準拠する。canonical 参照実装 gitignore-health-check.sh L270-277 の
-  # `add_dry_err=$(mktemp ...) ... 2>"${add_dry_err:-/dev/null}"` パターンと一字一句揃える
-  # (canonical drift 防止)。実害として、success path で git が emit する stderr 警告
-  # (例: `warning: in the working copy of '...', LF will be replaced by CRLF`) が success
-  # メッセージに混入することを防ぎ、`grep -qF "add '...'"` の false positive リスクを排除する。
+  # `add_dry_err=$(mktemp ...) ... if add_dry_out=$(...); then add_dry_rc=0; else add_dry_rc=$?; fi`
+  # パターンに **rc capture 構造ごと** 揃える (canonical drift 防止)。実害として、success path で
+  # git が emit する stderr 警告 (例: `warning: in the working copy of '...', LF will be replaced
+  # by CRLF`) が success メッセージに混入することを防ぎ、`grep -qF "add '...'"` の false positive
+  # リスクを排除する。
+  #
+  # PR #586 F-01 (cycle 5) 対応: cycle 4 で stderr 退避部分のみ canonical に揃え rc capture
+  # 構造を簡略な `var=$(cmd); rc=$?` に留めていたが、コメントは「一字一句揃える」と謳っており
+  # 主張と実装が乖離していた。cycle 6 で if-wrapper 構造に統一して drift を解消する。
+  # `set -e` 不在の bash block 内では機能等価だが、Wiki 経験則「canonical reference 文書の
+  # サンプルコードは canonical 実装と一字一句同期する」(patterns/high) を厳守する。
   dry_run_err=$(mktemp /tmp/rite-wiki-init-p13-dryrun-err-XXXXXX 2>/dev/null) || dry_run_err=""
-  dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}")
-  dry_run_rc=$?
+  if dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
+    dry_run_rc=0
+  else
+    dry_run_rc=$?
+  fi
 
   if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -qF "add '.rite/wiki/raw/.negation-probe'"; then
     echo "✅ .gitignore negation verification OK: $dry_run_out"

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -99,7 +99,7 @@ Wiki は既に初期化されています。
 - `separate_branch`: `set -o pipefail && ts=$(date +%s) && mkdir -p .rite/wiki.bak.$ts && git archive "$wiki_branch" -- .rite/wiki/ | tar -x -C .rite/wiki.bak.$ts && set +o pipefail && git branch -D "$wiki_branch" && { git push origin --delete "$wiki_branch" 2>/dev/null || true; }` で wiki ブランチからデータを取得後、既存ブランチを削除（`set -o pipefail` で `git archive` 失敗時にバックアップなしでブランチ削除に進行することを防止。`|| true` は `git push origin --delete` のみに適用。`git checkout --orphan` が同名ブランチ存在時に失敗するため削除が必要）
 - `same_branch`: `cp -r .rite/wiki .rite/wiki.bak.$(date +%s)` で working tree から直接コピー
 
-**変数保持指示**: Phase 1.2 で出力された `branch_strategy` と `wiki_branch` の値を保持し、Phase 2 および Phase 3 以降のすべての Bash ブロックで**リテラル値として埋め込んで**使用すること。Claude Code の Bash ツール間でシェル変数は保持されないため、各 Bash ブロックの冒頭で値をリテラルに再定義する必要がある。
+**変数保持指示**: Phase 1.2 で出力された `branch_strategy` と `wiki_branch` の値を保持し、**Phase 1.3 以降のすべての Bash ブロック** (Phase 1.3 / 2 / 3 / 3.5 / 3.5.1) で**リテラル値として埋め込んで**使用すること。Claude Code の Bash ツール間でシェル変数は保持されないため、各 Bash ブロックの冒頭で値をリテラルに再定義する必要がある。
 
 ### 1.3 same_branch 戦略向け .gitignore negation 自動注入
 
@@ -111,11 +111,11 @@ PR #564 で `.rite/wiki/` が `.gitignore` に追加されたため、`same_bran
 |---|------|
 | 1 | Phase 1.2 で取得した `branch_strategy == "same_branch"` |
 | 2 | `.gitignore` が存在する |
-| 3 | `.gitignore` に `^\.rite/wiki/$` に match する行が存在する（PR #564 以降のリポジトリ） |
+| 3 | `.gitignore` に `^\.rite/wiki/[[:space:]]*$` に match する行が存在する（PR #564 以降のリポジトリ。末尾 whitespace 許容で手動編集された `.gitignore` との衝突耐性を確保） |
 
 **Skip 条件** (idempotent):
 
-- `.gitignore` に既に `^!\.rite/wiki/$` に match する行が存在する → 既に注入済みのため silent skip
+- `.gitignore` に既に `^!\.rite/wiki/[[:space:]]*$` に match する行が存在する → 既に注入済みのため silent skip（末尾 whitespace 許容）
 
 #### 1.3.1 事前検査
 
@@ -132,10 +132,10 @@ if [ "$branch_strategy" != "same_branch" ]; then
 elif [ ! -f .gitignore ]; then
   state="skip"
   reason="gitignore_absent"
-elif ! grep -qE '^\.rite/wiki/$' .gitignore; then
+elif ! grep -qE '^\.rite/wiki/[[:space:]]*$' .gitignore; then
   state="skip"
   reason="rule_absent"
-elif grep -qE '^!\.rite/wiki/$' .gitignore; then
+elif grep -qE '^!\.rite/wiki/[[:space:]]*$' .gitignore; then
   state="skip"
   reason="already_negated"
 else
@@ -143,18 +143,23 @@ else
   reason="injection_needed"
 fi
 
-echo "GITIGNORE_NEGATION_STATE=$state; reason=$reason"
+# 2 行に分離して emit する (F-04 対応)。
+# 旧実装は `GITIGNORE_NEGATION_STATE=$state; reason=$reason` の 1 行 emit だったが、
+# bash としてはセミコロンが statement 区切りとなり意味論が混乱する。分離することで、
+# LLM の marker grep も後述テーブルの列挙も単一 key=value 行として扱える。
+echo "GITIGNORE_NEGATION_STATE=$state"
+echo "GITIGNORE_NEGATION_REASON=$reason"
 ```
 
-**LLM 分岐** (Bash ツール間でシェル変数は保持されないため、stdout の marker を読んで分岐する):
+**LLM 分岐** (Bash ツール間でシェル変数は保持されないため、上記 2 行の stdout marker を読んで分岐する):
 
-| `GITIGNORE_NEGATION_STATE` | 次の処理 |
-|---------------------------|---------|
-| `skip; reason=not_same_branch` | Phase 2 へ（通知不要 — separate_branch 戦略は worktree 経路で .gitignore の影響を受けない） |
-| `skip; reason=gitignore_absent` | Phase 2 へ（通知不要 — `.gitignore` がなければ ignore の影響も無し） |
-| `skip; reason=rule_absent` | Phase 2 へ（通知不要 — PR #564 以前のリポジトリで `.rite/wiki/` が ignore されていない） |
-| `skip; reason=already_negated` | `✅ .gitignore に既に negation エントリが存在します（idempotent skip）` を表示して Phase 2 へ |
-| `prompt; reason=injection_needed` | Phase 1.3.2 へ進む |
+| `GITIGNORE_NEGATION_STATE` | `GITIGNORE_NEGATION_REASON` | 次の処理 |
+|---------------------------|------------------------------|---------|
+| `skip` | `not_same_branch` | Phase 2 へ（通知不要 — separate_branch 戦略は worktree 経路で .gitignore の影響を受けない） |
+| `skip` | `gitignore_absent` | Phase 2 へ（通知不要 — `.gitignore` がなければ ignore の影響も無し） |
+| `skip` | `rule_absent` | Phase 2 へ（通知不要 — PR #564 以前のリポジトリで `.rite/wiki/` が ignore されていない） |
+| `skip` | `already_negated` | `✅ .gitignore に既に negation エントリが存在します（idempotent skip）` を表示して Phase 2 へ |
+| `prompt` | `injection_needed` | Phase 1.3.2 へ進む |
 
 #### 1.3.2 ユーザー確認
 
@@ -195,33 +200,76 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 **Edit ツール呼び出しパラメータ**:
 
 - `file_path`: `.gitignore`
-- `old_string`: `# <<< gitignore-wiki-section-end (anchor / F-09 対応)`（一意にマッチ）
-- `new_string`: 上記 `old_string` + 改行 + 上記 negation ブロック全文
+- `old_string`: 次の 1 行を exact match する（一意にマッチ）:
+  ```
+  # <<< gitignore-wiki-section-end (anchor / F-09 対応)
+  ```
+- `new_string`: **以下の 7 行を literal で指定**する（`old_string` の 1 行 + 改行 + negation ブロック 6 行。**コードフェンス ` ``` ` は含めない**）:
+  ```
+  # <<< gitignore-wiki-section-end (anchor / F-09 対応)
+  # >>> gitignore-wiki-negation-start (Issue #568 — same_branch 戦略用 negation 自動注入)
+  # 本プロジェクトは same_branch 戦略のため、.rite/wiki/ 配下を再包含する。
+  # verification 手順は本 .gitignore 上部の Step 1-5 コメントを参照。
+  !.rite/wiki/
+  !.rite/wiki/**
+  # <<< gitignore-wiki-negation-end
+  ```
+  **注意点**: (1) 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない (2) 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない (3) old_string と new_string の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く
 
 `!.rite/wiki/**` は glob を明示する防御的エントリで、単独では機能しない（parent exclusion が残るため）が、gitignore を消費する一部のツール (IDE の VCS integration 等) への defense-in-depth として推奨される（`.gitignore` 上部 Step 1 コメントと同じ根拠）。
 
 #### 1.3.4 verification
 
-> **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。
+> **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` L281 付近の `grep -qF` パターン参照。
 
 ```bash
-mkdir -p .rite/wiki/raw
-touch .rite/wiki/raw/.negation-probe
+# F-02 対応: signal-specific trap で probe ファイルの残留を防ぐ。
+# SIGINT/SIGTERM/SIGHUP で rm -f がスキップされ、Phase 3.1 の same_branch ブロックの
+# `git add .rite/wiki/` に probe (.negation-probe) が混入する経路を塞ぐ。
+# 既存 Phase 3.1 の _rite_wiki_init_cleanup と同パターン (canonical bash-trap-patterns.md 準拠)。
+_rite_wiki_negation_probe_cleanup() {
+  rm -f .rite/wiki/raw/.negation-probe
+}
+trap 'rc=$?; _rite_wiki_negation_probe_cleanup; exit $rc' EXIT
+trap '_rite_wiki_negation_probe_cleanup; exit 130' INT
+trap '_rite_wiki_negation_probe_cleanup; exit 143' TERM
+trap '_rite_wiki_negation_probe_cleanup; exit 129' HUP
 
-# verification: rc=0 かつ stdout に "add '" を含めば negation OK
-dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>&1)
-dry_run_rc=$?
-
-if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -q "^add '"; then
-  echo "✅ .gitignore negation verification OK: $dry_run_out"
+# F-07 対応: mkdir / touch の失敗を明示的にハンドリングする。
+# permission/disk full/readonly 等で probe 作成失敗時、verification 自体を skip して
+# WARNING を表示する (non-blocking、Phase 2 へ進行)。silent に `git add --dry-run` を
+# 実行して pathspec mismatch 警告 (rc=128) を「negation 不在」と誤認することを防ぐ。
+probe_created="false"
+if mkdir -p .rite/wiki/raw 2>/dev/null && touch .rite/wiki/raw/.negation-probe 2>/dev/null; then
+  probe_created="true"
 else
-  echo "WARNING: .gitignore negation verification failed (rc=$dry_run_rc)" >&2
-  echo "  stdout/stderr: $dry_run_out" >&2
-  echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
-  echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
+  echo "WARNING: negation probe の作成に失敗しました (read-only fs / permission / disk full の可能性)" >&2
+  echo "  verification を skip して Phase 2 に進行します (non-blocking)" >&2
+  echo "  Phase 3.1 の git add で negation が効いていなければそこで改めてエラーが出ます" >&2
 fi
 
-# probe 削除（commit 混入防止）
+if [ "$probe_created" = "true" ]; then
+  # verification: rc=0 かつ stdout に canonical pattern `add '<path>'` (probe フルパス) を含めば OK
+  # F-03 対応: `grep -q "^add '"` (単純プレフィックス) では偶然 `add '...'` で始まる任意
+  # パスが出ると false positive になる。gitignore-health-check.sh L281 の canonical impl と
+  # 同じく `grep -qF "add '<probe path 全体>'"` で完全パス fixed-string match に統一する。
+  dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>&1)
+  dry_run_rc=$?
+
+  if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -qF "add '.rite/wiki/raw/.negation-probe'"; then
+    echo "✅ .gitignore negation verification OK: $dry_run_out"
+  else
+    echo "WARNING: .gitignore negation verification failed (rc=$dry_run_rc)" >&2
+    echo "  stdout/stderr: $dry_run_out" >&2
+    echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
+    echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
+  fi
+fi
+
+# cleanup trap を明示解除 (正常完了時)。trap handler は probe を削除する。
+# trap - で正常完了時の early-rm と signal 中断時の trap-rm が二重にならないよう、
+# cleanup を trap 経由に一本化する。
+trap - EXIT INT TERM HUP
 rm -f .rite/wiki/raw/.negation-probe
 ```
 

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -101,6 +101,134 @@ Wiki は既に初期化されています。
 
 **変数保持指示**: Phase 1.2 で出力された `branch_strategy` と `wiki_branch` の値を保持し、Phase 2 および Phase 3 以降のすべての Bash ブロックで**リテラル値として埋め込んで**使用すること。Claude Code の Bash ツール間でシェル変数は保持されないため、各 Bash ブロックの冒頭で値をリテラルに再定義する必要がある。
 
+### 1.3 same_branch 戦略向け .gitignore negation 自動注入
+
+PR #564 で `.rite/wiki/` が `.gitignore` に追加されたため、`same_branch` 戦略ユーザーは Phase 3.1 の `git add .rite/wiki/` が "paths are ignored" で hard fail します。本 Phase は negation エントリ (`!.rite/wiki/` および `!.rite/wiki/**`) を対話的に追記し、hard fail を未然に防ぎます。
+
+**発動条件** (すべて満たすときのみ):
+
+| # | 条件 |
+|---|------|
+| 1 | Phase 1.2 で取得した `branch_strategy == "same_branch"` |
+| 2 | `.gitignore` が存在する |
+| 3 | `.gitignore` に `^\.rite/wiki/$` に match する行が存在する（PR #564 以降のリポジトリ） |
+
+**Skip 条件** (idempotent):
+
+- `.gitignore` に既に `^!\.rite/wiki/$` に match する行が存在する → 既に注入済みのため silent skip
+
+#### 1.3.1 事前検査
+
+```bash
+# Phase 1.2 の値をリテラル埋め込み（例: branch_strategy="same_branch"）
+branch_strategy="{branch_strategy}"
+
+state="skip"
+reason=""
+
+if [ "$branch_strategy" != "same_branch" ]; then
+  state="skip"
+  reason="not_same_branch"
+elif [ ! -f .gitignore ]; then
+  state="skip"
+  reason="gitignore_absent"
+elif ! grep -qE '^\.rite/wiki/$' .gitignore; then
+  state="skip"
+  reason="rule_absent"
+elif grep -qE '^!\.rite/wiki/$' .gitignore; then
+  state="skip"
+  reason="already_negated"
+else
+  state="prompt"
+  reason="injection_needed"
+fi
+
+echo "GITIGNORE_NEGATION_STATE=$state; reason=$reason"
+```
+
+**LLM 分岐** (Bash ツール間でシェル変数は保持されないため、stdout の marker を読んで分岐する):
+
+| `GITIGNORE_NEGATION_STATE` | 次の処理 |
+|---------------------------|---------|
+| `skip; reason=not_same_branch` | Phase 2 へ（通知不要 — separate_branch 戦略は worktree 経路で .gitignore の影響を受けない） |
+| `skip; reason=gitignore_absent` | Phase 2 へ（通知不要 — `.gitignore` がなければ ignore の影響も無し） |
+| `skip; reason=rule_absent` | Phase 2 へ（通知不要 — PR #564 以前のリポジトリで `.rite/wiki/` が ignore されていない） |
+| `skip; reason=already_negated` | `✅ .gitignore に既に negation エントリが存在します（idempotent skip）` を表示して Phase 2 へ |
+| `prompt; reason=injection_needed` | Phase 1.3.2 へ進む |
+
+#### 1.3.2 ユーザー確認
+
+`AskUserQuestion` で次のように確認:
+
+```
+質問: same_branch 戦略を検出しました。.gitignore に negation エントリ (!.rite/wiki/ と !.rite/wiki/**) を自動追記しますか？
+
+背景: PR #564 で .rite/wiki/ が .gitignore に追加されたため、same_branch 戦略では git add .rite/wiki/ が exit 1 で失敗します。negation を追記するとこの問題が解消されます。
+
+オプション:
+- negation エントリを追記（推奨）: Phase 1.3.3 で自動追記 → Phase 1.3.4 で verification 実行
+- スキップ: 手動で追記するか、separate_branch 戦略に切り替えてください（Phase 3.1 で hard fail する可能性あり）
+- キャンセル: 初期化を中止
+```
+
+**選択肢別処理**:
+
+| 選択肢 | 処理 |
+|--------|------|
+| negation エントリを追記（推奨） | Phase 1.3.3 へ |
+| スキップ | `⚠️ Phase 3.1 の git add で失敗する可能性があります（手動で .gitignore に !.rite/wiki/ と !.rite/wiki/** を追記してください）` を表示して Phase 2 へ |
+| キャンセル | 初期化全体を中止（exit） |
+
+#### 1.3.3 `.gitignore` への追記
+
+Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-end (anchor / F-09 対応)` 行の **直後** に以下のブロックを挿入する（PR #564 で配置された wiki section の直後を指定することで、関連コメントと配置を近接させる）:
+
+```
+# >>> gitignore-wiki-negation-start (Issue #568 — same_branch 戦略用 negation 自動注入)
+# 本プロジェクトは same_branch 戦略のため、.rite/wiki/ 配下を再包含する。
+# verification 手順は本 .gitignore 上部の Step 1-5 コメントを参照。
+!.rite/wiki/
+!.rite/wiki/**
+# <<< gitignore-wiki-negation-end
+```
+
+**Edit ツール呼び出しパラメータ**:
+
+- `file_path`: `.gitignore`
+- `old_string`: `# <<< gitignore-wiki-section-end (anchor / F-09 対応)`（一意にマッチ）
+- `new_string`: 上記 `old_string` + 改行 + 上記 negation ブロック全文
+
+`!.rite/wiki/**` は glob を明示する防御的エントリで、単独では機能しない（parent exclusion が残るため）が、gitignore を消費する一部のツール (IDE の VCS integration 等) への defense-in-depth として推奨される（`.gitignore` 上部 Step 1 コメントと同じ根拠）。
+
+#### 1.3.4 verification
+
+> **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。
+
+```bash
+mkdir -p .rite/wiki/raw
+touch .rite/wiki/raw/.negation-probe
+
+# verification: rc=0 かつ stdout に "add '" を含めば negation OK
+dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>&1)
+dry_run_rc=$?
+
+if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -q "^add '"; then
+  echo "✅ .gitignore negation verification OK: $dry_run_out"
+else
+  echo "WARNING: .gitignore negation verification failed (rc=$dry_run_rc)" >&2
+  echo "  stdout/stderr: $dry_run_out" >&2
+  echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
+  echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
+fi
+
+# probe 削除（commit 混入防止）
+rm -f .rite/wiki/raw/.negation-probe
+```
+
+**成功時**: `✅ .gitignore に negation エントリを追記しました` を追加で表示し Phase 2 へ。
+
+**失敗時 (non-blocking)**: WARNING 表示のみで Phase 2 に進行する。Phase 3.1 の `git add .rite/wiki/` で改めてエラーが出れば、そこでユーザーに手動対応を促す。
+
 ## Phase 2: ディレクトリ構造の作成
 
 ### 2.1 Plugin Root の解決

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -112,6 +112,7 @@ PR #564 で `.rite/wiki/` が `.gitignore` に追加されたため、`same_bran
 | 1 | Phase 1.2 で取得した `branch_strategy == "same_branch"` |
 | 2 | `.gitignore` が存在する |
 | 3 | `.gitignore` に `^\.rite/wiki/[[:space:]]*$` に match する行が存在する（PR #564 以降のリポジトリ。末尾 whitespace 許容で手動編集された `.gitignore` との衝突耐性を確保） |
+| 4 | `.gitignore` に `# <<< gitignore-wiki-section-end` anchor が存在する（Phase 1.3.3 Edit ツールが anchor を `old_string` に hardcode するため、不在の場合 hard fail する。consumer project は本 anchor を持たないため early skip + 手動追記案内へ分岐する） |
 
 **Skip 条件** (idempotent):
 
@@ -138,6 +139,17 @@ elif ! grep -qE '^\.rite/wiki/[[:space:]]*$' .gitignore; then
 elif grep -qE '^!\.rite/wiki/[[:space:]]*$' .gitignore; then
   state="skip"
   reason="already_negated"
+elif ! grep -qF '# <<< gitignore-wiki-section-end' .gitignore; then
+  # PR #586 F-01 対応: Phase 1.3.3 Edit ツールが hardcode する anchor が不在の場合、
+  # Edit が `old_string not found` で hard fail するため、early skip + 手動追記案内に分岐する。
+  # 本 anchor は rite-workflow 自己開発 repo の .gitignore L131 のみに存在し、consumer project には
+  # distribution 経路がない (templates/ に該当 .gitignore template なし、/rite:init Phase 4.6 と
+  # gitignore-health-check.sh どちらも anchor を inject しない)。consumer が手動で `.rite/wiki/` を
+  # 追加した .gitignore は条件 1-3 を満たすが anchor を持たないため、本条件で fall-back する。
+  # grep -qF (fixed-string match) を使うのは anchor コメント文字列に regex メタ文字 (括弧) が
+  # 含まれるため (`(anchor / F-09 対応)`)。
+  state="skip"
+  reason="anchor_absent"
 else
   state="prompt"
   reason="injection_needed"
@@ -159,6 +171,7 @@ echo "GITIGNORE_NEGATION_REASON=$reason"
 | `skip` | `gitignore_absent` | Phase 2 へ（通知不要 — `.gitignore` がなければ ignore の影響も無し） |
 | `skip` | `rule_absent` | Phase 2 へ（通知不要 — PR #564 以前のリポジトリで `.rite/wiki/` が ignore されていない） |
 | `skip` | `already_negated` | `✅ .gitignore に既に negation エントリが存在します（idempotent skip）` を表示して Phase 2 へ |
+| `skip` | `anchor_absent` | `⚠️ .gitignore に '# <<< gitignore-wiki-section-end' anchor が見つかりません。Phase 1.3.3 の自動追記を skip します。手動で .gitignore 末尾に !.rite/wiki/ と !.rite/wiki/** を追記してください` を表示して Phase 2 へ（Phase 3.1 の git add で hard fail するリスクをユーザーに明示） |
 | `prompt` | `injection_needed` | Phase 1.3.2 へ進む |
 
 #### 1.3.2 ユーザー確認
@@ -250,9 +263,10 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 # を参照する経路を閉じる。
 probe_mkdir_err=""
 probe_touch_err=""
+dry_run_err=""
 
 _rite_wiki_init_phase13_cleanup() {
-  rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
+  rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" "${dry_run_err:-}" .rite/wiki/raw/.negation-probe
 }
 trap 'rc=$?; _rite_wiki_init_phase13_cleanup; exit $rc' EXIT
 trap '_rite_wiki_init_phase13_cleanup; exit 130' INT
@@ -292,14 +306,27 @@ if [ "$probe_created" = "true" ]; then
   # false positive になるため、`grep -qF "add '<probe path 全体>'"` で完全パス fixed-string
   # match に統一する (canonical: plugins/rite/hooks/scripts/gitignore-health-check.sh の
   # `grep -qF "add '${negation_probe}'"` パターン)。
-  dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>&1)
+  #
+  # PR #586 F-02 対応: stderr を独立 tempfile に退避し stdout に merge しない。
+  # 同一ファイル内 L555 のプロジェクト規約「2>&1 は付けない: 構造化 stdout と WARNING stderr
+  # の分離を維持する」に準拠する。canonical 参照実装 gitignore-health-check.sh L270-277 の
+  # `add_dry_err=$(mktemp ...) ... 2>"${add_dry_err:-/dev/null}"` パターンと一字一句揃える
+  # (canonical drift 防止)。実害として、success path で git が emit する stderr 警告
+  # (例: `warning: in the working copy of '...', LF will be replaced by CRLF`) が success
+  # メッセージに混入することを防ぎ、`grep -qF "add '...'"` の false positive リスクを排除する。
+  dry_run_err=$(mktemp /tmp/rite-wiki-init-p13-dryrun-err-XXXXXX 2>/dev/null) || dry_run_err=""
+  dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}")
   dry_run_rc=$?
 
   if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -qF "add '.rite/wiki/raw/.negation-probe'"; then
     echo "✅ .gitignore negation verification OK: $dry_run_out"
   else
     echo "WARNING: .gitignore negation verification failed (rc=$dry_run_rc)" >&2
-    echo "  stdout/stderr: $dry_run_out" >&2
+    echo "  stdout: $dry_run_out" >&2
+    if [ -n "$dry_run_err" ] && [ -s "$dry_run_err" ]; then
+      echo "  stderr (先頭 3 行):" >&2
+      head -3 "$dry_run_err" | sed 's/^/    /' >&2
+    fi
     echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
     echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
   fi
@@ -314,7 +341,7 @@ fi
 #     到達できなかった場合の保険として動作する。
 # 明示 rm を trap 解除より前に置くことで、rm〜trap 解除間の micro-race window を排除する。
 # trap 解除後は EXIT trap が発火しないため、script 終了時に冗長 rm が走らない。
-rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" .rite/wiki/raw/.negation-probe
+rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" "${dry_run_err:-}" .rite/wiki/raw/.negation-probe
 trap - EXIT INT TERM HUP
 ```
 


### PR DESCRIPTION
## 概要

- `/rite:wiki:init` に **Phase 1.3 same_branch 戦略向け .gitignore negation 自動注入** を新設
- `wiki.branch_strategy: "same_branch"` 検出時かつ `.gitignore` に `.rite/wiki/` ルール存在時に、`AskUserQuestion` で対話的に `!.rite/wiki/` と `!.rite/wiki/**` を追記する
- 追記後は probe ファイル (`.rite/wiki/raw/.negation-probe`) を使った `git add --dry-run` ベースの verification を実行
- 既に negation 存在時は silent skip（idempotent 保証）

## 背景

PR #564 で `.rite/wiki/` を `.gitignore` に追加したことで、`same_branch` 戦略ユーザーは Phase 3.1 の `git add .rite/wiki/` が "paths are ignored" で hard fail する経路が生じていた。コメントには手動手順が載っていたが、ユーザーの負担が高く UX が悪かった。本 Issue は PR #564 レビュー時に devops reviewer が推奨事項 #2 として挙げた follow-up 項目。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `plugins/rite/commands/wiki/init.md` | Phase 1.2 と Phase 2 の間に Phase 1.3 を新設。サブ節 1.3.1 事前検査 / 1.3.2 AskUserQuestion / 1.3.3 Edit 指示 / 1.3.4 verification の 4 節構成 |

### 発動条件（すべて満たすとき）

1. `branch_strategy == "same_branch"`
2. `.gitignore` が存在する
3. `.gitignore` に `^\.rite/wiki/$` が match する（PR #564 以降の repo）

### Skip 条件

- `.gitignore` に既に `^!\.rite/wiki/$` が match する行がある → `already_negated` で silent skip

## 完了条件

- [x] `/rite:wiki:init` で `same_branch` strategy 検出時に negation 追記を対話的に提示
- [x] ユーザー承認時に `.gitignore` に negation エントリ自動追記
- [x] 追記後 verification (`git add --dry-run`) で negation 有効性を確認
- [x] 既に negation エントリが存在する場合は idempotent に skip

## Known Issues（本 PR のスコープ外）

`/rite:lint` で検出された既存 warnings（本 PR の変更ファイル `init.md` とは無関係、個別対応は別 Issue で追跡する方針）:

| Phase | 件数 | 内容 |
|-------|------|------|
| 3.5 drift check | 32 | `reason 'commit_rc_4' / 'no' / 'trigger_exit_'` が review.md / fix.md の eval-table に未登録 |
| 3.6 bang-backtick | 1 | `plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md:153` の closing backtick 前 space+! |
| 3.8 wiki-growth | 1 | PR #583 / #582 / #581 の raw source が wiki branch に未蓄積（Phase X.X.W 発火漏れの可能性） |

いずれも non-blocking warning（`[lint:success]` と同等扱い）。

## Test plan

- [x] init.md に `### 1.3 same_branch 戦略向け .gitignore negation 自動注入` 見出しが存在（Grep 確認）
- [x] 1.3.1 bash に `GITIGNORE_NEGATION_STATE=` marker が存在（Grep 確認）
- [x] 1.3.3 に `!.rite/wiki/` および `!.rite/wiki/**` が文字列として含まれる（Grep 確認）
- [x] 1.3.4 verification bash に `git add --dry-run .rite/wiki/raw/.negation-probe` と `rm -f .rite/wiki/raw/.negation-probe` が存在（Grep 確認）
- [x] 4 経路（非 same_branch / `.gitignore` 不在 / 既存 negation / 新規追記）の bash path review 完了
- [ ] 実際の `/rite:wiki:init` 実行による e2e 動作確認（新規 `same_branch` repo で要検証 — follow-up）

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
