### PR TITLE
refactor(commands): wiki/ingest.md Phase 2.2/2.3 mktemp に canonical trap を統一 (#566)

### DIFF
--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -135,6 +135,8 @@ _rite_<scope>_<phase>_cleanup() {
 - `plugins/rite/commands/wiki/lint.md` Phase 6.0 (`_rite_wiki_lint_phase60_cleanup`)
 - `plugins/rite/commands/wiki/lint.md` Phase 6.2 (`_rite_wiki_lint_phase62_cleanup`) — PR #564 で追加、page_err / awk_diag / sort_err の 3 tempfile を保護
 - `plugins/rite/commands/wiki/lint.md` Phase 8.3 (`_rite_wiki_lint_phase83_cleanup`) — PR #564 cycle 11 F-03 対応で追加、add_err / commit_err の 2 tempfile を保護 (same_branch path のみ)
+- `plugins/rite/commands/wiki/ingest.md` Phase 2.2 (`_rite_wiki_ingest_phase22_cleanup`) — Issue #566 対応で追加、`find_err` tempfile を保護 (PR #564 で lint.md 側が canonical 化された後、ingest.md 側で trap 未保護のまま残っていた site を対称化)
+- `plugins/rite/commands/wiki/ingest.md` Phase 2.3 (`_rite_wiki_ingest_phase23_cleanup`) — Issue #566 対応で追加、`cat_err` tempfile を保護。`for candidate` ループ内で trap が反復ごとに再設定されるが bash 仕様上 idempotent
 - `plugins/rite/commands/wiki/ingest.md` Phase 5.2 (`_rite_wiki_ingest_phase52_cleanup`) — PR #564 F-01 対応で旧名 `_rite_ingest_phase52_cleanup` から `wiki` scope prefix 付きにリネーム (scope 衝突回避、規約準拠)。`_reset_err` tempfile を保護
 
 命名規約:

--- a/plugins/rite/commands/wiki/ingest.md
+++ b/plugins/rite/commands/wiki/ingest.md
@@ -234,6 +234,20 @@ fi
 candidates=()
 # メイン候補: wiki worktree (separate_branch) or dev ツリー (same_branch)
 if [ -d "$wiki_raw_root" ]; then
+  # Issue #566 対応: canonical signal-specific trap (4 行 EXIT/INT/TERM/HUP) で find_err tempfile orphan 防止
+  # (lint.md Phase 6.0 / 6.2 / 8.3 + ingest.md Phase 5.2 と対称化、../pr/references/bash-trap-patterns.md#signal-specific-trap-template 準拠)。
+  # 旧実装は trap 未保護で mktemp 成功直後に SIGINT/SIGTERM/SIGHUP が来ると find_err tempfile が orphan 化していた。
+  find_err=""
+  _rite_wiki_ingest_phase22_cleanup() {
+    # BSD variant に統一 (lint.md Phase 6.0 / 6.2 / 8.3 + ingest.md Phase 5.2 と対称化)。
+    # bash-trap-patterns.md の『BSD/macOS rm の rm -f "" 対応 (空引数ガード variant)』規範に準拠。
+    [ -n "${find_err:-}" ] && rm -f "$find_err"
+  }
+  trap 'rc=$?; _rite_wiki_ingest_phase22_cleanup; exit $rc' EXIT
+  trap '_rite_wiki_ingest_phase22_cleanup; exit 130' INT
+  trap '_rite_wiki_ingest_phase22_cleanup; exit 143' TERM
+  trap '_rite_wiki_ingest_phase22_cleanup; exit 129' HUP
+
   # F-11 対応: 1 行 WARNING を 3 行 loud WARNING に拡張 (lint.md Phase 6.0 / 6.2 と対称化)。
   # find の stderr が握り潰されると raw source 候補が silent 脱落し、`n_raw_sources` の不正確な
   # initialization を起こすため、対処と影響を明示する。
@@ -312,6 +326,21 @@ esac
 ```bash
 # Issue #547: candidate は常に実ファイルパスなので、prefix の剥がし処理は不要
 actual_path="$candidate"
+
+# Issue #566 対応: canonical signal-specific trap (4 行 EXIT/INT/TERM/HUP) で cat_err tempfile orphan 防止
+# (lint.md Phase 6.0 / 6.2 / 8.3 + ingest.md Phase 5.2 と対称化、../pr/references/bash-trap-patterns.md#signal-specific-trap-template 準拠)。
+# 旧実装は trap 未保護で mktemp 成功直後に SIGINT/SIGTERM/SIGHUP が来ると cat_err tempfile が orphan 化していた。
+# 本スニペットは for candidate ループ内で実行されるため、trap は反復ごとに再設定される (bash 仕様上 idempotent、overwrite 安全)。
+cat_err=""
+_rite_wiki_ingest_phase23_cleanup() {
+  # BSD variant に統一 (lint.md Phase 6.0 / 6.2 / 8.3 + ingest.md Phase 5.2 と対称化)。
+  # bash-trap-patterns.md の『BSD/macOS rm の rm -f "" 対応 (空引数ガード variant)』規範に準拠。
+  [ -n "${cat_err:-}" ] && rm -f "$cat_err"
+}
+trap 'rc=$?; _rite_wiki_ingest_phase23_cleanup; exit $rc' EXIT
+trap '_rite_wiki_ingest_phase23_cleanup; exit 130' INT
+trap '_rite_wiki_ingest_phase23_cleanup; exit 143' TERM
+trap '_rite_wiki_ingest_phase23_cleanup; exit 129' HUP
 
 cat_err=$(mktemp /tmp/rite-wiki-ingest-cat-err-XXXXXX 2>/dev/null) || {
   echo "WARNING: stderr 退避 tempfile (cat_err) の mktemp に失敗しました。cat の詳細エラー情報は失われます" >&2


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/ingest.md` Phase 2.2 (`find_err`) と Phase 2.3 (`cat_err`) の `mktemp` 周辺を canonical signal-specific trap で保護し、PR #564 で canonical 化された wiki/lint.md 4 site + 同 ingest.md Phase 5.2 と対称化する。旧実装は trap 未保護で SIGINT/SIGTERM/SIGHUP が `mktemp`〜`rm` 間に到達すると tempfile が orphan として残る構造的リスクがあった。

Closes #566

## 変更内容

### `plugins/rite/commands/wiki/ingest.md`

- **Phase 2.2 (`find_err`)**: `_rite_wiki_ingest_phase22_cleanup` を定義し、4 行 trap (EXIT/INT/TERM/HUP, exit code 130/143/129) で `find_err` tempfile を保護。`find_err=""` 先行宣言 → cleanup 関数定義 → 4 行 trap → mktemp の canonical 順序に従う。
- **Phase 2.3 (`cat_err`)**: `_rite_wiki_ingest_phase23_cleanup` を定義し、同じく 4 行 trap を設置。`for candidate` ループ内で実行されるため trap は反復ごとに再設定される（bash 仕様上 idempotent、overwrite 安全）ことをコメントで明示。
- いずれも BSD variant (`[ -n "${var:-}" ] && rm -f "$var"`) を採用し、既存の `_rite_wiki_ingest_phase52_cleanup` と対称化。

### `plugins/rite/commands/pr/references/bash-trap-patterns.md`

- 参照実装一覧 (L132-138) に新規 2 関数 (`_rite_wiki_ingest_phase22_cleanup` / `_rite_wiki_ingest_phase23_cleanup`) を追記。命名規約 `_rite_wiki_ingest_phase{22,23}_cleanup`（小数点除去連結形式）準拠。

## 背景

PR #564 のレビューで code-quality / error-handling 両 reviewer が推奨事項 / 調査推奨として指摘していた既存 site。PR #564 scope 外のため別 Issue (#566) で追跡していた。

## 完了条件

- [x] `find_err` と `cat_err` mktemp が canonical signal-specific trap (EXIT/INT/TERM/HUP の exit code 130/143/129) で保護される
- [x] `bash-trap-patterns.md` 参照実装一覧に新規 cleanup 関数を追記
- [x] `_rite_wiki_ingest_phase{22,23}_cleanup` の命名規約に準拠

## 検証

| 検証項目 | 結果 |
|---------|------|
| `grep -c '_rite_wiki_ingest_phase22_cleanup' ingest.md` | 5（定義 1 + trap 4） |
| `grep -c '_rite_wiki_ingest_phase23_cleanup' ingest.md` | 5（定義 1 + trap 4） |
| `bash-trap-patterns.md` に両関数が追記されている | ✅ |
| `/rite:lint` (プラグイン固有チェック) | #566 変更由来の新規 finding なし |

## Known Issues

`/rite:lint` で以下の warning を検出したが、いずれも本 PR 由来ではなく既存課題（non-blocking）:

- **Distributed fix drift check**: 32 件（pr/review.md など、本 PR 対象外の既存 drift）
- **Bang-backtick check**: 1 件（`wiki/references/bash-cross-boundary-state-transfer.md:153`、本 PR 対象外）
- **Wiki growth check**: 1 件（直近マージ PR #583/#582/#581 に Phase X.X.W 経由の raw source なし、本 PR 対象外）

## 関連

- 元の PR: #564（lint.md 側の canonical 化 + F-01 で同 ingest.md Phase 5.2 リネーム）
- 元の review 指摘: PR #564 code-quality-reviewer 推奨事項 #2 / error-handling-reviewer 調査推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
