### PR TITLE
docs(wiki): lint.md Phase 6.2 / 8.3 placeholder gate を canonical exit code 一覧に同期

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -1731,6 +1731,8 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 - **例外 (`exit 1` fail-fast)**:
   - Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 の `branch_strategy` 未知値 (5 箇所で同型、設定ミスの silent 通過防止)
   - Phase 1.1 / Phase 1.3 の `{mode}` placeholder 残留検知 (2 箇所で同型、Claude substitute 忘れの silent 通過防止)
+  - Phase 6.2 の placeholder 残留検知 (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種で同型、PR #564 F-01 / F-21、LLM substitute 忘れによる silent `missing_concept` 誤分類防止)
+  - Phase 8.3 の `{log_entry}` placeholder 残留検知 (PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止)
   - Phase 8.1 の counter placeholder (`n_contradictions` / `n_stale` / `n_orphans` / `n_missing_concept` / `n_broken_refs`) 残留 / 非整数検知 (5 counter で同型、Issue #573、LLM substitute 忘れによる silent `lint:clean` 誤 emit 防止)
 - 内部 bash 構文エラー等の unrecoverable error のみ非 0 exit となる可能性あり
 
@@ -1744,6 +1746,8 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 | GNU date 非互換環境 | Phase 4 skip（exit 0 + WARNING） | Phase 1.2 |
 | Wiki 未初期化 | `/rite:wiki:init` を案内 (`--auto` モード時は 6 フィールド 0 件 1 行を出力後 exit 0) | Phase 1.3 |
 | `{mode}` placeholder 残留 (Phase 1.1 / Phase 1.3 の 2 箇所) | **exit 1 で fail-fast**（Claude substitute 忘れの silent 通過防止、2 箇所で同型） | Phase 1.1 / Phase 1.3 |
+| Phase 6.2 の placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種) | **exit 1 で fail-fast**（PR #564 F-01 / F-21、LLM substitute 忘れによる silent `missing_concept` 誤分類防止、3 種で同型） | Phase 6.2 |
+| Phase 8.3 の `{log_entry}` placeholder 残留 | **exit 1 で fail-fast**（PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止） | Phase 8.3 |
 | Phase 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数検知 | **exit 1 で fail-fast**（Issue #573、LLM substitute 忘れによる silent `lint:clean` 誤 emit 防止、5 counter で同型） | Phase 8.1 |
 | `git ls-tree` 失敗 | WARNING + `pages_list=""`/`raw_list=""` で継続（exit 0） | Phase 2.2 |
 | `branch_strategy` が未知の値 (Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 の 5 箇所) | **exit 1 で fail-fast**（設定ミスの silent 通過防止、5 箇所で同型） | Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 |


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/lint.md` の L1371 コメントが「5 site 対称化 (Phase 1.1 / 1.3 / 6.2 / 8.3 / 本 8.1)」を主張する一方、9.3 exit code 節リストとエラーハンドリング表は Phase 1.1 / 1.3 / 8.1 の 3 site のみが登録され Phase 6.2 / 8.3 が drift していた。canonical 一覧に Phase 6.2 / 8.3 placeholder gate 行を追加し、宣言と実態を一致させる。

## 変更内容

`plugins/rite/commands/wiki/lint.md` の以下 2 箇所に行を追加 (合計 +4 行):

1. **9.3 exit code 節「例外 (`exit 1` fail-fast)」リスト** (L1731 周辺):
   - Phase 6.2 の 3 placeholder gate (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}`、PR #564 F-01 / F-21 で導入)
   - Phase 8.3 の `{log_entry}` placeholder gate (PR #564 F-14 で導入)

2. **エラーハンドリング表** (L1741 周辺):
   - Phase 6.2 placeholder gate 行
   - Phase 8.3 `{log_entry}` placeholder gate 行

既存 entry (Phase 1.1/1.3 mode、Phase 8.1 counter) と同型フォーマットを踏襲。

## 期待される効果

将来の読者が「文書化されていない `exit 1` 経路」に遭遇する regression を防ぐ。L1371 の「5 site 対称化」宣言が canonical 一覧と完全一致する。

## スコープ外

Phase 8.3 の `{branch_strategy}` placeholder gate (L1488-1493、PR #564 で導入) も canonical 一覧未登録の drift だが、Issue #580 のスコープ外。後続 Issue 候補。

## 関連

Closes #580

- 元 PR: #579 (Issue #573)
- drift 導入元: #564

## チェックリスト

- [x] 9.3 リストに Phase 6.2 行追加
- [x] 9.3 リストに Phase 8.3 `{log_entry}` 行追加
- [x] エラー表に Phase 6.2 行追加
- [x] エラー表に Phase 8.3 `{log_entry}` 行追加
- [x] 既存 3 site (Phase 1.1/1.3/8.1) と同型フォーマット維持

## Test Plan

- [x] grep で 9.3 節 (L1730-1736) に Phase 6.2 / log_entry 行が存在することを確認
- [x] grep でエラー表 (L1741-1755) に Phase 6.2 / Phase 8.3 行が存在することを確認
- [x] L1371 コメント本文 (5 site 対称化宣言) は変更不要 — canonical 一覧側を追従させた

🤖 Generated with [Claude Code](https://claude.com/claude-code)
