### PR TITLE
refactor(wiki): lint Phase 2.3 same_branch index 読出成功経路に selective surface を追加 (#577)

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -359,7 +359,11 @@ if [ "$branch_strategy" = "separate_branch" ]; then
   fi
 else
   if index_content=$(cat .rite/wiki/index.md 2>"${index_err:-/dev/null}"); then
-    :
+    # selective surface pattern: cat は通常 stderr を成功経路で emit しないが、separate_branch
+    # 成功経路 (直上 git show) と対称化するため同型 surface を配置する (Issue #577)。
+    # BSD cat 等が diagnostic を emit する稀なケースで silent に warning を握りつぶさないための
+    # defense-in-depth として機能する (PR #576 Phase 6.0 で同型対称化を完了済み)。
+    [ -n "$index_err" ] && [ -s "$index_err" ] && head -3 "$index_err" | sed 's/^/  WARNING(cat hint): /' >&2
   else
     echo "WARNING: .rite/wiki/index.md を読み出せません" >&2
     [ -n "$index_err" ] && [ -s "$index_err" ] && head -3 "$index_err" | sed 's/^/  /' >&2


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/lint.md` Phase 2.3 same_branch 経路の index 読出 **成功経路** (line 362) にのみ残っていた `:` (no-op) を、separate_branch 成功経路 (line 350-352) と同型の **selective surface pattern** に置換し、Phase 2.3 の両経路挙動を対称化する。

## 背景

- 本 PR は PR #576 で Phase 6.0 について完了した同型対称化の続き。Phase 2.3 では separate_branch 側にだけ `WARNING(git hint):` の selective surface が存在していたため非対称が残存していた。
- レビュー推奨事項は PR #576 レビュー時に prompt-engineer / code-quality の両 reviewer が一致して言及（Observed Likelihood: Hypothetical、重要度なし）。

## 変更内容

**1 file changed, 5 insertions(+), 1 deletion(-)**

- `plugins/rite/commands/wiki/lint.md` Phase 2.3 same_branch 成功経路の `:` を以下に置換:
  - 4 行コメント: selective surface pattern の根拠（PR #576 Phase 6.0 参照 + BSD cat diagnostic 対策 + defense-in-depth）
  - surface 本体: `[ -n "$index_err" ] && [ -s "$index_err" ] && head -3 "$index_err" | sed 's/^/  WARNING(cat hint): /' >&2`

## 影響範囲

- 成功経路のみの変更で、既存 error path の挙動は不変。
- cat は通常 stderr を成功経路で emit しないため実害は低く、BSD cat 等の diagnostic emit を silent に握りつぶさない defense-in-depth。

## スコープ外（意図的）

- `LC_ALL=C cat` の採用は Phase 2.3 では既存採用実績がなく、Issue の「対処」要件は surface pattern のみを対象としている。完全 locale 固定は別 Issue 候補。

## 検証

- `Grep 'WARNING(cat hint)' plugins/rite/commands/wiki/lint.md` が 2 件ヒット（Phase 2.3 line 366 / Phase 6.0 line 704）で、`WARNING(git hint)` と合わせて Phase 2.3 両経路が同型 surface を持つことを確認。
- `/rite:lint` の plugin-specific checks (Phase 3.5-3.9) 全て success。本 PR の変更スコープに起因する新規 finding なし。

## 関連

Closes #577

- 元の PR: #576 (Phase 6.0 対称化)
- 関連 Issue: #571 (Phase 6.0 対称化のきっかけとなった経緯)
- 参考 PR: #564 (selective surface pattern の canonical 参照実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
