### PR TITLE
fix(skills): wiki SKILL.md の lint カテゴリキーワード drift を解消

### DIFF
--- a/plugins/rite/skills/wiki/SKILL.md
+++ b/plugins/rite/skills/wiki/SKILL.md
@@ -8,8 +8,9 @@ description: |
   unregistered raw sources, and broken references, or initialize the Wiki structure.
   Activates on "wiki", "ingest", "query", "lint", "経験則", "知識ページ",
   "Wiki 蓄積", "経験則を残す", "経験則を参照", "Wiki 検索", "Wiki Lint",
-  "Wiki 品質", "missing_concept", "欠落概念", "unregistered_raw",
-  "未登録 raw", "broken_refs", "壊れた相互参照",
+  "Wiki 品質", "矛盾チェック", "陳腐化", "孤児ページ",
+  "欠落概念", "missing_concept", "壊れた相互参照", "broken_refs",
+  "未登録 raw", "unregistered_raw",
   "wiki:init", "wiki:ingest", "wiki:query", "wiki:lint",
   "/rite:wiki:".
 ---
@@ -23,7 +24,7 @@ description: |
 - wiki, Wiki, 経験則, 知識ページ
 - ingest, 蓄積, 経験則を残す
 - query, 経験則を参照, Wiki 検索
-- lint, Wiki Lint, Wiki 品質, 矛盾チェック, 陳腐化, 孤児ページ, 欠落概念, missing_concept, 未登録 raw, unregistered_raw, 壊れた相互参照, broken_refs
+- lint, Wiki Lint, Wiki 品質, 矛盾チェック, 陳腐化, 孤児ページ, 欠落概念, missing_concept, 壊れた相互参照, broken_refs, 未登録 raw, unregistered_raw
 - `/rite:wiki:init`, `/rite:wiki:ingest`, `/rite:wiki:query`, `/rite:wiki:lint`
 
 ## アーキテクチャ概要


### PR DESCRIPTION
## 概要

- `plugins/rite/skills/wiki/SKILL.md` の description block (L9-15) と Auto-Activation Keywords body (L27) の drift を解消
- 既存 3 日本語キーワード `矛盾チェック` / `陳腐化` / `孤児ページ` を description block に追加
- 両ブロックを `lint.md` canonical 順 (矛盾 → 陳腐化 → 孤児 → 欠落 → 壊れた → 未登録) と 日→英 pair 順に統一

## 変更内容

| ファイル | 変更 |
|---------|------|
| `plugins/rite/skills/wiki/SKILL.md` | description block L11-13 を 4 行化し 3 キーワードを追加、L27 の `壊れた相互参照, broken_refs` と `未登録 raw, unregistered_raw` の順序を canonical に再整列 |

## 背景

PR #583 (Issue #565) のレビューで prompt-engineer-reviewer が指摘したスコープ外の推奨事項から作成。Issue #565 は新規 6 カテゴリ追加のみをスコープとしたため、既存 3 カテゴリの drift 解消は本 Issue #584 として別切り出し。

Wiki 経験則「reference document の用語統一は文脈類義語群全体を対象にする」（高確信度）に基づき、YAML frontmatter description と本文階層の両方を一度に同期。

## 完了条件の充足

- [x] description block に `矛盾チェック` / `陳腐化` / `孤児ページ` の 3 キーワードが含まれる
- [x] description block と Auto-Activation Keywords セクションの lint カテゴリ集合・並び順が完全一致 (drift なし)
- [x] Issue #565 で追加した新規 6 キーワードも canonical 並び順に再整列

## Test plan

- [x] `sed -n '11,13p' SKILL.md` と L27 を目視比較し集合・順序一致を確認
- [x] `diff <(desc_set) <(body_set)` で集合の完全一致を bash 検証
- [x] description block / body 両方で lint カテゴリの出現順が canonical 順と一致することを grep で確認

## 関連

Closes #584

- 元 PR: #583
- 元 Issue: #565
- canonical SoT: `plugins/rite/commands/wiki/lint.md` L2, L11-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
