### PR TITLE
fix(commands): wiki/init.md L333 の git add --dry-run に -- 引数区切りを追加し canonical と一字一句同期

### DIFF
--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -330,7 +330,7 @@ if [ "$probe_created" = "true" ]; then
   # `set -e` 不在の bash block 内では機能等価だが、Wiki 経験則「canonical reference 文書の
   # サンプルコードは canonical 実装と一字一句同期する」(patterns/high) を厳守する。
   dry_run_err=$(mktemp /tmp/rite-wiki-init-p13-dryrun-err-XXXXXX 2>/dev/null) || dry_run_err=""
-  if dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
+  if dry_run_out=$(git add --dry-run -- .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
     dry_run_rc=0
   else
     dry_run_rc=$?


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/init.md` Phase 1.3.4 verification の `git add --dry-run` 呼び出しに `--` 引数区切りを追加し、canonical 実装 `plugins/rite/hooks/scripts/gitignore-health-check.sh` L273 と一字一句同期します。

## 背景

PR #586 cycle 7 re-review で code-quality reviewer が「rc capture 構造は揃ったが `--` 引数セパレータが欠落」と指摘。probe path (`.rite/wiki/raw/.negation-probe`) に leading `-` がないため functional impact は実質 None ですが、L320-331 のコメントで謳う「一字一句同期」の主張と実装の subtle drift として可視化されました。Wiki 経験則「canonical reference 文書のサンプルコードは canonical 実装と一字一句同期する」(patterns/high) を厳格適用するための drift 解消です。

## 変更内容

### `plugins/rite/commands/wiki/init.md` L333

```diff
-  if dry_run_out=$(git add --dry-run .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
+  if dry_run_out=$(git add --dry-run -- .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
```

canonical (`gitignore-health-check.sh` L273: `git add --dry-run -- "$negation_probe"`) と `-- ` 引数区切りの位置まで完全一致。

## Test plan

- [x] lint (`/rite:lint`): 0 errors / 33 warnings (drift 32 + bang-backtick 1、全て pre-existing、develop baseline と一致)
- [x] 変更後の L333 を `grep -n "git add --dry-run -- \.rite/wiki/raw/\.negation-probe"` で確認
- [x] canonical (`gitignore-health-check.sh` L273) との `-- ` 引数区切り同期を diff で確認
- [x] Issue #587 チェックリスト完了 (2/2)

## Known Issues

なし。lint 警告 33 件は全て pre-existing (develop baseline と一致)、本 PR は新規 warning を導入しません。

## 関連 Issue

Closes #587

関連:
- 元の PR: #586 (cycle 7 re-review で本指摘を検出)
- canonical 参照: `plugins/rite/hooks/scripts/gitignore-health-check.sh` L273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
