### PR TITLE
fix(commands): wiki/init.md Phase 1.3.4 に dry_run_out/dry_run_rc 事前宣言を追加し canonical と一字一句同期

### DIFF
--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -330,6 +330,8 @@ if [ "$probe_created" = "true" ]; then
   # `set -e` 不在の bash block 内では機能等価だが、Wiki 経験則「canonical reference 文書の
   # サンプルコードは canonical 実装と一字一句同期する」(patterns/high) を厳守する。
   dry_run_err=$(mktemp /tmp/rite-wiki-init-p13-dryrun-err-XXXXXX 2>/dev/null) || dry_run_err=""
+  dry_run_out=""
+  dry_run_rc=0
   if dry_run_out=$(git add --dry-run -- .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
     dry_run_rc=0
   else


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/init.md` Phase 1.3.4 verification ブロックに canonical 実装 `plugins/rite/hooks/scripts/gitignore-health-check.sh` L270-277 との **一字一句同期** を達成するため、`dry_run_out=""` と `dry_run_rc=0` の事前宣言 2 行を追加しました。

PR #586 cycle 7 code-quality-reviewer 推奨事項 #2 (LOW / Confidence 75) の drift 解消対応です。

## 関連 Issue

Closes #588

## 変更内容

- `plugins/rite/commands/wiki/init.md` L332 `dry_run_err=$(mktemp ...)` 行の直後に以下 2 行を挿入

  ```bash
  dry_run_out=""
  dry_run_rc=0
  ```

結果として canonical と同じ 5 行構造（`_err=...` → `_out=""` → `_rc=0` → `if _out=$(...); then _rc=0; else _rc=$?; fi`）に揃います。

## 背景

- `set -e` 不在の bash block 内では `if var=$(cmd); then ...` が assignment を保証するため、宣言 2 行の追加は **functional 等価**（動作変化なし）
- ただし、canonical reference 文書のサンプルコードは canonical 実装と一字一句同期するという Wiki 経験則（patterns/high）を厳守するための drift 解消

## テスト計画

- [x] Read で init.md L333/L334 に `dry_run_out=""`/`dry_run_rc=0` が追加されたことを確認
- [x] canonical (`gitignore-health-check.sh` L270-277) と init.md の該当 5 行ブロックが同一構造であることを確認（変数名を除き）
- [x] プラグイン固有 lint チェック（drift / bang-backtick / doc-heavy / wiki-growth / gitignore-health）実行済み — 既存警告のみで本 PR 変更と無関係

## 関連

- 元の PR: #586
- canonical 参照: `plugins/rite/hooks/scripts/gitignore-health-check.sh` L270-277

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
