### PR TITLE
docs(wiki): lint.md Phase 8.3 entry を {log_entry}/{branch_strategy} 2 種包含に拡張 (#591)

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -1736,7 +1736,7 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
   - Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 の `branch_strategy` 未知値 (5 箇所で同型、設定ミスの silent 通過防止)
   - Phase 1.1 / Phase 1.3 の `{mode}` placeholder 残留検知 (2 箇所で同型、Claude substitute 忘れの silent 通過防止)
   - Phase 6.2 の placeholder 残留検知 (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種で同型、PR #564 F-01 / F-21、LLM substitute 忘れによる silent `missing_concept` 誤分類防止)
-  - Phase 8.3 の `{log_entry}` placeholder 残留検知 (PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止)
+  - Phase 8.3 の placeholder 残留検知 (`{log_entry}` / `{branch_strategy}` の 2 種、PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止)
   - Phase 8.1 の counter placeholder (`n_contradictions` / `n_stale` / `n_orphans` / `n_missing_concept` / `n_broken_refs`) 残留 / 非整数検知 (5 counter で同型、Issue #573、LLM substitute 忘れによる silent `lint:clean` 誤 emit 防止)
 - 内部 bash 構文エラー等の unrecoverable error のみ非 0 exit となる可能性あり
 
@@ -1751,7 +1751,7 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 | Wiki 未初期化 | `/rite:wiki:init` を案内 (`--auto` モード時は 6 フィールド 0 件 1 行を出力後 exit 0) | Phase 1.3 |
 | `{mode}` placeholder 残留 (Phase 1.1 / Phase 1.3 の 2 箇所) | **exit 1 で fail-fast**（Claude substitute 忘れの silent 通過防止、2 箇所で同型） | Phase 1.1 / Phase 1.3 |
 | Phase 6.2 の placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種) | **exit 1 で fail-fast**（PR #564 F-01 / F-21、LLM substitute 忘れによる silent `missing_concept` 誤分類防止、3 種で同型） | Phase 6.2 |
-| Phase 8.3 の `{log_entry}` placeholder 残留 | **exit 1 で fail-fast**（PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止） | Phase 8.3 |
+| Phase 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種) | **exit 1 で fail-fast**（PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止、2 種で同型） | Phase 8.3 |
 | Phase 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数検知 | **exit 1 で fail-fast**（Issue #573、LLM substitute 忘れによる silent `lint:clean` 誤 emit 防止、5 counter で同型） | Phase 8.1 |
 | `git ls-tree` 失敗 | WARNING + `pages_list=""`/`raw_list=""` で継続（exit 0） | Phase 2.2 |
 | `branch_strategy` が未知の値 (Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 の 5 箇所) | **exit 1 で fail-fast**（設定ミスの silent 通過防止、5 箇所で同型） | Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 |

--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -1736,7 +1736,7 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
   - Phase 2.2 / Phase 6.0 / Phase 6.2 / Phase 8.2 / Phase 8.3 の `branch_strategy` 未知値 (5 箇所で同型、設定ミスの silent 通過防止)
   - Phase 1.1 / Phase 1.3 の `{mode}` placeholder 残留検知 (2 箇所で同型、Claude substitute 忘れの silent 通過防止)
   - Phase 6.2 の placeholder 残留検知 (`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種で同型、PR #564 F-01 / F-21、LLM substitute 忘れによる silent `missing_concept` 誤分類防止)
-  - Phase 8.3 の placeholder 残留検知 (`{log_entry}` / `{branch_strategy}` の 2 種、PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止)
+  - Phase 8.3 の placeholder 残留検知 (`{log_entry}` / `{branch_strategy}` の 2 種で同型、PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止)
   - Phase 8.1 の counter placeholder (`n_contradictions` / `n_stale` / `n_orphans` / `n_missing_concept` / `n_broken_refs`) 残留 / 非整数検知 (5 counter で同型、Issue #573、LLM substitute 忘れによる silent `lint:clean` 誤 emit 防止)
 - 内部 bash 構文エラー等の unrecoverable error のみ非 0 exit となる可能性あり
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/lint.md` の canonical 一覧（9.3 exit code 節 + エラーハンドリング表）の Phase 8.3 entry を `{log_entry}` 単独表現から `{log_entry}` / `{branch_strategy}` の 2 種包含に拡張し、PR #590 以降残っていた drift を解消します（方針 B 採択、5 site 数は維持）。

Closes #591

## 背景

- PR #590 (Issue #580) で Phase 8.3 entry は canonical 一覧に登録されたが、登録されたのは `{log_entry}` placeholder gate（L1474-1484, PR #564 F-14）のみ。
- 実装上は Phase 8.3 内に 2 種目の placeholder 残留 fail-fast gate として `{branch_strategy}` gate（L1492-1497, PR #564 F-04）が独立して存在するが、canonical 一覧には未登録のままだった。
- prompt-engineer reviewer による PR #590 レビューで「スコープ外の推奨事項」として指摘済み。

## 対処（方針 B: Phase 8.3 entry の集約）

既存 Phase 8.3 entry を 2 種包含に拡張し、5 site 数（Phase 1.1 / 1.3 / 6.2 / 8.3 / 8.1）は維持します。canonical 6 site 化（方針 A）は採用していません。

### 9.3 exit code 節（L1739）

```diff
-  - Phase 8.3 の `{log_entry}` placeholder 残留検知 (PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止)
+  - Phase 8.3 の placeholder 残留検知 (`{log_entry}` / `{branch_strategy}` の 2 種、PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止)
```

### エラーハンドリング表（L1754）

```diff
-| Phase 8.3 の `{log_entry}` placeholder 残留 | **exit 1 で fail-fast**（PR #564 F-14、LLM substitute 忘れによる literal `{log_entry}` を含む意味不明な commit landed 防止） | Phase 8.3 |
+| Phase 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種) | **exit 1 で fail-fast**（PR #564 F-04 / F-14、LLM substitute 忘れによる literal 残留 commit landed 防止、2 種で同型） | Phase 8.3 |
```

両エントリに由来 (PR #564 F-04 / F-14) と「2 種で同型」を明記し、Phase 6.2 entry（`{branch_strategy}` / `{wiki_branch}` / `{pages_list}` の 3 種で同型）と同形式の表現パターンに揃えました。

## 方針 A を採用しなかった理由

方針 A は 9.3 exit code 節とエラーハンドリング表に Phase 8.3 `{branch_strategy}` を**独立行**として追加し、「canonical 6 site 化」にするもの。これは以下の理由で却下しました:

1. `plugins/rite/commands/wiki/lint.md` 全体で「5 site 対称化」「5 箇所で同型」literal 表現が既に複数箇所（L40, L1374-1375, L308, L725, L728 等）に埋め込まれており、6 site 化するとそれらとの一貫性が崩れる。
2. 5 site は `{branch_strategy}` 未知値 fail-fast（Phase 2.2 / 6.0 / 6.2 / 8.2 / 8.3）の軸で定義されており、placeholder 残留 gate の数とは独立した軸。行追加で 6 site に増やす操作は軸の混同を招く。
3. Phase 6.2 entry が既に「3 種で同型」形式で複数 placeholder を 1 行で扱っており、Phase 8.3 も同形式に揃える方が一貫性が高い。

## 変更なし

- Phase 8.3 実装コード（L1492-1497、`{branch_strategy}` placeholder gate 本体）は無変更。
- 5 site 対称化コメント（L1374-1375 等）も無変更。
- その他 canonical 4 entry も無変更。

## チェックリスト

- [x] 9.3 exit code 節の Phase 8.3 entry を 2 種包含に拡張（L1739）
- [x] エラーハンドリング表の Phase 8.3 entry を 2 種包含に拡張（L1754）
- [x] 5 site 数を維持（新規行追加せず既存 entry 拡張）
- [x] 由来（PR #564 F-04 / F-14）を両 entry に明記
- [x] `Grep "Phase 8.3 の placeholder 残留.*\{log_entry\}.*\{branch_strategy\}.*2 種"` で両 entry が検出されることを確認

## Known Issues

- 本プロジェクトは lint/build/test コマンドが未構成（`rite-config.yml` の `commands.lint: null` 等、docs/plugin 定義のみのプロジェクトのため）。`/rite:lint` は `[lint:skipped]` で完了。
- plugin-specific check（Phase 3.5-3.9）では pre-existing warning が検出されたが、いずれも本 PR の diff に起因しない既存 drift（distributed-fix-drift-check: 32 件は `pr/review.md` 等、bang-backtick-check: 1 件は `wiki/references/bash-cross-boundary-state-transfer.md`）。別 Issue として追跡対象外（本 PR スコープ外の pre-existing tech debt）。

## 関連

- 元 PR: #590（Phase 8.3 の 5 site 対称化登録）
- 元 Issue: #580（5 site 対称化の canonical 登録）
- drift 導入元: PR #564 F-04（`{branch_strategy}` placeholder gate の Phase 8.3 追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
