### PR TITLE
refactor(wiki): lint Phase 2.3 same_branch cat に LC_ALL=C を付与し Phase 6.0 と locale 固定を完全対称化

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -358,11 +358,13 @@ if [ "$branch_strategy" = "separate_branch" ]; then
     index_read_ok="false"
   fi
 else
-  if index_content=$(cat .rite/wiki/index.md 2>"${index_err:-/dev/null}"); then
-    # selective surface pattern: cat は通常 stderr を成功経路で emit しないが、separate_branch
-    # 成功経路 (直上 git show) と対称化するため同型 surface を配置する (Issue #577)。
-    # BSD cat 等が diagnostic を emit する稀なケースで silent に warning を握りつぶさないための
-    # defense-in-depth として機能する (PR #576 Phase 6.0 で同型対称化を完了済み)。
+  if index_content=$(LC_ALL=C cat .rite/wiki/index.md 2>"${index_err:-/dev/null}"); then
+    # selective surface pattern + locale 固定 (LC_ALL=C): cat は通常 stderr を成功経路で emit
+    # しないが、separate_branch 成功経路 (直上 git show) と対称化するため同型 surface を配置する
+    # (Issue #577)。BSD cat 等が diagnostic を emit する稀なケースで silent に warning を握り
+    # つぶさない defense-in-depth として機能し、`LC_ALL=C` で Phase 6.0 (line 698) との locale
+    # 固定も統一済み (Issue #593 — 将来 error path に stderr pattern match を追加した際、
+    # ja_JP.UTF-8 等で localize された diagnostic による silent regression を予防)。
     [ -n "$index_err" ] && [ -s "$index_err" ] && head -3 "$index_err" | sed 's/^/  WARNING(cat hint): /' >&2
   else
     echo "WARNING: .rite/wiki/index.md を読み出せません" >&2

--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -362,9 +362,10 @@ else
     # selective surface pattern + locale 固定 (LC_ALL=C): cat は通常 stderr を成功経路で emit
     # しないが、separate_branch 成功経路 (直上 git show) と対称化するため同型 surface を配置する
     # (Issue #577)。BSD cat 等が diagnostic を emit する稀なケースで silent に warning を握り
-    # つぶさない defense-in-depth として機能し、`LC_ALL=C` で Phase 6.0 (line 698) との locale
-    # 固定も統一済み (Issue #593 — 将来 error path に stderr pattern match を追加した際、
-    # ja_JP.UTF-8 等で localize された diagnostic による silent regression を予防)。
+    # つぶさない defense-in-depth として機能し、`LC_ALL=C` で Phase 6.0 same_branch 経路
+    # (`LC_ALL=C cat .rite/wiki/log.md`) との locale 固定も統一済み (Issue #593 — 将来 error path
+    # に stderr pattern match を追加した際、ja_JP.UTF-8 等で localize された diagnostic による
+    # silent regression を予防)。
     [ -n "$index_err" ] && [ -s "$index_err" ] && head -3 "$index_err" | sed 's/^/  WARNING(cat hint): /' >&2
   else
     echo "WARNING: .rite/wiki/index.md を読み出せません" >&2


### PR DESCRIPTION
## 概要

Phase 2.3 same_branch 経路の `cat .rite/wiki/index.md` 呼び出しに `LC_ALL=C` を付与し、Phase 6.0 (line 700 の `LC_ALL=C cat .rite/wiki/log.md`) と完全に locale 固定を対称化した。

## 変更内容

- `plugins/rite/commands/wiki/lint.md` L361: `cat .rite/wiki/index.md` → `LC_ALL=C cat .rite/wiki/index.md`
- L362-367 の 4 行コメントを 6 行に更新: locale 固定の rationale (Issue #593) と Phase 6.0 (line 698) との対称化を明記、Issue #577 の selective surface pattern 出典は保持

## 背景

PR #592 (Issue #577) で Phase 2.3 same_branch 成功経路に selective surface pattern を追加した際、両 reviewer (prompt-engineer / code-quality) が独立に LC_ALL=C 非対称を推奨事項として指摘していた。本 PR で対称化を完成させる。

ja_JP.UTF-8 等の locale 下で cat の stderr diagnostic が localize された場合、将来 error path で `No such file or directory|cannot open` 等の stderr pattern match を追加した際に silent regression が起きるリスクを予防する defense-in-depth。

## スコープ

本 PR の scope は line 361 cat のみ。L350 separate_branch git show (LC_ALL=C 未付与) は別 Issue として scope 外。

## 検証

- ✅ `Grep "LC_ALL=C cat .rite/wiki/index.md" lint.md` がマッチ (L361)
- ✅ `Grep "Issue #593" lint.md` がマッチ (L366)
- ✅ `Grep "LC_ALL=C cat .rite/wiki/log.md" lint.md` がマッチ (L700, 未変更 — regression guard)

## 関連

- 元の PR: #592 (Phase 2.3 selective surface 対称化)
- 関連 PR: #576 (Phase 6.0 対称化、LC_ALL=C 採用元)
- 関連 Issue: #577 (Phase 2.3 対称化シリーズ)

## Known Issues

- lint コマンド未設定（docs-only repo）
- 既存ファイルに対する drift check 32 / bang-backtick 1 の warning あり（変更スコープ外）

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)
