### PR TITLE
refactor(wiki): lint.md 冒頭テーブルの列挙順を frontmatter description 順に統一

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -12,8 +12,8 @@ Wiki Lint エンジン。`.rite/wiki/pages/` 配下の Wiki ページと `.rite/
 | **陳腐化** | `updated` frontmatter が閾値（デフォルト 90 日）を超えて更新されていないページ | Yes |
 | **孤児ページ** | `pages/` 配下に存在するが `index.md` の「ページ一覧」テーブルに登録されていないページ | Yes |
 | **欠落概念 (missing_concept)** | `raw/` に `ingested: true` の Raw Source があるが、対応ページも `sources.ref` 登録も `ingest:skip` 記録も存在しない真の欠落 | Yes |
-| **未登録 raw (unregistered_raw)** | `ingested: true` で `sources.ref` 未登録だが、`log.md` に `ingest:skip` 記録がある raw。意図的に経験則化しなかった件数の informational 指標 | **No** (`n_warnings` 不加算) |
 | **壊れた相互参照** | ページ本文の Markdown リンク `](...)` が `pages/` 配下の実在ファイルを指していない | Yes |
+| **未登録 raw (unregistered_raw)** | `ingested: true` で `sources.ref` 未登録だが、`log.md` に `ingest:skip` 記録がある raw。意図的に経験則化しなかった件数の informational 指標 | **No** (`n_warnings` 不加算) |
 
 > **Reference**: [Wiki Patterns](../../references/wiki-patterns.md) — ディレクトリ構造、ブランチ管理、テンプレート展開の共通パターン
 > **Reference**: [Plugin Path Resolution](../../references/plugin-path-resolution.md) — `{plugin_root}` の解決手順


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/lint.md` 冒頭テーブルの列挙順を frontmatter description 順に統一し canonical SoT を単一化する。具体的には「未登録 raw (unregistered_raw)」行を「壊れた相互参照」行の後 (末尾) に移動し、「5 ブロッキング観点連続 → 1 informational 末尾隔離」という概念構造に整列。

## 背景

Issue #595 は PR #594 (Issue #584) で code-quality reviewer が検出したスコープ外推奨事項から作成された。

`plugins/rite/commands/wiki/lint.md` 内部に列挙順が 2 通り共存していた:

- **frontmatter description (L2)**: 矛盾 → 陳腐化 → 孤児 → 欠落概念 → 壊れた相互参照 + 未登録 raw (末尾 informational 隔離)
- **本文冒頭テーブル (before)**: 矛盾 → 陳腐化 → 孤児ページ → 欠落概念 → **未登録 raw** → 壊れた相互参照 (未登録 raw が中間挿入)

PR #594 で SKILL.md の Activates list を frontmatter description 順に整列した前例があり、本 PR はその延長で残っていた drift を解消する。Wiki 経験則「frontmatter description と本文階層の同時整列」(PR #594 successful application heuristic) を継承。

## 変更

本文冒頭テーブル内で「未登録 raw (unregistered_raw)」行と「壊れた相互参照」行の順序を入れ替え、frontmatter description と同順に揃えた。

## 影響範囲

表示順のみの変更。`rite:wiki:lint` の検出ロジック・ブロッキング判定 (Yes/No 列)・引数仕様・出力フォーマットには一切影響しない。`n_unregistered_raw` / 出力セクション (未登録 raw (skip 済)) 等の単独参照箇所は列挙順概念を含まないため drift なし。

## 関連 Issue

Closes #595

## 変更ファイル

- `plugins/rite/commands/wiki/lint.md` - 変更 (1 insertion, 1 deletion: テーブル 2 行 swap)

## Known Issues

本 PR のスコープ外。lint の plugin-specific check で以下 warning を検出 (いずれも本 PR 変更外ファイルに存在する既存 drift で、`commands.lint: null` 環境での non-blocking warning 扱い):

- Drift check: 32 findings in `plugins/rite/commands/pr/review.md` (wiki ingest reason enum drift — 別 track で継続対応中)
- Bang-backtick check: 1 finding in `plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md` L153

## Test plan

- [ ] Grep で lint.md 冒頭テーブル内の行順が「矛盾 → 陳腐化 → 孤児ページ → 欠落概念 → 壊れた相互参照 → 未登録 raw」になっていることを確認
- [ ] frontmatter description (L2) の列挙順と本文冒頭テーブルの列挙順が一致することを確認
- [ ] `n_unregistered_raw` / 出力セクション等の単独参照箇所に drift がないことを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
