### PR TITLE
refactor(commands): wiki/init.md L253/L320 の line 番号 literal 参照を semantic anchor に置換

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,10 @@ temp/
 #   mkdir -p .rite/wiki/raw
 #   touch   .rite/wiki/raw/.negation-probe
 #
+# >>> DRIFT-CHECK ANCHOR: negation verification canonical <<<
+# Downstream reference: plugins/rite/commands/wiki/init.md Phase 1.3.4. init.md 側は
+# 本節 (Step 3 + check-ignore 回避理由) を semantic anchor 経由で参照する。節内の
+# Step 3 コマンド / 期待出力を変更する際は init.md Phase 1.3.4 bash block と同期.
 # Step 3. **動作確認の正典** (必須 — Step 1 の negation を追加した時点 / rebase した時点 /
 #         .gitignore に関わる変更を review した時点で毎回実行する。F-02 / F-06 対応):
 #
@@ -111,6 +115,7 @@ temp/
 # `pattern` フィールドの `!` prefix を手動 parse しないと negation 成立か単純 match か判別不能。
 # **`git add --dry-run` を sanity check の正典** として採用し、check-ignore は参考情報に
 # とどめる (Source: git documentation — git check-ignore(1)、`pattern` column の `!` prefix 仕様)。
+# >>> DRIFT-CHECK ANCHOR END: negation verification canonical <<<
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Idempotency 注 (F-07 対応):

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -250,7 +250,7 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 
 #### 1.3.4 verification
 
-> **Reference**: `.gitignore` L84-L113 の「動作確認の正典」節。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` L281 付近の `grep -qF` パターン参照。
+> **Reference**: `.gitignore` の `DRIFT-CHECK ANCHOR: negation verification canonical` 節（「動作確認の正典」 + `git check-ignore -v` を sanity check に使わない理由）。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` の `DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check` 節の `grep -qF` パターン参照。
 
 ```bash
 # signal-specific trap で probe ファイルの残留を防ぐ
@@ -317,7 +317,8 @@ if [ "$probe_created" = "true" ]; then
   #
   # PR #586 F-02 対応: stderr を独立 tempfile に退避し stdout に merge しない。
   # 同一ファイル内 Phase 3.5.1 のプロジェクト規約「2>&1 は付けない: 構造化 stdout と WARNING stderr
-  # の分離を維持する」に準拠する。canonical 参照実装 gitignore-health-check.sh L270-277 の
+  # の分離を維持する」に準拠する。canonical 参照実装 gitignore-health-check.sh の
+  # `DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture` 節の
   # `add_dry_err=$(mktemp ...) ... if add_dry_out=$(...); then add_dry_rc=0; else add_dry_rc=$?; fi`
   # パターンに **rc capture 構造ごと** 揃える (canonical drift 防止)。実害として、success path で
   # git が emit する stderr 警告 (例: `warning: in the working copy of '...', LF will be replaced

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -267,6 +267,11 @@ case "$branch_strategy" in
       exit 2
     }
 
+    # >>> DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture <<<
+    # Downstream reference: plugins/rite/commands/wiki/init.md Phase 1.3.4 verification
+    # block. Keep the mktemp stderr capture + if-wrapper rc capture structure one-for-one
+    # with init.md's copy — Wiki 経験則 patterns/high「canonical reference 文書のサンプル
+    # コードは canonical 実装と一字一句同期する」.
     add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
     add_dry_out=""
     add_dry_rc=0
@@ -275,7 +280,13 @@ case "$branch_strategy" in
     else
       add_dry_rc=$?
     fi
+    # >>> DRIFT-CHECK ANCHOR END: same_branch add_dry_run rc capture <<<
 
+    # >>> DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check <<<
+    # Downstream reference: plugins/rite/commands/wiki/init.md Phase 1.3.4 verification
+    # block. Keep the `grep -qF "add '${negation_probe}'"` full-path fixed-string match
+    # one-for-one with init.md's copy — simple `grep -q "^add '"` 単純 prefix は
+    # false positive を招く.
     # Healthy negation: rc=0 + stdout like `add '.rite/wiki/raw/.rite-lint-negation-probe'`
     # Broken negation: rc=1 + stderr contains "paths are ignored"
     if [ "$add_dry_rc" -eq 0 ] && printf '%s' "$add_dry_out" | grep -qF "add '${negation_probe}'"; then
@@ -287,6 +298,7 @@ case "$branch_strategy" in
       echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see .gitignore L66-75 for setup steps)." >&2
       findings=$((findings + 1))
     fi
+    # >>> DRIFT-CHECK ANCHOR END: same_branch negation grep-qF healthy check <<<
     # probe cleanup handled by trap
     ;;
 esac


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/init.md` L253 / L320 のコメント内に残存していた canonical ファイルへの line 番号 literal 参照 (`L84-L113`, `L281 付近`, `L270-277`) を semantic anchor 参照に置換しました。Wiki 経験則 patterns/high「DRIFT-CHECK ANCHOR は semantic name 参照で記述する（line 番号禁止）」を適用し、canonical 側の行追加/削除による参照陳腐化リスクを解消します。

## 変更内容

### 1. canonical 側に DRIFT-CHECK ANCHOR を埋め込み

- `plugins/rite/hooks/scripts/gitignore-health-check.sh`
  - `# >>> DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture <<<` で `add_dry_err=$(mktemp ...)` + if-wrapper rc capture ブロックを囲む
  - `# >>> DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check <<<` で `grep -qF "add '${negation_probe}'"` ブロックを囲む
- `.gitignore`
  - `# >>> DRIFT-CHECK ANCHOR: negation verification canonical <<<` で Step 3「動作確認の正典」 + 「`git check-ignore -v` を sanity check に使わない理由」節を囲む

### 2. init.md 側の line 番号 literal 参照を semantic anchor 参照に置換

- `plugins/rite/commands/wiki/init.md` L253 (Phase 1.3.4 Reference): `.gitignore L84-L113 の「動作確認の正典」節` → `` `.gitignore` の `DRIFT-CHECK ANCHOR: negation verification canonical` 節 ``、`gitignore-health-check.sh L281 付近` → `` gitignore-health-check.sh の `DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check` 節 ``
- `plugins/rite/commands/wiki/init.md` L320-322 (Phase 1.3.4 コメント): `canonical 参照実装 gitignore-health-check.sh L270-277 の` → `` canonical 参照実装 gitignore-health-check.sh の `DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture` 節の ``

## 関連 Issue

Closes #597

## 動作確認

- [x] `grep -c "DRIFT-CHECK ANCHOR\(.*END\)\?: same_branch add_dry_run rc capture"` → 2 件
- [x] `grep -c "DRIFT-CHECK ANCHOR\(.*END\)\?: same_branch negation grep-qF healthy check"` → 2 件
- [x] `grep -c "DRIFT-CHECK ANCHOR\(.*END\)\?: negation verification canonical"` (.gitignore) → 2 件
- [x] `init.md` 内で `L84-L113` / `L281 付近` / `L270-277` が消滅
- [x] `/rite:lint` の distributed-fix-drift-check / bang-backtick-check: 変更ファイル内 finding 0 件 (regression なし)

## Known Issues

scope 外の既存 lint 警告 (本 PR の変更とは無関係):

- distributed-fix-drift-check: 32 件 (いずれも本 PR 変更ファイル外)
- bang-backtick-check: 1 件 (`plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md:153`)

これらは本 Issue の scope 外のため別途対応対象です。
