### PR TITLE
fix(pr-cleanup): `if !` インライン code の preprocessor bash eval 誤発火を解消 (#609)

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -1495,7 +1495,7 @@ If `pending_count == 0`, skip Phase 4.W.2-4.W.3 and proceed to Phase 5. Otherwis
 >
 > **Identity reference**: [workflow-identity.md](../../skills/rite-workflow/references/workflow-identity.md) の `no_step_omission` / `no_context_introspection` / `clear_resume_is_canonical` / `quality_over_expediency` principle を参照。
 
-**Pre-write** (before invoking `rite:wiki:ingest`, Issue #604): Update `.rite-flow-state` to `cleanup_pre_ingest` so `stop-guard.sh` blocks premature `end_turn` during sub-skill execution and surfaces the phase-specific HINT (sub-skill in-flight, output `<!-- [cleanup:completed] -->` after Phase 5 in the SAME response turn). The `if !` rc capture is mandatory — silent patch failure here disables the stop-guard defence-in-depth that exists specifically to keep this turn from ending mid-sub-skill (#608 follow-up):
+**Pre-write** (before invoking `rite:wiki:ingest`, Issue #604): Update `.rite-flow-state` to `cleanup_pre_ingest` so `stop-guard.sh` blocks premature `end_turn` during sub-skill execution and surfaces the phase-specific HINT (sub-skill in-flight, output `<!-- [cleanup:completed] -->` after Phase 5 in the SAME response turn). The `if ! cmd; then` rc capture is mandatory — silent patch failure here disables the stop-guard defence-in-depth that exists specifically to keep this turn from ending mid-sub-skill (#608 follow-up):
 
 ```bash
 if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -1619,7 +1619,7 @@ trap - EXIT INT TERM HUP
    - **Yes** — terminal state reached. `.rite-flow-state.phase` is already `cleanup_completed` and `active: false`. **本 Yes 分岐は terminal 到達後の重複呼び出し防止のための例外経路**であり、non-terminal (phase=cleanup_pre_ingest) 時点の Step 1 正規路 (Correct-pattern の Step 1「Runs 🚨 Mandatory After Wiki Ingest Pre-write (writes cleanup_post_ingest)」) と矛盾しないことに留意する。Step 1 below MUST be skipped. 理由: `cleanup_completed` は terminal state であり、Step 1 の `flow-state-update.sh patch --if-exists` は active=false でも file が存在すれば patch するため、phase を `cleanup_post_ingest` に巻き戻して flow-state を破壊する。phase-transition-whitelist.sh の terminal acceptance は next phase のみを判定し、prev が terminal でも accept するため whitelist 保護には依存できない — 実行しないことで確実に防ぐ。
    - **No** — Phase 5 has NOT been output yet (phase=cleanup_pre_ingest など non-terminal 状態)。Steps 1-2 below are **critical** — execute immediately to force the workflow into the terminal state (Step 1 が正規 handoff パス)。
 
-**Step 1**: Update `.rite-flow-state` to post-ingest phase (atomic). The `if !` rc capture is mandatory — silent failure here means the next stop-guard evaluation observes the stale `cleanup_pre_ingest` state and the HINT shown to the LLM no longer matches the actual workflow position (#608 follow-up):
+**Step 1**: Update `.rite-flow-state` to post-ingest phase (atomic). The `if ! cmd; then` rc capture is mandatory — silent failure here means the next stop-guard evaluation observes the stale `cleanup_pre_ingest` state and the HINT shown to the LLM no longer matches the actual workflow position (#608 follow-up):
 
 ```bash
 if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -1794,7 +1794,7 @@ git stash pop
 > 3. Phase 5.3 Step 1: flow-state deactivate (下記 Step 1) — bash 出力はユーザー可視だが、`(Bash completed with no output)` のため最終行にならない
 > 4. Phase 5.3 Step 2: `<!-- [cleanup:completed] -->` HTML コメント (下記 Step 2、絶対最終行 — rendered view では不可視、grep 可能)
 
-**Step 1**: Deactivate flow state to terminal `cleanup_completed` (idempotent — safe to re-execute). The `if !` rc capture is mandatory — silent failure here leaves `.rite-flow-state.active = true`, which causes the **next** session-end / stop-guard evaluation to surface a stale HINT for the already-completed cleanup workflow (#608 follow-up):
+**Step 1**: Deactivate flow state to terminal `cleanup_completed` (idempotent — safe to re-execute). The `if ! cmd; then` rc capture is mandatory — silent failure here leaves `.rite-flow-state.active = true`, which causes the **next** session-end / stop-guard evaluation to surface a stale HINT for the already-completed cleanup workflow (#608 follow-up):
 
 ```bash
 if ! bash {plugin_root}/hooks/flow-state-update.sh patch \


### PR DESCRIPTION
Closes #609
Parent: #604 (follow-up), #608 (導入 PR、本件の regression 発生元)

## Summary

- `/rite:pr:cleanup` slash command が Claude Code preprocessor 層で bash syntax error により起動不能になっていた regression を解消
- `cleanup.md` L1498 / L1622 / L1797 の ``The `if !` rc capture …`` 表現を ``The `if ! cmd; then` rc capture …`` に変更し、``!`` 直後に closing backtick が来る ``!` `` パターンを排除
- 意味論的な説明 (「bash `if ! cmd; then` パターンでは `$?` が常に 0 になる罠を避けるため command substitution 形式で rc を捕捉する」) は保持

## Root Cause

Claude Code の slash command preprocessor は ``!`<cmd>` `` を bash command substitution 構文として解釈する。PR #608 で追加された 3 箇所の ``The `if !` rc capture`` には:

1. ``!`` の直後に closing backtick が続く ``!` `` パターン
2. 次の `` ` `` (```bash コードフェンス) までの任意の説明文字列

の組み合わせがあり、preprocessor が説明文字列を bash eval → `(#608 follow-up)` の `(` で syntax error となっていた。

再現 stderr:
```
Error: Shell command failed for pattern "!` rc capture is mandatory — silent patch failure here disables the stop-guard defence-in-depth that exists specifically to keep this turn from ending mid-sub-skill (#608 follow-up):
`": /bin/bash: eval: 行 3: 予期しないトークン `(' 周辺に構文エラーがあります
```

## Impact

- PR #608 マージ以降、`/rite:pr:cleanup` を起動した全セッションで Phase 0 の orchestrator にすら到達できない状態だった
- その副作用として cleanup の最終 phase (Phase 3 = worktree cleanup) が走らず、`develop` worktree (`/tmp/rite-dev-608-cq`) が stale のまま残存するという二次障害も発生していた (本 PR の scope 外、別タスクで掃除)

## Non-regression (Issue #604 対応分)

- 変更は **説明テキスト内のインライン code の表記のみ**
- `if ! bash {plugin_root}/hooks/flow-state-update.sh patch …; then … fi` の bash ブロック本体には一切手を入れていない
- よって Issue #604 の AC-1 (Phase 4 → Phase 5 sentinel 到達) / AC-2 (ingest 単独の Phase 9 到達) / AC-4 (auto-lint 失敗時の Phase 9 出力) には回帰がない

## Follow-up (別 Issue 候補)

`grep -rn "!\`" plugins/rite/commands/` で以下の潜在的に同型の ``!` `` パターンを検出済み。いずれも slash command 起動経路の preprocessor を通過する可能性があるため、本 PR マージ後に別 Issue で一斉に掃討することを推奨:

- `plugins/rite/commands/wiki/init.md:247` — ``行頭を `#` または `!` から直接開始する`` (`` `!` `` で end backtick 直前が `!`)
- `plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md:153` — ``「`if !` は `$?` が常に 0」`` (3 箇所)

本 PR では reported blocker の解消のみに絞っている (Issue #609 の Out of Scope)。

## Test plan

- [x] `grep -c "!\`" plugins/rite/commands/pr/cleanup.md` → 0 (AC-3 / T-03)
- [ ] マージ後 `/rite:pr:cleanup <PR番号>` を実行し preprocessor error が出ず Phase 0 以降に進むことを確認 (AC-1 / T-01、手動 E2E)
- [ ] 同じ実行で Phase 4 → Phase 5 → `<!-- [cleanup:completed] -->` sentinel 到達を確認 (AC-2 / T-02、Issue #604 回帰チェック)
- [ ] stale worktree (`/tmp/rite-dev-608-cq`) を手動で削除 (本 PR scope 外、別タスク)

🤖 Generated with [Claude Code](https://claude.com/claude-code)