### PR TITLE
fix(wiki): 残存 `!`+backtick pattern を preprocessor 安全表現へ移行 (#611)

### DIFF
--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -244,7 +244,7 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 1. 末尾改行は Edit ツールが自動付与するため new_string の末尾に付与しない
 2. 提示したコードフェンス ` ``` ` は Markdown の表示用で、new_string には含めない
 3. `old_string` と `new_string` の先頭行は同一文字列で、その後に 6 行の negation ブロックが続く
-4. 各行の先頭インデントは 0 スペース。Markdown レンダラや Claude が参照時に余計な先頭空白を認識した場合でも、new_string では**行頭を `#` または `!` から直接開始する**（`  # >>> ...` のような先頭空白は含めない）
+4. 各行の先頭インデントは 0 スペース。Markdown レンダラや Claude が参照時に余計な先頭空白を認識した場合でも、new_string では**行頭を `#` または 「!」 から直接開始する**（`  # >>> ...` のような先頭空白は含めない）
 
 `!.rite/wiki/**` は glob を明示する防御的エントリで、単独では機能しない（parent exclusion が残るため）が、gitignore を消費する一部のツール (IDE の VCS integration 等) への defense-in-depth として推奨される（`.gitignore` 上部 Step 1 コメントと同じ根拠）。
 
@@ -544,7 +544,7 @@ plugin_root="{plugin_root}"
 
 if [ "$branch_strategy" = "separate_branch" ]; then
   # wiki-worktree-setup.sh は冪等 (既存なら no-op) で安全に呼べる
-  # 注意: `if ! cmd; then rc=$?` パターンは bash 仕様上 `$?` が常に `!` の終了 status (= 0) を
+  # 注意: `if ! cmd; then rc=$?` パターンは bash 仕様上 `$?` が常に 「!」 の終了 status (= 0) を
   # 返すため、setup.sh の真の rc (1=env error / 2=disabled / 3=worktree add 失敗) を捕捉できない。
   # `set +e; cmd; rc=$?; set -e` で明示的に capture する (ingest.md Phase 1.3 と対称)。
   set +e

--- a/plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md
+++ b/plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md
@@ -150,7 +150,7 @@ stderr を tempfile に退避し、**stderr pattern matching** で legitimate ab
 
 ```bash
 # F-21 対応: 2 文分割形式 (lint.md Phase 6.0 の R-03 推奨形式) に統一する。
-# 旧 `if ! log_err=$(...); then` 形式は bash 既知の罠「`if !` は `$?` が常に 0」と隣接した形で、
+# 旧 `if ! log_err=$(...); then` 形式は bash 既知の罠「`if ! cmd; then` は `$?` が常に 0」と隣接した形で、
 # 規範文書として読者を混乱させる。本 Pattern 3 の説明本文 (R-03 対応) では明示的に「2 文分割形式」を
 # 推奨しているのに、Pattern 3 例自体が `if ! var=$(...); then` 形式を使うのは内部矛盾の見え方だった。
 # F-16 対応: mktemp 失敗時の WARNING + 対処 + 影響 の 3 行 loud emit を canonical とする


### PR DESCRIPTION
## 概要

PR #610 (Issue #609 の root fix) で `cleanup.md` 側は解消済みだったが、同型の `!`+backtick pattern が残存していた以下 3 箇所を PR #610 と同じ canonical 表現に一斉移行する。

- `plugins/rite/commands/wiki/init.md` L247: `` `!` `` → `「!」`
- `plugins/rite/commands/wiki/init.md` L547: `` `!` `` → `「!」`
- `plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md` L153: `` `if !` `` → `` `if ! cmd; then` `` (#610 canonical)

## 位置付け

- **#604** / PR #608: `wiki-auto-ingest` 多層防御の root (本 PR scope 外)
- **#609** / PR #610: `cleanup.md` で `!`+backtick を実効的に発火させた root fix (同 PR で初の canonical 表現導入)
- **#611** (本 PR): #609 / #610 の follow-up — `wiki/init.md` 配下および reference の**対称残存 site を最終掃討**し、preprocessor が `!`+backtick を bash command substitution として誤マッチするリスクを網羅的に除去する

## 変更内容

- 意味 (行頭 `!` から直接開始 / `if !` の bash 罠解説) は完全に保持
- `` `!` `` は「!」全角鉤括弧へ（半角 `!` と意味的同一視可能な説明文脈、bash コードではない）
- `` `if !` `` は `` `if ! cmd; then` `` へ（PR #610 で採用済みの canonical 表現）

## Test plan

- [x] **AC-1 (静的検証)**: `grep -o '!\`' plugins/rite/commands/wiki/init.md plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md` が 0 件 (手元で確認済み)
- [x] **T-01**: 上記 grep 検証で 0 件合格
- [x] **Bang-backtick lint**: `plugins/rite/hooks/scripts/bang-backtick-check.sh --all` が 0 findings
- [ ] **AC-2 / T-02 (手動 E2E)**: マージ後に `/rite:wiki:init` を手動実行し preprocessor エラーなく Phase 0 以降に進むことを確認 (レビュワー or マージ者)

## Closes

Closes #611

refs #604 #609 #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
