### PR TITLE
docs(wiki): preprocessor safe 表記 convention (「!」 vs `if ! cmd; then`) の判断基準を文書化 (#613)

### DIFF
--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -35,6 +35,45 @@
 # `bang-bracket-alt-paren-url`, regex literal `bang-backslash-bracket`, and
 # bash negation `if-space-bang-space-cmd` are intentionally NOT matched.
 #
+# Safe equivalents (writing convention)
+# -------------------------------------
+# When this check flags a line, the canonical rewrite depends on **what the
+# inline code span refers to**. Two styles have emerged from the #609-#611
+# fix series and MUST be applied consistently:
+#
+#   Style A: full-width corner brackets (「!」)
+#       Use when the span refers to the literal bang character itself as a
+#       standalone token (e.g. "行頭を # または 「!」 から開始する").
+#       Adopted in: commands/wiki/init.md L247, L547.
+#
+#   Style B: expansion form (`if ! cmd; then`)
+#       Use when the span quotes a shell syntax fragment containing `!` as
+#       an operator (e.g. "the `if ! cmd; then` rc capture is mandatory").
+#       Expand the fragment to its full minimal form so `!` is no longer
+#       adjacent to a closing backtick.
+#       Adopted in: commands/pr/cleanup.md, commands/wiki/references/
+#       bash-cross-boundary-state-transfer.md L153.
+#
+# Judgment flow
+# -------------
+#   1. Is the span referring to the `!` character itself (noun)? -> Style A.
+#   2. Is the span quoting shell syntax that uses `!` as an operator (verb)?
+#      -> Style B (expand to a runnable minimal fragment).
+#   3. Ambiguous? Prefer Style B — expansion almost always reads naturally,
+#      whereas Style A only fits when the sentence grammar demands a single
+#      character literal.
+#
+# Both styles avoid the P1/P2 patterns above by construction:
+#   - Style A replaces the backtick-bang adjacency with a non-backtick span
+#     (full-width 「...」 does not interact with bash history expansion).
+#   - Style B moves the 「!」 away from the closing backtick by adding the
+#     command continuation (`cmd; then`), defeating the P1 space-bang-before-
+#     closing-backtick shape.
+#
+# Out of scope: detecting the non-adjacent `if ! ` space-bang-space pattern.
+# That extension is tracked separately (see the --strict mode proposal on
+# Issue #613 Out of scope).
+#
 # Usage:
 #   bang-backtick-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
 #


### PR DESCRIPTION
## 概要

`bang-backtick-check.sh` の冒頭コメントに「Safe equivalents (writing convention)」セクションを追加し、preprocessor 安全化で採用される 2 系統の canonical 表現（全角鉤括弧 `「!」` / 展開形 `` `if ! cmd; then` ``）の使い分け判断基準を明文化。

#609–#611 系列で確立した暗黙知を enforcement script 本体に co-locate し、将来同種の修正で drift するリスクを防止する。

## 主な変更

- `plugins/rite/hooks/scripts/bang-backtick-check.sh` header コメントに **Safe equivalents (writing convention)** セクションを追加
  - Style A: 全角鉤括弧 `「!」` — standalone な bang 文字を指す文脈
  - Style B: 展開形 `` `if ! cmd; then` `` — shell 構文断片を引用する文脈
  - 判断フロー（noun ならば A / verb operator ならば B / 曖昧なら B を優先）
  - Out of scope として `--strict` mode 拡張への参照

## 検証

- 既存テスト `test-bang-backtick-check.sh`: **18/18 PASS**（検出ロジック無変更）
- `--all` scan (plugins/rite/commands/**/*.md + skills/**/*.md): **0 findings**
- 自身の header に対する self-check: 2 findings（L15/L191 の regex リテラル documentation — 本 PR 以前から存在）

## 関連 Issue

Closes #613

## 由来

- 元の PR: #612
- 元 Issue: #611
- 関連系列: #604 / #608 / #609 / #610

## Out of scope

- `bang-backtick-check.sh` の `--strict` mode 追加（`if ! ` space 経由 pattern 検出）は別 Issue として扱うべき independent な拡張

## チェックリスト

- [x] 既存テストが全 PASS
- [x] `--all` scan で 0 findings（.md ファイル）
- [x] 新規セクションは既存 P1/P2 パターン説明と整合
- [x] 追記内容自体が Style A/B 契約に準拠（行 70 は Style A を適用して自己整合）
