### PR TITLE
refactor(wiki): SKILL.md EN description を canonical と整列

### DIFF
--- a/plugins/rite/skills/wiki/SKILL.md
+++ b/plugins/rite/skills/wiki/SKILL.md
@@ -5,7 +5,7 @@ description: |
   LLM Wiki pattern (Karpathy). Use when the user asks to ingest review/fix/issue
   outcomes into Wiki pages, query accumulated experiential knowledge by keyword,
   lint the Wiki for contradictions, stale pages, orphans, missing concepts,
-  unregistered raw sources, and broken references, or initialize the Wiki structure.
+  broken references, and unregistered raw sources, or initialize the Wiki structure.
   Activates on "wiki", "ingest", "query", "lint", "経験則", "知識ページ",
   "Wiki 蓄積", "経験則を残す", "経験則を参照", "Wiki 検索", "Wiki Lint",
   "Wiki 品質", "矛盾チェック", "陳腐化", "孤児ページ",


### PR DESCRIPTION
## 概要

`plugins/rite/skills/wiki/SKILL.md` の EN frontmatter description 末尾の列挙順を canonical SoT (`commands/wiki/lint.md` 冒頭テーブル) と同期する 1 行の refactor。

PR #601 で lint.md を canonical SoT に統一したが、同じ SKILL.md 内の EN description (L7-8) のみが旧順序 `unregistered raw sources, and broken references,` のまま残存していた。JA Activates (L12-13) / JA Auto-Activation (L27) は既に canonical 順 (壊れた相互参照 → 未登録 raw) になっており、EN description のみが drift 源だった。

## 変更内容

- `plugins/rite/skills/wiki/SKILL.md` L8: `unregistered raw sources, and broken references,` → `broken references, and unregistered raw sources,`

これにより SKILL.md 内 3 箇所（L7-8 EN / L12-13 JA Activates / L27 JA Auto-Activation）の列挙順が canonical 順 (contradictions → stale → orphans → missing → **broken** → **unregistered raw**) で統一される。

## 関連 Issue

Closes #603

## テスト計画

- [x] `grep -n 'broken references, and unregistered raw sources' SKILL.md` が L8 を返す
- [x] SKILL.md 内 3 箇所で `broken` が `unregistered` より前に出現する
- [x] Plugin-specific drift checks (bang-backtick / doc-heavy / wiki-growth / gitignore-health) すべて 0 findings
- [x] `git diff --name-only origin/develop...HEAD` が `plugins/rite/skills/wiki/SKILL.md` のみを返す

## Known Issues

- distributed-fix-drift-check が既存の 32 findings を報告しているが、これらは本 PR 変更対象外のファイル（`plugins/rite/commands/pr/review.md` の reason enum 等）に対する既存 drift であり、本 PR 変更 (SKILL.md L8 のみ) とは無関係。
