### PR TITLE
refactor(commands): init.md:145 / health-check.sh:298 の残存 line 番号 literal を semantic anchor 化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,11 @@ temp/
 # ─────────────────────────────────────────────────────────────────────────────
 # same_branch 戦略ユーザー向け — verification-first セットアップ手順 (F-05 / F-10 対応)
 # ─────────────────────────────────────────────────────────────────────────────
+# >>> DRIFT-CHECK ANCHOR: same_branch verification-first setup steps <<<
+# Downstream reference: plugins/rite/hooks/scripts/gitignore-health-check.sh の
+# `same_branch strategy requires '!.rite/wiki/' negation entry` Hint メッセージが
+# 本節 (Step 1-5) を semantic anchor 経由で参照する。Step 1-5 のコマンド / 期待出力を
+# 変更する際は同 Hint メッセージと同期.
 # Step 1. negation エントリの追加 (本 .gitignore に **追記** する):
 #
 #   # 必須 — parent directory 除外を解除。これがないと配下ファイルを再包含できません:
@@ -100,6 +105,8 @@ temp/
 # Step 5. probe ファイルの片付け (commit に混入させないため。Step 3 が OK を返した後に実行):
 #
 #   rm -f .rite/wiki/raw/.negation-probe
+#
+# >>> DRIFT-CHECK ANCHOR END: same_branch verification-first setup steps <<<
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # `git check-ignore -v` を sanity check に使わない理由 (F-02 / F-06 対応):

--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,10 @@ temp/
 # >>> DRIFT-CHECK ANCHOR: same_branch verification-first setup steps <<<
 # Downstream reference: plugins/rite/hooks/scripts/gitignore-health-check.sh の
 # `same_branch strategy requires '!.rite/wiki/' negation entry` Hint メッセージが
-# 本節 (Step 1-5) を semantic anchor 経由で参照する。Step 1-5 のコマンド / 期待出力を
-# 変更する際は同 Hint メッセージと同期.
+# 本節 (Step 1-5 + check-ignore 回避理由) を semantic anchor 経由で参照する。Step 1-5
+# のコマンド / 期待出力を変更する際は同 Hint メッセージと同期.
+# 内側に `DRIFT-CHECK ANCHOR: negation verification canonical` anchor を入れ子で
+# 包含する (Step 3「動作確認の正典」 + 「check-ignore 回避理由」の 2 節)。
 # Step 1. negation エントリの追加 (本 .gitignore に **追記** する):
 #
 #   # 必須 — parent directory 除外を解除。これがないと配下ファイルを再包含できません:
@@ -106,8 +108,6 @@ temp/
 #
 #   rm -f .rite/wiki/raw/.negation-probe
 #
-# >>> DRIFT-CHECK ANCHOR END: same_branch verification-first setup steps <<<
-#
 # ─────────────────────────────────────────────────────────────────────────────
 # `git check-ignore -v` を sanity check に使わない理由 (F-02 / F-06 対応):
 # ─────────────────────────────────────────────────────────────────────────────
@@ -123,6 +123,7 @@ temp/
 # **`git add --dry-run` を sanity check の正典** として採用し、check-ignore は参考情報に
 # とどめる (Source: git documentation — git check-ignore(1)、`pattern` column の `!` prefix 仕様)。
 # >>> DRIFT-CHECK ANCHOR END: negation verification canonical <<<
+# >>> DRIFT-CHECK ANCHOR END: same_branch verification-first setup steps <<<
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Idempotency 注 (F-07 対応):

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -142,7 +142,7 @@ elif grep -qE '^!\.rite/wiki/[[:space:]]*$' .gitignore; then
 elif ! grep -qF '# <<< gitignore-wiki-section-end (anchor / F-09 対応)' .gitignore; then
   # PR #586 F-01 対応: Phase 1.3.3 Edit ツールが hardcode する anchor が不在の場合、
   # Edit が `old_string not found` で hard fail するため、early skip + 手動追記案内に分岐する。
-  # 本 anchor は rite-workflow 自己開発 repo の .gitignore L131 のみに存在し、consumer project には
+  # 本 anchor は rite-workflow 自己開発 repo の .gitignore の `# <<< gitignore-wiki-section-end (anchor / F-09 対応)` 行のみに存在し、consumer project には
   # distribution 経路がない (templates/ に該当 .gitignore template なし、/rite:init Phase 4.6 と
   # gitignore-health-check.sh どちらも anchor を inject しない)。consumer が手動で `.rite/wiki/` を
   # 追加した .gitignore は条件 1-3 を満たすが anchor を持たないため、本条件で fall-back する。

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -295,7 +295,7 @@ case "$branch_strategy" in
       echo "==> gitignore-health-check: DRIFT DETECTED (same_branch): negation override for '.rite/wiki/' missing or broken" >&2
       echo "==> git add --dry-run $negation_probe returned rc=$add_dry_rc" >&2
       [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ] && head -3 "$add_dry_err" | sed 's/^/  /' >&2
-      echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see .gitignore L66-75 for setup steps)." >&2
+      echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see '.gitignore' の 'DRIFT-CHECK ANCHOR: same_branch verification-first setup steps' 節 for setup steps)." >&2
       findings=$((findings + 1))
     fi
     # >>> DRIFT-CHECK ANCHOR END: same_branch negation grep-qF healthy check <<<

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -295,7 +295,7 @@ case "$branch_strategy" in
       echo "==> gitignore-health-check: DRIFT DETECTED (same_branch): negation override for '.rite/wiki/' missing or broken" >&2
       echo "==> git add --dry-run $negation_probe returned rc=$add_dry_rc" >&2
       [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ] && head -3 "$add_dry_err" | sed 's/^/  /' >&2
-      echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see '.gitignore' の 'DRIFT-CHECK ANCHOR: same_branch verification-first setup steps' 節 for setup steps)." >&2
+      echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see section 'DRIFT-CHECK ANCHOR: same_branch verification-first setup steps' in .gitignore for setup steps)." >&2
       findings=$((findings + 1))
     fi
     # >>> DRIFT-CHECK ANCHOR END: same_branch negation grep-qF healthy check <<<


### PR DESCRIPTION
## 概要

`plugins/rite/commands/wiki/init.md:145` / `plugins/rite/hooks/scripts/gitignore-health-check.sh:298` に残存していた line 番号 literal 参照 (`L131` / `L66-75`) を semantic anchor 参照に置換しました。PR #605 (Issue #597) と同じパターンを踏襲し、Wiki 経験則 patterns/high「DRIFT-CHECK ANCHOR は semantic name 参照で記述する（line 番号禁止）」を適用します。

## 変更内容

### 1. canonical 側 (`.gitignore`) に新 anchor を追加

`# >>> DRIFT-CHECK ANCHOR: same_branch verification-first setup steps <<<` で Step 1-5 の setup 手順節を囲みます (Step 3 内側の既存 `negation verification canonical` anchor は入れ子のまま温存)。

### 2. 参照側 (2 ファイル) を semantic 参照に置換

- `plugins/rite/commands/wiki/init.md:145`: `.gitignore L131 のみに存在` → `.gitignore の \`# <<< gitignore-wiki-section-end (anchor / F-09 対応)\` 行のみに存在`
- `plugins/rite/hooks/scripts/gitignore-health-check.sh:298`: `see .gitignore L66-75 for setup steps` → `see '.gitignore' の 'DRIFT-CHECK ANCHOR: same_branch verification-first setup steps' 節 for setup steps`

## 関連 Issue

Closes #606

## 動作確認

- [x] `grep -c 'DRIFT-CHECK ANCHOR.*: same_branch verification-first setup steps'` (.gitignore) → 2 件 (start/end)
- [x] `init.md` 内で `.gitignore L131` literal が消滅
- [x] `gitignore-health-check.sh` 内で `.gitignore L66-75` literal が消滅
- [x] `/rite:lint` Phase 3.5-3.9 実行 — 本 PR 変更ファイル (`.gitignore` / `init.md` / `gitignore-health-check.sh`) に対する finding は 0 件 (regression なし)

## Known Issues

本 PR の scope 外:

- **distributed-fix-drift-check の pre-existing finding 32 件**: すべて `plugins/rite/commands/pr/fix.md` および `plugins/rite/commands/pr/review.md` の `reason` 列挙 / heredoc ラップパターンに関する既存 P2/P3/P5 findings で、本 PR 変更ファイル外。別途対応対象。
- **`plugins/rite/hooks/scripts/gitignore-health-check.sh` に残存する他の line 番号 literal 参照**:
  - L10: `` per `.gitignore` header L101-113 spec ``
  - L248: `` Per .gitignore L101-113 spec ``
  - L256: `` the header L45-L49 exit code contract ``
  これらは本 Issue の scope 外（Issue #606 は L298 のみを対象）。follow-up Issue として別途起票候補。
