### PR TITLE
fix(issue-create): create-interview sub-skill return 後の implicit stop を防ぐ多層防御

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -13,6 +13,32 @@ Execute the adaptive interview for Issue creation. This sub-command is invoked f
 
 ---
 
+## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
+
+> **Issue #622 (regression of #552)**: This section was historically placed at the end of the file (titled "Defense-in-Depth: Flow State Update (Before Return)"). In the Bug Fix / Chore preset path (Phase 0.4.1 → skip Phase 0.5), the LLM running this sub-skill sometimes skipped the Defense-in-Depth bash block and jumped directly to the return output. The result: `.rite-flow-state.phase` stayed at `create_interview`, which had no dedicated `stop-guard.sh` case arm in versions prior to #622 fix, so the orchestrator's implicit stop after `<!-- [interview:skipped] -->` was not blocked and the user had to type `continue` manually. Moving the flow-state write to the **absolute beginning** of the sub-skill guarantees it runs regardless of interview scope.
+>
+> **DRIFT-CHECK ANCHOR (semantic)**: This section is mirrored by `stop-guard.sh` `create_interview` case arm (Issue #622) and `phase-transition-whitelist.sh` `create_interview → create_post_interview` edge. The three sites form a 3-site symmetry — when updating any one, update the others.
+
+**MUST run before any interview logic** (Phase 0.4.1 scope evaluation, Phase 0.5 deep-dive, or return-output emission). This bash block is **not optional** and **not conditional on interview scope**. Execute it even when Phase 0.4.1 determines the Bug Fix / Chore preset (interview scope = "skip"):
+
+```bash
+if [ -f ".rite-flow-state" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "create_post_interview" \
+    --next "rite:issue:create-interview Pre-flight completed. Proceed to Phase 0.4.1/0.5 if applicable, then return to caller. Caller MUST proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
+else
+  bash {plugin_root}/hooks/flow-state-update.sh create \
+    --phase "create_post_interview" --issue 0 --branch "" --pr 0 \
+    --next "rite:issue:create-interview Pre-flight completed. Proceed to Phase 0.4.1/0.5 if applicable, then return to caller. Caller MUST proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
+fi
+```
+
+**Why `create_post_interview` (not `create_interview_running`) at Pre-flight time**: The caller (`create.md` Delegation to Interview Pre-write) has already written `create_interview` to signal that delegation is in flight. The Pre-flight advances the phase to `create_post_interview` **before** the interview runs so that, no matter at which point the sub-skill exits (normal completion, early exit via Bug Fix preset, or unexpected stop), the stop-guard routes to the `create_post_interview` WORKFLOW_HINT which correctly tells the orchestrator to run the 🚨 Mandatory After Interview section and proceed to Phase 0.6. This is safe because `create_post_interview → create_delegation` is the only whitelisted forward transition — the orchestrator must still execute Delegation Routing to advance past it.
+
+**Idempotence**: Running this multiple times within a single sub-skill invocation is safe; each call refreshes the timestamp and `next_action` but does not regress the phase (patch mode sets `previous_phase` from the pre-update `.phase`, which stays `create_post_interview` on re-entry).
+
+---
+
 ## Phase 0.4.1: Adaptive Interview Depth
 
 After Phase 0.4 completes, determine the interview scope for Phase 0.5 based on tentative complexity and task type. This avoids excessive questioning for simple Issues.
@@ -493,23 +519,21 @@ Interview results are mapped to Implementation Contract sections (Section 1-9) f
 
 ---
 
-## Defense-in-Depth: Flow State Update (Before Return)
+## Return Output Format (Before Return)
 
-> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0).
+> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0). The flow-state write was moved to the 🚨 MANDATORY Pre-flight section at the top of this file (Issue #622) so the post-interview phase is recorded regardless of interview scope. The idempotent re-patch below is retained as a defense-in-depth second write that refreshes the timestamp and `next_action` immediately before emitting the return output.
 
-Before returning control to the caller, update `.rite-flow-state` to the post-interview phase. This ensures the stop-guard routes correctly even if the caller's 🚨 Mandatory After section is not executed immediately:
+Immediately before emitting the three-line return block, re-patch `.rite-flow-state` to refresh the timestamp. This is idempotent with the 🚨 MANDATORY Pre-flight write (same phase, same transition target):
 
 ```bash
 if [ -f ".rite-flow-state" ]; then
   bash {plugin_root}/hooks/flow-state-update.sh patch \
     --phase "create_post_interview" \
     --next "rite:issue:create-interview completed. Proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
-else
-  bash {plugin_root}/hooks/flow-state-update.sh create \
-    --phase "create_post_interview" --issue 0 --branch "" --pr 0 \
-    --next "rite:issue:create-interview completed. Proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop."
 fi
 ```
+
+> **Why patch mode only (no create fallback here)**: The 🚨 MANDATORY Pre-flight section at the top already handles the "file missing" branch (`create` mode). By the time execution reaches the return-output section, `.rite-flow-state` is guaranteed to exist with `.phase = create_post_interview`. A second `create` call here would reset `previous_phase` to an empty string and defeat the whitelist-based transition check in stop-guard — patch mode preserves the transition chain correctly.
 
 After the flow-state update above, output the appropriate result pattern. Emit the caller-continuation reminder **immediately before** the result pattern. Both the plain-text reminder and the HTML comment precede the result pattern, and the result pattern itself is wrapped in an HTML comment (Issue #561 UX fix) — all three MUST be the last visible lines of this sub-skill's output, in the order below:
 

--- a/plugins/rite/hooks/stop-guard.sh
+++ b/plugins/rite/hooks/stop-guard.sh
@@ -293,6 +293,18 @@ fi
 WORKFLOW_HINT=""
 WORKFLOW_INCIDENT_TYPE=""
 case "$PHASE" in
+  create_interview)
+    # Issue #622: /rite:issue:create Delegation to Interview Pre-write recorded create_interview
+    # but the interview sub-skill Defense-in-Depth patch (create_post_interview) did not fire
+    # yet (either the sub-skill has not been invoked, is mid-execution, or its Pre-flight bash
+    # block was skipped — the Bug Fix / Chore preset path in create-interview.md Phase 0.4.1
+    # is the most likely offender since it skips Phase 0.5 and historically inlined the
+    # Defense-in-Depth bash block at the end of the markdown only). stop-guard must block in
+    # either position so the workflow does not silently end the turn before delegation.
+    # DRIFT-CHECK ANCHOR (semantic): create-interview.md 🚨 MANDATORY Pre-flight section /
+    # phase-transition-whitelist.sh create_interview entry と 3 site 対称。
+    WORKFLOW_HINT="HINT: /rite:issue:create Delegation to Interview Pre-write recorded create_interview. The block may have fired immediately before the rite:issue:create-interview Skill invoke, OR while the interview sub-skill is mid-execution (create-interview.md MUST write create_post_interview via its 🚨 MANDATORY Pre-flight section before returning). In either case, do NOT stop. Continue: if interview has not been invoked yet, invoke it; if interview has returned <!-- [interview:skipped] --> or <!-- [interview:completed] --> but .rite-flow-state.phase is still create_interview, the sub-skill Pre-flight patch was skipped — run 🚨 Mandatory After Interview Step 1 (patch create_post_interview) manually → Phase 0.6 → Delegation Routing → terminal sub-skill in the SAME response turn. DO NOT stop before <!-- [create:completed:{N}] --> is output."
+    ;;
   create_post_interview)
     WORKFLOW_HINT="HINT: Sub-skill rite:issue:create-interview returned. The return tag is a CONTINUATION TRIGGER, not a turn boundary. Immediately run Phase 0.6 (Task Decomposition Decision) → Delegation Routing Pre-write → invoke rite:issue:create-register (or create-decompose) in the SAME response turn. No GitHub Issue has been created yet."
     ;;

--- a/plugins/rite/hooks/tests/stop-guard.test.sh
+++ b/plugins/rite/hooks/tests/stop-guard.test.sh
@@ -782,6 +782,54 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-622-A: create_interview phase (active=true, fresh) → exit 2 (block with HINT)
+# Issue #622: stop-guard MUST block implicit stop while the interview sub-skill
+# is mid-execution (or before its 🚨 MANDATORY Pre-flight has run). Prior to #622
+# there was no `create_interview` case arm, so the general-block path fired
+# without a phase-specific WORKFLOW_HINT and workflow_incident sentinel emit
+# was possible but without routing guidance.
+# --------------------------------------------------------------------------
+echo "TC-622-A: create_interview active → exit 2 (block with HINT)"
+dir622a="$GUARD_TEST_DIR/tc622a"
+mkdir -p "$dir622a"
+fresh_ts="${fresh_ts:-$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")}"
+create_state_file "$dir622a" "{\"active\": true, \"phase\": \"create_interview\", \"previous_phase\": \"\", \"next_action\": \"After rite:issue:create-interview returns: proceed to Phase 0.6. Do NOT stop.\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 0, \"pr_number\": 0, \"error_count\": 0, \"session_id\": \"sid-622a\"}"
+stderr_file622a="$(mktemp "$GUARD_TEST_DIR/stderr622a.XXXXXX")"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir622a\", \"session_id\": \"sid-622a\"}"
+output=$(echo "$input" | bash "$GUARD" 2>"$stderr_file622a") && rc=0 || rc=$?
+# HINT の前半 (Delegation to Interview Pre-write) と後半 (MANDATORY Pre-flight / [create:completed:) を
+# 2 段で検証し、HINT 文言が改変された場合の regression を確実に検出する
+if [ $rc -eq 2 ] \
+    && grep -q "Delegation to Interview Pre-write recorded create_interview" "$stderr_file622a" \
+    && grep -q "MANDATORY Pre-flight" "$stderr_file622a" \
+    && grep -q '\[create:completed:' "$stderr_file622a"; then
+  pass "create_interview active → blocked with #622 HINT"
+else
+  fail "expected exit 2 with #622 HINT (Delegation to Interview + MANDATORY Pre-flight + [create:completed:), got rc=$rc stderr='$(cat "$stderr_file622a")'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-622-B: create_interview phase emits workflow_incident sentinel to stderr
+# Issue #622: verify the workflow_incident_emit.sh helper is invoked for the
+# create_interview phase (same contract as create_post_interview TC-475-A).
+# The sentinel is echoed to stderr via the exit-2 feedback contract.
+# --------------------------------------------------------------------------
+echo "TC-622-B: create_interview active → workflow_incident sentinel in stderr"
+dir622b="$GUARD_TEST_DIR/tc622b"
+mkdir -p "$dir622b"
+create_state_file "$dir622b" "{\"active\": true, \"phase\": \"create_interview\", \"previous_phase\": \"\", \"next_action\": \"continue\", \"updated_at\": \"$fresh_ts\", \"issue_number\": 622, \"pr_number\": 0, \"error_count\": 0, \"session_id\": \"sid-622b\"}"
+stderr_file622b="$(mktemp "$GUARD_TEST_DIR/stderr622b.XXXXXX")"
+input="{\"stop_hook_active\": false, \"cwd\": \"$dir622b\", \"session_id\": \"sid-622b\"}"
+output=$(echo "$input" | bash "$GUARD" 2>"$stderr_file622b") && rc=0 || rc=$?
+if [ $rc -eq 2 ] \
+    && grep -q "WORKFLOW_INCIDENT=1" "$stderr_file622b" \
+    && grep -q "type=manual_fallback_adopted" "$stderr_file622b"; then
+  pass "create_interview phase emits workflow_incident sentinel to stderr"
+else
+  fail "expected WORKFLOW_INCIDENT sentinel for create_interview, got rc=$rc stderr='$(cat "$stderr_file622b")'"
+fi
+
+# --------------------------------------------------------------------------
 # TC-475-D: create_completed is terminal — no block
 # --------------------------------------------------------------------------
 echo "TC-475-D: create_completed + active=false → exit 0 (terminal)"

--- a/tests/regression/issue-622-repro.md
+++ b/tests/regression/issue-622-repro.md
@@ -79,10 +79,15 @@ tail -30 .rite-stop-guard-diag.log | grep -E 'phase=create_'
 | Caller workflow | `/rite:issue:create` | `/rite:pr:cleanup` |
 | Sub-skill | `rite:issue:create-interview` | `rite:wiki:ingest` |
 | 停止ポイント | `<!-- [interview:skipped] -->` 出力後 | `<!-- [ingest:completed] -->` 出力後 |
-| 共通根本原因 | sub-skill Defense-in-Depth (flow-state write) の Markdown-embedded instruction 構造が LLM skip を許す + stop-guard の case arm 不足 | 同上 (cleanup の場合は `cleanup_pre_ingest` / `cleanup_post_ingest` arm は存在するが、ring 構造により間欠的に fire しない) |
-| 対策パターン | 冒頭 🚨 MANDATORY Pre-flight (create-interview.md) + stop-guard `create_interview` arm (#622) | wiki:ingest 側の類似 Pre-flight 化 (#621 で対応) |
+| Root cause 分類 (Decision Log) | H2 (stop-guard の case arm 不足) が主因 + H1/H3 が副因 | H1 (ingest.md 三点セットが turn-boundary heuristic 強化) + H3 (Pre-check list の self-introspection 依存) の複合 (#621 Decision Log 参照) |
+| 対策パターン | **冒頭 🚨 MANDATORY Pre-flight (create-interview.md)** + **stop-guard `create_interview` case arm 追加** (case arm 不在が主因のため新規追加) | **既存 5 層防御の補強**: (a) cleanup.md Pre-check list Item 0 の機械化 (`[routing-check] ingest=matched\|unmatched` 1 行出力義務化)、(b) ingest.md Phase 9.1 三点セット #2 (caller 継続 HTML コメント) と #3 (sentinel) の間に recap 挿入禁止 MUST NOT 行追加、(c) test-stop-guard-cleanup.sh / docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md 新規 (既存の cleanup_pre_ingest / cleanup_post_ingest arm は存在するため新規追加不要) |
 
-**結論**: 両 Issue とも「sub-skill return 経路での implicit stop」という同型問題を持つが、具体的な caller / sub-skill / phase 名が異なるため、同一ファイル内統合ではなく、同パターン (冒頭 Pre-flight + stop-guard case arm) の個別適用が必要。
+**結論**: 両 Issue は「sub-skill return 経路での implicit stop」という同型問題を持つが、根本原因と既存防御層の状態が異なるため**対策は非対称**となった:
+
+- **#622 は冒頭 Pre-flight + stop-guard case arm 追加**: 既存 stop-guard に `create_interview` arm が不在だったため、新規防御層を追加する必要があった
+- **#621 は既存 5 層防御の補強**: stop-guard arm (`cleanup_pre_ingest` / `cleanup_post_ingest`) は既に存在し、root cause も turn-boundary heuristic 強化と self-introspection 依存の方が主因だったため、Pre-check 機械化と MUST NOT 行の追加で対応
+
+共通根本原因として「sub-skill Defense-in-Depth が Markdown embedded instruction で LLM skip を許す」構造はあるが、既存防御層の欠落箇所が異なるため、同型の fix を両 PR で複製するのではなく、それぞれの workflow の欠落層を個別に補強する設計とした。
 
 ## 6. テスト
 

--- a/tests/regression/issue-622-repro.md
+++ b/tests/regression/issue-622-repro.md
@@ -1,0 +1,95 @@
+# Regression fixture: Issue #622 — create-interview sub-skill return 後の implicit stop
+
+- **Issue**: #622
+- **Sibling**: #621 (cleanup workflow 内の同型問題)
+- **Original**: #552 (CLOSED — 対策導入時)
+
+## 1. 再現手順 (baseline: 修正前)
+
+### 1.1 前提条件
+
+- `plugins/rite/hooks/hooks.json` が native plugin hook として登録されている (`Stop` hook = `stop-guard.sh`)
+- `jq` がインストールされている
+- `.rite-flow-state` が存在しない (fresh start)
+
+### 1.2 実行
+
+```bash
+/rite:issue:create "テスト用の bug fix Issue"
+```
+
+### 1.3 期待される regression 挙動 (修正前)
+
+以下が一気通貫で実行される**はず**だが、step 5 と step 6 の間で turn が切れる:
+
+1. `create.md` Phase 0.1 で What/Why/Where 抽出
+2. Phase 0.3 類似 Issue 検索
+3. **Delegation to Interview Pre-write**: `.rite-flow-state.phase = create_interview` に patch
+4. `Skill: rite:issue:create-interview` invoke
+5. `create-interview.md` が Bug Fix preset を適用 (Phase 0.4.1 → skip Phase 0.5)。`<!-- [interview:skipped] -->` を最終行として emit
+6. ⚠️ **turn 境界形成 (implicit stop)** — user に `Crunched for 2m XXs` が表示される
+7. user が `continue` を入力
+8. `create.md` の 🚨 Mandatory After Interview → Phase 0.6 → Delegation Routing → `create-register` invoke
+
+### 1.4 Evidence 確認
+
+```bash
+# stop-guard diag log を確認
+tail -30 .rite-stop-guard-diag.log | grep -E 'phase=create_'
+```
+
+修正前は `phase=create_interview` / `phase=create_post_interview` の blocking record が**皆無** — stop-guard が fire していない。
+
+## 2. 期待動作 (AC-2: 修正後)
+
+step 5 と step 8 が **同 turn 内で連続実行される**。`Crunched for ...` の turn 境界が形成されない。
+
+### 2.1 Evidence 確認 (修正後)
+
+```bash
+# stop-guard diag log に create_* phase の block が記録される
+tail -30 .rite-stop-guard-diag.log | grep -E 'phase=create_'
+# 期待: 少なくとも create_interview or create_post_interview phase での EXIT:2 reason=blocking 行が存在
+```
+
+## 3. 根本原因分析 (AC-4)
+
+本 regression の根本原因を 4 仮説で分析 (Issue body 参照):
+
+| ID | 仮説 | 評価 |
+|---|---|---|
+| H1 | sentinel 最終 3 行が turn-boundary heuristic を強化 | **部分支持** — 3 行の順序 (plain-text blockquote → HTML comment → sentinel HTML comment) は heuristic に影響するが、stop-guard が fire すれば打ち消される |
+| H2 | stop-guard の case 分岐に `create_interview` arm が不在 / sub-skill Defense-in-Depth が skip される | **主要原因** — diag log に create_* phase の block record が皆無であることから、stop-guard が fire していない実態が裏付けられる |
+| H3 | Pre-check list Item 0 が LLM self-introspection に依存 | **二次要因** — 本質的には Markdown 指示による soft enforcement であり、強制力は stop-guard に依存 |
+| H4 | sub-skill loading mechanism が独立ブロックとして提示 | **未検証** — Claude Code 内部の Skill loading 挙動に依存、本 Issue のスコープ外 |
+
+**結論**: H2 が主因。副次的に H1/H3 が寄与。
+
+## 4. 修正の主要ポイント
+
+| 修正 | 場所 | 狙い |
+|---|---|---|
+| 1 | `plugins/rite/hooks/stop-guard.sh` に `create_interview` case arm 追加 | sub-skill mid-execution / Pre-flight 未実行状態での stop 試行を block し、WORKFLOW_HINT で継続指示を emit |
+| 2 | `plugins/rite/commands/issue/create-interview.md` の Defense-in-Depth を sub-skill 冒頭の 🚨 MANDATORY Pre-flight として移動 | Bug Fix / Chore preset (Phase 0.5 skip) 経路でも必ず `create_post_interview` に patch され、stop-guard の `create_post_interview` case arm に routing される |
+
+## 5. #621 との合同分析 (AC-7)
+
+| 項目 | #622 (create) | #621 (cleanup) |
+|---|---|---|
+| Caller workflow | `/rite:issue:create` | `/rite:pr:cleanup` |
+| Sub-skill | `rite:issue:create-interview` | `rite:wiki:ingest` |
+| 停止ポイント | `<!-- [interview:skipped] -->` 出力後 | `<!-- [ingest:completed] -->` 出力後 |
+| 共通根本原因 | sub-skill Defense-in-Depth (flow-state write) の Markdown-embedded instruction 構造が LLM skip を許す + stop-guard の case arm 不足 | 同上 (cleanup の場合は `cleanup_pre_ingest` / `cleanup_post_ingest` arm は存在するが、ring 構造により間欠的に fire しない) |
+| 対策パターン | 冒頭 🚨 MANDATORY Pre-flight (create-interview.md) + stop-guard `create_interview` arm (#622) | wiki:ingest 側の類似 Pre-flight 化 (#621 で対応) |
+
+**結論**: 両 Issue とも「sub-skill return 経路での implicit stop」という同型問題を持つが、具体的な caller / sub-skill / phase 名が異なるため、同一ファイル内統合ではなく、同パターン (冒頭 Pre-flight + stop-guard case arm) の個別適用が必要。
+
+## 6. テスト
+
+| Test ID | AC | 実装 |
+|---|----|------|
+| T-03 | AC-3 | `plugins/rite/hooks/tests/stop-guard.test.sh` の TC-622-A / TC-622-B (新規追加) |
+| T-01 (baseline) | AC-1 | 本 fixture の Section 1 を手動実行 |
+| T-02 (e2e) | AC-2 | 修正後 commit で本 fixture の Section 1 を実行し Section 2 の evidence を確認 |
+| T-05 | AC-6 | 本ファイルの存在を `tests/regression/issue-622-repro.md` で確認 |
+| T-06 | AC-7 | 本ファイル Section 5 に cross-issue 分析を記録 |


### PR DESCRIPTION
## Summary

- `stop-guard.sh` に `create_interview` case arm を追加 (sub-skill mid-execution / Pre-flight 未実行状態での stop 試行を block)
- `create-interview.md` の Defense-in-Depth を sub-skill 冒頭の 🚨 MANDATORY Pre-flight として移動 (Bug Fix/Chore preset で Phase 0.5 skip される経路でも必ず `create_post_interview` に patch)
- TC-622-A / TC-622-B / `tests/regression/issue-622-repro.md` で AC-3/AC-4/AC-6/AC-7 を担保

Closes #622

## Context

Issue #552 で導入した 8 層 defense-in-depth (anti/correct-pattern / Pre-check list / Bypass prohibition / 🚨 Mandatory After Interview / `stop-guard.sh` / HTML comment sentinel / dual form caller hint) が機能せず、`/rite:issue:create` 実行時に `rite:issue:create-interview` sub-skill return 後に turn が implicit stop する regression が再発。

## Root Cause (AC-4)

**主因 (H2)**: `stop-guard.sh` に `create_interview` case arm が不在 (`create_post_interview` 以降のみ)。かつ `.rite-stop-guard-diag.log` に create_* phase の block record が**皆無** — stop-guard が create workflow 経路で発火していない実態の裏付け。

**補助因 (H1+H3)**: `create-interview.md` の Defense-in-Depth bash block が Markdown の説明 + code block 構造であり、Bug Fix / Chore preset (Phase 0.5 skip) 経路で LLM が実行を skip できた。その結果 phase が `create_interview` のままで残り、case arm 不在の fall-through path が走っていた。

## 修正設計

| # | 修正 | 場所 | 効果 |
|---|------|------|------|
| 1 | `create_interview` case arm 追加 | `plugins/rite/hooks/stop-guard.sh` | sub-skill 実行中 or Pre-flight 未実行状態での stop 試行を block + WORKFLOW_HINT emit (#604 cleanup / #618 ingest と対称) |
| 2 | Defense-in-Depth → 🚨 MANDATORY Pre-flight 移動 | `plugins/rite/commands/issue/create-interview.md` 冒頭 | interview scope (Bug Fix/Chore で skip) に関係なく **必ず** `create_post_interview` に patch |
| 3 | Return Output Format 整理 | `create-interview.md` 末尾 | idempotent 再 patch を defense-in-depth 二重書き込みとして残す (patch mode のみ、`create` fallback は削除) |
| 4 | TC-622-A / TC-622-B 追加 | `plugins/rite/hooks/tests/stop-guard.test.sh` | `create_interview` phase での block + sentinel emit を単体検証 (AC-3) |
| 5 | `tests/regression/issue-622-repro.md` | 新規 | 再現手順 + 根本原因分析 + #621 合同分析を記録 (AC-4/AC-6/AC-7) |

## Test plan

- [x] `bash plugins/rite/hooks/tests/stop-guard.test.sh` — TC-622-A/B を含む 44 passed (pre-existing 1 failure は develop 由来、本 PR で regression ゼロ)
- [x] `bash -n` で `stop-guard.sh` / `stop-guard.test.sh` の syntax 確認
- [ ] **AC-2 e2e 検証** (merge 後別 session で): `/rite:issue:create "<test input>"` を手動実行し `<!-- [create:completed:{N}] -->` まで user 介入なしで到達することを確認
- [ ] **AC-3 diag log 検証** (e2e 実行時): `.rite-stop-guard-diag.log` に `phase=create_interview` or `phase=create_post_interview` の EXIT:2 reason=blocking 行が記録されることを確認

## AC-5 defense-in-depth 維持確認

| Layer | Status |
|---|---|
| anti-pattern / correct-pattern | 維持 (create.md) |
| Pre-check list Item 0-3 | 維持 (create.md) |
| Bypass prohibition (verbatim 二重) | 維持 (create.md) |
| 🚨 Mandatory After Interview Step 1-3 | 維持 (create.md) |
| stop-guard.sh case arm | **強化** (create_interview arm 追加) |
| HTML comment sentinel (#561) | 維持 (create-interview.md) |
| dual form caller hint (#552) | 維持 (create-interview.md) |
| flow-state Pre-flight write | **強化** (末尾 Defense-in-Depth → 冒頭 🚨 MANDATORY Pre-flight) |

撤去・縮小はゼロ、2 層を強化。

## AC-7 Decision Log: #621 との合同分析

| 項目 | #622 (create) | #621 (cleanup) |
|---|---|---|
| Caller workflow | `/rite:issue:create` | `/rite:pr:cleanup` |
| Sub-skill | `rite:issue:create-interview` | `rite:wiki:ingest` |
| 停止ポイント | `<!-- [interview:skipped] -->` 出力後 | `<!-- [ingest:completed] -->` 出力後 |
| 共通根本原因 | sub-skill Defense-in-Depth が Markdown embedded instruction で LLM skip 可能 + stop-guard の case arm 不足 | 同型 |
| 対策パターン | 冒頭 🚨 MANDATORY Pre-flight + stop-guard `create_interview` arm | 同パターンを wiki:ingest 側に適用済み (#621 fix) |

両 Issue は同型問題の別 workflow instance。統合 fix ではなく同パターンの個別適用が正解 (caller / sub-skill / phase 名が異なるため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)