### PR TITLE
feat(lint): bidirectional backlink format 機械検証を /rite:lint に追加 (#627)

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -686,6 +686,41 @@ fi
 - `gitignore_health_finding_count`: Extract from `gitignore_health_output` by matching the line `==> Total gitignore-health-check findings: N` (regex: `/Total gitignore-health-check findings: (\d+)/`). If no match found, default to 0
 - `gitignore_health_output`: Script output (truncated if >50 lines)
 
+### 3.10 Plugin-specific Checks (Backlink Format Check) — Issue #627
+
+Execute the backlink format check script to detect bidirectional backlink format invariant violations. PR #620 (Issue #620) established colon notation (file-path-colon-phase-number) as the canonical format for `Downstream reference:` backlink comments, and PR #626 unified all 9 existing sites. This lint check detects regressions to the two legacy dialects (PR #605 space-separated dialect and PR #619 parenthetical DRIFT-CHECK ANCHOR dialect). See `plugins/rite/hooks/scripts/backlink-format-check.sh` header and `.rite/wiki/pages/patterns/drift-check-anchor-semantic-name.md` for the canonical format specification.
+
+**Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
+
+**Skip condition**: Script file does not exist (e.g., marketplace install without hooks/scripts directory).
+
+**Execution:**
+
+```bash
+if [ -f {plugin_root}/hooks/scripts/backlink-format-check.sh ]; then
+  backlink_format_output=$(bash {plugin_root}/hooks/scripts/backlink-format-check.sh --all --quiet 2>&1)
+  backlink_format_exit_code=$?
+else
+  backlink_format_exit_code=-1  # script not found
+fi
+```
+
+**Result handling:**
+
+| Exit Code | `backlink_format_status` | Action |
+|-----------|--------------------------|--------|
+| 0 | `success` | No dialect violations — continue to Phase 4 |
+| 1 | `warning` | Dialect violation detected — record as **warning** (does NOT cause `[lint:error]`). Display findings but allow flow to continue |
+| 2 | `error` | Invocation error — record as warning, display error message |
+| -1 | `skipped` | Script not found — skip silently |
+
+**Important**: Backlink format check results are treated as **warnings**, not errors — same policy as Phase 3.5 / 3.6 / 3.7 / 3.8 / 3.9 checks. A finding does NOT change the overall lint result pattern (`[lint:success]` remains `[lint:success]`). Issue #627 specifies warning-level non-blocking behaviour so the canonical format guideline can be enforced progressively without gating CI.
+
+**Record backlink format check results** for Phase 4 reporting:
+- `backlink_format_status`: `success` / `warning` / `error` / `skipped`
+- `backlink_format_finding_count`: Extract from `backlink_format_output` by matching the line `==> Total backlink-format findings: N` (regex: `/Total backlink-format findings: (\d+)/`). If no match found, default to 0
+- `backlink_format_output`: Script output (truncated if >50 lines)
+
 ---
 
 ## Phase 4: Report Results
@@ -872,6 +907,7 @@ Analyze the error content and present fix suggestions when possible:
 | Wiki growth check (#524) | {wiki_growth_status} ({wiki_growth_finding_count} findings) |
 | Terminal output check (#561) | {verify_terminal_status} ({verify_terminal_finding_count} findings) |
 | Gitignore health check (#567) | {gitignore_health_status} ({gitignore_health_finding_count} findings) |
+| Backlink format check (#627) | {backlink_format_status} ({backlink_format_finding_count} findings) |
 | {i18n:lint_duration} | {duration} |
 
 {i18n:lint_next_steps}:
@@ -882,7 +918,7 @@ Analyze the error content and present fix suggestions when possible:
 > **{i18n:lint_standalone_note}**: {i18n:lint_standalone_note_detail}
 ```
 
-**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Terminal output check (#561)` row follows the same policy as `Wiki growth check`: omit when `verify_terminal_status` is `skipped` (marketplace install without hooks directory), and display with `success` / `warning` / `error` otherwise. The `Gitignore health check (#567)` row follows the same policy: omit when `gitignore_health_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = healthy rule / legitimate no-op; `warning` = drift detected; `error` = invocation failure). **Asymmetry note**: The `{i18n:lint_drift_check}` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. Phase 3.7 (`Doc-heavy patterns drift check`) and Phase 3.8 (`Wiki growth check`) and Phase 0.6 (`Terminal output check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
+**Note**: The `{i18n:lint_test}` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `{i18n:lint_drift_check}` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Terminal output check (#561)` row follows the same policy as `Wiki growth check`: omit when `verify_terminal_status` is `skipped` (marketplace install without hooks directory), and display with `success` / `warning` / `error` otherwise. The `Gitignore health check (#567)` row follows the same policy: omit when `gitignore_health_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = healthy rule / legitimate no-op; `warning` = drift detected; `error` = invocation failure). The `Backlink format check (#627)` row follows the same policy: omit when `backlink_format_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no dialect violations; `warning` = legacy dialect detected; `error` = invocation failure). **Asymmetry note**: The `{i18n:lint_drift_check}` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. Phase 3.7 (`Doc-heavy patterns drift check`) and Phase 3.8 (`Wiki growth check`) and Phase 0.6 (`Terminal output check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -698,7 +698,7 @@ Execute the backlink format check script to detect bidirectional backlink format
 
 ```bash
 if [ -f {plugin_root}/hooks/scripts/backlink-format-check.sh ]; then
-  backlink_format_output=$(bash {plugin_root}/hooks/scripts/backlink-format-check.sh --all --quiet 2>&1)
+  backlink_format_output=$(bash {plugin_root}/hooks/scripts/backlink-format-check.sh --all 2>&1)
   backlink_format_exit_code=$?
 else
   backlink_format_exit_code=-1  # script not found
@@ -830,7 +830,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the `.r
 {gitignore_health_output}
 ```
 
-These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, or gitignore-health warnings/invocation errors.
+**Backlink format check appendix (Issue #627)** (both standalone and E2E): When `backlink_format_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output / gitignore-health. When status is `warning` (exit 1, dialect violations detected), the appendix output includes each violation line (`[backlink-format][P1] file:NN: ...`) so reviewers can identify and fix the offending backlink format. When status is `error` (exit 2, invocation failure), the appendix contains the stderr diagnostic:
+
+```
+⚠️ Backlink format check: {backlink_format_finding_count} findings detected ({backlink_format_status}, non-blocking)
+{backlink_format_output}
+```
+
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, gitignore-health, or backlink-format warnings/invocation errors.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 

--- a/plugins/rite/hooks/scripts/backlink-format-check.sh
+++ b/plugins/rite/hooks/scripts/backlink-format-check.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# backlink-format-check.sh
+#
+# Detect bidirectional backlink format invariant violations in rite-workflow
+# files. PR #620 (Issue #620) established **colon notation** as the canonical
+# format for `Downstream reference:` comments, and PR #626 unified all 9
+# existing sites to the canonical form. This lint check detects future
+# regressions back to the PR #605 / PR #619 dialects.
+#
+# Canonical format (PR #620) is described in the wiki canonical page:
+#     .rite/wiki/pages/patterns/drift-check-anchor-semantic-name.md
+# and uses the shape `reference-keyword filepath-colon-phase-number`.
+#
+# Expected canonical pattern (grep-verifiable) — see the wiki page above for
+# the exact regex. This script detects the two legacy dialects that PR #620
+# replaced:
+#
+#   P1: space-separated (PR #605 old dialect)
+#       semantics: the file path and Phase token are separated by a SPACE
+#                  instead of a COLON. Canonical uses colon; this dialect
+#                  uses a space.
+#
+#   P2: parenthetical (PR #619 old dialect)
+#       semantics: the backlink includes a parenthetical qualifier naming
+#                  the DRIFT-CHECK anchor. PR #620 dropped this qualifier
+#                  because filepath-colon-phase already uniquely identifies
+#                  the anchor within each Phase.
+#
+# Exact regex literals are kept INSIDE the awk program below (not in this
+# header) so the script does not flag itself when run with --all over
+# hooks/scripts/. Same header-comment policy as bang-backtick-check.sh.
+#
+# Lines where `Downstream reference:` is not followed by any Phase number
+# (e.g. free-prose references to Hint messages) are neither canonical nor
+# NG — both patterns intentionally require a `Phase` token, so such lines
+# silently pass. This is by design: they reference different semantic
+# targets and are not covered by the PR #620 invariant.
+#
+# Out of scope:
+#   - Wiki canonical pages under `.rite/wiki/` — not on the development
+#     branch (separate `wiki` branch via worktree). Intentional scope
+#     boundary per Issue #627 "(backticks 内の example は除外)" note.
+#   - `Downstream reference:` lines inside Markdown code fences. Lines
+#     *inside* fenced blocks are still scanned because lint.md Phase 3.5-3.9
+#     scripts treat them uniformly — see bang-backtick-check.sh for the
+#     same policy precedent. If false positives surface in wiki pages that
+#     get committed to the dev branch, add a fence-aware mode in a follow-up.
+#
+# Usage:
+#   backlink-format-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
+#
+# Exit codes:
+#   0  No backlink format violations
+#   1  Violation pattern detected
+#   2  Invocation error (bad args, missing directories)
+
+set -uo pipefail
+
+REPO_ROOT=""
+QUIET=0
+declare -a TARGETS=()
+USE_ALL=0
+
+usage() {
+  cat <<'EOF'
+Usage: backlink-format-check.sh [options]
+
+Options:
+  --all              Scan plugins/rite/commands/**/*.md, plugins/rite/hooks/scripts/**/*.sh,
+                     and the repository-root .gitignore
+  --target FILE      Check FILE (repeatable). Path relative to repo root.
+  --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
+  --quiet            Suppress progress/summary log lines on stderr (per-finding
+                     output on stdout is preserved; still exits non-zero on
+                     detection).
+  -h, --help         Show this help
+
+Exit codes:
+  0  No violations detected
+  1  Violation pattern detected
+  2  Invocation error (bad args, missing directories)
+EOF
+}
+
+log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*" >&2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) USE_ALL=1; shift ;;
+    --target) TARGETS+=("$2"); shift 2 ;;
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to $REPO_ROOT" >&2; exit 2; }
+
+# Resolve --all target list. Explicitly check directory existence so marketplace
+# installs (where hooks/scripts lives separately from the plugin commands/) get
+# a clear diagnostic instead of the generic "no targets specified" fallback.
+if [ "$USE_ALL" -eq 1 ]; then
+  commands_dir="plugins/rite/commands"
+  scripts_dir="plugins/rite/hooks/scripts"
+  gitignore_path=".gitignore"
+  found_any=0
+  if [ -d "$commands_dir" ]; then
+    found_any=1
+  else
+    echo "WARNING: $commands_dir not found under $REPO_ROOT (skipped)" >&2
+  fi
+  if [ -d "$scripts_dir" ]; then
+    found_any=1
+  else
+    echo "WARNING: $scripts_dir not found under $REPO_ROOT (skipped)" >&2
+  fi
+  if [ -f "$gitignore_path" ]; then
+    found_any=1
+  else
+    echo "WARNING: $gitignore_path not found under $REPO_ROOT (skipped)" >&2
+  fi
+  if [ "$found_any" -eq 0 ]; then
+    echo "ERROR: --all requested but none of $commands_dir, $scripts_dir, or $gitignore_path exist under $REPO_ROOT" >&2
+    echo "  Likely cause: invoked outside the rite plugin repo (e.g. marketplace install)" >&2
+    echo "  Recovery: run from the rite plugin source tree, or pass --target FILE explicitly" >&2
+    exit 2
+  fi
+  if [ -d "$commands_dir" ]; then
+    while IFS= read -r f; do
+      TARGETS+=("$f")
+    done < <(find "$commands_dir" -type f -name '*.md' 2>/dev/null | sort)
+  fi
+  # Self-exclusion: the awk regex literals in this script would match
+  # themselves when scanned. Compute the script's own path relative to
+  # REPO_ROOT and skip it in --all mode. --target still accepts explicit
+  # self-reference so test harnesses can verify behaviour deliberately.
+  self_abs="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
+  self_rel=""
+  case "$self_abs" in
+    "$REPO_ROOT"/*) self_rel="${self_abs#"$REPO_ROOT"/}" ;;
+  esac
+  if [ -d "$scripts_dir" ]; then
+    while IFS= read -r f; do
+      if [ -n "$self_rel" ] && [ "$f" = "$self_rel" ]; then
+        continue
+      fi
+      TARGETS+=("$f")
+    done < <(find "$scripts_dir" -type f -name '*.sh' 2>/dev/null | sort)
+  fi
+  if [ -f "$gitignore_path" ]; then
+    TARGETS+=("$gitignore_path")
+  fi
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "ERROR: no targets specified (use --all or --target FILE)" >&2
+  usage >&2
+  exit 2
+fi
+
+FINDINGS_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
+trap 'rm -f "$FINDINGS_FILE"' EXIT
+
+# ----- Scan one file for both patterns ---------------------------------------
+#
+# Uses awk `while (match(...))` so multiple violations on a single line are
+# all reported. Each P1/P2 occurrence emits a dedicated finding line.
+check_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    echo "WARNING: target not found: $file" >&2
+    return 0
+  fi
+  awk -v F="$file" '
+    {
+      line = $0
+      # P1: space-separated dialect.
+      #   "Downstream reference: " + <non-space-run> + " Phase " + <digits>.<digits>
+      # The [^ ]+ run must NOT itself end in ":Phase" — otherwise
+      #   "Downstream reference: lint.md:Phase 8.3, same file:Phase 5.1"
+      # would match at the "same file Phase 5.1" substring (false positive).
+      # We guard this by requiring the token right before " Phase " to not
+      # contain ":Phase" already.
+      pos = 1
+      while (pos <= length(line)) {
+        sub_s = substr(line, pos)
+        if (!match(sub_s, /Downstream reference: [^ ]+ Phase [0-9]+\.[0-9.]*[0-9]/)) break
+        hit = substr(sub_s, RSTART, RLENGTH)
+        # False-positive filter: canonical sequences include "Phase X.Y, same file:Phase Z.W".
+        # Extract the token between "reference: " and " Phase" — if it contains ":Phase"
+        # (e.g. "lint.md:Phase 8.3,") the hit is the tail of a canonical comma-separated
+        # list, not a space-separated dialect.
+        tail = substr(hit, length("Downstream reference: ") + 1)
+        sp_idx = index(tail, " Phase")
+        token = substr(tail, 1, sp_idx - 1)
+        if (index(token, ":Phase") == 0) {
+          print "[backlink-format][P1] " F ":" NR ": space-separated dialect (expected colon): " hit
+        }
+        pos = pos + RSTART + RLENGTH - 1
+      }
+      # P2: parenthetical DRIFT-CHECK ANCHOR qualifier on a Downstream reference line.
+      if (match(line, /Downstream reference:.*\(DRIFT-CHECK ANCHOR:/)) {
+        print "[backlink-format][P2] " F ":" NR ": parenthetical (DRIFT-CHECK ANCHOR: ...) qualifier"
+      }
+    }
+  ' "$file" >> "$FINDINGS_FILE"
+}
+
+log "Scanning ${#TARGETS[@]} file(s)..."
+for t in "${TARGETS[@]}"; do
+  check_file "$t"
+done
+
+if [ -s "$FINDINGS_FILE" ]; then
+  cat "$FINDINGS_FILE"
+  total=$(wc -l < "$FINDINGS_FILE")
+else
+  total=0
+fi
+log "==> Total backlink-format findings: ${total}"
+
+if [ "$total" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Issue #620 で team guideline 化された bidirectional backlink の **コロン記法 canonical format** (`<file>:Phase X.Y`) からの drift を自動検出する lint check を `/rite:lint` に追加する。

- PR #620 で 3 dialect (colon / space-separated / parenthetical DRIFT-CHECK ANCHOR) が colon に unification
- PR #626 review で canonical format 統一 refactor が 0 findings で cross-validate された
- 現状は grep で手動検証可能だが team guideline 準拠を CI レベルで担保するため機械検証を導入

warning-level / non-blocking (Phase 3.5-3.9 既存 check と同ポリシー) で段階的に適用する。

Closes #627

## 変更内容

### 新規作成

- `plugins/rite/hooks/scripts/backlink-format-check.sh`
  - `bang-backtick-check.sh` の構造を踏襲した bash + awk スクリプト
  - `--all` / `--target FILE` / `--repo-root DIR` / `--quiet` オプション
  - 2 種 NG dialect を検出:
    - **P1 (PR #605 旧 dialect)**: space-separated — ファイルパスと Phase が スペース で区切られている
    - **P2 (PR #619 旧 dialect)**: parenthetical — `(DRIFT-CHECK ANCHOR: ...)` 括弧記法
  - Exit codes: `0` clean / `1` violation detected / `2` invocation error
  - 集計行: `==> Total backlink-format findings: N`
  - **self-exclusion**: `--all` 時は自身 (backlink-format-check.sh) を scan 対象から除外 (awk regex literal の self-hit を防ぐ)
  - Phase 番号 regex `[0-9]+\.[0-9.]*[0-9]` で多階層 Phase (例: `5.4.4.1`) を完全取得

### 更新

- `plugins/rite/commands/lint.md`
  - **Phase 3.10** 新設 — Phase 3.5-3.9 既存 check と同構造 (condition / skip / execution table / result handling / recording)
  - **Phase 4.3 summary table** に `Backlink format check (#627)` 行を追加
  - lint 結果パターン (`[lint:success]`) に影響しない warning-level non-blocking ポリシー

## 検査対象 scope (`--all`)

| Path | 理由 |
|------|------|
| `plugins/rite/commands/**/*.md` | command 手順書 (内部 anchor 参照多数) |
| `plugins/rite/hooks/scripts/**/*.sh` | bash スクリプト内の `# Downstream reference:` コメント |
| `.gitignore` (project root) | 構造ブロック内の `# Downstream reference:` コメント |

Wiki canonical page (`.rite/wiki/pages/patterns/drift-check-anchor-semantic-name.md`) は develop branch に存在せず worktree separated で管理されるため scope 対象外。

## 検証結果

### 既存 9 site: 0 findings pass

```
$ bash plugins/rite/hooks/scripts/backlink-format-check.sh --all --quiet
(exit 0)
```

既存の 9 site (lint.md / ingest.md × 4 / gitignore-health-check.sh × 2 / .gitignore × 2、うち 8 site が canonical colon notation、1 site は Phase 番号を含まない Hint message 参照で両 NG pattern にマッチせず silent pass) は全て pass。

### 旧 dialect 検出 test

`/tmp/backlink-test.md` に P1 (space-separated) と P2 (parenthetical) を各 1 行投入:

```
[backlink-format][P1] /tmp/backlink-test.md:6: space-separated dialect (expected colon): Downstream reference: plugins/rite/commands/wiki/init.md Phase 1.3.4
[backlink-format][P2] /tmp/backlink-test.md:9: parenthetical (DRIFT-CHECK ANCHOR: ...) qualifier
==> Total backlink-format findings: 2
(exit 1)
```

2 findings を検出、canonical 形式 2 行は silent pass (false positive なし)。

## チェックリスト

- [x] lint check script の実装
- [x] /rite:lint Phase 3.X に組み込み (warning-level、non-blocking)
- [x] 既存 9 site が 0 findings で pass することを検証
- [x] 旧 dialect の再導入 PR に対して検出されることを検証

## Test plan

- [x] `bash plugins/rite/hooks/scripts/backlink-format-check.sh --all --quiet` で既存 site 0 findings pass
- [x] `/tmp/backlink-test.md` fixture で旧 dialect 2 種が検出されること
- [ ] PR review で self-check (`/rite:pr:review`) を通過

## 関連

- 元 Issue: #627
- 関連 PR: #626 (cross-validation 評価された canonical format 統一 refactor)
- 関連 Issue: #620 (team guideline 化 / 完了条件 R4 = オプション項目)
- Wiki canonical: `.rite/wiki/pages/patterns/drift-check-anchor-semantic-name.md` L178-204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
