### PR TITLE
fix(pr:cleanup): 完了メッセージ「次のステップ」末尾の余計な空行を削除

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -1806,15 +1806,17 @@ git stash pop
 2. `/rite:issue:start <issue_number>` で新しい作業を開始
 ```
 
+> **⚠️ MUST NOT (#633, Phase 9.2 三点セット規約整合)**: 「次のステップ:」ブロック最終項目 (`2. /rite:issue:start ...`) の直後に余計な空行を出力してはならない。Phase 5.3 Step 1 bash 実行は最終項目直後に連続して行い、Phase 5.3 Step 2 HTML コメント sentinel は bash 実行直後に連続して出力する (下記 Phase 5.3 Output ordering 参照)。末尾空行は LLM turn-boundary heuristic を誤発火させうる fragile 要因であり、Phase 9.2 三点セット規約 (完了メッセージ → 次のステップ → HTML コメント sentinel の連続出力、`wiki/lint.md` Phase 9.2 canonical pattern 参照) と整合させること。
+
 ### 5.3 Terminal Completion (Issue #604)
 
 > **⚠️ MUST NOT (#604, mirrors #561)**: 「ユーザー可視最終行 = `[cleanup:completed]` の bare bracket 形式」で turn を終わらせてはならない。bare sentinel は LLM の turn-boundary heuristic を誤発火させ、Mode B 症状 (recap 出力後の implicit stop) を再発させる既知リスク (Issue #561 解消条件)。**HTML コメント形式 (`<!-- [cleanup:completed] -->`) のみ許容**。
 >
-> **Output ordering** (絶対遵守 — Phase 5.1 / 5.2 は前段 sub-phase として Phase 5.3 進入前に既に出力済み、下記 Phase 5.3 Step 1/2 の番号と直接対応):
+> **Output ordering** (絶対遵守 — **各ブロック間に余計な空行を挿入しない** (#633)。Phase 5.1 / 5.2 は前段 sub-phase として Phase 5.3 進入前に既に出力済み、下記 Phase 5.3 Step 1/2 の番号と直接対応):
 > 1. Phase 5.1 Cleanup Result Summary — 前段で出力済み (ユーザー可視メッセージ + チェックリスト + 警告群)
-> 2. Phase 5.2 Guidance for Next Steps — 前段で出力済み (ユーザー可視 next-steps ブロック)
-> 3. Phase 5.3 Step 1: flow-state deactivate (下記 Step 1) — bash 出力はユーザー可視だが、`(Bash completed with no output)` のため最終行にならない
-> 4. Phase 5.3 Step 2: `<!-- [cleanup:completed] -->` HTML コメント (下記 Step 2、絶対最終行 — rendered view では不可視、grep 可能)
+> 2. Phase 5.2 Guidance for Next Steps — 前段で出力済み (ユーザー可視 next-steps ブロック、**最終項目 (`2. /rite:issue:start ...`) の直後に余計な空行を入れない** — Phase 9.2 三点セット規約整合、#633)
+> 3. Phase 5.3 Step 1: flow-state deactivate (下記 Step 1) — Phase 5.2 最終項目直後に連続実行する (中間に空行を挟まない、#633)。bash 出力はユーザー可視だが、`(Bash completed with no output)` のため最終行にならない
+> 4. Phase 5.3 Step 2: `<!-- [cleanup:completed] -->` HTML コメント (下記 Step 2、Step 1 bash 実行直後に連続出力、絶対最終行 — rendered view では不可視、grep 可能)
 
 **Step 1**: Deactivate flow state to terminal `cleanup_completed` (idempotent — safe to re-execute). The `if ! cmd; then` rc capture is mandatory — silent failure here leaves `.rite-flow-state.active = true`, which causes the **next** session-end / stop-guard evaluation to surface a stale HINT for the already-completed cleanup workflow (#608 follow-up):
 


### PR DESCRIPTION
## 概要

`/rite:pr:cleanup` 完了時の「次のステップ」ブロック最終項目 (`2. /rite:issue:start ...`) の直後に余計な空行が出力される問題を修正。末尾整形を Phase 9.2 三点セット規約（完了メッセージ → 次のステップ → HTML コメント sentinel の連続出力）と整合させる。

## 関連 Issue

Closes #633

## 変更内容

- `plugins/rite/commands/pr/cleanup.md` Phase 5.2 に MUST NOT blockquote note を追加し、「次のステップ」ブロック最終項目直後の余計な空行を禁止（#633、Phase 9.2 三点セット規約整合、`wiki/lint.md` Phase 9.2 canonical pattern 参照）。
- Phase 5.3 Output ordering の箇条書きを更新し、「各ブロック間に余計な空行を挿入しない」明示と、Phase 5.2 最終項目後の空行禁止を #633 参照で追記。

## 変更ファイル

- `plugins/rite/commands/pr/cleanup.md` - 変更（+6/-4）

## 影響範囲

- `/rite:pr:cleanup` の完了メッセージ出力整形（prose-only 変更）。
- cleanup 本体処理（ブランチ削除、Projects Status 更新、Issue クローズ、Wiki ingest / lint 連動、`.rite-flow-state` deactivate）には変更なし（AC-3 Non-regression）。

## Acceptance Criteria

- [x] **AC-1**: Given `/rite:pr:cleanup` が正常完走したとき, When 完了メッセージが出力される, Then 「次のステップ」ブロック最終項目直後に余計な空行が存在しない（Phase 5.2 MUST NOT note + Phase 5.3 Output ordering 明示化で担保）。
- [x] **AC-2**: Given cleanup が末尾 sentinel を出力する仕様のとき, When 完了メッセージが出力される, Then 「完了メッセージ → 次のステップ → 末尾 sentinel」の順序と規約通りの空行数で出力される（Phase 5.3 Output ordering 箇条書き更新で担保）。
- [x] **AC-3 (Non-regression)**: Given 本修正が適用された状態で cleanup を実行, When 本体処理を伴うとき, Then 出力整形以外の動作に変化がない（prose-only 変更、bash / flow-state-update / `[cleanup:completed]` sentinel 無変更）。

## Test plan

- [ ] `/rite:pr:cleanup` を実際に実行し、「次のステップ」最終項目直後の余計な空行が消えていることを目視確認
- [ ] 完了メッセージ → 次のステップ → `<!-- [cleanup:completed] -->` の順序・間隔が規約通りに出力されることを確認
- [ ] cleanup 本体処理（ブランチ削除、Projects Status 更新、Issue クローズ、Wiki 連動、`.rite-flow-state` deactivate）に regression がないことを smoke test

## 設計判断

- **アプローチ選択**: Phase 5.2 の `次のステップ:` ブロック自体は変更せず、その直後に MUST NOT blockquote note を追加する方針を採用（既存の Phase 5.3 内 MUST NOT #604 と記述スタイルを揃える）。`wiki/lint.md` Phase 9.2 の canonical 三点セットパターン（`echo ""` で中間空行、末尾連続出力）を参照として明示。
- **参照整備**: PR #625/#627/#629/#630/#632 で整備された Phase 9.2 三点セット規約の延長として cleanup 出力にも適用。Decision Log にも同延長である旨を Issue に記録済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
