### PR TITLE
docs: refresh CLAUDE.md architecture diagram + archive BEST_PRACTICES_ALIGNMENT (#641)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,34 +9,42 @@ Claude Code Rite Workflow - Claude Code 用 Issue ドリブン開発ワークフ
 plugins/rite/.claude-plugin/       # プラグイン固有メタデータ（plugin.json）
 plugins/rite/
 ├── commands/         # スキルから呼び出される実行手順書（Markdown）
-│   ├── issue/        #   Issue 操作（start, create, list, edit, close, update, implement など）
-│   ├── pr/           #   PR 操作（create, review, fix, ready, cleanup）
-│   ├── sprint/       #   Sprint 操作（plan, list, current, execute, team-execute）
-│   ├── wiki/         #   Experience Wiki 操作（init, query, ingest, lint）
-│   ├── skill/        #   スキル操作（suggest）
-│   ├── template/     #   テンプレート操作（reset）
-│   ├── init.md       #   初回セットアップ
-│   ├── getting-started.md  # オンボーディングガイド
-│   ├── investigate.md  # 構造化コード調査
-│   ├── lint.md       #   品質チェック
-│   ├── resume.md     #   作業再開
-│   └── workflow.md   #   ワークフローガイド表示
+│   ├── issue/        #   メイン (list, create, start, update, close, edit, recall) +
+│   │                 #   サブスキル (create-{interview,decompose,register}, implement,
+│   │                 #   implementation-plan, completion-report, branch-setup,
+│   │                 #   parent-routing, child-issue-selection, work-memory-init)
+│   ├── pr/           #   メイン (create, ready, review, fix, cleanup) +
+│   │                 #   references/ (fact-check, internal-consistency, fix-relaxation-rules,
+│   │                 #   assessment-rules, reviewer-fallbacks, bash-trap-patterns 等)
+│   ├── sprint/       #   Sprint 操作（list, current, plan, execute, team-execute）
+│   ├── wiki/         #   Experience Wiki 操作（init, query, ingest, lint）+ references/
+│   ├── skill/        #   /rite:skill:suggest
+│   ├── template/     #   /rite:template:reset
+│   └── init.md / getting-started.md / investigate.md / lint.md / resume.md / workflow.md
 ├── skills/           # Claude Code が自動検出するスキル定義（SKILL.md）
-│   ├── rite-workflow/  #   メインスキル + references/（コーディング原則、コンテキスト管理等）
-│   ├── reviewers/      #   レビュアースキル + 各レビュー基準
+│   ├── rite-workflow/  #   メインスキル + references/（コーディング原則、コンテキスト管理）
+│   ├── reviewers/      #   レビュアースキル + 13 種別の基準ファイル + references/
 │   ├── investigate/    #   コード調査スキル
-│   └── wiki/           #   Experience Wiki スキル
+│   └── wiki/           #   Experience Wiki スキル（opt-out）
 ├── agents/           # PR レビュー用サブエージェント定義
-├── templates/        # 完了報告・Issue・PR テンプレート
-├── references/       # gh CLI パターン、GraphQL ヘルパー
-├── scripts/          # ユーティリティスクリプト（Projects 統合 Issue 作成等）
-├── hooks/            # セッション開始/終了、通知、pre/post-compact、stop-guard、
-│                     # work memory 同期、wiki ingest/query トリガ、workflow incident 検出
-└── i18n/             # 多言語対応（ja.yml, en.yml）
+│                     # _reviewer-base.md（共通原則）+ 13 reviewer agent + sprint-teammate
+├── templates/        # config/（rite-config.yml 最小デフォルト）、project-types/、
+│                     # issue/, pr/, review/, wiki/ の各フォーマット
+├── references/       # gh CLI パターン、GraphQL、severity-levels、investigation-protocol、
+│                     # wiki-patterns、workflow-incident-emit-protocol、review-result-schema 等
+├── scripts/          # Projects 統合 Issue 作成、Sub-Issue リンク、レビュー結果抽出・計測 等
+├── hooks/            # Claude Code ライフサイクルフック（session / compact / stop-guard /
+│   │                 # preflight / pre-tool-bash-guard / post-tool-wm-sync /
+│   │                 # phase-transition-whitelist / verify-terminal-output /
+│   │                 # wiki-ingest-trigger / wiki-query-inject / workflow-incident-emit /
+│   │                 # session-ownership / hook-preamble 等）+ hooks.json
+│   ├── scripts/      #   Wiki commit / worktree / backlink / gitignore-health check 等のヘルパー
+│   └── tests/        #   hook レベルの自動テストスイート
+└── i18n/             # 多言語対応（ja.yml / en.yml の legacy + ja/, en/ 配下の分割ファイル）
 rite-config.yml        # プロジェクト固有設定（ブランチ戦略、Projects連携、Wiki、review loop 等）
 ```
 
-**コンポーネント間の関係**: スキル（`skills/`）がエントリポイント → コマンド（`commands/`）を Skill ツール経由で実行 → コマンド内からエージェント（`agents/`）やリファレンス（`references/`）を参照
+**コンポーネント間の関係**: スキル（`skills/`）がエントリポイント → コマンド（`commands/`）を Skill ツール経由で実行 → コマンド内からエージェント（`agents/`）やリファレンス（`references/` / `commands/*/references/`）を参照。hooks/ は Claude Code のライフサイクルから独立に発火し、orchestrator とコンテキスト注入・sentinel emit で連携する。ディレクトリ・ファイルの完全な一覧は `docs/SPEC.md` の Plugin Structure 節を参照。
 
 ## 開発ルール
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,7 +155,6 @@ iteration:
 
 - [仕様書](docs/SPEC.ja.md)
 - [設定リファレンス](docs/CONFIGURATION.md)
-- [Best Practices 対応表](docs/BEST_PRACTICES_ALIGNMENT.md)
 - [English Documentation](README.md)
 
 ## 必要要件

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ See [Configuration Reference](docs/CONFIGURATION.md) for all options.
 
 - [Full Specification](docs/SPEC.md)
 - [Configuration Reference](docs/CONFIGURATION.md)
-- [Best Practices Alignment](docs/BEST_PRACTICES_ALIGNMENT.md)
 - [日本語ドキュメント](README.ja.md)
 
 ## Requirements

--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -2184,7 +2184,6 @@ Closes #XXX
 ## 参考資料
 
 - [Best Practices for Claude Code](https://code.claude.com/docs/en/best-practices)
-- [Best Practices 対応表](BEST_PRACTICES_ALIGNMENT.md) - rite workflow のベストプラクティス準拠状況
 - [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
 - [GitHub CLI Documentation](https://cli.github.com/manual/)
 - [Conventional Commits](https://www.conventionalcommits.org/)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2119,7 +2119,6 @@ Closes #XXX
 ## References
 
 - [Best Practices for Claude Code](https://code.claude.com/docs/en/best-practices)
-- [Best Practices Alignment](BEST_PRACTICES_ALIGNMENT.md) - How rite workflow aligns with best practices
 - [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
 - [GitHub CLI Documentation](https://cli.github.com/manual/)
 - [Conventional Commits](https://www.conventionalcommits.org/)

--- a/docs/archive/BEST_PRACTICES_ALIGNMENT.md
+++ b/docs/archive/BEST_PRACTICES_ALIGNMENT.md
@@ -3,7 +3,7 @@
 > **Archived (2026-04-21)**: This document records the v0.1–v0.3 era Best
 > Practices alignment history and is kept for reference only. Some tables
 > (notably "Current Agents" and "Current Structure") reflect the state at
-> the time they were written and no longer match v1.0.0+ implementation —
+> the time they were written and no longer match v0.4.0+ implementation —
 > `tools: frontmatter` has been removed from all reviewer agents (#357),
 > 13 reviewer agents are in use (not 3), and the CLAUDE.md example shown
 > is from the 20-line era. For the current specification see

--- a/docs/archive/BEST_PRACTICES_ALIGNMENT.md
+++ b/docs/archive/BEST_PRACTICES_ALIGNMENT.md
@@ -1,4 +1,13 @@
-# Best Practices for Claude Code Alignment
+# Best Practices for Claude Code Alignment (Archived)
+
+> **Archived (2026-04-21)**: This document records the v0.1–v0.3 era Best
+> Practices alignment history and is kept for reference only. Some tables
+> (notably "Current Agents" and "Current Structure") reflect the state at
+> the time they were written and no longer match v1.0.0+ implementation —
+> `tools: frontmatter` has been removed from all reviewer agents (#357),
+> 13 reviewer agents are in use (not 3), and the CLAUDE.md example shown
+> is from the 20-line era. For the current specification see
+> [`docs/SPEC.md`](../SPEC.md) and [`docs/CONFIGURATION.md`](../CONFIGURATION.md).
 
 This document describes how rite workflow aligns with [Best Practices for Claude Code](https://code.claude.com/docs/en/best-practices).
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` のアーキテクチャ図を v1.0.0+ 実装に合わせて刷新。commands/issue のサブスキル列挙、commands/pr/references と commands/wiki/references の明記、hooks のカテゴリ具体化（phase-transition-whitelist / verify-terminal-output / wiki-ingest-trigger / wiki-query-inject / workflow-incident-emit 等 12 種を列挙）、hooks/scripts/ と hooks/tests/ の追加、templates の config/review/wiki サブディレクトリ明示、skills/*/references/ 言及、詳細は docs/SPEC.md Plugin Structure 節を参照する誘導を追加
- `docs/BEST_PRACTICES_ALIGNMENT.md` を `docs/archive/BEST_PRACTICES_ALIGNMENT.md` に `git mv`。冒頭に archive header を追加して現行仕様 (docs/SPEC.md / CONFIGURATION.md) への誘導を明示
- README.md / README.ja.md の Documentation 目次、docs/SPEC.md / docs/SPEC.ja.md の References セクションから BEST_PRACTICES_ALIGNMENT リンクを削除

## Context

develop ブランチの実装とドキュメントを整合化する 4 フェーズ計画の Phase 3。先行 PR: #638 (Phase 1 Commands 表), #640 (Phase 2 SPEC.md/ja 構造刷新)。残り Phase 4 (CHANGELOG Unreleased 整備) は別 PR で対応予定。

BEST_PRACTICES_ALIGNMENT.md は v0.1-v0.3 期の歴史文書として陳腐化が深刻 (Current Agents 表が 3 reviewer のみ、tools/model 情報が v1.0.0 での frontmatter 削除 #357 前のまま、Current Structure コードブロックが旧 CLAUDE.md 20 行時代の例示) のため、個別更新ではなく archive 退避を選択 (方針は計画時に AskUserQuestion で確定)。

## コミット分割

1. **`docs(claude-md): refresh architecture diagram to reflect v1.0.0+ impl`** — CLAUDE.md アーキテクチャ図更新 (+30/-22)
2. **`docs: archive BEST_PRACTICES_ALIGNMENT and remove stale references`** — archive 退避 + header 追加 + 4 ドキュメントからの参照削除 (+10/-5)

## Test plan

- [x] `grep -rn 'BEST_PRACTICES_ALIGNMENT' --include='*.md' --include='*.yml' plugins/ docs/ README.md README.ja.md CLAUDE.md` で archive パス以外の参照が 0 件であることを確認済み
- [x] `docs/BEST_PRACTICES_ALIGNMENT.md` が存在せず `docs/archive/BEST_PRACTICES_ALIGNMENT.md` のみ存在することを確認
- [x] CLAUDE.md 内のファイル名が実装に存在することを確認（false positive 除く: `_reviewer-base.md` の `_` prefix と `~/.claude/settings.json` の外部参照）
- [x] archive header に現行仕様 (docs/SPEC.md / docs/CONFIGURATION.md) への誘導リンクが存在することを確認

Closes #641

Refs: #357 #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)