### PR TITLE
docs(changelog): populate Unreleased with post-v1.0.0 develop activity (#643)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -16,6 +16,30 @@ Phase 番号取扱方針: エントリは機能名レベルで変更を記述し
 
 ## [Unreleased]
 
+### 追加
+
+- **`/rite:lint` に bidirectional backlink format 機械検証を追加** — Wiki ページがコロン記法の canonical な bidirectional backlink 参照を維持しているかを `/rite:lint` が機械的に検証する。Phase 3.x で非ブロッキングの構造 drift チェックとして実行され、不整合は最終レポートに表示される (#627)。
+
+### 変更
+
+- **docs: develop 実装を SPEC / README / CLAUDE.md / CHANGELOG に反映** — v0.4.0 後の複数 PR によるドキュメント整合化スイープ:
+  - Commands 表 + Agent File Format Note — README / README.ja / SPEC / SPEC.ja の Commands 表に `/rite:issue:recall` を追加、README.ja に `/rite:init --upgrade` 行を追加、`subagent_type: general-purpose` の Note を named-subagent 記述に差し替え (#637 / #638)
+  - SPEC の Plugin Structure ツリーを v0.4.0+ 実装に合わせて全面書換 (commands/issue のサブスキル、commands/pr/references、commands/wiki、agents/_reviewer-base、skills/{investigate,wiki}、hooks/{scripts,tests}、templates/{config,review,wiki}、scripts 拡充、references 拡充)、Configuration セクションを `docs/CONFIGURATION.md` ポインタに圧縮、Hook Specification に post-compact / phase-transition-whitelist / verify-terminal-output / session-ownership / issue-comment-wm-sync / wiki-ingest-trigger + wiki-query-inject / workflow-incident-emit / hook-preamble / helper-scripts のサブセクションを追加 (#639 / #640)
+  - CLAUDE.md アーキテクチャ図を刷新、`docs/BEST_PRACTICES_ALIGNMENT.md` を v0.1–v0.3 期の歴史文書として `docs/archive/` 配下に退避 (#641 / #642)
+  - CHANGELOG Unreleased を v0.4.0 後の develop 活動で整備 (本 PR, #643)
+  - repo 全体の version rename 1.0.0 → 0.4.0 (次期リリースは v1.0.0 ではなく v0.4.0 として出す方針)。version ファイル、README バッジ、CHANGELOG [1.0.0] エントリ → [0.4.0]、内部の `v1.0.0 (#557)` 参照を更新 (#645)
+- **`commands/` 全体で bidirectional backlink format をコロン記法に統一** — `refactor(commands)` によるプロジェクト全体の Wiki 相互参照スタイル整列 (#620 / #626) および `wiki/ingest.md` / `wiki/lint.md` の既存 DRIFT-CHECK ANCHOR ブロックに bidirectional backlink エントリを追加 (#607 / #619)。
+- **semantic anchor 移行** — `commands/init.md:145` と `hooks/scripts/gitignore-health-check.sh:298` に残存していた line 番号 literal を将来の編集に耐性のある semantic anchor に置換 (#617)。
+- **`/rite:wiki:lint` `--auto` 早期 return の整列** — Phase 1.1 / 1.3 の早期 return 経路を Phase 9.2 三点セット規約に整合させ、sentinel / status-line / continuation-hint の出力を統一 (#630 / #632)。
+- **Wiki スキル整備** — `skills/wiki/SKILL.md` EN description を canonical と整列 (#603 / #616)、`wiki/lint.md` 完了レポート UX 出力順を canonical frontmatter 順に整列 (#615)。
+
+### 修正
+
+- **サブスキル return 後の implicit stop 多層防御** — 累積対策 (#534 / #628 / #618 / #621 / #604 / #634) により、サブスキル return → orchestrator 継続経路が Bash heuristic 起因の implicit stop に対して強固になる。`create-interview`、`wiki/ingest.md` Phase 8 auto-lint、`pr/cleanup` wiki-ingest return、`pr/cleanup` wiki-auto-ingest Phase 5 境界をカバー。`INTERVIEW_DONE=1` plain-text marker (#634 / #636) と `stop-guard.sh` case-arm `WORKFLOW_HINT` の Step 0 Immediate Bash Action による拡張を含む。
+- **`wiki/lint.md` Phase 9.2 `--auto` continuation sentinel** — `--auto` 出力が明示的な continuation sentinel を emit するようになり、警告付き完了と silent-skip の区別が caller 側で可能になった (#625 / #629)。
+- **`pr/cleanup` 完了メッセージの末尾空行** — 「次のステップ」見出し後の不要な末尾空行を削除し、ターミナル表示をクリーンに (#633 / #635)。
+- **`wiki/` と `pr/cleanup` の preprocessor-safe 表記への移行** — スラッシュコマンドのプリプロセッサが bash で eval してしまう (結果として `slash command not found`) `!`+backtick 表現を、`#613` で文書化された規約に従って `if ! cmd; then` 形式へ移行 (#609 / #610, #611 / #612, #614)。
+
 ## [0.4.0] - 2026-04-17
 
 ### 破壊的変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ rationale and Keep a Changelog 1.1.0 "Guiding Principles" for conventions.
 
 ## [Unreleased]
 
+### Added
+
+- **Bidirectional backlink format verification in `/rite:lint`** — `/rite:lint` now mechanically verifies that Wiki pages maintain bidirectional backlink references in the canonical colon-delimited form. Runs as a non-blocking structural drift check in Phase 3.x and surfaces mismatches in the final report (#627).
+
+### Changed
+
+- **docs: reflect v0.4.0+ implementation across SPEC / README / CLAUDE.md / CHANGELOG** — Multi-PR documentation alignment sweep after v0.4.0:
+  - Commands table + Agent File Format Note — added `/rite:issue:recall` to README / README.ja / SPEC / SPEC.ja Commands tables, added `/rite:init --upgrade` to README.ja, replaced the `subagent_type: general-purpose` note with the named-subagent description (#637 / #638)
+  - SPEC Plugin Structure tree refreshed to match v0.4.0+ file layout (commands/issue sub-skills, commands/pr/references, commands/wiki, agents/_reviewer-base, skills/{investigate,wiki}, hooks/{scripts,tests}, templates/{config,review,wiki}, scripts expansion, references expansion); Configuration section compressed to a pointer to `docs/CONFIGURATION.md`; Hook Specification extended with post-compact / phase-transition-whitelist / verify-terminal-output / session-ownership / issue-comment-wm-sync / wiki-ingest-trigger + wiki-query-inject / workflow-incident-emit / hook-preamble / helper-scripts sub-sections (#639 / #640)
+  - CLAUDE.md architecture diagram refreshed; `docs/BEST_PRACTICES_ALIGNMENT.md` archived under `docs/archive/` as historical v0.1–v0.3 reference (#641 / #642)
+  - CHANGELOG Unreleased populated with post-v0.4.0 develop activity (this PR, #643)
+  - Repo-wide version rename 1.0.0 → 0.4.0 (next release planned as v0.4.0 not v1.0.0); version files, README badges, CHANGELOG [1.0.0] entry → [0.4.0], and internal `v1.0.0 (#557)` references updated (#645)
+- **Bidirectional backlink format unified to colon notation** across `commands/` — `refactor(commands)` aligning Wiki cross-reference style project-wide (#620 / #626), and extending existing DRIFT-CHECK ANCHOR blocks in `wiki/ingest.md` / `wiki/lint.md` with bidirectional backlink entries (#607 / #619).
+- **Semantic anchor migration** — replaced residual hard-coded line-number literals in `commands/init.md:145` and `hooks/scripts/gitignore-health-check.sh:298` with semantic anchors resilient to future edits (#617).
+- **`/rite:wiki:lint` `--auto` early-return alignment** — Phase 1.1 / 1.3 early-return paths aligned with the Phase 9.2 three-piece convention so sentinel / status-line / continuation-hint emission is uniform (#630 / #632).
+- **Wiki skill polish** — `skills/wiki/SKILL.md` EN description aligned with its canonical form (#603 / #616); `wiki/lint.md` completion-report UX output order aligned with the canonical frontmatter order (#615).
+
+### Fixed
+
+- **Sub-skill return implicit-stop multi-layer defense** — Accumulated fixes (#534 / #628 / #618 / #621 / #604 / #634) hardening the sub-skill return → orchestrator continuation path against Bash heuristic-induced implicit stops. Covers `create-interview`, `wiki/ingest.md` Phase 8 auto-lint, `pr/cleanup` wiki-ingest return, and `pr/cleanup` wiki-auto-ingest Phase 5 boundaries. Includes `INTERVIEW_DONE=1` plain-text marker (#634 / #636) and `stop-guard.sh` case-arm `WORKFLOW_HINT` expansion with Step 0 Immediate Bash Action.
+- **`wiki/lint.md` Phase 9.2 `--auto` continuation sentinel** — `--auto` output now emits an explicit continuation sentinel so callers can distinguish completed-with-warnings from silent-skip (#625 / #629).
+- **`pr/cleanup` completion message trailing blank line** — Removed the spurious trailing blank line after the "次のステップ" heading for cleaner terminal rendering (#633 / #635).
+- **Preprocessor-safe syntax migration in `wiki/` and `pr/cleanup`** — Residual `!`+backtick expressions that the slash-command preprocessor evaluated via bash (causing `slash command not found` failures) were migrated to the `if ! cmd; then` form per the convention documented in #613 (#609 / #610, #611 / #612, #614).
+
 ## [0.4.0] - 2026-04-17
 
 ### BREAKING CHANGE


### PR DESCRIPTION
## Summary

- v1.0.0 (2026-04-17) 以降に develop へ積まれた 15+ PR を `CHANGELOG.md` / `CHANGELOG.ja.md` の `## [Unreleased]` セクションに Added / Changed / Fixed のサブセクションとして集約
- 次回リリース時はリリース日の付与のみで済む状態に整備
- ja/en 両方で parity を保って記述

## Context

develop ブランチの実装とドキュメントを整合化する 4 フェーズ計画の Phase 4（最終）。先行 PR: #638 (Phase 1), #640 (Phase 2), #642 (Phase 3)。

v1.0.0 リリース以降、develop には以下のような PR が積まれているが CHANGELOG には未記録だった:

- **feat**: #627 bidirectional backlink format 機械検証 (user-facing)
- **refactor**: #620/#626, #607/#619, #617, #630/#632, #603/#616, #615
- **fix**: #634/#636, #633/#635, #625/#629, #618/#624, #621/#623, #609/#610, #611/#612, #604/#608

Phase 1-4 の整合化作業も Changed の 1 エントリとしてまとめて記録した。

## エントリ構成ポリシー

CHANGELOG 冒頭コメント (L9-16) の指針に従い:
- feature-name level で記述し、内部 `Phase X.Y.Z` 識別子には依存しない
- `review.md` / `fix.md` / `start.md` 等の内部リファクタで番号が振り直されても安定

## Test plan

- [x] `/rite:lint` の bidirectional backlink format 検証 (#627) が Added に個別エントリとして存在
- [x] docs 整合化タスク (Phase 1-4) が Changed の単一エントリとして集約され、各 Phase のカバー範囲が sub-bullet で列挙されている
- [x] 累積的 implicit stop 多層防御系 (#534/#628/#618/#621/#604/#634) が Fixed の単一エントリに集約されている
- [x] ja/en 両方の Unreleased セクションで 3 サブセクション (Added/Changed/Fixed) の parity を維持
- [x] 実装変更を伴わない内部リファクタリング単発の PR は個別列挙を避けてグループ化

Closes #643

Refs: #534 #603 #604 #607 #609 #611 #615 #617 #618 #620 #621 #625 #627 #628 #630 #633 #634 #637 #639 #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)