### PR TITLE
fix(scripts): silent fail 解消と AC-3 機械検証ガード (#669)

### DIFF
--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -200,10 +200,11 @@ The script handles errors internally with the following behavior:
 | Error Case | Response |
 |------------|----------|
 | `gh issue create` failure | Output JSON with `project_registration: "failed"` + `exit 1`. Caller's `result=$(bash ...)` captures stdout but gets non-zero exit code |
-| `gh project item-add` failure | Output JSON with `project_registration: "failed"` + `exit 0` (non-blocking) or `exit 1` |
-| `item_id` retrieval failure (after fallback to last: 20) | Output JSON with `project_registration: "partial"` + `exit 0` |
-| Field setup failure | Retry once, then output JSON with `project_registration: "partial"` + `exit 0` |
-| Projects not configured | Output JSON with `project_registration: "skipped"` + `exit 0` |
+| `gh project item-add` failure (after 3 retries) | Output JSON with `project_registration: "failed"` + `exit 0` (non-blocking) or `exit 1`. **stderr emit**: `ERROR: Projects registration failed: ...` |
+| `item_id` retrieval failure (after fallback to last: 20 + 3 retries) | Output JSON with `project_registration: "partial"` + `exit 0`. **stderr emit** on each failure |
+| Field setup failure (after 3 retries) | Output JSON with `project_registration: "partial"` + `exit 0`. **stderr emit** on each failure |
+| Iteration assignment failure (after 3 retries) | `project_registration` becomes `partial`, **stderr emit** on each failure. Issue still created with status set |
+| Projects not configured | Output JSON with `project_registration: "skipped"` + `exit 0`. **No stderr emit** (intentional skip, not failure) |
 
 **Exit code convention:**
 - `exit 0`: Success or non-blocking failure (Projects-related issues when `non_blocking_projects: true`)
@@ -215,6 +216,27 @@ The script handles errors internally with the following behavior:
 - Warnings are collected in the `warnings` array for caller to display
 - If `result` is empty (script crashed), callers should check `$?` and handle gracefully
 
+### Silent Fail Prohibition (#669)
+
+Issue #669 strengthens the script so that **Projects registration failures are never silently absorbed** by the warnings array alone. Two reinforcement layers are in place:
+
+1. **stderr emit on every registration failure** — `add_warning_with_stderr` writes `ERROR: Projects registration failed: <reason>` to stderr in addition to appending to the warnings array. The early `enabled=false` skip path uses plain `add_warning` so it stays silent (intentional skip, not failure).
+2. **3-attempt exponential backoff on transient API errors** — `gh project item-add`, all GraphQL queries (`fields`, `items`, mutations), and `gh project item-edit` are wrapped in `retry_with_backoff 3 ...` (sleeps `RETRY_DELAY * 2^(n-1)` seconds — defaults to 1s, 2s between attempts; tests set `RETRY_DELAY=0`). This satisfies the MUST 2 / MUST NOT 2 requirements:
+   - MUST: stderr surfaces root cause
+   - MUST NOT: failures are not confined to the warnings array under exit code 0
+
+### Static Guard for Direct `gh issue create` Invocations (#669 AC-3)
+
+`plugins/rite/scripts/check-no-direct-gh-issue-create.sh` provides a mechanical check: every Issue creation path in `/rite:issue:start` and the parent-routing module must go through this script. Run it against any new orchestrator/sub-skill files:
+
+```bash
+bash plugins/rite/scripts/check-no-direct-gh-issue-create.sh \
+  plugins/rite/commands/issue/start.md \
+  plugins/rite/commands/issue/parent-routing.md
+```
+
+Exit 0 = no violations. Exit 1 = direct `gh issue create -...` / `gh issue create $...` / `gh issue create "..."` / `gh issue create '...'` invocation found (after stripping fenced code blocks, blockquotes, Markdown comments, and inline backticks). Tests live at `plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh` and include positive, negative, and false-positive-avoidance cases (TC-001 through TC-010).
+
 ---
 
 ## Script Internal Details
@@ -224,4 +246,5 @@ The script automatically handles:
 - Item ID retrieval with fallback (last: 10 → last: 20)
 - Field ID and option ID resolution from project field metadata
 - Iteration auto-assignment when `iteration.mode: "auto"`
-- Single retry on field setup failures
+- 3-attempt exponential backoff retry on transient API failures (#669)
+- stderr emit for every Projects registration failure (#669)

--- a/plugins/rite/scripts/check-no-direct-gh-issue-create.sh
+++ b/plugins/rite/scripts/check-no-direct-gh-issue-create.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# check-no-direct-gh-issue-create.sh (#669)
+# Static guard: ensure target files do not contain direct `gh issue create`
+# invocations. Enforces AC-3 — all Issue creation paths in /rite:issue:start
+# (and parent-routing) must go through create-issue-with-projects.sh.
+#
+# The guard skips:
+#   - Lines inside fenced code blocks (``` or ~~~)
+#   - Blockquote lines (starting with `> ` or whitespace+`> `)
+#   - Markdown comments (<!-- ... --> on a single line, or multi-line spans)
+#   - Inline backtick spans (`...`) within otherwise-prose lines
+#
+# Usage:
+#   check-no-direct-gh-issue-create.sh <file.md> [<file.md> ...]
+#
+# Exit codes:
+#   0 - No violations
+#   1 - One or more violations found (printed to stderr with file:line:content)
+#   2 - Usage error (no arguments / file not found)
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <file.md> [<file.md> ...]" >&2
+  exit 2
+fi
+
+violations=0
+for file in "$@"; do
+  if [ ! -f "$file" ]; then
+    echo "ERROR: File not found: $file" >&2
+    exit 2
+  fi
+  matches=$(awk '
+    BEGIN { in_code = 0; in_comment = 0 }
+
+    # Code fence toggles
+    /^```/ || /^~~~/ { in_code = !in_code; next }
+    in_code { next }
+
+    # Blockquote: skip entire line (both narrative quotes and quoted code samples)
+    /^[[:space:]]*>[[:space:]]/ { next }
+
+    # Markdown comment: handle single-line and multi-line forms
+    /<!--/ {
+      if (/-->/) { next }   # single-line comment
+      in_comment = 1
+      next
+    }
+    in_comment {
+      if (/-->/) { in_comment = 0 }
+      next
+    }
+
+    # For the remaining narrative lines, strip inline backtick spans before
+    # the pattern check so that prose using backticks does not false-positive.
+    #
+    # Detection pattern: literal `gh issue create ` followed by one of:
+    #   - dash (option flag)
+    #   - dollar (shell variable expansion)
+    #   - double-quote (quoted argument)
+    #   - single-quote (also quoted argument, encoded as octal 047)
+    # This distinguishes real shell invocations from English prose where the
+    # next word is a normal noun like "invocation" or "directly".
+    {
+      tmp = $0
+      gsub(/`[^`]*`/, "", tmp)
+      if (tmp ~ /gh issue create [-$"\047]/) {
+        printf "%s:%d: %s\n", FILENAME, NR, $0
+      }
+    }
+  ' "$file")
+  if [ -n "$matches" ]; then
+    echo "VIOLATION: Direct 'gh issue create' invocation detected (#669 AC-3 violation):" >&2
+    printf '%s\n' "$matches" >&2
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "" >&2
+  echo "Total files with violations: $violations" >&2
+  echo "All Issue creation must go through plugins/rite/scripts/create-issue-with-projects.sh." >&2
+  echo "See Issue #669 (AC-3 / 4.4 MUST NOT 1) for guidance." >&2
+  exit 1
+fi
+
+exit 0

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -58,11 +58,48 @@ add_warning() {
   WARNINGS_ARR+=("$1")
 }
 
+# add_warning_with_stderr (#669): Projects registration failures must NOT be silent.
+# Caller contract: only invoke for failures within the Projects registration phase
+# (after PROJECTS_ENABLED=true gate at L171). Do NOT use for the enabled=false skip
+# path or for informational Iteration-not-configured cases — those use add_warning.
+add_warning_with_stderr() {
+  WARNINGS_ARR+=("$1")
+  printf 'ERROR: Projects registration failed: %s\n' "$1" >&2
+}
+
 RETRY_DELAY="${RETRY_DELAY:-1}"
 if ! [[ "$RETRY_DELAY" =~ ^[0-9]+$ ]]; then
   add_warning "Invalid RETRY_DELAY value: '${RETRY_DELAY:0:20}'. Using default 1"
   RETRY_DELAY=1
 fi
+
+# retry_with_backoff (#669): exponential backoff retry for transient API failures.
+# Usage: result=$(retry_with_backoff <max_attempts> <stderr_file> <command...>)
+# Sleeps RETRY_DELAY * 2^(n-1) seconds between attempts (1s, 2s, 4s for default delay).
+# Set RETRY_DELAY=0 in tests to skip sleep entirely.
+# Returns stdout of last attempt; exit code is exit code of last attempt.
+retry_with_backoff() {
+  local max_attempts="$1"; shift
+  local stderr_file="$1"; shift
+  local attempt=1
+  local rc=0
+  local output=""
+  while [ "$attempt" -le "$max_attempts" ]; do
+    # Capture rc directly from command substitution (avoid `if ... fi` resetting $? to 0).
+    output=$("$@" 2>"$stderr_file")
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$output"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      sleep $(( RETRY_DELAY * (1 << (attempt - 1)) ))
+    fi
+    attempt=$(( attempt + 1 ))
+  done
+  printf '%s' "$output"
+  return "$rc"
+}
 
 # --- Helper: output JSON result to stdout ---
 output_result() {
@@ -175,8 +212,9 @@ fi
 PROJECT_REG="ok"
 
 # Step 2.1: Add Issue to Project (capture item ID directly via --format json)
-ITEM_ADD_RESULT=$(gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL" --format json 2>"$GH_ERR_FILE") || {
-  add_warning "gh project item-add failed for Issue #$ISSUE_NUMBER: $(cat "$GH_ERR_FILE")"
+# #669: 3-attempt exponential backoff for transient API failures.
+ITEM_ADD_RESULT=$(retry_with_backoff 3 "$GH_ERR_FILE" gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL" --format json) || {
+  add_warning_with_stderr "gh project item-add failed for Issue #$ISSUE_NUMBER after 3 attempts: $(cat "$GH_ERR_FILE")"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "failed"
   if [ "$NON_BLOCKING" = "true" ]; then
     exit 0
@@ -196,13 +234,14 @@ fi
 
 # Whitelist validation for GQL_ROOT (defense against GraphQL injection, CWE-943)
 if [[ "$GQL_ROOT" != "user" && "$GQL_ROOT" != "organization" ]]; then
-  add_warning "Invalid GQL_ROOT value: $GQL_ROOT"
+  add_warning_with_stderr "Invalid GQL_ROOT value: $GQL_ROOT"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 fi
 
 # Step 2.3: Retrieve project item ID and field information
-GQL_RESULT=$(gh api graphql -f query="
+# #669: 3-attempt exponential backoff for transient API failures.
+GQL_FIELDS_QUERY="
 query(\$owner: String!, \$projectNumber: Int!) {
   ${GQL_ROOT}(login: \$owner) {
     projectV2(number: \$projectNumber) {
@@ -242,8 +281,9 @@ query(\$owner: String!, \$projectNumber: Int!) {
       }
     }
   }
-}" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER" 2>"$GH_ERR_FILE") || {
-  add_warning "GraphQL query failed for project field retrieval: $(cat "$GH_ERR_FILE")"
+}"
+GQL_RESULT=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_FIELDS_QUERY" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER") || {
+  add_warning_with_stderr "GraphQL query failed for project field retrieval after 3 attempts: $(cat "$GH_ERR_FILE")"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 }
@@ -251,7 +291,7 @@ query(\$owner: String!, \$projectNumber: Int!) {
 # Extract project ID (use --arg for safe variable passing to jq)
 PROJECT_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" '.data[$root].projectV2.id // empty')
 if [ -z "$PROJECT_ID" ]; then
-  add_warning "Could not extract project ID"
+  add_warning_with_stderr "Could not extract project ID"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 fi
@@ -262,8 +302,8 @@ if [ -z "$ITEM_ID" ]; then
   ITEM_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" --argjson num "$ISSUE_NUMBER" '.data[$root].projectV2.items.nodes[] | select(.content.number == $num) | .id // empty')
 fi
 if [ -z "$ITEM_ID" ]; then
-  # Retry with larger window
-  GQL_RETRY=$(gh api graphql -f query="
+  # Retry with larger window. #669: 3-attempt exponential backoff for transient failures.
+  GQL_ITEMS_QUERY="
 query(\$owner: String!, \$projectNumber: Int!) {
   ${GQL_ROOT}(login: \$owner) {
     projectV2(number: \$projectNumber) {
@@ -279,11 +319,12 @@ query(\$owner: String!, \$projectNumber: Int!) {
       }
     }
   }
-}" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER" 2>"$GH_ERR_FILE") || { add_warning "GraphQL retry query failed: $(cat "$GH_ERR_FILE")"; true; }
+}"
+  GQL_RETRY=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_ITEMS_QUERY" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER") || { add_warning_with_stderr "GraphQL items lookup query failed after 3 attempts: $(cat "$GH_ERR_FILE")"; true; }
 
   ITEM_ID=$(printf '%s\n' "$GQL_RETRY" | jq -r --arg root "$GQL_ROOT" --argjson num "$ISSUE_NUMBER" '.data[$root].projectV2.items.nodes[] | select(.content.number == $num) | .id // empty' 2>"$FIELD_ERR_FILE")
   if [ -z "$ITEM_ID" ]; then
-    add_warning "Could not find item ID for Issue #$ISSUE_NUMBER in project"
+    add_warning_with_stderr "Could not find item ID for Issue #$ISSUE_NUMBER in project"
     output_result "$ISSUE_URL" "$ISSUE_NUMBER" "$PROJECT_ID" "" "partial"
     exit 0
   fi
@@ -318,18 +359,15 @@ set_field() {
   local option_id="${result##*|}"
 
   if [ -z "$field_id" ] || [ -z "$option_id" ]; then
-    add_warning "Field '$field_name' or option '$field_value' not found in project"
+    add_warning_with_stderr "Field '$field_name' or option '$field_value' not found in project"
     PROJECT_REG="partial"
     return 0
   fi
 
-  if ! gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$field_id" --single-select-option-id "$option_id" 2>"$FIELD_ERR_FILE"; then
-    # Retry once
-    sleep "$RETRY_DELAY"
-    if ! gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$field_id" --single-select-option-id "$option_id" 2>"$FIELD_ERR_FILE"; then
-      add_warning "Failed to set $field_name=$field_value for Issue #$ISSUE_NUMBER: $(cat "$FIELD_ERR_FILE")"
-      PROJECT_REG="partial"
-    fi
+  # #669: Replace ad-hoc 1-retry loop with retry_with_backoff (3 attempts, exponential backoff).
+  if ! retry_with_backoff 3 "$FIELD_ERR_FILE" gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$field_id" --single-select-option-id "$option_id" >/dev/null; then
+    add_warning_with_stderr "Failed to set $field_name=$field_value for Issue #$ISSUE_NUMBER after 3 attempts: $(cat "$FIELD_ERR_FILE")"
+    PROJECT_REG="partial"
   fi
 }
 
@@ -354,7 +392,8 @@ if [ "$ITERATION_MODE" = "auto" ]; then
       | .id // empty
     ')
     if [ -n "$CURRENT_ITER_ID" ]; then
-      gh api graphql -f query='
+      # #669: 3-attempt exponential backoff for transient API failures.
+      ITER_MUTATION='
 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
   updateProjectV2ItemFieldValue(
     input: {
@@ -366,8 +405,9 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
   ) {
     projectV2Item { id }
   }
-}' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$ITER_FIELD_ID" -f iterationId="$CURRENT_ITER_ID" 2>"$GH_ERR_FILE" || {
-        add_warning "Iteration assignment failed for Issue #$ISSUE_NUMBER: $(cat "$GH_ERR_FILE")"
+}'
+      retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$ITER_MUTATION" -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$ITER_FIELD_ID" -f iterationId="$CURRENT_ITER_ID" >/dev/null || {
+        add_warning_with_stderr "Iteration assignment failed for Issue #$ISSUE_NUMBER after 3 attempts: $(cat "$GH_ERR_FILE")"
         PROJECT_REG="partial"
       }
     else

--- a/plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh
+++ b/plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh
@@ -129,6 +129,33 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-006a (#669 F-03): Tilde fence (~~~) → no false positive (exit 0)
+# 検証: awk pattern が ` ``` ` と `~~~` の両方を code fence として認識し、
+# tilde fence 内の literal 呼び出しを誤検出しないこと。
+# --------------------------------------------------------------------------
+echo "TC-006a: Tilde fence (~~~) content → exit 0 (#669 F-03)"
+tilde_file="$TEST_DIR/tilde-fence.md"
+cat > "$tilde_file" <<'EOF'
+# Reference (tilde fence)
+
+Negative reference example using tilde fence:
+
+~~~bash
+# DO NOT do this:
+gh issue create --title "x" --body "y"
+~~~
+
+The script enforces the rule.
+EOF
+rc=0
+output=$(bash "$TARGET" "$tilde_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Tilde fence (~~~) content → exit 0 (no false positive)"
+else
+  fail "Expected exit 0, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
 # TC-007: Blockquote (> ...) → no false positive (exit 0)
 # --------------------------------------------------------------------------
 echo "TC-007: Blockquote content → exit 0"

--- a/plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh
+++ b/plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# Tests for check-no-direct-gh-issue-create.sh (#669 AC-3)
+# Usage: bash plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/../check-no-direct-gh-issue-create.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+echo "=== check-no-direct-gh-issue-create.sh tests (#669 AC-3) ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-001: No arguments → exit 2 (usage error)
+# --------------------------------------------------------------------------
+echo "TC-001: No arguments → exit 2"
+rc=0
+output=$(bash "$TARGET" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "No arguments → exit 2 (usage error)"
+else
+  fail "Expected exit 2, got $rc"
+fi
+
+# --------------------------------------------------------------------------
+# TC-002: Non-existent file → exit 2
+# --------------------------------------------------------------------------
+echo "TC-002: Non-existent file → exit 2"
+rc=0
+output=$(bash "$TARGET" "$TEST_DIR/does-not-exist.md" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "Non-existent file → exit 2"
+else
+  fail "Expected exit 2, got $rc"
+fi
+
+# --------------------------------------------------------------------------
+# TC-003: Clean file (no direct calls) → exit 0
+# --------------------------------------------------------------------------
+echo "TC-003: Clean file → exit 0"
+clean_file="$TEST_DIR/clean.md"
+cat > "$clean_file" <<'EOF'
+# Clean File
+
+This file has no direct gh issue create invocations.
+
+It uses create-issue-with-projects.sh exclusively.
+EOF
+rc=0
+output=$(bash "$TARGET" "$clean_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Clean file → exit 0"
+else
+  fail "Expected exit 0, got $rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-004: Direct invocation in narrative bash → exit 1
+# --------------------------------------------------------------------------
+echo "TC-004: Direct invocation in narrative bash → exit 1"
+violation_file="$TEST_DIR/violation.md"
+cat > "$violation_file" <<'EOF'
+# Violation Example
+
+Run the following:
+
+bash command directly: gh issue create --title "x" --body "y"
+EOF
+rc=0
+output=$(bash "$TARGET" "$violation_file" 2>&1) || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "VIOLATION"; then
+  pass "Direct invocation detected → exit 1 + VIOLATION message"
+else
+  fail "Expected exit 1 + VIOLATION, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-005: Inline backtick (`gh issue create`) → no false positive (exit 0)
+# --------------------------------------------------------------------------
+echo "TC-005: Inline backtick prose → exit 0"
+backtick_file="$TEST_DIR/backtick.md"
+cat > "$backtick_file" <<'EOF'
+# Documentation
+
+The orchestrator must NOT execute `gh issue create` directly.
+
+It also forbids `gh issue create --title "x"` — use the helper script instead.
+EOF
+rc=0
+output=$(bash "$TARGET" "$backtick_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Inline backtick prose → exit 0 (no false positive)"
+else
+  fail "Expected exit 0, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-006: Code fence (```bash ... ```) → no false positive (exit 0)
+# --------------------------------------------------------------------------
+echo "TC-006: Code fence content → exit 0"
+fence_file="$TEST_DIR/fence.md"
+cat > "$fence_file" <<'EOF'
+# Reference
+
+Negative reference example below (must not trigger guard):
+
+```bash
+# DO NOT do this:
+gh issue create --title "x" --body "y"
+```
+
+The script enforces the rule.
+EOF
+rc=0
+output=$(bash "$TARGET" "$fence_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Code fence content → exit 0 (no false positive)"
+else
+  fail "Expected exit 0, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-007: Blockquote (> ...) → no false positive (exit 0)
+# --------------------------------------------------------------------------
+echo "TC-007: Blockquote content → exit 0"
+quote_file="$TEST_DIR/quote.md"
+cat > "$quote_file" <<'EOF'
+# Quoted reference
+
+> Note: do not invoke gh issue create directly. Use the helper.
+
+This is the rule.
+EOF
+rc=0
+output=$(bash "$TARGET" "$quote_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Blockquote content → exit 0 (no false positive)"
+else
+  fail "Expected exit 0, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-008: Markdown comment (<!-- ... -->) → no false positive (exit 0)
+# --------------------------------------------------------------------------
+echo "TC-008: Markdown comment → exit 0"
+comment_file="$TEST_DIR/comment.md"
+cat > "$comment_file" <<'EOF'
+# Comment
+
+<!-- TODO: replace this with helper. The old code used gh issue create -->
+
+Body content.
+
+<!--
+Multi-line note:
+gh issue create was used here
+in the past.
+-->
+
+End.
+EOF
+rc=0
+output=$(bash "$TARGET" "$comment_file" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Markdown comment → exit 0 (no false positive)"
+else
+  fail "Expected exit 0, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-009: Multiple files → exit 1 if any has violation
+# --------------------------------------------------------------------------
+echo "TC-009: Mixed files (1 clean + 1 violation) → exit 1"
+rc=0
+output=$(bash "$TARGET" "$clean_file" "$violation_file" 2>&1) || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "Total files with violations: 1"; then
+  pass "Mixed files → exit 1 + violation count"
+else
+  fail "Expected exit 1 with violation count, got rc=$rc, output='$output'"
+fi
+
+# --------------------------------------------------------------------------
+# TC-010: AC-3 baseline — production target files must pass
+# Validates that the actual in-scope files of #669 currently pass the guard.
+# This is the regression check: if a future change introduces a direct call,
+# this TC fails immediately.
+# --------------------------------------------------------------------------
+echo "TC-010: AC-3 baseline — start.md and parent-routing.md must pass"
+rc=0
+output=$(bash "$TARGET" \
+  "$REPO_ROOT/plugins/rite/commands/issue/start.md" \
+  "$REPO_ROOT/plugins/rite/commands/issue/parent-routing.md" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "AC-3 baseline: in-scope files have 0 direct gh issue create invocations"
+else
+  fail "AC-3 violated in production files: rc=$rc, output='$output'"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -388,7 +388,7 @@ fi
 # --------------------------------------------------------------------------
 # TC-013: Field edit failure → partial (non-blocking)
 # --------------------------------------------------------------------------
-echo "TC-013: Field edit failure → partial registration"
+echo "TC-013: Field edit failure → partial registration + stderr emit (#669 F-01)"
 body_file=$(create_body_file "Test field fail")
 run_script "$(jq -n --arg bf "$body_file" '{
   issue: {title: "Field Fail", body_file: $bf},
@@ -403,10 +403,14 @@ run_script "$(jq -n --arg bf "$body_file" '{
 }')" "field_edit_fail"
 if [ "$LAST_RC" -eq 0 ]; then
   reg=$(json_field '.project_registration')
-  if [ "$reg" = "partial" ]; then
-    pass "Field edit failure: exit=0, reg=$reg"
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  if [ "$reg" = "partial" ] \
+     && echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "Failed to set" \
+     && echo "$stderr_content" | grep -q "after 3 attempts"; then
+    pass "Field edit failure: exit=0, reg=$reg + stderr emit + retry-count message"
   else
-    fail "Expected reg=partial, got $reg"
+    fail "Expected reg=partial + stderr 'ERROR: Projects registration failed:' + 'Failed to set' + 'after 3 attempts', got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -2)'"
   fi
 else
   fail "Expected exit 0, got $LAST_RC"
@@ -552,6 +556,40 @@ if [ "$LAST_RC" -eq 0 ]; then
     pass "Iteration auto-assign: reg=$reg"
   else
     fail "Expected reg=ok, got $reg"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-019b (#669 F-02): Iteration mutation failure → stderr emit + reg=partial
+# 検証: iteration assignment mutation 失敗時に retry_with_backoff が 3 回試行し、
+# add_warning_with_stderr が "Iteration assignment failed" + "after 3 attempts" を
+# stderr に emit すること。silent-fail 解消対象として明示されている経路。
+# --------------------------------------------------------------------------
+echo "TC-019b: Iteration mutation failure → stderr emit + reg=partial (#669 F-02)"
+body_file=$(create_body_file "Test iteration mutation fail")
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Iter Mutation Fail", body_file: $bf},
+  projects: {
+    enabled: true,
+    project_number: 2,
+    owner: "test-owner",
+    status: "Todo",
+    iteration: {mode: "auto", field_name: "Sprint"}
+  },
+  options: {non_blocking_projects: true}
+}')" "iteration_mutation_fail"
+if [ "$LAST_RC" -eq 0 ]; then
+  reg=$(json_field '.project_registration')
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  if [ "$reg" = "partial" ] \
+     && echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "Iteration assignment failed" \
+     && echo "$stderr_content" | grep -q "after 3 attempts"; then
+    pass "Iteration mutation failure: exit=0, reg=$reg + stderr emit + retry-count message"
+  else
+    fail "Expected reg=partial + stderr 'Iteration assignment failed' + 'after 3 attempts', got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -3)'"
   fi
 else
   fail "Expected exit 0, got $LAST_RC"
@@ -780,10 +818,11 @@ if [ "$LAST_RC" -eq 0 ]; then
   stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
   reg=$(json_field '.project_registration')
   if echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "after 3 attempts" \
      && [ "$reg" = "partial" ]; then
-    pass "graphql fail → stderr emit + reg=$reg"
+    pass "graphql fail → stderr emit + reg=$reg + retry-count message (#669 F-04)"
   else
-    fail "Expected stderr emit + reg=partial, got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -2)'"
+    fail "Expected stderr emit + 'after 3 attempts' + reg=partial, got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -2)'"
   fi
 else
   fail "Expected exit 0, got $LAST_RC"

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -596,6 +596,40 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-019c (#669 cycle 2 follow-up): GraphQL items lookup query failure
+# 検証: ITEM_ID が item-add からも fields query.items.nodes からも取得不可な状況で、
+# GQL_ITEMS_QUERY (items lookup retry) が retry_with_backoff 3 回失敗時に
+# add_warning_with_stderr が "GraphQL items lookup query failed after 3 attempts"
+# を stderr emit すること (silent-fail 5 path の最後の経路)
+# --------------------------------------------------------------------------
+echo "TC-019c: GraphQL items lookup query failure → stderr emit + reg=partial (#669 cycle 2 follow-up)"
+body_file=$(create_body_file "Test items lookup fail")
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Items Lookup Fail", body_file: $bf},
+  projects: {
+    enabled: true,
+    project_number: 2,
+    owner: "test-owner",
+    status: "Todo"
+  },
+  options: {non_blocking_projects: true}
+}')" "gql_items_lookup_fail"
+if [ "$LAST_RC" -eq 0 ]; then
+  reg=$(json_field '.project_registration')
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  if [ "$reg" = "partial" ] \
+     && echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "GraphQL items lookup query failed" \
+     && echo "$stderr_content" | grep -q "after 3 attempts"; then
+    pass "items lookup fail → exit=0, reg=$reg + stderr emit + retry-count message"
+  else
+    fail "Expected reg=partial + stderr 'GraphQL items lookup query failed' + 'after 3 attempts', got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -3)'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
 # TC-020: Iteration field not found → warning
 # --------------------------------------------------------------------------
 echo "TC-020: Iteration field missing → warning"
@@ -791,13 +825,16 @@ if [ "$LAST_RC" -eq 0 ]; then
   stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
   reg=$(json_field '.project_registration')
   warn_count=$(json_field '.warnings | length')
+  # cycle 2 follow-up: "gh project item-add failed" literal assert を追加
+  # silent-fail 復帰 regression を厳密に検出可能化
   if echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "gh project item-add failed" \
      && echo "$stderr_content" | grep -q "after 3 attempts" \
      && [ "$reg" = "failed" ] \
      && [ "$warn_count" -gt 0 ]; then
-    pass "item-add fail → stderr emit + reg=$reg + warnings=$warn_count"
+    pass "item-add fail → stderr emit + 'gh project item-add failed' literal + reg=$reg + warnings=$warn_count"
   else
-    fail "Expected stderr 'ERROR: Projects registration failed:' + 'after 3 attempts' + reg=failed + warnings>=1, got reg=$reg, warnings=$warn_count, stderr='$(printf '%s' "$stderr_content" | head -2)'"
+    fail "Expected stderr 'ERROR: Projects registration failed:' + 'gh project item-add failed' + 'after 3 attempts' + reg=failed + warnings>=1, got reg=$reg, warnings=$warn_count, stderr='$(printf '%s' "$stderr_content" | head -2)'"
   fi
 else
   fail "Expected exit 0 (NON_BLOCKING=true), got $LAST_RC"

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -739,6 +739,80 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-027 (#669): Projects registration failure emits root cause to stderr
+# (not just to warnings JSON). MUST 2 / MUST NOT 2: silent fail prohibited.
+# --------------------------------------------------------------------------
+echo "TC-027: project_add failure → stderr contains 'ERROR: Projects registration failed:' (#669)"
+body_file=$(create_body_file)
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Stderr emit test", body_file: $bf},
+  projects: {enabled: true, project_number: 6, owner: "test-owner", status: "Todo"},
+  options: {non_blocking_projects: true}
+}')" "project_add_fail"
+if [ "$LAST_RC" -eq 0 ]; then
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  reg=$(json_field '.project_registration')
+  warn_count=$(json_field '.warnings | length')
+  if echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && echo "$stderr_content" | grep -q "after 3 attempts" \
+     && [ "$reg" = "failed" ] \
+     && [ "$warn_count" -gt 0 ]; then
+    pass "item-add fail → stderr emit + reg=$reg + warnings=$warn_count"
+  else
+    fail "Expected stderr 'ERROR: Projects registration failed:' + 'after 3 attempts' + reg=failed + warnings>=1, got reg=$reg, warnings=$warn_count, stderr='$(printf '%s' "$stderr_content" | head -2)'"
+  fi
+else
+  fail "Expected exit 0 (NON_BLOCKING=true), got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-028 (#669): GraphQL field retrieval failure emits root cause to stderr.
+# Validates retry_with_backoff retry count messaging in error output.
+# --------------------------------------------------------------------------
+echo "TC-028: graphql_fail → stderr contains 'ERROR: Projects registration failed:' (#669)"
+body_file=$(create_body_file)
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "GraphQL stderr test", body_file: $bf},
+  projects: {enabled: true, project_number: 6, owner: "test-owner", status: "Todo"},
+  options: {non_blocking_projects: true}
+}')" "graphql_fail"
+if [ "$LAST_RC" -eq 0 ]; then
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  reg=$(json_field '.project_registration')
+  if echo "$stderr_content" | grep -q "ERROR: Projects registration failed:" \
+     && [ "$reg" = "partial" ]; then
+    pass "graphql fail → stderr emit + reg=$reg"
+  else
+    fail "Expected stderr emit + reg=partial, got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -2)'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-029 (#669): enabled=false skip path does NOT emit stderr (R6 既存挙動維持).
+# Caller contract: add_warning_with_stderr must only fire for registration failures,
+# not for the early skip when projects are disabled.
+# --------------------------------------------------------------------------
+echo "TC-029: enabled=false → no stderr emit (R6 skip path) (#669)"
+body_file=$(create_body_file)
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Skip path test", body_file: $bf},
+  projects: {enabled: false}
+}')"
+if [ "$LAST_RC" -eq 0 ]; then
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  reg=$(json_field '.project_registration')
+  if [ "$reg" = "skipped" ] && ! echo "$stderr_content" | grep -q "ERROR: Projects registration failed:"; then
+    pass "enabled=false → reg=skipped, stderr clean"
+  else
+    fail "Expected reg=skipped + no stderr emit, got reg=$reg, stderr='$(printf '%s' "$stderr_content" | head -2)'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ $FAIL -gt 0 ]; then

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -22,6 +22,8 @@
 #   "url_parse_fail"       - gh issue create returns non-URL string (no trailing number)
 #   "iteration_mutation_fail" - GraphQL fields query OK (iteration field present),
 #                              but the iteration assignment mutation fails (#669 F-02)
+#   "gql_items_lookup_fail"  - GraphQL fields query OK (items.nodes=[]),
+#                              but the GQL_ITEMS_QUERY (items lookup retry) fails (#669 cycle 2 follow-up)
 #
 # Scenarios (projects-status-update.sh):
 #   "psu_success"              - Issue in project, Status updated
@@ -112,8 +114,9 @@ FLJSON
           echo "error: failed to add item to project" >&2
           exit 1
         fi
-        # no_item_id_no_json: simulate item-add succeeding but without JSON output
-        if [ "$SCENARIO" = "no_item_id_no_json" ]; then
+        # no_item_id_no_json / gql_items_lookup_fail: simulate item-add succeeding but without JSON output
+        # (forces ITEM_ID retrieval to fall through to GQL_RESULT.items.nodes, then GQL_ITEMS_QUERY retry)
+        if [ "$SCENARIO" = "no_item_id_no_json" ] || [ "$SCENARIO" = "gql_items_lookup_fail" ]; then
           exit 0
         fi
         # Check if --format json was requested (pair detection: --format followed by json)
@@ -187,8 +190,13 @@ ITEMJSON
 
         # Detect query shape: projects-status-update.sh queries `repository(owner:`
         # while create-issue-with-projects.sh queries `user|organization(login:`.
+        # gql_items_lookup_fail (#669 cycle 2 follow-up): fields query (containing
+        # `fields(first: 20)`) succeeds with empty items, but the items lookup
+        # retry query (containing `items(last: 20)` and NOT `fields(first: 20)`)
+        # fails with exit 1.
         is_repository_query=false
         is_mutation=false
+        is_items_lookup_only=false
         for arg in "$@"; do
           if [[ "$arg" == query=* ]]; then
             if [[ "$arg" == *"repository(owner:"* ]]; then
@@ -197,9 +205,17 @@ ITEMJSON
             if [[ "$arg" == *mutation* ]]; then
               is_mutation=true
             fi
+            if [[ "$arg" == *"items(last: 20)"* ]] && [[ "$arg" != *"fields(first: 20)"* ]]; then
+              is_items_lookup_only=true
+            fi
             break
           fi
         done
+
+        if [ "$SCENARIO" = "gql_items_lookup_fail" ] && [ "$is_items_lookup_only" = true ]; then
+          echo "error: GraphQL items lookup query failed" >&2
+          exit 1
+        fi
 
         if [ "$is_mutation" = true ]; then
           # iteration_mutation_fail: simulate iteration assignment mutation failure (#669 F-02)
@@ -268,7 +284,7 @@ ITEMJSON
         fi
 
         ITEMS_NODES="[{\"id\":\"${MOCK_ITEM_ID}\",\"content\":{\"number\":${MOCK_ISSUE_NUMBER}}}]"
-        if [ "$SCENARIO" = "no_item_id" ] || [ "$SCENARIO" = "no_item_id_no_json" ]; then
+        if [ "$SCENARIO" = "no_item_id" ] || [ "$SCENARIO" = "no_item_id_no_json" ] || [ "$SCENARIO" = "gql_items_lookup_fail" ]; then
           ITEMS_NODES="[]"
         fi
 

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -20,6 +20,8 @@
 #   "no_current_iteration" - GraphQL includes iteration field but only future iterations
 #   "no_project_id"        - GraphQL returns null project ID
 #   "url_parse_fail"       - gh issue create returns non-URL string (no trailing number)
+#   "iteration_mutation_fail" - GraphQL fields query OK (iteration field present),
+#                              but the iteration assignment mutation fails (#669 F-02)
 #
 # Scenarios (projects-status-update.sh):
 #   "psu_success"              - Issue in project, Status updated
@@ -200,6 +202,11 @@ ITEMJSON
         done
 
         if [ "$is_mutation" = true ]; then
+          # iteration_mutation_fail: simulate iteration assignment mutation failure (#669 F-02)
+          if [ "$SCENARIO" = "iteration_mutation_fail" ]; then
+            echo "error: iteration mutation failed" >&2
+            exit 1
+          fi
           # No stdout output for mutations (only exit code matters to caller)
           exit 0
         fi
@@ -273,7 +280,9 @@ ITEMJSON
         # Iteration field (conditionally included based on scenario)
         ITER_FIELD=""
         MOCK_CURRENT_SPRINT_START=$(date +%Y-%m-01)
-        if [ "$SCENARIO" = "iteration_success" ]; then
+        if [ "$SCENARIO" = "iteration_success" ] || [ "$SCENARIO" = "iteration_mutation_fail" ]; then
+          # iteration_mutation_fail も fields query では Sprint field + current iteration を返し、
+          # mutation 段階で初めて失敗させる (#669 F-02)
           ITER_FIELD=',
             {
               "id": "FIELD_SPRINT",


### PR DESCRIPTION
## 概要

- Issue #669 の根本原因を調査した結果、`start.md` / `parent-routing.md` には `gh issue create` の直接呼び出しは **0 件**（仮説 A 反証）。真の問題は `create-issue-with-projects.sh` の **silent fail** 経路（`add_warning` が warnings 配列にしか反映されず stderr emit されない）だったため、これを解消する。
- `add_warning_with_stderr` ヘルパーで Projects 登録段階の失敗（item-add / GraphQL / field 設定 / iteration assignment）すべてを stderr に `ERROR: Projects registration failed: <reason>` として emit。`enabled=false` の skip パスは silent を維持（R6 既存挙動）。
- `retry_with_backoff` ヘルパーで `gh project item-add`、GraphQL クエリ、`gh project item-edit` を 3 回 exponential backoff retry に統一（1s / 2s / 4s、テストでは `RETRY_DELAY=0`）。
- 新規スクリプト `check-no-direct-gh-issue-create.sh` で AC-3（直接呼び出し 0 件）を機械検証。code-fence / blockquote / Markdown コメント / inline backtick を除外し、`gh issue create [-$"\047]` パターンで shell 実呼び出しのみ検出。

## 関連

Closes #669

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/scripts/create-issue-with-projects.sh` | `add_warning_with_stderr` / `retry_with_backoff` ヘルパー追加、silent fail 経路 11 箇所を stderr emit 対応、API 呼び出し 5 箇所を 3 回 retry に統一 |
| `plugins/rite/scripts/tests/create-issue-with-projects.test.sh` | T-02 検証として TC-027 (item-add 失敗 stderr emit) / TC-028 (GraphQL 失敗 stderr emit) / TC-029 (`enabled=false` skip パスは silent 維持) を追加 |
| `plugins/rite/scripts/check-no-direct-gh-issue-create.sh` (新規) | AC-3 機械検証用 grep ガード。awk で code-fence / blockquote / Markdown コメント / inline backtick を除外し、shell 実呼び出しのみ検出 |
| `plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh` (新規) | T-03 検証として TC-001-010（usage / 違反検出 / inline backtick / code-fence / blockquote / Markdown コメントの誤検出回避 / AC-3 baseline）を実装 |
| `plugins/rite/references/issue-create-with-projects.md` | Error Handling セクションに silent fail 解消ルール（stderr emit + 3 回 retry）と AC-3 ガードの説明を追記 |

## Acceptance Criteria 対応

| AC | 対応 |
|----|------|
| AC-1 (sub-Issue が Projects に Todo 登録) | 既存挙動 + S1/S2 で failure visibility 強化 |
| AC-2 (3 回 retry 後 stderr emit) | `retry_with_backoff` + `add_warning_with_stderr`（TC-027/028 で検証） |
| AC-3 (`gh issue create` 直接呼び出し 0 件 grep 機械検証) | `check-no-direct-gh-issue-create.sh` + TC-010 baseline 検証 |
| AC-4 (実環境 sub-Issue 派生 → Projects 目視確認) | 下記「手動検証手順」を参照 |
| AC-5 (`/rite:issue:create` 経由は変更なし) | `commands/issue/create-decompose.md` / `create-register.md` を grep で確認、本 PR で触らず |

## 検証

- `bash plugins/rite/scripts/tests/create-issue-with-projects.test.sh` → **30/30 PASS**（既存 TC 27 件 + 新規 TC-027/028/029）
- `bash plugins/rite/scripts/tests/check-no-direct-gh-issue-create.test.sh` → **10/10 PASS**
- `bash plugins/rite/scripts/tests/projects-status-update.test.sh` → **21/21 PASS**（非回帰）
- `bash plugins/rite/scripts/tests/run-all.sh` → 全 PASS

## 手動検証手順（AC-4 / AC-5）

### AC-4: 実環境 sub-Issue 派生 → Projects 自動登録目視確認

1. テスト用の親 Issue を作成（例: `gh issue create --title "test: parent for #669 verification" --body "## Sub-Issues\n- [ ] sub task A\n- [ ] sub task B"`）。
2. `/rite:issue:start <親 Issue 番号>` を実行し、`parent-routing.md` 1.5.4.5 経路で sub-Issue 自動分解を発動。
3. GitHub Projects ボード (https://github.com/users/B16B1RD/projects/6) で sub-Issue が `Status: Todo` で自動登録されていることを目視確認。
4. 失敗時の挙動確認: `gh project item-add` を一時的に block する状況を作って `/rite:issue:start` を実行し、stderr に `ERROR: Projects registration failed:` が出ることを確認。

### AC-5: `/rite:issue:create` 経由の非回帰

1. `/rite:issue:create` で単一 Issue を作成（例: `chore: test for #669 AC-5`）。
2. Projects ボードで `Status: Todo` で登録されることを確認。
3. Iteration / Priority / Complexity 等の custom field が rite-config.yml の default 設定通り配置されることを確認。

## Known Issues

- **lint 未実行**: `rite-config.yml` の `commands.lint` が未設定（プロジェクト方針）。プラグイン固有チェック（Phase 3.5-3.10）はすべて実行済みで、本 PR 由来の指摘は 0 件（drift check 32 findings は既存 `review.md` / `fix.md` / `close.md` の pre-existing warning で本 PR と無関係、non-blocking）。
- **未登録 Issue (#663-#668) の遡及登録**: Issue #669 §9 Decision Log の通り Out of Scope。本 PR マージ後に Phase 5.6 で別 Issue 化を再評価する（PR review/fix 経由 = `/rite:pr:*` Out of Scope, #100 対応済み）。

## Test plan

- [x] `create-issue-with-projects.test.sh` 全 PASS（27 既存 + 3 新規 = 30 件）
- [x] `check-no-direct-gh-issue-create.test.sh` 全 PASS（10 件、誤検出回避シナリオ含む）
- [x] `projects-status-update.test.sh` 全 PASS（非回帰、21 件）
- [ ] AC-4 実環境検証（手動、上記手順）
- [ ] AC-5 `/rite:issue:create` 非回帰検証（手動、上記手順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
