### PR TITLE
feat(hooks): #678 flow-state-update.sh のマルチステート対応 (per-session file API + schema_version)

### DIFF
--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -30,6 +30,10 @@
 #   --session                Session UUID override (create mode; defaults to .rite-session-id)
 #   --preserve-error-count   Preserve existing .error_count during patch (same-phase self-patch; patch mode only;
 #                            silently ignored in create/increment modes for drift-symmetry with caller-side consistency)
+#   --legacy-mode            Force legacy single-file path (`.rite-flow-state`) regardless of
+#                            rite-config.yml `flow_state.schema_version`. Used by migration script
+#                            (#2) and tooling that must read/write the pre-migration source. Without
+#                            this flag, schema_version=2 (default) writes to `.rite/sessions/{session_id}.flow-state`.
 #
 # Exit codes:
 #   0: Success
@@ -44,7 +48,70 @@ source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 
 # Resolve repository root
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$(pwd)" 2>/dev/null) || STATE_ROOT="$(pwd)"
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+LEGACY_FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+
+# --- Multi-state helpers (#672 / #678) ---
+# Issue #672 design (Option A: per-session file) routes flow-state writes to
+# .rite/sessions/{session_id}.flow-state when schema_version=2. Migration to
+# call sites is staged across #3-#5; this script is the single API surface.
+
+# Resolve session_id from --session arg, or fall back to .rite-session-id file.
+# Validates UUID format (rejects tampered or corrupt content).
+_resolve_session_id() {
+  local provided_sid="${1:-}"
+  if [[ -n "$provided_sid" ]]; then
+    echo "$provided_sid"
+    return 0
+  fi
+  local sid_file="$STATE_ROOT/.rite-session-id"
+  local sid
+  sid=$(cat "$sid_file" 2>/dev/null | tr -d '[:space:]') || sid=""
+  if [[ -n "$sid" && ! "$sid" =~ ^[0-9a-f-]{36}$ ]]; then
+    sid=""
+  fi
+  echo "$sid"
+}
+
+# Resolve flow_state.schema_version from rite-config.yml.
+# Returns "1" (legacy single-file) or "2" (per-session file).
+# Defaults to "1" on parse failure / absent / unrecognized value (safe fallback).
+_resolve_schema_version() {
+  local cfg="$STATE_ROOT/rite-config.yml"
+  if [[ ! -f "$cfg" ]]; then
+    echo "1"
+    return 0
+  fi
+  # Section-range extract guards against `enabled:` 行が enclosing section の外側にある regression
+  # (cf. start.md Phase 5.0 workflow_incident_enabled parser).
+  local section
+  section=$(sed -n '/^flow_state:/,/^[a-zA-Z]/p' "$cfg" 2>/dev/null) || section=""
+  if [[ -z "$section" ]]; then
+    echo "1"
+    return 0
+  fi
+  local v
+  v=$(printf '%s\n' "$section" | grep -E '^[[:space:]]+schema_version:' | head -1 \
+    | sed 's/#.*//' | sed 's/.*schema_version:[[:space:]]*//' \
+    | tr -d '[:space:]"'"'"'')
+  case "$v" in
+    1|2) echo "$v" ;;
+    *) echo "1" ;;
+  esac
+}
+
+# Resolve flow-state file path based on (effective_schema_version, legacy_mode, session_id).
+# - When legacy_mode is "true", schema_version != "2", or session_id is empty -> legacy path
+# - Otherwise -> per-session new path
+_resolve_session_state_path() {
+  local sv="$1"
+  local lm="$2"
+  local sid="$3"
+  if [[ "$lm" == "true" ]] || [[ "$sv" != "2" ]] || [[ -z "$sid" ]]; then
+    echo "$LEGACY_FLOW_STATE"
+    return 0
+  fi
+  echo "$STATE_ROOT/.rite/sessions/${sid}.flow-state"
+}
 
 # --- Argument parsing ---
 MODE="${1:-}"
@@ -61,6 +128,7 @@ IF_EXISTS=false
 FIELD=""
 SESSION=""
 PRESERVE_ERROR_COUNT=false
+LEGACY_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -73,11 +141,32 @@ while [[ $# -gt 0 ]]; do
     --active)   ACTIVE="$2"; shift 2 ;;
     --if-exists) IF_EXISTS=true; shift ;;
     --preserve-error-count) PRESERVE_ERROR_COUNT=true; shift ;;
+    --legacy-mode) LEGACY_MODE=true; shift ;;
     --field)    FIELD="$2"; shift 2 ;;
     --session)  SESSION="$2"; shift 2 ;;
     *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# --- Resolve effective schema version and target flow-state path ---
+# session_id is needed for both create/patch/increment to route writes to the
+# session-owned file when schema_version=2. patch/increment auto-read from
+# .rite-session-id when --session is not provided (caller-side simplification).
+SESSION=$(_resolve_session_id "$SESSION")
+SCHEMA_VERSION=$(_resolve_schema_version)
+if [[ "$LEGACY_MODE" == "true" ]]; then
+  EFFECTIVE_SCHEMA_VERSION="1"
+else
+  EFFECTIVE_SCHEMA_VERSION="$SCHEMA_VERSION"
+fi
+FLOW_STATE=$(_resolve_session_state_path "$EFFECTIVE_SCHEMA_VERSION" "$LEGACY_MODE" "$SESSION")
+
+# Ensure parent directory exists for the new format. mkdir -p is idempotent and
+# silently succeeds if already present. Failure (e.g., permission denied) is
+# surfaced by the subsequent mktemp/mv path.
+if [[ "$EFFECTIVE_SCHEMA_VERSION" == "2" ]] && [[ -n "$SESSION" ]] && [[ "$LEGACY_MODE" != "true" ]]; then
+  mkdir -p "$STATE_ROOT/.rite/sessions" 2>/dev/null || true
+fi
 
 # --- Validation ---
 case "$MODE" in
@@ -135,15 +224,9 @@ case "$MODE" in
     if [[ -z "$ACTIVE" ]]; then
       ACTIVE="true"
     fi
-    # Auto-read session_id from .rite-session-id if --session was not provided or is empty (#216)
-    if [[ -z "$SESSION" ]]; then
-      _session_id_file="$STATE_ROOT/.rite-session-id"
-      SESSION=$(cat "$_session_id_file" 2>/dev/null | tr -d '[:space:]') || SESSION=""
-      # Validate UUID format (reject tampered or corrupt content)
-      if [[ -n "$SESSION" && ! "$SESSION" =~ ^[0-9a-f-]{36}$ ]]; then
-        SESSION=""
-      fi
-    fi
+    # session_id is now resolved upfront via _resolve_session_id() (see top-level
+    # block after arg parsing). The previous in-mode auto-read (#216) is folded
+    # into the helper so patch/increment also benefit.
     # Session ownership: overwrite protection for active state owned by another session
     if [[ -n "$SESSION" && -f "$FLOW_STATE" ]]; then
       _existing_active=$(jq -r '.active // false' "$FLOW_STATE" 2>/dev/null) || _existing_active="false"
@@ -207,6 +290,16 @@ case "$MODE" in
     # 診断メッセージを出す。`set -euo pipefail` 下で mv 失敗は script を非 0 exit させるが、
     # else branch は jq 失敗のみを surface するため、disk full / permission denied / EXDEV 等の
     # mv 失敗要因が silent に握りつぶされる (silent failure-hunter 指摘)。patch / increment mode と対称化。
+    #
+    # #678: schema_version=2 (Option A per-session file) では create object に schema_version: 2 を含め、
+    # Migration 検出条件「schema_version キー無 or < 2」(design doc Migration 戦略) と整合させる。
+    # legacy mode では schema_version field を含めず、旧形式 reader (#3-#5 移行前の hook 群) との
+    # bytewise 互換を保つ。
+    if [[ "$EFFECTIVE_SCHEMA_VERSION" == "2" ]]; then
+      _create_filter='{schema_version: 2, active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}'
+    else
+      _create_filter='{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}'
+    fi
     if jq -n \
       --argjson active "$ACTIVE" \
       --argjson issue "$ISSUE" \
@@ -218,7 +311,7 @@ case "$MODE" in
       --arg next "$NEXT" \
       --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
       --arg sid "$SESSION" \
-      '{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}' \
+      "$_create_filter" \
       > "$TMP_STATE"; then
       if ! mv "$TMP_STATE" "$FLOW_STATE"; then
         _log_flow_diag "flow_state_mv_failed mode=create phase=$PHASE issue=$ISSUE"

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -56,16 +56,25 @@ LEGACY_FLOW_STATE="$STATE_ROOT/.rite-flow-state"
 # call sites is staged across #3-#5; this script is the single API surface.
 
 # Resolve session_id from --session arg, or fall back to .rite-session-id file.
-# Validates UUID format (rejects tampered or corrupt content).
+# Validates UUID format (rejects tampered or corrupt content) on **both** paths:
+# the file-read path AND the --session arg path. Validation parity prevents
+# path traversal via `--session "../foo"` (review #686 F-01).
 _resolve_session_id() {
   local provided_sid="${1:-}"
   if [[ -n "$provided_sid" ]]; then
-    echo "$provided_sid"
-    return 0
+    if [[ "$provided_sid" =~ ^[0-9a-f-]{36}$ ]]; then
+      echo "$provided_sid"
+      return 0
+    fi
+    # Reject malformed --session arg (non-UUID input could escape .rite/sessions/).
+    # Fail-fast rather than legacy fallback: silent fallback would hide the spec
+    # drift and let the caller think a per-session file was created.
+    echo "ERROR: invalid session_id format: '$provided_sid' (expected UUID ^[0-9a-f-]{36}\$)" >&2
+    return 1
   fi
   local sid_file="$STATE_ROOT/.rite-session-id"
   local sid
-  sid=$(cat "$sid_file" 2>/dev/null | tr -d '[:space:]') || sid=""
+  sid=$(tr -d '[:space:]' < "$sid_file" 2>/dev/null) || sid=""
   if [[ -n "$sid" && ! "$sid" =~ ^[0-9a-f-]{36}$ ]]; then
     sid=""
   fi
@@ -152,7 +161,9 @@ done
 # session_id is needed for both create/patch/increment to route writes to the
 # session-owned file when schema_version=2. patch/increment auto-read from
 # .rite-session-id when --session is not provided (caller-side simplification).
-SESSION=$(_resolve_session_id "$SESSION")
+if ! SESSION=$(_resolve_session_id "$SESSION"); then
+  exit 1
+fi
 SCHEMA_VERSION=$(_resolve_schema_version)
 if [[ "$LEGACY_MODE" == "true" ]]; then
   EFFECTIVE_SCHEMA_VERSION="1"
@@ -161,11 +172,23 @@ else
 fi
 FLOW_STATE=$(_resolve_session_state_path "$EFFECTIVE_SCHEMA_VERSION" "$LEGACY_MODE" "$SESSION")
 
-# Ensure parent directory exists for the new format. mkdir -p is idempotent and
-# silently succeeds if already present. Failure (e.g., permission denied) is
-# surfaced by the subsequent mktemp/mv path.
-if [[ "$EFFECTIVE_SCHEMA_VERSION" == "2" ]] && [[ -n "$SESSION" ]] && [[ "$LEGACY_MODE" != "true" ]]; then
-  mkdir -p "$STATE_ROOT/.rite/sessions" 2>/dev/null || true
+# Ensure parent directory exists for the new format. The path-based check below
+# is the single source of truth — `_resolve_session_state_path` already encodes
+# the (schema_version, legacy_mode, session_id) decision, so we just compare the
+# resolved path to the legacy fallback (review #686 F-04). Failures surface via
+# `_log_flow_diag` (symmetric with mv-failure path) rather than being silently
+# suppressed (review #686 F-05).
+if [[ "$FLOW_STATE" != "$LEGACY_FLOW_STATE" ]]; then
+  _flow_state_dir=$(dirname "$FLOW_STATE")
+  if ! mkdir -p "$_flow_state_dir" 2>/dev/null; then
+    # _log_flow_diag is defined later in the file (line ~135); inline the diag
+    # write here because we exit before reaching that definition's call sites.
+    _diag_file="$STATE_ROOT/.rite-stop-guard-diag.log"
+    echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] flow_state_mkdir_failed path=$_flow_state_dir" >> "$_diag_file" 2>/dev/null || true
+    echo "ERROR: failed to create $_flow_state_dir (permission denied / disk full / parent is a regular file?)" >&2
+    exit 1
+  fi
+  unset _flow_state_dir
 fi
 
 # --- Validation ---
@@ -253,12 +276,15 @@ case "$MODE" in
     # When the file exists but is corrupt, fail-fast — silently treating corruption
     # as a cold start would erase the prior phase and effectively bypass the
     # whitelist for the next transition (error-handling CRITICAL #2).
+    # Error messages reference $FLOW_STATE (the resolved path) rather than the
+    # legacy literal `.rite-flow-state` so users running on schema_version=2
+    # see the actual per-session path (review #686 F-06).
     PREV_PHASE=""
     if [[ -f "$FLOW_STATE" ]]; then
       if [[ ! -s "$FLOW_STATE" ]]; then
-        echo "ERROR: .rite-flow-state exists but is empty ($FLOW_STATE)" >&2
+        echo "ERROR: flow-state file exists but is empty: $FLOW_STATE" >&2
         echo "  previous_phase cannot be preserved; failing fast to avoid silent cold-start." >&2
-        echo "  対処: .rite-flow-state を /rite:resume で復旧するか、既存ファイルを削除してから再度 /rite:issue:start を実行" >&2
+        echo "  対処: $FLOW_STATE を /rite:resume で復旧するか、既存ファイルを削除してから再度 /rite:issue:start を実行" >&2
         exit 1
       fi
       # Validate JSON parse; distinguish "missing .phase" (acceptable → "") from
@@ -267,10 +293,10 @@ case "$MODE" in
       if PREV_PHASE=$(jq -r '.phase // ""' "$FLOW_STATE" 2>"${_jq_err:-/dev/null}"); then
         : # jq ok
       else
-        echo "ERROR: .rite-flow-state parse failed ($FLOW_STATE)" >&2
+        echo "ERROR: flow-state file parse failed: $FLOW_STATE" >&2
         [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | sed 's/^/  /' >&2
         echo "  previous_phase cannot be preserved; failing fast to avoid silent cold-start." >&2
-        echo "  対処: 既存の .rite-flow-state を確認し、必要なら /rite:resume で復旧してください" >&2
+        echo "  対処: $FLOW_STATE を確認し、必要なら /rite:resume で復旧してください" >&2
         [ -n "$_jq_err" ] && rm -f "$_jq_err"
         exit 1
       fi
@@ -295,10 +321,15 @@ case "$MODE" in
     # Migration 検出条件「schema_version キー無 or < 2」(design doc Migration 戦略) と整合させる。
     # legacy mode では schema_version field を含めず、旧形式 reader (#3-#5 移行前の hook 群) との
     # bytewise 互換を保つ。
+    #
+    # DRY (review #686 F-02): 旧実装は 11 フィールドの object literal を if/else で全コピーしており、
+    # 将来の field 追加で片方を更新し忘れる drift リスクがあった。共通 base を 1 か所に定義し、
+    # 新形式は jq の object merge `+` で `schema_version: 2` を prepend する。
+    _create_base='{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}'
     if [[ "$EFFECTIVE_SCHEMA_VERSION" == "2" ]]; then
-      _create_filter='{schema_version: 2, active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}'
+      _create_filter="{schema_version: 2} + $_create_base"
     else
-      _create_filter='{active: $active, issue_number: $issue, branch: $branch, phase: $phase, previous_phase: $prev_phase, pr_number: $pr, parent_issue_number: $parent_issue, next_action: $next, updated_at: $ts, session_id: $sid, last_synced_phase: ""}'
+      _create_filter="$_create_base"
     fi
     if jq -n \
       --argjson active "$ACTIVE" \

--- a/plugins/rite/hooks/flow-state-update.sh
+++ b/plugins/rite/hooks/flow-state-update.sh
@@ -180,15 +180,26 @@ FLOW_STATE=$(_resolve_session_state_path "$EFFECTIVE_SCHEMA_VERSION" "$LEGACY_MO
 # suppressed (review #686 F-05).
 if [[ "$FLOW_STATE" != "$LEGACY_FLOW_STATE" ]]; then
   _flow_state_dir=$(dirname "$FLOW_STATE")
-  if ! mkdir -p "$_flow_state_dir" 2>/dev/null; then
-    # _log_flow_diag is defined later in the file (line ~135); inline the diag
-    # write here because we exit before reaching that definition's call sites.
+  # Capture mkdir stderr so the kernel's specific failure reason
+  # (`mkdir: cannot create directory '...': Not a directory` / `Permission denied` /
+  # `No space left on device` 等) reaches the user instead of being suppressed
+  # to /dev/null (review #686 cycle 2 LOW). Symmetric with the create-mode
+  # `_jq_err` capture pattern.
+  _mkdir_err=$(mktemp 2>/dev/null) || _mkdir_err=""
+  if ! mkdir -p "$_flow_state_dir" 2>"${_mkdir_err:-/dev/null}"; then
+    # _log_flow_diag is defined later in the file; inline the diag write here
+    # because we exit before reaching that definition's call sites.
     _diag_file="$STATE_ROOT/.rite-stop-guard-diag.log"
     echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] flow_state_mkdir_failed path=$_flow_state_dir" >> "$_diag_file" 2>/dev/null || true
     echo "ERROR: failed to create $_flow_state_dir (permission denied / disk full / parent is a regular file?)" >&2
+    if [ -n "$_mkdir_err" ] && [ -s "$_mkdir_err" ]; then
+      head -3 "$_mkdir_err" | sed 's/^/  /' >&2
+    fi
+    [ -n "$_mkdir_err" ] && rm -f "$_mkdir_err"
     exit 1
   fi
-  unset _flow_state_dir
+  [ -n "$_mkdir_err" ] && rm -f "$_mkdir_err"
+  unset _flow_state_dir _mkdir_err
 fi
 
 # --- Validation ---
@@ -394,7 +405,7 @@ case "$MODE" in
     else
       _log_flow_diag "flow_state_jq_failed mode=patch phase=$PHASE"
       rm -f "$TMP_STATE"
-      echo "ERROR: jq patch failed" >&2
+      echo "ERROR: flow-state file parse failed (patch mode): $FLOW_STATE" >&2
       exit 1
     fi
     ;;
@@ -412,7 +423,7 @@ case "$MODE" in
     else
       _log_flow_diag "flow_state_jq_failed mode=increment field=$FIELD"
       rm -f "$TMP_STATE"
-      echo "ERROR: jq increment failed" >&2
+      echo "ERROR: flow-state file parse failed (increment mode): $FLOW_STATE" >&2
       exit 1
     fi
     ;;

--- a/plugins/rite/hooks/tests/flow-state-update.test.sh
+++ b/plugins/rite/hooks/tests/flow-state-update.test.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+# Tests for flow-state-update.sh — multi-state (per-session file) API
+# Covers Issue #678 acceptance criteria:
+#   - AC-9       : atomic write integrity (new format)
+#   - AC-LOCAL-1 : new create writes .rite/sessions/{id}.flow-state with schema_version: 2
+#   - AC-LOCAL-2 : two parallel sessions keep state files independent
+#   - AC-LOCAL-3 : --preserve-error-count retains error_count on same-phase self-patch
+# Plus non-regression for legacy-mode, schema_version=1 config, increment mode,
+# and patch mode session_id auto-read.
+#
+# Usage: bash plugins/rite/hooks/tests/flow-state-update.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../flow-state-update.sh"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+# Each test uses its own TEST_DIR so failures don't pollute others.
+make_test_dir() {
+  local d
+  d=$(mktemp -d)
+  (
+    cd "$d"
+    git init -q
+    echo a > a && git add a
+    git -c user.email=t@test.local -c user.name=test commit -q -m init
+  )
+  echo "$d"
+}
+
+write_config() {
+  # $1=test_dir, $2=schema_version (1 or 2 or "absent")
+  local d="$1" sv="$2"
+  if [[ "$sv" == "absent" ]]; then
+    : > "$d/rite-config.yml"
+  else
+    cat > "$d/rite-config.yml" << EOF
+flow_state:
+  schema_version: $sv
+EOF
+  fi
+}
+
+write_session_id() {
+  echo "$2" > "$1/.rite-session-id"
+}
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+echo "=== flow-state-update.sh tests (multi-state API #678) ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# T-LOCAL-1 / AC-LOCAL-1: new create writes per-session file with schema_version: 2
+# --------------------------------------------------------------------------
+echo "T-LOCAL-1 (AC-LOCAL-1): create with schema_version=2 writes new format"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="11111111-1111-1111-1111-111111111111"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "create_interview" --issue 100 --branch "test" \
+  --pr 0 --next "test" >/dev/null 2>&1)
+
+NEW="$TD/.rite/sessions/$SID.flow-state"
+LEG="$TD/.rite-flow-state"
+if [ -f "$NEW" ] && [ ! -f "$LEG" ]; then
+  pass "new format file created at .rite/sessions/{sid}.flow-state, legacy absent"
+else
+  fail "expected new format only; new=$([ -f "$NEW" ] && echo y || echo n) legacy=$([ -f "$LEG" ] && echo y || echo n)"
+fi
+
+if [ -f "$NEW" ] && [ "$(jq -r '.schema_version' "$NEW")" = "2" ]; then
+  pass "schema_version: 2 present in new format object"
+else
+  fail "schema_version field missing or wrong: $([ -f "$NEW" ] && jq -r '.schema_version // \"absent\"' "$NEW")"
+fi
+
+# Required 11 fields from existing schema must all be present (drift guard)
+if [ -f "$NEW" ]; then
+  expected_fields="active issue_number branch phase previous_phase pr_number parent_issue_number next_action updated_at session_id last_synced_phase"
+  missing=""
+  for f in $expected_fields; do
+    if ! jq -e "has(\"$f\")" "$NEW" >/dev/null 2>&1; then
+      missing="$missing $f"
+    fi
+  done
+  if [ -z "$missing" ]; then
+    pass "all 11 required fields present"
+  else
+    fail "missing required fields:$missing"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# T-LOCAL-2 / AC-LOCAL-2: two parallel sessions keep files independent
+# --------------------------------------------------------------------------
+echo ""
+echo "T-LOCAL-2 (AC-LOCAL-2): parallel sessions keep state independent"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_A="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+SID_B="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+write_session_id "$TD" "$SID_A"
+(cd "$TD" && bash "$HOOK" create \
+  --phase "phase_a" --issue 1 --branch "ba" --pr 0 --next "na" >/dev/null 2>&1)
+
+write_session_id "$TD" "$SID_B"
+(cd "$TD" && bash "$HOOK" create \
+  --phase "phase_b" --issue 2 --branch "bb" --pr 0 --next "nb" >/dev/null 2>&1)
+
+A="$TD/.rite/sessions/$SID_A.flow-state"
+B="$TD/.rite/sessions/$SID_B.flow-state"
+if [ -f "$A" ] && [ -f "$B" ]; then
+  pass "both session files created"
+else
+  fail "session files missing: a=$([ -f "$A" ] && echo y || echo n) b=$([ -f "$B" ] && echo y || echo n)"
+fi
+
+if [ "$(jq -r '.phase' "$A")" = "phase_a" ] && [ "$(jq -r '.phase' "$B")" = "phase_b" ]; then
+  pass "both sessions retain independent phase values"
+else
+  fail "phase mismatch: a=$(jq -r '.phase' "$A" 2>/dev/null) b=$(jq -r '.phase' "$B" 2>/dev/null)"
+fi
+
+# Patching session B should not modify session A
+write_session_id "$TD" "$SID_B"
+(cd "$TD" && bash "$HOOK" patch \
+  --phase "phase_b_post" --next "np" >/dev/null 2>&1)
+if [ "$(jq -r '.phase' "$A")" = "phase_a" ] && [ "$(jq -r '.phase' "$B")" = "phase_b_post" ]; then
+  pass "patch on session B leaves session A untouched"
+else
+  fail "isolation violated: a=$(jq -r '.phase' "$A") b=$(jq -r '.phase' "$B")"
+fi
+
+# --------------------------------------------------------------------------
+# T-LOCAL-3 / AC-LOCAL-3: --preserve-error-count retains error_count on self-patch
+# --------------------------------------------------------------------------
+echo ""
+echo "T-LOCAL-3 (AC-LOCAL-3): --preserve-error-count retains error_count"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="22222222-2222-2222-2222-222222222222"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+TARGET="$TD/.rite/sessions/$SID.flow-state"
+tmp=$(mktemp); jq '.error_count = 5' "$TARGET" > "$tmp" && mv "$tmp" "$TARGET"
+
+# Same-phase self-patch with --preserve-error-count → keeps 5
+(cd "$TD" && bash "$HOOK" patch --phase "p" --next "n2" --preserve-error-count >/dev/null 2>&1)
+ec=$(jq -r '.error_count' "$TARGET")
+if [ "$ec" = "5" ]; then
+  pass "--preserve-error-count keeps error_count=5"
+else
+  fail "--preserve-error-count dropped error_count: got $ec, expected 5"
+fi
+
+# Same-phase self-patch without --preserve-error-count → resets to 0
+tmp=$(mktemp); jq '.error_count = 5' "$TARGET" > "$tmp" && mv "$tmp" "$TARGET"
+(cd "$TD" && bash "$HOOK" patch --phase "p" --next "n3" >/dev/null 2>&1)
+ec=$(jq -r '.error_count' "$TARGET")
+if [ "$ec" = "0" ]; then
+  pass "patch without preserve flag resets error_count to 0 (non-regression)"
+else
+  fail "default patch failed to reset: got $ec, expected 0"
+fi
+
+# --------------------------------------------------------------------------
+# T-LOCAL-4 / AC-9: atomic write integrity — original preserved on jq failure
+# --------------------------------------------------------------------------
+echo ""
+echo "T-LOCAL-4 (AC-9): atomic write keeps original intact when jq fails"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="33333333-3333-3333-3333-333333333333"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "intact_phase" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+TARGET="$TD/.rite/sessions/$SID.flow-state"
+ORIG_HASH=$(sha256sum "$TARGET" | awk '{print $1}')
+
+# Corrupt the file to make jq parse fail (simulates partial-write recovery)
+# patch mode reads the file via jq; on parse failure the script must exit
+# without mv-ing a partial temp into the target.
+echo "{not valid json" > "$TARGET"
+set +e
+(cd "$TD" && bash "$HOOK" patch --phase "wont_apply" --next "n2" >/dev/null 2>&1)
+rc=$?
+set -e
+
+# After jq failure: TARGET stays as corrupted content (we corrupted it deliberately)
+# AND no orphan .rite-flow-state.XXXXXX temp remains.
+orphan=$(ls "$TD/.rite/sessions/" 2>/dev/null | grep -E '\.flow-state\.[a-zA-Z0-9]{6,}$' || true)
+if [ "$rc" -ne 0 ] && [ -z "$orphan" ]; then
+  pass "patch mode exits non-zero on jq failure with no temp orphan"
+else
+  fail "rc=$rc orphan='$orphan'"
+fi
+
+# Restore valid JSON, then test create-mode behavior on simulated mv failure
+# by making the parent directory read-only.
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="44444444-4444-4444-4444-444444444444"
+write_session_id "$TD" "$SID"
+(cd "$TD" && bash "$HOOK" create \
+  --phase "v1" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+TARGET="$TD/.rite/sessions/$SID.flow-state"
+V1_HASH=$(sha256sum "$TARGET" | awk '{print $1}')
+V1_PHASE=$(jq -r '.phase' "$TARGET")
+
+# Corrupt the existing state to a non-JSON form. create mode requires reading
+# .phase via jq; parse failure must fail-fast without overwriting the file.
+echo "{corrupt" > "$TARGET"
+set +e
+(cd "$TD" && bash "$HOOK" create \
+  --phase "v2" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+rc2=$?
+set -e
+remaining=$(cat "$TARGET")
+if [ "$rc2" -ne 0 ] && [ "$remaining" = "{corrupt" ]; then
+  pass "create mode fail-fast on corrupt state preserves file content (no silent overwrite)"
+else
+  fail "rc2=$rc2 remaining='$remaining'"
+fi
+
+# --------------------------------------------------------------------------
+# Non-regression: --legacy-mode forces legacy single-file path
+# --------------------------------------------------------------------------
+echo ""
+echo "TC-NR-1: --legacy-mode forces .rite-flow-state regardless of schema_version=2"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="55555555-5555-5555-5555-555555555555"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "lp" --issue 1 --branch "b" --pr 0 --next "n" --legacy-mode >/dev/null 2>&1)
+LEG="$TD/.rite-flow-state"
+NEW="$TD/.rite/sessions/$SID.flow-state"
+if [ -f "$LEG" ] && [ ! -f "$NEW" ]; then
+  pass "--legacy-mode wrote legacy path, no new format file"
+else
+  fail "leg=$([ -f "$LEG" ] && echo y || echo n) new=$([ -f "$NEW" ] && echo y || echo n)"
+fi
+
+# Legacy create object MUST NOT contain schema_version (bytewise compat)
+if [ -f "$LEG" ] && ! jq -e 'has("schema_version")' "$LEG" >/dev/null 2>&1; then
+  pass "legacy object omits schema_version (bytewise compat with pre-#678 readers)"
+else
+  fail "legacy object has schema_version field (compat regression)"
+fi
+
+# --------------------------------------------------------------------------
+# Non-regression: schema_version=1 in config writes legacy path
+# --------------------------------------------------------------------------
+echo ""
+echo "TC-NR-2: rite-config.yml schema_version=1 writes legacy path"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 1
+SID="66666666-6666-6666-6666-666666666666"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+if [ -f "$TD/.rite-flow-state" ] && [ ! -f "$TD/.rite/sessions/$SID.flow-state" ]; then
+  pass "schema_version=1 writes legacy path"
+else
+  fail "schema_version=1 routing wrong"
+fi
+
+# --------------------------------------------------------------------------
+# Non-regression: rite-config.yml absent → legacy path (safe fallback)
+# --------------------------------------------------------------------------
+echo ""
+echo "TC-NR-3: rite-config.yml absent → legacy fallback"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+# No rite-config.yml at all
+SID="77777777-7777-7777-7777-777777777777"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create \
+  --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+if [ -f "$TD/.rite-flow-state" ]; then
+  pass "absent config defaults to legacy path"
+else
+  fail "absent config did not write legacy"
+fi
+
+# --------------------------------------------------------------------------
+# Non-regression: increment mode with new format
+# --------------------------------------------------------------------------
+echo ""
+echo "TC-NR-4: increment mode operates on per-session file"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID="88888888-8888-8888-8888-888888888888"
+write_session_id "$TD" "$SID"
+
+(cd "$TD" && bash "$HOOK" create --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" increment --field error_count >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" increment --field error_count >/dev/null 2>&1)
+TARGET="$TD/.rite/sessions/$SID.flow-state"
+ec=$(jq -r '.error_count // 0' "$TARGET")
+if [ "$ec" = "2" ]; then
+  pass "increment mode increments error_count on new format file"
+else
+  fail "increment broke: got $ec expected 2"
+fi
+
+# --------------------------------------------------------------------------
+# Non-regression: --if-exists on absent target exits 0 (new format)
+# --------------------------------------------------------------------------
+echo ""
+echo "TC-NR-5: --if-exists exits 0 when new format file absent"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+write_session_id "$TD" "99999999-9999-9999-9999-999999999999"
+
+set +e
+(cd "$TD" && bash "$HOOK" patch --phase "p" --next "n" --if-exists >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "--if-exists on absent file exits 0"
+else
+  fail "--if-exists wrong exit: $rc"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/flow-state-update.test.sh
+++ b/plugins/rite/hooks/tests/flow-state-update.test.sh
@@ -61,7 +61,13 @@ cleanup() {
     [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
   done
 }
+# Signal-specific traps mirror flow-state-update.sh (review #686 F-09): EXIT
+# alone leaks /tmp/tmp.XXXX TEST_DIRs when the run is interrupted with Ctrl+C
+# or killed externally. POSIX exit codes per BSD/Linux convention.
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
 
 echo "=== flow-state-update.sh tests (multi-state API #678) ==="
 echo ""
@@ -110,10 +116,20 @@ if [ -f "$NEW" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# T-LOCAL-2 / AC-LOCAL-2: two parallel sessions keep files independent
+# T-LOCAL-2 / AC-LOCAL-2: two sessions keep state independent
+#
+# Coverage strategy (review #686 F-07): AC-LOCAL-2 says "並行 2 session" but
+# verifies state independence regardless of timing. This test combines:
+#   (a) sequential interleave  — A.create → B.create → B.patch — proves that
+#       per-session paths route writes independently.
+#   (b) concurrent create      — A.create & B.create wait — proves that the
+#       mkdir/mktemp/mv sequence has no race against a concurrent peer hitting
+#       the same `.rite/sessions/` parent dir.
+# Sub-second timing on (b) is best-effort (depends on host scheduler), but
+# both files MUST exist after the wait regardless of execution order.
 # --------------------------------------------------------------------------
 echo ""
-echo "T-LOCAL-2 (AC-LOCAL-2): parallel sessions keep state independent"
+echo "T-LOCAL-2 (AC-LOCAL-2): sessions keep state independent (sequential interleave)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
 write_config "$TD" 2
 SID_A="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -130,7 +146,7 @@ write_session_id "$TD" "$SID_B"
 A="$TD/.rite/sessions/$SID_A.flow-state"
 B="$TD/.rite/sessions/$SID_B.flow-state"
 if [ -f "$A" ] && [ -f "$B" ]; then
-  pass "both session files created"
+  pass "both session files created (sequential interleave)"
 else
   fail "session files missing: a=$([ -f "$A" ] && echo y || echo n) b=$([ -f "$B" ] && echo y || echo n)"
 fi
@@ -149,6 +165,39 @@ if [ "$(jq -r '.phase' "$A")" = "phase_a" ] && [ "$(jq -r '.phase' "$B")" = "pha
   pass "patch on session B leaves session A untouched"
 else
   fail "isolation violated: a=$(jq -r '.phase' "$A") b=$(jq -r '.phase' "$B")"
+fi
+
+# (b) Concurrent create — both creates fire in parallel & wait for both PIDs.
+# Tests the mkdir/mktemp/mv pipeline against a concurrent peer hitting the same
+# .rite/sessions/ parent dir. Per-session paths are structurally race-free, but
+# the assertion is that BOTH files exist regardless of completion order.
+echo ""
+echo "T-LOCAL-2 (concurrent create): two sessions create in parallel with wait"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_C="cccccccc-cccc-cccc-cccc-cccccccccccc"
+SID_D="dddddddd-dddd-dddd-dddd-dddddddddddd"
+
+# Each session passes its UUID via --session (avoids .rite-session-id race).
+(cd "$TD" && bash "$HOOK" create --session "$SID_C" \
+  --phase "phase_c" --issue 1 --branch "bc" --pr 0 --next "nc" >/dev/null 2>&1) &
+PID_C=$!
+(cd "$TD" && bash "$HOOK" create --session "$SID_D" \
+  --phase "phase_d" --issue 2 --branch "bd" --pr 0 --next "nd" >/dev/null 2>&1) &
+PID_D=$!
+wait "$PID_C" "$PID_D"
+
+C="$TD/.rite/sessions/$SID_C.flow-state"
+D="$TD/.rite/sessions/$SID_D.flow-state"
+if [ -f "$C" ] && [ -f "$D" ]; then
+  pass "both session files created under concurrent execution"
+else
+  fail "concurrent create lost a file: c=$([ -f "$C" ] && echo y || echo n) d=$([ -f "$D" ] && echo y || echo n)"
+fi
+if [ "$(jq -r '.phase' "$C" 2>/dev/null)" = "phase_c" ] && [ "$(jq -r '.phase' "$D" 2>/dev/null)" = "phase_d" ]; then
+  pass "concurrent sessions retain independent phase values"
+else
+  fail "concurrent phase mismatch: c=$(jq -r '.phase' "$C" 2>/dev/null) d=$(jq -r '.phase' "$D" 2>/dev/null)"
 fi
 
 # --------------------------------------------------------------------------
@@ -186,10 +235,24 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# T-LOCAL-4 / AC-9: atomic write integrity — original preserved on jq failure
+# T-LOCAL-4 / AC-9: corrupt-state fail-fast preserves no-orphan invariant
+#
+# AC-9 spec scope (review #686 F-08): The literal "atomic write 中の SIGKILL →
+# state 破壊なし" cannot be reproduced deterministically in bash (kill -9 timing
+# during a subshell is racy). We split the spec into two verifiable pieces:
+#
+#   1. mktemp + mv pattern (atomicity guarantee) — verified by inspection of
+#      flow-state-update.sh (mktemp `${FLOW_STATE}.XXXXXX` + `mv`); the kernel
+#      rename(2) is atomic, so a SIGKILL between mv-call boundary keeps the
+#      target either fully old or fully new.
+#   2. Fail-fast on corrupt input — when the script detects partial-write or
+#      corruption (jq parse error in patch / create read), it exits non-zero
+#      WITHOUT mv-ing a partial temp into the target. This is the deterministic
+#      half of AC-9 that this test covers (Part A: patch mode, Part B: create
+#      mode). True SIGKILL stress is left to manual integration testing.
 # --------------------------------------------------------------------------
 echo ""
-echo "T-LOCAL-4 (AC-9): atomic write keeps original intact when jq fails"
+echo "T-LOCAL-4 (AC-9 part A): patch mode fail-fast on corrupt JSON, no orphan temp"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
 write_config "$TD" 2
 SID="33333333-3333-3333-3333-333333333333"
@@ -198,19 +261,17 @@ write_session_id "$TD" "$SID"
 (cd "$TD" && bash "$HOOK" create \
   --phase "intact_phase" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
 TARGET="$TD/.rite/sessions/$SID.flow-state"
-ORIG_HASH=$(sha256sum "$TARGET" | awk '{print $1}')
 
-# Corrupt the file to make jq parse fail (simulates partial-write recovery)
-# patch mode reads the file via jq; on parse failure the script must exit
-# without mv-ing a partial temp into the target.
+# Corrupt the file to make jq parse fail. patch mode reads the file via jq;
+# on parse failure the script must exit without mv-ing a partial temp into
+# the target.
 echo "{not valid json" > "$TARGET"
 set +e
 (cd "$TD" && bash "$HOOK" patch --phase "wont_apply" --next "n2" >/dev/null 2>&1)
 rc=$?
 set -e
 
-# After jq failure: TARGET stays as corrupted content (we corrupted it deliberately)
-# AND no orphan .rite-flow-state.XXXXXX temp remains.
+# Post-conditions: rc != 0 AND no orphan ${FLOW_STATE}.XXXXXX temp remains.
 orphan=$(ls "$TD/.rite/sessions/" 2>/dev/null | grep -E '\.flow-state\.[a-zA-Z0-9]{6,}$' || true)
 if [ "$rc" -ne 0 ] && [ -z "$orphan" ]; then
   pass "patch mode exits non-zero on jq failure with no temp orphan"
@@ -218,8 +279,12 @@ else
   fail "rc=$rc orphan='$orphan'"
 fi
 
-# Restore valid JSON, then test create-mode behavior on simulated mv failure
-# by making the parent directory read-only.
+# Part B: create mode fail-fast on corrupt state preserves file content.
+# Verifies that when create mode encounters a corrupt JSON (jq parse fail in
+# PREV_PHASE capture), it exits 1 BEFORE writing — the corrupted bytes remain
+# untouched (no silent overwrite that would erase forensic evidence).
+echo ""
+echo "T-LOCAL-4 (AC-9 part B): create mode fail-fast on corrupt state preserves bytes"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
 write_config "$TD" 2
 SID="44444444-4444-4444-4444-444444444444"
@@ -227,8 +292,6 @@ write_session_id "$TD" "$SID"
 (cd "$TD" && bash "$HOOK" create \
   --phase "v1" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
 TARGET="$TD/.rite/sessions/$SID.flow-state"
-V1_HASH=$(sha256sum "$TARGET" | awk '{print $1}')
-V1_PHASE=$(jq -r '.phase' "$TARGET")
 
 # Corrupt the existing state to a non-JSON form. create mode requires reading
 # .phase via jq; parse failure must fail-fast without overwriting the file.

--- a/plugins/rite/hooks/tests/flow-state-update.test.sh
+++ b/plugins/rite/hooks/tests/flow-state-update.test.sh
@@ -266,17 +266,26 @@ TARGET="$TD/.rite/sessions/$SID.flow-state"
 # on parse failure the script must exit without mv-ing a partial temp into
 # the target.
 echo "{not valid json" > "$TARGET"
+err_log_a="$TD/err-part-a.log"
 set +e
-(cd "$TD" && bash "$HOOK" patch --phase "wont_apply" --next "n2" >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" patch --phase "wont_apply" --next "n2" >/dev/null 2>"$err_log_a")
 rc=$?
 set -e
 
-# Post-conditions: rc != 0 AND no orphan ${FLOW_STATE}.XXXXXX temp remains.
+# Post-conditions: rc != 0 AND no orphan ${FLOW_STATE}.XXXXXX temp remains AND
+# the failure message identifies the parse error (review #686 cycle 2 LOW —
+# verify stderr content, not just exit code, so a regression that drops the
+# message but keeps `exit 1` is still caught).
 orphan=$(ls "$TD/.rite/sessions/" 2>/dev/null | grep -E '\.flow-state\.[a-zA-Z0-9]{6,}$' || true)
 if [ "$rc" -ne 0 ] && [ -z "$orphan" ]; then
   pass "patch mode exits non-zero on jq failure with no temp orphan"
 else
   fail "rc=$rc orphan='$orphan'"
+fi
+if grep -q "parse failed" "$err_log_a"; then
+  pass "patch fail-fast preserves parse-failure message in stderr"
+else
+  fail "patch stderr missing 'parse failed' message: $(head -3 "$err_log_a")"
 fi
 
 # Part B: create mode fail-fast on corrupt state preserves file content.
@@ -296,9 +305,10 @@ TARGET="$TD/.rite/sessions/$SID.flow-state"
 # Corrupt the existing state to a non-JSON form. create mode requires reading
 # .phase via jq; parse failure must fail-fast without overwriting the file.
 echo "{corrupt" > "$TARGET"
+err_log_b="$TD/err-part-b.log"
 set +e
 (cd "$TD" && bash "$HOOK" create \
-  --phase "v2" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+  --phase "v2" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>"$err_log_b")
 rc2=$?
 set -e
 remaining=$(cat "$TARGET")
@@ -306,6 +316,67 @@ if [ "$rc2" -ne 0 ] && [ "$remaining" = "{corrupt" ]; then
   pass "create mode fail-fast on corrupt state preserves file content (no silent overwrite)"
 else
   fail "rc2=$rc2 remaining='$remaining'"
+fi
+if grep -q "parse failed" "$err_log_b"; then
+  pass "create fail-fast preserves parse-failure message in stderr"
+else
+  fail "create stderr missing 'parse failed' message: $(head -3 "$err_log_b")"
+fi
+
+# --------------------------------------------------------------------------
+# T-LOCAL-5: F-01 path-traversal regression test (review #686 cycle 2 MEDIUM)
+#
+# Cycle 1 commit `432a507` added UUID validation to _resolve_session_id's
+# --session arg path. The fix rejects malformed input with rc=1 and an
+# "invalid session_id format" error, instead of silently writing to
+# `.rite/sessions/../foo.flow-state` (which resolves to `.rite/foo.flow-state`
+# escaping the per-session sandbox). This test guards the security invariant
+# from regressions: validation order, regex, return code, and stderr message
+# all matter — losing any one of them silently re-opens the traversal.
+# --------------------------------------------------------------------------
+echo ""
+echo "T-LOCAL-5 (#686 F-01): --session UUID validation rejects path traversal"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+
+err_log="$TD/err-traversal.log"
+set +e
+(cd "$TD" && bash "$HOOK" create --session "../escape" \
+  --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>"$err_log")
+rc_traversal=$?
+set -e
+
+# Three independent assertions — losing any one of them re-opens the regression
+if [ "$rc_traversal" -ne 0 ]; then
+  pass "--session traversal input rejected with non-zero exit ($rc_traversal)"
+else
+  fail "--session traversal accepted (rc=0); UUID validation regressed"
+fi
+if grep -q "invalid session_id format" "$err_log"; then
+  pass "--session traversal emits 'invalid session_id format' error"
+else
+  fail "missing 'invalid session_id format' in stderr: $(head -3 "$err_log")"
+fi
+# No file should leak outside .rite/sessions/. Both relative and absolute
+# escape patterns are checked.
+if [ ! -e "$TD/.rite-flow-state.escape" ] && [ ! -e "$TD/escape.flow-state" ] \
+  && [ ! -e "$TD/.rite/escape.flow-state" ]; then
+  pass "--session traversal did not create any escape-path file"
+else
+  fail "traversal escape file detected"
+fi
+
+# Also verify a non-UUID but harmless string (no slashes) still rejected.
+err_log2="$TD/err-bad-uuid.log"
+set +e
+(cd "$TD" && bash "$HOOK" create --session "not-a-uuid" \
+  --phase "p" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>"$err_log2")
+rc_bad=$?
+set -e
+if [ "$rc_bad" -ne 0 ] && grep -q "invalid session_id format" "$err_log2"; then
+  pass "--session 'not-a-uuid' rejected (defense-in-depth, non-traversal input)"
+else
+  fail "non-UUID --session not rejected: rc=$rc_bad"
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/flow-state-update.sh` を **Option A: per-session file**（`.rite/sessions/{session_id}.flow-state`）方式に対応させる基本 API を実装しました。`schema_version: 2` を新規追加し、現行の `jq -n create` object と atomic write (mktemp + mv) パターンを per-session path に流用しています。

PR #677 で landed した `docs/designs/multi-session-state.md § Decision Log` の Phase 1 採択（Option A）を実装フェーズへ移行する **critical path 起点** として、後続の hook 系 Issue (#3-#5) と migration (#2) と test 群 (#6-#7) の前提となる基本 API を確立します。

## 主な変更

- `_resolve_session_id` / `_resolve_schema_version` / `_resolve_session_state_path` の 3 helper を新設
- arg parsing に `--legacy-mode` flag を追加（migration script #2 用の内部 flag）
- `FLOW_STATE` 変数を `schema_version` + `legacy_mode` + `session_id` から動的解決
- 新形式時は `.rite/sessions/` を `mkdir -p` で auto-create
- create mode の `jq -n` object に `schema_version: 2` フィールドを条件付き追加（新形式時のみ）
- session_id auto-read を全 mode で共通化（patch / increment も `.rite-session-id` から auto-read）
- `tests/flow-state-update.test.sh` を新規作成（**16 tests / 全 PASS**）
  - T-LOCAL-1〜4 + AC-9 + 5 件の非回帰テスト

## Acceptance Criteria

| AC | 検証テスト | 状態 |
|----|-----------|------|
| AC-9: atomic write integrity（新形式） | T-LOCAL-4（jq parse failure / corrupt state での fail-fast） | ✅ PASS |
| AC-LOCAL-1: schema_version: 2 で新形式 file 作成 | T-LOCAL-1 | ✅ PASS |
| AC-LOCAL-2: 並行 2 session で file が独立保持 | T-LOCAL-2 | ✅ PASS |
| AC-LOCAL-3: --preserve-error-count の error_count 保持 | T-LOCAL-3 | ✅ PASS |

## 動作切替の仕組み

| `flow_state.schema_version` (rite-config.yml) | `--legacy-mode` flag | 動作 |
|----------------------------------------------|----------------------|------|
| `2`（PR #677 で確定値） | 未指定 | 新形式 path `.rite/sessions/{session_id}.flow-state`（schema_version=2 を含む） |
| `2` | 指定 | 旧形式 path `.rite-flow-state`（schema_version field 含めず、bytewise 互換） |
| `1` | (irrelevant) | 旧形式 path `.rite-flow-state` |
| absent / parse error | (irrelevant) | 旧形式 path（safe fallback） |

`--legacy-mode` は migration script (#2) からの内部用途を想定しています。

## Out of Scope

本 Issue では以下を扱いません（後続 Issue で対応）:

- 旧形式 → 新形式の migration 機構（#2 で実装）
- 全 hook 群の API 移行（`session-start.sh` / `session-end.sh` / `pre-compact.sh` / `post-compact.sh` / `pre-tool-bash-guard.sh` / `post-tool-wm-sync.sh` を #3, #4, #5 で順次移行）
- test スイートの追加（#6, #7 で対応 — ただし本 PR で T-LOCAL 4 件は実装済み）
- `rite-config.yml` への `flow_state.schema_version` 設定追加（PR #677 で実施済み）

## 関連 Issue

Closes #678

- 親 Issue: #672 — `.rite-flow-state` マルチステート構造再設計
- 直前 PR: #677 — Decision Log Phase 1 (Option A 採択)
- Wiki 経験則: 「前提条件の silent omit が AND 論理の防御層チェーンを全体無効化する」(Issue #660)
- Wiki 経験則: 「jq -n create mode: 既存値を読み取ってから再構築する」

## 変更ファイル

- `plugins/rite/hooks/flow-state-update.sh` - 変更（helper 関数 3 件追加、`--legacy-mode` flag 追加、FLOW_STATE 動的解決、jq -n object 条件付き schema_version）
- `plugins/rite/hooks/tests/flow-state-update.test.sh` - 追加（16 tests / 361 行）

## Test Plan

- [x] `bash plugins/rite/hooks/tests/flow-state-update.test.sh` — 16/16 PASS
- [x] `bash plugins/rite/hooks/tests/run-tests.sh` — 13/14 passed（pre-compact.test.sh の 1 件失敗は本 PR 範囲外の pre-existing）
- [x] Smoke test: schema_version=2 default で新 path 動作確認
- [x] Smoke test: `--legacy-mode` flag で旧 path 動作確認
- [x] Smoke test: schema_version=1 config で旧 path 動作確認
- [x] Smoke test: 並行 2 session で file 独立保持確認
- [x] Smoke test: `--preserve-error-count` の error_count 保持確認
- [x] Smoke test: increment mode が新 path で動作することを確認

## Known Issues

`distributed-fix-drift-check.sh` で 32 件の warning が検出されていますが、すべて `plugins/rite/commands/pr/fix.md` の `reason` enum drift で **本 PR と無関係の pre-existing 事象** です（`flow-state-update.sh` への参照は 0 件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
