### PR TITLE
feat(hooks): #679 旧形式 .rite-flow-state の自動 migration 機構

### DIFF
--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -229,14 +229,17 @@ chmod 600 "$TMP_NEW" 2>/dev/null || true
 # Capture jq stderr so build failures surface their root cause (e.g. malformed
 # legacy JSON, missing field path) instead of silently emitting a generic
 # "jq build new-format object failed" message. Use the canonical helper to stay
-# symmetric with state-read.sh / flow-state-update.sh / _resolve-cross-session-guard.sh
-# (the helper applies chmod 600 and emits a 3-line WARNING block on mktemp failure).
-# `|| jq_err=""` keeps migration running when the helper itself fails: the helper
-# already prints its own WARNING to stderr, so falling back to "no stderr capture"
-# loses diagnostic depth but does not silently skip the migration.
+# symmetric with state-read.sh / flow-state-update.sh / _resolve-cross-session-guard.sh /
+# _resolve-session-id-from-file.sh / resume-active-flag-restore.sh (the helper
+# applies chmod 600 and emits a 3-line WARNING block on mktemp failure, and is
+# documented to "always exit 0" — so a `|| jq_err=""` fallback would diverge from
+# the 5 sibling caller sites). Helper-binary missing is the only path where this
+# would propagate: that case is caught by the standard `set -euo pipefail`
+# behavior at the top of this script, which is the intended fail-fast for
+# deployment defects.
 jq_err=$(bash "$SCRIPT_DIR/../_mktemp-stderr-guard.sh" \
   "migrate-flow-state" "migrate-jq-err" \
-  "jq build new-format object 失敗時の root cause が表示されません") || jq_err=""
+  "jq build new-format object 失敗時の root cause が表示されません")
 
 # Build the new-format object by merging schema_version: 2 with the legacy
 # fields. Missing fields fall back to defaults compatible with the

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -145,14 +145,20 @@ fi
 if [ -z "$SESSION_ID" ]; then
   # Generate fresh UUID. Try uuidgen first (POSIX-ish), fall back to
   # /proc/sys/kernel/random/uuid (Linux), then python3 (last resort).
+  # Use a 2-step capture pattern (raw → tr) so a uuidgen failure under
+  # `set -euo pipefail` does not propagate up the pipeline and abort the
+  # script before reaching the next fallback. Symmetric with how
+  # `_LEGACY_SID` is captured above.
   if command -v uuidgen >/dev/null 2>&1; then
-    SESSION_ID=$(uuidgen 2>/dev/null | tr 'A-F' 'a-f')
+    _raw=$(uuidgen 2>/dev/null) || _raw=""
+    [ -n "$_raw" ] && SESSION_ID=$(printf '%s' "$_raw" | tr 'A-F' 'a-f')
   fi
   if [ -z "$SESSION_ID" ] && [ -r /proc/sys/kernel/random/uuid ]; then
-    SESSION_ID=$(tr -d '\n' < /proc/sys/kernel/random/uuid | tr 'A-F' 'a-f')
+    _raw=$(tr -d '\n' < /proc/sys/kernel/random/uuid 2>/dev/null) || _raw=""
+    [ -n "$_raw" ] && SESSION_ID=$(printf '%s' "$_raw" | tr 'A-F' 'a-f')
   fi
   if [ -z "$SESSION_ID" ] && command -v python3 >/dev/null 2>&1; then
-    SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null)
+    SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null) || SESSION_ID=""
   fi
   if [ -z "$SESSION_ID" ]; then
     echo "[rite] ERROR: cannot generate UUID — uuidgen / /proc/sys/kernel/random/uuid / python3 all unavailable" >&2

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -9,7 +9,9 @@
 #   1. Detect legacy file
 #   2. Resolve session_id (read from legacy state, or generate fresh UUID)
 #   3. Atomic write new format file (mktemp + mv)
-#   4. Rename legacy source to `.rite-flow-state.legacy.{timestamp}`
+#   4. Rename legacy source to `.rite-flow-state.legacy.{timestamp}.{pid}.{random}`
+#      (suffix unique-ifies the path so concurrent migrations within the same
+#      second don't silently overwrite each other's backup — #747 cycle 4 HIGH)
 #   5. Emit explicit migration message on stderr (silent skip is forbidden — AC-8)
 #
 # Failure handling preserves legacy state untouched:
@@ -173,7 +175,11 @@ NEW_FILE="$SESSIONS_DIR/${SESSION_ID}.flow-state"
 # concurrency is the documented use case (Issue #672 multi-session-state.md
 # §Migration), so the race is plausible enough to defend against.
 TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
-BACKUP_FILE="$STATE_ROOT/.rite-flow-state.legacy.${TIMESTAMP}.$$.${RANDOM}"
+# `${RANDOM:-0}` defends against the rare case where the parent shell
+# unset `$RANDOM` before sourcing this script. In a freshly forked bash
+# subprocess (the standard invocation path) `$RANDOM` is always defined,
+# but the fallback keeps the suffix non-empty under any caller.
+BACKUP_FILE="$STATE_ROOT/.rite-flow-state.legacy.${TIMESTAMP}.$$.${RANDOM:-0}"
 
 # --- Dry-run early exit (before any filesystem mutation) ---
 if [ "$DRY_RUN" = "true" ]; then
@@ -225,9 +231,12 @@ chmod 600 "$TMP_NEW" 2>/dev/null || true
 # "jq build new-format object failed" message. Use the canonical helper to stay
 # symmetric with state-read.sh / flow-state-update.sh / _resolve-cross-session-guard.sh
 # (the helper applies chmod 600 and emits a 3-line WARNING block on mktemp failure).
+# `|| jq_err=""` keeps migration running when the helper itself fails: the helper
+# already prints its own WARNING to stderr, so falling back to "no stderr capture"
+# loses diagnostic depth but does not silently skip the migration.
 jq_err=$(bash "$SCRIPT_DIR/../_mktemp-stderr-guard.sh" \
   "migrate-flow-state" "migrate-jq-err" \
-  "jq build new-format object 失敗時の root cause が表示されません")
+  "jq build new-format object 失敗時の root cause が表示されません") || jq_err=""
 
 # Build the new-format object by merging schema_version: 2 with the legacy
 # fields. Missing fields fall back to defaults compatible with the

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -167,8 +167,13 @@ if [ -z "$SESSION_ID" ]; then
 fi
 
 NEW_FILE="$SESSIONS_DIR/${SESSION_ID}.flow-state"
+# Append PID + RANDOM to the seconds-precision timestamp so two migrations
+# starting in the same second don't resolve to the same BACKUP_FILE path.
+# `mv` would otherwise silently overwrite the first backup. Multi-session
+# concurrency is the documented use case (Issue #672 multi-session-state.md
+# §Migration), so the race is plausible enough to defend against.
 TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
-BACKUP_FILE="$STATE_ROOT/.rite-flow-state.legacy.${TIMESTAMP}"
+BACKUP_FILE="$STATE_ROOT/.rite-flow-state.legacy.${TIMESTAMP}.$$.${RANDOM}"
 
 # --- Dry-run early exit (before any filesystem mutation) ---
 if [ "$DRY_RUN" = "true" ]; then

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -173,11 +173,32 @@ if ! mkdir -p "$SESSIONS_DIR" 2>/dev/null; then
 fi
 chmod 700 "$SESSIONS_DIR" 2>/dev/null || true
 
+# Signal-specific trap to clean up the temp file if the script is interrupted
+# between mktemp and the final mv. Without this, SIGINT/SIGTERM/SIGHUP arriving
+# in the race window would leave a `.rite/sessions/{sid}.flow-state.XXXXXX`
+# orphan that subsequent readers see as a "non-UUID flow-state file". The
+# 2-state commit pattern below (`TMP_NEW=""` after successful mv) disarms the
+# trap once the write is committed.
+TMP_NEW=""
+jq_err=""
+_rite_migrate_cleanup() {
+  rm -f "${TMP_NEW:-}" "${jq_err:-}"
+}
+trap 'rc=$?; _rite_migrate_cleanup; exit $rc' EXIT
+trap '_rite_migrate_cleanup; exit 130' INT
+trap '_rite_migrate_cleanup; exit 143' TERM
+trap '_rite_migrate_cleanup; exit 129' HUP
+
 if ! TMP_NEW=$(mktemp "${NEW_FILE}.XXXXXX" 2>/dev/null); then
   echo "[rite] ERROR: migration step 3 (mktemp under $SESSIONS_DIR) failed — legacy state preserved at $LEGACY_FILE" >&2
   exit 1
 fi
 chmod 600 "$TMP_NEW" 2>/dev/null || true
+
+# Capture jq stderr so build failures surface their root cause (e.g. malformed
+# legacy JSON, missing field path) instead of silently emitting a generic
+# "jq build new-format object failed" message.
+jq_err=$(mktemp /tmp/rite-migrate-jq-err-XXXXXX 2>/dev/null) || jq_err=""
 
 # Build the new-format object by merging schema_version: 2 with the legacy
 # fields. Missing fields fall back to defaults compatible with the
@@ -208,18 +229,22 @@ if ! jq -n \
     + (if $L.wm_comment_id   then {wm_comment_id: $L.wm_comment_id}     else {} end)
     + (if $L.error_count     then {error_count: $L.error_count}         else {} end)
     + (if $L.loop_count      then {loop_count: $L.loop_count}           else {} end)
-  ' > "$TMP_NEW" 2>/dev/null
+  ' > "$TMP_NEW" 2>"${jq_err:-/dev/null}"
 then
-  rm -f "$TMP_NEW" 2>/dev/null || true
   echo "[rite] ERROR: migration step 3 (jq build new-format object) failed — legacy state preserved at $LEGACY_FILE" >&2
+  if [ -n "$jq_err" ] && [ -s "$jq_err" ]; then
+    head -3 "$jq_err" | sed 's/^/  /' >&2
+  fi
   exit 1
 fi
+[ -n "$jq_err" ] && rm -f "$jq_err"
+jq_err=""
 
 if ! mv "$TMP_NEW" "$NEW_FILE" 2>/dev/null; then
-  rm -f "$TMP_NEW" 2>/dev/null || true
   echo "[rite] ERROR: migration step 3 (atomic mv $TMP_NEW → $NEW_FILE) failed — legacy state preserved at $LEGACY_FILE" >&2
   exit 1
 fi
+TMP_NEW=""  # disarm trap cleanup — file is now committed under its final name
 
 # --- Step 4: Rename legacy source to backup path ---
 if ! mv "$LEGACY_FILE" "$BACKUP_FILE" 2>/dev/null; then
@@ -228,6 +253,15 @@ if ! mv "$LEGACY_FILE" "$BACKUP_FILE" 2>/dev/null; then
   echo "[rite] ERROR: migration step 4 (rename $LEGACY_FILE → $BACKUP_FILE) failed — new-format file removed, legacy state preserved" >&2
   exit 1
 fi
+
+# Defense-in-depth (#679 review MEDIUM): tighten backup file permissions to 600.
+# `mv` preserves the source inode mode, so a manually-created legacy file with
+# mode 644 (e.g. from `echo > .rite-flow-state` under umask 022) would otherwise
+# leak its content (session_id / issue_number / branch / phase) to other users
+# on a shared host. Symmetric with flow-state-update.sh's writer doctrine which
+# always chmod 600 on tempfiles before mv. Best-effort skip if chmod fails
+# (filesystem without ACL support / SELinux constraint).
+chmod 600 "$BACKUP_FILE" 2>/dev/null || true
 
 # --- Step 5: Emit explicit migration message (silent skip forbidden — AC-8) ---
 echo "[rite] migrated: $LEGACY_FILE → $NEW_FILE (backup: $BACKUP_FILE)" >&2

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -52,12 +52,16 @@ SESSIONS_DIR="$STATE_ROOT/.rite/sessions"
 # operation via `rite-config.yml` (`flow_state.schema_version: 1`) or when the
 # config is absent (default = legacy = "1"). Only schema_version=2 enables
 # migration. This is the documented rollback path (Issue #672 §Rollback).
-# Reuses the canonical _resolve-schema-version.sh helper for drift symmetry
-# with state-read.sh and flow-state-update.sh.
-SCRIPT_DIR_FOR_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_RESOLVE_SCHEMA="$SCRIPT_DIR_FOR_HELPER/../_resolve-schema-version.sh"
+# Reuses the canonical _resolve-schema-version.sh helper. The helper is
+# documented to "always exit 0" (echoes "1" or "2" on stdout), so we call it
+# without a defensive `|| fallback` to stay symmetric with state-read.sh and
+# flow-state-update.sh's _resolve_schema_version function. If the helper file
+# is missing, fall through to the legacy default; the resolution itself never
+# fails by contract.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_RESOLVE_SCHEMA="$SCRIPT_DIR/../_resolve-schema-version.sh"
 if [ -x "$_RESOLVE_SCHEMA" ]; then
-  CONFIG_SCHEMA_VERSION=$(bash "$_RESOLVE_SCHEMA" "$STATE_ROOT" 2>/dev/null) || CONFIG_SCHEMA_VERSION="1"
+  CONFIG_SCHEMA_VERSION=$(bash "$_RESOLVE_SCHEMA" "$STATE_ROOT")
 else
   CONFIG_SCHEMA_VERSION="1"
 fi
@@ -127,7 +131,9 @@ fi
 SESSION_ID=""
 _LEGACY_SID=$(jq -r '.session_id // empty' "$LEGACY_FILE" 2>/dev/null) || _LEGACY_SID=""
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# SCRIPT_DIR was set at the top of this script (during config schema resolution);
+# reuse it instead of re-computing. The two earlier declarations were equivalent
+# since BASH_SOURCE[0] is invariant within a single invocation.
 RESOLVE_SID="$SCRIPT_DIR/../_resolve-session-id.sh"
 
 if [ -n "$_LEGACY_SID" ] && [ -x "$RESOLVE_SID" ]; then
@@ -181,8 +187,16 @@ chmod 700 "$SESSIONS_DIR" 2>/dev/null || true
 # trap once the write is committed.
 TMP_NEW=""
 jq_err=""
+NEW_FILE_TO_CLEANUP=""
+NEW_FILE_COMMITTED=false
 _rite_migrate_cleanup() {
   rm -f "${TMP_NEW:-}" "${jq_err:-}"
+  # Roll back the new-format file when step 4 has not committed it yet.
+  # NEW_FILE_TO_CLEANUP is set after step 3's atomic mv; NEW_FILE_COMMITTED
+  # flips to true only after step 4's rename succeeds.
+  if [ -n "${NEW_FILE_TO_CLEANUP:-}" ] && [ "${NEW_FILE_COMMITTED:-false}" != "true" ]; then
+    rm -f "$NEW_FILE_TO_CLEANUP"
+  fi
 }
 trap 'rc=$?; _rite_migrate_cleanup; exit $rc' EXIT
 trap '_rite_migrate_cleanup; exit 130' INT
@@ -197,8 +211,12 @@ chmod 600 "$TMP_NEW" 2>/dev/null || true
 
 # Capture jq stderr so build failures surface their root cause (e.g. malformed
 # legacy JSON, missing field path) instead of silently emitting a generic
-# "jq build new-format object failed" message.
-jq_err=$(mktemp /tmp/rite-migrate-jq-err-XXXXXX 2>/dev/null) || jq_err=""
+# "jq build new-format object failed" message. Use the canonical helper to stay
+# symmetric with state-read.sh / flow-state-update.sh / _resolve-cross-session-guard.sh
+# (the helper applies chmod 600 and emits a 3-line WARNING block on mktemp failure).
+jq_err=$(bash "$SCRIPT_DIR/../_mktemp-stderr-guard.sh" \
+  "migrate-flow-state" "migrate-jq-err" \
+  "jq build new-format object 失敗時の root cause が表示されません")
 
 # Build the new-format object by merging schema_version: 2 with the legacy
 # fields. Missing fields fall back to defaults compatible with the
@@ -246,21 +264,37 @@ if ! mv "$TMP_NEW" "$NEW_FILE" 2>/dev/null; then
 fi
 TMP_NEW=""  # disarm trap cleanup — file is now committed under its final name
 
+# Track NEW_FILE so step 4 failure can route through the same trap-managed
+# rollback path as step 3, instead of an ad-hoc inline rm. NEW_FILE_COMMITTED
+# stays "false" until step 4 succeeds; on any signal/error before that,
+# `_rite_migrate_cleanup` removes the new-format file to preserve the
+# rollback semantics tested by TC-10.
+NEW_FILE_TO_CLEANUP="$NEW_FILE"
+NEW_FILE_COMMITTED=false
+
 # --- Step 4: Rename legacy source to backup path ---
+# Tighten the source file's mode to 600 *before* the rename so the backup
+# inode is born private. `mv` preserves the source inode mode, so doing
+# `chmod 600` after `mv` opens a SIGINT/SIGKILL race window where the
+# backup remains world-readable. Pre-mv chmod is symmetric with
+# flow-state-update.sh's atomic-write block, which `chmod 600` the tempfile
+# before mv. Best-effort: skip on filesystems without permission bit support.
+chmod 600 "$LEGACY_FILE" 2>/dev/null || true
 if ! mv "$LEGACY_FILE" "$BACKUP_FILE" 2>/dev/null; then
-  # Roll back the new-format file so the user can retry on the next session start.
-  rm -f "$NEW_FILE" 2>/dev/null || true
   echo "[rite] ERROR: migration step 4 (rename $LEGACY_FILE → $BACKUP_FILE) failed — new-format file removed, legacy state preserved" >&2
+  # Roll back the new-format file via trap cleanup (NEW_FILE_COMMITTED still false).
   exit 1
 fi
 
-# Defense-in-depth (#679 review MEDIUM): tighten backup file permissions to 600.
-# `mv` preserves the source inode mode, so a manually-created legacy file with
-# mode 644 (e.g. from `echo > .rite-flow-state` under umask 022) would otherwise
-# leak its content (session_id / issue_number / branch / phase) to other users
-# on a shared host. Symmetric with flow-state-update.sh's writer doctrine which
-# always chmod 600 on tempfiles before mv. Best-effort skip if chmod fails
-# (filesystem without ACL support / SELinux constraint).
+# Step 4 succeeded — disarm the new-format rollback so subsequent signals
+# don't delete a committed file.
+NEW_FILE_COMMITTED=true
+
+# Defense-in-depth: re-apply chmod 600 to the backup file. The pre-mv chmod
+# above already makes this redundant on filesystems where it succeeded, but
+# we keep the post-mv invocation so that ACL-restricted environments which
+# refused the source-side chmod still get a chance to tighten the backup
+# (some filesystems allow chmod on the destination but not the source).
 chmod 600 "$BACKUP_FILE" 2>/dev/null || true
 
 # --- Step 5: Emit explicit migration message (silent skip forbidden — AC-8) ---

--- a/plugins/rite/hooks/scripts/migrate-flow-state.sh
+++ b/plugins/rite/hooks/scripts/migrate-flow-state.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# rite workflow — Legacy `.rite-flow-state` Auto Migration (Issue #672 / #679)
+#
+# Detects legacy `.rite-flow-state` files (`schema_version` missing or `< 2`)
+# and migrates them to the per-session path `.rite/sessions/{session_id}.flow-state`
+# (Option A, multi-state design — see docs/designs/multi-session-state.md).
+#
+# Migration is a 5-step rename strategy:
+#   1. Detect legacy file
+#   2. Resolve session_id (read from legacy state, or generate fresh UUID)
+#   3. Atomic write new format file (mktemp + mv)
+#   4. Rename legacy source to `.rite-flow-state.legacy.{timestamp}`
+#   5. Emit explicit migration message on stderr (silent skip is forbidden — AC-8)
+#
+# Failure handling preserves legacy state untouched:
+#   - step 3 failure: no new file left behind, legacy intact
+#   - step 4 failure: new file removed, legacy intact
+#
+# Usage:
+#   STATE_ROOT="/path/to/repo" bash migrate-flow-state.sh           # apply
+#   STATE_ROOT="/path/to/repo" bash migrate-flow-state.sh --dry-run # detect only
+#
+# Exit codes:
+#   0 — migrated, no-op (already v2 or no legacy file), or dry-run completed
+#   1 — migration failed (legacy state preserved)
+#
+# Called from `session-start.sh` at the earliest opportunity so subsequent
+# hook reads land on the per-session path.
+
+set -euo pipefail
+
+# --- Argument parsing ---
+DRY_RUN=false
+case "${1:-}" in
+  --dry-run) DRY_RUN=true ;;
+  '') ;;
+  *) echo "ERROR: unknown argument: $1 (expected: --dry-run)" >&2; exit 1 ;;
+esac
+
+# --- STATE_ROOT resolution ---
+STATE_ROOT="${STATE_ROOT:-$PWD}"
+if [ ! -d "$STATE_ROOT" ]; then
+  echo "ERROR: STATE_ROOT does not exist: $STATE_ROOT" >&2
+  exit 1
+fi
+
+LEGACY_FILE="$STATE_ROOT/.rite-flow-state"
+SESSIONS_DIR="$STATE_ROOT/.rite/sessions"
+
+# --- Honor `flow_state.schema_version` rollback flag ---
+# Migration must NOT run when the user explicitly opts into legacy single-file
+# operation via `rite-config.yml` (`flow_state.schema_version: 1`) or when the
+# config is absent (default = legacy = "1"). Only schema_version=2 enables
+# migration. This is the documented rollback path (Issue #672 §Rollback).
+# Reuses the canonical _resolve-schema-version.sh helper for drift symmetry
+# with state-read.sh and flow-state-update.sh.
+SCRIPT_DIR_FOR_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_RESOLVE_SCHEMA="$SCRIPT_DIR_FOR_HELPER/../_resolve-schema-version.sh"
+if [ -x "$_RESOLVE_SCHEMA" ]; then
+  CONFIG_SCHEMA_VERSION=$(bash "$_RESOLVE_SCHEMA" "$STATE_ROOT" 2>/dev/null) || CONFIG_SCHEMA_VERSION="1"
+else
+  CONFIG_SCHEMA_VERSION="1"
+fi
+if [ "$CONFIG_SCHEMA_VERSION" != "2" ]; then
+  # Rollback / config-absent path: legacy operation is the user's stated choice.
+  # Silent no-op (the user will see the explicit migration message only when
+  # they opt into v2 via config — that's where the AC-8 contract applies).
+  exit 0
+fi
+
+# --- Step 1: Detect legacy file ---
+if [ ! -f "$LEGACY_FILE" ]; then
+  # No legacy file — nothing to migrate. Silent no-op (this is the common path
+  # on systems already running schema_version=2).
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[rite] ERROR: jq is required for migrate-flow-state.sh but was not found in PATH" >&2
+  exit 1
+fi
+
+# Empty legacy file is treated as "nothing meaningful to migrate". Remove it
+# so subsequent hook reads land on the per-session path without confusion.
+if [ ! -s "$LEGACY_FILE" ]; then
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[rite] dry-run: would remove empty legacy file: $LEGACY_FILE" >&2
+    exit 0
+  fi
+  rm -f "$LEGACY_FILE" 2>/dev/null || true
+  exit 0
+fi
+
+# Validate JSON parse before reading schema_version. Corrupt JSON must NOT be
+# silently treated as "missing schema_version" — that would force a destructive
+# migration on an unreadable file.
+if ! _SCHEMA_VERSION_RAW=$(jq -r '.schema_version // empty' "$LEGACY_FILE" 2>/dev/null); then
+  echo "[rite] ERROR: legacy file is not valid JSON: $LEGACY_FILE — manual recovery required, skipping migration" >&2
+  exit 1
+fi
+
+# Determine if this file actually needs migration (schema_version missing or < 2).
+# Non-numeric values fall through to "needs migration" (treated like missing).
+_NEEDS_MIGRATION=false
+if [ -z "$_SCHEMA_VERSION_RAW" ]; then
+  _NEEDS_MIGRATION=true
+elif ! [[ "$_SCHEMA_VERSION_RAW" =~ ^[0-9]+$ ]]; then
+  _NEEDS_MIGRATION=true
+elif [ "$_SCHEMA_VERSION_RAW" -lt 2 ]; then
+  _NEEDS_MIGRATION=true
+fi
+
+if [ "$_NEEDS_MIGRATION" != "true" ]; then
+  # Already schema_version >= 2 in the legacy path. Treat as legitimate — a
+  # writer (e.g., flow-state-update.sh) may have chosen the legacy path
+  # intentionally because no session_id was available at write time. We do
+  # not remove the file: doing so would discard the only copy of that state.
+  # No-op. The per-session path is the canonical location going forward; if
+  # this legacy file is later confirmed orphaned, manual cleanup is the path
+  # forward — out of scope for automatic migration.
+  exit 0
+fi
+
+# --- Step 2: Resolve session_id ---
+# Prefer the session_id stored inside the legacy file. If absent, malformed,
+# or empty, generate a fresh UUID so the migrated file has a valid identifier.
+SESSION_ID=""
+_LEGACY_SID=$(jq -r '.session_id // empty' "$LEGACY_FILE" 2>/dev/null) || _LEGACY_SID=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_SID="$SCRIPT_DIR/../_resolve-session-id.sh"
+
+if [ -n "$_LEGACY_SID" ] && [ -x "$RESOLVE_SID" ]; then
+  if validated=$(bash "$RESOLVE_SID" "$_LEGACY_SID" 2>/dev/null); then
+    SESSION_ID="$validated"
+  fi
+fi
+
+if [ -z "$SESSION_ID" ]; then
+  # Generate fresh UUID. Try uuidgen first (POSIX-ish), fall back to
+  # /proc/sys/kernel/random/uuid (Linux), then python3 (last resort).
+  if command -v uuidgen >/dev/null 2>&1; then
+    SESSION_ID=$(uuidgen 2>/dev/null | tr 'A-F' 'a-f')
+  fi
+  if [ -z "$SESSION_ID" ] && [ -r /proc/sys/kernel/random/uuid ]; then
+    SESSION_ID=$(tr -d '\n' < /proc/sys/kernel/random/uuid | tr 'A-F' 'a-f')
+  fi
+  if [ -z "$SESSION_ID" ] && command -v python3 >/dev/null 2>&1; then
+    SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null)
+  fi
+  if [ -z "$SESSION_ID" ]; then
+    echo "[rite] ERROR: cannot generate UUID — uuidgen / /proc/sys/kernel/random/uuid / python3 all unavailable" >&2
+    exit 1
+  fi
+fi
+
+NEW_FILE="$SESSIONS_DIR/${SESSION_ID}.flow-state"
+TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+BACKUP_FILE="$STATE_ROOT/.rite-flow-state.legacy.${TIMESTAMP}"
+
+# --- Dry-run early exit (before any filesystem mutation) ---
+if [ "$DRY_RUN" = "true" ]; then
+  echo "[rite] dry-run: would migrate $LEGACY_FILE → $NEW_FILE (backup: $BACKUP_FILE)" >&2
+  exit 0
+fi
+
+# --- Step 3: Atomic write new format file (mktemp + mv) ---
+# Ensure target directory exists with restrictive permissions (multi-user
+# host protection — symmetric with flow-state-update.sh).
+if ! mkdir -p "$SESSIONS_DIR" 2>/dev/null; then
+  echo "[rite] ERROR: migration step 3 (mkdir $SESSIONS_DIR) failed — legacy state preserved at $LEGACY_FILE" >&2
+  exit 1
+fi
+chmod 700 "$SESSIONS_DIR" 2>/dev/null || true
+
+if ! TMP_NEW=$(mktemp "${NEW_FILE}.XXXXXX" 2>/dev/null); then
+  echo "[rite] ERROR: migration step 3 (mktemp under $SESSIONS_DIR) failed — legacy state preserved at $LEGACY_FILE" >&2
+  exit 1
+fi
+chmod 600 "$TMP_NEW" 2>/dev/null || true
+
+# Build the new-format object by merging schema_version: 2 with the legacy
+# fields. Missing fields fall back to defaults compatible with the
+# `flow-state-update.sh` create object (active=false, issue_number=0,
+# branch="", phase="", previous_phase="", pr_number=0,
+# parent_issue_number=0, next_action="", last_synced_phase="").
+# session_id and updated_at are forced to migration-time values.
+if ! jq -n \
+  --slurpfile legacy "$LEGACY_FILE" \
+  --arg sid "$SESSION_ID" \
+  --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" \
+  '
+    ($legacy[0] // {}) as $L
+    | {
+        schema_version: 2,
+        active: ($L.active // false),
+        issue_number: (($L.issue_number // 0) | tonumber? // 0),
+        branch: ($L.branch // ""),
+        phase: ($L.phase // ""),
+        previous_phase: ($L.previous_phase // ""),
+        pr_number: (($L.pr_number // 0) | tonumber? // 0),
+        parent_issue_number: (($L.parent_issue_number // 0) | tonumber? // 0),
+        next_action: ($L.next_action // ""),
+        updated_at: $ts,
+        session_id: $sid,
+        last_synced_phase: ($L.last_synced_phase // "")
+      }
+    + (if $L.wm_comment_id   then {wm_comment_id: $L.wm_comment_id}     else {} end)
+    + (if $L.error_count     then {error_count: $L.error_count}         else {} end)
+    + (if $L.loop_count      then {loop_count: $L.loop_count}           else {} end)
+  ' > "$TMP_NEW" 2>/dev/null
+then
+  rm -f "$TMP_NEW" 2>/dev/null || true
+  echo "[rite] ERROR: migration step 3 (jq build new-format object) failed — legacy state preserved at $LEGACY_FILE" >&2
+  exit 1
+fi
+
+if ! mv "$TMP_NEW" "$NEW_FILE" 2>/dev/null; then
+  rm -f "$TMP_NEW" 2>/dev/null || true
+  echo "[rite] ERROR: migration step 3 (atomic mv $TMP_NEW → $NEW_FILE) failed — legacy state preserved at $LEGACY_FILE" >&2
+  exit 1
+fi
+
+# --- Step 4: Rename legacy source to backup path ---
+if ! mv "$LEGACY_FILE" "$BACKUP_FILE" 2>/dev/null; then
+  # Roll back the new-format file so the user can retry on the next session start.
+  rm -f "$NEW_FILE" 2>/dev/null || true
+  echo "[rite] ERROR: migration step 4 (rename $LEGACY_FILE → $BACKUP_FILE) failed — new-format file removed, legacy state preserved" >&2
+  exit 1
+fi
+
+# --- Step 5: Emit explicit migration message (silent skip forbidden — AC-8) ---
+echo "[rite] migrated: $LEGACY_FILE → $NEW_FILE (backup: $BACKUP_FILE)" >&2
+
+exit 0

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -117,7 +117,13 @@ WARN_MSG
     fi
 fi
 
-# Clean up stale temporary files (older than 1 minute to avoid deleting in-progress writes)
+# Clean up stale temporary files (older than 1 minute to avoid deleting in-progress writes).
+# Mirrors the same find command in session-start.sh (which is the canonical source).
+# `-not -name '.rite-flow-state.legacy.*'` excludes the migration backup so it
+# remains the manual-recovery source of truth (#679, #747 cycle 4 CRITICAL).
+# DRY note: this cleanup is duplicated across session-start.sh and session-end.sh.
+# Future hardening: extract into a shared helper to prevent one-sided regressions
+# (the cycle 3 fix to session-start.sh missed this hook, surfacing as cycle 4 CRITICAL).
 if [ -d "$CWD" ]; then
-    find "$CWD" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -type f -mmin +1 -delete 2>/dev/null || true
+    find "$CWD" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -not -name ".rite-flow-state.legacy.*" -type f -mmin +1 -delete 2>/dev/null || true
 fi

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -329,8 +329,13 @@ if [ "$SOURCE" = "clear" ]; then
   _reset_active_state
 fi
 
-# Clean up stale temporary files (older than 1 minute to avoid deleting in-progress writes)
-find "$STATE_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -type f -mmin +1 -delete 2>/dev/null || true
+# Clean up stale temporary files (older than 1 minute to avoid deleting in-progress writes).
+# `.rite-flow-state.??????*` is intended to match mktemp tempfiles
+# (`.rite-flow-state.<6-hex>`), but its trailing `*` also matches the migration
+# backup (`.rite-flow-state.legacy.<timestamp>`, e.g. `.rite-flow-state.legacy.20260430T120000Z`)
+# because `legacy` is 6 chars and `.<timestamp>` is consumed by `*`. Excluding
+# the legacy backup keeps it as the manual-recovery source of truth (#679).
+find "$STATE_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -not -name ".rite-flow-state.legacy.*" -type f -mmin +1 -delete 2>/dev/null || true
 
 # Extract all fields in a single jq call for efficiency
 # cycle 11 MEDIUM F-04: unit separator \x1f (\037) を使用する理由。tab は POSIX IFS whitespace

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -331,10 +331,11 @@ fi
 
 # Clean up stale temporary files (older than 1 minute to avoid deleting in-progress writes).
 # `.rite-flow-state.??????*` is intended to match mktemp tempfiles
-# (`.rite-flow-state.<6-hex>`), but its trailing `*` also matches the migration
-# backup (`.rite-flow-state.legacy.<timestamp>`, e.g. `.rite-flow-state.legacy.20260430T120000Z`)
-# because `legacy` is 6 chars and `.<timestamp>` is consumed by `*`. Excluding
-# the legacy backup keeps it as the manual-recovery source of truth (#679).
+# (`.rite-flow-state.<6-hex>`), but its `??????*` glob matches **any suffix
+# of 6 or more chars**, which includes the migration backup name
+# (`.rite-flow-state.legacy.<timestamp>.<pid>.<random>`). Adding
+# `-not -name '.rite-flow-state.legacy.*'` keeps the migration backup as the
+# manual-recovery source of truth (#679, #747 cycle 4 CRITICAL).
 find "$STATE_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -not -name ".rite-flow-state.legacy.*" -type f -mmin +1 -delete 2>/dev/null || true
 
 # Extract all fields in a single jq call for efficiency

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -232,6 +232,18 @@ with open(out_path, "w") as f:
   fi
 fi
 
+# Auto-migrate legacy `.rite-flow-state` to the per-session path
+# (`.rite/sessions/{session_id}.flow-state`) when schema_version is missing or < 2.
+# Issue #672 (multi-state design) / #679 (migration). The script is non-blocking:
+# any error is reported to stderr but the hook continues with the legacy file so
+# the user can retry on the next session start. The explicit migration message
+# (AC-8 — silent skip forbidden) flows through stderr to the user's terminal.
+_migrate_script="$SCRIPT_DIR/scripts/migrate-flow-state.sh"
+if [ -x "$_migrate_script" ]; then
+  STATE_ROOT="$STATE_ROOT" bash "$_migrate_script" || true
+fi
+unset _migrate_script
+
 STATE_FILE="$STATE_ROOT/.rite-flow-state"
 
 if [ ! -f "$STATE_FILE" ]; then

--- a/plugins/rite/hooks/tests/migrate-flow-state.test.sh
+++ b/plugins/rite/hooks/tests/migrate-flow-state.test.sh
@@ -319,6 +319,28 @@ else
 fi
 _teardown
 
+# ---------- TC-18: backup file survives session-start.sh find cleanup (#747 cycle 3 CRITICAL) ----------
+# Regression guard: session-start.sh's stale tempfile cleanup uses the glob
+# `.rite-flow-state.??????*` which incidentally matches `.rite-flow-state.legacy.<timestamp>`
+# because `legacy` is exactly 6 chars and `.<timestamp>` is consumed by `*`.
+# Without the `-not -name '.rite-flow-state.legacy.*'` exception, the backup
+# disappears the next time session-start.sh runs after the file is older than
+# 1 minute. This TC simulates that condition by back-dating the backup file
+# and invoking the same find command session-start.sh uses.
+echo "TC-18: backup file survives session-start.sh stale-tempfile cleanup (#747 cycle 3 CRITICAL)"
+_setup
+echo '{"active":true,"issue_number":2,"phase":"phaseV","session_id":"77889900-aabb-ccdd-eeff-112233445566"}' > "$TEST_ROOT/.rite-flow-state"
+STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
+backup_glob=("$TEST_ROOT"/.rite-flow-state.legacy.*)
+backup_file="${backup_glob[0]}"
+_assert "TC-18.backup-created" "$([ -f "$backup_file" ] && echo true || echo false)"
+# Back-date the backup file by 2 minutes so the `-mmin +1` predicate matches.
+touch -d "2 minutes ago" "$backup_file" 2>/dev/null || touch -t "$(date -d '2 minutes ago' +%Y%m%d%H%M.%S 2>/dev/null || date -v -2M +%Y%m%d%H%M.%S 2>/dev/null)" "$backup_file"
+# Run the same find command session-start.sh uses (with the legacy exception).
+find "$TEST_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -not -name ".rite-flow-state.legacy.*" -type f -mmin +1 -delete 2>/dev/null || true
+_assert "TC-18.backup-survives-cleanup" "$([ -f "$backup_file" ] && echo true || echo false)"
+_teardown
+
 # ---------- Summary ----------
 echo ""
 echo "==============================="

--- a/plugins/rite/hooks/tests/migrate-flow-state.test.sh
+++ b/plugins/rite/hooks/tests/migrate-flow-state.test.sh
@@ -290,6 +290,23 @@ _assert "TC-16.no-output" "$([ -z "$out" ] && echo true || echo false)"
 _assert "TC-16.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
 _teardown
 
+# ---------- TC-17: backup file gets chmod 600 (security review MEDIUM, #679) ----------
+echo "TC-17: backup file is chmod'd to 600 after step 4 rename (defense-in-depth)"
+_setup
+# Create a legacy file that was manually written with mode 644 (the threat scenario)
+echo '{"active":true,"issue_number":1,"phase":"phaseW","session_id":"66778899-aabb-ccdd-eeff-001122334455"}' > "$TEST_ROOT/.rite-flow-state"
+chmod 644 "$TEST_ROOT/.rite-flow-state"
+STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
+backup_file=("$TEST_ROOT"/.rite-flow-state.legacy.*)
+if [ -f "${backup_file[0]}" ]; then
+  # stat -c on Linux, stat -f on BSD/macOS — try both
+  perm=$(stat -c '%a' "${backup_file[0]}" 2>/dev/null || stat -f '%A' "${backup_file[0]}" 2>/dev/null)
+  _assert "TC-17.backup-mode-600" "$([ "$perm" = "600" ] && echo true || echo false)"
+else
+  _assert "TC-17.backup-mode-600" "false"
+fi
+_teardown
+
 # ---------- TC-14: backup file content equals pre-migration legacy content ----------
 echo "TC-14: backup file content equals legacy content byte-for-byte (rename, not rebuild)"
 _setup

--- a/plugins/rite/hooks/tests/migrate-flow-state.test.sh
+++ b/plugins/rite/hooks/tests/migrate-flow-state.test.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+# Tests for hooks/scripts/migrate-flow-state.sh — Issue #672 / #679.
+#
+# Covers acceptance criteria:
+#   AC-8 (Issue #672)        — legacy state auto-migration with explicit warning (silent skip forbidden)
+#   AC-LOCAL-1 (Issue #679)  — session-start.sh fires migration; new format created with schema_version=2 + backup
+#   AC-LOCAL-2 (Issue #679)  — migration failure leaves legacy source intact + ERROR message emitted
+#   AC-LOCAL-3 (Issue #679)  — dry-run mode: detection only, no filesystem mutation
+#   AC-LOCAL-4 (Issue #679)  — after rename, the legacy path is ENOENT so other sessions early-exit
+#
+# Usage: bash plugins/rite/hooks/tests/migrate-flow-state.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../scripts/migrate-flow-state.sh"
+SESSION_START="$SCRIPT_DIR/../session-start.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "ERROR: migrate-flow-state.sh missing or not executable: $SCRIPT" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# Each test case runs in a fresh tempdir.  We export STATE_ROOT to that dir.
+# _teardown is called explicitly at the end of every test block — we deliberately
+# avoid `trap RETURN` because it would fire when _setup itself returns and clear
+# TEST_ROOT before the test body could read it.
+_setup() {
+  TEST_ROOT=$(mktemp -d)
+  # Migration is gated on `flow_state.schema_version: 2` in rite-config.yml.
+  # All migrate-flow-state tests assume the user has opted into v2.
+  cat > "$TEST_ROOT/rite-config.yml" <<'EOF'
+flow_state:
+  schema_version: 2
+EOF
+}
+_teardown() {
+  if [ -n "${TEST_ROOT:-}" ] && [ -d "$TEST_ROOT" ]; then
+    rm -rf "$TEST_ROOT" 2>/dev/null || true
+  fi
+  TEST_ROOT=""
+}
+
+_assert() {
+  local label="$1"
+  local cond="$2"
+  if [ "$cond" = "true" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ $label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$label")
+    echo "  ✗ $label"
+  fi
+}
+
+_count_files() {
+  # Count files matching glob in $1 (works with no matches → returns 0).
+  local pattern="$1"
+  local count=0
+  for f in $pattern; do
+    [ -e "$f" ] && count=$((count + 1))
+  done
+  echo "$count"
+}
+
+# ---------- TC-01: No legacy file → silent no-op ----------
+echo "TC-01: no legacy file → silent no-op"
+_setup
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+_assert "TC-01.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-01.no-output" "$([ -z "$out" ] && echo true || echo false)"
+_assert "TC-01.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-02: schema_version=2 already → silent no-op (legacy left intact) ----------
+# Files written to the legacy path with schema_version=2 are treated as legitimate
+# (e.g., flow-state-update.sh may choose the legacy path when no session_id is
+# available at write time). The migration script must NOT delete them — doing so
+# would discard the only copy of that state.
+echo "TC-02: schema_version>=2 in legacy → silent no-op (legacy intact)"
+_setup
+echo '{"schema_version":2,"active":false,"phase":"completed"}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+_assert "TC-02.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-02.no-output" "$([ -z "$out" ] && echo true || echo false)"
+_assert "TC-02.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-02.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+_assert "TC-02.no-backup" "$(if compgen -G "$TEST_ROOT/.rite-flow-state.legacy.*" >/dev/null; then echo false; else echo true; fi)"
+_teardown
+
+# ---------- TC-03: dry-run on legacy file → detection msg only ----------
+echo "TC-03: dry-run → detection only, no filesystem mutation"
+_setup
+echo '{"active":true,"issue_number":672,"phase":"phase5_lint","session_id":"00112233-4455-6677-8899-aabbccddeeff"}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" --dry-run 2>&1)
+rc=$?
+_assert "TC-03.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-03.dryrun-msg" "$(echo "$out" | grep -q 'dry-run: would migrate' && echo true || echo false)"
+_assert "TC-03.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-03.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+_assert "TC-03.no-backup" "$(if compgen -G "$TEST_ROOT/.rite-flow-state.legacy.*" >/dev/null; then echo false; else echo true; fi)"
+_teardown
+
+# ---------- TC-04: full migration with valid session_id ----------
+echo "TC-04: full migration preserves session_id and core fields, schema_version=2 added"
+_setup
+mkdir -p "$TEST_ROOT/.rite/sessions"
+cat > "$TEST_ROOT/.rite-flow-state" <<JSON
+{"active":true,"issue_number":672,"branch":"feat/issue-672-x","phase":"phase5_lint","previous_phase":"phase5_post_review","pr_number":42,"parent_issue_number":100,"next_action":"resume","session_id":"00112233-4455-6677-8899-aabbccddeeff","last_synced_phase":"phase5_post_lint","wm_comment_id":987654321}
+JSON
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+new_file="$TEST_ROOT/.rite/sessions/00112233-4455-6677-8899-aabbccddeeff.flow-state"
+backup_count=$(_count_files "$TEST_ROOT/.rite-flow-state.legacy.*")
+_assert "TC-04.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-04.migration-msg" "$(echo "$out" | grep -q '\[rite\] migrated:' && echo true || echo false)"
+_assert "TC-04.new-file-exists" "$([ -f "$new_file" ] && echo true || echo false)"
+_assert "TC-04.legacy-removed" "$([ ! -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-04.backup-created" "$([ "$backup_count" -eq 1 ] && echo true || echo false)"
+_assert "TC-04.schema-version-2" "$([ "$(jq -r .schema_version "$new_file")" = "2" ] && echo true || echo false)"
+_assert "TC-04.session-id-preserved" "$([ "$(jq -r .session_id "$new_file")" = "00112233-4455-6677-8899-aabbccddeeff" ] && echo true || echo false)"
+_assert "TC-04.issue-number-preserved" "$([ "$(jq -r .issue_number "$new_file")" = "672" ] && echo true || echo false)"
+_assert "TC-04.branch-preserved" "$([ "$(jq -r .branch "$new_file")" = "feat/issue-672-x" ] && echo true || echo false)"
+_assert "TC-04.phase-preserved" "$([ "$(jq -r .phase "$new_file")" = "phase5_lint" ] && echo true || echo false)"
+_assert "TC-04.pr-number-preserved" "$([ "$(jq -r .pr_number "$new_file")" = "42" ] && echo true || echo false)"
+_assert "TC-04.parent-issue-preserved" "$([ "$(jq -r .parent_issue_number "$new_file")" = "100" ] && echo true || echo false)"
+_assert "TC-04.wm-comment-preserved" "$([ "$(jq -r .wm_comment_id "$new_file")" = "987654321" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-05: legacy without session_id → fresh UUID generated ----------
+echo "TC-05: legacy without session_id → UUID generated, new file at .rite/sessions/{uuid}.flow-state"
+_setup
+echo '{"active":false,"issue_number":1,"phase":""}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+sessions=("$TEST_ROOT/.rite/sessions/"*.flow-state)
+generated_count=${#sessions[@]}
+_assert "TC-05.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-05.exactly-one-new-file" "$([ "$generated_count" -eq 1 ] && [ -f "${sessions[0]}" ] && echo true || echo false)"
+if [ -f "${sessions[0]}" ]; then
+  generated_sid=$(jq -r .session_id "${sessions[0]}")
+  _assert "TC-05.generated-uuid-format" "$(if [[ "$generated_sid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then echo true; else echo false; fi)"
+fi
+_teardown
+
+# ---------- TC-06: schema_version=1 (numeric) → migrated ----------
+echo "TC-06: schema_version=1 (legacy explicit version) → migrated"
+_setup
+echo '{"schema_version":1,"active":true,"issue_number":2,"phase":"phase2"}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+sessions=("$TEST_ROOT/.rite/sessions/"*.flow-state)
+_assert "TC-06.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-06.migrated" "$([ -f "${sessions[0]:-/nonexistent}" ] && echo true || echo false)"
+[ -f "${sessions[0]:-/nonexistent}" ] && \
+  _assert "TC-06.schema-version-bumped-to-2" "$([ "$(jq -r .schema_version "${sessions[0]}")" = "2" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-07: invalid JSON in legacy → ERROR, legacy intact ----------
+echo "TC-07: invalid JSON in legacy → ERROR + legacy preserved (no destructive migration)"
+_setup
+echo 'not-valid-json{{{' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1) || rc=$?
+rc=${rc:-$?}
+_assert "TC-07.exit-non-zero" "$([ "$rc" -ne 0 ] && echo true || echo false)"
+_assert "TC-07.error-msg" "$(echo "$out" | grep -q 'ERROR.*not valid JSON' && echo true || echo false)"
+_assert "TC-07.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-07.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+unset rc
+_teardown
+
+# ---------- TC-08: dry-run when no legacy → silent no-op ----------
+echo "TC-08: dry-run with no legacy → silent no-op"
+_setup
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" --dry-run 2>&1)
+rc=$?
+_assert "TC-08.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-08.no-output" "$([ -z "$out" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-09: empty legacy file → removed silently ----------
+echo "TC-09: empty legacy file → removed silently (treated as nothing meaningful)"
+_setup
+: > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+_assert "TC-09.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-09.legacy-removed" "$([ ! -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-09.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-10: AC-LOCAL-2 — step 4 failure (rename) → new file rolled back, legacy intact ----------
+echo "TC-10: step 4 (rename) failure → new file removed, legacy preserved (rollback semantics)"
+_setup
+# Make the legacy file a directory entry that 'mv' cannot rename out of: by
+# making the parent directory read-only AFTER the new file has been written.
+# We simulate this by intercepting via a wrapper that simulates rename failure.
+# Simpler approach: use a legacy that points to a path on a write-protected
+# subdir for rename. We use chmod a-w on STATE_ROOT.
+echo '{"active":true,"issue_number":3,"phase":"phaseX","session_id":"11223344-5566-7788-99aa-bbccddeeff00"}' > "$TEST_ROOT/.rite-flow-state"
+# Pre-create sessions dir so step 3 succeeds quickly.
+mkdir -p "$TEST_ROOT/.rite/sessions"
+chmod 555 "$TEST_ROOT"  # read+exec only — mv into . will fail (rename for backup)
+set +e
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+set -e
+chmod 755 "$TEST_ROOT"  # restore so cleanup works
+new_file="$TEST_ROOT/.rite/sessions/11223344-5566-7788-99aa-bbccddeeff00.flow-state"
+_assert "TC-10.exit-non-zero" "$([ "$rc" -ne 0 ] && echo true || echo false)"
+_assert "TC-10.error-step-4" "$(echo "$out" | grep -q 'step 4' && echo true || echo false)"
+_assert "TC-10.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-10.new-file-rolled-back" "$([ ! -f "$new_file" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-11: AC-LOCAL-1 — session-start.sh fires migration when STATE_ROOT has legacy ----------
+echo "TC-11: session-start.sh fires migration on startup (integration)"
+_setup
+echo '{"active":true,"issue_number":42,"branch":"feat/x","phase":"phase5_lint","next_action":"resume","session_id":"22334455-6677-8899-aabb-ccddeeff0011"}' > "$TEST_ROOT/.rite-flow-state"
+# Run session-start.sh with a mocked input (cwd=$TEST_ROOT, source=startup, session_id matches existing).
+# We invoke session-start.sh directly with fake stdin so the migration block fires.
+hook_input='{"cwd":"'"$TEST_ROOT"'","source":"startup","session_id":"22334455-6677-8899-aabb-ccddeeff0011"}'
+set +e
+out=$(echo "$hook_input" | bash "$SESSION_START" 2>&1)
+rc=$?
+set -e
+new_file="$TEST_ROOT/.rite/sessions/22334455-6677-8899-aabb-ccddeeff0011.flow-state"
+_assert "TC-11.session-start-completes" "$([ "$rc" -eq 0 ] && echo true || echo false)"
+_assert "TC-11.migration-msg-on-stderr" "$(echo "$out" | grep -q '\[rite\] migrated:' && echo true || echo false)"
+_assert "TC-11.new-format-file-created" "$([ -f "$new_file" ] && echo true || echo false)"
+_assert "TC-11.legacy-renamed" "$([ ! -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-11.backup-exists" "$(if compgen -G "$TEST_ROOT/.rite-flow-state.legacy.*" >/dev/null; then echo true; else echo false; fi)"
+_teardown
+
+# ---------- TC-12: AC-LOCAL-4 — after migration the legacy path is ENOENT ----------
+echo "TC-12: after migration, legacy path is ENOENT (other sessions early-exit)"
+_setup
+echo '{"active":true,"issue_number":99,"phase":"phaseY","session_id":"33445566-7788-99aa-bbcc-ddeeff001122"}' > "$TEST_ROOT/.rite-flow-state"
+STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
+# At this point the legacy file must NOT exist. Any subsequent reader probing
+# the old path receives ENOENT and falls into its [ ! -f ] early-exit branch.
+_assert "TC-12.legacy-enoent" "$([ ! -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-12.new-format-present" "$([ -f "$TEST_ROOT/.rite/sessions/33445566-7788-99aa-bbcc-ddeeff001122.flow-state" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-13: stdout is empty (only stderr is used for messages) ----------
+echo "TC-13: stdout never contains migration text (caller pipelines stay clean)"
+_setup
+echo '{"active":true,"issue_number":7,"phase":"phaseZ","session_id":"44556677-8899-aabb-ccdd-eeff00112233"}' > "$TEST_ROOT/.rite-flow-state"
+stdout=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>/dev/null)
+_assert "TC-13.stdout-empty" "$([ -z "$stdout" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-15: rollback path — schema_version=1 in config → migration skipped ----------
+echo "TC-15: rollback path (flow_state.schema_version: 1) → silent no-op, legacy untouched"
+_setup
+# Override the v2 config installed by _setup with the rollback config.
+cat > "$TEST_ROOT/rite-config.yml" <<'EOF'
+flow_state:
+  schema_version: 1
+EOF
+echo '{"active":true,"issue_number":42,"phase":"phase5_lint"}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+_assert "TC-15.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-15.no-output" "$([ -z "$out" ] && echo true || echo false)"
+_assert "TC-15.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_assert "TC-15.no-sessions-dir" "$([ ! -d "$TEST_ROOT/.rite/sessions" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-16: missing rite-config.yml → migration skipped (default = legacy) ----------
+echo "TC-16: missing rite-config.yml → silent no-op (default schema_version is 1)"
+_setup
+rm -f "$TEST_ROOT/rite-config.yml"  # remove the v2 config installed by _setup
+echo '{"active":true,"issue_number":99,"phase":"phaseX"}' > "$TEST_ROOT/.rite-flow-state"
+out=$(STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" 2>&1)
+rc=$?
+_assert "TC-16.exit-0" "$([ $rc -eq 0 ] && echo true || echo false)"
+_assert "TC-16.no-output" "$([ -z "$out" ] && echo true || echo false)"
+_assert "TC-16.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
+_teardown
+
+# ---------- TC-14: backup file content equals pre-migration legacy content ----------
+echo "TC-14: backup file content equals legacy content byte-for-byte (rename, not rebuild)"
+_setup
+legacy_payload='{"active":true,"issue_number":11,"phase":"phaseQ","session_id":"55667788-99aa-bbcc-ddee-ff0011223344","custom_field":"do-not-lose-me"}'
+echo "$legacy_payload" > "$TEST_ROOT/.rite-flow-state"
+STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
+backup_glob=("$TEST_ROOT"/.rite-flow-state.legacy.*)
+backup_file="${backup_glob[0]}"
+backup_payload=$(cat "$backup_file")
+_assert "TC-14.backup-equals-legacy" "$([ "$backup_payload" = "$legacy_payload" ] && echo true || echo false)"
+_teardown
+
+# ---------- Summary ----------
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+echo "All migrate-flow-state tests passed!"

--- a/plugins/rite/hooks/tests/migrate-flow-state.test.sh
+++ b/plugins/rite/hooks/tests/migrate-flow-state.test.sh
@@ -319,26 +319,51 @@ else
 fi
 _teardown
 
-# ---------- TC-18: backup file survives session-start.sh find cleanup (#747 cycle 3 CRITICAL) ----------
-# Regression guard: session-start.sh's stale tempfile cleanup uses the glob
-# `.rite-flow-state.??????*` which incidentally matches `.rite-flow-state.legacy.<timestamp>`
-# because `legacy` is exactly 6 chars and `.<timestamp>` is consumed by `*`.
-# Without the `-not -name '.rite-flow-state.legacy.*'` exception, the backup
-# disappears the next time session-start.sh runs after the file is older than
-# 1 minute. This TC simulates that condition by back-dating the backup file
-# and invoking the same find command session-start.sh uses.
-echo "TC-18: backup file survives session-start.sh stale-tempfile cleanup (#747 cycle 3 CRITICAL)"
+# ---------- TC-18: backup file survives session-start/session-end find cleanup (#747 cycle 3 CRITICAL) ----------
+# Regression guard: both session-start.sh and session-end.sh use the glob
+# `.rite-flow-state.??????*` which matches any suffix of 6+ chars — including
+# the migration backup name. Without `-not -name '.rite-flow-state.legacy.*'`,
+# the backup disappears the next time either hook runs after the file ages
+# past `-mmin +1`. This TC verifies (1) the spec backup name does follow the
+# `legacy.*` convention, (2) back-dated backups survive the protected find,
+# (3) the same find without the exception would have deleted the backup
+# (counter-test, defense-in-depth against the exception being removed in
+# future refactors).
+echo "TC-18: backup file survives session-start/end stale-tempfile cleanup (#747 cycle 3/4 CRITICAL)"
 _setup
 echo '{"active":true,"issue_number":2,"phase":"phaseV","session_id":"77889900-aabb-ccdd-eeff-112233445566"}' > "$TEST_ROOT/.rite-flow-state"
 STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
 backup_glob=("$TEST_ROOT"/.rite-flow-state.legacy.*)
 backup_file="${backup_glob[0]}"
 _assert "TC-18.backup-created" "$([ -f "$backup_file" ] && echo true || echo false)"
-# Back-date the backup file by 2 minutes so the `-mmin +1` predicate matches.
-touch -d "2 minutes ago" "$backup_file" 2>/dev/null || touch -t "$(date -d '2 minutes ago' +%Y%m%d%H%M.%S 2>/dev/null || date -v -2M +%Y%m%d%H%M.%S 2>/dev/null)" "$backup_file"
-# Run the same find command session-start.sh uses (with the legacy exception).
+
+# Naming convention guard: the spec assumes the backup contains the literal
+# `legacy.` token so the find exception can target it. If a future refactor
+# changes the naming, this assertion fails before the silent-deletion regression
+# can re-occur.
+_assert "TC-18.backup-name-contains-legacy" "$([[ "$backup_file" == *.rite-flow-state.legacy.* ]] && echo true || echo false)"
+
+# Back-date the backup file by 2 minutes so `-mmin +1` matches. Verify the
+# back-date actually took effect — otherwise the survives-cleanup assertion
+# would be a false positive (file looks fresh, find skips it for an unrelated
+# reason). 3-tier touch fallback: GNU `touch -d`, GNU `date -d`, BSD `date -v`.
+touch -d "2 minutes ago" "$backup_file" 2>/dev/null \
+  || touch -t "$(date -d '2 minutes ago' +%Y%m%d%H%M.%S 2>/dev/null || date -v -2M +%Y%m%d%H%M.%S 2>/dev/null)" "$backup_file" 2>/dev/null
+backup_mtime=$(stat -c '%Y' "$backup_file" 2>/dev/null || stat -f '%m' "$backup_file" 2>/dev/null || echo 0)
+now_epoch=$(date +%s)
+_assert "TC-18.back-date-applied" "$([ $((now_epoch - backup_mtime)) -gt 60 ] && echo true || echo false)"
+
+# (a) Protected find (matches session-start.sh / session-end.sh canonical form): backup MUST survive.
 find "$TEST_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -not -name ".rite-flow-state.legacy.*" -type f -mmin +1 -delete 2>/dev/null || true
-_assert "TC-18.backup-survives-cleanup" "$([ -f "$backup_file" ] && echo true || echo false)"
+_assert "TC-18.backup-survives-protected-cleanup" "$([ -f "$backup_file" ] && echo true || echo false)"
+
+# (b) Counter-test: unprotected find (the exception removed) MUST delete the backup.
+# Defense-in-depth guard: if a future refactor accidentally removes the
+# `-not -name` exception, this counter-test still confirms the regression
+# would have triggered, helping a maintainer understand the protective
+# intent of (a).
+find "$TEST_ROOT" -maxdepth 1 \( -name ".rite-flow-state.tmp.*" -o -name ".rite-flow-state.??????*" \) -type f -mmin +1 -delete 2>/dev/null || true
+_assert "TC-18.backup-deleted-by-unprotected-cleanup" "$([ ! -f "$backup_file" ] && echo true || echo false)"
 _teardown
 
 # ---------- Summary ----------

--- a/plugins/rite/hooks/tests/migrate-flow-state.test.sh
+++ b/plugins/rite/hooks/tests/migrate-flow-state.test.sh
@@ -290,6 +290,18 @@ _assert "TC-16.no-output" "$([ -z "$out" ] && echo true || echo false)"
 _assert "TC-16.legacy-intact" "$([ -f "$TEST_ROOT/.rite-flow-state" ] && echo true || echo false)"
 _teardown
 
+# ---------- TC-14: backup file content equals pre-migration legacy content ----------
+echo "TC-14: backup file content equals legacy content byte-for-byte (rename, not rebuild)"
+_setup
+legacy_payload='{"active":true,"issue_number":11,"phase":"phaseQ","session_id":"55667788-99aa-bbcc-ddee-ff0011223344","custom_field":"do-not-lose-me"}'
+echo "$legacy_payload" > "$TEST_ROOT/.rite-flow-state"
+STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
+backup_glob=("$TEST_ROOT"/.rite-flow-state.legacy.*)
+backup_file="${backup_glob[0]}"
+backup_payload=$(cat "$backup_file")
+_assert "TC-14.backup-equals-legacy" "$([ "$backup_payload" = "$legacy_payload" ] && echo true || echo false)"
+_teardown
+
 # ---------- TC-17: backup file gets chmod 600 (security review MEDIUM, #679) ----------
 echo "TC-17: backup file is chmod'd to 600 after step 4 rename (defense-in-depth)"
 _setup
@@ -305,18 +317,6 @@ if [ -f "${backup_file[0]}" ]; then
 else
   _assert "TC-17.backup-mode-600" "false"
 fi
-_teardown
-
-# ---------- TC-14: backup file content equals pre-migration legacy content ----------
-echo "TC-14: backup file content equals legacy content byte-for-byte (rename, not rebuild)"
-_setup
-legacy_payload='{"active":true,"issue_number":11,"phase":"phaseQ","session_id":"55667788-99aa-bbcc-ddee-ff0011223344","custom_field":"do-not-lose-me"}'
-echo "$legacy_payload" > "$TEST_ROOT/.rite-flow-state"
-STATE_ROOT="$TEST_ROOT" bash "$SCRIPT" >/dev/null 2>&1
-backup_glob=("$TEST_ROOT"/.rite-flow-state.legacy.*)
-backup_file="${backup_glob[0]}"
-backup_payload=$(cat "$backup_file")
-_assert "TC-14.backup-equals-legacy" "$([ "$backup_payload" = "$legacy_payload" ] && echo true || echo false)"
 _teardown
 
 # ---------- Summary ----------


### PR DESCRIPTION
## 概要

旧形式 `.rite-flow-state` (`schema_version` 不在 or `< 2`) を新形式 `.rite/sessions/{session_id}.flow-state` へ自動 migration する機構を実装しました。設計準拠の 5-step rename 方式で、silent skip 禁止 (AC-8) を遵守しています。

## 関連 Issue

Closes #679
親 Issue: #672 (`.rite-flow-state` マルチステート構造再設計、依存先 #678 完了済み)

## 変更内容

### 新規ファイル

#### `plugins/rite/hooks/scripts/migrate-flow-state.sh` (152 行)

5-step rename 方式の migration ロジック:

1. 検出: `.rite-flow-state` 存在 + `schema_version` 欠落 or `< 2`
2. session_id 解決: 旧 state から read、不在なら `_resolve-session-id.sh` 経由でフォーマット検証 → fallback で `uuidgen` / `/proc/sys/kernel/random/uuid` / `python3` で UUID 生成
3. atomic write: `mktemp + mv` で `.rite/sessions/{session_id}.flow-state` に新形式書込 (`schema_version: 2` 強制、12 必須フィールド + optional `wm_comment_id` / `error_count` / `loop_count` 保持)
4. rename: 旧 source → `.rite-flow-state.legacy.{timestamp}` へ atomic mv
5. stderr emit: `[rite] migrated: ... (backup: ...)` を必ず出力 (silent skip 禁止)

その他:
- `--dry-run` mode (検出結果のみ stderr emit、実 file 変更なし)
- step 3/4 失敗時の rollback (新形式 file 削除、旧 source 無傷)
- `rite-config.yml` の `flow_state.schema_version: 2` 設定時のみ動作 (rollback path = `schema_version: 1` を尊重)
- `chmod 700` (`.rite/sessions/`) と `chmod 600` (tempfile) で multi-user host での metadata leak を防止

#### `plugins/rite/hooks/tests/migrate-flow-state.test.sh` (16 TC / 61 assertions)

| TC | カバー範囲 |
|----|----------|
| TC-01 | legacy 不在 → silent no-op |
| TC-02 | schema_version=2 既存 → silent no-op (legacy 無傷) |
| TC-03 | dry-run → 検出 msg のみ、実 file 変更なし |
| TC-04 | full migration (12 フィールド + optional `wm_comment_id` 保持) |
| TC-05 | session_id 不在 → UUID 生成 (RFC 4122 形式) |
| TC-06 | `schema_version: 1` 明示 → migration 実行 |
| TC-07 | invalid JSON → ERROR + legacy 無傷 |
| TC-08 | dry-run + legacy 不在 → silent no-op |
| TC-09 | empty legacy → 削除して exit 0 |
| TC-10 | step 4 (rename) 失敗 → 新 file rollback、legacy 無傷 (AC-LOCAL-2) |
| TC-11 | session-start.sh integration (AC-LOCAL-1) |
| TC-12 | rename 後の legacy path ENOENT (AC-LOCAL-4) |
| TC-13 | stdout 空 (caller pipeline 安全) |
| TC-14 | backup content == legacy content (rename = atomic) |
| TC-15 | `flow_state.schema_version: 1` (rollback) → migration skip |
| TC-16 | rite-config.yml 不在 → migration skip (default = legacy) |

### 変更ファイル

#### `plugins/rite/hooks/session-start.sh` (+12 行)

`STATE_FILE` 解決の直前 (最も早いタイミング) で `migrate-flow-state.sh` を発火:

```bash
_migrate_script="$SCRIPT_DIR/scripts/migrate-flow-state.sh"
if [ -x "$_migrate_script" ]; then
  STATE_ROOT="$STATE_ROOT" bash "$_migrate_script" || true
fi
```

非ブロッキング (`|| true`)。migration 失敗で hook 全体が落ちないようにし、ユーザーは旧形式運用を継続可。

## 設計準拠

`docs/designs/multi-session-state.md` § Migration 戦略 で確定した 5-step rename 方式に完全準拠:

> rename 後の旧 path への参照は ENOENT になり、他 session は標準分岐で early-exit する設計

## Acceptance Criteria

- [x] **AC-8** (Issue #672): silent skip 禁止 — migration 時に stderr に `[rite] migrated: ...` を必ず emit
- [x] **AC-LOCAL-1**: session-start.sh が migration を発火、新形式 file (`schema_version: 2`) と `.legacy.{ts}` backup を生成
- [x] **AC-LOCAL-2**: step 3/4 失敗時、旧 source 無傷 + ERROR メッセージ emit
- [x] **AC-LOCAL-3**: dry-run mode で実 file 変更なし、検出結果のみ stderr
- [x] **AC-LOCAL-4**: rename 後の旧 path ENOENT → 他 session は `[ ! -f "$FLOW_STATE" ]` で early-exit

## テスト結果

- **新規 16 TC / 61 assertions**: 全 pass (`bash plugins/rite/hooks/tests/migrate-flow-state.test.sh`)
- **既存 hook テストスイート**: 私の変更による regression なし。`pre-compact.test.sh` の TC-005a/b 2 件失敗は **develop でも発生する pre-existing failure** で本 PR とは無関係 (verify 済み)
- **新規ファイルへの lint warning**: 0 件 (Phase 3.5 distributed-fix-drift / 3.6 bang-backtick / 3.12 comment-journal / 3.13 comment-line-ref で 0 件)

## Known Issues

なし。

## チェックリスト

- [x] `migrate-flow-state.sh` の実装 (5-step + failure handling)
- [x] `session-start.sh` への migration 発火点組み込み
- [x] dry-run mode の実装
- [x] AC-8 + AC-LOCAL-1〜4 の test 追加
- [x] migration 警告メッセージの文言レビュー (silent skip 禁止の遵守)

## Test plan

- [x] `bash plugins/rite/hooks/tests/migrate-flow-state.test.sh` で 16 TC / 61 assertions pass を確認
- [x] `bash plugins/rite/hooks/tests/run-tests.sh` で全体テスト suite 実行、本 PR による regression なし (pre-existing 2 件のみ)
- [x] `chmod 700/600` permission の確認
- [ ] 実際に旧形式 `.rite-flow-state` (`schema_version` 不在) を pre-place した状態でセッション起動し、自動 migration が走ることを手動確認 (本 PR の dogfooding 対象)

## 後続 Issue

`session-start.sh` の `STATE_FILE` 参照は本 PR では旧 path のまま (migration 後に ENOENT)。新 path への完全 API 移行は #680 (lifecycle hooks) で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
