### PR TITLE
refactor(hooks): #680 lifecycle 4 hooks の自 session state 参照対応

### DIFF
--- a/plugins/rite/hooks/_resolve-flow-state-path.sh
+++ b/plugins/rite/hooks/_resolve-flow-state-path.sh
@@ -8,7 +8,8 @@
 #   - per-session: <state_root>/.rite/sessions/<session_id>.flow-state
 #   - legacy:      <state_root>/.rite-flow-state
 #
-# Resolution rules (mirrors state-read.sh / flow-state-update.sh semantics):
+# Resolution rules (mirrors path-selection rules of state-read.sh / flow-state-update.sh;
+# cross-session classification is the caller's responsibility via session-ownership.sh):
 #   1. schema_version=2 + valid UUID SID + per-session file exists
 #      -> per-session path
 #   2. schema_version=2 + valid UUID SID + per-session absent + legacy exists
@@ -18,6 +19,12 @@
 #      -> per-session path (for fresh writes; writers create the file)
 #   4. schema_version=1 OR missing SID OR invalid UUID
 #      -> legacy path
+#
+# Note: state-read.sh additionally performs cross-session classification
+# (same/empty/foreign/corrupt/invalid_uuid 5-way) to reject reads from another
+# session's state file. This helper does NOT replicate that — lifecycle hooks
+# instead use `check_session_ownership` from session-ownership.sh for the same
+# guarantee. See Cross-session ownership note below.
 #
 # Cross-session ownership checking is the caller's responsibility. This helper
 # resolves the path only. Lifecycle hooks already invoke

--- a/plugins/rite/hooks/_resolve-flow-state-path.sh
+++ b/plugins/rite/hooks/_resolve-flow-state-path.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# rite workflow - Flow-State Path Resolver (private internal helper)
+#
+# Resolves the active flow-state file path for lifecycle hooks
+# (session-start / session-end / pre-compact / post-compact).
+#
+# Returns one of:
+#   - per-session: <state_root>/.rite/sessions/<session_id>.flow-state
+#   - legacy:      <state_root>/.rite-flow-state
+#
+# Resolution rules (mirrors state-read.sh / flow-state-update.sh semantics):
+#   1. schema_version=2 + valid UUID SID + per-session file exists
+#      -> per-session path
+#   2. schema_version=2 + valid UUID SID + per-session absent + legacy exists
+#      -> legacy path (lets the lifecycle hook touch the still-current legacy
+#         file before migration completes)
+#   3. schema_version=2 + valid UUID SID + neither file exists
+#      -> per-session path (for fresh writes; writers create the file)
+#   4. schema_version=1 OR missing SID OR invalid UUID
+#      -> legacy path
+#
+# Cross-session ownership checking is the caller's responsibility. This helper
+# resolves the path only. Lifecycle hooks already invoke
+# `check_session_ownership` (session-ownership.sh) for the "other session"
+# branch, so layering another guard here would duplicate that contract.
+#
+# Why this exists (Issue #680):
+#   The lifecycle 4 hooks each used the same hardcoded `<state_root>/.rite-flow-state`
+#   path, which forces a global single-file lock and breaks the O(1)-per-session
+#   guarantee that schema_version=2 promised. Centralising the resolution here
+#   keeps the four hooks consistent (Wiki #586 — state machine 2-place drift)
+#   while leaving state-read.sh / flow-state-update.sh untouched (Issue #4/#5
+#   handle them).
+#
+# Usage:
+#   STATE_FILE=$(bash plugins/rite/hooks/_resolve-flow-state-path.sh "$STATE_ROOT")
+#
+# Arguments:
+#   $1 state_root  Repository root (typically resolved via state-path-resolve.sh)
+#
+# Exit codes:
+#   0 — success (path printed to stdout)
+#   1 — argument error / helper deploy regression
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Helper deploy fail-fast (mirrors state-read.sh / flow-state-update.sh pattern).
+# Validate only the helpers actually invoked below to avoid pulling in unrelated
+# core helpers (e.g. _resolve-cross-session-guard.sh) that this helper does not use.
+bash "$SCRIPT_DIR/_validate-helpers.sh" "$SCRIPT_DIR" \
+  _resolve-session-id-from-file.sh \
+  _resolve-schema-version.sh \
+  _validate-state-root.sh \
+  || exit $?
+
+STATE_ROOT="${1:-}"
+if [ -z "$STATE_ROOT" ]; then
+  echo "ERROR: usage: $0 <state_root>" >&2
+  exit 1
+fi
+
+# STATE_ROOT path validation (path traversal / shell metacharacters / control
+# characters). Symmetric with _resolve-schema-version.sh / _resolve-session-id-from-file.sh.
+bash "$SCRIPT_DIR/_validate-state-root.sh" "$STATE_ROOT" || exit $?
+
+LEGACY_FILE="$STATE_ROOT/.rite-flow-state"
+
+SCHEMA_VERSION=$(bash "$SCRIPT_DIR/_resolve-schema-version.sh" "$STATE_ROOT")
+SESSION_ID=$(bash "$SCRIPT_DIR/_resolve-session-id-from-file.sh" "$STATE_ROOT")
+
+if [ "$SCHEMA_VERSION" = "2" ] && [ -n "$SESSION_ID" ]; then
+  PER_SESSION_FILE="$STATE_ROOT/.rite/sessions/${SESSION_ID}.flow-state"
+  if [ -f "$PER_SESSION_FILE" ]; then
+    echo "$PER_SESSION_FILE"
+    exit 0
+  fi
+  if [ -f "$LEGACY_FILE" ]; then
+    # Legacy still in place (mid-migration window). Use it; the next write
+    # via flow-state-update.sh will move the content into the per-session file.
+    echo "$LEGACY_FILE"
+    exit 0
+  fi
+  # Neither file exists yet — return the per-session path so writers create
+  # the file there directly.
+  echo "$PER_SESSION_FILE"
+  exit 0
+fi
+
+echo "$LEGACY_FILE"

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -24,7 +24,10 @@ fi
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
 COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+# Resolve active flow-state file path (Issue #680).
+# Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
+FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
+  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
 LOCKDIR="$COMPACT_STATE.lockdir"
 
 # --- Cleanup helper ---

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -27,7 +27,10 @@ fi
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
 COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+# Resolve active flow-state file path (Issue #680).
+# Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
+FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
+  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
 LOCKDIR="$COMPACT_STATE.lockdir"
 
 # --- Cleanup function (covers all temp files) ---

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -28,7 +28,11 @@ fi
 # Resolve state file path using state-path-resolve.sh (consistent with other hooks)
 # SCRIPT_DIR already set in preamble block above
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
-STATE_FILE="$STATE_ROOT/.rite-flow-state"
+
+# Resolve active flow-state file path (Issue #680).
+# Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
+STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
+  || STATE_FILE="$STATE_ROOT/.rite-flow-state"
 
 # Get current branch
 BRANCH=$(cd "$CWD" && git branch --show-current 2>/dev/null || echo "")
@@ -114,6 +118,20 @@ WARN_MSG
         # Intentionally not exit 1 here (unlike pre-compact.sh) — session-end
         # prioritizes cleanup over strict error propagation
         rm -f "$TMP_FILE"
+    fi
+
+    # AC-10 (Issue #680): clean up per-session flow-state file on normal session end.
+    # When schema_version=2 routes state to `.rite/sessions/<sid>.flow-state`, the
+    # file is unique to this session and has no value after the session terminates.
+    # Detection: STATE_FILE matches `*/.rite/sessions/*.flow-state` (the per-session
+    # path returned by `_resolve-flow-state-path.sh`).
+    # Legacy `.rite-flow-state` is intentionally preserved (it may be the only
+    # state file in repos still running schema_version=1, and active=false marks
+    # it as terminated for /rite:resume's recovery flow).
+    # Stale-file cleanup (long-running sessions / crash leftovers) is out of scope
+    # for this Issue per Issue #680 §4.3 (handled by a follow-up).
+    if [[ "$STATE_FILE" == *"/.rite/sessions/"*".flow-state" ]] && [ -f "$STATE_FILE" ]; then
+        rm -f "$STATE_FILE" 2>/dev/null || true
     fi
 fi
 

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -120,9 +120,11 @@ WARN_MSG
         rm -f "$TMP_FILE"
     fi
 
-    # AC-10 (Issue #680): clean up per-session flow-state file on normal session end.
-    # When schema_version=2 routes state to `.rite/sessions/<sid>.flow-state`, the
-    # file is unique to this session and has no value after the session terminates.
+    # AC-10 (Issue #680): clean up per-session flow-state file on session end.
+    # Note: this block also runs after the jq deactivation `else` arm above —
+    # i.e. when the .active=false update failed. The per-session file is unique
+    # to this session, so even a corrupt one has no value post-termination, and
+    # leaving it would only confuse the next session-start defensive reset.
     # Detection: STATE_FILE matches `*/.rite/sessions/*.flow-state` (the per-session
     # path returned by `_resolve-flow-state-path.sh`).
     # Legacy `.rite-flow-state` is intentionally preserved (it may be the only

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -244,7 +244,14 @@ if [ -x "$_migrate_script" ]; then
 fi
 unset _migrate_script
 
-STATE_FILE="$STATE_ROOT/.rite-flow-state"
+# Resolve active flow-state file path (Issue #680).
+# `_resolve-flow-state-path.sh` returns the per-session file
+# (`.rite/sessions/<sid>.flow-state`) when schema_version=2 and a valid
+# session_id is present, otherwise the legacy `.rite-flow-state`. The
+# fallback `|| STATE_FILE=...` keeps the hook non-blocking under helper
+# deploy regression (e.g. chmod -x or partial install).
+STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
+  || STATE_FILE="$STATE_ROOT/.rite-flow-state"
 
 if [ ! -f "$STATE_FILE" ]; then
   # Clean stale compact state on startup/clear when no flow state exists (#756, #800)

--- a/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# Tests for _resolve-flow-state-path.sh
+# Usage: bash plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/../_resolve-flow-state-path.sh"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# Helper: create a per-session test fixture with schema_version=2 + given session_id
+# Args: $1 = test-dir, $2 = session_id (optional, default valid UUID), $3 = create_per_session (true/false)
+make_fixture_v2() {
+  local dir="$1"
+  local sid="${2:-11111111-2222-3333-4444-555555555555}"
+  local create_per="${3:-false}"
+  mkdir -p "$dir"
+  printf '%s' "$sid" > "$dir/.rite-session-id"
+  cat > "$dir/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+  if [ "$create_per" = "true" ]; then
+    mkdir -p "$dir/.rite/sessions"
+    echo '{"active":true}' > "$dir/.rite/sessions/${sid}.flow-state"
+  fi
+}
+
+# Helper: create a v1 (legacy) fixture
+make_fixture_v1() {
+  local dir="$1"
+  mkdir -p "$dir"
+  # No rite-config.yml = schema_version=1 by default
+}
+
+echo "=== _resolve-flow-state-path.sh tests ==="
+echo ""
+
+# --- TC-001: Missing argument → exit 1 ---
+echo "TC-001: Missing argument → exit 1"
+if bash "$HELPER" 2>/dev/null; then
+  fail "Expected exit 1 for missing argument"
+else
+  pass "exit 1 on missing argument"
+fi
+echo ""
+
+# --- TC-002: schema_version=1 (no rite-config.yml) → legacy path ---
+echo "TC-002: No rite-config.yml → legacy path"
+dir002="$TEST_DIR/tc002"
+make_fixture_v1 "$dir002"
+result=$(bash "$HELPER" "$dir002")
+expected="$dir002/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "v1 default → legacy path returned"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-003: schema_version=1 explicit → legacy path ---
+echo "TC-003: Explicit schema_version=1 → legacy path"
+dir003="$TEST_DIR/tc003"
+mkdir -p "$dir003"
+cat > "$dir003/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 1
+EOF
+result=$(bash "$HELPER" "$dir003")
+expected="$dir003/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "v1 explicit → legacy path"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-004: schema_version=2 + valid SID + per-session file exists → per-session ---
+echo "TC-004: v2 + valid SID + per-session present → per-session path"
+dir004="$TEST_DIR/tc004"
+sid004="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+make_fixture_v2 "$dir004" "$sid004" "true"
+result=$(bash "$HELPER" "$dir004")
+expected="$dir004/.rite/sessions/${sid004}.flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "per-session path returned when file exists"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-005: schema_version=2 + valid SID + per-session ABSENT + legacy exists → legacy fallback ---
+echo "TC-005: v2 + valid SID + per-session absent + legacy present → legacy"
+dir005="$TEST_DIR/tc005"
+make_fixture_v2 "$dir005" "" "false"
+echo '{"active":true}' > "$dir005/.rite-flow-state"
+result=$(bash "$HELPER" "$dir005")
+expected="$dir005/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "legacy fallback when per-session absent (mid-migration window)"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-006: schema_version=2 + valid SID + neither file exists → per-session path (for fresh writes) ---
+echo "TC-006: v2 + valid SID + neither file → per-session path (writers create)"
+dir006="$TEST_DIR/tc006"
+sid006="00112233-4455-6677-8899-aabbccddeeff"
+make_fixture_v2 "$dir006" "$sid006" "false"
+result=$(bash "$HELPER" "$dir006")
+expected="$dir006/.rite/sessions/${sid006}.flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "per-session path returned for fresh writes (file absent)"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-007: schema_version=2 + invalid SID (non-UUID) → legacy path ---
+echo "TC-007: v2 + invalid SID → legacy fallback"
+dir007="$TEST_DIR/tc007"
+mkdir -p "$dir007"
+echo "not-a-uuid" > "$dir007/.rite-session-id"
+cat > "$dir007/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+result=$(bash "$HELPER" "$dir007")
+expected="$dir007/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "legacy fallback on invalid SID (non-UUID)"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-008: schema_version=2 + missing .rite-session-id → legacy path ---
+echo "TC-008: v2 + no .rite-session-id → legacy fallback"
+dir008="$TEST_DIR/tc008"
+mkdir -p "$dir008"
+cat > "$dir008/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+# No .rite-session-id file
+result=$(bash "$HELPER" "$dir008")
+expected="$dir008/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "legacy fallback when .rite-session-id missing"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-009: schema_version=2 + empty .rite-session-id → legacy path ---
+echo "TC-009: v2 + empty .rite-session-id → legacy fallback"
+dir009="$TEST_DIR/tc009"
+mkdir -p "$dir009"
+echo "" > "$dir009/.rite-session-id"
+cat > "$dir009/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+result=$(bash "$HELPER" "$dir009")
+expected="$dir009/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "legacy fallback when .rite-session-id empty"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-010: STATE_ROOT path traversal attempt → rejected by _validate-state-root.sh ---
+echo "TC-010: Path traversal STATE_ROOT → rejected"
+if bash "$HELPER" "../../etc" 2>/dev/null; then
+  fail "Path traversal should be rejected"
+else
+  pass "Path traversal rejected"
+fi
+echo ""
+
+# --- TC-011: schema_version=2 + invalid value (e.g., "abc") → defaults to legacy ---
+echo "TC-011: schema_version=invalid → legacy fallback"
+dir011="$TEST_DIR/tc011"
+mkdir -p "$dir011"
+sid011="aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+echo "$sid011" > "$dir011/.rite-session-id"
+cat > "$dir011/rite-config.yml" <<EOF
+flow_state:
+  schema_version: abc
+EOF
+result=$(bash "$HELPER" "$dir011")
+expected="$dir011/.rite-flow-state"
+if [ "$result" = "$expected" ]; then
+  pass "Invalid schema_version → legacy"
+else
+  fail "Expected '$expected', got '$result'"
+fi
+echo ""
+
+# --- TC-012: Stable output (idempotent) — calling twice returns identical path ---
+echo "TC-012: Idempotent output (called twice)"
+dir012="$TEST_DIR/tc012"
+sid012="12121212-3434-3434-5656-787878787878"
+make_fixture_v2 "$dir012" "$sid012" "true"
+r1=$(bash "$HELPER" "$dir012")
+r2=$(bash "$HELPER" "$dir012")
+if [ "$r1" = "$r2" ]; then
+  pass "Idempotent: identical output across calls"
+else
+  fail "Output diverged: '$r1' vs '$r2'"
+fi
+echo ""
+
+# --- Summary ---
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ $FAIL -eq 0 ]

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -130,6 +130,62 @@ else
   fail "unexpected stdout: $OUTPUT"
 fi
 
+# --- TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true + recovering → recovery output ---
+# Verifies post-compact reads & writes the per-session file (not legacy) when
+# schema_version=2 + valid SID + per-session file exists, and that the
+# `.active=true` precondition path still triggers recovery.
+echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session + recovering → auto-recovery from per-session file"
+TC_DIR=$(setup_test "tc680a")
+sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
+mkdir -p "$TC_DIR/.rite/sessions"
+echo "$sid680a" > "$TC_DIR/.rite-session-id"
+cat > "$TC_DIR/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+per_session_file="$TC_DIR/.rite/sessions/${sid680a}.flow-state"
+jq -n '{active: true, issue_number: 680, phase: "phase5_review", next_action: "review", loop_count: 0, pr_number: 0, branch: "refactor/issue-680-test", session_id: "'"$sid680a"'"}' > "$per_session_file"
+jq -n '{compact_state: "recovering", compact_state_set_at: "2026-04-30T12:00:00Z", active_issue: 680}' > "$TC_DIR/.rite-compact-state"
+
+OUTPUT=$(echo '{"cwd": "'"$TC_DIR"'", "source": "auto"}' | bash "$HOOK" 2>/dev/null) || true
+if echo "$OUTPUT" | grep -q "Auto-compact recovery" && echo "$OUTPUT" | grep -q "Issue #680"; then
+  pass "TC-680-A: recovery output read from per-session file (.active=true preserved)"
+else
+  fail "TC-680-A: expected Auto-compact recovery for Issue #680 from per-session, got: $OUTPUT"
+fi
+# Counter-assertion: compact_state transitioned to normal
+cs_state=$(jq -r '.compact_state' "$TC_DIR/.rite-compact-state" 2>/dev/null)
+if [ "$cs_state" = "normal" ]; then
+  pass "TC-680-A: compact_state transitioned to normal after per-session recovery"
+else
+  fail "TC-680-A: compact_state expected 'normal', got '$cs_state'"
+fi
+
+# --- TC-680-B (Issue #680): per-session active=false + recovering → cleanup ---
+echo "TC-680-B (Issue #680): per-session active=false → cleanup (no recovery)"
+TC_DIR=$(setup_test "tc680b")
+sid680b="22222222-3333-4444-5555-666666666666"
+mkdir -p "$TC_DIR/.rite/sessions"
+echo "$sid680b" > "$TC_DIR/.rite-session-id"
+cat > "$TC_DIR/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+jq -n '{active: false, issue_number: 681}' > "$TC_DIR/.rite/sessions/${sid680b}.flow-state"
+jq -n '{compact_state: "recovering"}' > "$TC_DIR/.rite-compact-state"
+
+OUTPUT=$(echo '{"cwd": "'"$TC_DIR"'", "source": "auto"}' | bash "$HOOK" 2>/dev/null) || true
+if [ -z "$OUTPUT" ]; then
+  pass "TC-680-B: per-session active=false → no recovery output (silent exit)"
+else
+  fail "TC-680-B: expected silent exit on active=false, got: $OUTPUT"
+fi
+if [ ! -f "$TC_DIR/.rite-compact-state" ]; then
+  pass "TC-680-B: compact_state cleaned up on per-session inactive flow"
+else
+  fail "TC-680-B: compact_state not cleaned up"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -546,6 +546,42 @@ else
 fi
 echo ""
 
+# --- TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → updated_at touched ---
+# Verifies pre-compact reads & writes the per-session file (not legacy) when
+# schema_version=2 + valid SID + per-session file exists. Also confirms the
+# `.active=true` precondition path still fires the workflow-active branch.
+echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → updated_at touched"
+dir680a="$TEST_DIR/tc680a"
+mkdir -p "$dir680a/.rite/sessions"
+sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
+echo "$sid680a" > "$dir680a/.rite-session-id"
+cat > "$dir680a/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+per_session_file="$dir680a/.rite/sessions/${sid680a}.flow-state"
+echo '{"active": true, "phase": "phase5_review", "issue_number": 680, "branch": "refactor/issue-680-test", "updated_at": "2020-01-01T00:00:00+00:00"}' \
+  > "$per_session_file"
+old_ts=$(jq -r '.updated_at' "$per_session_file" 2>/dev/null)
+output=$(run_hook "$dir680a") && rc=0 || rc=$?
+if [ $rc -eq 0 ] && [ -f "$per_session_file" ]; then
+  new_ts=$(jq -r '.updated_at' "$per_session_file" 2>/dev/null)
+  if [ "$new_ts" != "$old_ts" ] && [ -n "$new_ts" ]; then
+    pass "TC-680-A: per-session file updated_at refreshed (per-session resolution working)"
+  else
+    fail "TC-680-A: per-session updated_at not refreshed (old=$old_ts new=$new_ts)"
+  fi
+else
+  fail "TC-680-A: hook exited non-zero or per-session file missing (rc=$rc)"
+fi
+# Counter-assertion: workflow-active stdout fired (.active=true precondition)
+if echo "$output" | grep -q "STOP. Compact detected. Issue #680"; then
+  pass "TC-680-A: workflow-active stdout fired on per-session path (.active=true preserved)"
+else
+  fail "TC-680-A: workflow-active stdout missing — .active=true precondition broke on per-session path"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -409,6 +409,79 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-680-A (Issue #680, AC-10): per-session flow-state file is removed on session end
+# --------------------------------------------------------------------------
+echo "TC-680-A (Issue #680, AC-10): per-session file → cleanup on session end"
+dir680a="$TEST_DIR/tc680a"
+mkdir -p "$dir680a/.rite/sessions"
+sid680a="abcdef01-2345-6789-abcd-ef0123456789"
+echo "$sid680a" > "$dir680a/.rite-session-id"
+cat > "$dir680a/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+per_session_file="$dir680a/.rite/sessions/${sid680a}.flow-state"
+echo '{"active": true, "phase": "phase5_review", "issue_number": 680, "branch": "refactor/issue-680-test"}' > "$per_session_file"
+run_hook "$dir680a" >/dev/null || true
+if [ ! -f "$per_session_file" ]; then
+  pass "TC-680-A: per-session file removed after session-end (AC-10)"
+else
+  fail "TC-680-A: per-session file not removed (still at $per_session_file)"
+fi
+# Counter-assertion: legacy file (which never existed) was not created
+if [ ! -f "$dir680a/.rite-flow-state" ]; then
+  pass "TC-680-A: legacy file not created (no leakage to legacy path)"
+else
+  fail "TC-680-A: legacy file unexpectedly created"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-680-B (Issue #680): legacy flow-state file is preserved (NOT deleted) on session end
+# --------------------------------------------------------------------------
+echo "TC-680-B (Issue #680): legacy file → preserved (active=false marker only)"
+dir680b="$TEST_DIR/tc680b"
+mkdir -p "$dir680b"
+# No rite-config.yml → schema_version=1 (legacy mode)
+create_state_file "$dir680b" '{"active": true, "phase": "phase5_review", "issue_number": 681}'
+run_hook "$dir680b" >/dev/null || true
+if [ -f "$dir680b/.rite-flow-state" ]; then
+  active_after=$(jq -r '.active' "$dir680b/.rite-flow-state" 2>/dev/null)
+  if [ "$active_after" = "false" ]; then
+    pass "TC-680-B: legacy file preserved with active=false (backward compat)"
+  else
+    fail "TC-680-B: legacy file present but active=$active_after (expected false)"
+  fi
+else
+  fail "TC-680-B: legacy file unexpectedly removed (would break v1 backward compat)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-680-C (Issue #680, AC-LOCAL-2): .active=true precondition preserved on per-session path
+# Defense-in-depth: ensure jq -r '.active' / `_state_active=...` paths still
+# fire correctly when the resolved STATE_FILE is per-session, not legacy.
+# --------------------------------------------------------------------------
+echo "TC-680-C (Issue #680, AC-LOCAL-2): per-session active=true → lifecycle warning fires"
+dir680c="$TEST_DIR/tc680c"
+mkdir -p "$dir680c/.rite/sessions"
+sid680c="11111111-2222-3333-4444-555555555555"
+echo "$sid680c" > "$dir680c/.rite-session-id"
+cat > "$dir680c/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+echo '{"active": true, "phase": "create_interview", "issue_number": 682, "branch": "feat/issue-682"}' \
+  > "$dir680c/.rite/sessions/${sid680c}.flow-state"
+run_hook "$dir680c" >/dev/null || true
+if [ -f "${LAST_STDERR_FILE:-}" ] && grep -q "/rite:issue:create lifecycle was not completed" "$LAST_STDERR_FILE"; then
+  pass "TC-680-C: .active=true precondition fires lifecycle warning on per-session path (AND-logic preserved)"
+else
+  fail "TC-680-C: lifecycle warning missing — .active=true precondition broke on per-session path"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -764,6 +764,60 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → "Active rite workflow detected"
+# Verifies that session-start reads the per-session file (not legacy) when
+# schema_version=2 + valid SID + per-session file exists, and that the
+# `.active=true` precondition still fires the workflow-detected output.
+# --------------------------------------------------------------------------
+echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → workflow detected"
+dir680a="$TEST_DIR/tc680a"
+mkdir -p "$dir680a/.rite/sessions"
+sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
+echo "$sid680a" > "$dir680a/.rite-session-id"
+cat > "$dir680a/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+ts_t680a=$(iso8601_now 0)
+cat > "$dir680a/.rite/sessions/${sid680a}.flow-state" <<EOF
+{"active": true, "issue_number": 680, "branch": "refactor/issue-680-test", "phase": "phase5_review", "next_action": "review", "loop_count": 0, "session_id": "$sid680a", "updated_at": "$ts_t680a"}
+EOF
+output=$(run_hook_with_session "$dir680a" "resume" "$sid680a") && rc=0 || rc=$?
+if [ $rc -eq 0 ] && echo "$output" | grep -q "Active rite workflow detected" \
+   && echo "$output" | grep -q "Issue: #680"; then
+  pass "TC-680-A: per-session file read → 'Active rite workflow detected' fired (AC-LOCAL-2)"
+else
+  fail "TC-680-A: expected workflow-detected output from per-session file; got rc=$rc, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-680-B (Issue #680): per-session active=false → no workflow-detected output
+# Counter-assertion: ensure the .active=false branch on per-session path
+# does NOT trigger the workflow-detected output (AND-logic precondition).
+# --------------------------------------------------------------------------
+echo "TC-680-B (Issue #680): per-session active=false → no detection (AND-logic preserved)"
+dir680b="$TEST_DIR/tc680b"
+mkdir -p "$dir680b/.rite/sessions"
+sid680b="22222222-3333-4444-5555-666666666666"
+echo "$sid680b" > "$dir680b/.rite-session-id"
+cat > "$dir680b/rite-config.yml" <<EOF
+flow_state:
+  schema_version: 2
+EOF
+ts_t680b=$(iso8601_now 0)
+cat > "$dir680b/.rite/sessions/${sid680b}.flow-state" <<EOF
+{"active": false, "issue_number": 681, "branch": "refactor/issue-681-test", "phase": "completed", "session_id": "$sid680b", "updated_at": "$ts_t680b"}
+EOF
+output=$(run_hook_with_session "$dir680b" "resume" "$sid680b") && rc=0 || rc=$?
+if [ $rc -eq 0 ] && [ -z "$output" ]; then
+  pass "TC-680-B: per-session active=false → no detection output (silent exit)"
+else
+  fail "TC-680-B: expected silent exit; got rc=$rc, output='$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Summary

- lifecycle 系 4 hooks (`session-start.sh` / `session-end.sh` / `pre-compact.sh` / `post-compact.sh`) の `.rite-flow-state` 参照を新 helper `_resolve-flow-state-path.sh` 経由に切替
- session 数増加に対して O(1) を実現（schema_version=2 + 有効 SID なら自 session の `.rite/sessions/{sid}.flow-state` を参照、それ以外は legacy fallback）
- AC-10: session 正常終了時に per-session file を削除する cleanup ロジックを `session-end.sh` に追加
- Wiki #660 の `.active=true` 前提を AND 論理で保全（per-session 経路でも jq 経由で同一 key を参照するため挙動不変）

## 関連 Issue

Closes #680
親 Issue: #672

## 変更ファイル

### 新規

- `plugins/rite/hooks/_resolve-flow-state-path.sh`: 共通 resolver helper (純粋関数、lifecycle 4 hooks 専用)
- `plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh`: helper 単体テスト (12 TC)

### 修正

- `plugins/rite/hooks/session-start.sh`: STATE_FILE 解決を helper 経由に
- `plugins/rite/hooks/session-end.sh`: STATE_FILE 解決を helper 経由 + AC-10 cleanup ロジック追加
- `plugins/rite/hooks/pre-compact.sh`: FLOW_STATE 解決を helper 経由に
- `plugins/rite/hooks/post-compact.sh`: FLOW_STATE 解決を helper 経由に
- `plugins/rite/hooks/tests/{session-start,session-end,pre-compact,post-compact}.test.sh`: schema_version=2 + per-session 経路 TC + AC-10 cleanup TC を追加

## 検証

| Test | Before | After | Δ |
|------|--------|-------|---|
| `_resolve-flow-state-path.test.sh` (新規) | – | 12 PASS | +12 |
| `session-start.test.sh` | 33 PASS | 35 PASS | +2 |
| `session-end.test.sh` | 20 PASS | 24 PASS | +4 |
| `pre-compact.test.sh` | 18 PASS / 2 FAIL | 20 PASS / 2 FAIL | +2 (失敗は既存問題、本 PR とは無関係) |
| `post-compact.test.sh` | 10 PASS | 14 PASS | +4 |

合計 105 PASS / 2 FAIL（2 件は develop 同じく失敗する pre-existing issue で本 PR で touch していない）

## Acceptance Criteria 充足

| AC | 充足 | 検証手段 |
|----|------|---------|
| AC-2 (単独運用 non-regression) | ✅ | 既存テスト全 pass、追加 TC で legacy 経路の互換性確認 |
| AC-7 (Session Ownership 系再検証) | ✅ | session-start TC-T01〜T05 / session-end TC-680-C で確認 |
| AC-10 (正常終了時 cleanup) | ✅ | session-end TC-680-A で per-session file 削除を確認 |
| AC-LOCAL-1 (既存 hooks/tests pass) | ✅ | 4 hook + helper test 合計 105 PASS（既存 2 失敗は本 PR と無関係） |
| AC-LOCAL-2 (`.active=true` 前提保全) | ✅ | 各 hook の TC-680-A/B/C で AND 論理経路を再検証 |

## 設計判断・決定事項

### 1. 新 helper 抽出 (vs 4 hook で inline)

Wiki 経験則 #586「state machine を 2 箇所で記述する場合は同期」を踏まえ、4 hook で同一 resolution ロジックを 4 重複させる代わりに新 helper 1 箇所で宣言。drift リスクを構造的に解消。

### 2. flow-state-update.sh / state-read.sh への helper 集約は本 Issue 対象外

これらにも独自の resolution ロジックがあるが、Issue body の Out スコープに従い touch しない (Issue #4/#5 で扱う)。3 箇所の resolution 重複は認識しているが、既存テストの drift リスクを避けるため本 PR では現状維持。

### 3. AC-10 cleanup の trigger 条件

`STATE_FILE` が `.rite/sessions/UUID.flow-state` パターンに一致する場合のみ削除。legacy `.rite-flow-state` は backward compat のため保持し、`.active=false` でマークするのみ (旧形式運用 repo の resume 機能を壊さない)。stale file 検出 (long-running / crash) は本 Issue 対象外 (Issue body 4.3 明記)。

### 4. find glob collision 回避 (Wiki PR #747 経験則)

新 cleanup の対象パス `.rite/sessions/UUID.flow-state` は既存 cleanup glob `.rite-flow-state.??????*` (session-start/end の find -maxdepth 1) と衝突しない（プレフィックス相違 + ディレクトリスコープ相違）。

## Known Issues

- `pre-compact.test.sh` TC-005 / TC-005b: develop ブランチでも同様に失敗する既存の問題。本 PR では touch していない（独立に修正されるべき別 Issue 候補）
- 既存 lint warnings (drift check 32 / bang-backtick 4 / comment-journal 228 / comment-line-ref 21): 本 PR で新規導入したものなし（develop 同等）

## Test plan

- [ ] CI で lint がスキップ (commands.lint=null) された状態で全 plugin-specific check が pass することを確認
- [ ] schema_version=2 + valid SID の経路で 4 hook の test が pass することを確認
- [ ] schema_version=1 (legacy) の経路で既存 TC が non-regression であることを確認
- [ ] session-end.sh の AC-10 cleanup ロジックが per-session file を削除すること、legacy file を保持することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
