### PR TITLE
refactor(hooks): #681 tool 系 2 hooks + session-ownership helper の自 session state 参照対応

### DIFF
--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -27,7 +27,14 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 # SCRIPT_DIR already set in preamble block above
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+# Per-session state path resolution (Issue #681): _resolve-flow-state-path.sh
+# returns the per-session file (`<root>/.rite/sessions/<session_id>.flow-state`)
+# when schema_version=2 with a valid SID, or the legacy `.rite-flow-state` path
+# otherwise. The atomic write below (last_synced_phase update) targets whichever
+# file the resolver returns, preserving per-session isolation under schema 2 and
+# falling back to the single-file lock under schema 1.
+FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
+  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
 [ -f "$FLOW_STATE" ] || exit 0
 
 # cycle 12 HIGH F-01: unit separator \x1f に変更 (POSIX whitespace IFS collapse bug、

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -33,8 +33,16 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 # otherwise. The atomic write below (last_synced_phase update) targets whichever
 # file the resolver returns, preserving per-session isolation under schema 2 and
 # falling back to the single-file lock under schema 1.
-FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
-  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null); then
+  :
+else
+  # Resolver failed (helper deploy regression / path validation rejection).
+  # stderr was suppressed above to keep the hook silent in the common case;
+  # surface the failure under RITE_DEBUG so deploy regressions are observable.
+  [ -n "${RITE_DEBUG:-}" ] && echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] post-tool-wm-sync: _resolve-flow-state-path.sh failed, falling back to legacy path" \
+    >> "$STATE_ROOT/.rite-flow-debug.log" 2>/dev/null || true
+  FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+fi
 [ -f "$FLOW_STATE" ] || exit 0
 
 # cycle 12 HIGH F-01: unit separator \x1f に変更 (POSIX whitespace IFS collapse bug、
@@ -48,7 +56,15 @@ _flow_data=$(jq -r '[(.active // false | tostring), (.issue_number // "" | tostr
 IFS=$'\x1f' read -r _active issue_number _phase _last_synced_phase <<< "$_flow_data"
 [ "$_active" = "true" ] || exit 0
 [ -n "$issue_number" ] || exit 0
-# Session ownership check (#173): skip sync for other session's state
+# Session ownership check (#173): skip sync for other session's state.
+#
+# Note (Issue #681 F-04): under schema_version=2 with a per-session $FLOW_STATE,
+# `check_session_ownership` returns "own" via its schema-2 fast-path without
+# invoking jq, so the failure path is structurally absent and the
+# `|| _ownership="own"` defensive default is dead code in that branch. The
+# fallback remains active for schema_version=1 (legacy single-file path),
+# where extract_session_id / get_state_session_id may fail under
+# environmental issues (jq error, IO error). Keep both branches.
 _ownership=$(check_session_ownership "$INPUT" "$FLOW_STATE" 2>/dev/null) || _ownership="own"
 [ "$_ownership" != "other" ] || exit 0
 # Defense-in-depth: don't recreate WM for completed workflows (#776)

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -172,8 +172,16 @@ if [ -z "$BLOCKED_PATTERN" ]; then
     # State file lookup: if $STATE_ROOT_PATH is empty (e.g., CWD outside git repo and
     # state-path-resolve.sh failed), skip the check entirely — no state file means no
     # create lifecycle to enforce, which is the documented "allow" path.
+    #
+    # Per-session state path resolution (Issue #681): _resolve-flow-state-path.sh
+    # returns the per-session file (`<root>/.rite/sessions/<session_id>.flow-state`)
+    # when schema_version=2 with a valid SID, or the legacy `.rite-flow-state` path
+    # otherwise. This keeps Pattern 5 working under both schemas without inlining
+    # schema/SID resolution here. Mode B AND-logic (.active=true && phase=create_*)
+    # below operates on whichever file the resolver returns.
     if [ -n "$STATE_ROOT_PATH" ]; then
-      STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
+      STATE_FILE_PATH=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT_PATH" 2>/dev/null) \
+        || STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
       if [ -f "$STATE_FILE_PATH" ]; then
         STATE_PHASE=$(jq -r '.phase // empty' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PHASE=""
         STATE_ACTIVE=$(jq -r '.active // false' "$STATE_FILE_PATH" 2>/dev/null) || STATE_ACTIVE="false"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -180,8 +180,17 @@ if [ -z "$BLOCKED_PATTERN" ]; then
     # schema/SID resolution here. Mode B AND-logic (.active=true && phase=create_*)
     # below operates on whichever file the resolver returns.
     if [ -n "$STATE_ROOT_PATH" ]; then
-      STATE_FILE_PATH=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT_PATH" 2>/dev/null) \
-        || STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
+      if STATE_FILE_PATH=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT_PATH" 2>/dev/null); then
+        :
+      else
+        # Resolver failed (helper deploy regression / path validation rejection).
+        # Surface the failure under RITE_DEBUG so deploy regressions are observable
+        # — the legacy fallback would otherwise let Mode B AND-logic operate on the
+        # wrong state file silently when schema_version=2 is configured (Issue #681 F-01).
+        [ -n "${RITE_DEBUG:-}" ] && echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] pre-tool-bash-guard: _resolve-flow-state-path.sh failed, falling back to legacy path" \
+          >> "$STATE_ROOT_PATH/.rite-flow-debug.log" 2>/dev/null || true
+        STATE_FILE_PATH="${STATE_ROOT_PATH}/.rite-flow-state"
+      fi
       if [ -f "$STATE_FILE_PATH" ]; then
         STATE_PHASE=$(jq -r '.phase // empty' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PHASE=""
         STATE_ACTIVE=$(jq -r '.active // false' "$STATE_FILE_PATH" 2>/dev/null) || STATE_ACTIVE="false"

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -6,6 +6,7 @@
 # Functions:
 #   extract_session_id <hook_json>  - Extract session_id from hook JSON payload
 #   get_state_session_id <file>     - Get session_id from .rite-flow-state
+#   is_per_session_state_file <path> - Detect per-session file structure (schema 2)
 #   check_session_ownership <hook_json> <state_file> - Check if state belongs to current session
 #   parse_iso8601_to_epoch <timestamp> - Convert ISO 8601 timestamp to epoch seconds
 #
@@ -13,6 +14,17 @@
 #   source "$SCRIPT_DIR/session-ownership.sh"
 #   ownership=$(check_session_ownership "$INPUT" "$STATE_FILE")
 #   # ownership: "own" | "legacy" | "other" | "stale"
+#
+# Role transition (Issue #681): With schema_version=2 (per-session files),
+# session ownership is structurally guaranteed by the session_id encoded in
+# the filename — the resolver (`_resolve-flow-state-path.sh`) only returns
+# a per-session path that matches the current session. `check_session_ownership`
+# therefore uses a fast-path "own" classification when the path matches the
+# `*/.rite/sessions/*.flow-state` pattern, falling through to the legacy
+# 4-state classification only for `<root>/.rite-flow-state` (schema 1).
+# `is_per_session_state_file` exposes the same predicate to callers that want
+# to short-circuit ownership checks (e.g., when reading a path that has just
+# been resolved by `_resolve-flow-state-path.sh`).
 
 # Extract session_id from hook JSON payload
 # Args: $1 = hook JSON string (from stdin of the hook)
@@ -38,6 +50,27 @@ get_state_session_id() {
   echo "$sid"
 }
 
+# Detect whether a state file path follows the per-session structure (schema 2).
+# Args: $1 = state file path
+# Returns: 0 (true) if path matches `*/.rite/sessions/*.flow-state`, 1 otherwise.
+# Exit code: 0 or 1 (boolean — usable in `if is_per_session_state_file ...`)
+#
+# Why this exists (Issue #681): With schema_version=2 the resolver
+# (`_resolve-flow-state-path.sh`) only returns a per-session path whose session_id
+# segment matches the current session, so the file is structurally owned by
+# this session and the 4-state legacy classification is unnecessary. Callers
+# that already hold a resolver output can use this predicate to short-circuit
+# `check_session_ownership` entirely; `check_session_ownership` itself uses
+# the same predicate as a fast-path before falling through to the legacy
+# logic for the schema-1 `<root>/.rite-flow-state` single-file form.
+is_per_session_state_file() {
+  local state_file="$1"
+  case "$state_file" in
+    */.rite/sessions/*.flow-state) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Check session ownership of .rite-flow-state
 # Args: $1 = hook JSON string, $2 = path to .rite-flow-state
 # Output: "own" (same session), "legacy" (no session_id in state),
@@ -46,15 +79,30 @@ get_state_session_id() {
 # Exit code: always 0
 #
 # Decision matrix:
-#   hook session_id empty  → "own" (backward compat: can't determine, assume own)
-#   state session_id empty → "legacy" (pre-session-ownership state, treat as own)
-#   hook == state          → "own"
+#   path is per-session file → "own" (structural guarantee, schema 2 fast-path)
+#   hook session_id empty    → "own" (backward compat: can't determine, assume own)
+#   state session_id empty   → "legacy" (pre-session-ownership state, treat as own)
+#   hook == state            → "own"
 #   hook != state:
-#     updated_at > 2h ago  → "stale" (safe to overwrite)
-#     updated_at <= 2h ago → "other" (active session, do not overwrite)
+#     updated_at > 2h ago    → "stale" (safe to overwrite)
+#     updated_at <= 2h ago   → "other" (active session, do not overwrite)
+#
+# Issue #681: the per-session fast-path replaces the schema-2 portion of the
+# legacy 4-state classification with a structural check. The remaining branches
+# preserve schema-1 behavior unchanged so lifecycle hooks (#680) and pre-compact
+# that depend on "legacy"/"other"/"stale" outputs continue to work.
 check_session_ownership() {
   local hook_json="$1"
   local state_file="$2"
+
+  # Schema-2 fast-path: per-session file structure encodes ownership in the
+  # filename. The resolver only returns a per-session path that matches the
+  # current session, so any caller passing such a path is reading its own
+  # state by construction.
+  if is_per_session_state_file "$state_file"; then
+    echo "own"
+    return 0
+  fi
 
   local hook_sid
   hook_sid=$(extract_session_id "$hook_json")

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -95,17 +95,31 @@ check_session_ownership() {
   local hook_json="$1"
   local state_file="$2"
 
+  local hook_sid
+  hook_sid=$(extract_session_id "$hook_json")
+
   # Schema-2 fast-path: per-session file structure encodes ownership in the
   # filename. The resolver only returns a per-session path that matches the
-  # current session, so any caller passing such a path is reading its own
-  # state by construction.
+  # current session by construction, so the typical caller passing such a
+  # path is reading its own state. As defense-in-depth (review #681 F-02),
+  # when the hook payload provides a session_id, verify that the filename's
+  # session_id segment matches it. This prevents a future caller bypassing
+  # the resolver and silently passing a foreign per-session file from being
+  # classified as "own".
   if is_per_session_state_file "$state_file"; then
+    if [ -n "$hook_sid" ]; then
+      local fname_sid
+      fname_sid=$(basename "$state_file" .flow-state)
+      if [ "$hook_sid" != "$fname_sid" ]; then
+        # Foreign per-session file passed by a non-resolver caller —
+        # treat the same as legacy "other" (different session, fresh).
+        echo "other"
+        return 0
+      fi
+    fi
     echo "own"
     return 0
   fi
-
-  local hook_sid
-  hook_sid=$(extract_session_id "$hook_json")
 
   # If we can't determine our own session_id, assume ownership (backward compat)
   if [ -z "$hook_sid" ]; then

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -207,6 +207,77 @@ else
 fi
 echo ""
 
+# --- TC-PER-SESSION-1: per-session state file (Issue #681) → phase diff detection works ---
+# Verifies _resolve-flow-state-path.sh integration: when schema_version=2 with a valid SID
+# and a per-session file exists, the hook reads from `.rite/sessions/<sid>.flow-state`
+# (not the legacy `.rite-flow-state`). Phase diff detection must still work end-to-end.
+echo "TC-PER-SESSION-1: per-session state file → phase diff detected"
+dir_ps="$TEST_DIR/tc_per_session"
+mkdir -p "$dir_ps/.rite-work-memory" "$dir_ps/.rite/sessions"
+echo "existing wm" > "$dir_ps/.rite-work-memory/issue-42.md"
+cat > "$dir_ps/rite-config.yml" <<'CFG_EOF'
+flow_state:
+  schema_version: 2
+CFG_EOF
+sid_ps="00000000-0000-4000-8000-000000000042"
+printf '%s' "$sid_ps" > "$dir_ps/.rite-session-id"
+cat > "$dir_ps/.rite/sessions/${sid_ps}.flow-state" <<STATE_EOF
+{
+  "schema_version": 2,
+  "active": true,
+  "issue_number": 42,
+  "phase": "phase3_plan",
+  "last_synced_phase": "phase2_post_work_memory",
+  "session_id": "$sid_ps",
+  "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+}
+STATE_EOF
+# Intentionally do NOT create the legacy `.rite-flow-state` — the resolver must
+# pick the per-session path when schema_version=2 + valid SID + per-session file exists.
+export RITE_DEBUG=1
+run_hook "$dir_ps" || true
+unset RITE_DEBUG
+if [ -f "$dir_ps/.rite-flow-debug.log" ] && grep -q "phase changed:" "$dir_ps/.rite-flow-debug.log" 2>/dev/null; then
+  pass "Phase change detected via per-session state file (schema 2)"
+else
+  fail "Phase change not detected when reading from per-session state file"
+fi
+echo ""
+
+# TC-PER-SESSION-2: per-session state, last_synced_phase update writes to per-session file
+echo "TC-PER-SESSION-2: per-session state → last_synced_phase atomic write targets per-session path"
+dir_ps2="$TEST_DIR/tc_per_session_2"
+mkdir -p "$dir_ps2/.rite-work-memory" "$dir_ps2/.rite/sessions"
+echo "existing wm" > "$dir_ps2/.rite-work-memory/issue-42.md"
+cat > "$dir_ps2/rite-config.yml" <<'CFG_EOF'
+flow_state:
+  schema_version: 2
+CFG_EOF
+sid_ps2="00000000-0000-4000-8000-000000000043"
+printf '%s' "$sid_ps2" > "$dir_ps2/.rite-session-id"
+ps2_state="$dir_ps2/.rite/sessions/${sid_ps2}.flow-state"
+cat > "$ps2_state" <<STATE_EOF
+{
+  "schema_version": 2,
+  "active": true,
+  "issue_number": 42,
+  "phase": "phase5_post_lint",
+  "last_synced_phase": "phase5_lint",
+  "session_id": "$sid_ps2",
+  "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+}
+STATE_EOF
+run_hook "$dir_ps2" || true
+# After the hook, last_synced_phase in the per-session file should be updated to phase5_post_lint.
+updated_lsp=$(jq -r '.last_synced_phase // empty' "$ps2_state" 2>/dev/null)
+# Legacy .rite-flow-state must NOT have been created (per-session resolver was used).
+if [ "$updated_lsp" = "phase5_post_lint" ] && [ ! -f "$dir_ps2/.rite-flow-state" ]; then
+  pass "last_synced_phase updated in per-session file, no legacy file created"
+else
+  fail "Expected per-session last_synced_phase=phase5_post_lint and no legacy file (got lsp=$updated_lsp, legacy=$([ -f "$dir_ps2/.rite-flow-state" ] && echo present || echo absent))"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -207,11 +207,11 @@ else
 fi
 echo ""
 
-# --- TC-PER-SESSION-1: per-session state file (Issue #681) → phase diff detection works ---
+# --- TC-POST-WM-PER-SESSION-1: per-session state file (Issue #681) → phase diff detection works ---
 # Verifies _resolve-flow-state-path.sh integration: when schema_version=2 with a valid SID
 # and a per-session file exists, the hook reads from `.rite/sessions/<sid>.flow-state`
 # (not the legacy `.rite-flow-state`). Phase diff detection must still work end-to-end.
-echo "TC-PER-SESSION-1: per-session state file → phase diff detected"
+echo "TC-POST-WM-PER-SESSION-1: per-session state file → phase diff detected"
 dir_ps="$TEST_DIR/tc_per_session"
 mkdir -p "$dir_ps/.rite-work-memory" "$dir_ps/.rite/sessions"
 echo "existing wm" > "$dir_ps/.rite-work-memory/issue-42.md"
@@ -244,8 +244,8 @@ else
 fi
 echo ""
 
-# TC-PER-SESSION-2: per-session state, last_synced_phase update writes to per-session file
-echo "TC-PER-SESSION-2: per-session state → last_synced_phase atomic write targets per-session path"
+# TC-POST-WM-PER-SESSION-2: per-session state, last_synced_phase update writes to per-session file
+echo "TC-POST-WM-PER-SESSION-2: per-session state → last_synced_phase atomic write targets per-session path"
 dir_ps2="$TEST_DIR/tc_per_session_2"
 mkdir -p "$dir_ps2/.rite-work-memory" "$dir_ps2/.rite/sessions"
 echo "existing wm" > "$dir_ps2/.rite-work-memory/issue-42.md"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1137,10 +1137,10 @@ assert_p5_deny "TC-111 eval 'gh issue create' blocked (quote normalization)" "ev
 assert_p5_deny "TC-112 backslash line continuation blocked" $'gh \\\n  issue \\\n  create --title x'
 
 # --------------------------------------------------------------------------
-# TC-PER-SESSION-1+: Pattern 5 with schema_version=2 per-session state (Issue #681)
+# TC-PRE-GUARD-PER-SESSION-1+: Pattern 5 with schema_version=2 per-session state (Issue #681)
 # --------------------------------------------------------------------------
 echo ""
-echo "=== TC-PER-SESSION-1+: Pattern 5 with per-session state file (Issue #681) ==="
+echo "=== TC-PRE-GUARD-PER-SESSION-1+: Pattern 5 with per-session state file (Issue #681) ==="
 
 # Helper: create a tmp cwd with rite-config.yml (schema 2), .rite-session-id,
 # and a per-session flow-state file under .rite/sessions/<sid>.flow-state.
@@ -1175,31 +1175,31 @@ STATE_EOF
   echo "$dir"
 }
 
-# TC-PER-SESSION-1: gh issue create + per-session create_interview active → deny
-echo "TC-PER-SESSION-1: gh issue create + per-session create_interview active → deny"
+# TC-PRE-GUARD-PER-SESSION-1: gh issue create + per-session create_interview active → deny
+echo "TC-PRE-GUARD-PER-SESSION-1: gh issue create + per-session create_interview active → deny"
 tmpdir=$(make_cwd_with_per_session_state "create_interview" "true")
 rc=0
 output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x' --body 'y'") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
 if [ "$decision" = "deny" ] && [[ "$reason" == *"create-lifecycle-direct-gh-issue"* ]]; then
-  pass "TC-PER-SESSION-1 gh issue create blocked via per-session state (schema 2)"
+  pass "TC-PRE-GUARD-PER-SESSION-1 gh issue create blocked via per-session state (schema 2)"
 else
-  fail "TC-PER-SESSION-1 expected deny, got decision=$decision reason=$reason"
+  fail "TC-PRE-GUARD-PER-SESSION-1 expected deny, got decision=$decision reason=$reason"
 fi
 rm -rf "$tmpdir"
 
-# TC-PER-SESSION-2: gh issue create + per-session create_completed → allow
+# TC-PRE-GUARD-PER-SESSION-2: gh issue create + per-session create_completed → allow
 # (verifies the per-session resolver path still respects the create_completed allow branch)
-echo "TC-PER-SESSION-2: gh issue create + per-session create_completed → allow"
+echo "TC-PRE-GUARD-PER-SESSION-2: gh issue create + per-session create_completed → allow"
 tmpdir=$(make_cwd_with_per_session_state "create_completed" "true")
 rc=0
 output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 if [ -z "$decision" ] || [ "$decision" != "deny" ]; then
-  pass "TC-PER-SESSION-2 allowed when phase=create_completed in per-session state"
+  pass "TC-PRE-GUARD-PER-SESSION-2 allowed when phase=create_completed in per-session state"
 else
-  fail "TC-PER-SESSION-2 expected allow, got decision=$decision"
+  fail "TC-PRE-GUARD-PER-SESSION-2 expected allow, got decision=$decision"
 fi
 rm -rf "$tmpdir"
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1137,6 +1137,73 @@ assert_p5_deny "TC-111 eval 'gh issue create' blocked (quote normalization)" "ev
 assert_p5_deny "TC-112 backslash line continuation blocked" $'gh \\\n  issue \\\n  create --title x'
 
 # --------------------------------------------------------------------------
+# TC-PER-SESSION-1+: Pattern 5 with schema_version=2 per-session state (Issue #681)
+# --------------------------------------------------------------------------
+echo ""
+echo "=== TC-PER-SESSION-1+: Pattern 5 with per-session state file (Issue #681) ==="
+
+# Helper: create a tmp cwd with rite-config.yml (schema 2), .rite-session-id,
+# and a per-session flow-state file under .rite/sessions/<sid>.flow-state.
+# This exercises the _resolve-flow-state-path.sh integration: when the resolver
+# returns the per-session path, Pattern 5 must still read phase/active from it
+# and apply the same Mode B AND-logic.
+make_cwd_with_per_session_state() {
+  local phase="$1"
+  local active="$2"
+  local sid="${3:-00000000-0000-4000-8000-000000000001}"
+  local dir
+  dir=$(mktemp -d "/tmp/rite-test-681.XXXXXX")
+  cat > "$dir/rite-config.yml" <<'CFG_EOF'
+flow_state:
+  schema_version: 2
+CFG_EOF
+  printf '%s' "$sid" > "$dir/.rite-session-id"
+  mkdir -p "$dir/.rite/sessions"
+  cat > "$dir/.rite/sessions/${sid}.flow-state" <<STATE_EOF
+{
+  "schema_version": 2,
+  "phase": "$phase",
+  "active": $active,
+  "issue_number": 0,
+  "branch": "",
+  "pr_number": 0,
+  "next_action": "test",
+  "updated_at": "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")",
+  "session_id": "$sid"
+}
+STATE_EOF
+  echo "$dir"
+}
+
+# TC-PER-SESSION-1: gh issue create + per-session create_interview active → deny
+echo "TC-PER-SESSION-1: gh issue create + per-session create_interview active → deny"
+tmpdir=$(make_cwd_with_per_session_state "create_interview" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x' --body 'y'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"create-lifecycle-direct-gh-issue"* ]]; then
+  pass "TC-PER-SESSION-1 gh issue create blocked via per-session state (schema 2)"
+else
+  fail "TC-PER-SESSION-1 expected deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$tmpdir"
+
+# TC-PER-SESSION-2: gh issue create + per-session create_completed → allow
+# (verifies the per-session resolver path still respects the create_completed allow branch)
+echo "TC-PER-SESSION-2: gh issue create + per-session create_completed → allow"
+tmpdir=$(make_cwd_with_per_session_state "create_completed" "true")
+rc=0
+output=$(run_guard_with_cwd "$tmpdir" "gh issue create --title 'x'") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ -z "$decision" ] || [ "$decision" != "deny" ]; then
+  pass "TC-PER-SESSION-2 allowed when phase=create_completed in per-session state"
+else
+  fail "TC-PER-SESSION-2 expected allow, got decision=$decision"
+fi
+rm -rf "$tmpdir"
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/session-ownership.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership.test.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Tests for session-ownership.sh helper library
+# Usage: bash plugins/rite/hooks/tests/session-ownership.test.sh
+#
+# Coverage:
+#   - extract_session_id        (hook JSON parsing)
+#   - get_state_session_id      (state file parsing)
+#   - is_per_session_state_file (Issue #681 path predicate)
+#   - check_session_ownership   (4-state legacy + per-session fast-path)
+#   - parse_iso8601_to_epoch    (timezone normalization)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/../session-ownership.sh"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ✅ PASS: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  ❌ FAIL: $1"
+}
+
+# Source the library under test
+# shellcheck source=../session-ownership.sh
+source "$LIB"
+
+echo "=== session-ownership.sh tests ==="
+echo ""
+
+# --- TC-001: is_per_session_state_file matches per-session pattern ---
+echo "TC-001: is_per_session_state_file matches /<root>/.rite/sessions/<sid>.flow-state"
+if is_per_session_state_file "/tmp/repo/.rite/sessions/00000000-0000-4000-8000-000000000001.flow-state"; then
+  pass "Per-session path matched"
+else
+  fail "Per-session path should match"
+fi
+echo ""
+
+# --- TC-002: is_per_session_state_file rejects legacy path ---
+echo "TC-002: is_per_session_state_file rejects /<root>/.rite-flow-state"
+if is_per_session_state_file "/tmp/repo/.rite-flow-state"; then
+  fail "Legacy path should not match per-session pattern"
+else
+  pass "Legacy path correctly rejected"
+fi
+echo ""
+
+# --- TC-003: is_per_session_state_file rejects empty/unrelated paths ---
+echo "TC-003: is_per_session_state_file rejects empty / unrelated paths"
+all_ok=1
+if is_per_session_state_file ""; then all_ok=0; fi
+if is_per_session_state_file "/some/random/path.txt"; then all_ok=0; fi
+if is_per_session_state_file "/tmp/.rite/sessions/foo.txt"; then all_ok=0; fi  # missing .flow-state suffix
+if [ "$all_ok" = "1" ]; then
+  pass "Empty / unrelated paths correctly rejected"
+else
+  fail "Empty or unrelated paths should not match"
+fi
+echo ""
+
+# --- TC-004: check_session_ownership returns "own" for per-session file (fast-path) ---
+# Issue #681: structurally-owned per-session files bypass the 4-state legacy check.
+# The hook_json contains a *different* session_id than what would otherwise be in
+# the state file — the fast-path must NOT consult that mismatch.
+echo "TC-004: check_session_ownership returns 'own' for per-session path (fast-path)"
+hook_json='{"session_id": "current-session-uuid"}'
+ps_path="/tmp/repo/.rite/sessions/different-session-uuid.flow-state"
+result=$(check_session_ownership "$hook_json" "$ps_path")
+if [ "$result" = "own" ]; then
+  pass "Per-session path returns 'own' (structural fast-path, mismatched SIDs ignored)"
+else
+  fail "Expected 'own' for per-session path, got '$result'"
+fi
+echo ""
+
+# --- TC-005: check_session_ownership uses 4-state classification for legacy paths ---
+echo "TC-005: check_session_ownership returns 'own' for legacy path with matching session_id"
+state_file="$TEST_DIR/tc005.rite-flow-state"
+cat > "$state_file" <<'STATE_EOF'
+{
+  "session_id": "session-aaa",
+  "active": true,
+  "updated_at": "2026-04-30T00:00:00+00:00"
+}
+STATE_EOF
+hook_json='{"session_id": "session-aaa"}'
+# Build a legacy-style path so the per-session fast-path is not hit
+legacy_path="$TEST_DIR/.rite-flow-state"
+cp "$state_file" "$legacy_path"
+result=$(check_session_ownership "$hook_json" "$legacy_path")
+if [ "$result" = "own" ]; then
+  pass "Legacy path with matching SID returns 'own' (4-state classification preserved)"
+else
+  fail "Expected 'own', got '$result'"
+fi
+echo ""
+
+# --- TC-006: check_session_ownership returns 'legacy' for state without session_id ---
+echo "TC-006: check_session_ownership returns 'legacy' for state file missing session_id"
+legacy_state="$TEST_DIR/tc006.rite-flow-state"
+cat > "$legacy_state" <<'STATE_EOF'
+{
+  "active": true,
+  "updated_at": "2026-04-30T00:00:00+00:00"
+}
+STATE_EOF
+# Use a non-per-session path
+hook_json='{"session_id": "current-uuid"}'
+result=$(check_session_ownership "$hook_json" "$legacy_state")
+if [ "$result" = "legacy" ]; then
+  pass "Legacy state file (no session_id) returns 'legacy'"
+else
+  fail "Expected 'legacy', got '$result'"
+fi
+echo ""
+
+# --- TC-007: check_session_ownership returns 'other' for foreign session within 2h ---
+echo "TC-007: check_session_ownership returns 'other' for fresh foreign-session state"
+foreign_state="$TEST_DIR/tc007.rite-flow-state"
+fresh_ts=$(date -u -d '5 minutes ago' +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null \
+  || date -u -v-5M +"%Y-%m-%dT%H:%M:%S+00:00")
+cat > "$foreign_state" <<STATE_EOF
+{
+  "session_id": "foreign-session",
+  "active": true,
+  "updated_at": "$fresh_ts"
+}
+STATE_EOF
+hook_json='{"session_id": "current-session"}'
+result=$(check_session_ownership "$hook_json" "$foreign_state")
+if [ "$result" = "other" ]; then
+  pass "Fresh foreign-session state returns 'other'"
+else
+  fail "Expected 'other', got '$result'"
+fi
+echo ""
+
+# --- TC-008: check_session_ownership returns 'stale' for foreign session > 2h ---
+echo "TC-008: check_session_ownership returns 'stale' for foreign-session state > 2h old"
+stale_state="$TEST_DIR/tc008.rite-flow-state"
+stale_ts=$(date -u -d '3 hours ago' +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null \
+  || date -u -v-3H +"%Y-%m-%dT%H:%M:%S+00:00")
+cat > "$stale_state" <<STATE_EOF
+{
+  "session_id": "foreign-session",
+  "active": true,
+  "updated_at": "$stale_ts"
+}
+STATE_EOF
+hook_json='{"session_id": "current-session"}'
+result=$(check_session_ownership "$hook_json" "$stale_state")
+if [ "$result" = "stale" ]; then
+  pass "Stale foreign-session state (>2h) returns 'stale'"
+else
+  fail "Expected 'stale', got '$result'"
+fi
+echo ""
+
+# --- TC-009: extract_session_id parses session_id from hook JSON ---
+echo "TC-009: extract_session_id parses .session_id from hook JSON"
+sid=$(extract_session_id '{"session_id": "abc-123", "tool_name": "Bash"}')
+if [ "$sid" = "abc-123" ]; then
+  pass "extract_session_id correctly returns abc-123"
+else
+  fail "Expected abc-123, got '$sid'"
+fi
+sid_empty=$(extract_session_id '{"tool_name": "Bash"}')
+if [ -z "$sid_empty" ]; then
+  pass "extract_session_id returns empty string when session_id absent"
+else
+  fail "Expected empty, got '$sid_empty'"
+fi
+echo ""
+
+# --- TC-010: get_state_session_id parses session_id from state file ---
+echo "TC-010: get_state_session_id parses session_id from state file"
+gsid_file="$TEST_DIR/tc010.state"
+cat > "$gsid_file" <<'STATE_EOF'
+{ "session_id": "state-session-xyz", "active": true }
+STATE_EOF
+gsid=$(get_state_session_id "$gsid_file")
+if [ "$gsid" = "state-session-xyz" ]; then
+  pass "get_state_session_id correctly returns state-session-xyz"
+else
+  fail "Expected state-session-xyz, got '$gsid'"
+fi
+gsid_missing=$(get_state_session_id "$TEST_DIR/nonexistent.state")
+if [ -z "$gsid_missing" ]; then
+  pass "get_state_session_id returns empty for missing file"
+else
+  fail "Expected empty for missing file, got '$gsid_missing'"
+fi
+echo ""
+
+# --- TC-011: parse_iso8601_to_epoch handles +00:00 / +09:00 / Z suffix ---
+echo "TC-011: parse_iso8601_to_epoch normalizes timezone offsets"
+e1=$(parse_iso8601_to_epoch "2026-04-30T12:00:00+00:00")
+e2=$(parse_iso8601_to_epoch "2026-04-30T21:00:00+09:00")
+e3=$(parse_iso8601_to_epoch "2026-04-30T12:00:00Z")
+# All three timestamps refer to the same instant: 2026-04-30 12:00 UTC
+if [ "$e1" = "$e2" ] && [ "$e1" = "$e3" ] && [ "$e1" != "0" ]; then
+  pass "Equivalent timestamps yield identical epoch ($e1)"
+else
+  fail "Epoch normalization failed: e1=$e1 e2=$e2 e3=$e3"
+fi
+e_invalid=$(parse_iso8601_to_epoch "not-a-timestamp")
+if [ "$e_invalid" = "0" ]; then
+  pass "Invalid timestamp returns 0"
+else
+  fail "Expected 0 for invalid timestamp, got '$e_invalid'"
+fi
+echo ""
+
+# --- Summary ---
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/session-ownership.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership.test.sh
@@ -25,6 +25,9 @@ cleanup() {
   rm -rf "$TEST_DIR"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
 
 pass() {
   PASS=$((PASS + 1))
@@ -74,18 +77,77 @@ else
 fi
 echo ""
 
-# --- TC-004: check_session_ownership returns "own" for per-session file (fast-path) ---
+# --- TC-003b: is_per_session_state_file edge cases (empty SID part, non-UUID-like) ---
+# Issue #681 F-06: the predicate uses path pattern matching only, so it accepts
+# any non-empty SID-like segment between `/sessions/` and `.flow-state`. These
+# tests pin the current behavior so future SID validation tightening can be
+# detected as a deliberate change.
+echo "TC-003b: is_per_session_state_file edge cases — empty SID segment is accepted by current path-pattern semantics"
+# `/.rite/sessions/.flow-state` has an empty SID segment. The current case glob
+# `*/.rite/sessions/*.flow-state` does not enforce non-empty SID, so this matches.
+# Asserting the *current* behavior here documents the contract; if the predicate
+# is later strengthened to require a non-empty UUID-like segment, this test will
+# fail and force an explicit decision.
+if is_per_session_state_file "/repo/.rite/sessions/.flow-state"; then
+  pass "Empty SID segment is currently accepted (documented behavior, future SID validation may tighten this)"
+else
+  fail "Empty SID segment is rejected — predicate semantics changed unexpectedly"
+fi
+# Non-UUID-like SID (e.g. arbitrary string) is also accepted by the current
+# pattern-only check. Document this for the same reason.
+if is_per_session_state_file "/repo/.rite/sessions/not-a-uuid.flow-state"; then
+  pass "Non-UUID SID segment is currently accepted (documented behavior)"
+else
+  fail "Non-UUID SID segment is rejected — predicate semantics changed unexpectedly"
+fi
+echo ""
+
+# --- TC-004: check_session_ownership returns "own" for per-session file (matching SID fast-path) ---
 # Issue #681: structurally-owned per-session files bypass the 4-state legacy check.
-# The hook_json contains a *different* session_id than what would otherwise be in
-# the state file — the fast-path must NOT consult that mismatch.
-echo "TC-004: check_session_ownership returns 'own' for per-session path (fast-path)"
-hook_json='{"session_id": "current-session-uuid"}'
-ps_path="/tmp/repo/.rite/sessions/different-session-uuid.flow-state"
+# When the hook payload's session_id matches the filename's session_id segment,
+# the fast-path returns "own" without consulting the file body.
+echo "TC-004: check_session_ownership returns 'own' for per-session path with matching SID"
+sid_match="00000000-0000-4000-8000-000000000004"
+hook_json="{\"session_id\": \"$sid_match\"}"
+ps_path="/tmp/repo/.rite/sessions/${sid_match}.flow-state"
 result=$(check_session_ownership "$hook_json" "$ps_path")
 if [ "$result" = "own" ]; then
-  pass "Per-session path returns 'own' (structural fast-path, mismatched SIDs ignored)"
+  pass "Per-session path with matching SID returns 'own' (structural fast-path)"
 else
-  fail "Expected 'own' for per-session path, got '$result'"
+  fail "Expected 'own' for matching per-session path, got '$result'"
+fi
+echo ""
+
+# --- TC-004b: check_session_ownership returns "other" for foreign per-session file (defense-in-depth) ---
+# Issue #681 F-02: when the hook payload's session_id is non-empty AND does not match
+# the filename's session_id segment, the fast-path defense-in-depth branch must
+# return "other" rather than silently classifying as "own". This prevents a future
+# caller bypassing the resolver from being misclassified as own (AC-4 alignment).
+echo "TC-004b: check_session_ownership returns 'other' for foreign per-session path (defense-in-depth)"
+sid_self="00000000-0000-4000-8000-000000000004b1"
+sid_other="00000000-0000-4000-8000-000000000004b2"
+hook_json="{\"session_id\": \"$sid_self\"}"
+foreign_ps_path="/tmp/repo/.rite/sessions/${sid_other}.flow-state"
+result=$(check_session_ownership "$hook_json" "$foreign_ps_path")
+if [ "$result" = "other" ]; then
+  pass "Foreign per-session path returns 'other' (filename SID mismatch detected)"
+else
+  fail "Expected 'other' for foreign per-session path, got '$result'"
+fi
+echo ""
+
+# --- TC-004c: check_session_ownership returns "own" for per-session file with empty hook SID ---
+# Backward-compat: when hook_json lacks session_id (legacy hook input), fall through
+# to "own" — same behavior as legacy 4-state classification's "can't determine, assume own"
+# branch.
+echo "TC-004c: check_session_ownership returns 'own' for per-session path with empty hook SID"
+hook_json='{}'
+ps_path="/tmp/repo/.rite/sessions/some-session-uuid.flow-state"
+result=$(check_session_ownership "$hook_json" "$ps_path")
+if [ "$result" = "own" ]; then
+  pass "Per-session path with empty hook SID returns 'own' (backward-compat fast-path)"
+else
+  fail "Expected 'own' for per-session path with empty hook SID, got '$result'"
 fi
 echo ""
 


### PR DESCRIPTION
## 概要

兄弟 Issue #680 (lifecycle 4 hooks の自 session state 参照対応) の対称適用として、tool 系 2 hooks (`pre-tool-bash-guard.sh` / `post-tool-wm-sync.sh`) と `session-ownership.sh` helper を `_resolve-flow-state-path.sh` 経由 + per-session file 構造前提に refactor する。Session Ownership 機構（#173 系列）のガード層を新形式の前提部品へ役割転換する。

## 関連 Issue

Closes #681

親 Issue: #672

## 変更内容

### Production code (3 files)

- **`plugins/rite/hooks/pre-tool-bash-guard.sh`**: Pattern 5 (`gh issue create` lifecycle block) の `STATE_FILE_PATH` 取得を `_resolve-flow-state-path.sh` 経由に切替。Mode B AND-logic (`.active=true && phase=create_*`) は完全保全。schema_version=2 の per-session file (`<root>/.rite/sessions/<sid>.flow-state`) と schema_version=1 の legacy file (`<root>/.rite-flow-state`) の両方で動作。
- **`plugins/rite/hooks/post-tool-wm-sync.sh`**: `FLOW_STATE` 取得を `_resolve-flow-state-path.sh` 経由に切替。`last_synced_phase` の atomic write も resolved path 上で実施。`[ "$_active" = "true" ] || exit 0` 等の active check と phase diff detection ロジックは保全。
- **`plugins/rite/hooks/session-ownership.sh`**: 新 helper `is_per_session_state_file()` を追加（per-session 構造を path で判定）。`check_session_ownership()` に schema-2 fast-path を導入し、per-session file パターンに合致する path では構造的に "own" を返す（4 状態判定をバイパス）。schema-1 legacy file では従来通り 4 状態判定を維持し、既存 4 API (`extract_session_id` / `get_state_session_id` / `check_session_ownership` / `parse_iso8601_to_epoch`) の signature と戻り値は完全互換。

### Tests (3 files)

- **`plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`**: per-session file fixture (`make_cwd_with_per_session_state`) を追加し、Pattern 5 が `<root>/.rite/sessions/<sid>.flow-state` 経由でも正常 block / allow することを verify する 2 TC を追加。
- **`plugins/rite/hooks/tests/post-tool-wm-sync.test.sh`**: per-session file fixture 経路で phase diff detection が動作し、`last_synced_phase` の atomic write が per-session file 上で完結する（legacy file が作られない）ことを verify する 2 TC を追加。
- **`plugins/rite/hooks/tests/session-ownership.test.sh`** (新規): `is_per_session_state_file` の predicate 動作 + 既存 4 helper の unit test 計 14 TC。

### `phase-transition-whitelist.sh`

flow-state path を直接持たない library のため変更なし（library として source される際の phase 名 helper としての役割は本 Issue 範囲外）。

## Acceptance Criteria

- ✅ **AC-2** (Issue #672 担当部分): tool 系 hook 経路で全 phase が単独運用通り通過
- ✅ **AC-4** (stop-guard ownership 遵守): per-session file fast-path により、別 session が active な per-session state を持つ場合も本 hook の経路では干渉しない
- ✅ **AC-7** (Session Ownership 系列再検証): 既存 hook tests 全 pass
- ✅ **AC-LOCAL-1** (既存 hooks/tests 全 pass): pre-tool-bash-guard.test.sh 134/134, post-tool-wm-sync.test.sh 11/11
- ✅ **AC-LOCAL-2** (helper simplification): `is_per_session_state_file()` 追加 + `check_session_ownership()` に schema-2 fast-path 導入

## Test Results

| Test File | Result |
|-----------|--------|
| `pre-tool-bash-guard.test.sh` | 134 件 pass (新規 2 件 + 既存 132 件) |
| `post-tool-wm-sync.test.sh` | 11 件 pass (新規 2 件 + 既存 9 件) |
| `session-ownership.test.sh` (新規) | 14 件 pass |
| **合計** | **159 件 pass / 0 fail** |

Plugin internal lint check (Phase 3.5-3.13) も実行し、本 PR で変更したファイルに新規 finding はゼロ。bash -n syntax check も全 6 ファイル OK。

## チェックリスト

- [x] pre-tool-bash-guard.sh の per-session path 切替 + Mode B defense wiring 保全
- [x] post-tool-wm-sync.sh の per-session path 切替
- [x] session-ownership.sh helper の simplification (4 状態 → 構造化 fast-path 導入)
- [x] phase-transition-whitelist.sh の確認（変更不要）
- [x] 3 hook tests の更新 (2 件) + 1 件新規作成
- [x] session-ownership.sh の旧 helper caller の grep 確認（adapter pattern 不要、API 完全互換）

## Wiki 経験則の反映

- **Asymmetric Fix Transcription**: pre-tool-bash-guard と post-tool-wm-sync の同形 path resolution 切替を対称的に適用、Grep で cross-check 済
- **Design doc は現 HEAD の SoT を verify してから書く**: develop HEAD の各対象ファイルを Read で実測してから refactor（記憶ベース参照を排除）
- **DRIFT-CHECK ANCHOR は semantic name 参照**: 追加コメントは line 番号参照を使用せず、Phase 名 / 関数名 / Issue 番号で参照

## Known Issues

なし。
