### PR TITLE
refactor(hooks): #749 lifecycle 4 hooks observability 改善 (PR #748 follow-up)

### DIFF
--- a/plugins/rite/hooks/_resolve-flow-state-path.sh
+++ b/plugins/rite/hooks/_resolve-flow-state-path.sh
@@ -47,14 +47,27 @@
 #   `_resolve-cross-session-guard.sh` here because this helper does not call
 #   it directly — the caller-side check is sufficient.
 #
-# Current callers (4 lifecycle hooks):
-#   - plugins/rite/hooks/session-start.sh     (defensive reset on startup/clear)
-#   - plugins/rite/hooks/session-end.sh       (deactivation on session end)
-#   - plugins/rite/hooks/pre-compact.sh       (timestamp update before compact)
-#   - plugins/rite/hooks/post-compact.sh      (recovering→normal transition)
+# Current callers:
+#   Lifecycle 4 hooks (with Issue #749 stderr pass-through pattern, contract critical):
+#     - plugins/rite/hooks/session-start.sh   (defensive reset on startup/clear)
+#     - plugins/rite/hooks/session-end.sh     (deactivation on session end)
+#     - plugins/rite/hooks/pre-compact.sh     (timestamp update before compact)
+#     - plugins/rite/hooks/post-compact.sh    (recovering→normal transition)
 #
-#   New callers (e.g., future lifecycle 5th hook) MUST follow the caller
-#   contract above. Add the new caller name here when introducing one.
+#   Other hooks (no stderr pass-through, RITE_DEBUG-gated diagnostic only — Issue #681):
+#     - plugins/rite/hooks/post-tool-wm-sync.sh   (writer; check_session_ownership 呼出済)
+#     - plugins/rite/hooks/pre-tool-bash-guard.sh (read-only; ownership check 不要)
+#
+#   Command-level callers (silent fall-through to empty state_file via `|| state_file=""`):
+#     - plugins/rite/commands/issue/create.md             (lines 517, 712)
+#     - plugins/rite/commands/issue/create-interview.md   (lines 43, 568)
+#     - plugins/rite/commands/pr/cleanup.md               (line 151)
+#
+#   New callers MUST follow the caller contract above. When adding a new
+#   caller, append it under the appropriate category here AND update the
+#   keyword loop in tests/_resolve-flow-state-path.test.sh
+#   (TC-749-CALLER-CONTRACT) so the static grep test enforces enumeration
+#   completeness.
 #
 # Why this exists (Issue #680):
 #   The lifecycle 4 hooks each used the same hardcoded `<state_root>/.rite-flow-state`

--- a/plugins/rite/hooks/_resolve-flow-state-path.sh
+++ b/plugins/rite/hooks/_resolve-flow-state-path.sh
@@ -31,6 +31,31 @@
 # `check_session_ownership` (session-ownership.sh) for the "other session"
 # branch, so layering another guard here would duplicate that contract.
 #
+# ⚠️ Caller contract (Issue #749):
+#   When this helper returns a per-session path
+#   (`<state_root>/.rite/sessions/<sid>.flow-state`), the caller MUST invoke
+#   `check_session_ownership` from session-ownership.sh and skip the modify
+#   path on the "other" branch. Reading or modifying another session's active
+#   per-session state file would clobber its in-flight work memory and trip
+#   stop-guard whitelist violations on its next phase transition.
+#
+#   Failing this contract risks: (1) silent overwrite of another session's
+#   .active=false transition, (2) double-emit of cross-session incidents,
+#   (3) lifecycle warnings (#475 / #608) firing for the wrong session.
+#
+#   `_validate-helpers.sh` intentionally does NOT validate
+#   `_resolve-cross-session-guard.sh` here because this helper does not call
+#   it directly — the caller-side check is sufficient.
+#
+# Current callers (4 lifecycle hooks):
+#   - plugins/rite/hooks/session-start.sh     (defensive reset on startup/clear)
+#   - plugins/rite/hooks/session-end.sh       (deactivation on session end)
+#   - plugins/rite/hooks/pre-compact.sh       (timestamp update before compact)
+#   - plugins/rite/hooks/post-compact.sh      (recovering→normal transition)
+#
+#   New callers (e.g., future lifecycle 5th hook) MUST follow the caller
+#   contract above. Add the new caller name here when introducing one.
+#
 # Why this exists (Issue #680):
 #   The lifecycle 4 hooks each used the same hardcoded `<state_root>/.rite-flow-state`
 #   path, which forces a global single-file lock and breaks the O(1)-per-session

--- a/plugins/rite/hooks/_resolve-flow-state-path.sh
+++ b/plugins/rite/hooks/_resolve-flow-state-path.sh
@@ -59,9 +59,9 @@
 #     - plugins/rite/hooks/pre-tool-bash-guard.sh (read-only; ownership check 不要)
 #
 #   Command-level callers (silent fall-through to empty state_file via `|| state_file=""`):
-#     - plugins/rite/commands/issue/create.md             (lines 517, 712)
-#     - plugins/rite/commands/issue/create-interview.md   (lines 43, 568)
-#     - plugins/rite/commands/pr/cleanup.md               (line 151)
+#     - plugins/rite/commands/issue/create.md
+#     - plugins/rite/commands/issue/create-interview.md
+#     - plugins/rite/commands/pr/cleanup.md
 #
 #   New callers MUST follow the caller contract above. When adding a new
 #   caller, append it under the appropriate category here AND update the

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -26,8 +26,20 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
-FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
-  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+#
+# Issue #749: stderr pass-through for diagnostic visibility.
+# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
+_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
+  :
+else
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+  fi
+  FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+  echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2
+fi
+[ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 LOCKDIR="$COMPACT_STATE.lockdir"
 
 # --- Cleanup helper ---

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -105,10 +105,10 @@ IFS=$'\x1f' read -r ISSUE PHASE NEXT_ACTION LOOP PR BRANCH <<< "$FLOW_DATA"
 # --- Transition compact_state to normal (inside lock) ---
 TMP_COMPACT=""
 cleanup() {
-  # `_resolve_err` is rm-ed synchronously above (line ~51); include in cleanup
-  # as defense-in-depth for SIGINT/SIGTERM arriving after trap install.
-  # `rm -f` on already-removed file is a harmless no-op.
-  rm -f "$TMP_COMPACT" "${_resolve_err:-}" 2>/dev/null
+  # `_resolve_err` の synchronous rm は trap install より前で実行される (resolver 直後)
+  # ため、ここで cleanup() に含める必要はない (dead code)。trap が発火する時点では既に
+  # 削除済みで no-op となる。trap install 前の race window は同期 rm 自身でカバーされる。
+  rm -f "$TMP_COMPACT" 2>/dev/null
   release_wm_lock "$LOCKDIR"
 }
 trap cleanup EXIT TERM INT

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -28,22 +28,22 @@ COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
 # Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
-# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
-# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# `_mktemp-stderr-guard.sh`. 詳細は session-start.sh の同パターンを参照。
+# filter は state-read.sh cross-session guard の 3-pattern を `^ERROR:` で
+# superset 化した 4-pattern 拡張版 (resolver self-validation の ERROR: を捕捉)。
 # success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
 # を silent drop しないようにする。
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "post-compact" \
   "resolve-flow-state-err" \
   "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
-if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
-else
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
+# Single-pass branch (filter runs once regardless of resolver exit status).
+_resolve_failed=0
+FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1
+if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+  grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+fi
+if [ "$_resolve_failed" -eq 1 ]; then
   FLOW_STATE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2
 fi
@@ -105,7 +105,10 @@ IFS=$'\x1f' read -r ISSUE PHASE NEXT_ACTION LOOP PR BRANCH <<< "$FLOW_DATA"
 # --- Transition compact_state to normal (inside lock) ---
 TMP_COMPACT=""
 cleanup() {
-  rm -f "$TMP_COMPACT" 2>/dev/null
+  # `_resolve_err` is rm-ed synchronously above (line ~51); include in cleanup
+  # as defense-in-depth for SIGINT/SIGTERM arriving after trap install.
+  # `rm -f` on already-removed file is a harmless no-op.
+  rm -f "$TMP_COMPACT" "${_resolve_err:-}" 2>/dev/null
   release_wm_lock "$LOCKDIR"
 }
 trap cleanup EXIT TERM INT

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -27,14 +27,22 @@ COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
-# Issue #749: stderr pass-through for diagnostic visibility.
-# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
-_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+# Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
+# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
+# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
+# を silent drop しないようにする。
+_resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
+  "post-compact" \
+  "resolve-flow-state-err" \
+  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  :
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+  fi
 else
   if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
   fi
   FLOW_STATE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -31,22 +31,22 @@ COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
 # Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
-# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
-# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# `_mktemp-stderr-guard.sh`. 詳細は session-start.sh の同パターンを参照。
+# filter は state-read.sh cross-session guard の 3-pattern を `^ERROR:` で
+# superset 化した 4-pattern 拡張版 (resolver self-validation の ERROR: を捕捉)。
 # success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
 # を silent drop しないようにする。
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "pre-compact" \
   "resolve-flow-state-err" \
   "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
-if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
-else
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
+# Single-pass branch (filter runs once regardless of resolver exit status).
+_resolve_failed=0
+FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1
+if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+  grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+fi
+if [ "$_resolve_failed" -eq 1 ]; then
   FLOW_STATE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2
 fi
@@ -57,7 +57,12 @@ LOCKDIR="$COMPACT_STATE.lockdir"
 TMP_FILE=""
 TMP_COMPACT=""
 cleanup() {
-  rm -f "$TMP_FILE" "$TMP_COMPACT" 2>/dev/null
+  # `_resolve_err` is normally rm-ed synchronously above (line ~54), but include
+  # it here as defense-in-depth: if SIGINT/SIGTERM arrives between trap install
+  # and end of script (e.g., during work-memory-update.sh sourcing or lock
+  # acquisition), this ensures the resolver stderr tempfile is not orphaned.
+  # `rm -f` on already-removed file is a harmless no-op.
+  rm -f "$TMP_FILE" "$TMP_COMPACT" "${_resolve_err:-}" 2>/dev/null
   release_wm_lock "$LOCKDIR"
 }
 

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -57,12 +57,10 @@ LOCKDIR="$COMPACT_STATE.lockdir"
 TMP_FILE=""
 TMP_COMPACT=""
 cleanup() {
-  # `_resolve_err` is normally rm-ed synchronously above (line ~54), but include
-  # it here as defense-in-depth: if SIGINT/SIGTERM arrives between trap install
-  # and end of script (e.g., during work-memory-update.sh sourcing or lock
-  # acquisition), this ensures the resolver stderr tempfile is not orphaned.
-  # `rm -f` on already-removed file is a harmless no-op.
-  rm -f "$TMP_FILE" "$TMP_COMPACT" "${_resolve_err:-}" 2>/dev/null
+  # `_resolve_err` の synchronous rm は trap install より前で実行される (resolver 直後)
+  # ため、ここで cleanup() に含める必要はない (dead code)。trap が発火する時点では既に
+  # 削除済みで no-op となる。trap install 前の race window は同期 rm 自身でカバーされる。
+  rm -f "$TMP_FILE" "$TMP_COMPACT" 2>/dev/null
   release_wm_lock "$LOCKDIR"
 }
 

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -30,14 +30,22 @@ COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
-# Issue #749: stderr pass-through for diagnostic visibility.
-# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
-_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+# Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
+# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
+# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
+# を silent drop しないようにする。
+_resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
+  "pre-compact" \
+  "resolve-flow-state-err" \
+  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  :
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+  fi
 else
   if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
   fi
   FLOW_STATE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -29,8 +29,20 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 COMPACT_STATE="$STATE_ROOT/.rite-compact-state"
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
-FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
-  || FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+#
+# Issue #749: stderr pass-through for diagnostic visibility.
+# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
+_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+if FLOW_STATE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
+  :
+else
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+  fi
+  FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+  echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($FLOW_STATE)" >&2
+fi
+[ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 LOCKDIR="$COMPACT_STATE.lockdir"
 
 # --- Cleanup function (covers all temp files) ---

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -31,8 +31,20 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
-STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
-  || STATE_FILE="$STATE_ROOT/.rite-flow-state"
+#
+# Issue #749: stderr pass-through for diagnostic visibility.
+# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
+_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
+  :
+else
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+  fi
+  STATE_FILE="$STATE_ROOT/.rite-flow-state"
+  echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2
+fi
+[ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 # Get current branch
 BRANCH=$(cd "$CWD" && git branch --show-current 2>/dev/null || echo "")
@@ -116,7 +128,13 @@ WARN_MSG
         mv "$TMP_FILE" "$STATE_FILE"
     else
         # Intentionally not exit 1 here (unlike pre-compact.sh) — session-end
-        # prioritizes cleanup over strict error propagation
+        # prioritizes cleanup over strict error propagation.
+        # Issue #749: emit WARNING so the user knows the deactivate failed
+        # (mirrors pre-compact.sh diagnostic line-prefix `rite: <hook>: ...`).
+        # Without this, .active=false silently fails to be written and the
+        # next session-start defensive reset has no signal that recovery is
+        # needed (#475 / #608 follow-up).
+        echo "rite: session-end: failed to deactivate state file (Issue #${ISSUE_NUMBER:-unknown})" >&2
         rm -f "$TMP_FILE"
     fi
 

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -33,22 +33,22 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
 # Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
-# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
-# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# `_mktemp-stderr-guard.sh`. 詳細は session-start.sh の同パターンを参照。
+# filter は state-read.sh cross-session guard の 3-pattern を `^ERROR:` で
+# superset 化した 4-pattern 拡張版 (resolver self-validation の ERROR: を捕捉)。
 # success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
 # を silent drop しないようにする。
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "session-end" \
   "resolve-flow-state-err" \
   "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
-if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
-else
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
+# Single-pass branch (filter runs once regardless of resolver exit status).
+_resolve_failed=0
+STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1
+if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+  grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+fi
+if [ "$_resolve_failed" -eq 1 ]; then
   STATE_FILE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2
 fi
@@ -142,10 +142,10 @@ WARN_MSG
         # Without this, .active=false silently fails to be written and the
         # next session-start defensive reset has no signal that recovery is
         # needed (#475 / #608 follow-up).
-        # WARNING に state_file path を含めることで `Issue #unknown` fallback
-        # 時 (detached HEAD / non-issue branch / git 未初期化) でも debug 情報
+        # WARNING に state_file path を含めることで、Issue 番号が解決できない
+        # 経路 (detached HEAD / non-issue branch / git 未初期化) でも debug 情報
         # が残る。`${ISSUE_NUMBER:+ (Issue #$ISSUE_NUMBER)}` で issue 番号は
-        # 解決できた場合のみ追記する。
+        # 解決できた場合のみ追記し、空の場合は `(Issue #...)` 部分そのものを省略する。
         echo "rite: session-end: failed to deactivate state file: $STATE_FILE${ISSUE_NUMBER:+ (Issue #$ISSUE_NUMBER)}" >&2
         rm -f "$TMP_FILE"
     fi

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -32,14 +32,22 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 # Resolve active flow-state file path (Issue #680).
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
-# Issue #749: stderr pass-through for diagnostic visibility.
-# Mirrors state-read.sh `_classify_err` doctrine (cycle 41 F-01).
-_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+# Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
+# `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。詳細は session-start.sh
+# の同パターンを参照。filter は state-read.sh:148 と同型 (4-pattern 包括)。
+# success arm でも tempfile を inspect して helper graceful-degrade 経路の WARNING
+# を silent drop しないようにする。
+_resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
+  "session-end" \
+  "resolve-flow-state-err" \
+  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  :
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+  fi
 else
   if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
   fi
   STATE_FILE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2
@@ -134,7 +142,11 @@ WARN_MSG
         # Without this, .active=false silently fails to be written and the
         # next session-start defensive reset has no signal that recovery is
         # needed (#475 / #608 follow-up).
-        echo "rite: session-end: failed to deactivate state file (Issue #${ISSUE_NUMBER:-unknown})" >&2
+        # WARNING に state_file path を含めることで `Issue #unknown` fallback
+        # 時 (detached HEAD / non-issue branch / git 未初期化) でも debug 情報
+        # が残る。`${ISSUE_NUMBER:+ (Issue #$ISSUE_NUMBER)}` で issue 番号は
+        # 解決できた場合のみ追記する。
+        echo "rite: session-end: failed to deactivate state file: $STATE_FILE${ISSUE_NUMBER:+ (Issue #$ISSUE_NUMBER)}" >&2
         rm -f "$TMP_FILE"
     fi
 

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -248,10 +248,26 @@ unset _migrate_script
 # `_resolve-flow-state-path.sh` returns the per-session file
 # (`.rite/sessions/<sid>.flow-state`) when schema_version=2 and a valid
 # session_id is present, otherwise the legacy `.rite-flow-state`. The
-# fallback `|| STATE_FILE=...` keeps the hook non-blocking under helper
-# deploy regression (e.g. chmod -x or partial install).
-STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>/dev/null) \
-  || STATE_FILE="$STATE_ROOT/.rite-flow-state"
+# fallback path keeps the hook non-blocking under helper deploy regression
+# (e.g. chmod -x or partial install).
+#
+# Issue #749: stderr pass-through for diagnostic visibility.
+# `_validate-helpers.sh` and `_validate-state-root.sh` emit `ERROR:` lines
+# to stderr on deploy regression / path traversal; the previous
+# `2>/dev/null` silently dropped them, hiding the legacy-fallback root
+# cause from the user. Mirrors state-read.sh `_classify_err` doctrine
+# (cycle 41 F-01).
+_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
+  :
+else
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+  fi
+  STATE_FILE="$STATE_ROOT/.rite-flow-state"
+  echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2
+fi
+[ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 if [ ! -f "$STATE_FILE" ]; then
   # Clean stale compact state on startup/clear when no flow state exists (#756, #800)

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -252,11 +252,15 @@ unset _migrate_script
 # (e.g. chmod -x or partial install).
 #
 # Issue #749: stderr pass-through for diagnostic visibility, via canonical
-# helper `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。
+# helper `_mktemp-stderr-guard.sh`.
 # - mktemp 失敗時に 3 行 WARNING を emit (silent fall-through 解消)
 # - chmod 600 / TMPDIR 尊重を helper 経由で取得
-# - filter は state-read.sh:148 と同型 (`^WARNING:|^ERROR:|^  |^jq: `)
-#   で indented continuation 行と raw `jq:` parse error も pass-through
+# - filter は state-read.sh の cross-session guard pass-through (3-pattern:
+#   `^WARNING:|^  |^jq: `) を `^ERROR:` で superset 化した 4-pattern 拡張版。
+#   `_resolve-flow-state-path.sh` は `_validate-helpers.sh` / `_validate-state-root.sh`
+#   経由で `ERROR:` 行を emit する (resolver self-validation contract) ため、
+#   reader-side filter より広い範囲を要求する。indented continuation 行と
+#   raw `jq:` parse error は state-read.sh と同じく pass-through する
 # - success arm でも tempfile を inspect する (`_resolve-flow-state-path.sh`
 #   が graceful-degrade で exit 0 を返す経路、例えば `_resolve-session-id-from-file.sh`
 #   の tr IO failure による empty SID + WARNING 出力 + exit 0 経路で
@@ -265,14 +269,15 @@ _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "session-start" \
   "resolve-flow-state-err" \
   "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
-if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
-else
-  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
-  fi
+# Single-pass branch: capture resolver outcome, then run filter once regardless
+# of success/failure (helper may graceful-degrade exit 0 with WARNING in stderr,
+# e.g., empty SID via tr IO failure — both paths require pass-through).
+_resolve_failed=0
+STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1
+if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+  grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+fi
+if [ "$_resolve_failed" -eq 1 ]; then
   STATE_FILE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2
 fi

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -251,18 +251,27 @@ unset _migrate_script
 # fallback path keeps the hook non-blocking under helper deploy regression
 # (e.g. chmod -x or partial install).
 #
-# Issue #749: stderr pass-through for diagnostic visibility.
-# `_validate-helpers.sh` and `_validate-state-root.sh` emit `ERROR:` lines
-# to stderr on deploy regression / path traversal; the previous
-# `2>/dev/null` silently dropped them, hiding the legacy-fallback root
-# cause from the user. Mirrors state-read.sh `_classify_err` doctrine
-# (cycle 41 F-01).
-_resolve_err=$(mktemp /tmp/rite-resolve-flow-state-err-XXXXXX 2>/dev/null) || _resolve_err=""
+# Issue #749: stderr pass-through for diagnostic visibility, via canonical
+# helper `_mktemp-stderr-guard.sh` (PR #688 cycle 9 F-02 で抽出済み)。
+# - mktemp 失敗時に 3 行 WARNING を emit (silent fall-through 解消)
+# - chmod 600 / TMPDIR 尊重を helper 経由で取得
+# - filter は state-read.sh:148 と同型 (`^WARNING:|^ERROR:|^  |^jq: `)
+#   で indented continuation 行と raw `jq:` parse error も pass-through
+# - success arm でも tempfile を inspect する (`_resolve-flow-state-path.sh`
+#   が graceful-degrade で exit 0 を返す経路、例えば `_resolve-session-id-from-file.sh`
+#   の tr IO failure による empty SID + WARNING 出力 + exit 0 経路で
+#   inner helper の WARNING を silent drop しないため)
+_resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
+  "session-start" \
+  "resolve-flow-state-err" \
+  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 if STATE_FILE=$("$SCRIPT_DIR/_resolve-flow-state-path.sh" "$STATE_ROOT" 2>"${_resolve_err:-/dev/null}"); then
-  :
+  if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
+  fi
 else
   if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
-    grep -E '^WARNING:|^ERROR:' "$_resolve_err" >&2 || true
+    grep -E '^WARNING:|^ERROR:|^  |^jq: ' "$_resolve_err" >&2 || true
   fi
   STATE_FILE="$STATE_ROOT/.rite-flow-state"
   echo "[rite] WARNING: flow-state path resolution failed, falling back to legacy ($STATE_FILE)" >&2

--- a/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
@@ -241,15 +241,24 @@ header_block=$(awk '/^# ⚠️ Caller contract/,/^# Why this exists/' "$HELPER")
 header_lines=$(printf '%s' "$header_block" | wc -l)
 if [ -z "$header_block" ]; then
   fail "Caller contract section not found in header (awk range extraction returned empty)"
-elif [ "$header_lines" -gt 50 ]; then
-  # Sanity check: if awk captured > 50 lines, the end marker `# Why this exists`
+elif [ "$header_lines" -gt 70 ]; then
+  # Sanity check: if awk captured > 70 lines, the end marker `# Why this exists`
   # was likely removed/renamed and awk fell through to EOF. This protects
   # against false PASS via accidental keyword appearances in code body.
-  fail "Header section sanity check failed: extracted $header_lines lines (expected < 50). End marker '# Why this exists' may have been removed/renamed"
+  # Upper bound bumped from 50 → 70 when the caller list expanded to include
+  # non-lifecycle hook callers (post-tool-wm-sync.sh, pre-tool-bash-guard.sh)
+  # and command-level callers (create.md, create-interview.md, cleanup.md).
+  fail "Header section sanity check failed: extracted $header_lines lines (expected < 70). End marker '# Why this exists' may have been removed/renamed"
 else
   contract_failed=0
+  # Lifecycle 4 hooks (with stderr pass-through pattern) + non-lifecycle hooks
+  # (RITE_DEBUG-gated diagnostic) + command-level callers (silent fall-through).
+  # Enforces enumeration completeness per actual `grep -rn _resolve-flow-state-path`
+  # results. New callers MUST be added both here and in the helper header.
   for keyword in 'Caller contract' 'check_session_ownership' 'Current callers' \
-                 'session-start.sh' 'session-end.sh' 'pre-compact.sh' 'post-compact.sh'; do
+                 'session-start.sh' 'session-end.sh' 'pre-compact.sh' 'post-compact.sh' \
+                 'post-tool-wm-sync.sh' 'pre-tool-bash-guard.sh' \
+                 'create.md' 'create-interview.md' 'cleanup.md'; do
     if ! printf '%s' "$header_block" | grep -qF "$keyword"; then
       fail "Header section missing required keyword: '$keyword'"
       contract_failed=1
@@ -257,7 +266,7 @@ else
     fi
   done
   if [ $contract_failed -eq 0 ]; then
-    pass "Caller contract section + 4 lifecycle hook callers documented in scoped header ($header_lines lines)"
+    pass "Caller contract section + 6 hook callers + 3 command callers documented in scoped header ($header_lines lines)"
   fi
 fi
 echo ""

--- a/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
@@ -228,15 +228,24 @@ echo ""
 # silent-regression vector this TC defends against — a future helper change must
 # update the contract section here, otherwise this assertion fails.
 #
-# F-11: Constrain the grep scope to the header comment block (between the
+# Constrain the grep scope to the header comment block (between the
 # `Caller contract` marker and the `Why this exists` boundary) so that future
 # additions of these keywords elsewhere in the file (e.g., shebang, code body,
 # error messages) do not accidentally satisfy the assertion without updating
 # the actual contract documentation.
+# Defensive: end marker absence guard — if the awk range matcher fails to find
+# the end pattern, it captures until EOF and could falsely PASS via accidental
+# keyword appearances in code body. See line-count sanity check below.
 echo "TC-749-CALLER-CONTRACT: header documents caller contract + caller list"
 header_block=$(awk '/^# ⚠️ Caller contract/,/^# Why this exists/' "$HELPER")
+header_lines=$(printf '%s' "$header_block" | wc -l)
 if [ -z "$header_block" ]; then
   fail "Caller contract section not found in header (awk range extraction returned empty)"
+elif [ "$header_lines" -gt 50 ]; then
+  # Sanity check: if awk captured > 50 lines, the end marker `# Why this exists`
+  # was likely removed/renamed and awk fell through to EOF. This protects
+  # against false PASS via accidental keyword appearances in code body.
+  fail "Header section sanity check failed: extracted $header_lines lines (expected < 50). End marker '# Why this exists' may have been removed/renamed"
 else
   contract_failed=0
   for keyword in 'Caller contract' 'check_session_ownership' 'Current callers' \
@@ -248,7 +257,7 @@ else
     fi
   done
   if [ $contract_failed -eq 0 ]; then
-    pass "Caller contract section + 4 lifecycle hook callers documented in scoped header"
+    pass "Caller contract section + 4 lifecycle hook callers documented in scoped header ($header_lines lines)"
   fi
 fi
 echo ""

--- a/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
@@ -222,6 +222,26 @@ else
 fi
 echo ""
 
+# --- TC-749-CALLER-CONTRACT (Issue #749, AC-2 / AC-LOCAL-2) ---
+# Static grep test: verify that the helper header documents the caller contract
+# and lists current lifecycle hook callers. Drift between code and docs is the
+# silent-regression vector this TC defends against — a future helper change must
+# update the contract section here, otherwise this assertion fails.
+echo "TC-749-CALLER-CONTRACT: header documents caller contract + caller list"
+contract_failed=0
+for keyword in 'Caller contract' 'check_session_ownership' 'Current callers' \
+               'session-start.sh' 'session-end.sh' 'pre-compact.sh' 'post-compact.sh'; do
+  if ! grep -qF "$keyword" "$HELPER"; then
+    fail "Header missing required keyword: '$keyword'"
+    contract_failed=1
+    break
+  fi
+done
+if [ $contract_failed -eq 0 ]; then
+  pass "Caller contract section + 4 lifecycle hook callers documented in header"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ $FAIL -eq 0 ]

--- a/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-flow-state-path.test.sh
@@ -227,18 +227,29 @@ echo ""
 # and lists current lifecycle hook callers. Drift between code and docs is the
 # silent-regression vector this TC defends against — a future helper change must
 # update the contract section here, otherwise this assertion fails.
+#
+# F-11: Constrain the grep scope to the header comment block (between the
+# `Caller contract` marker and the `Why this exists` boundary) so that future
+# additions of these keywords elsewhere in the file (e.g., shebang, code body,
+# error messages) do not accidentally satisfy the assertion without updating
+# the actual contract documentation.
 echo "TC-749-CALLER-CONTRACT: header documents caller contract + caller list"
-contract_failed=0
-for keyword in 'Caller contract' 'check_session_ownership' 'Current callers' \
-               'session-start.sh' 'session-end.sh' 'pre-compact.sh' 'post-compact.sh'; do
-  if ! grep -qF "$keyword" "$HELPER"; then
-    fail "Header missing required keyword: '$keyword'"
-    contract_failed=1
-    break
+header_block=$(awk '/^# ⚠️ Caller contract/,/^# Why this exists/' "$HELPER")
+if [ -z "$header_block" ]; then
+  fail "Caller contract section not found in header (awk range extraction returned empty)"
+else
+  contract_failed=0
+  for keyword in 'Caller contract' 'check_session_ownership' 'Current callers' \
+                 'session-start.sh' 'session-end.sh' 'pre-compact.sh' 'post-compact.sh'; do
+    if ! printf '%s' "$header_block" | grep -qF "$keyword"; then
+      fail "Header section missing required keyword: '$keyword'"
+      contract_failed=1
+      break
+    fi
+  done
+  if [ $contract_failed -eq 0 ]; then
+    pass "Caller contract section + 4 lifecycle hook callers documented in scoped header"
   fi
-done
-if [ $contract_failed -eq 0 ]; then
-  pass "Caller contract section + 4 lifecycle hook callers documented in header"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -212,6 +212,11 @@ dir_749="$TEST_DIR/tc749-passthrough"
 mkdir -p "$dir_749"
 jq -n '{active: true, issue_number: 749, phase: "phase5_test", next_action: "test", loop_count: 0, pr_number: 0, branch: "refactor/issue-749-test"}' \
   > "$dir_749/.rite-flow-state"
+# Seed compact_state so post-compact.sh actually exercises the recovery transition
+# (instead of the early `! -f compact_state` exit path). This lets us assert the
+# fallback path was loaded by observing the recovering→normal state transition.
+jq -n '{compact_state: "recovering", compact_state_set_at: "2026-04-01T00:00:00Z", active_issue: 749}' \
+  > "$dir_749/.rite-compact-state"
 
 stderr_file="$(mktemp "$TEST_DIR/stderr.749.XXXXXX")"
 echo "{\"cwd\": \"$dir_749\", \"source\": \"auto\"}" \
@@ -228,14 +233,17 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
-# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
-# post-compact.sh exits silently when no .rite-compact-state exists, so we verify
-# the fallback path was *opened* by checking there is no other error pattern indicating
-# the resolver returned a different (typo'd) path.
-if ! printf '%s' "$stderr_749" | grep -qE 'No such file or directory.*\.rite-flow-state[^.]'; then
-  pass "Legacy fallback path resolved to expected .rite-flow-state target"
+# Positive evidence: assert the legacy fallback path was actually used by
+# observing the compact_state transition. With compact_state="recovering"
+# seeded above, post-compact.sh on the fallback FLOW_STATE should transition
+# it to "normal". If the fallback path silently broke, post-compact.sh would
+# either ENOENT or transition the wrong file, and compact_state would remain
+# "recovering".
+compact_state_after=$(jq -r '.compact_state' "$dir_749/.rite-compact-state" 2>/dev/null)
+if [ "$compact_state_after" = "normal" ]; then
+  pass "Legacy fallback path was loaded (compact_state transitioned recovering→normal)"
 else
-  fail "Unexpected ENOENT for fallback path: $stderr_749"
+  fail "Expected compact_state=normal after recovery; got: $compact_state_after"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -187,5 +187,48 @@ else
 fi
 
 echo ""
+
+# --------------------------------------------------------------------------
+# TC-749-STDERR-PASSTHROUGH (Issue #749, AC-1 / AC-LOCAL-1)
+# --------------------------------------------------------------------------
+echo "TC-749-STDERR-PASSTHROUGH: helper failure → ERROR pass-through + fallback WARNING"
+
+HOOKS_REAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+sbx_749="$(mktemp -d "$TEST_DIR/sbx-hooks-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR/." "$sbx_749/"
+cat > "$sbx_749/_resolve-flow-state-path.sh" <<'FAKE_RESOLVER_EOF'
+#!/bin/bash
+echo "ERROR: TC-749 simulated _resolve-flow-state-path failure" >&2
+exit 1
+FAKE_RESOLVER_EOF
+chmod +x "$sbx_749/_resolve-flow-state-path.sh"
+
+# post-compact.sh exits early when no flow_state — provide an active legacy file
+# so the resolver path is exercised, the fallback FLOW_STATE points at it, and
+# the hook continues to attempt recovery (which will exit silently when there
+# is no .rite-compact-state). The point of this TC is the stderr pass-through,
+# not the recovery output.
+dir_749="$TEST_DIR/tc749-passthrough"
+mkdir -p "$dir_749"
+jq -n '{active: true, issue_number: 749, phase: "phase5_test", next_action: "test", loop_count: 0, pr_number: 0, branch: "refactor/issue-749-test"}' \
+  > "$dir_749/.rite-flow-state"
+
+stderr_file="$(mktemp "$TEST_DIR/stderr.749.XXXXXX")"
+echo "{\"cwd\": \"$dir_749\", \"source\": \"auto\"}" \
+  | bash "$sbx_749/post-compact.sh" >/dev/null 2>"$stderr_file" || true
+stderr_749="$(cat "$stderr_file")"
+
+if printf '%s' "$stderr_749" | grep -qF 'TC-749 simulated _resolve-flow-state-path failure'; then
+  pass "ERROR line from helper passed through to caller stderr"
+else
+  fail "Expected ERROR pass-through; got stderr: $stderr_749"
+fi
+if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, falling back to legacy'; then
+  pass "Fallback WARNING emitted to stderr"
+else
+  fail "Expected fallback WARNING; got stderr: $stderr_749"
+fi
+echo ""
+
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -228,6 +228,15 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
+# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# post-compact.sh exits silently when no .rite-compact-state exists, so we verify
+# the fallback path was *opened* by checking there is no other error pattern indicating
+# the resolver returned a different (typo'd) path.
+if ! printf '%s' "$stderr_749" | grep -qE 'No such file or directory.*\.rite-flow-state[^.]'; then
+  pass "Legacy fallback path resolved to expected .rite-flow-state target"
+else
+  fail "Unexpected ENOENT for fallback path: $stderr_749"
+fi
 echo ""
 
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -582,6 +582,44 @@ else
 fi
 echo ""
 
+# --------------------------------------------------------------------------
+# TC-749-STDERR-PASSTHROUGH (Issue #749, AC-1 / AC-LOCAL-1)
+# --------------------------------------------------------------------------
+echo "TC-749-STDERR-PASSTHROUGH: helper failure → ERROR pass-through + fallback WARNING"
+
+HOOKS_REAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+sbx_749="$(mktemp -d "$TEST_DIR/sbx-hooks-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR/." "$sbx_749/"
+cat > "$sbx_749/_resolve-flow-state-path.sh" <<'FAKE_RESOLVER_EOF'
+#!/bin/bash
+echo "ERROR: TC-749 simulated _resolve-flow-state-path failure" >&2
+exit 1
+FAKE_RESOLVER_EOF
+chmod +x "$sbx_749/_resolve-flow-state-path.sh"
+
+dir_749="$TEST_DIR/tc749-passthrough"
+mkdir -p "$dir_749"
+cat > "$dir_749/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 749, "phase": "phase5_test", "branch": "refactor/issue-749-test"}
+EOF
+
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.749.XXXXXX")"
+echo "{\"cwd\": \"$dir_749\"}" \
+  | bash "$sbx_749/pre-compact.sh" >/dev/null 2>"$LAST_STDERR_FILE" || true
+stderr_749="$(cat "$LAST_STDERR_FILE")"
+
+if printf '%s' "$stderr_749" | grep -qF 'TC-749 simulated _resolve-flow-state-path failure'; then
+  pass "ERROR line from helper passed through to caller stderr"
+else
+  fail "Expected ERROR pass-through; got stderr: $stderr_749"
+fi
+if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, falling back to legacy'; then
+  pass "Fallback WARNING emitted to stderr"
+else
+  fail "Expected fallback WARNING; got stderr: $stderr_749"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -618,7 +618,7 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
-# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# Positive evidence: assert the legacy fallback path was actually used.
 # pre-compact.sh updates `.updated_at` on the resolved FLOW_STATE. If the fallback
 # silently broke (typo / missing file), this would not happen.
 updated_at_after=$(jq -r '.updated_at // empty' "$dir_749/.rite-flow-state" 2>/dev/null)

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -618,6 +618,15 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
+# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# pre-compact.sh updates `.updated_at` on the resolved FLOW_STATE. If the fallback
+# silently broke (typo / missing file), this would not happen.
+updated_at_after=$(jq -r '.updated_at // empty' "$dir_749/.rite-flow-state" 2>/dev/null)
+if [ -n "$updated_at_after" ]; then
+  pass "Legacy fallback path was loaded (.updated_at present after pre-compact)"
+else
+  fail "Expected .updated_at in legacy state file; got: '$updated_at_after'"
+fi
 echo ""
 
 # --- Summary ---

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -517,6 +517,15 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
+# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# session-end.sh should deactivate the legacy state file (set .active=false). If the
+# fallback path silently broke, the file would remain .active=true.
+deactivated_active=$(jq -r '.active' "$dir_749/.rite-flow-state" 2>/dev/null)
+if [ "$deactivated_active" = "false" ]; then
+  pass "Legacy fallback path was loaded (.active flipped to false)"
+else
+  fail "Expected .active=false in legacy state file; got: $deactivated_active"
+fi
 echo ""
 
 # --------------------------------------------------------------------------
@@ -531,24 +540,41 @@ sbx_jq="$(mktemp -d "$TEST_DIR/sbx-hooks-jq-XXXXXX")"
 cp -a "$HOOKS_REAL_DIR/." "$sbx_jq/"
 
 # Inject a fake jq into a private bin dir at the front of PATH that exits 1
-# only on the deactivation invocation (`.active = false | .updated_at = $ts`),
-# while passing through all other jq calls unchanged so the hook can still parse
-# its inputs (cwd, source, ownership probe, lifecycle phase, etc.).
-fake_jq_bin="$(mktemp -d "$TEST_DIR/fakejq-XXXXXX")"
-cat > "$fake_jq_bin/jq" <<'FAKE_JQ_EOF'
+# only on the deactivation invocation, while passing through all other jq calls
+# unchanged so the hook can still parse its inputs (cwd, source, ownership probe,
+# lifecycle phase, etc.).
+#
+# Note (F-10): The fake jq発火 pattern below uses a relaxed match
+# (`*'.active'*'.updated_at'*`) instead of the exact production string, so that
+# harmless jq expression refactors (whitespace tweaks, order swaps) do not break
+# this TC. The underlying invariant being tested is "WARNING is emitted when jq
+# atomic write fails", not "the production jq expression has not been touched".
+#
+# Note (F-06): Resolve the real jq path via `command -v jq` rather than
+# hardcoding `/usr/bin/jq`, because macOS Homebrew installs jq under
+# `/opt/homebrew/bin/jq` and Nix uses `/run/current-system/sw/bin/jq`, etc.
+JQ_REAL="$(command -v jq)"
+if [ -z "$JQ_REAL" ]; then
+  fail "TC-749-JQ-WRITE-WARN: real jq not found in PATH (cannot build fake jq)"
+else
+  fake_jq_bin="$(mktemp -d "$TEST_DIR/fakejq-XXXXXX")"
+  # Use double-quoted heredoc so $JQ_REAL is expanded into the fake script
+  cat > "$fake_jq_bin/jq" <<FAKE_JQ_EOF
 #!/bin/bash
 # Fake jq: fail only on the session-end deactivation invocation
-for arg in "$@"; do
-  case "$arg" in
-    *'.active = false | .updated_at = $ts'*)
+# Pattern intentionally relaxed (F-10) — see test file comment above for rationale
+for arg in "\$@"; do
+  case "\$arg" in
+    *'.active'*'.updated_at'*)
       echo "fake jq: simulated failure for TC-749-JQ-WRITE-WARN" >&2
       exit 1
       ;;
   esac
 done
-exec /usr/bin/jq "$@"
+exec '$JQ_REAL' "\$@"
 FAKE_JQ_EOF
-chmod +x "$fake_jq_bin/jq"
+  chmod +x "$fake_jq_bin/jq"
+fi
 
 dir_jq="$TEST_DIR/tc749-jq"
 mkdir -p "$dir_jq"
@@ -572,10 +598,19 @@ if printf '%s' "$stderr_jq" | grep -qF 'rite: session-end: failed to deactivate 
 else
   fail "Expected jq-write WARNING; got stderr: $stderr_jq"
 fi
-if printf '%s' "$stderr_jq" | grep -qF '#749'; then
+# F-08: Assert the structural invariant ("WARNING contains an Issue number")
+# instead of the literal '#749', which only happened to match because the
+# test branch was named `refactor/issue-749-jqwarn`.
+if printf '%s' "$stderr_jq" | grep -qE 'Issue #[0-9]+'; then
   pass "WARNING includes Issue number from branch detection"
 else
-  fail "Expected '#749' in WARNING; got stderr: $stderr_jq"
+  fail "Expected 'Issue #<number>' in WARNING; got stderr: $stderr_jq"
+fi
+# F-05: Assert state_file path appears in WARNING (so $STATE_FILE substitution works)
+if printf '%s' "$stderr_jq" | grep -qF '.rite-flow-state'; then
+  pass "WARNING includes state file path"
+else
+  fail "Expected state file path '.rite-flow-state' in WARNING; got stderr: $stderr_jq"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -482,6 +482,104 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-749-STDERR-PASSTHROUGH (Issue #749, AC-1 / AC-LOCAL-1)
+# --------------------------------------------------------------------------
+echo "TC-749-STDERR-PASSTHROUGH: helper failure → ERROR pass-through + fallback WARNING"
+
+HOOKS_REAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+sbx_749="$(mktemp -d "$TEST_DIR/sbx-hooks-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR/." "$sbx_749/"
+cat > "$sbx_749/_resolve-flow-state-path.sh" <<'FAKE_RESOLVER_EOF'
+#!/bin/bash
+echo "ERROR: TC-749 simulated _resolve-flow-state-path failure" >&2
+exit 1
+FAKE_RESOLVER_EOF
+chmod +x "$sbx_749/_resolve-flow-state-path.sh"
+
+dir_749="$TEST_DIR/tc749-passthrough"
+mkdir -p "$dir_749"
+cat > "$dir_749/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 749, "phase": "phase5_test", "branch": "refactor/issue-749-test"}
+EOF
+
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.749.XXXXXX")"
+echo "{\"cwd\": \"$dir_749\"}" \
+  | bash "$sbx_749/session-end.sh" >/dev/null 2>"$LAST_STDERR_FILE" || true
+stderr_749="$(cat "$LAST_STDERR_FILE")"
+
+if printf '%s' "$stderr_749" | grep -qF 'TC-749 simulated _resolve-flow-state-path failure'; then
+  pass "ERROR line from helper passed through to caller stderr"
+else
+  fail "Expected ERROR pass-through; got stderr: $stderr_749"
+fi
+if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, falling back to legacy'; then
+  pass "Fallback WARNING emitted to stderr"
+else
+  fail "Expected fallback WARNING; got stderr: $stderr_749"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-749-JQ-WRITE-WARN (Issue #749, AC-3)
+# --------------------------------------------------------------------------
+# Verify that when jq fails to write the deactivated state (else arm of the
+# atomic write block), session-end emits a diagnostic WARNING to stderr
+# instead of silently swallowing the failure.
+echo "TC-749-JQ-WRITE-WARN: jq atomic write failure → WARNING emitted"
+
+sbx_jq="$(mktemp -d "$TEST_DIR/sbx-hooks-jq-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR/." "$sbx_jq/"
+
+# Inject a fake jq into a private bin dir at the front of PATH that exits 1
+# only on the deactivation invocation (`.active = false | .updated_at = $ts`),
+# while passing through all other jq calls unchanged so the hook can still parse
+# its inputs (cwd, source, ownership probe, lifecycle phase, etc.).
+fake_jq_bin="$(mktemp -d "$TEST_DIR/fakejq-XXXXXX")"
+cat > "$fake_jq_bin/jq" <<'FAKE_JQ_EOF'
+#!/bin/bash
+# Fake jq: fail only on the session-end deactivation invocation
+for arg in "$@"; do
+  case "$arg" in
+    *'.active = false | .updated_at = $ts'*)
+      echo "fake jq: simulated failure for TC-749-JQ-WRITE-WARN" >&2
+      exit 1
+      ;;
+  esac
+done
+exec /usr/bin/jq "$@"
+FAKE_JQ_EOF
+chmod +x "$fake_jq_bin/jq"
+
+dir_jq="$TEST_DIR/tc749-jq"
+mkdir -p "$dir_jq"
+(
+  cd "$dir_jq" && git init -q \
+    && git -c user.name=test -c user.email=test@test.com commit --allow-empty -m init -q \
+    && git checkout -B "refactor/issue-749-jqwarn" -q
+)
+cat > "$dir_jq/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 749, "phase": "phase5_test", "branch": "refactor/issue-749-jqwarn"}
+EOF
+
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.749jq.XXXXXX")"
+PATH="$fake_jq_bin:$PATH" \
+  bash -c "echo '{\"cwd\": \"$dir_jq\"}' | bash '$sbx_jq/session-end.sh'" \
+  >/dev/null 2>"$LAST_STDERR_FILE" || true
+stderr_jq="$(cat "$LAST_STDERR_FILE")"
+
+if printf '%s' "$stderr_jq" | grep -qF 'rite: session-end: failed to deactivate state file'; then
+  pass "WARNING emitted on jq atomic write failure"
+else
+  fail "Expected jq-write WARNING; got stderr: $stderr_jq"
+fi
+if printf '%s' "$stderr_jq" | grep -qF '#749'; then
+  pass "WARNING includes Issue number from branch detection"
+else
+  fail "Expected '#749' in WARNING; got stderr: $stderr_jq"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -562,7 +562,7 @@ else
   cat > "$fake_jq_bin/jq" <<FAKE_JQ_EOF
 #!/bin/bash
 # Fake jq: fail only on the session-end deactivation invocation
-# Pattern intentionally relaxed (F-10) — see test file comment above for rationale
+# Pattern intentionally relaxed — see test file comment above for rationale
 for arg in "\$@"; do
   case "\$arg" in
     *'.active'*'.updated_at'*)

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -517,7 +517,7 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
-# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# Positive evidence: assert the legacy fallback path was actually used.
 # session-end.sh should deactivate the legacy state file (set .active=false). If the
 # fallback path silently broke, the file would remain .active=true.
 deactivated_active=$(jq -r '.active' "$dir_749/.rite-flow-state" 2>/dev/null)
@@ -544,14 +544,14 @@ cp -a "$HOOKS_REAL_DIR/." "$sbx_jq/"
 # unchanged so the hook can still parse its inputs (cwd, source, ownership probe,
 # lifecycle phase, etc.).
 #
-# Note (F-10): The fake jq発火 pattern below uses a relaxed match
-# (`*'.active'*'.updated_at'*`) instead of the exact production string, so that
-# harmless jq expression refactors (whitespace tweaks, order swaps) do not break
-# this TC. The underlying invariant being tested is "WARNING is emitted when jq
-# atomic write fails", not "the production jq expression has not been touched".
+# The fake jq pattern below uses a relaxed match (`*'.active'*'.updated_at'*`)
+# instead of the exact production string, so that harmless jq expression
+# refactors (whitespace tweaks, order swaps) do not break this TC. The
+# underlying invariant being tested is "WARNING is emitted when jq atomic
+# write fails", not "the production jq expression has not been touched".
 #
-# Note (F-06): Resolve the real jq path via `command -v jq` rather than
-# hardcoding `/usr/bin/jq`, because macOS Homebrew installs jq under
+# Resolve the real jq path via `command -v jq` rather than hardcoding
+# `/usr/bin/jq`, because macOS Homebrew installs jq under
 # `/opt/homebrew/bin/jq` and Nix uses `/run/current-system/sw/bin/jq`, etc.
 JQ_REAL="$(command -v jq)"
 if [ -z "$JQ_REAL" ]; then
@@ -598,19 +598,30 @@ if printf '%s' "$stderr_jq" | grep -qF 'rite: session-end: failed to deactivate 
 else
   fail "Expected jq-write WARNING; got stderr: $stderr_jq"
 fi
-# F-08: Assert the structural invariant ("WARNING contains an Issue number")
-# instead of the literal '#749', which only happened to match because the
-# test branch was named `refactor/issue-749-jqwarn`.
+# Assert the structural invariant ("WARNING contains an Issue number") instead
+# of a literal number, which would only match by coincidence with the test
+# branch name and become brittle if the branch convention changes.
 if printf '%s' "$stderr_jq" | grep -qE 'Issue #[0-9]+'; then
   pass "WARNING includes Issue number from branch detection"
 else
   fail "Expected 'Issue #<number>' in WARNING; got stderr: $stderr_jq"
 fi
-# F-05: Assert state_file path appears in WARNING (so $STATE_FILE substitution works)
+# Assert state_file path appears in WARNING (so $STATE_FILE substitution works
+# and operators can locate the failed deactivation target without grepping git).
 if printf '%s' "$stderr_jq" | grep -qF '.rite-flow-state'; then
   pass "WARNING includes state file path"
 else
   fail "Expected state file path '.rite-flow-state' in WARNING; got stderr: $stderr_jq"
+fi
+# Assert jq stderr is passed through to the caller (not silently swallowed).
+# session-end.sh runs `jq ... > "$TMP_FILE"` without `2>/dev/null`, so jq's own
+# error diagnostics (line/column on parse errors, or here our fake script's
+# stderr) MUST reach the user. Locking this in test prevents a future refactor
+# from adding `2>/dev/null` and silently dropping the production jq diagnostic.
+if printf '%s' "$stderr_jq" | grep -qF 'fake jq: simulated failure'; then
+  pass "jq stderr passed through to caller"
+else
+  fail "Expected fake jq stderr in WARNING; got stderr: $stderr_jq"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -687,8 +687,8 @@ src_hook_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
 cp "$src_hook_dir/session-start.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/hook-preamble.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/state-path-resolve.sh" "$sandbox_hook_dir/"
-# F-01 (Issue #749): canonical mktemp helper も sandbox にコピーする
-cp "$src_hook_dir/_mktemp-stderr-guard.sh" "$sandbox_hook_dir/" 2>/dev/null || true
+# Sandbox に canonical mktemp helper を含める (silent suppress 禁止 — sibling cp と同じ fail-fast)
+cp "$src_hook_dir/_mktemp-stderr-guard.sh" "$sandbox_hook_dir/"
 # Stub session-ownership.sh: define helpers that don't break source, but omit check_session_ownership
 cat > "$sandbox_hook_dir/session-ownership.sh" <<'STUB_EOF'
 #!/bin/bash
@@ -726,7 +726,7 @@ cp "$src_hook_dir_b/session-start.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/hook-preamble.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/state-path-resolve.sh" "$sandbox_hook_dir_b/"
 # F-01 (Issue #749): canonical mktemp helper も sandbox にコピーする
-cp "$src_hook_dir_b/_mktemp-stderr-guard.sh" "$sandbox_hook_dir_b/" 2>/dev/null || true
+cp "$src_hook_dir_b/_mktemp-stderr-guard.sh" "$sandbox_hook_dir_b/"
 cat > "$sandbox_hook_dir_b/session-ownership.sh" <<'STUB_EOF'
 #!/bin/bash
 extract_session_id() { echo ""; }
@@ -862,10 +862,12 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
 fi
-# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# Positive evidence: assert the legacy fallback path was actually used.
 # session-start.sh on `source=startup` performs a defensive reset that flips
 # .active=true → false on the resolved STATE_FILE. If the fallback path silently
 # broke (e.g., typo in `.rite-flow_state`), the legacy file would not be written.
+# This complements the WARNING text assertion above by verifying side-effect
+# rather than just stderr output.
 deactivated_active=$(jq -r '.active' "$dir_749/.rite-flow-state" 2>/dev/null)
 if [ "$deactivated_active" = "false" ]; then
   pass "Legacy fallback path was loaded (defensive reset flipped .active to false)"

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -818,6 +818,49 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-749-STDERR-PASSTHROUGH (Issue #749, AC-1 / AC-LOCAL-1)
+# --------------------------------------------------------------------------
+# Verify that when _resolve-flow-state-path.sh exits non-zero, its stderr
+# (ERROR: lines from _validate-helpers.sh / _validate-state-root.sh) is passed
+# through to the user, AND a fallback WARNING is emitted. This defends against
+# the silent-fall-through regression that the previous `2>/dev/null` produced.
+echo "TC-749-STDERR-PASSTHROUGH: helper failure → ERROR pass-through + fallback WARNING"
+
+HOOKS_REAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+sbx_749="$(mktemp -d "$TEST_DIR/sbx-hooks-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR/." "$sbx_749/"
+cat > "$sbx_749/_resolve-flow-state-path.sh" <<'FAKE_RESOLVER_EOF'
+#!/bin/bash
+echo "ERROR: TC-749 simulated _resolve-flow-state-path failure" >&2
+exit 1
+FAKE_RESOLVER_EOF
+chmod +x "$sbx_749/_resolve-flow-state-path.sh"
+
+dir_749="$TEST_DIR/tc749"
+mkdir -p "$dir_749"
+# Seed legacy state file (active=true) so the fallback path has something to load
+cat > "$dir_749/.rite-flow-state" <<EOF
+{"active": true, "issue_number": 749, "phase": "phase5_test", "branch": "refactor/issue-749-test", "next_action": "test", "loop_count": 0}
+EOF
+
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.749.XXXXXX")"
+echo "{\"cwd\": \"$dir_749\", \"source\": \"startup\"}" \
+  | bash "$sbx_749/session-start.sh" >/dev/null 2>"$LAST_STDERR_FILE" || true
+stderr_749="$(cat "$LAST_STDERR_FILE")"
+
+if printf '%s' "$stderr_749" | grep -qF 'TC-749 simulated _resolve-flow-state-path failure'; then
+  pass "ERROR line from helper passed through to caller stderr"
+else
+  fail "Expected ERROR pass-through; got stderr: $stderr_749"
+fi
+if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, falling back to legacy'; then
+  pass "Fallback WARNING emitted to stderr"
+else
+  fail "Expected fallback WARNING; got stderr: $stderr_749"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -725,7 +725,7 @@ src_hook_dir_b="$(cd "$SCRIPT_DIR/.." && pwd)"
 cp "$src_hook_dir_b/session-start.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/hook-preamble.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/state-path-resolve.sh" "$sandbox_hook_dir_b/"
-# F-01 (Issue #749): canonical mktemp helper も sandbox にコピーする
+# Issue #749: canonical mktemp helper を sandbox に同期コピーする (silent suppress 禁止 — sibling cp と同じ fail-fast)
 cp "$src_hook_dir_b/_mktemp-stderr-guard.sh" "$sandbox_hook_dir_b/"
 cat > "$sandbox_hook_dir_b/session-ownership.sh" <<'STUB_EOF'
 #!/bin/bash

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -687,6 +687,8 @@ src_hook_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
 cp "$src_hook_dir/session-start.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/hook-preamble.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/state-path-resolve.sh" "$sandbox_hook_dir/"
+# F-01 (Issue #749): canonical mktemp helper も sandbox にコピーする
+cp "$src_hook_dir/_mktemp-stderr-guard.sh" "$sandbox_hook_dir/" 2>/dev/null || true
 # Stub session-ownership.sh: define helpers that don't break source, but omit check_session_ownership
 cat > "$sandbox_hook_dir/session-ownership.sh" <<'STUB_EOF'
 #!/bin/bash
@@ -723,6 +725,8 @@ src_hook_dir_b="$(cd "$SCRIPT_DIR/.." && pwd)"
 cp "$src_hook_dir_b/session-start.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/hook-preamble.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/state-path-resolve.sh" "$sandbox_hook_dir_b/"
+# F-01 (Issue #749): canonical mktemp helper も sandbox にコピーする
+cp "$src_hook_dir_b/_mktemp-stderr-guard.sh" "$sandbox_hook_dir_b/" 2>/dev/null || true
 cat > "$sandbox_hook_dir_b/session-ownership.sh" <<'STUB_EOF'
 #!/bin/bash
 extract_session_id() { echo ""; }
@@ -857,6 +861,16 @@ if printf '%s' "$stderr_749" | grep -qF 'flow-state path resolution failed, fall
   pass "Fallback WARNING emitted to stderr"
 else
   fail "Expected fallback WARNING; got stderr: $stderr_749"
+fi
+# F-07: Assert the legacy fallback path was actually used (not just the WARNING text).
+# session-start.sh on `source=startup` performs a defensive reset that flips
+# .active=true → false on the resolved STATE_FILE. If the fallback path silently
+# broke (e.g., typo in `.rite-flow_state`), the legacy file would not be written.
+deactivated_active=$(jq -r '.active' "$dir_749/.rite-flow-state" 2>/dev/null)
+if [ "$deactivated_active" = "false" ]; then
+  pass "Legacy fallback path was loaded (defensive reset flipped .active to false)"
+else
+  fail "Expected .active=false in legacy state file after defensive reset; got: $deactivated_active"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

PR #748 (Issue #680) cycle 1 で error-handling reviewer から指摘された 3 件 (HIGH 1 + MEDIUM 2) のうち、Likelihood-Evidence anchor の literal 形式不備により Phase 5.3.0 で推奨事項に降格された 3 件を統合的に対応します。3 件はすべて lifecycle hooks の **observability 改善** という共通テーマを持ちます。

## 変更内容

### 1. silent fall-through 解消 (元 HIGH)
4 lifecycle hooks (`session-start.sh` / `session-end.sh` / `pre-compact.sh` / `post-compact.sh`) で `_resolve-flow-state-path.sh` の `2>/dev/null` を stderr pass-through pattern に置換。`_validate-helpers.sh` (chmod -x / 部分配置) と `_validate-state-root.sh` (path traversal) が出力する `ERROR:` 行を user に届け、legacy path への silent 降格時に診断情報を保全。state-read.sh `_classify_err` doctrine (cycle 41 F-01) と整合。

### 2. caller contract 文書化 (元 MEDIUM)
`_resolve-flow-state-path.sh` header に **Caller contract** 節と **Current callers** 一覧 (4 lifecycle hooks) を追加。`check_session_ownership` 必須要件と、怠った場合のリスク (別 session の active state を modify、cross-session incident の double-emit、lifecycle 警告の誤発火) を明記。新規 caller 追加時の silent regression リスクを構造化して防ぐ。

### 3. session-end.sh jq write 失敗 WARNING (元 MEDIUM)
jq atomic write の失敗 else arm に `rite: session-end: failed to deactivate state file (Issue #${ISSUE_NUMBER:-unknown})` の 1 行を追加。pre-compact.sh の `rite: <hook>: ...` prefix 形式と整合。診断ログ無しでは user は `.active=false` への deactivate が成功したかを確認できなかった silent failure を解消。

## Acceptance Criteria

- [x] **AC-1** (silent fall-through 解消): 4 hooks すべてで helper 失敗時に `grep -E '^WARNING:|^ERROR:'` 経由で stderr pass-through する
- [x] **AC-2** (caller contract 文書化): header に Caller contract 節と現 caller 一覧が明記されている
- [x] **AC-3** (jq write WARNING): jq write 失敗 else arm で `rite: session-end: failed to deactivate state file` の WARNING が stderr に出力される
- [x] **AC-4** (non-regression): 既存 hooks/tests pass + 新規 TC で stderr pass-through 動作を verify
- [x] **AC-LOCAL-1**: silent fall-through 経路を意図的に発生させた fixture で WARNING 出力を assert
- [x] **AC-LOCAL-2**: caller contract 文書化の static grep test (header に必須キーワードが含まれることを check)

## Test Results

- 新規 TC: `T-stderr-passthrough` (4 hook 共通 sandbox 経由 fake-fail)、`T-caller-contract-doc` (header static grep)、`T-jq-write-failure-warning` (fake jq 経由 fail-arm 検証) — 全 PASS
- run-tests.sh: 27/28 ファイル PASS
- 既存テスト全件 non-regression 確認

## Known Issues

- `pre-compact.test.sh` TC-005 / TC-005b は本 PR と無関係に develop で pre-existing で fail。Issue out-of-scope のため本 PR では対応しない (rite-workflow の lint/drift system の警告も同様に pre-existing → 別 Issue 化検討)

## 関連 Issue

Closes #749

- 親 Issue: #672 (lifecycle hooks per-session 化、umbrella)
- 起源 PR: #748 (Issue #680 - 本指摘の発生元)
- Wiki 経験則: state-read.sh cycle 41 F-01 stderr pass-through doctrine

## Test plan

- [ ] 4 hook ファイルが stderr pass-through pattern を含むことを確認
- [ ] `_resolve-flow-state-path.sh` header に Caller contract 節が存在することを確認
- [ ] session-end.sh jq write else arm に WARNING が追加されていることを確認
- [ ] 新規 TC (T-stderr-passthrough × 4, T-caller-contract-doc, T-jq-write-failure-warning) がすべて PASS
- [ ] `bash plugins/rite/hooks/tests/run-tests.sh` で non-regression (pre-compact.sh の 2 件は pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
