### PR TITLE
test(hooks): #683 並行 2 session regression + Session Ownership 系再検証 + AND 論理 8 種防御層

### DIFF
--- a/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
+++ b/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
@@ -48,13 +48,15 @@ fi
 
 make_test_dir() {
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
+  [ -n "$d" ] && [ -d "$d" ] || { echo "ERROR: test dir invalid" >&2; return 1; }
   (
+    set -e
     cd "$d"
     git init -q
     echo a > a && git add a
     git -c user.email=t@test.local -c user.name=test commit -q -m init
-  )
+  ) || { echo "ERROR: test fixture setup failed in $d" >&2; return 1; }
   echo "$d"
 }
 
@@ -211,7 +213,7 @@ fi
 # Layer 8: case arm — phase-transition-whitelist.sh の declare -gA テーブル
 # --------------------------------------------------------------------------
 echo "Layer 8 (case arm): phase-transition-whitelist.sh の declare -gA + 関数 dispatch"
-case_arm_count=$(grep -cE 'declare -gA _RITE_PHASE_TRANSITIONS' "$WHITELIST" 2>/dev/null || echo 0)
+case_arm_count=$(grep -E 'declare -gA _RITE_PHASE_TRANSITIONS' "$WHITELIST" 2>/dev/null | wc -l)
 if [ "$case_arm_count" -ge 1 ]; then
   pass "Layer 8 evidence: declare -gA _RITE_PHASE_TRANSITIONS が存在 ($case_arm_count 箇所)"
 else
@@ -255,34 +257,37 @@ write_session_id "$TD" "$SID_INV"
 (cd "$TD" && bash "$HOOK" create --session "$SID_INV" \
   --phase "create_interview" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
 INV_F="$TD/.rite/sessions/$SID_INV.flow-state"
-jq '.active = false' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
 
-HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_INV" \
-  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "echo silent-skip-test"}}')
+# `gh issue create` は phase=create_interview で AND-logic gate が block 対象とする command。
+# active=false → guard は早期 silent skip (stdout 空 / deny JSON なし)
+# active=true → defense pathway 評価に進み stdout に permissionDecision: deny JSON を出力
+# pre-tool-bash-guard は exit 0 のまま stdout で deny を表現するため、stdout 内容で判定する。
+HOOK_INPUT_BLOCKING=$(jq -n --arg cwd "$TD" --arg sid "$SID_INV" \
+  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "gh issue create --title test --body test"}}')
+
+jq '.active = false' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
 set +e
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
-rc_false=$?
+out_false=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e
 
-# active=true でも (phase=create_interview AND-condition 成立)
 jq '.active = true' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
 set +e
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
-rc_true=$?
+out_true=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e
 
-# active=false → exit 0 (silent skip = 防御層が gate を通す)
-if [ "$rc_false" -eq 0 ]; then
-  pass "AND-logic: active=false で pre-tool-bash-guard が exit 0 (silent skip = 防御層 no-op)"
+# active=false: deny JSON が出力されない (silent skip = 防御層 no-op、Wiki #660 root cause 経路)
+if ! echo "$out_false" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  pass "AND-logic (active=false): permissionDecision: deny が出力されない (silent skip = 防御層 no-op)"
 else
-  fail "AND-logic: active=false でも guard が block (rc=$rc_false) — silent skip 契約違反"
+  fail "AND-logic (active=false): active=false でも guard が block JSON を出力 (silent skip 契約違反)"
 fi
 
-# active=true → 防御層が evaluation pathway を通る (rc 0 or 2 のいずれかで安定)
-if [ "$rc_true" -eq 0 ] || [ "$rc_true" -eq 2 ]; then
-  pass "AND-logic: active=true で pre-tool-bash-guard が evaluation pathway を通る (rc=$rc_true)"
+# active=true: deny JSON が出力される (AND-logic fire = .active=true 前提が機能している)
+# 旧 `rc=0 or 2` 検査では active 値に関わらず常に pass するため #660 regression を検出不能だった
+if echo "$out_true" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  pass "AND-logic invariant (active=true): permissionDecision: deny が出力 (AND-logic fire verified、#660 regression なし)"
 else
-  fail "AND-logic: active=true で guard が異常 exit code (rc=$rc_true)"
+  fail "AND-logic invariant (active=true): active=true でも guard が block JSON を出力しない (silent AND-logic skip = #660 regression)"
 fi
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
+++ b/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# AND-logic defense chain (Wiki 経験則 #660: 「前提条件の silent omit が AND 論理の防御層
+# チェーンを全体無効化する」) を新形式 (per-session file, schema_version=2) 上で verify。
+#
+# Issue #683 / parent #672 AC-LOCAL-3:
+#   - AND 論理 8 種防御層が新形式上で動作 (.rite-stop-guard-diag.log 相当の trace で verify)
+#
+# 8 種防御層:
+#   1. declarative      : commands/issue/*.md prose で `--active true` literal を declare
+#   2. sentinel         : workflow-incident-emit.sh が WORKFLOW_INCIDENT=1 sentinel を emit
+#   3. Pre-check        : commands で state-read.sh --field phase 経由の pre-condition check
+#   4. whitelist        : phase-transition-whitelist.sh が source 可能で case arm を持つ
+#   5. Pre-flight       : preflight-check.sh が --command-id 引数を受け付け、compact_state を gate
+#   6. Step 0           : create.md の "Step 0 Immediate Bash" pattern (turn 境界回避)
+#   7. 4-site 対称化    : `--active true` が 4 site 以上 (create.md / create-interview.md / start.md 系列) で symmetry
+#   8. case arm         : phase-transition-whitelist.sh の declare -gA テーブル + rite_phase_transition_allowed 関数
+#
+# 各 layer について以下を verify:
+#   (a) Evidence Test  : layer の存在を grep / file existence で mechanical に検出
+#   (b) AND-logic Test : `.active=true` で fire / `.active=false` で silent skip という contract が成立
+#
+# Note (architecture drift since #660): stop-guard.sh は #674 で removal 済み。
+# `.rite-stop-guard-diag.log` は現存しないため、layer 4/5/8 の AND-logic は
+# phase-transition-whitelist.sh と pre-tool-bash-guard.sh の挙動で間接観測する。
+#
+# Out of scope (#684 で扱う):
+#   - migration / atomic write integrity / cleanup / crash resume
+#
+# Usage: bash plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR/.."
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+HOOK="$HOOK_DIR/flow-state-update.sh"
+WHITELIST="$HOOK_DIR/phase-transition-whitelist.sh"
+PREFLIGHT="$HOOK_DIR/preflight-check.sh"
+INCIDENT_EMIT="$HOOK_DIR/workflow-incident-emit.sh"
+PRE_TOOL_GUARD="$HOOK_DIR/pre-tool-bash-guard.sh"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+make_test_dir() {
+  local d
+  d=$(mktemp -d)
+  (
+    cd "$d"
+    git init -q
+    echo a > a && git add a
+    git -c user.email=t@test.local -c user.name=test commit -q -m init
+  )
+  echo "$d"
+}
+
+write_config() {
+  local d="$1" sv="$2"
+  cat > "$d/rite-config.yml" << EOF
+flow_state:
+  schema_version: $sv
+EOF
+}
+
+write_session_id() {
+  echo "$2" > "$1/.rite-session-id"
+}
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+  return 0
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+
+echo "=== and-logic-defense-chain tests (Wiki 経験則 #660 / Issue #683 AC-LOCAL-3) ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# Layer 1: declarative — commands/issue/*.md prose で --active true literal を declare
+# --------------------------------------------------------------------------
+echo "Layer 1 (declarative): commands で --active true literal が declare されている"
+declarative_count=$(git -C "$REPO_ROOT" grep -nE '\-\-active true' plugins/rite/commands/issue/ 2>/dev/null | wc -l)
+if [ "$declarative_count" -gt 0 ]; then
+  pass "Layer 1 evidence: --active true literal が commands/issue/ 内に $declarative_count 箇所 (declarative 層成立)"
+else
+  fail "Layer 1: --active true literal が commands/issue/ 内に存在しない (declarative 層欠落)"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 2: sentinel — workflow-incident-emit.sh が WORKFLOW_INCIDENT=1 を emit
+# --------------------------------------------------------------------------
+echo "Layer 2 (sentinel): workflow-incident-emit.sh が WORKFLOW_INCIDENT=1 sentinel を emit"
+if [ -x "$INCIDENT_EMIT" ] || [ -f "$INCIDENT_EMIT" ]; then
+  pass "Layer 2 evidence: workflow-incident-emit.sh が存在"
+else
+  fail "Layer 2: workflow-incident-emit.sh が存在しない"
+fi
+
+# Runtime: emit が WORKFLOW_INCIDENT=1 sentinel を出力するか
+sentinel_out=$(bash "$INCIDENT_EMIT" --type skill_load_failure --details "test details" --pr-number 0 2>/dev/null) || sentinel_out=""
+if echo "$sentinel_out" | grep -q "WORKFLOW_INCIDENT=1"; then
+  pass "Layer 2 runtime: emit 結果に WORKFLOW_INCIDENT=1 が含まれる"
+else
+  fail "Layer 2 runtime: WORKFLOW_INCIDENT=1 sentinel が emit されない (out=$sentinel_out)"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 3: Pre-check — commands で state-read.sh --field phase 経由の pre-condition
+# --------------------------------------------------------------------------
+echo "Layer 3 (Pre-check): commands で state-read.sh --field phase pre-condition check"
+precheck_count=$(git -C "$REPO_ROOT" grep -nE 'state-read\.sh --field phase' plugins/rite/commands/ 2>/dev/null | wc -l)
+if [ "$precheck_count" -gt 0 ]; then
+  pass "Layer 3 evidence: state-read.sh --field phase 呼び出しが commands/ に $precheck_count 箇所"
+else
+  fail "Layer 3: Pre-check pattern が commands/ に存在しない"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 4: whitelist — phase-transition-whitelist.sh が source 可能で whitelist を持つ
+# --------------------------------------------------------------------------
+echo "Layer 4 (whitelist): phase-transition-whitelist.sh が source 可能で whitelist を持つ"
+if [ -f "$WHITELIST" ]; then
+  pass "Layer 4 evidence: phase-transition-whitelist.sh が存在"
+else
+  fail "Layer 4: phase-transition-whitelist.sh が存在しない"
+fi
+
+# Runtime: source して関数が呼べるか
+set +e
+(
+  set +u
+  source "$WHITELIST"
+  if declare -f rite_phase_transition_allowed >/dev/null 2>&1; then
+    # 既知の遷移 (phase1_5_parent → phase1_5_post_parent) が allow される
+    if rite_phase_transition_allowed "phase1_5_parent" "phase1_5_post_parent"; then
+      exit 0
+    else
+      exit 1
+    fi
+  else
+    exit 2
+  fi
+)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "Layer 4 runtime: rite_phase_transition_allowed が known transition を allow"
+else
+  fail "Layer 4 runtime: whitelist 関数が機能しない (rc=$rc)"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 5: Pre-flight — preflight-check.sh が --command-id を受け付け compact gate
+# --------------------------------------------------------------------------
+echo "Layer 5 (Pre-flight): preflight-check.sh が --command-id を受け付け、normal state で exit 0"
+if [ -f "$PREFLIGHT" ]; then
+  pass "Layer 5 evidence: preflight-check.sh が存在"
+else
+  fail "Layer 5: preflight-check.sh が存在しない"
+fi
+
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+# compact state なし → normal → exit 0
+set +e
+(cd "$TD" && bash "$PREFLIGHT" --command-id "/rite:issue:start" --cwd "$TD" >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "Layer 5 runtime: compact_state=normal で preflight-check は exit 0 (allow)"
+else
+  fail "Layer 5 runtime: normal state で preflight-check が block (rc=$rc)"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 6: Step 0 — create.md の "Step 0 Immediate Bash" pattern (turn 境界回避)
+# --------------------------------------------------------------------------
+echo "Layer 6 (Step 0): create.md に Step 0 Immediate Bash pattern が存在"
+step0_count=$(git -C "$REPO_ROOT" grep -nE '(Step 0 Immediate Bash|Step 0:[[:space:]]*Immediate)' plugins/rite/commands/issue/create.md 2>/dev/null | wc -l)
+if [ "$step0_count" -gt 0 ]; then
+  pass "Layer 6 evidence: create.md に Step 0 Immediate Bash pattern が $step0_count 箇所"
+else
+  fail "Layer 6: Step 0 Immediate Bash pattern が create.md に存在しない"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 7: 4-site 対称化 — --active true が 4 site 以上で symmetric
+# --------------------------------------------------------------------------
+echo "Layer 7 (4-site 対称化): --active true が 4 site 以上で symmetric"
+site_count=$(git -C "$REPO_ROOT" grep -lE '\-\-active true' plugins/rite/commands/issue/ 2>/dev/null | wc -l)
+if [ "$site_count" -ge 4 ]; then
+  pass "Layer 7 evidence: --active true を含む commands/issue/ file が $site_count 件 (≥4)"
+else
+  fail "Layer 7: 4-site 対称化が崩れている ($site_count files)"
+fi
+
+# --------------------------------------------------------------------------
+# Layer 8: case arm — phase-transition-whitelist.sh の declare -gA テーブル
+# --------------------------------------------------------------------------
+echo "Layer 8 (case arm): phase-transition-whitelist.sh の declare -gA + 関数 dispatch"
+case_arm_count=$(grep -cE 'declare -gA _RITE_PHASE_TRANSITIONS' "$WHITELIST" 2>/dev/null || echo 0)
+if [ "$case_arm_count" -ge 1 ]; then
+  pass "Layer 8 evidence: declare -gA _RITE_PHASE_TRANSITIONS が存在 ($case_arm_count 箇所)"
+else
+  fail "Layer 8: case arm/dispatch table が存在しない"
+fi
+
+# Runtime: 不正な遷移は reject される
+set +e
+(
+  set +u
+  source "$WHITELIST"
+  if declare -f rite_phase_transition_allowed >/dev/null 2>&1; then
+    if rite_phase_transition_allowed "phase1_5_parent" "phase5_completion"; then
+      exit 1  # 想定外: reject されるべき遷移が allow された
+    else
+      exit 0  # 期待通り reject
+    fi
+  else
+    exit 2
+  fi
+)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "Layer 8 runtime: 不正な遷移 (phase1_5_parent → phase5_completion) は reject される"
+else
+  fail "Layer 8 runtime: 不正な遷移が reject されない (rc=$rc)"
+fi
+
+# --------------------------------------------------------------------------
+# AND-logic invariant: active=false 状態で防御層は silent skip / active=true で fire
+# (#660 root cause = active=true 前提を omit すると 8 layer 全体が無効化される)
+# --------------------------------------------------------------------------
+echo "AND-logic invariant: active=false で defense layer は silent skip / active=true で fire"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_INV="abcdefab-cdef-abcd-efab-cdefabcdefab"
+write_session_id "$TD" "$SID_INV"
+
+# active=false setup
+(cd "$TD" && bash "$HOOK" create --session "$SID_INV" \
+  --phase "create_interview" --issue 1 --branch "b" --pr 0 --next "n" >/dev/null 2>&1)
+INV_F="$TD/.rite/sessions/$SID_INV.flow-state"
+jq '.active = false' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
+
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_INV" \
+  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "echo silent-skip-test"}}')
+set +e
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
+rc_false=$?
+set -e
+
+# active=true でも (phase=create_interview AND-condition 成立)
+jq '.active = true' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
+set +e
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
+rc_true=$?
+set -e
+
+# active=false → exit 0 (silent skip = 防御層が gate を通す)
+if [ "$rc_false" -eq 0 ]; then
+  pass "AND-logic: active=false で pre-tool-bash-guard が exit 0 (silent skip = 防御層 no-op)"
+else
+  fail "AND-logic: active=false でも guard が block (rc=$rc_false) — silent skip 契約違反"
+fi
+
+# active=true → 防御層が evaluation pathway を通る (rc 0 or 2 のいずれかで安定)
+if [ "$rc_true" -eq 0 ] || [ "$rc_true" -eq 2 ]; then
+  pass "AND-logic: active=true で pre-tool-bash-guard が evaluation pathway を通る (rc=$rc_true)"
+else
+  fail "AND-logic: active=true で guard が異常 exit code (rc=$rc_true)"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+echo "Defense layer mapping:"
+echo "  Layer 1 declarative      : commands prose で --active true literal を declare"
+echo "  Layer 2 sentinel         : workflow-incident-emit.sh が WORKFLOW_INCIDENT=1 emit"
+echo "  Layer 3 Pre-check        : state-read.sh --field phase pre-condition"
+echo "  Layer 4 whitelist        : phase-transition-whitelist.sh が source 可能"
+echo "  Layer 5 Pre-flight       : preflight-check.sh の compact_state gate"
+echo "  Layer 6 Step 0           : create.md の Step 0 Immediate Bash"
+echo "  Layer 7 4-site 対称化    : --active true の 4-site symmetric distribution"
+echo "  Layer 8 case arm         : phase-transition-whitelist.sh の declare -gA dispatch"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
+++ b/plugins/rite/hooks/tests/and-logic-defense-chain.test.sh
@@ -113,7 +113,15 @@ else
 fi
 
 # Runtime: emit が WORKFLOW_INCIDENT=1 sentinel を出力するか
-sentinel_out=$(bash "$INCIDENT_EMIT" --type skill_load_failure --details "test details" --pr-number 0 2>/dev/null) || sentinel_out=""
+# stderr 退避で emit script の syntax error / 引数 parse 失敗 / permission error を可視化
+emit_err=$(mktemp)
+if ! sentinel_out=$(bash "$INCIDENT_EMIT" --type skill_load_failure --details "test details" --pr-number 0 2>"$emit_err"); then
+  emit_rc=$?
+  emit_stderr_preview=$(head -3 "$emit_err")
+  echo "  WARN: workflow-incident-emit.sh rc=$emit_rc. stderr: ${emit_stderr_preview:-<empty>}" >&2
+  sentinel_out=""
+fi
+rm -f "$emit_err"
 if echo "$sentinel_out" | grep -q "WORKFLOW_INCIDENT=1"; then
   pass "Layer 2 runtime: emit 結果に WORKFLOW_INCIDENT=1 が含まれる"
 else
@@ -265,12 +273,25 @@ INV_F="$TD/.rite/sessions/$SID_INV.flow-state"
 HOOK_INPUT_BLOCKING=$(jq -n --arg cwd "$TD" --arg sid "$SID_INV" \
   '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "gh issue create --title test --body test"}}')
 
-jq '.active = false' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
+# `jq | mv` の `&&` 連鎖は bash の "tested context" 例外で jq 失敗時に silent fall-through する。
+# helper で if/else 化し fail-fast パターンに統一 (session-ownership-regression.test.sh と対称)。
+patch_active() {
+  local file="$1" value="$2"
+  if jq ".active = $value" "$file" > "${file}.tmp"; then
+    mv "${file}.tmp" "$file"
+  else
+    echo "ERROR: jq patch failed for $file (.active = $value)" >&2
+    rm -f "${file}.tmp"
+    exit 1
+  fi
+}
+
+patch_active "$INV_F" false
 set +e
 out_false=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e
 
-jq '.active = true' "$INV_F" > "${INV_F}.tmp" && mv "${INV_F}.tmp" "$INV_F"
+patch_active "$INV_F" true
 set +e
 out_true=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e

--- a/plugins/rite/hooks/tests/concurrent-sessions.test.sh
+++ b/plugins/rite/hooks/tests/concurrent-sessions.test.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# Tests for concurrent 2-session state independence (Issue #683 / parent #672 AC-1)
+#
+# Coverage:
+#   - T-01       : 2 並行セッションでの state 独立性
+#                  (a) sequential interleave / (b) concurrent create with wait
+#                  (c) concurrent patch (independent updates) / (d) cross-session isolation
+#   - T-LOCAL-1  : flake-free 100 連続実行 (concurrent create)
+#
+# Issue #672 の core value proposition (lock 不要で並行性が構造的に保証される) を
+# verify する CRITICAL path。マルチステート (per-session file, schema_version=2)
+# の上でのみ pass する設計。
+#
+# Out of scope (#684 で扱う):
+#   - migration / atomic write integrity / cleanup / crash resume
+#
+# Usage: bash plugins/rite/hooks/tests/concurrent-sessions.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../flow-state-update.sh"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+make_test_dir() {
+  local d
+  d=$(mktemp -d)
+  (
+    cd "$d"
+    git init -q
+    echo a > a && git add a
+    git -c user.email=t@test.local -c user.name=test commit -q -m init
+  )
+  echo "$d"
+}
+
+write_config() {
+  # $1=test_dir, $2=schema_version
+  local d="$1" sv="$2"
+  cat > "$d/rite-config.yml" << EOF
+flow_state:
+  schema_version: $sv
+EOF
+}
+
+write_session_id() {
+  echo "$2" > "$1/.rite-session-id"
+}
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+  return 0
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+
+echo "=== concurrent-sessions tests (Issue #683 / parent #672 AC-1) ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-1: sequential interleave (両 session が独立に作成される)
+# --------------------------------------------------------------------------
+echo "TC-1: sequential interleave (independent per-session files)"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_A="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa01"
+SID_B="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb01"
+
+(cd "$TD" && bash "$HOOK" create --session "$SID_A" \
+  --phase "create_interview" --issue 100 --branch "test-a" --pr 0 --next "next-a" >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" create --session "$SID_B" \
+  --phase "start_implementation" --issue 200 --branch "test-b" --pr 0 --next "next-b" >/dev/null 2>&1)
+
+A="$TD/.rite/sessions/$SID_A.flow-state"
+B="$TD/.rite/sessions/$SID_B.flow-state"
+
+if [ -f "$A" ] && [ -f "$B" ]; then
+  pass "両 session の per-session file が存在"
+else
+  fail "missing files: a=$([ -f "$A" ] && echo y || echo n) b=$([ -f "$B" ] && echo y || echo n)"
+fi
+
+if [ "$(jq -r '.phase' "$A")" = "create_interview" ] && [ "$(jq -r '.phase' "$B")" = "start_implementation" ]; then
+  pass "phase が独立に保持されている"
+else
+  fail "phase mismatch: a=$(jq -r '.phase' "$A" 2>/dev/null) b=$(jq -r '.phase' "$B" 2>/dev/null)"
+fi
+
+if [ "$(jq -r '.issue_number' "$A")" = "100" ] && [ "$(jq -r '.issue_number' "$B")" = "200" ]; then
+  pass "issue_number が独立に保持されている"
+else
+  fail "issue_number mismatch"
+fi
+
+if [ "$(jq -r '.session_id' "$A")" = "$SID_A" ] && [ "$(jq -r '.session_id' "$B")" = "$SID_B" ]; then
+  pass "session_id が各 file に正しく書き込まれている"
+else
+  fail "session_id mismatch"
+fi
+
+# --------------------------------------------------------------------------
+# TC-2: concurrent create — 同時起動で両 file が独立に作成される
+# --------------------------------------------------------------------------
+echo "TC-2: concurrent create (parallel subshells with wait)"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_C="cccccccc-cccc-cccc-cccc-cccccccccc01"
+SID_D="dddddddd-dddd-dddd-dddd-dddddddddd01"
+
+(
+  cd "$TD"
+  bash "$HOOK" create --session "$SID_C" \
+    --phase "phase_c" --issue 1 --branch "bc" --pr 0 --next "nc" >/dev/null 2>&1
+) &
+PID_C=$!
+(
+  cd "$TD"
+  bash "$HOOK" create --session "$SID_D" \
+    --phase "phase_d" --issue 2 --branch "bd" --pr 0 --next "nd" >/dev/null 2>&1
+) &
+PID_D=$!
+
+wait "$PID_C" || fail "session C concurrent create failed (rc=$?)"
+wait "$PID_D" || fail "session D concurrent create failed (rc=$?)"
+
+C="$TD/.rite/sessions/$SID_C.flow-state"
+D="$TD/.rite/sessions/$SID_D.flow-state"
+
+if [ -f "$C" ] && [ -f "$D" ]; then
+  pass "concurrent create で両 file が存在"
+else
+  fail "concurrent create: c=$([ -f "$C" ] && echo y || echo n) d=$([ -f "$D" ] && echo y || echo n)"
+fi
+
+if [ "$(jq -r '.phase' "$C")" = "phase_c" ] && [ "$(jq -r '.phase' "$D")" = "phase_d" ]; then
+  pass "concurrent create で phase が独立"
+else
+  fail "concurrent create phase: c=$(jq -r '.phase' "$C" 2>/dev/null) d=$(jq -r '.phase' "$D" 2>/dev/null)"
+fi
+
+# --------------------------------------------------------------------------
+# TC-3: concurrent patch — 一方の patch が他方の state に波及しない
+# --------------------------------------------------------------------------
+echo "TC-3: concurrent patch (cross-session isolation)"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_E="eeeeeeee-eeee-eeee-eeee-eeeeeeeeee01"
+SID_F="ffffffff-ffff-ffff-ffff-ffffffffff01"
+
+# Both sessions create first
+(cd "$TD" && bash "$HOOK" create --session "$SID_E" \
+  --phase "phase_e1" --issue 10 --branch "be" --pr 0 --next "ne" >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" create --session "$SID_F" \
+  --phase "phase_f1" --issue 20 --branch "bf" --pr 0 --next "nf" >/dev/null 2>&1)
+
+# Then patch concurrently
+(
+  cd "$TD"
+  bash "$HOOK" patch --session "$SID_E" \
+    --phase "phase_e2" --next "ne2" >/dev/null 2>&1
+) &
+PID_E=$!
+(
+  cd "$TD"
+  bash "$HOOK" patch --session "$SID_F" \
+    --phase "phase_f2" --next "nf2" >/dev/null 2>&1
+) &
+PID_F=$!
+
+wait "$PID_E" || fail "session E concurrent patch failed (rc=$?)"
+wait "$PID_F" || fail "session F concurrent patch failed (rc=$?)"
+
+E="$TD/.rite/sessions/$SID_E.flow-state"
+F="$TD/.rite/sessions/$SID_F.flow-state"
+
+if [ "$(jq -r '.phase' "$E")" = "phase_e2" ] && [ "$(jq -r '.phase' "$F")" = "phase_f2" ]; then
+  pass "concurrent patch で各 session が独立に更新されている"
+else
+  fail "concurrent patch phase: e=$(jq -r '.phase' "$E" 2>/dev/null) f=$(jq -r '.phase' "$F" 2>/dev/null)"
+fi
+
+# Cross-session isolation: issue_number / branch は patch されていないので保持
+if [ "$(jq -r '.issue_number' "$E")" = "10" ] && [ "$(jq -r '.issue_number' "$F")" = "20" ]; then
+  pass "patch されない field (issue_number) が保持されている"
+else
+  fail "patch field leaked: e_issue=$(jq -r '.issue_number' "$E" 2>/dev/null) f_issue=$(jq -r '.issue_number' "$F" 2>/dev/null)"
+fi
+
+# --------------------------------------------------------------------------
+# TC-4: same-issue concurrent — 両 session が同一 Issue を target にしても独立
+# --------------------------------------------------------------------------
+echo "TC-4: same-issue concurrent (両 session が同 Issue でも state は分離)"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_G="11111111-1111-1111-1111-111111111101"
+SID_H="22222222-2222-2222-2222-222222222201"
+
+(
+  cd "$TD"
+  bash "$HOOK" create --session "$SID_G" \
+    --phase "phase_g" --issue 999 --branch "bg" --pr 0 --next "ng" >/dev/null 2>&1
+) &
+PID_G=$!
+(
+  cd "$TD"
+  bash "$HOOK" create --session "$SID_H" \
+    --phase "phase_h" --issue 999 --branch "bh" --pr 0 --next "nh" >/dev/null 2>&1
+) &
+PID_H=$!
+wait "$PID_G"; wait "$PID_H"
+
+G="$TD/.rite/sessions/$SID_G.flow-state"
+H="$TD/.rite/sessions/$SID_H.flow-state"
+if [ -f "$G" ] && [ -f "$H" ]; then
+  pass "same-issue でも 2 session が独立 file を持つ"
+else
+  fail "same-issue concurrent missing file"
+fi
+if [ "$(jq -r '.branch' "$G")" = "bg" ] && [ "$(jq -r '.branch' "$H")" = "bh" ]; then
+  pass "same-issue でも branch field は session ごとに独立"
+else
+  fail "same-issue branch leaked"
+fi
+
+# --------------------------------------------------------------------------
+# T-LOCAL-1: flake-free 100 iterations of concurrent create
+# Issue #683 AC-LOCAL-1: 並行性テストが新形式 hook 群で 100% pass (10 連続実行で flake 0)
+# 10 連続が AC だが、より強い保証として 100 連続を採用
+# --------------------------------------------------------------------------
+echo "T-LOCAL-1: 100 iteration flake-free check (concurrent create)"
+ITERATIONS=100
+flake=0
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+
+# Each iteration uses fresh session UUIDs to avoid file reuse interference.
+for i in $(seq 1 "$ITERATIONS"); do
+  hex_i=$(printf "%012x" "$i")
+  SID_X="aaaaaaaa-aaaa-aaaa-aaaa-${hex_i}"
+  SID_Y="bbbbbbbb-bbbb-bbbb-bbbb-${hex_i}"
+  (
+    cd "$TD"
+    bash "$HOOK" create --session "$SID_X" \
+      --phase "px_$i" --issue "$i" --branch "bx_$i" --pr 0 --next "nx" >/dev/null 2>&1
+  ) &
+  pid_x=$!
+  (
+    cd "$TD"
+    bash "$HOOK" create --session "$SID_Y" \
+      --phase "py_$i" --issue "$i" --branch "by_$i" --pr 0 --next "ny" >/dev/null 2>&1
+  ) &
+  pid_y=$!
+  wait "$pid_x" || { flake=$((flake + 1)); continue; }
+  wait "$pid_y" || { flake=$((flake + 1)); continue; }
+
+  fx="$TD/.rite/sessions/$SID_X.flow-state"
+  fy="$TD/.rite/sessions/$SID_Y.flow-state"
+  if [ ! -f "$fx" ] || [ ! -f "$fy" ]; then
+    flake=$((flake + 1))
+    continue
+  fi
+  px=$(jq -r '.phase' "$fx" 2>/dev/null || echo "")
+  py=$(jq -r '.phase' "$fy" 2>/dev/null || echo "")
+  if [ "$px" != "px_$i" ] || [ "$py" != "py_$i" ]; then
+    flake=$((flake + 1))
+    continue
+  fi
+done
+
+if [ "$flake" -eq 0 ]; then
+  pass "100 iteration concurrent create: flake=0 (構造的並行性保証 verified)"
+else
+  fail "100 iteration concurrent create: flake=$flake / 100"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/concurrent-sessions.test.sh
+++ b/plugins/rite/hooks/tests/concurrent-sessions.test.sh
@@ -263,14 +263,22 @@ for i in $(seq 1 "$ITERATIONS"); do
       --phase "py_$i" --issue "$i" --branch "by_$i" --pr 0 --next "ny" >/dev/null 2>&1
   ) &
   pid_y=$!
-  if ! wait "$pid_x"; then
-    rc=$?; echo "  flake at iter=$i pid=x rc=$rc" >&2
-    flake=$((flake + 1)); continue
-  fi
-  if ! wait "$pid_y"; then
-    rc=$?; echo "  flake at iter=$i pid=y rc=$rc" >&2
-    flake=$((flake + 1)); continue
-  fi
+  # `if ! wait $pid` の `$?` は bash の否定演算子適用後の値 (0) になり真の rc を取れないため
+  # `wait || { rc=$?; ... }` パターンを使う。continue 前に未 reap の pid_y も明示的に wait で reap し
+  # orphan が次 iter の per-session file 書き込みに影響する race を防ぐ。
+  wait "$pid_x" || {
+    rc_x=$?
+    echo "  flake at iter=$i pid=x rc=$rc_x" >&2
+    wait "$pid_y" 2>/dev/null || true
+    flake=$((flake + 1))
+    continue
+  }
+  wait "$pid_y" || {
+    rc_y=$?
+    echo "  flake at iter=$i pid=y rc=$rc_y" >&2
+    flake=$((flake + 1))
+    continue
+  }
 
   fx="$TD/.rite/sessions/$SID_X.flow-state"
   fy="$TD/.rite/sessions/$SID_Y.flow-state"

--- a/plugins/rite/hooks/tests/concurrent-sessions.test.sh
+++ b/plugins/rite/hooks/tests/concurrent-sessions.test.sh
@@ -29,13 +29,15 @@ fi
 
 make_test_dir() {
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
+  [ -n "$d" ] && [ -d "$d" ] || { echo "ERROR: test dir invalid" >&2; return 1; }
   (
+    set -e
     cd "$d"
     git init -q
     echo a > a && git add a
     git -c user.email=t@test.local -c user.name=test commit -q -m init
-  )
+  ) || { echo "ERROR: test fixture setup failed in $d" >&2; return 1; }
   echo "$d"
 }
 
@@ -46,10 +48,6 @@ write_config() {
 flow_state:
   schema_version: $sv
 EOF
-}
-
-write_session_id() {
-  echo "$2" > "$1/.rite-session-id"
 }
 
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
@@ -221,7 +219,8 @@ PID_G=$!
     --phase "phase_h" --issue 999 --branch "bh" --pr 0 --next "nh" >/dev/null 2>&1
 ) &
 PID_H=$!
-wait "$PID_G"; wait "$PID_H"
+wait "$PID_G" || fail "TC-4 G concurrent create failed (rc=$?)"
+wait "$PID_H" || fail "TC-4 H concurrent create failed (rc=$?)"
 
 G="$TD/.rite/sessions/$SID_G.flow-state"
 H="$TD/.rite/sessions/$SID_H.flow-state"
@@ -264,8 +263,14 @@ for i in $(seq 1 "$ITERATIONS"); do
       --phase "py_$i" --issue "$i" --branch "by_$i" --pr 0 --next "ny" >/dev/null 2>&1
   ) &
   pid_y=$!
-  wait "$pid_x" || { flake=$((flake + 1)); continue; }
-  wait "$pid_y" || { flake=$((flake + 1)); continue; }
+  if ! wait "$pid_x"; then
+    rc=$?; echo "  flake at iter=$i pid=x rc=$rc" >&2
+    flake=$((flake + 1)); continue
+  fi
+  if ! wait "$pid_y"; then
+    rc=$?; echo "  flake at iter=$i pid=y rc=$rc" >&2
+    flake=$((flake + 1)); continue
+  fi
 
   fx="$TD/.rite/sessions/$SID_X.flow-state"
   fy="$TD/.rite/sessions/$SID_Y.flow-state"

--- a/plugins/rite/hooks/tests/session-ownership-regression.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership-regression.test.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# Session Ownership 系列 (#173 / #206 / #216 / #558 / #660) regression on
+# multi-state format (per-session file, schema_version=2).
+#
+# Issue #683 / parent #672 AC-7 を verify する。
+# 過去 5 件の Issue で導入した防御層が、新形式上でも構造的に成立することを mechanical に確認する。
+#
+# Coverage:
+#   - TC-173 (Per-session isolation)         : 2 session が異なる per-session file に独立に書き込む
+#   - TC-206 (SOURCE=startup/clear reset)    : startup/clear 時に自 session の state が active=false にリセット
+#   - TC-216 (.rite-session-id auto-read)    : flow-state-update.sh が --session 省略時に file 経由で読み取る
+#   - TC-558 (Other-session preservation)    : 他 session の state は reset しない (核心)
+#   - TC-660 (active=true gate)              : active=false / true で防御層 (AND-logic) が正しく振舞う
+#
+# Out of scope (#684 で扱う):
+#   - migration / atomic write integrity / cleanup / crash resume
+#
+# Note (architecture drift since #660): stop-guard.sh は #674 で removal 済み。
+# #660 の active=true 前提は現在 pre-tool-bash-guard.sh の AND-logic
+# (`.active=true && phase=create_*`) に継承されており、ここを TC-660 で verify する。
+#
+# Usage: bash plugins/rite/hooks/tests/session-ownership-regression.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR/.."
+HOOK="$HOOK_DIR/flow-state-update.sh"
+SESSION_START="$HOOK_DIR/session-start.sh"
+PRE_TOOL_GUARD="$HOOK_DIR/pre-tool-bash-guard.sh"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+make_test_dir() {
+  local d
+  d=$(mktemp -d)
+  (
+    cd "$d"
+    git init -q
+    echo a > a && git add a
+    git -c user.email=t@test.local -c user.name=test commit -q -m init
+  )
+  echo "$d"
+}
+
+write_config() {
+  local d="$1" sv="$2"
+  cat > "$d/rite-config.yml" << EOF
+flow_state:
+  schema_version: $sv
+EOF
+}
+
+write_session_id() {
+  echo "$2" > "$1/.rite-session-id"
+}
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+  return 0
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+
+echo "=== session-ownership-regression tests (Issue #683 / parent #672 AC-7) ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-173: Per-session file isolation (single-file race window が消滅)
+# --------------------------------------------------------------------------
+echo "TC-173 (Per-session isolation): 2 session が異なる per-session file に独立書き込み"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_A="11111111-1111-1111-1111-111111111111"
+SID_B="22222222-2222-2222-2222-222222222222"
+
+(cd "$TD" && bash "$HOOK" create --session "$SID_A" \
+  --phase "p_a" --issue 100 --branch "ba" --pr 0 --next "na" >/dev/null 2>&1)
+(cd "$TD" && bash "$HOOK" create --session "$SID_B" \
+  --phase "p_b" --issue 200 --branch "bb" --pr 0 --next "nb" >/dev/null 2>&1)
+
+A="$TD/.rite/sessions/$SID_A.flow-state"
+B="$TD/.rite/sessions/$SID_B.flow-state"
+
+if [ -f "$A" ] && [ -f "$B" ] \
+  && [ "$(jq -r '.session_id' "$A")" = "$SID_A" ] \
+  && [ "$(jq -r '.session_id' "$B")" = "$SID_B" ]; then
+  pass "TC-173: per-session file が session_id で一意にアドレスされる (race window 構造的に消滅)"
+else
+  fail "TC-173: per-session file の独立性が成立していない"
+fi
+
+# 単一ファイル時代の競合シナリオ (B が A を上書き) が新形式では起きないことを確認
+if [ "$(jq -r '.phase' "$A")" = "p_a" ] && [ "$(jq -r '.issue_number' "$A")" = "100" ]; then
+  pass "TC-173: A の state が B の create で破壊されていない"
+else
+  fail "TC-173: A の state が破壊されている (single-file race regression)"
+fi
+
+# --------------------------------------------------------------------------
+# TC-216: .rite-session-id auto-read by flow-state-update.sh
+# AC-1: session-start.sh saves UUID / AC-2: flow-state-update reads it / AC-3: fallback
+# --------------------------------------------------------------------------
+echo "TC-216 (.rite-session-id auto-read):"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_AUTO="33333333-3333-3333-3333-333333333333"
+write_session_id "$TD" "$SID_AUTO"
+
+# AC-2: --session 省略時に .rite-session-id を auto-read
+(cd "$TD" && bash "$HOOK" create \
+  --phase "p_auto" --issue 1 --branch "b_auto" --pr 0 --next "n_auto" >/dev/null 2>&1)
+
+AUTO="$TD/.rite/sessions/$SID_AUTO.flow-state"
+if [ -f "$AUTO" ] && [ "$(jq -r '.session_id' "$AUTO")" = "$SID_AUTO" ]; then
+  pass "TC-216 AC-2: --session 省略時に .rite-session-id 経由で UUID が解決される"
+else
+  fail "TC-216 AC-2: auto-read が機能していない (file_exists=$([ -f "$AUTO" ] && echo y || echo n))"
+fi
+
+# AC-3: --session 引数指定時は引数優先 (.rite-session-id を上書きしない)
+SID_OVERRIDE="44444444-4444-4444-4444-444444444444"
+(cd "$TD" && bash "$HOOK" create --session "$SID_OVERRIDE" \
+  --phase "p_ov" --issue 2 --branch "b_ov" --pr 0 --next "n_ov" >/dev/null 2>&1)
+
+OV="$TD/.rite/sessions/$SID_OVERRIDE.flow-state"
+if [ -f "$OV" ] && [ "$(jq -r '.session_id' "$OV")" = "$SID_OVERRIDE" ]; then
+  pass "TC-216 AC-3: --session 引数指定時は引数値が優先される"
+else
+  fail "TC-216 AC-3: --session 引数が無視されている"
+fi
+
+# --------------------------------------------------------------------------
+# TC-206 + TC-558: SOURCE=startup/clear reset と他 session preservation
+# AC-01 (own reset) / AC-02 (other not reset) / AC-03 (legacy reset)
+# --------------------------------------------------------------------------
+echo "TC-206 + TC-558 (SOURCE=startup reset semantics):"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_OWN="55555555-5555-5555-5555-555555555555"
+write_session_id "$TD" "$SID_OWN"
+
+# 自セッションの state を作成 (active=true)
+(cd "$TD" && bash "$HOOK" create --session "$SID_OWN" \
+  --phase "phase_x" --issue 10 --branch "bx" --pr 0 --next "nx" >/dev/null 2>&1)
+
+OWN="$TD/.rite/sessions/$SID_OWN.flow-state"
+[ "$(jq -r '.active' "$OWN")" = "true" ] || fail "TC-558 setup: own state が active=true で作成されていない"
+
+# レガシー単一ファイルを「他 session の state」として配置 (per-session file 形式の他 session を
+# 新規作成すると別 path に書かれて session-start のリゾルバが見にいく対象に乗らないため、
+# レガシー path に other session_id の state を書いて 「session-start.sh が own session の
+# state file を resolve した結果に対して reset 処理を行う」 路を pin する)
+SID_OTHER="66666666-6666-6666-6666-666666666666"
+
+# session-start.sh を SOURCE=startup で起動 (own session)
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_OWN" \
+  '{cwd: $cwd, session_id: $sid, source: "startup"}')
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+
+# AC-01: own session の state は reset (active=false)
+if [ "$(jq -r '.active' "$OWN")" = "false" ]; then
+  pass "TC-206/558 AC-01: SOURCE=startup で own session の state が active=false にリセット"
+else
+  fail "TC-206/558 AC-01: own state が reset されていない (active=$(jq -r '.active' "$OWN"))"
+fi
+
+# AC-02: 他 session の state は reset しない
+echo "TC-558 AC-02: 他 session の per-session state は reset されない"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_ME="77777777-7777-7777-7777-777777777777"
+SID_OTHER="88888888-8888-8888-8888-888888888888"
+write_session_id "$TD" "$SID_ME"
+
+# 他 session の state を作成 (active=true)
+(cd "$TD" && bash "$HOOK" create --session "$SID_OTHER" \
+  --phase "phase_other" --issue 20 --branch "b_other" --pr 0 --next "n_other" >/dev/null 2>&1)
+OTHER="$TD/.rite/sessions/$SID_OTHER.flow-state"
+[ "$(jq -r '.active' "$OTHER")" = "true" ] || fail "TC-558 AC-02 setup: other state が active=true でない"
+
+# session-start.sh を SOURCE=startup で起動 (own session_id = SID_ME)
+# session-start.sh の resolver は own session_id 経由で per-session file を resolve するため、
+# SID_OTHER の per-session file は触られない (構造的に他 session に手を出せない)
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_ME" \
+  '{cwd: $cwd, session_id: $sid, source: "startup"}')
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+
+# 他 session の state は active=true のまま
+if [ "$(jq -r '.active' "$OTHER")" = "true" ]; then
+  pass "TC-558 AC-02: 他 session (SID_OTHER) の state は active=true のまま"
+else
+  fail "TC-558 AC-02: 他 session の state が破壊された (active=$(jq -r '.active' "$OTHER"))"
+fi
+
+# AC-03: SOURCE=clear でも同様
+echo "TC-206 AC-2 (SOURCE=clear reset)"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_CLEAR="99999999-9999-9999-9999-999999999999"
+write_session_id "$TD" "$SID_CLEAR"
+(cd "$TD" && bash "$HOOK" create --session "$SID_CLEAR" \
+  --phase "phase_c" --issue 30 --branch "bc" --pr 0 --next "nc" >/dev/null 2>&1)
+CLEAR_F="$TD/.rite/sessions/$SID_CLEAR.flow-state"
+
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_CLEAR" \
+  '{cwd: $cwd, session_id: $sid, source: "clear"}')
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+
+if [ "$(jq -r '.active' "$CLEAR_F")" = "false" ]; then
+  pass "TC-206 AC-2: SOURCE=clear でも own session state が active=false にリセット"
+else
+  fail "TC-206 AC-2: clear で reset されていない"
+fi
+
+# --------------------------------------------------------------------------
+# TC-660: active=true gate (AND-logic in pre-tool-bash-guard.sh)
+# AC-2 (active=false → no block) / AC-3 (active=true → block in defense scope)
+# --------------------------------------------------------------------------
+echo "TC-660 (active=true gate, AND-logic):"
+TD=$(make_test_dir); cleanup_dirs+=("$TD")
+write_config "$TD" 2
+SID_GATE="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+write_session_id "$TD" "$SID_GATE"
+
+# Setup: active=false で create_interview phase
+(cd "$TD" && bash "$HOOK" create --session "$SID_GATE" \
+  --phase "create_interview" --issue 40 --branch "bg" --pr 0 --next "ng" >/dev/null 2>&1)
+GATE_F="$TD/.rite/sessions/$SID_GATE.flow-state"
+# active=false に強制 patch
+jq '.active = false' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+
+# AC-2: active=false → pre-tool-bash-guard は許可 (exit 0)
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
+  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "echo test"}}')
+set +e
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "TC-660 AC-2: active=false で pre-tool-bash-guard は exit 0 (block しない)"
+else
+  fail "TC-660 AC-2: active=false でも pre-tool-bash-guard が block (rc=$rc)"
+fi
+
+# AC-3: active=true & phase=create_interview & non-allowed Bash command → guard が defense fire
+# phase が create_interview / create_post_interview の AND-logic の Mode B 経路を pin
+jq '.active = true' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+
+# 防御層は phase=create_interview の context で `gh issue create` 等を block するロジック。
+# 単純な "echo test" は allow-list に入っているため fire しない可能性がある。
+# 本テストでは「active=true + phase=create_interview の組合せが defense decision pathway を
+# trigger できる」ことを mechanical に verify する。実際の defense 出力ではなく、guard が
+# "条件成立 → 評価実行" の path に進むことを active=false case との対比で確認する設計。
+# (詳細な defense fire は stop-guard.sh removal 後の現状では pre-tool-bash-guard 単体の
+#  挙動に依存し、test fixture からは間接観測しかできないため、AND-logic の "active 必須"
+#  contract が成立していることをもって AC-3 の core proposition を満たす)
+guard_active=$(jq -r '.active' "$GATE_F")
+guard_phase=$(jq -r '.phase' "$GATE_F")
+if [ "$guard_active" = "true" ] && [ "$guard_phase" = "create_interview" ]; then
+  pass "TC-660 AC-3: active=true && phase=create_interview の AND condition が成立 (defense pathway 入口)"
+else
+  fail "TC-660 AC-3: AND condition 不成立 (active=$guard_active phase=$guard_phase)"
+fi
+
+# AC-3 補強: active=true 状態で同じ Bash 入力を guard に通したときの exit code が
+# active=false 時と異なる経路を取る (= AND-logic が fire 評価に進む) ことを確認する。
+# 結果が exit 0 (allow) でも exit 2 (deny) でも、active=false の早期 exit と区別できれば良い。
+# ここでは "exit code が 0/2 のいずれかで安定する" ことを smoke check として pass 判定する。
+HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
+  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "echo test"}}')
+set +e
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] || [ "$rc" -eq 2 ]; then
+  pass "TC-660 AC-3: active=true 経路で guard が正常 exit code (0 or 2) を返す"
+else
+  fail "TC-660 AC-3: active=true 経路で異常 exit code (rc=$rc)"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+echo "Issue mapping:"
+echo "  TC-173: Per-session isolation (race window 構造的消滅)"
+echo "  TC-216: .rite-session-id auto-read (AC-2 / AC-3)"
+echo "  TC-206 + TC-558: SOURCE=startup/clear reset semantics (AC-01 own / AC-02 other / AC-2 clear)"
+echo "  TC-660: active=true gate (AND-logic in pre-tool-bash-guard.sh)"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/session-ownership-regression.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership-regression.test.sh
@@ -37,13 +37,15 @@ fi
 
 make_test_dir() {
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
+  [ -n "$d" ] && [ -d "$d" ] || { echo "ERROR: test dir invalid" >&2; return 1; }
   (
+    set -e
     cd "$d"
     git init -q
     echo a > a && git add a
     git -c user.email=t@test.local -c user.name=test commit -q -m init
-  )
+  ) || { echo "ERROR: test fixture setup failed in $d" >&2; return 1; }
   echo "$d"
 }
 
@@ -160,16 +162,13 @@ write_session_id "$TD" "$SID_OWN"
 OWN="$TD/.rite/sessions/$SID_OWN.flow-state"
 [ "$(jq -r '.active' "$OWN")" = "true" ] || fail "TC-558 setup: own state が active=true で作成されていない"
 
-# レガシー単一ファイルを「他 session の state」として配置 (per-session file 形式の他 session を
-# 新規作成すると別 path に書かれて session-start のリゾルバが見にいく対象に乗らないため、
-# レガシー path に other session_id の state を書いて 「session-start.sh が own session の
-# state file を resolve した結果に対して reset 処理を行う」 路を pin する)
-SID_OTHER="66666666-6666-6666-6666-666666666666"
-
 # session-start.sh を SOURCE=startup で起動 (own session)
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_OWN" \
   '{cwd: $cwd, session_id: $sid, source: "startup"}')
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+ss_err=$(mktemp)
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
+  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+rm -f "$ss_err"
 
 # AC-01: own session の state は reset (active=false)
 if [ "$(jq -r '.active' "$OWN")" = "false" ]; then
@@ -197,7 +196,10 @@ OTHER="$TD/.rite/sessions/$SID_OTHER.flow-state"
 # SID_OTHER の per-session file は触られない (構造的に他 session に手を出せない)
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_ME" \
   '{cwd: $cwd, session_id: $sid, source: "startup"}')
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+ss_err=$(mktemp)
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
+  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+rm -f "$ss_err"
 
 # 他 session の state は active=true のまま
 if [ "$(jq -r '.active' "$OTHER")" = "true" ]; then
@@ -218,7 +220,10 @@ CLEAR_F="$TD/.rite/sessions/$SID_CLEAR.flow-state"
 
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_CLEAR" \
   '{cwd: $cwd, session_id: $sid, source: "clear"}')
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>&1) || true
+ss_err=$(mktemp)
+echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
+  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+rm -f "$ss_err"
 
 if [ "$(jq -r '.active' "$CLEAR_F")" = "false" ]; then
   pass "TC-206 AC-2: SOURCE=clear でも own session state が active=false にリセット"
@@ -268,28 +273,36 @@ jq '.active = true' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
 # (詳細な defense fire は stop-guard.sh removal 後の現状では pre-tool-bash-guard 単体の
 #  挙動に依存し、test fixture からは間接観測しかできないため、AND-logic の "active 必須"
 #  contract が成立していることをもって AC-3 の core proposition を満たす)
-guard_active=$(jq -r '.active' "$GATE_F")
-guard_phase=$(jq -r '.phase' "$GATE_F")
-if [ "$guard_active" = "true" ] && [ "$guard_phase" = "create_interview" ]; then
-  pass "TC-660 AC-3: active=true && phase=create_interview の AND condition が成立 (defense pathway 入口)"
-else
-  fail "TC-660 AC-3: AND condition 不成立 (active=$guard_active phase=$guard_phase)"
-fi
+# AC-3: active=true で `gh issue create` 等 phase=create_interview で block 対象となる Bash
+# 入力を渡し、guard の defense decision pathway (AND-logic fire) が走ることを stdout の
+# `permissionDecision: "deny"` JSON 出力で verify する。pre-tool-bash-guard は exit 0 のまま
+# stdout に JSON を返すため exit code 差分では区別できず、stdout 内容で判定する必要がある。
+HOOK_INPUT_BLOCKING=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
+  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "gh issue create --title test --body test"}}')
 
-# AC-3 補強: active=true 状態で同じ Bash 入力を guard に通したときの exit code が
-# active=false 時と異なる経路を取る (= AND-logic が fire 評価に進む) ことを確認する。
-# 結果が exit 0 (allow) でも exit 2 (deny) でも、active=false の早期 exit と区別できれば良い。
-# ここでは "exit code が 0/2 のいずれかで安定する" ことを smoke check として pass 判定する。
-HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
-  '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "echo test"}}')
+# active=false → guard は早期 silent skip (stdout 空 / 短い)
+jq '.active = false' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
 set +e
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$PRE_TOOL_GUARD" >/dev/null 2>&1)
-rc=$?
+out_active_false=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e
-if [ "$rc" -eq 0 ] || [ "$rc" -eq 2 ]; then
-  pass "TC-660 AC-3: active=true 経路で guard が正常 exit code (0 or 2) を返す"
+
+# active=true → guard は AND-logic 評価に進み deny JSON を出力
+jq '.active = true' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+set +e
+out_active_true=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
+set -e
+
+# active=false: deny JSON が出力されないこと (silent skip)
+if ! echo "$out_active_false" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  pass "TC-660 AC-3 (active=false): permissionDecision: deny が出力されない (silent skip = 防御層 no-op)"
 else
-  fail "TC-660 AC-3: active=true 経路で異常 exit code (rc=$rc)"
+  fail "TC-660 AC-3 (active=false): active=false でも guard が block JSON を出力した (silent skip 契約違反)"
+fi
+# active=true: deny JSON が出力されること (AND-logic fire)
+if echo "$out_active_true" | grep -q '"permissionDecision":[[:space:]]*"deny"'; then
+  pass "TC-660 AC-3 (active=true): permissionDecision: deny が出力 (AND-logic fire verified, #660 regression なし)"
+else
+  fail "TC-660 AC-3 (active=true): active=true でも guard が block JSON を出力しない (silent AND-logic skip = #660 regression)"
 fi
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/session-ownership-regression.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership-regression.test.sh
@@ -166,8 +166,11 @@ OWN="$TD/.rite/sessions/$SID_OWN.flow-state"
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_OWN" \
   '{cwd: $cwd, session_id: $sid, source: "startup"}')
 ss_err=$(mktemp)
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
-  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+if ! echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err"); then
+  ss_rc=$?
+  ss_stderr_preview=$(head -3 "$ss_err")
+  echo "  WARN: session-start.sh exited non-zero (rc=$ss_rc). stderr: ${ss_stderr_preview:-<empty>}" >&2
+fi
 rm -f "$ss_err"
 
 # AC-01: own session の state は reset (active=false)
@@ -197,8 +200,11 @@ OTHER="$TD/.rite/sessions/$SID_OTHER.flow-state"
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_ME" \
   '{cwd: $cwd, session_id: $sid, source: "startup"}')
 ss_err=$(mktemp)
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
-  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+if ! echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err"); then
+  ss_rc=$?
+  ss_stderr_preview=$(head -3 "$ss_err")
+  echo "  WARN: session-start.sh exited non-zero (rc=$ss_rc). stderr: ${ss_stderr_preview:-<empty>}" >&2
+fi
 rm -f "$ss_err"
 
 # 他 session の state は active=true のまま
@@ -221,8 +227,11 @@ CLEAR_F="$TD/.rite/sessions/$SID_CLEAR.flow-state"
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_CLEAR" \
   '{cwd: $cwd, session_id: $sid, source: "clear"}')
 ss_err=$(mktemp)
-echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err") || \
-  echo "  WARN: session-start.sh exited non-zero (rc=$?). stderr: $(head -3 "$ss_err")" >&2
+if ! echo "$HOOK_INPUT" | (cd "$TD" && bash "$SESSION_START" >/dev/null 2>"$ss_err"); then
+  ss_rc=$?
+  ss_stderr_preview=$(head -3 "$ss_err")
+  echo "  WARN: session-start.sh exited non-zero (rc=$ss_rc). stderr: ${ss_stderr_preview:-<empty>}" >&2
+fi
 rm -f "$ss_err"
 
 if [ "$(jq -r '.active' "$CLEAR_F")" = "false" ]; then
@@ -245,8 +254,20 @@ write_session_id "$TD" "$SID_GATE"
 (cd "$TD" && bash "$HOOK" create --session "$SID_GATE" \
   --phase "create_interview" --issue 40 --branch "bg" --pr 0 --next "ng" >/dev/null 2>&1)
 GATE_F="$TD/.rite/sessions/$SID_GATE.flow-state"
-# active=false に強制 patch
-jq '.active = false' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+
+# `jq | mv` の `&&` 連鎖は bash の "tested context" 例外で jq 失敗時に silent fall-through
+# する。helper で if/else 化し、jq 失敗時は明示 exit する fail-fast パターンに統一。
+patch_active() {
+  local file="$1" value="$2"
+  if jq ".active = $value" "$file" > "${file}.tmp"; then
+    mv "${file}.tmp" "$file"
+  else
+    echo "ERROR: jq patch failed for $file (.active = $value)" >&2
+    rm -f "${file}.tmp"
+    exit 1
+  fi
+}
+patch_active "$GATE_F" false
 
 # AC-2: active=false → pre-tool-bash-guard は許可 (exit 0)
 HOOK_INPUT=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
@@ -261,33 +282,20 @@ else
   fail "TC-660 AC-2: active=false でも pre-tool-bash-guard が block (rc=$rc)"
 fi
 
-# AC-3: active=true & phase=create_interview & non-allowed Bash command → guard が defense fire
-# phase が create_interview / create_post_interview の AND-logic の Mode B 経路を pin
-jq '.active = true' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
-
-# 防御層は phase=create_interview の context で `gh issue create` 等を block するロジック。
-# 単純な "echo test" は allow-list に入っているため fire しない可能性がある。
-# 本テストでは「active=true + phase=create_interview の組合せが defense decision pathway を
-# trigger できる」ことを mechanical に verify する。実際の defense 出力ではなく、guard が
-# "条件成立 → 評価実行" の path に進むことを active=false case との対比で確認する設計。
-# (詳細な defense fire は stop-guard.sh removal 後の現状では pre-tool-bash-guard 単体の
-#  挙動に依存し、test fixture からは間接観測しかできないため、AND-logic の "active 必須"
-#  contract が成立していることをもって AC-3 の core proposition を満たす)
-# AC-3: active=true で `gh issue create` 等 phase=create_interview で block 対象となる Bash
-# 入力を渡し、guard の defense decision pathway (AND-logic fire) が走ることを stdout の
-# `permissionDecision: "deny"` JSON 出力で verify する。pre-tool-bash-guard は exit 0 のまま
-# stdout に JSON を返すため exit code 差分では区別できず、stdout 内容で判定する必要がある。
+# AC-3: active=true で `gh issue create` (phase=create_interview で block 対象) を渡し、
+# stdout の `permissionDecision: "deny"` JSON 出力で AND-logic fire を verify する
+# (pre-tool-bash-guard は exit 0 のまま stdout で deny を表現する仕様のため、stdout match で判定)。
 HOOK_INPUT_BLOCKING=$(jq -n --arg cwd "$TD" --arg sid "$SID_GATE" \
   '{cwd: $cwd, session_id: $sid, tool_name: "Bash", tool_input: {command: "gh issue create --title test --body test"}}')
 
-# active=false → guard は早期 silent skip (stdout 空 / 短い)
-jq '.active = false' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+# active=false → guard は早期 silent skip (deny JSON なし)
+patch_active "$GATE_F" false
 set +e
 out_active_false=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e
 
 # active=true → guard は AND-logic 評価に進み deny JSON を出力
-jq '.active = true' "$GATE_F" > "${GATE_F}.tmp" && mv "${GATE_F}.tmp" "$GATE_F"
+patch_active "$GATE_F" true
 set +e
 out_active_true=$(echo "$HOOK_INPUT_BLOCKING" | (cd "$TD" && bash "$PRE_TOOL_GUARD" 2>/dev/null))
 set -e


### PR DESCRIPTION
## Summary

- 並行 2 session regression テスト (T-01) + Session Ownership 系列 (#173 / #206 / #216 / #558 / #660) の AC 再検証 (T-07) + Wiki 経験則 #660 の AND 論理 8 種防御層動作確認を新形式 (per-session file, schema_version=2) 上で mechanical に verify
- 親 Issue #672 の core value proposition (lock 不要で並行性が**構造的に保証**される) を CRITICAL path として pin
- 新規テスト 3 file / 35 assertion / 全 pass / 100 iter loop で flake=0 / pre-existing test に regression なし

Closes #683

## 関連 Issue

Closes #683

親 Issue: #672 (multi-state 構造再設計)

### 過去 5 Issue の AC 担当 mapping

| 担当 Issue | AC ID | 内容 | 担当テスト | 担当 TC |
|------------|-------|------|-----------|---------|
| #173 | (single-file race window) | 単一ファイル時代の競合シナリオ消滅 | concurrent-sessions / session-ownership-regression | TC-1 + TC-173 |
| #206 | AC-1 (startup reset) | startup 時に他セッションの active 状態がリセットされる | session-ownership-regression | TC-206 AC-1 (own state) |
| #206 | AC-2 (clear reset) | clear 時にも reset される | session-ownership-regression | TC-206 AC-2 |
| #216 | AC-1 (UUID save) | session-start.sh が UUID を `.rite-session-id` に保存 | (#680 で session-start.sh 経路で実装済み、本 Issue では non-regression として暗黙 verify) | — |
| #216 | AC-2 (auto-read) | flow-state-update.sh が `.rite-session-id` から auto-read | session-ownership-regression | TC-216 AC-2 |
| #216 | AC-3 (override) | --session 引数指定時は引数優先 | session-ownership-regression | TC-216 AC-3 |
| #558 | AC-01 (own reset) | 自セッションの state は startup で reset | session-ownership-regression | TC-206/558 AC-01 |
| #558 | AC-02 (other preserved) | 他セッションの state は reset しない (核心) | session-ownership-regression | TC-558 AC-02 |
| #558 | AC-03 (legacy reset) | session_id field なしの legacy state は従来通り reset | (legacy state の取扱は #679 migration で扱われ、本 Issue scope 外) | — |
| #558 | AC-04 (fail-safe) | check_session_ownership 失敗時は fail-safe で reset | (helper の単体 test は session-ownership.test.sh で既存 cover) | — |
| #660 | AC-2 (active=false → no fire) | active=false で defense layer は silent skip | session-ownership-regression / and-logic-defense-chain | TC-660 AC-2 / AND-logic invariant |
| #660 | AC-3 (active=true → fire) | active=true で防御層が evaluation pathway を通る | session-ownership-regression / and-logic-defense-chain | TC-660 AC-3 / AND-logic invariant |

> Note: #674 で `stop-guard.sh` は removal 済みのため、#660 の `.rite-stop-guard-diag.log` は現存しない。active=true 前提の AND-logic は現在 `pre-tool-bash-guard.sh` の `(.active=true && phase=create_*)` および `phase-transition-whitelist.sh` の whitelist enforcement に継承されている。本 PR ではこの 2 site での挙動で AC-2 / AC-3 の core proposition を verify する。

## 変更内容

### 新規ファイル (3 件)

| ファイル | 行数 | 内容 |
|---------|-----|------|
| `plugins/rite/hooks/tests/concurrent-sessions.test.sh` | 300 | T-01 (4 TC) + T-LOCAL-1 (100 iter flake check) = 11 assertion |
| `plugins/rite/hooks/tests/session-ownership-regression.test.sh` | 311 | TC-173 / TC-216 / TC-206+TC-558 / TC-660 = 10 assertion |
| `plugins/rite/hooks/tests/and-logic-defense-chain.test.sh` | 308 | Layer 1-8 evidence + Layer 2/4/5/8 runtime + AND-logic invariant = 14 assertion |

合計 919 行 / 35 assertion。

### 8 種防御層の網羅 (and-logic-defense-chain.test.sh)

| Layer | 名称 | Verify 対象 | Evidence | Runtime |
|-------|------|------------|----------|---------|
| 1 | declarative | commands/issue/*.md prose の `--active true` literal | grep ≥1 site | — |
| 2 | sentinel | `workflow-incident-emit.sh` が `WORKFLOW_INCIDENT=1` emit | file existence | emit 出力に `WORKFLOW_INCIDENT=1` 含む |
| 3 | Pre-check | commands で `state-read.sh --field phase` pre-condition | grep ≥1 site | — |
| 4 | whitelist | `phase-transition-whitelist.sh` source 可能 | file existence | `rite_phase_transition_allowed "phase1_5_parent" "phase1_5_post_parent"` allow |
| 5 | Pre-flight | `preflight-check.sh` の compact_state gate | file existence | normal state で exit 0 |
| 6 | Step 0 | `create.md` の `Step 0 Immediate Bash` pattern | grep ≥1 | — |
| 7 | 4-site 対称化 | `--active true` を含む commands/issue/*.md ≥4 file | grep ≥4 file | — |
| 8 | case arm | `phase-transition-whitelist.sh` の `declare -gA _RITE_PHASE_TRANSITIONS` | grep ≥1 | 不正遷移 (`phase1_5_parent → phase5_completion`) reject |
| (invariant) | AND-logic | active=false で silent skip / active=true で evaluation pathway | — | `pre-tool-bash-guard.sh` exit code 比較 |

### Out of Scope

- migration / atomic write integrity / cleanup / crash resume tests → **#684** で扱う
- Decision Log / SPEC.md 更新 → **#685** で扱う

## Test plan

- [x] `bash plugins/rite/hooks/tests/concurrent-sessions.test.sh` で 11 assertion 全 pass / flake=0
- [x] `bash plugins/rite/hooks/tests/session-ownership-regression.test.sh` で 10 assertion 全 pass
- [x] `bash plugins/rite/hooks/tests/and-logic-defense-chain.test.sh` で 14 assertion 全 pass
- [x] `bash plugins/rite/hooks/tests/run-tests.sh` でフルスイート実行 → 新規 3 file 全 PASS / pre-existing test (`pre-compact.test.sh` の TC-005 / TC-005b は **本 PR と無関係** に develop branch で既に failing、unrelated regression)
- [x] 100 iteration concurrent create で flake=0 (T-LOCAL-1)
- [x] 3 iteration smoke check (3 × 3 = 9 runs) で flake=0
- [x] lint (rite plugin internal checks) は新規 3 file に対し clean (warnings はすべて pre-existing で本 Issue scope 外)

## Risk / Rollback

### Risk

- T-01 が flake する → 構造的並行性保証の根拠が揺らぐ → 本 PR の core value verify が失敗
- T-07 で過去 5 Issue の regression test が 1 件でも fail → 過去対策が部分無効化されるリスク
- 8 種防御層の grep evidence test が誤判定 → CI で false negative 流入

### Rollback

- 本 PR の test 追加を revert (実装本体には影響なし、test ファイル削除のみで完結)
- 既存 test (`session-start.test.sh` 等) は本 PR で touch していないため、test 追加のみの rollback で済む

🤖 Generated with [Claude Code](https://claude.com/claude-code)
