### PR TITLE
feat(hooks): #691 bang-backtick-check を PostToolUse + PR/Ready 前段の二段ガードに昇格

### DIFF
--- a/plugins/rite/agents/type-design-reviewer.md
+++ b/plugins/rite/agents/type-design-reviewer.md
@@ -43,7 +43,7 @@ For each type definition:
 ### Step 4: Usefulness and Enforcement Check
 
 For each type exposed to consumers:
-- Do consumers need frequent type assertions or casts? `Grep` for `as Type` (TypeScript の型アサーション、および `!` non-null assertion 演算子の頻出も含む) や type guards (例: `instanceof`, `typeof`, ユーザー定義型ガード関数)
+- Do consumers need frequent type assertions or casts? `Grep` for `as Type` (TypeScript の型アサーション、および 「!」 non-null assertion 演算子の頻出も含む) や type guards (例: `instanceof`, `typeof`, ユーザー定義型ガード関数)
 - Does the type work well with the language's type inference?
 - Are generic type parameters actually varying across usage sites, or is there only one instantiation?
 - `Grep` for the type name across the codebase to assess adoption and usability patterns

--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -814,7 +814,7 @@ Detected pattern (in shell comments only, with shebang excluded):
 
 - `[A-Za-z][A-Za-z0-9_.-]*\.(sh|md|ts|py|js|tsx):[0-9]+`
 
-Exclusions: shebang `#!`, fenced code blocks, range form `:N-M`, backtick-quoted spans, whitelist markers (`# example:` / `<!-- example: -->` / `// example:`), self.
+Exclusions: shebang 「#!」, fenced code blocks, range form `:N-M`, backtick-quoted spans, whitelist markers (`# example:` / `<!-- example: -->` / `// example:`), self.
 
 **Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
 

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -136,7 +136,7 @@ case "$bang_rc" in
   1)
     echo "❌ Bang-backtick adjacency detected — PR submission blocked:" >&2
     printf '%s\n' "$bang_output" >&2
-    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand `if ! cmd; then`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
+    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand 'if ! cmd; then') — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
     exit 1
     ;;
   *)
@@ -148,7 +148,7 @@ case "$bang_rc" in
 esac
 ```
 
-> **On exit 1 from this bash block**: The orchestrator (`/rite:issue:start` Phase 5.3) treats this as a `[pr:create-failed]` equivalent. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` sentinel surfaces in Phase 5.4.4.1 (Workflow Incident Detection) for tracking when the failure cause is invocation-side (script missing / rc=2), not when an actual P1/P2/P3 finding is detected (rc=1 — a normal "fix the code" feedback path).
+> **On exit 1 from this bash block**: The bash block exits before any `pr/create.md` result pattern (`[pr:created:{N}]` / `[pr:create-failed]`) is emitted, so the orchestrator (`/rite:issue:start` Phase 5.3) treats this as a missing-result-pattern Skill invocation — the post-condition check at start.md emits a `skill_load_failure` sentinel via Phase 5.4.4.1 (Workflow Incident Detection) — **NOT** a `[pr:create-failed]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a separate stderr-only diagnostic in a different format than the canonical `[CONTEXT] WORKFLOW_INCIDENT=1; type=...; iteration_id=...` token used by Phase 5.4.4.1 grep, so it does NOT auto-register; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no sentinel is emitted at all (the failure is expected and the user fixes the code).
 
 ### 1.1 Retrieve Base Branch
 

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -108,6 +108,48 @@ If Issue number cannot be retrieved, delegate to Phase 1.4 fallback processing.
 
 ## Phase 1: Verify Current State
 
+### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)
+
+> **Reference**: Issue #691. Pre-submission hard gate for the parser-trigger pattern (backtick + bang adjacency in inline code spans of `plugins/rite/{commands,skills,agents,references}/**/*.md`). The underlying static check is `plugins/rite/hooks/scripts/bang-backtick-check.sh`.
+>
+> **DRIFT-CHECK ANCHOR (#691 §7 MUST)**: This bash block is intentionally synchronized between `commands/pr/create.md` §1.0 and `commands/pr/ready.md` §1.0. Any modification to either side MUST be replicated to the other. Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」の dominant failure mode を構造的に予防する。
+>
+> **Independent of `/rite:lint` Phase 3.6**: lint records bang-backtick findings as warnings (`[lint:success]` is preserved). This gate, in contrast, **blocks** PR mutation when the same pattern is present — lint is the early heads-up, this is the final hard gate before submission.
+
+Resolve plugin_root with the inline one-liner (per [Plugin Path Resolution](../../references/plugin-path-resolution.md#inline-one-liner-for-command-files)) and run the check:
+
+```bash
+plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
+
+if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-check.sh" ]; then
+  echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing; resolved_root=${plugin_root:-<empty>}" >&2
+  echo "ERROR: bang-backtick-check.sh not found. Cannot proceed with PR submission gate." >&2
+  exit 1
+fi
+
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1)
+bang_rc=$?
+case "$bang_rc" in
+  0)
+    : # clean — proceed to next sub-phase
+    ;;
+  1)
+    echo "❌ Bang-backtick adjacency detected — PR submission blocked:" >&2
+    printf '%s\n' "$bang_output" >&2
+    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand `if ! cmd; then`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
+    exit 1
+    ;;
+  *)
+    echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=invocation_error; rc=$bang_rc" >&2
+    echo "ERROR: bang-backtick-check.sh invocation error (rc=$bang_rc):" >&2
+    printf '%s\n' "$bang_output" >&2
+    exit 1
+    ;;
+esac
+```
+
+> **On exit 1 from this bash block**: The orchestrator (`/rite:issue:start` Phase 5.3) treats this as a `[pr:create-failed]` equivalent. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` sentinel surfaces in Phase 5.4.4.1 (Workflow Incident Detection) for tracking when the failure cause is invocation-side (script missing / rc=2), not when an actual P1/P2/P3 finding is detected (rc=1 — a normal "fix the code" feedback path).
+
 ### 1.1 Retrieve Base Branch
 
 Read `rite-config.yml` at the project root using the Read tool, and get the `branch.base` value:

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -83,6 +83,48 @@ Even if the argument is omitted, retrieve and use the PR number from work memory
 
 ## Phase 1: Identify the PR
 
+### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)
+
+> **Reference**: Issue #691. Pre-submission hard gate for the parser-trigger pattern (backtick + bang adjacency in inline code spans of `plugins/rite/{commands,skills,agents,references}/**/*.md`). The underlying static check is `plugins/rite/hooks/scripts/bang-backtick-check.sh`.
+>
+> **DRIFT-CHECK ANCHOR (#691 §7 MUST)**: This bash block is intentionally synchronized between `commands/pr/create.md` §1.0 and `commands/pr/ready.md` §1.0. Any modification to either side MUST be replicated to the other. Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」の dominant failure mode を構造的に予防する。
+>
+> **Independent of `/rite:lint` Phase 3.6**: lint records bang-backtick findings as warnings (`[lint:success]` is preserved). This gate, in contrast, **blocks** Ready transition when the same pattern is present — lint is the early heads-up, this is the final hard gate before Ready for review.
+
+Resolve plugin_root with the inline one-liner (per [Plugin Path Resolution](../../references/plugin-path-resolution.md#inline-one-liner-for-command-files)) and run the check:
+
+```bash
+plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
+
+if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-check.sh" ]; then
+  echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing; resolved_root=${plugin_root:-<empty>}" >&2
+  echo "ERROR: bang-backtick-check.sh not found. Cannot proceed with Ready gate." >&2
+  exit 1
+fi
+
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1)
+bang_rc=$?
+case "$bang_rc" in
+  0)
+    : # clean — proceed to next sub-phase
+    ;;
+  1)
+    echo "❌ Bang-backtick adjacency detected — Ready transition blocked:" >&2
+    printf '%s\n' "$bang_output" >&2
+    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand `if ! cmd; then`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
+    exit 1
+    ;;
+  *)
+    echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=invocation_error; rc=$bang_rc" >&2
+    echo "ERROR: bang-backtick-check.sh invocation error (rc=$bang_rc):" >&2
+    printf '%s\n' "$bang_output" >&2
+    exit 1
+    ;;
+esac
+```
+
+> **On exit 1 from this bash block**: The orchestrator (`/rite:issue:start` Phase 5.5) treats this as a `[ready:error]` equivalent. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` sentinel surfaces in Phase 5.4.4.1 (Workflow Incident Detection) for tracking when the failure cause is invocation-side (script missing / rc=2), not when an actual P1/P2/P3 finding is detected (rc=1 — a normal "fix the code" feedback path).
+
 ### 1.1 Check Arguments
 
 If a PR number is specified as an argument, use that PR.

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -111,7 +111,7 @@ case "$bang_rc" in
   1)
     echo "❌ Bang-backtick adjacency detected — Ready transition blocked:" >&2
     printf '%s\n' "$bang_output" >&2
-    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand `if ! cmd; then`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
+    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand 'if ! cmd; then') — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
     exit 1
     ;;
   *)
@@ -123,7 +123,7 @@ case "$bang_rc" in
 esac
 ```
 
-> **On exit 1 from this bash block**: The orchestrator (`/rite:issue:start` Phase 5.5) treats this as a `[ready:error]` equivalent. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` sentinel surfaces in Phase 5.4.4.1 (Workflow Incident Detection) for tracking when the failure cause is invocation-side (script missing / rc=2), not when an actual P1/P2/P3 finding is detected (rc=1 — a normal "fix the code" feedback path).
+> **On exit 1 from this bash block**: The bash block exits before any `pr/ready.md` result pattern (`[ready:completed]` / `[ready:error]`) is emitted, so the orchestrator (`/rite:issue:start` Phase 5.5) treats this as a missing-result-pattern Skill invocation — the post-condition check at start.md emits a `skill_load_failure` sentinel via Phase 5.4.4.1 (Workflow Incident Detection) — **NOT** a `[ready:error]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a separate stderr-only diagnostic in a different format than the canonical `[CONTEXT] WORKFLOW_INCIDENT=1; type=...; iteration_id=...` token used by Phase 5.4.4.1 grep, so it does NOT auto-register; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no sentinel is emitted at all (the failure is expected and the user fixes the code).
 
 ### 1.1 Check Arguments
 

--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -1291,7 +1291,7 @@ step 3 の 3 分岐は LLM が stdout の marker block (`---skipped_refs_begin/e
 
 ### 7.1 ページ本文の Markdown リンク抽出
 
-各 Wiki ページの本文から Markdown リンク `[text](path)` を抽出します。画像リンク（`![alt](path)` の `!` prefix）は対象外とし、pipefail を有効化して grep no-match を明示処理します:
+各 Wiki ページの本文から Markdown リンク `[text](path)` を抽出します。画像リンク（`![alt](path)` の 「!」 prefix）は対象外とし、pipefail を有効化して grep no-match を明示処理します:
 
 ```bash
 set -o pipefail

--- a/plugins/rite/hooks/hooks.json
+++ b/plugins/rite/hooks/hooks.json
@@ -64,6 +64,16 @@
           }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/bang-backtick-edit-hook.sh",
+            "timeout": 10
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit"
       }
     ]
   }

--- a/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
@@ -128,7 +128,7 @@ case "$hook_rc" in
     # without blocking Edit/Write completion.
     echo "⚠️ bang-backtick adjacency detected after Edit/Write of $REL_PATH:" >&2
     printf '%s\n' "$hook_output" >&2
-    echo "  → Apply Style A (full-width 「!」) or Style B (expand `if ! cmd`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for guidance." >&2
+    echo "  → Apply Style A (full-width 「!」) or Style B (expand 'if ! cmd') — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for guidance." >&2
     ;;
   2)
     # Invocation error in the underlying script. Per Issue #691 §4.5,

--- a/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# bang-backtick-edit-hook.sh
+#
+# PostToolUse(Edit|Write|MultiEdit) wrapper for bang-backtick-check.sh.
+# Filters tool_input.file_path so the static check only fires when an
+# Edit/Write touches a markdown file under the rite plugin tree
+# (`plugins/rite/{commands,skills,agents,references}/**/*.md`). Detection
+# emits a stderr warning but always exits 0 — this hook is warn-only and
+# MUST NOT block Edit/Write completion (per Issue #691 §4.5 and the
+# Claude Code hooks convention that PostToolUse failures should not break
+# tool execution after the fact).
+#
+# Issue #691 / Phase 5.1 (経路 C — immediate per-edit detection).
+# Companion to /rite:pr:create and /rite:pr:ready Phase 1 pre-check
+# (経路 D — pre-PR hard gate, exit 1).
+#
+# Exit semantics:
+#   - Always exit 0 (warn-only). Detection / invocation error / scope
+#     mismatch / hook plumbing failure all converge on exit 0 so
+#     Edit/Write tool execution is never retroactively blocked.
+#   - Diagnostic noise on stderr is gated by the underlying script's
+#     own behavior — we just forward it.
+set -uo pipefail
+
+# Resolve script paths.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/bang-backtick-check.sh"
+
+# Read PostToolUse JSON from stdin. `cat` may fail under pipe rupture; the
+# `|| INPUT=""` fallback keeps us in the safe exit-0 path.
+INPUT=$(cat 2>/dev/null) || INPUT=""
+[ -n "$INPUT" ] || exit 0
+
+# Extract tool_name and file_path. jq failures fall through to exit 0.
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# Filter on tool name. PostToolUse hooks.json uses matcher "Edit|Write" so
+# the harness already pre-filters, but this defense-in-depth check keeps
+# the wrapper safe under matcher drift / future tool additions.
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+# Bail if no file_path captured (defensive — should never happen for the
+# tools above, but the JSON contract is upstream-controlled).
+[ -n "$FILE_PATH" ] || exit 0
+
+# Resolve repo root. Prefer the cwd reported by the harness (matches the
+# user's working tree even if the hook runs from a different cwd); fall
+# back to git toplevel; final fallback is current pwd.
+REPO_ROOT=""
+if [ -n "$CWD" ] && [ -d "$CWD" ]; then
+  REPO_ROOT=$(cd "$CWD" && git rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT="$CWD"
+fi
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+fi
+
+# Normalize file_path to a path relative to REPO_ROOT. The check script
+# accepts only repo-root-relative paths via --target.
+case "$FILE_PATH" in
+  /*)
+    # Absolute path: strip REPO_ROOT prefix when present.
+    case "$FILE_PATH" in
+      "$REPO_ROOT"/*) REL_PATH="${FILE_PATH#"$REPO_ROOT"/}" ;;
+      *) exit 0 ;;  # Edit outside the repo root — out of scope.
+    esac
+    ;;
+  *)
+    REL_PATH="$FILE_PATH"
+    ;;
+esac
+
+# Scope filter: only rite plugin markdown under the four scan directories.
+# This intentionally mirrors bang-backtick-check.sh --all (commands /
+# skills / agents / references) so the per-edit guard cannot drift from
+# the bulk lint scope. Matcher uses bash glob — extglob would also work
+# but plain `case` keeps the script POSIX-friendly.
+case "$REL_PATH" in
+  plugins/rite/commands/*.md|\
+  plugins/rite/commands/*/*.md|\
+  plugins/rite/commands/*/*/*.md|\
+  plugins/rite/skills/*.md|\
+  plugins/rite/skills/*/*.md|\
+  plugins/rite/skills/*/*/*.md|\
+  plugins/rite/agents/*.md|\
+  plugins/rite/agents/*/*.md|\
+  plugins/rite/references/*.md|\
+  plugins/rite/references/*/*.md|\
+  plugins/rite/references/*/*/*.md)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Verify the underlying check script is present. Marketplace installs may
+# strip hooks/scripts/; in that case we silently skip rather than emit a
+# noisy WARNING for every edit.
+[ -f "$CHECK_SCRIPT" ] || exit 0
+
+# Verify the target file still exists (could have been deleted via Edit
+# `new_string=""` followed by another tool) — bang-backtick-check.sh
+# already handles missing files gracefully, but skipping early avoids
+# emitting a misleading WARNING when the user explicitly removed the file.
+[ -f "$REPO_ROOT/$REL_PATH" ] || exit 0
+
+# Run the check. We always pass --quiet so the wrapper controls log
+# verbosity; per-finding lines on stdout are still emitted (and we route
+# them to stderr so they show up in the hook diagnostic stream rather
+# than the tool output channel).
+hook_output=$(bash "$CHECK_SCRIPT" \
+  --repo-root "$REPO_ROOT" \
+  --target "$REL_PATH" \
+  --quiet 2>&1)
+hook_rc=$?
+
+case "$hook_rc" in
+  0)
+    # Clean — silent.
+    :
+    ;;
+  1)
+    # Pattern detected. Emit findings to stderr so the user sees them
+    # without blocking Edit/Write completion.
+    echo "⚠️ bang-backtick adjacency detected after Edit/Write of $REL_PATH:" >&2
+    printf '%s\n' "$hook_output" >&2
+    echo "  → Apply Style A (full-width 「!」) or Style B (expand `if ! cmd`) — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for guidance." >&2
+    ;;
+  2)
+    # Invocation error in the underlying script. Per Issue #691 §4.5,
+    # demote to warning — the bulk gate (経路 D) will catch any escape.
+    echo "⚠️ bang-backtick-check.sh invocation error during PostToolUse hook (rc=2):" >&2
+    printf '%s\n' "$hook_output" >&2
+    echo "  → Defense-in-depth: PR creation gate (経路 D) will re-run the check before submission." >&2
+    ;;
+  *)
+    # Unexpected exit code — surface but do not block.
+    echo "⚠️ bang-backtick-check.sh returned unexpected exit code $hook_rc:" >&2
+    printf '%s\n' "$hook_output" >&2
+    ;;
+esac
+
+exit 0

--- a/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
@@ -118,6 +118,23 @@ else
   fail "TC-1 stderr missing warning"
   cat "$hook_stderr" >&2
 fi
+# Negative assertion: hook script の "Style B" ACTION line に bash command substitution bug が
+# 混入していないこと。double-quoted echo 内に literal `if ! cmd` (backtick 隣接) を書くと bash が
+# command substitution として subshell 実行を試み、syntax error で Style B 修正例 ("if ! cmd")
+# 部分が空文字に化ける silent UX regression を防ぐ (旧コミット e50d08e で 3 site に同形混入)。
+if grep -qE "command substitution|構文エラー|unexpected end of file|unexpected EOF" "$hook_stderr"; then
+  fail "TC-1 stderr contains bash syntax error (command substitution bug regression)"
+  cat "$hook_stderr" >&2
+else
+  pass "TC-1 stderr free of bash command substitution syntax errors"
+fi
+# Positive assertion: ACTION ヒントの中核 ("Style B (expand 'if ! cmd')") が破損なく出力されていること
+if grep -qF "expand 'if ! cmd'" "$hook_stderr"; then
+  pass "TC-1 ACTION hint includes literal 'if ! cmd' (Style B example intact)"
+else
+  fail "TC-1 ACTION hint missing 'if ! cmd' literal (single-quote regression)"
+  cat "$hook_stderr" >&2
+fi
 rm -f "$hook_stderr"
 
 # ----- TC-2: AC-3 — clean rite plugin md is silent, exit 0 -----------------

--- a/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# bang-backtick-edit-hook.test.sh
+#
+# Regression tests for the PostToolUse(Edit|Write|MultiEdit) wrapper that
+# guards rite plugin markdown against bang-backtick adjacency injection.
+# Companion of `bang-backtick-check.sh` (which is the underlying scanner)
+# and the `/rite:pr:create` / `/rite:pr:ready` Phase 1.0 bulk gate.
+#
+# Issue #691 — 経路 C (immediate per-edit detection).
+#
+# Pinned acceptance criteria:
+#   AC-1 (Happy path: 経路 C 即時検出)
+#     Edit/Write of a rite-plugin markdown that contains the parser-trigger
+#     pattern emits a stderr warning while still exiting 0 (warn-only).
+#   AC-3 (Boundary: false positive なし)
+#     Edit/Write of a clean rite-plugin markdown is silent (exit 0, no
+#     warning).
+#   Matcher-limited (DoD §7 MUST NOT — "他 plugin edit に発火しない")
+#     A file_path outside `plugins/rite/{commands,skills,agents,references}`
+#     short-circuits to exit 0 with no scanner invocation.
+#
+# Usage: bash plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR/.."
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+HOOK="$HOOK_DIR/scripts/bang-backtick-edit-hook.sh"
+CHECK_SCRIPT="$HOOK_DIR/scripts/bang-backtick-check.sh"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+[ -f "$HOOK" ] || { echo "ERROR: hook not found at $HOOK" >&2; exit 1; }
+[ -f "$CHECK_SCRIPT" ] || { echo "ERROR: check script not found at $CHECK_SCRIPT" >&2; exit 1; }
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# Build a temporary repo that mirrors the rite plugin layout so the hook's
+# `plugins/rite/...` path filter sees what it expects.
+make_repo() {
+  local d
+  d=$(mktemp -d) || return 1
+  (
+    set -e
+    cd "$d"
+    git init -q
+    git -c user.email=t@test.local -c user.name=test commit -q --allow-empty -m init
+    mkdir -p plugins/rite/commands/pr
+    mkdir -p plugins/rite/skills
+    mkdir -p plugins/rite/agents
+    mkdir -p plugins/rite/references
+    mkdir -p other-plugin/commands
+  ) || return 1
+  echo "$d"
+}
+
+cleanup_dirs=()
+cleanup_files=()
+cleanup() {
+  # Disable set -e inside the trap — short-circuit `&&` chains return non-zero
+  # when the predicate is false, which would otherwise abort the trap and
+  # propagate to the script's exit code.
+  set +e
+  local d f
+  for d in "${cleanup_dirs[@]+"${cleanup_dirs[@]}"}"; do
+    # Sanity check: only rm directories under /tmp/ that we created via mktemp -d.
+    # Never accept the literal "/tmp" or any path that doesn't look like a temp dir.
+    case "$d" in
+      /tmp/tmp.*|/tmp/[A-Za-z0-9]*)
+        if [ -d "$d" ]; then rm -rf "$d"; fi
+        ;;
+      *) ;;
+    esac
+  done
+  for f in "${cleanup_files[@]+"${cleanup_files[@]}"}"; do
+    if [ -n "$f" ] && [ -f "$f" ]; then rm -f "$f"; fi
+  done
+}
+trap cleanup EXIT
+
+# Build a PostToolUse-style JSON payload.
+build_input() {
+  local tool_name="$1" file_path="$2" cwd="$3"
+  jq -n \
+    --arg tn "$tool_name" \
+    --arg fp "$file_path" \
+    --arg cwd "$cwd" \
+    '{hook_event_name:"PostToolUse", tool_name:$tn, tool_input:{file_path:$fp}, cwd:$cwd}'
+}
+
+# ----- TC-1: AC-1 — dirty rite plugin md emits warning, exit 0 -------------
+echo "TC-1: AC-1 — dirty rite plugin md emits warning, exits 0"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+target="$repo/plugins/rite/commands/pr/sample.md"
+# Inject a P1 pattern: backtick + space + bang + backtick adjacency.
+printf '%s\n' "Some prose with \` !\` adjacency to trigger detection." > "$target"
+input=$(build_input "Edit" "$target" "$repo")
+hook_stderr=$(mktemp)
+cleanup_files+=("$hook_stderr")
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-1 exit code 0 (warn-only)"
+else
+  fail "TC-1 exit code expected 0, got $hook_rc"
+fi
+if grep -q "bang-backtick adjacency detected" "$hook_stderr"; then
+  pass "TC-1 stderr contains 'bang-backtick adjacency detected'"
+else
+  fail "TC-1 stderr missing warning"
+  cat "$hook_stderr" >&2
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-2: AC-3 — clean rite plugin md is silent, exit 0 -----------------
+echo "TC-2: AC-3 — clean rite plugin md is silent, exits 0"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+target="$repo/plugins/rite/commands/pr/clean.md"
+# Use Style A (full-width corner brackets) — safe canonical rewrite.
+printf '%s\n' "Some prose using full-width 「!」 instead of bang-backtick." > "$target"
+input=$(build_input "Edit" "$target" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-2 exit code 0 (clean)"
+else
+  fail "TC-2 exit code expected 0, got $hook_rc"
+fi
+if [ ! -s "$hook_stderr" ] || ! grep -q "bang-backtick" "$hook_stderr"; then
+  pass "TC-2 stderr silent for clean file"
+else
+  fail "TC-2 stderr unexpectedly contained warning"
+  cat "$hook_stderr" >&2
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-3: matcher limited — file outside rite plugin tree skipped --------
+echo "TC-3: file outside rite plugin tree → silent skip"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+target="$repo/other-plugin/commands/sample.md"
+# Even with a P1 pattern present, the wrapper must not invoke the scanner.
+printf '%s\n' "Some prose with \` !\` adjacency that should be ignored." > "$target"
+input=$(build_input "Edit" "$target" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-3 exit code 0 (other plugin)"
+else
+  fail "TC-3 exit code expected 0, got $hook_rc"
+fi
+if [ ! -s "$hook_stderr" ] || ! grep -q "bang-backtick" "$hook_stderr"; then
+  pass "TC-3 stderr silent for non-rite path"
+else
+  fail "TC-3 stderr unexpectedly contained warning (matcher leak)"
+  cat "$hook_stderr" >&2
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-4: defense-in-depth — non Edit/Write tool short-circuits ---------
+echo "TC-4: tool_name=Bash short-circuits to exit 0"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+target="$repo/plugins/rite/commands/pr/sample.md"
+printf '%s\n' "Some prose with \` !\` adjacency." > "$target"
+input=$(build_input "Bash" "$target" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-4 exit code 0 (Bash tool)"
+else
+  fail "TC-4 exit code expected 0, got $hook_rc"
+fi
+if [ ! -s "$hook_stderr" ] || ! grep -q "bang-backtick" "$hook_stderr"; then
+  pass "TC-4 stderr silent for non-Edit/Write tool"
+else
+  fail "TC-4 stderr unexpectedly contained warning (tool filter leak)"
+  cat "$hook_stderr" >&2
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-5: empty file_path — defensive exit 0 ----------------------------
+echo "TC-5: empty file_path → exit 0"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+input=$(build_input "Edit" "" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-5 exit code 0 (empty file_path)"
+else
+  fail "TC-5 exit code expected 0, got $hook_rc"
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-6: missing file (deleted by Edit) — exit 0 silently --------------
+echo "TC-6: missing target file → silent exit 0"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+target="$repo/plugins/rite/commands/pr/ghost.md"
+# Note: target file is intentionally NOT created.
+input=$(build_input "Edit" "$target" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-6 exit code 0 (missing file)"
+else
+  fail "TC-6 exit code expected 0, got $hook_rc"
+fi
+if [ ! -s "$hook_stderr" ] || ! grep -q "bang-backtick" "$hook_stderr"; then
+  pass "TC-6 stderr silent for missing file"
+else
+  fail "TC-6 stderr unexpectedly contained warning"
+fi
+rm -f "$hook_stderr"
+
+# ----- TC-7: skills/ subdirectory triggers detection (path filter coverage) -
+echo "TC-7: rite skills/ subdir triggers detection (path filter coverage)"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+mkdir -p "$repo/plugins/rite/skills/example"
+target="$repo/plugins/rite/skills/example/SKILL.md"
+printf '%s\n' "Trigger: \` !\` adjacency in skills/." > "$target"
+input=$(build_input "Write" "$target" "$repo")
+hook_stderr=$(mktemp)
+hook_rc=0
+printf '%s' "$input" | bash "$HOOK" 2>"$hook_stderr" >/dev/null || hook_rc=$?
+if [ "$hook_rc" -eq 0 ]; then
+  pass "TC-7 exit code 0"
+else
+  fail "TC-7 exit code expected 0, got $hook_rc"
+fi
+if grep -q "bang-backtick adjacency detected" "$hook_stderr"; then
+  pass "TC-7 skills/ path triggers detection"
+else
+  fail "TC-7 skills/ path missing detection"
+  cat "$hook_stderr" >&2
+fi
+rm -f "$hook_stderr"
+
+# ----- Summary --------------------------------------------------------------
+echo ""
+echo "==> $PASS PASS / $FAIL FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# bang-backtick-pr-create-pre-check.test.sh
+#
+# Regression tests for the Phase 1.0 Pre-PR Gate added to
+# `commands/pr/create.md` and `commands/pr/ready.md` by Issue #691.
+# The gate invokes `bang-backtick-check.sh --all` and exits non-zero on
+# detection or invocation failure.
+#
+# This test pins three things:
+#   1. The underlying scanner's behavior on the present repository
+#      (clean develop must remain exit 0; deliberately seeded dirt must
+#      produce exit 1) — this is the runtime AC-2 / AC-3 evidence.
+#   2. The DRIFT-CHECK ANCHOR between create.md §1.0 and ready.md §1.0
+#      (the bash literal MUST be byte-for-byte identical between the
+#      two files — Wiki 経験則「Asymmetric Fix Transcription」予防).
+#   3. The non-regression of `/rite:lint` Phase 3.6 — lint.md must
+#      still invoke `bang-backtick-check.sh --all` AND treat its exit
+#      code as a warning rather than an error (AC-4).
+#
+# Issue #691 — 経路 D (pre-PR hard gate).
+#
+# Pinned acceptance criteria:
+#   AC-2 (Happy path: 経路 D PR 提出前 block) — TC-2
+#   AC-3 (Boundary: false positive なし)        — TC-1
+#   AC-4 (Non-regression: /rite:lint 経路)       — TC-5
+#   §4.5 sentinel emit (script 不在 / rc=2)       — TC-3
+#   §7 MUST DRIFT-CHECK ANCHOR (create/ready)    — TC-4
+#
+# Usage: bash plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR/.."
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+CHECK_SCRIPT="$HOOK_DIR/scripts/bang-backtick-check.sh"
+CREATE_MD="$PLUGIN_ROOT/commands/pr/create.md"
+READY_MD="$PLUGIN_ROOT/commands/pr/ready.md"
+LINT_MD="$PLUGIN_ROOT/commands/lint.md"
+PASS=0
+FAIL=0
+
+[ -f "$CHECK_SCRIPT" ] || { echo "ERROR: $CHECK_SCRIPT not found" >&2; exit 1; }
+[ -f "$CREATE_MD" ] || { echo "ERROR: $CREATE_MD not found" >&2; exit 1; }
+[ -f "$READY_MD" ] || { echo "ERROR: $READY_MD not found" >&2; exit 1; }
+[ -f "$LINT_MD" ] || { echo "ERROR: $LINT_MD not found" >&2; exit 1; }
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# ----- TC-1: AC-3 — clean repo state, --all exits 0 -------------------------
+echo "TC-1: AC-3 — current repo HEAD has no bang-backtick adjacency (clean state)"
+clean_rc=0
+clean_output=$(bash "$CHECK_SCRIPT" --repo-root "$REPO_ROOT" --all --quiet 2>&1) || clean_rc=$?
+if [ "$clean_rc" -eq 0 ]; then
+  pass "TC-1 --all exit 0 on clean repo"
+else
+  fail "TC-1 --all expected exit 0, got $clean_rc"
+  printf '%s\n' "$clean_output" | head -20 >&2
+fi
+
+# ----- TC-2: AC-2 — seeded dirt produces exit 1 ----------------------------
+echo "TC-2: AC-2 — seeded dirt in plugins/rite/commands/ produces exit 1"
+seed_dir=$(mktemp -d)
+trap 'rm -rf "$seed_dir"' EXIT
+# Recreate a minimal rite plugin layout so the scanner's --all has a tree to walk.
+mkdir -p "$seed_dir/plugins/rite/commands/pr"
+mkdir -p "$seed_dir/plugins/rite/skills"
+mkdir -p "$seed_dir/plugins/rite/agents"
+mkdir -p "$seed_dir/plugins/rite/references"
+# Inject a P1 pattern: backtick + space + bang + closing backtick adjacency.
+printf '%s\n' "Bad: \` !\` adjacency must trigger." > "$seed_dir/plugins/rite/commands/pr/dirty.md"
+seed_rc=0
+seed_output=$(bash "$CHECK_SCRIPT" --repo-root "$seed_dir" --all --quiet 2>&1) || seed_rc=$?
+if [ "$seed_rc" -eq 1 ]; then
+  pass "TC-2 --all exit 1 on seeded dirt"
+else
+  fail "TC-2 --all expected exit 1, got $seed_rc"
+  printf '%s\n' "$seed_output" | head -10 >&2
+fi
+if printf '%s\n' "$seed_output" | grep -q '\[bang-backtick\]'; then
+  pass "TC-2 finding line includes [bang-backtick] tag"
+else
+  fail "TC-2 finding line missing [bang-backtick] tag"
+fi
+
+# ----- TC-3: §4.5 — script-missing sentinel emit pattern ----------------
+# Simulate the Phase 1.0 bash block's missing-script branch by sourcing the
+# same logic in isolation: with a non-existent CHECK path, the case branch
+# must (a) emit the BANG_BACKTICK_CHECK_INVOCATION_FAILED=1 sentinel, and
+# (b) exit 1.
+echo "TC-3: §4.5 — script-missing emits sentinel and exits 1"
+fake_root="$seed_dir/no-such-plugin-root"
+sentinel_rc=0
+sentinel_stderr=$(mktemp)
+{
+  bash -c '
+    plugin_root="$1"
+    if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-check.sh" ]; then
+      echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing; resolved_root=${plugin_root:-<empty>}" >&2
+      echo "ERROR: bang-backtick-check.sh not found." >&2
+      exit 1
+    fi
+  ' _ "$fake_root" 2>"$sentinel_stderr"
+} || sentinel_rc=$?
+if [ "$sentinel_rc" -eq 1 ]; then
+  pass "TC-3 missing-script branch exits 1"
+else
+  fail "TC-3 missing-script branch expected exit 1, got $sentinel_rc"
+fi
+if grep -q 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing' "$sentinel_stderr"; then
+  pass "TC-3 sentinel emitted with reason=script_missing"
+else
+  fail "TC-3 sentinel missing"
+  cat "$sentinel_stderr" >&2
+fi
+rm -f "$sentinel_stderr"
+
+# ----- TC-4: §7 MUST — create.md/ready.md DRIFT-CHECK ANCHOR ---------------
+# The Phase 1.0 bash block invocation literal MUST be byte-for-byte identical
+# between create.md and ready.md (Wiki 経験則「Asymmetric Fix Transcription」).
+# We pin three sentinels: the scanner invocation, the sentinel emit literal,
+# and the sub-section header.
+echo "TC-4: §7 MUST — DRIFT-CHECK ANCHOR between create.md and ready.md"
+inv_create=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1' "$CREATE_MD" || true)
+inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1' "$READY_MD" || true)
+if [ "$inv_create" -ge 1 ] && [ "$inv_ready" -ge 1 ]; then
+  pass "TC-4 scanner invocation literal present in BOTH create.md and ready.md"
+else
+  fail "TC-4 scanner invocation literal mismatch (create=$inv_create, ready=$inv_ready)"
+fi
+
+sentinel_create=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$CREATE_MD" || true)
+sentinel_ready=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$READY_MD" || true)
+if [ "$sentinel_create" -ge 2 ] && [ "$sentinel_ready" -ge 2 ]; then
+  # ≥2 because the literal appears in both the script_missing branch and
+  # the rc=invocation_error branch.
+  pass "TC-4 sentinel literal present (≥2x) in BOTH create.md and ready.md"
+else
+  fail "TC-4 sentinel literal mismatch (create=$sentinel_create, ready=$sentinel_ready)"
+fi
+
+header_create=$(grep -c '^### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)$' "$CREATE_MD" || true)
+header_ready=$(grep -c '^### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)$' "$READY_MD" || true)
+if [ "$header_create" -eq 1 ] && [ "$header_ready" -eq 1 ]; then
+  pass "TC-4 sub-section header '### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)' present in BOTH"
+else
+  fail "TC-4 sub-section header mismatch (create=$header_create, ready=$header_ready)"
+fi
+
+# DRIFT-CHECK ANCHOR comment itself MUST appear in both files so future edits
+# see the synchronization requirement.
+anchor_create=$(grep -c 'DRIFT-CHECK ANCHOR' "$CREATE_MD" || true)
+anchor_ready=$(grep -c 'DRIFT-CHECK ANCHOR' "$READY_MD" || true)
+if [ "$anchor_create" -ge 1 ] && [ "$anchor_ready" -ge 1 ]; then
+  pass "TC-4 DRIFT-CHECK ANCHOR comment present in BOTH"
+else
+  fail "TC-4 DRIFT-CHECK ANCHOR comment missing (create=$anchor_create, ready=$anchor_ready)"
+fi
+
+# ----- TC-5: AC-4 — /rite:lint Phase 3.6 still invokes the same scanner ----
+echo "TC-5: AC-4 — /rite:lint Phase 3.6 unchanged (non-regression)"
+lint_inv=$(grep -c 'bang-backtick-check.sh --all' "$LINT_MD" || true)
+if [ "$lint_inv" -ge 1 ]; then
+  pass "TC-5 lint.md still invokes 'bang-backtick-check.sh --all'"
+else
+  fail "TC-5 lint.md missing scanner invocation (regression)"
+fi
+# Lint must keep treating findings as warnings (Phase 3.6 contract: exit 1
+# yields `bang_backtick_status: warning`, not error).
+if grep -q 'bang_backtick_status' "$LINT_MD"; then
+  pass "TC-5 lint.md retains bang_backtick_status warning record"
+else
+  fail "TC-5 lint.md missing bang_backtick_status record"
+fi
+
+# ----- Summary --------------------------------------------------------------
+echo ""
+echo "==> $PASS PASS / $FAIL FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -174,6 +174,26 @@ else
   fail "TC-5 lint.md missing bang_backtick_status record"
 fi
 
+# ----- TC-12: CRITICAL regression guard — Style B example must use single-quotes -
+# 旧コミット e50d08e で create.md / ready.md / hook script に backtick 囲みの literal
+# `if ! cmd; then` が混入し、bash double-quoted echo 内で command substitution が発火する
+# CRITICAL bug が発生 (3 site 同形 transcription、Wiki 経験則「Asymmetric Fix Transcription」の
+# inverse failure)。byte 比較で single-quote 囲みであることを pin する。
+echo "TC-12: CRITICAL regression — Style B 'if ! cmd; then' literal must use single-quotes (not backticks)"
+for f in "$CREATE_MD" "$READY_MD"; do
+  fname=$(basename "$f")
+  if grep -qF "expand 'if ! cmd; then'" "$f"; then
+    pass "TC-12 $fname uses single-quoted Style B example"
+  else
+    fail "TC-12 $fname does NOT use single-quoted Style B example (backtick regression?)"
+  fi
+  if grep -qF 'expand `if ! cmd; then`' "$f"; then
+    fail "TC-12 $fname STILL contains backtick-quoted Style B example (CRITICAL regression!)"
+  else
+    pass "TC-12 $fname free of backtick-quoted 'if ! cmd; then' literal"
+  fi
+done
+
 # ----- Summary --------------------------------------------------------------
 echo ""
 echo "==> $PASS PASS / $FAIL FAIL"

--- a/plugins/rite/skills/reviewers/tech-writer.md
+++ b/plugins/rite/skills/reviewers/tech-writer.md
@@ -40,7 +40,7 @@ The diff contains additions or deletions of comment/docstring tokens, including:
 - `"""..."""` (Python module/function/class docstrings)
 - `'''...'''` (Python alternative docstring form)
 - JSDoc blocks (`/** ... */` with `@param`, `@returns`, etc.)
-- Rustdoc (`///` and `//!`)
+- Rustdoc (`///` and 「//!」)
 - GoDoc (the comment block directly above an exported identifier)
 - `<!-- ... -->` (HTML / Markdown inline comments, when changed in a code file)
 


### PR DESCRIPTION
## 概要

`bang-backtick-check.sh` を rite plugin 同梱の自動ガード経路に組み込み、`!` 隣接 backtick による Skill loader triggering pattern (`/rite:pr:review` 起動不能 regression、Issue #687/#691 で観測) を `/rite:lint` 手動実行に依存せず検出する **二段ガード** を構築した。検出ロジック (P1/P2 regex) は不変、追加したのは **発火経路** のみ。

## 関連 Issue

Closes #691

## 変更点

### 経路 C: PostToolUse hook (Edit/Write 直後の即時検出)

- `plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh` 新設 (147 行)
- `plugins/rite/hooks/hooks.json` に `Edit|Write|MultiEdit` matcher を追加
- 検出時 stderr に `[bang-backtick] ...` 警告を emit (warn-only、Edit 自体は block しない、常に exit 0)
- rite plugin 配下 markdown (`commands/`, `skills/`) のみに発火 (他 plugin への波及防止 — TC-3 で検証)

### 経路 D: PR 提出前 hard gate

- `commands/pr/create.md` Phase 1.0 / `commands/pr/ready.md` Phase 1.0 に `bang-backtick-check.sh --all` を hard gate として追加
- 検出時 exit 1 で後続 Phase を block
- script 不在 / exit 2 時は `[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=...` sentinel emit
- create.md / ready.md は **DRIFT-CHECK ANCHOR** で symmetric 維持 (Wiki 経験則「Asymmetric Fix Transcription」予防、TC-4 で pin)

### 既存 finding 修正 (DoD「clean state で develop 維持」)

P3 finding 4 件を Style A (全角「！」) で書き換え:

- `plugins/rite/agents/type-design-reviewer.md`
- `plugins/rite/commands/lint.md`
- `plugins/rite/commands/wiki/lint.md`
- `plugins/rite/skills/reviewers/tech-writer.md`

### Regression test 追加

- 経路 C: `bang-backtick-edit-hook.test.sh` (13 TC — AC-1 / AC-3 / matcher 限定 / Bash tool 短絡)
- 経路 D: `bang-backtick-pr-create-pre-check.test.sh` (11 TC — AC-2 / AC-3 / AC-4 / sentinel emit / DRIFT-CHECK ANCHOR pin)

## Acceptance Criteria

- [x] AC-1〜AC-4 すべて実機 verified (24 TC PASS)
- [x] T-01〜T-04 すべて passing
- [x] `bang-backtick-check.sh --all` が clean state で develop 維持 (0 findings)
- [x] PostToolUse hook が他 plugin edit に発火しないこと確認 (TC-3)
- [x] `/rite:lint` 経由が regression なく機能すること確認 (TC-5 + 実機 lint で 0 findings)
- [x] 別 Issue として A (pre-commit) / B (CI) followup を起票 (#763, #764)

## テスト結果

| 試験 | 結果 |
|------|------|
| 経路 C テスト (`bang-backtick-edit-hook.test.sh`) | ✅ 13 PASS / 0 FAIL |
| 経路 D テスト (`bang-backtick-pr-create-pre-check.test.sh`) | ✅ 11 PASS / 0 FAIL |
| `bang-backtick-check.sh --all` (clean state) | ✅ 0 findings |
| `/rite:lint` Phase 3.6 (AC-4 non-regression) | ✅ 0 findings (warning level 維持) |

## Known Issues (本 PR スコープ外)

`/rite:lint` で検出された既存の non-blocking warning。本 PR の bang-backtick check には影響なし。

| Check | Findings | 取扱 |
|-------|---------|------|
| distributed-fix-drift | 32 | 既存問題 (本 PR 範囲外) |
| comment-journal | 218 | Issue #702 段階導入中 |
| comment-line-ref | 21 | test fixture 由来 |

すべて `[lint:success]` の warning レベル、PR 提出を block しない。

## Test plan

- [ ] レビューア観点: 経路 C/D の DRIFT-CHECK ANCHOR が将来の編集で破損しない構造か
- [ ] 経路 D の hard gate が既存の `/rite:pr:create`/`/rite:pr:ready` フローで誤動作しないこと
- [ ] PostToolUse matcher の path filter (`commands/`, `skills/`) が他 plugin に波及しないこと

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
