### PR TITLE
feat(skill): #769 SKILL.md description に Issue 起票系トリガーを追加 (P0-1)

### DIFF
--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: rite-workflow
 description: |
-  Automates the complete Issue-to-PR lifecycle: start working on Issues,
-  create branches, implement changes, run quality checks, and manage PRs —
-  all through a single workflow. Essential for any /rite: command, workflow
-  questions, or when working with Issues, branches, commits, or PRs.
-  Activates on "start issue", "create PR", "next steps", "workflow", "rite",
-  "Issue作業", "ブランチ", "コミット規約", "PR作成", "作業開始", "ワークフロー",
-  "次のステップ". Use for workflow state detection, phase transitions,
-  and command suggestions.
+  Automates the complete Issue-to-PR lifecycle: create new Issues,
+  start working on Issues, create branches, implement changes, run
+  quality checks, and manage PRs — all through a single workflow.
+  Essential for any /rite: command, workflow questions, or when
+  working with Issues, branches, commits, or PRs.
+  Activates on "create issue", "new issue", "起票", "Issue を作成",
+  "タスクを登録", "Issue 化", "新規 Issue", "start issue", "create PR",
+  "next steps", "workflow", "rite", "Issue作業", "ブランチ",
+  "コミット規約", "PR作成", "作業開始", "ワークフロー", "次のステップ".
+  Use for workflow state detection, phase transitions, and command
+  suggestions.
 ---
 
 # Rite Workflow Skill


### PR DESCRIPTION
## 概要

`plugins/rite/skills/rite-workflow/SKILL.md` の `description` フィールドに **Issue 起票系のトリガーフレーズ 7 件** を追加し、`/rite:issue:create` 系のクエリで auto-trigger 適合率を向上させる。

設計ドキュメント [`docs/designs/improve-issue-create-skill-design.md`](docs/designs/improve-issue-create-skill-design.md) **FR-1.1** (P0-1) に準拠。親 Issue は `#768` ([Umbrella] /rite:issue:create ワークフロー全面改善)。

## 関連 Issue

Closes #769

親 Issue: #768

## 変更内容

`plugins/rite/skills/rite-workflow/SKILL.md` の YAML frontmatter `description` フィールドのみを修正（11 行差分、1 ファイル）。

| 種別 | 内容 |
|------|------|
| 散文追加 | `Automates the complete Issue-to-PR lifecycle:` の冒頭に **`create new Issues`** を追加（lifecycle の最初に配置） |
| トリガー追加 | "Activates on" リストの先頭に **7 件** のトリガーフレーズを追加 |
| 既存トリガー | 11 件すべて保持（regression なし） |

### 追加した 7 トリガーと選定根拠

| # | トリガー | 選定根拠（Issue #769 ## 背景・問題 / FR-1.1） |
|---|---------|------------------------------------------|
| 1 | `"create issue"` | 英語で最も一般的な起票表現。PDF Skill Building Guide の "Activates on" 推奨パターン |
| 2 | `"new issue"` | 「新規 Issue」の英語直訳。GitHub UI の `New Issue` ボタンと表現一致 |
| 3 | `"起票"` | 日本語の業務用語として最も短く頻出 |
| 4 | `"Issue を作成"` | 日本語の自然な動詞句（「Issue を作って」など派生形を吸収） |
| 5 | `"タスクを登録"` | Issue を「タスク」と呼ぶプロジェクトでの一致率向上 |
| 6 | `"Issue 化"` | 「議論を Issue 化」「TODO を Issue 化」等の日本語業務用語 |
| 7 | `"新規 Issue"` | 「新規 Issue 作って」など名詞先行の自然な日本語 |

### 既存トリガー（保持）

`"start issue"`, `"create PR"`, `"next steps"`, `"workflow"`, `"rite"`, `"Issue作業"`, `"ブランチ"`, `"コミット規約"`, `"PR作成"`, `"作業開始"`, `"ワークフロー"`, `"次のステップ"` — 計 12 件すべて保持。

## 期待効果

- **auto-trigger 適合率向上**: 「Issue 起票したい」「create issue」「タスクを登録して」等のクエリで `/rite:issue:create` が自動起動する確率が向上
- **PDF Skill Building Guide 準拠**: Bad example `"missing triggers"` の解消（FR-1.1 / 親 Issue #768 の P0-1）

## 逆効果リスク / Mitigation

- **R1 (over-trigger)**: Issue 起票無関係なクエリで auto-fire するリスク
- **Mitigation**: Sub-Issue P4-10 (FR-5.1 `tests/issue-create-triggers.md`) で should-NOT-trigger ケース整備、偽陽性 0% 目標

## チェックリスト

- [x] `description` 末尾の "Activates on" リストにトリガーフレーズ追加
- [x] auto-trigger 手動確認 — **P4-10 (FR-5.1 trigger test) に延期**: 本 Issue P0-1 はトリガー追加のみ、auto-trigger テスト整備は P4-10 の責務として `tests/issue-create-triggers.md` で網羅予定
- [x] PR description にトリガーフレーズの選定根拠を記載（本 PR `### 追加した 7 トリガーと選定根拠` セクション）
- [x] `/rite:lint` を pass（plugin-specific check のみ実行、本変更による新規 finding なし）

## Test plan

- [x] Read `plugins/rite/skills/rite-workflow/SKILL.md` line 1-15 で 7 トリガーと `create new Issues` プローズを目視確認
- [x] `grep -F` で 7 新トリガー + 11 既存トリガー + 散文 `create new Issues` の存在を機械検証（regression check）
- [x] `/rite:lint` 全 12 plugin-specific check 実行（変更による新規 finding なし、3 件は pre-existing warnings）
- [ ] (将来) P4-10 で `tests/issue-create-triggers.md` を実装し、should-trigger / should-NOT-trigger 各 7 ケースで auto-trigger 適合率を計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)
