### PR TITLE
feat(commands): #770 commands/issue/*.md の description 書き直し + sub-skill negative trigger (P0-2)

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -1,5 +1,8 @@
 ---
-description: Issue の仕様書作成・分解・一括作成
+description: |
+  (Internal sub-skill — invoked by /rite:issue:create only. Do NOT invoke directly.)
+  Issue の仕様書作成・Sub-Issue 分解・一括作成を行う sub-skill。
+  Phase 0.7 仕様書生成 + Phase 0.8/0.9 分解・bulk-create を担当。
 ---
 
 # /rite:issue:create-decompose

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -1,5 +1,8 @@
 ---
-description: Issue 作成のためのインタビュー実行
+description: |
+  (Internal sub-skill — invoked by /rite:issue:create only. Do NOT invoke directly.)
+  Issue 作成のための適応的インタビューを実行する sub-skill。
+  Phase 0.4.1 規模感判定 + Phase 0.5 深堀り質問を担当。
 ---
 
 # /rite:issue:create-interview

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -1,5 +1,8 @@
 ---
-description: 単一 Issue の確認・作成・登録
+description: |
+  (Internal sub-skill — invoked by /rite:issue:create only. Do NOT invoke directly.)
+  単一 Issue の分類・確認・作成・Projects 登録を行う sub-skill。
+  Phase 1 分類 + Phase 2-4 作成・登録を担当（分解しない単一 Issue 経路）。
 ---
 
 # /rite:issue:create-register

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -1,5 +1,8 @@
 ---
-description: 新規 Issue を作成し、GitHub Projects に追加
+description: |
+  Issue 作成 / new issue / 起票 / Issue 化 — 新規 Issue を作成し、GitHub Projects に登録する。
+  重複検出・親 Issue 候補検出・XL 自動分解（Sub-Issue 作成 + 設計仕様書生成）を含む。
+  Use when 「Issue 作って」「タスクを起票」「create issue」「新規 Issue」など。
 ---
 
 # /rite:issue:create


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/` 配下の 4 ファイルの YAML frontmatter `description` を書き直し、Issue 起票系のオーケストレーション orchestrator (`create.md`) は auto-trigger 適合率を上げ、3 つの sub-skill (`create-interview.md` / `create-decompose.md` / `create-register.md`) は誤発火を抑制する。

設計仕様: `docs/designs/improve-issue-create-skill-design.md` FR-1.2 / FR-1.3。Issue #768 (Umbrella) のサブタスク P0-2。

## 関連 Issue

Closes #770

親 Issue: #768

## 変更内容

### `create.md` (orchestrator)

PDF パターン `[What it does] + [When to use] + [Key capabilities]` で書き直し、front-load にトリガーフレーズを配置:

```yaml
description: |
  Issue 作成 / new issue / 起票 / Issue 化 — 新規 Issue を作成し、GitHub Projects に登録する。
  重複検出・親 Issue 候補検出・XL 自動分解（Sub-Issue 作成 + 設計仕様書生成）を含む。
  Use when 「Issue 作って」「タスクを起票」「create issue」「新規 Issue」など。
```

### `create-interview.md` / `create-decompose.md` / `create-register.md` (sub-skill)

description 冒頭に negative trigger を明記:

```yaml
description: |
  (Internal sub-skill — invoked by /rite:issue:create only. Do NOT invoke directly.)
  ...
```

各ファイルの 2 行目以降には sub-skill が担当する Phase を 1 行で記載。

## 期待効果

- orchestrator (`create.md`) の auto-trigger 適合率向上
- sub-skill 3 ファイルの誤発火抑制

## テストプラン

- [x] 4 ファイルの YAML frontmatter 構文を ruby YAML.safe_load で検証
- [x] grep で create.md に「Issue 作成」「new issue」「起票」が含まれることを確認
- [x] grep で 3 sub-skill に "Internal sub-skill" が含まれることを確認
- [x] `bang-backtick-check.sh --all` (0 findings)
- [x] `distributed-fix-drift-check.sh --all` (本 PR 起因の drift なし)
- [x] `doc-heavy-patterns-drift-check.sh --all` (0 findings)
- [x] `gitignore-health-check.sh --quiet` (0 findings)
- [x] `verify-terminal-output.sh --quiet` (0 findings)

## Known Issues

- `commands.lint: null` (CLAUDE.md「ビルド・テスト・lint コマンドは未設定」) のため `/rite:lint` は `[lint:skipped]`。本 PR では plugin-specific checks (Phase 3.5-3.13) で実質的な品質保証を実施。

## レビュー観点

- frontmatter / body sync drift (Wiki PR #779 経験則): 対象 4 ファイルとも本文に description keyword 列を持たない構造のため、frontmatter のみが SoT で sync drift の懸念なし。
- over-trigger リスク (R1): orchestrator description のトリガー語句が増えたことで他コマンド誤発火する可能性 → P4-10 trigger test で測定 (本 PR 対象外)。
- negative trigger 機能性 (R2): "Do NOT invoke directly." だけで実効性は保証されないが、別防御層 (`pre-tool-bash-guard.sh` 等) は本 Sub-Issue 範囲外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
