### PR TITLE
test(hooks): #771 4-site bash 引数対称化の grep test を追加 (P4-12)

### DIFF
--- a/plugins/rite/hooks/tests/4-site-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/4-site-symmetry.test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Tests for 4-site bash literal symmetry across the create-interview workflow
+# (Issue #771 / parent #768 P4-12)
+#
+# Purpose:
+#   The /rite:issue:create workflow maintains symmetric bash literals
+#   (`flow-state-update.sh patch --phase X --active true --next "..." --preserve-error-count`)
+#   across multiple sites that must stay in lockstep. Past incidents
+#   (#525 / #552 / #561 / #622 / #634 / #651 / #660) have repeatedly shown that
+#   片肺更新 drift in any one site causes either:
+#     - error_count reset loop (verified-review cycle 3 F-01) when --preserve-error-count
+#       is dropped from one occurrence
+#     - active=false residue causing stop-guard early return (Issue #660) when --active true
+#       is dropped
+#
+#   The canonical anchor is the "DRIFT-CHECK ANCHOR (semantic, 4-site)" comment
+#   in `commands/issue/create.md` which enumerates the 4 sites:
+#     (1) create.md 🚨 Mandatory After Interview Step 0
+#     (2) create-interview.md 🚨 MANDATORY Pre-flight
+#     (3) create-interview.md Return Output re-patch
+#     (4) stop-guard.sh `create_post_interview` case arm WORKFLOW_HINT
+#
+# Scope adjustment for current implementation (per Issue #771 R1/R2 mitigation):
+#   - SCOPE: `commands/issue/create.md` and `commands/issue/create-interview.md`
+#     are the 2 actual files containing the 4-arg bash literal symmetry. Each file
+#     hosts 2 occurrences (Step 0 + Step 1 in create.md; Pre-flight + Return Output
+#     re-patch in create-interview.md), totaling the 4 occurrences described in
+#     the canonical anchor.
+#   - OUT OF SCOPE — `stop-guard.sh`: file does not exist as of Issue #771 work
+#     (verified 2026-05-03). The DRIFT-CHECK ANCHOR references it as a future site.
+#     When the file is added, extend `SITES` below to include it.
+#   - OUT OF SCOPE — `phase-transition-whitelist.sh`: this is a sourced library
+#     that does NOT accept `--phase` / `--active` / `--next` / `--preserve-error-count`
+#     as CLI arguments (it stores phase names in associative arrays). Including it
+#     in this CLI-arg symmetry test would produce false negatives. A separate
+#     test for phase-name registration (e.g., `create_post_interview` is whitelisted)
+#     is a different concern handled elsewhere if needed.
+#
+# Test cases:
+#   For each (site, arg) pair in SITES × REQUIRED_ARGS, assert that grep -cE
+#   reports >= 1. Coarse drift detector (won't catch removal from one occurrence
+#   if other occurrences in the same file remain) but matches the granularity
+#   anticipated by Issue #771 pseudo code.
+#
+# When this test fails:
+#   The 4-site bash literal symmetry has drifted. Locate the failing (file, arg)
+#   pair, inspect the DRIFT-CHECK ANCHOR comments in create.md / create-interview.md
+#   for guidance, and restore the missing argument. Do NOT relax the test to make
+#   it pass — symmetry restoration is the correct fix.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+SITES=(
+  "plugins/rite/commands/issue/create.md"
+  "plugins/rite/commands/issue/create-interview.md"
+)
+
+REQUIRED_ARGS=(
+  "--phase"
+  "--active"
+  "--next"
+  "--preserve-error-count"
+)
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+assert_arg_present() {
+  local site="$1" arg="$2"
+  local count
+  count=$(grep -cE -- "$arg" "$REPO_ROOT/$site" 2>/dev/null || echo 0)
+  if [ "$count" -ge 1 ]; then
+    echo "  ✅ $site: $arg (count=$count)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌ $site: $arg (count=0, expected >= 1)"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$site|$arg")
+  fi
+}
+
+for arg in "${REQUIRED_ARGS[@]}"; do
+  echo "=== Checking: $arg present in all sites ==="
+  for site in "${SITES[@]}"; do
+    if [ ! -f "$REPO_ROOT/$site" ]; then
+      echo "  ❌ $site: FILE NOT FOUND"
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("$site|FILE_NOT_FOUND")
+      continue
+    fi
+    assert_arg_present "$site" "$arg"
+  done
+done
+
+echo
+echo "─── test-4-site-symmetry.sh summary ──────────────────────"
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "Failed assertions:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  echo
+  echo "⚠️ 4-site bash literal symmetry drift detected."
+  echo "   Locate the failing (file, arg) pair above and inspect the"
+  echo "   'DRIFT-CHECK ANCHOR (semantic, 4-site)' comments in"
+  echo "   commands/issue/create.md and commands/issue/create-interview.md."
+  echo "   Restore the missing --phase / --active / --next / --preserve-error-count"
+  echo "   argument so the canonical bash literals stay in lockstep."
+  exit 1
+fi
+
+echo "OK: 4-site symmetry verified"
+exit 0

--- a/plugins/rite/hooks/tests/4-site-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/4-site-symmetry.test.sh
@@ -72,7 +72,8 @@ FAILED_NAMES=()
 assert_arg_present() {
   local site="$1" arg="$2"
   local count
-  count=$(grep -cE -- "$arg" "$REPO_ROOT/$site" 2>/dev/null || echo 0)
+  count=$(grep -cE -- "$arg" "$REPO_ROOT/$site" 2>/dev/null || true)
+  count=${count:-0}
   if [ "$count" -ge 1 ]; then
     echo "  ✅ $site: $arg (count=$count)"
     PASS=$((PASS + 1))
@@ -97,7 +98,7 @@ for arg in "${REQUIRED_ARGS[@]}"; do
 done
 
 echo
-echo "─── test-4-site-symmetry.sh summary ──────────────────────"
+echo "─── $(basename "$0") summary ──────────────────────"
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"
 


### PR DESCRIPTION
## 概要

- create.md / create-interview.md に存在する `--phase` / `--active` / `--next` / `--preserve-error-count` の **4 引数 bash literal 対称化** を grep で機械検証する metatest を新設
- 過去 incident #525 / #552 / #561 / #622 / #634 / #651 / #660 で構築された symmetry 防御層が片肺更新 drift で破壊されないようにする
- Sub-Issue P1-3 (references/ 抽出 refactor) の前倒し pre-flight として配置 (#771 Phase 1 前倒し)

## 関連 Issue

Closes #771

親 Issue: #768

## 変更内容

| ファイル | 内容 |
|---------|------|
| `plugins/rite/hooks/tests/4-site-symmetry.test.sh` | 新規作成 (120 行)。create.md / create-interview.md の 2 site × 4 引数 = 8 assertion |

## scope 調整 (Issue #771 R2 — baseline 確認結果)

実装時の baseline 確認で、Issue body の pseudo code が前提とする 4 site のうち 2 site が現実と異なることが判明したため、scope を実態に合わせて調整。

| Issue body の前提 site | 実態 | 対応 |
|----------------------|------|------|
| `commands/issue/create.md` | ✅ 実在 (`--phase`/`--active`/`--next`/`--preserve-error-count` 多数) | テスト対象 |
| `commands/issue/create-interview.md` | ✅ 実在 (同上) | テスト対象 |
| `hooks/scripts/stop-guard.sh` | ❌ ファイル未実装 | scope 外 (header コメントで明記) |
| `hooks/scripts/phase-transition-whitelist.sh` | sourced library で CLI 引数を持たない | scope 外 (header コメントで明記) |

ファイル名は `run-tests.sh` の `*.test.sh` glob convention に合わせ `4-site-symmetry.test.sh` (元案: `test-4-site-symmetry.sh`) とし、既存ランナーへ自動統合される。

## drift 検知能力の確認 (実装中の S5 mock test)

- `--preserve-error-count` を create.md から全削除 → ✅ FAIL 検知
- 1 occurrence のみ削除 → 検知されない (count >= 1 方式の coarse granularity、Issue body pseudo code と同粒度)
- restore 後 `git diff --stat` で残差なし

より厳密な per-block 検査は P1-3 refactor 後の後続 Issue で追加予定。

## チェックリスト

- [x] `plugins/rite/hooks/tests/test-4-site-symmetry.sh` 新規作成 (`4-site-symmetry.test.sh` に名称調整)
- [x] `phase-transition-whitelist.sh` の引数要件を実装時に確認 (CLI 引数なし → scope 外)
- [x] 既存 4-site の baseline 確認 → 必要に応じて修正 (2 site に scope 調整)
- [x] hooks/tests 既存ランナーへの統合 (`*.test.sh` glob で auto-pickup)
- [x] テスト実行で `OK: 4-site symmetry verified` を確認
- [x] `/rite:lint` を pass

## Test plan

- [x] standalone 実行: `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` → exit 0 + `OK: 4-site symmetry verified`
- [x] 統合実行: `bash plugins/rite/hooks/tests/run-tests.sh` 内で picked up + pass
- [x] drift mock: create.md から `--preserve-error-count` 全削除 → FAIL 検知 → restore 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
