### PR TITLE
refactor(create): #773 PR 4/8 — complexity-gate.md 抽出

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -76,21 +76,7 @@ After Phase 0.4 completes, determine the interview scope for Phase 0.5 based on 
 
 ### Tentative Complexity Estimation
 
-Estimate tentative complexity from information gathered in Phases 0.1-0.4. This estimation is used for:
-1. **Adaptive Interview Depth** (below) — determines which interview perspectives to apply
-2. **Task decomposition decision** (Phase 0.6) — XL triggers decomposition
-
-| Tentative Complexity | Criteria | Example |
-|---------------------|----------|---------|
-| **XS** | Change location is clear, 1 to a few lines of modification | typo fix, constant value change |
-| **S** | Content update in a single file, implementation method is uniquely determined | function fix, style adjustment |
-| **M** | Multiple files (approx. 2-5 files) or involves one design decision | small feature addition |
-| **L** | Multiple files (approx. 6-10 files), requires multiple design decisions | medium-scale feature, design change |
-| **XL** | Large-scale change (10+ files) or spans multiple domains, architecture-level design decisions | new system construction, architecture change |
-
-**Notes**:
-- In Phase 0.6 decomposition decision, only XL triggers decomposition (L is not subject to decomposition)
-- The final complexity (XS/S/M/L/XL) is determined in Phase 1.1 and recorded in the Issue
+> **Moved (Issue #773 P1-3 PR 4/8)**: 本セクションの定義は [`references/complexity-gate.md#tentative-complexity-estimation`](./references/complexity-gate.md#tentative-complexity-estimation) に移動しました。Phase 0.1-0.4 の情報から複雑度 (XS/S/M/L/XL) を暫定推定するロジックで、(1) 後続の Adaptive Interview Depth による perspective filtering と (2) Phase 0.6 task decomposition decision (XL のみ trigger) に使われます。最終 complexity は Phase 1.1 Heuristics Scoring (`create-register.md`) で確定します。
 
 ### Complexity-Based Interview Scope
 
@@ -191,7 +177,7 @@ Based on complexity {complexity}, conducting a {standard: standard / full: full}
 
 ### Tentative Complexity
 
-The tentative complexity was estimated in Phase 0.4.1. Refer to the "Tentative Complexity Estimation" section there for criteria and the complexity table. The estimated value drives the interview scope (Phase 0.4.1) and the task decomposition decision (Phase 0.6).
+The tentative complexity was estimated in Phase 0.4.1. Refer to [`references/complexity-gate.md#tentative-complexity-estimation`](./references/complexity-gate.md#tentative-complexity-estimation) for criteria and the complexity table. The estimated value drives the interview scope (Phase 0.4.1) and the task decomposition decision (Phase 0.6).
 
 ### Interview Perspectives
 

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -42,7 +42,7 @@ Classify, confirm, create, and register a single Issue. This sub-command is invo
 
 #### Complexity Heuristics Scoring
 
-> 本 subsection の定義は [`references/complexity-gate.md#complexity-heuristics-scoring`](./references/complexity-gate.md#complexity-heuristics-scoring) に移動しました (Issue #773 P1-3 PR 4/8)。Score テーブル (6 条件、各 +1) と Score → complexity mapping (0-1=XS / 2=S / 3-4=M / 5=L / 6+=XL) を参照してください。
+> **Moved (Issue #773 P1-3 PR 4/8)**: 本 subsection の定義は [`references/complexity-gate.md#complexity-heuristics-scoring`](./references/complexity-gate.md#complexity-heuristics-scoring) に移動しました。Score テーブル (6 条件、各 +1) と Score → complexity mapping (0-1=XS / 2=S / 3-4=M / 5=L / 6+=XL) を参照してください。
 
 ### 1.2 Work Type Classification
 

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -32,28 +32,17 @@ Classify, confirm, create, and register a single Issue. This sub-command is invo
 
 ### 1.1 Complexity Estimation
 
-Finalize the complexity using the tentative estimation from Phase 0.4.1 as a baseline. Refer to the Tentative Complexity Estimation table in `create-interview.md` Phase 0.4.1 for the base criteria (XS through XL).
-
-**When Phase 0.4.1 was not executed** (Phase 0.1.5 early decomposition path): Use XL as the tentative baseline (the task was detected as large-scope in Phase 0.1.5). Heuristics Scoring below takes precedence and may adjust the final complexity downward if the scoring conditions indicate a lower complexity.
+> **Moved (Issue #773 P1-3 PR 4/8)**: 本セクションの定義は [`references/complexity-gate.md`](./references/complexity-gate.md) に移動しました。Phase 0.4.1 の Tentative Complexity Estimation を baseline として、Heuristics Scoring を primary method で最終 complexity を確定します。詳細:
+>
+> - [Tentative Complexity Estimation](./references/complexity-gate.md#tentative-complexity-estimation) — XS/S/M/L/XL の判定基準テーブル
+> - [Complexity Heuristics Scoring](./references/complexity-gate.md#complexity-heuristics-scoring) — Score テーブルと Score → complexity mapping
+> - [Final Complexity Decision Rules](./references/complexity-gate.md#final-complexity-decision-rules) — Tentative と Heuristics の優先順位、Phase 0.4.1 not executed の baseline (XL)
+>
+> 最終 complexity は Issue Meta section に記録される。
 
 #### Complexity Heuristics Scoring
 
-Use the Heuristics Scoring as the primary method. The Tentative Complexity Estimation table serves as a quick reference for intuitive estimation; when the two disagree, the Heuristics Score takes precedence.
-
-Score +1 for each matching condition:
-
-| Condition | Score |
-|-----------|-------|
-| Changed files > 3 | +1 |
-| Spans multiple modules/services | +1 |
-| Public API/interface changes | +1 |
-| Migration/backward compatibility needed | +1 |
-| Strict non-functional requirements | +1 |
-| 2+ unresolved design decisions | +1 |
-
-Score to complexity: 0-1 = XS, 2 = S, 3-4 = M, 5 = L, 6+ = XL
-
-Use information from Phase 0.1-0.5 to evaluate each condition. The final complexity is recorded in the Issue Meta section.
+> 本 subsection の定義は [`references/complexity-gate.md#complexity-heuristics-scoring`](./references/complexity-gate.md#complexity-heuristics-scoring) に移動しました (Issue #773 P1-3 PR 4/8)。Score テーブル (6 条件、各 +1) と Score → complexity mapping (0-1=XS / 2=S / 3-4=M / 5=L / 6+=XL) を参照してください。
 
 ### 1.2 Work Type Classification
 

--- a/plugins/rite/commands/issue/references/complexity-gate.md
+++ b/plugins/rite/commands/issue/references/complexity-gate.md
@@ -1,0 +1,67 @@
+# Complexity Gate — Tentative Complexity Estimation + Heuristics Scoring
+
+> **Source of Truth**: 本ファイルは `/rite:issue:create` workflow における **複雑度判定 (XS/S/M/L/XL)** の正規定義 SoT である。Tentative Complexity Estimation (interview 中の暫定推定) と Complexity Heuristics Scoring (Issue 化時の最終決定) の 2 段階を集約する。`create-interview.md` Phase 0.4.1 / `create-register.md` Phase 1.1 からは本 reference へ semantic 参照する。
+>
+> **抽出経緯**: Issue #773 (#768 P1-3 PR 4/8) で `create-interview.md` Phase 0.4.1 内 "Tentative Complexity Estimation" subsection と `create-register.md` Phase 1.1 全体を本 reference に集約。元ファイルには見出しと redirect notice のみ stub 残置 (歴史的アンカー保持 + caller 内ナビゲーション維持)。caller の機能リンクは本ファイルのアンカー (`#tentative-complexity-estimation` / `#complexity-heuristics-scoring` / `#final-complexity-decision-rules`) へ書き換え済み。
+
+## Tentative Complexity Estimation
+
+`create-interview.md` Phase 0.4.1 で Phase 0.1-0.4 の情報から暫定推定する。用途:
+
+1. **Adaptive Interview Depth** (Phase 0.5 の interview perspective filtering) — どの interview perspective を適用するか決定
+2. **Task Decomposition Decision** (Phase 0.6) — XL は decomposition trigger
+
+| Tentative Complexity | Criteria | Example |
+|---------------------|----------|---------|
+| **XS** | Change location is clear, 1 to a few lines of modification | typo fix, constant value change |
+| **S** | Content update in a single file, implementation method is uniquely determined | function fix, style adjustment |
+| **M** | Multiple files (approx. 2-5 files) or involves one design decision | small feature addition |
+| **L** | Multiple files (approx. 6-10 files), requires multiple design decisions | medium-scale feature, design change |
+| **XL** | Large-scale change (10+ files) or spans multiple domains, architecture-level design decisions | new system construction, architecture change |
+
+**Notes**:
+
+- Phase 0.6 decomposition decision では **XL のみ** decomposition trigger (L は対象外)
+- 最終 complexity (XS/S/M/L/XL) は Phase 1.1 で決定し Issue Meta section に記録される
+- Tentative は Phase 1.1 Heuristics Scoring の **baseline** として使われる ([Final Complexity Decision Rules](#final-complexity-decision-rules) 参照、Heuristics 優先)
+
+---
+
+## Complexity Heuristics Scoring
+
+`create-register.md` Phase 1.1 で **最終 complexity** を確定する。[Tentative Complexity Estimation](#tentative-complexity-estimation) を baseline として、Heuristics Scoring を **primary method** で使用する。Tentative テーブルは直感的な quick reference として、Heuristics Scoring は精度のある最終決定として使い分ける。両者が **不一致** の場合は Heuristics Score が優先される。
+
+Score を +1 する条件:
+
+| Condition | Score |
+|-----------|-------|
+| Changed files > 3 | +1 |
+| Spans multiple modules/services | +1 |
+| Public API/interface changes | +1 |
+| Migration/backward compatibility needed | +1 |
+| Strict non-functional requirements | +1 |
+| 2+ unresolved design decisions | +1 |
+
+Score → complexity mapping:
+
+| Score | Complexity |
+|-------|------------|
+| 0-1 | XS |
+| 2 | S |
+| 3-4 | M |
+| 5 | L |
+| 6+ | XL |
+
+Phase 0.1-0.5 の情報を使って各条件を評価する。最終 complexity は Issue Meta section に記録される。
+
+---
+
+## Final Complexity Decision Rules
+
+Tentative Complexity Estimation と Heuristics Scoring が **不一致** の場合、Heuristics Score が優先される。両者の関係性:
+
+| 状況 | Behavior |
+|------|----------|
+| Tentative と Heuristics が一致 | その値を最終 complexity として採用 |
+| Tentative と Heuristics が不一致 | **Heuristics Score 優先** (Tentative は quick reference のみ) |
+| Phase 0.4.1 が実行されなかった (Phase 0.1.5 early decomposition path) | Tentative baseline として **XL** を採用 (Phase 0.1.5 で large-scope と検出済み) — Heuristics Scoring 優先のため scoring 条件が低 complexity を示せば downward に調整される |

--- a/plugins/rite/templates/issue/default.md
+++ b/plugins/rite/templates/issue/default.md
@@ -55,18 +55,7 @@ Legend: `M` = MUST (required), `S` = SHOULD (recommended), `O` = OMIT (skip)
 
 ## Complexity Heuristics
 
-Score +1 for each matching condition:
-
-| Condition | Score |
-|-----------|-------|
-| Changed files > 3 | +1 |
-| Spans multiple modules/services | +1 |
-| Public API/interface changes | +1 |
-| Migration/backward compatibility needed | +1 |
-| Strict non-functional requirements | +1 |
-| 2+ unresolved design decisions | +1 |
-
-Score to complexity: 0-1 = XS, 2 = S, 3-4 = M, 5 = L, 6+ = XL
+> **Moved (Issue #773 P1-3 PR 4/8)**: 本セクションの定義は [`../../commands/issue/references/complexity-gate.md#complexity-heuristics-scoring`](../../commands/issue/references/complexity-gate.md#complexity-heuristics-scoring) に移動しました。Score テーブル (6 条件、各 +1) と Score → complexity mapping (0-1=XS / 2=S / 3-4=M / 5=L / 6+=XL) を参照してください。本テンプレート内の Heuristics 表は SoT (`references/complexity-gate.md`) の単一定義に集約されています。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #773 (#768 P1-3 PR 4/8) — `commands/issue/references/complexity-gate.md` を新設し、`create-interview.md` Phase 0.4.1 内 "Tentative Complexity Estimation" subsection と `create-register.md` Phase 1.1 全体を本 reference に集約。

## 関連 Issue

Closes はしません (本 PR 単独では Issue を完了しないため)。Issue #773 の PR 分割推奨 4/8 として進捗を記録します。

- Issue: #773
- 親 Issue: #768

## 変更内容

### 新規ファイル

- `plugins/rite/commands/issue/references/complexity-gate.md` (67 行)
  - Tentative Complexity Estimation (XS/S/M/L/XL の判定基準テーブル)
  - Complexity Heuristics Scoring (Score テーブル + Score → complexity mapping)
  - Final Complexity Decision Rules (Tentative と Heuristics の優先順位、Phase 0.4.1 not executed の baseline)

### Stub 化

- `create-interview.md` Phase 0.4.1 内 "Tentative Complexity Estimation" subsection
  - 見出し残置 + redirect notice (`#tentative-complexity-estimation` へ)
  - 534 → 520 行 (-14)

- `create-register.md` Phase 1.1 全体
  - "1.1 Complexity Estimation" 見出し + "Complexity Heuristics Scoring" 見出し残置 (歴史的アンカー保持)
  - 各 stub に redirect notice
  - 650 → 639 行 (-11)

### 内部リンク更新

- `create-interview.md` Phase 0.5 内 "Tentative Complexity" subsection から `references/complexity-gate.md#tentative-complexity-estimation` への直接リンクに更新 (semantic name 参照、Wiki 経験則「Asymmetric Fix Transcription」の dominant pattern 防止)

## PR 4/8 進捗

| 項目 | 状態 |
|------|------|
| 8 references ファイル新規作成 | 4/8 完了 (本 PR で `complexity-gate.md` 追加) |
| `create-interview.md` 行数 | 641 → 520 (PR 1, 3, 4 累計) |
| `create-register.md` 行数 | 650 → 639 (本 PR で初着手) |
| `create.md` 本体スリム化 | PR 6 で実施予定 (≤250 行は全 PR 完了後) |

## チェックリスト

- [x] `references/complexity-gate.md` 新規作成
- [x] `create-interview.md` Phase 0.4.1 stub 化
- [x] `create-register.md` Phase 1.1 stub 化
- [x] 内部リンク更新 (Phase 0.5 内 "Tentative Complexity" subsection)
- [x] AC-3 grep 検証 4 phrase が `create.md` 本体に残ること (本 PR は `create.md` を変更しないため対象外)
- [x] 既存 hooks tests pass (`/rite:lint` で確認済み)
- [x] `/rite:lint` pass (本 PR 変更ファイルに新規 findings なし)

## 検証

- ✅ `complexity-gate.md` 存在、`Tentative Complexity` / `Heuristics Scoring` / `Final Complexity Decision Rules` の 3 セクション含む
- ✅ `create-interview.md` の `PR 4/8` marker 1 件 (Tentative subsection stub のみ)
- ✅ `create-register.md` の `PR 4/8` marker 2 件 (Phase 1.1 stub + Heuristics Scoring stub)
- ✅ Bang-backtick check clean (Phase 1.0 pre-PR gate pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
