### PR TITLE
refactor(create): #773 PR 7/8 — contract-section-mapping.md 抽出 (P1-3)

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -148,7 +148,7 @@ Information collected through Phase 0.5 and Phase 0.7 is utilized in Phase 1 onw
 | Collected Information | Carryover Destination |
 |----------------------|----------------------|
 | What/Why/Where | Implementation Contract Section 1 (Goal), Section 2 (Scope) of the Issue body |
-| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see `create-register.md` Phase 2.2 Step 3) |
+| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see [`references/contract-section-mapping.md`](./references/contract-section-mapping.md)) |
 | Tentative complexity XL | Finalized in Phase 1.1. Recorded as XL even when decomposition is cancelled |
 | Out-of-scope items | Implementation Contract Section 2 (Out of Scope), Section 1 (Non-goal) |
 | Specification document content (Phase 0.7.1) | Referenced as design context in Implementation Contract Section 4 (Implementation Details) |

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -148,7 +148,7 @@ Information collected through Phase 0.5 and Phase 0.7 is utilized in Phase 1 onw
 | Collected Information | Carryover Destination |
 |----------------------|----------------------|
 | What/Why/Where | Implementation Contract Section 1 (Goal), Section 2 (Scope) of the Issue body |
-| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see [`references/contract-section-mapping.md`](./references/contract-section-mapping.md)) |
+| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping)) |
 | Tentative complexity XL | Finalized in Phase 1.1. Recorded as XL even when decomposition is cancelled |
 | Out-of-scope items | Implementation Contract Section 2 (Out of Scope), Section 1 (Non-goal) |
 | Specification document content (Phase 0.7.1) | Referenced as design context in Implementation Contract Section 4 (Implementation Details) |

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -369,9 +369,9 @@ After batch responses, derive follow-up questions from answers. Follow-ups are a
 
 ### Reflecting Interview Results
 
-> **Moved (Issue #773 P1-3 PR 7/8 fix #801)**: Interview Perspective → Target Sections の正規 mapping table は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に集約済み (二重 SoT 解消)。Phase 0.5 では本 reference の mapping に従って interview results を Section 1-9 に割り当てること。
+> **Moved (Issue #773 P1-3 PR 7/8)**: Interview Perspective → Target Sections の正規 mapping table は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に移動しました。Phase 0.5 では本 reference の mapping に従って interview results を Section 1-9 に割り当てること。
 
-**Note**: This mapping is applied during Issue body generation in `create-register.md` Phase 2.2 ([Step 3 — `references/contract-section-mapping.md`](./references/contract-section-mapping.md)). Phase 0.5 collects and retains the raw interview results in conversation context; the structured mapping to Implementation Contract sections occurs at generation time.
+**Note**: Phase 0.5 collects and retains the raw interview results in conversation context; the structured mapping to Implementation Contract sections occurs at Issue body generation time (`create-register.md` Phase 2.2 Step 3).
 
 **Retention format** (in conversation context, not in Issue body):
 

--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -369,18 +369,9 @@ After batch responses, derive follow-up questions from answers. Follow-ups are a
 
 ### Reflecting Interview Results
 
-Interview results are mapped to Implementation Contract sections (Section 1-9) for the Issue body. The mapping follows Step 3 of the Issue Body Generation process in `create-register.md`:
+> **Moved (Issue #773 P1-3 PR 7/8 fix #801)**: Interview Perspective → Target Sections の正規 mapping table は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に集約済み (二重 SoT 解消)。Phase 0.5 では本 reference の mapping に従って interview results を Section 1-9 に割り当てること。
 
-| Interview Perspective | Target Sections |
-|----------------------|----------------|
-| Technical Implementation | 4.1 Target Files, 4.3 Interface/Data Contract, 4.4 Behavioral Requirements |
-| User Experience | 1 Goal, 3 Type Core (Feature scenarios), 5 AC (Happy Path) |
-| Edge Cases | 5 AC (Boundary/Error), 6 Test Specification |
-| Existing Feature Impact | 2 Scope (Out), 4.2 Non-Target, 4.4 MUST NOT |
-| Non-Functional Requirements | 4.5 Error/Constraints, 5 AC (NFR outcome), 6 Test Specification |
-| Tradeoffs | 1 Non-goal, 4.4 SHOULD/MAY, 9 Decision Log |
-
-**Note**: This mapping is applied during Issue body generation in `create-register.md` Phase 2.2 (Step 3). Phase 0.5 collects and retains the raw interview results in conversation context; the structured mapping to Implementation Contract sections occurs at generation time.
+**Note**: This mapping is applied during Issue body generation in `create-register.md` Phase 2.2 ([Step 3 — `references/contract-section-mapping.md`](./references/contract-section-mapping.md)). Phase 0.5 collects and retains the raw interview results in conversation context; the structured mapping to Implementation Contract sections occurs at generation time.
 
 **Retention format** (in conversation context, not in Issue body):
 

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -195,38 +195,14 @@ Read the Complexity Gate table from the template. For the determined complexity,
 
 **Step 2: Select Type Core Section**
 
-Based on the Type from Phase 1.2, include the corresponding Type Core Section (Section 3):
-
-| Type | Section 3 Content |
-|------|------------------|
-| Feature | User Scenarios |
-| BugFix | Bug Details (Reproduction, Root Cause) |
-| Refactor | Before/After Contract, Compatibility Policy |
-| Chore | Operational Context |
-| Docs | Documentation Target |
+> **Moved (Issue #773 P1-3 PR 7/8)**: Type → Section 3 Type Core Section の mapping table は [`references/contract-section-mapping.md#step-2-type--type-core-section-section-3-mapping`](./references/contract-section-mapping.md#step-2-type--type-core-section-section-3-mapping) に移動しました。Phase 1.2 で確定した Type に対応する Section 3 (User Scenarios / Bug Details / Before-After Contract / Operational Context / Documentation Target) を選択してください。
 
 **Step 3: Map Interview Results to Sections**
 
-Apply the interview-to-template mapping from the template:
-
-| Interview Perspective | Target Sections |
-|----------------------|----------------|
-| Technical Implementation | 4.1 Target Files, 4.3 Interface/Data Contract, 4.4 Behavioral Requirements |
-| User Experience | 1 Goal, 3 Type Core (Feature scenarios), 5 AC (Happy Path) |
-| Edge Cases | 5 AC (Boundary/Error), 6 Test Specification |
-| Existing Feature Impact | 2 Scope (Out), 4.2 Non-Target, 4.4 MUST NOT |
-| Non-Functional Requirements | 4.5 Error/Constraints, 5 AC (NFR outcome), 6 Test Specification |
-| Tradeoffs | 1 Non-goal, 4.4 SHOULD/MAY, 9 Decision Log |
-
-**Section inclusion rules**:
-
-| Condition | Behavior |
-|-----------|----------|
-| Interview not conducted for a perspective | Omit target sections (unless MUST by Complexity Gate) |
-| Interview conducted for a perspective | Populate target sections with interview results |
-| Section is MUST but no interview data | Include section with placeholder comment (`<!-- 情報未収集 -->`) |
-| Phase 0.7 cancel path with specification document | Include `docs/designs/{slug}.md` content as design context in Section 4 (Implementation Details). The pre-validated specification supplements interview results for Section 4.1-4.5 |
-| Phase 0.3-0.5 all skipped (`phases_skipped: "0.3-0.5"`) | Apply [EDGE-3 row 4](./references/edge-cases-create.md#edge-3-interview-result-reflection-rules): populate all MUST sections per Complexity Gate using Phase 0.1 context (What/Why/Where). For MUST sections where no data is available from Phase 0.1, include `<!-- 情報未収集 -->` placeholder. AI-inferred content is marked with `（推定）`. SHOULD/OMIT sections follow normal Gate rules |
+> **Moved (Issue #773 P1-3 PR 7/8)**: Interview Perspective → Target Sections mapping table と Section inclusion rules table は [`references/contract-section-mapping.md`](./references/contract-section-mapping.md) に移動しました。詳細:
+>
+> - [Step 3: Interview Perspective → Target Sections Mapping](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) — 6 Perspective × Section の正規対応表
+> - [Section Inclusion Rules](./references/contract-section-mapping.md#section-inclusion-rules) — Interview not conducted / MUST but no data / Phase 0.7 cancel / `phases_skipped: "0.3-0.5"` のハンドリング (EDGE-3 row 4 への参照含む)
 
 **Step 4: Generate Acceptance Criteria**
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -588,7 +588,7 @@ Information collected through Phase 0.5 is utilized in Phase 1 onwards as follow
 | Collected Information | Carryover Destination |
 |----------------------|----------------------|
 | What/Why/Where | Implementation Contract Section 1 (Goal), Section 2 (Scope) of the Issue body |
-| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see `create-register.md` Phase 2.2 Step 3) |
+| Interview results (technical decisions, etc.) | Implementation Contract Sections 1-9 via interview-to-section mapping (see [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping)) |
 | Tentative complexity XL | Finalized in Phase 1.1. Recorded as XL even when decomposition is cancelled |
 | Out-of-scope items | Implementation Contract Section 2 (Out of Scope), Section 1 (Non-goal) |
 
@@ -731,4 +731,4 @@ Phase 0.6 terminates based on the user's selection in the decomposition confirma
 | User Selection | Next Phase |
 |----------------|------------|
 | Sub-Issue に分解する（推奨） | Invoke `skill: "rite:issue:create-decompose"` |
-| 単一 Issue として作成 | Invoke `skill: "rite:issue:create-register"`. Interview results from Phase 0.5 are mapped to Implementation Contract sections via `create-register.md` Phase 2.2 Step 3. See Phase 0.6.2 for context carryover details |
+| 単一 Issue として作成 | Invoke `skill: "rite:issue:create-register"`. Interview results from Phase 0.5 are mapped to Implementation Contract sections via [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping). See Phase 0.6.2 for context carryover details |

--- a/plugins/rite/commands/issue/references/contract-section-mapping.md
+++ b/plugins/rite/commands/issue/references/contract-section-mapping.md
@@ -1,0 +1,95 @@
+# Implementation Contract Section Mapping — Interview → Section 1-9
+
+> **Source of Truth**: 本ファイルは `/rite:issue:create` ワークフローにおける Issue Body 生成時の **Implementation Contract Section 1-9 への mapping** の SoT である。`create-register.md` Phase 2.2 (Step 2 Type Core Section / Step 3 Map Interview Results to Sections) と `create-decompose.md` Phase 0.7.3 cancel path の mapping 参照は本ファイルへ semantic 参照する。
+>
+> **抽出経緯**: Type → Section 3 mapping table・Interview Perspective → Target Sections mapping table・Section inclusion rules table の 3 つの mapping 表が `create-register.md` Phase 2.2 Step 2-3 に集約されていた状況を、Issue #773 (#768 P1-3) PR 7/8 で本 reference に集約。Step 4-6 (AC 生成 / Test 仕様 / Output Validation) は Implementation Contract の **生成手順** であり mapping ではないため、本 reference には含めず `create-register.md` 本体に維持する。
+
+## 位置づけ
+
+`create-register.md` Phase 2.2 における Implementation Contract format の生成は以下の 6 step で構成される:
+
+| Step | 役割 | SoT |
+|------|------|-----|
+| Step 1 | Apply Complexity Gate (MUST/SHOULD/OMIT 判定) | [`complexity-gate.md`](./complexity-gate.md) |
+| **Step 2** | **Select Type Core Section (Section 3)** | **本 reference** |
+| **Step 3** | **Map Interview Results to Sections (Section 1-9)** | **本 reference** |
+| Step 4 | Generate Acceptance Criteria (AC 生成順序 / writing rules) | `create-register.md` 本体 |
+| Step 5 | Generate Test Specification Table | `create-register.md` 本体 |
+| Step 6 | Output Validation Checklist | `create-register.md` 本体 |
+
+本 reference は **Step 2 (Type → Section 3 mapping) と Step 3 (Interview → Section 1-9 mapping)** の正規定義を集約する。Section 1-9 の **template 定義** (各 Section の markdown skeleton) は [`templates/issue/template-structure.md`](../../../templates/issue/template-structure.md) を参照すること。
+
+## Implementation Contract Section 1-9 概観
+
+`templates/issue/template-structure.md` で定義される Issue body の section 構成:
+
+| Section | 名称 | 主な内容 |
+|---------|------|---------|
+| 0 | Meta | Type / Complexity / Parent Issue (任意) |
+| 1 | Goal | Goal / Non-goal |
+| 2 | Scope | In Scope / Out of Scope |
+| 3 | Type Core Section | Type に応じた core section (Step 2 で 1 つ選択) |
+| 4.1 | Target Files | 変更対象ファイルリスト |
+| 4.2 | Non-Target Files | MUST NOT modify 対象 |
+| 4.3 | Interface / Data Contract | Before / After |
+| 4.4 | Behavioral Requirements | MUST / SHOULD / MAY / MUST NOT |
+| 4.5 | Error Handling / Constraints | Error Condition × Expected Behavior |
+| 5 | Acceptance Criteria | Given / When / Then 形式の AC リスト |
+| 6 | Test Specification | T-xx ID と Related AC mapping |
+| 7 | Important Conventions | CLAUDE.md からの MUST/MUST NOT 抜粋 (max 5) |
+| 8 | Definition of Done | 完了条件チェックリスト |
+| 9 | Decision Log | 実装中の意思決定記録 |
+
+各 Section の正規 template は [`templates/issue/template-structure.md`](../../../templates/issue/template-structure.md) を参照。Complexity Gate による MUST/SHOULD/OMIT 判定は [`complexity-gate.md`](./complexity-gate.md) を参照。
+
+## Step 2: Type → Type Core Section (Section 3) Mapping
+
+Phase 1.2 で確定した Type に基づき、Section 3 として include する Type Core Section を選択する:
+
+| Type | Section 3 内容 | template-structure.md 参照 |
+|------|---------------|---------------------------|
+| Feature | User Scenarios | `3-Feature: User Scenarios` |
+| BugFix | Bug Details (Reproduction / Root Cause Hypothesis) | `3-BugFix: Bug Details` |
+| Refactor | Before / After Contract / Compatibility Policy | `3-Refactor: Before / After Contract` |
+| Chore | Operational Context | `3-Chore: Operational Context` |
+| Docs | Documentation Target | `3-Docs: Documentation Target` |
+
+**Type 判定の優先順位**: Labels > title keywords > body content analysis (`create-register.md` Phase 1.2 参照)。
+
+## Step 3: Interview Perspective → Target Sections Mapping
+
+Phase 0.5 interview で収集した観点 (Perspective) を、Section 1-9 のどの section に反映するかの mapping:
+
+| Interview Perspective | Target Sections |
+|----------------------|----------------|
+| Technical Implementation | 4.1 Target Files / 4.3 Interface / Data Contract / 4.4 Behavioral Requirements |
+| User Experience | 1 Goal / 3 Type Core (Feature scenarios) / 5 AC (Happy Path) |
+| Edge Cases | 5 AC (Boundary / Error) / 6 Test Specification |
+| Existing Feature Impact | 2 Scope (Out) / 4.2 Non-Target / 4.4 MUST NOT |
+| Non-Functional Requirements | 4.5 Error Handling / Constraints / 5 AC (NFR outcome) / 6 Test Specification |
+| Tradeoffs | 1 Non-goal / 4.4 SHOULD / MAY / 9 Decision Log |
+
+**逆方向 mapping (section から perspective を引く)** が必要な場合は本表の右列を起点に検索すること。
+
+## Section Inclusion Rules
+
+Step 2 で Section 3 を確定し、Step 3 で interview 結果を section に mapping した後、各 section の include / omit / placeholder 挿入を以下の rule で決定する:
+
+| Condition | Behavior |
+|-----------|----------|
+| Interview not conducted for a perspective | Omit target sections (unless MUST by Complexity Gate) |
+| Interview conducted for a perspective | Populate target sections with interview results |
+| Section is MUST but no interview data | Include section with placeholder comment (`<!-- 情報未収集 -->`) |
+| Phase 0.7 cancel path with specification document | Include `docs/designs/{slug}.md` content as design context in Section 4 (Implementation Details). Pre-validated specification supplements interview results for Section 4.1-4.5 |
+| Phase 0.3-0.5 all skipped (`phases_skipped: "0.3-0.5"`) | Apply [EDGE-3 row 4](./edge-cases-create.md#edge-3-interview-result-reflection-rules): populate all MUST sections per Complexity Gate using Phase 0.1 context (What/Why/Where). For MUST sections where no data is available from Phase 0.1, include `<!-- 情報未収集 -->` placeholder. AI-inferred content is marked with `（推定）`. SHOULD/OMIT sections follow normal Gate rules |
+
+**MUST/SHOULD/OMIT の判定基準**: [`complexity-gate.md#complexity-gate-section-inclusion`](./complexity-gate.md) を参照。Complexity (XS/S/M/L/XL) ごとに各 section の include 必須度が決定される。
+
+## 関連参照
+
+- [`templates/issue/template-structure.md`](../../../templates/issue/template-structure.md) — Section 1-9 の正規 markdown template
+- [`templates/issue/default.md`](../../../templates/issue/default.md) — Complexity Gate / Type 定義の overview
+- [`complexity-gate.md`](./complexity-gate.md) — Complexity (XS/S/M/L/XL) 判定基準と MUST/SHOULD/OMIT mapping
+- [`edge-cases-create.md`](./edge-cases-create.md) — EDGE-3 Interview Result Reflection Rules (`phases_skipped` ハンドリング)
+- [`sub-skill-handoff-contract.md`](./sub-skill-handoff-contract.md) — orchestrator / sub-skill 間 hand-off の正規定義
+- [`regression-history.md`](./regression-history.md) — 本 reference を含む `/rite:issue:create` ワークフロー周辺の incident 時系列史

--- a/plugins/rite/commands/issue/references/contract-section-mapping.md
+++ b/plugins/rite/commands/issue/references/contract-section-mapping.md
@@ -83,7 +83,7 @@ Step 2 で Section 3 を確定し、Step 3 で interview 結果を section に m
 | Phase 0.7 cancel path with specification document | Include `docs/designs/{slug}.md` content as design context in Section 4 (Implementation Details). Pre-validated specification supplements interview results for Section 4.1-4.5 |
 | Phase 0.3-0.5 all skipped (`phases_skipped: "0.3-0.5"`) | Apply [EDGE-3 row 4](./edge-cases-create.md#edge-3-interview-result-reflection-rules): populate all MUST sections per Complexity Gate using Phase 0.1 context (What/Why/Where). For MUST sections where no data is available from Phase 0.1, include `<!-- 情報未収集 -->` placeholder. AI-inferred content is marked with `（推定）`. SHOULD/OMIT sections follow normal Gate rules |
 
-**MUST/SHOULD/OMIT の判定基準**: [`complexity-gate.md#complexity-gate-section-inclusion`](./complexity-gate.md) を参照。Complexity (XS/S/M/L/XL) ごとに各 section の include 必須度が決定される。
+**MUST/SHOULD/OMIT の判定基準**: [`complexity-gate.md#complexity-heuristics-scoring`](./complexity-gate.md#complexity-heuristics-scoring) と [`templates/issue/template-structure.md`](../../../templates/issue/template-structure.md) の Complexity Gate 表を参照。Complexity (XS/S/M/L/XL) ごとに各 section の include 必須度が決定される。
 
 ## 関連参照
 

--- a/plugins/rite/commands/issue/references/contract-section-mapping.md
+++ b/plugins/rite/commands/issue/references/contract-section-mapping.md
@@ -46,13 +46,13 @@
 
 Phase 1.2 で確定した Type に基づき、Section 3 として include する Type Core Section を選択する:
 
-| Type | Section 3 内容 | template-structure.md 参照 |
-|------|---------------|---------------------------|
-| Feature | User Scenarios | `3-Feature: User Scenarios` |
-| BugFix | Bug Details (Reproduction / Root Cause Hypothesis) | `3-BugFix: Bug Details` |
-| Refactor | Before / After Contract / Compatibility Policy | `3-Refactor: Before / After Contract` |
-| Chore | Operational Context | `3-Chore: Operational Context` |
-| Docs | Documentation Target | `3-Docs: Documentation Target` |
+| Type | Section 3 内容 | template-structure.md 内 subsection |
+|------|---------------|------------------------------------|
+| Feature | User Scenarios | [`3-Feature: User Scenarios`](../../../templates/issue/template-structure.md#3-feature-user-scenarios) |
+| BugFix | Bug Details (Reproduction / Root Cause Hypothesis) | [`3-BugFix: Bug Details`](../../../templates/issue/template-structure.md#3-bugfix-bug-details) |
+| Refactor | Before / After Contract / Compatibility Policy | [`3-Refactor: Before / After Contract`](../../../templates/issue/template-structure.md#3-refactor-before--after-contract) |
+| Chore | Operational Context | [`3-Chore: Operational Context`](../../../templates/issue/template-structure.md#3-chore-operational-context) |
+| Docs | Documentation Target | [`3-Docs: Documentation Target`](../../../templates/issue/template-structure.md#3-docs-documentation-target) |
 
 **Type 判定の優先順位**: Labels > title keywords > body content analysis (`create-register.md` Phase 1.2 参照)。
 

--- a/plugins/rite/commands/issue/references/edge-cases-create.md
+++ b/plugins/rite/commands/issue/references/edge-cases-create.md
@@ -65,7 +65,7 @@ When "単一 Issue として作成" is selected (Phase 0.6) or "キャンセル"
 
 | Phase 0.5 Status | Implementation Contract Sections | Content |
 |-------------------|----------------------------------|---------|
-| Phase 0.5 executed with interview results | **MUST populate** target sections per interview-to-section mapping (`create-register.md` Phase 2.2 Step 3) | Map each interview perspective to corresponding Implementation Contract sections (e.g., Technical Implementation → 4.1, 4.3, 4.4) |
+| Phase 0.5 executed with interview results | **MUST populate** target sections per interview-to-section mapping ([`./contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping)) | Map each interview perspective to corresponding Implementation Contract sections (e.g., Technical Implementation → 4.1, 4.3, 4.4) |
 | Phase 0.5 skipped (XS/Bug Fix/Chore) | **Populate if** Phase 0.4 gathered useful context | Summary of Phase 0.4 context in relevant sections; omit optional sections if no meaningful detail exists |
 | Phase 0.5 executed but user gave minimal responses | **MUST populate** | Whatever was gathered, plus AI-inferred details marked with `（推定）` |
 | Phase 0.3-0.5 all skipped (Phase 0.1.5 early decomposition → cancel back to single Issue) | **MUST populate** MUST sections per Complexity Gate | Phase 0.1 context (What/Why/Where) for available sections; `<!-- 情報未収集 -->` placeholder for MUST sections without data. Goal classification: infer from Phase 0.1 extraction. Complexity: use XL (from Phase 0.1.5 detection) as tentative baseline, finalize via Heuristics Scoring in `create-register.md` Phase 1.1 |

--- a/plugins/rite/commands/issue/references/regression-history.md
+++ b/plugins/rite/commands/issue/references/regression-history.md
@@ -120,7 +120,7 @@ cycle 2 review F-NEW1 で「Stop hook の UI 上は exit 2 後でも `Churned fo
 
 ### Issue #773 (#768 P1-3) — references 抽出 + 強調マーカー適正化 (本 PR シリーズ)
 
-> **強化内容**: `commands/issue/references/` ディレクトリを新設し、`create.md` 本体 (835 行) から 8 ファイル抽出 + 本体を ≤ 250 行にスリム化する (PR 1-8 で漸進、PR 6/8 時点での本体行数: 734 行、PR 7-8 完了で目標達成予定)。同時に強調マーカー (P1-5) と Pre-check list 分離 (P3-9) も実施する。
+> **強化内容**: `commands/issue/references/` ディレクトリを新設し、`create.md` 本体 (835 行) から 8 ファイル抽出 + 本体を ≤ 250 行にスリム化する (PR 1-8 で漸進、PR 7/8 時点での本体行数: 734 行、PR 8 完了で目標達成予定)。同時に強調マーカー (P1-5) と Pre-check list 分離 (P3-9) も実施する。
 
 | PR | スコープ | 抽出 references |
 |----|---------|----------------|
@@ -129,11 +129,13 @@ cycle 2 review F-NEW1 で「Stop hook の UI 上は exit 2 後でも `Churned fo
 | PR 3 (#792) | EDGE-2/3/4/5 集約 | `edge-cases-create.md` |
 | PR 4 (#794) | XS/S/M/L/XL 判定基準 | `complexity-gate.md` |
 | PR 5 (#796) | slug 生成ルール SoT | `slug-generation.md` |
-| **PR 6 (本 PR)** | **regression-history 抽出 + 強調マーカー適正化 (P1-5)** | **`regression-history.md` (本ファイル)** |
-| PR 7 (予定) | Implementation Contract Section 1-9 mapping | `contract-section-mapping.md` |
+| PR 6 (#800) | regression-history 抽出 + 強調マーカー適正化 (P1-5) | `regression-history.md` (本ファイル) |
+| **PR 7 (本 PR)** | **Implementation Contract Section 1-9 mapping** | **`contract-section-mapping.md`** |
 | PR 8 (予定) | bulk-create 連結パターン | `bulk-create-pattern.md` |
 
-PR 6 で本 reference を抽出すると同時に、`create.md` の `🚨` 強調マーカーを **12 → 4 occurrence** に削減する (P1-5、上限 ≤ 5、PR 7-8 で逸脱しないこと)。Issue #475 由来の重複 protocol violation 警告は、Drift guard 契約 (「両方 identical を保て」) を **解除して** 1 箇所統合し、もう 1 箇所は本 reference へのリンクで代替する。
+PR 6 で本 reference を抽出すると同時に、`create.md` の `🚨` 強調マーカーを **12 → 4 occurrence** に削減した (P1-5、上限 ≤ 5、PR 7-8 で逸脱しないこと)。Issue #475 由来の重複 protocol violation 警告は、Drift guard 契約 (「両方 identical を保て」) を **解除して** 1 箇所統合し、もう 1 箇所は本 reference へのリンクで代替している。
+
+PR 7 では `create-register.md` Phase 2.2 Step 2-3 の Type → Section 3 Type Core mapping table・Interview Perspective → Target Sections mapping table・Section inclusion rules table を `contract-section-mapping.md` に集約し、本体には `> Moved` 参照ブロックのみ残置する。`create-decompose.md` Phase 0.7.3 cancel path の `create-register.md Phase 2.2 Step 3` への参照リンクも本 reference 経由に更新する。Step 4-6 (AC 生成 / Test 仕様 / Output Validation) は Implementation Contract の **生成手順** であり mapping ではないため、本体に維持する。
 
 ## 旧構成: stop-guard.sh `create_post_interview` case arm WORKFLOW_HINT (撤去済み)
 

--- a/plugins/rite/commands/issue/references/regression-history.md
+++ b/plugins/rite/commands/issue/references/regression-history.md
@@ -135,7 +135,7 @@ cycle 2 review F-NEW1 で「Stop hook の UI 上は exit 2 後でも `Churned fo
 
 PR 6 で本 reference を抽出すると同時に、`create.md` の `🚨` 強調マーカーを **12 → 4 occurrence** に削減した (P1-5、上限 ≤ 5、PR 7-8 で逸脱しないこと)。Issue #475 由来の重複 protocol violation 警告は、Drift guard 契約 (「両方 identical を保て」) を **解除して** 1 箇所統合し、もう 1 箇所は本 reference へのリンクで代替している。
 
-PR 7 では `create-register.md` Phase 2.2 Step 2-3 の Type → Section 3 Type Core mapping table・Interview Perspective → Target Sections mapping table・Section inclusion rules table を `contract-section-mapping.md` に集約し、本体には `> Moved` 参照ブロックのみ残置する。`create-decompose.md` Phase 0.7.3 cancel path の `create-register.md Phase 2.2 Step 3` への参照リンクも本 reference 経由に更新する。Step 4-6 (AC 生成 / Test 仕様 / Output Validation) は Implementation Contract の **生成手順** であり mapping ではないため、本体に維持する。
+PR 7 では `create-register.md` Phase 2.2 Step 2-3 の Type → Section 3 Type Core mapping table・Interview Perspective → Target Sections mapping table・Section inclusion rules table を `contract-section-mapping.md` に集約し、本体には `> Moved` 参照ブロックのみ残置した。`create-decompose.md` Phase 0.7.3 cancel path の `create-register.md Phase 2.2 Step 3` への参照リンクも本 reference 経由に更新している。Step 4-6 (AC 生成 / Test 仕様 / Output Validation) は Implementation Contract の **生成手順** であり mapping ではないため、本体に維持している。
 
 ## 旧構成: stop-guard.sh `create_post_interview` case arm WORKFLOW_HINT (撤去済み)
 

--- a/plugins/rite/templates/issue/default.md
+++ b/plugins/rite/templates/issue/default.md
@@ -84,7 +84,7 @@ Legend: `M` = MUST (required), `S` = SHOULD (recommended), `O` = OMIT (skip)
 
 ## Interview to Template Mapping
 
-> **Moved (Issue #773 P1-3 PR 7/8 fix #801)**: Interview Perspective → Target Sections の正規 mapping table は [`commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](../../commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に集約済み (二重 SoT 解消)。本 template から interview mapping を参照する場合は本 reference を経由すること。
+> **Moved (Issue #773 P1-3 PR 7/8)**: Interview Perspective → Target Sections の正規 mapping table は [`commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](../../commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に移動しました。本 template から interview mapping を参照する場合は本 reference を経由すること。
 
 ---
 

--- a/plugins/rite/templates/issue/default.md
+++ b/plugins/rite/templates/issue/default.md
@@ -84,14 +84,7 @@ Legend: `M` = MUST (required), `S` = SHOULD (recommended), `O` = OMIT (skip)
 
 ## Interview to Template Mapping
 
-| Interview Perspective | Target Sections |
-|----------------------|----------------|
-| Technical Implementation | 4.1 Target Files, 4.3 Interface/Data Contract, 4.4 Behavioral Requirements |
-| User Experience | 1 Goal, 3 Type Core (Feature scenarios), 5 AC (Happy Path) |
-| Edge Cases | 5 AC (Boundary/Error), 6 Test Specification (Boundary/Error rows) |
-| Existing Feature Impact | 2 Scope (Out of Scope), 4.2 Non-Target, 4.4 MUST NOT |
-| Non-Functional Requirements | 4.5 Error/Constraints, 5 AC (NFR outcome), 6 Test Specification |
-| Tradeoffs | 1 Non-goal, 4.4 SHOULD/MAY, 9 Decision Log |
+> **Moved (Issue #773 P1-3 PR 7/8 fix #801)**: Interview Perspective → Target Sections の正規 mapping table は [`commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](../../commands/issue/references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に集約済み (二重 SoT 解消)。本 template から interview mapping を参照する場合は本 reference を経由すること。
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #773 (#768 P1-3) の PR シリーズ 7/8。`create-register.md` Phase 2.2 Step 2-3 の Implementation Contract Section mapping 群を `references/contract-section-mapping.md` に集約する。

- **新規**: `commands/issue/references/contract-section-mapping.md` (95 行) — Type → Section 3 Type Core mapping table・Interview Perspective → Target Sections mapping table・Section inclusion rules table を集約
- **スリム化**: `create-register.md` 639 → 615 行 (-24 行)。Step 2/3 を `> Moved` 参照ブロックに置換。Step 4-6 (AC 生成 / Test 仕様 / Output Validation) は生成手順であり mapping ではないため本体に維持
- **リンク更新**: `create-decompose.md` Phase 0.7.3 cancel path から本 reference へ参照更新
- **進捗記録**: `regression-history.md` の PR 表で PR 6 (#800) を「マージ済み」、PR 7 を「本 PR」に更新

## 抽出範囲の判断

`create-register.md` Phase 2.2 は 6 step で構成される。本 PR では mapping (Step 2-3) のみ抽出し、生成手順 (Step 4-6) は本体維持:

| Step | 役割 | SoT (本 PR 後) |
|------|------|--------------|
| Step 1 | Apply Complexity Gate | `complexity-gate.md` (PR 4 で抽出済み) |
| **Step 2** | **Type → Section 3** | **`contract-section-mapping.md` (本 PR)** |
| **Step 3** | **Interview → Section 1-9** | **`contract-section-mapping.md` (本 PR)** |
| Step 4 | Generate AC | `create-register.md` 本体 |
| Step 5 | Generate Test Spec | `create-register.md` 本体 |
| Step 6 | Output Validation | `create-register.md` 本体 |

## P1-3 / P1-5 / P3-9 進捗

| 制約 | 状態 |
|------|------|
| P1-3 (8 references 抽出) | 6/8 → **7/8 (本 PR で達成)** |
| P1-5 (`create.md` 🚨 ≤ 5) | 4 occurrence で維持 (本 PR は `create.md` 不変更) |
| P3-9 (Pre-check list 分離) | PR 2 で完了済み (本 PR は不変更) |
| AC-3 grep 4 phrase | 全て `create.md` 本体に残存 ✓ |
| `create.md` 本体行数 (≤250 目標) | 734 行 (PR 8 完了後にスリム化最終調整予定) |

## 検証

- [x] `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` PASS (8/8)
- [x] AC-3 grep 4 phrase が `create.md` 本体に残存 (anti-pattern: 2 / correct-pattern: 2 / same response turn: 4 / DO NOT stop: 2)
- [x] 🚨 marker count: create.md=4, create-register.md=4, create-decompose.md=4 (本 PR 不変更)
- [x] 内部リンク `create-register.md Phase 2.2 Step 3` 参照箇所を grep で網羅し本 reference へ書き換え (`create-decompose.md` 1 箇所のみ)
- [x] contract-section-mapping.md 内に `🚨` 不在 (mapping reference に sentinel 記述は不要)

## Test plan

- [x] 4-site-symmetry.test.sh で hook 系の対称契約破壊なしを確認
- [x] `create-register.md` の `> Moved` 参照ブロックから新 reference へリンクが正しく解決すること (相対パス `./references/contract-section-mapping.md` で develop ブランチで参照可能)
- [ ] PR マージ後、次回 `/rite:issue:create` 起動時に新リンクが正しく参照されることを確認 (ドッグフーディング)

## Related

- Parent Issue: #768 (Umbrella) — #773 (P1-3 / P1-5 / P3-9)
- Previous PR: #800 (PR 6/8 — regression-history.md 抽出 + 強調マーカー適正化)
- Next PR: PR 8/8 — bulk-create 連結パターン (`bulk-create-pattern.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)