### PR TITLE
refactor(create): #773 PR 8/8 — bulk-create-pattern.md 抽出 + create-decompose.md 本体スリム化 (P1-3)

### DIFF
--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -362,7 +362,7 @@ XL（{count} 件の Sub-Issue に分解）
 
 ### 0.9.2 Bulk Creation of Sub-Issues
 
-> **Source of Truth**: Pre-amble + Per-Sub-Issue body の bash literal / placeholder descriptions / Sub-Issue body structure / Error handling for partial failures / anti-pattern 例の正規定義は [`references/bulk-create-pattern.md`](./references/bulk-create-pattern.md) を参照する。
+> **Partial Moved (Issue #773 P1-3 PR 8/8)**: Pre-amble + Per-Sub-Issue body の bash literal / placeholder descriptions / Sub-Issue body structure / Error handling for partial failures / anti-pattern 例の正規定義は [`references/bulk-create-pattern.md`](./references/bulk-create-pattern.md) を参照する。critical 警告は本体に維持 (NFR-2 protected、下記 ⚠️ CRITICAL 段落参照)。
 
 Phase 0.9.2 は **2 つの部分** から構成され、両者は **a single Bash tool invocation** で実行されることが MUST 要件:
 

--- a/plugins/rite/commands/issue/create-decompose.md
+++ b/plugins/rite/commands/issue/create-decompose.md
@@ -362,147 +362,27 @@ XL（{count} 件の Sub-Issue に分解）
 
 ### 0.9.2 Bulk Creation of Sub-Issues
 
-Phase 0.9.2 consists of **two parts** that MUST be executed in **a single Bash tool invocation** so that shell state (the accumulator arrays) is preserved across all Sub-Issue iterations:
+> **Source of Truth**: Pre-amble + Per-Sub-Issue body の bash literal / placeholder descriptions / Sub-Issue body structure / Error handling for partial failures / anti-pattern 例の正規定義は [`references/bulk-create-pattern.md`](./references/bulk-create-pattern.md) を参照する。
 
-1. **Pre-amble** (executed exactly **once** at the top): declare the accumulator arrays.
-2. **Per-Sub-Issue body** (repeated **N times**, one iteration per entry in the Phase 0.8 decomposition list): create the Sub-Issue and append its number/URL to the accumulators.
+Phase 0.9.2 は **2 つの部分** から構成され、両者は **a single Bash tool invocation** で実行されることが MUST 要件:
+
+1. **Pre-amble** (1 回のみ実行): accumulator arrays (`SUB_ISSUE_NUMBERS` / `SUB_ISSUE_URLS`) を宣言する
+2. **Per-Sub-Issue body** (Phase 0.8 分解 list の項目数 N 回実行): Sub-Issue を作成し accumulator に append する
 
 > **⚠️ CRITICAL (AC-1 enforcement — single-Bash-invocation requirement)**:
-> - Concatenate the Pre-amble and **all N copies of the Per-Sub-Issue body** into **one single Bash tool call**. Each copy of the body MUST have `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` substituted with that iteration's actual values **before** execution.
-> - Do **NOT** split the iterations across multiple Bash tool invocations. Bash variables (including `SUB_ISSUE_NUMBERS`/`SUB_ISSUE_URLS`) do not persist across separate Bash tool calls. If split, the arrays will be empty when Phase 0.9.4 runs, and the AC-1 empty-array guard will fail-fast with `exit 1`.
-> - The Pre-amble appears **exactly once** at the top of the combined script. Do not re-declare the arrays inside each per-Sub-Issue body — that would reset accumulated state.
-> - After every successful create, the per-Sub-Issue body appends `sub_issue_number` to `SUB_ISSUE_NUMBERS` and `sub_issue_url` to `SUB_ISSUE_URLS`. This bookkeeping is what allows Phase 0.9.4 (Sub-issues API linkage) to iterate over all created Sub-Issues. Phase 0.9.4 is the AC-1 enforcement boundary: if the array is empty, linkage is silently skipped and AC-1 is violated.
-> - This is the single most common silent-skip risk in this command — do not omit the bookkeeping or split the script under any circumstance.
+> - Pre-amble + **all N copies of the Per-Sub-Issue body** + Phase 0.9.4 linkage を **one single Bash tool call** に連結する。各 Per-Sub-Issue body 複製は実行前に `{sub_issue_title}` / `{sub_issue_body}` / `{estimated_complexity}` を当該反復の実値で置換する。
+> - **Do NOT split the iterations across multiple Bash tool invocations**。Bash 変数 (`SUB_ISSUE_NUMBERS` / `SUB_ISSUE_URLS` accumulator arrays を含む) は別 Bash tool 呼び出し境界で消失する。分割すると Phase 0.9.4 が空配列を参照し、AC-1 enforcement が silent 違反される (per-call linkage failure は non-blocking)。Phase 0.9.4 の空配列 fail-fast (`exit 1`) が最終防御層。
+> - Pre-amble は結合 script の先頭に **exactly once** 配置する。各 Per-Sub-Issue body 内で配列を再宣言してはならない (蓄積状態がリセットされる)。
+> - 各 successful create 後、Per-Sub-Issue body は `sub_issue_number` を `SUB_ISSUE_NUMBERS` に、`sub_issue_url` を `SUB_ISSUE_URLS` に append する。この bookkeeping により Phase 0.9.4 (Sub-issues API linkage) が全 Sub-Issue を反復可能となる。
+> - これは本コマンドにおける **silent-skip risk 最大の箇所**。bookkeeping 省略 / script 分割は **いかなる事情でも許容されない**。
 
-#### Pre-amble (execute exactly once, at the top of the combined script)
+具体的な bash literal (Pre-amble + Per-Sub-Issue body)、placeholder descriptions、Sub-Issue body structure、Error handling for partial failures、anti-pattern (split 禁止) の正規定義は [`references/bulk-create-pattern.md`](./references/bulk-create-pattern.md) を参照すること。本体には上記 critical 警告 (NFR-2 protected) のみを残し、実装詳細は references に集約する形で認知負荷を低減する。
 
-```bash
-# === Loop pre-amble (このブロックは結合スクリプトの先頭で1回だけ実行) ===
-# SUB_ISSUE_NUMBERS / SUB_ISSUE_URLS は Per-Sub-Issue body の全反復で蓄積され、
-# 同一 Bash ツール呼び出し内の Phase 0.9.4 から参照される。
-SUB_ISSUE_NUMBERS=()
-SUB_ISSUE_URLS=()
-```
+各 Sub-Issue 作成成功後の post-processing:
 
-#### Per-Sub-Issue body (paste once per entry in the decomposition list, in the same Bash invocation)
-
-For each Sub-Issue in the Phase 0.8 decomposition list, append a copy of the following block to the combined script — substituting `{sub_issue_title}`, `{sub_issue_body}`, and `{estimated_complexity}` with that iteration's actual values. All copies share the accumulator arrays declared in the Pre-amble above.
-
-```bash
-# === Per-Sub-Issue body (N 回複製して連結。各複製ごとに placeholder を実値で置換) ===
-# Generate body content from Phase 0.8 decomposition and the structure defined below (see "Sub-Issue body structure")
-# Note: Empty check is required because {sub_issue_body} is dynamically generated.
-tmpfile=$(mktemp)
-trap 'rm -f "$tmpfile"' EXIT
-
-cat <<'BODY_EOF' > "$tmpfile"
-{sub_issue_body}
-BODY_EOF
-
-if [ ! -s "$tmpfile" ]; then
-  echo "ERROR: Issue body is empty for Sub-Issue '{sub_issue_title}'" >&2
-else
-  result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
-    --arg title "{sub_issue_title}" \
-    --arg body_file "$tmpfile" \
-    --argjson projects_enabled {projects_enabled} \
-    --argjson project_number {project_number} \
-    --arg owner "{owner}" \
-    --arg priority "{priority}" \
-    --arg complexity "{estimated_complexity}" \
-    --arg iter_mode "none" \
-    '{
-      issue: { title: $title, body_file: $body_file },
-      projects: {
-        enabled: $projects_enabled,
-        project_number: $project_number,
-        owner: $owner,
-        status: "Todo",
-        priority: $priority,
-        complexity: $complexity,
-        iteration: { mode: $iter_mode }
-      },
-      options: { source: "xl_decomposition", non_blocking_projects: true }
-    }'
-  )")
-
-  if [ -z "$result" ]; then
-    echo "ERROR: create-issue-with-projects.sh returned empty result for Sub-Issue '{sub_issue_title}'" >&2
-    # Skip accumulation for this Sub-Issue but continue to the next iteration block.
-    # NOTE: We intentionally do NOT use `continue` here because each per-Sub-Issue body
-    # is concatenated as a flat sequence (not wrapped in a for/while loop), and `continue`
-    # outside a loop is a bash syntax error. The else-branch below handles the skip.
-  else
-    sub_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
-    sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
-    sub_project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
-    # project_id/item_id は XL 分解パスでは後続フェーズで使用しないため省略
-    printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
-
-    # === MANDATORY: 配列に蓄積（Phase 0.9.4 が参照） ===
-    # 数値であることを検証してから追加（"null" や空文字を弾く）
-    if [[ "$sub_issue_number" =~ ^[0-9]+$ ]]; then
-      SUB_ISSUE_NUMBERS+=("$sub_issue_number")
-      SUB_ISSUE_URLS+=("$sub_issue_url")
-    else
-      echo "⚠️ Sub-Issue '{sub_issue_title}' の番号が不正のため linkage 配列に追加しません: '$sub_issue_number'" >&2
-    fi
-  fi
-fi
-# === Per-Sub-Issue body 終了。次の Sub-Issue があれば、ここに次の複製を連結する ===
-```
-
-> **Alternative (advanced)**: If you prefer an explicit loop structure, you may instead wrap the per-Sub-Issue body in `for sub_entry in ...; do ... done` after expanding the decomposition list as bash array entries. In that case `continue` (instead of the else-branch skip) becomes syntactically valid. Either approach is acceptable as long as the Pre-amble runs once and all iterations execute in the same Bash tool invocation.
-
-**Placeholder descriptions:**
-- `{estimated_complexity}`: Complexity estimated during Phase 0.8 decomposition (XS/S/M/L/XL per Sub-Issue)
-- `{priority}`: Inherited from parent Issue priority
-- `{owner}`: Repository owner (from `github.projects.owner` in `rite-config.yml`, or `gh repo view --json owner --jq '.owner.login'`)
-- `{repo}`: Repository name (from `gh repo view --json name --jq '.name'`). Required by Phase 0.9.4's `link-sub-issue.sh` invocation; if omitted, the GraphQL `repository(owner:..., name:"{repo}")` lookup will always fail with "Could not resolve to a Repository", and AC-1 will be silently violated (per-call failures are non-blocking).
-- `{parent_issue_number}`: The parent Issue number created in Phase 0.9.1 (the one whose Sub-Issues are being created)
-
-**Error handling for partial failures:**
-- If a Sub-Issue creation fails mid-loop, log the error and continue with remaining Sub-Issues
-- After the loop completes, report which Sub-Issues succeeded and which failed in Phase 0.9.6
-- The user can retry failed ones manually via `/rite:issue:create`
-
-After each Sub-Issue is created:
-1. Retain `sub_issue_url` and `sub_issue_number` for Tasklist update in Phase 0.9.3
-2. The script handles Projects registration + field setup internally
-
-**Sub-Issue body structure**:
-
-```markdown
-## 概要
-
-{この Sub-Issue で実装する内容}
-
-## 親 Issue
-
-#{parent_issue_number} - {parent_issue_title}
-
-## 設計ドキュメント
-
-詳細な仕様は [docs/designs/{slug}.md](docs/designs/{slug}.md) を参照してください。
-
-## 変更内容
-
-{具体的な変更内容}
-
-## 依存関係
-
-{依存する Sub-Issue があれば記載}
-
-## 複雑度
-
-{complexity}
-
-## チェックリスト
-
-- [ ] 実装完了
-- [ ] テスト追加/更新
-- [ ] ドキュメント更新（必要な場合）
-```
+1. `sub_issue_url` / `sub_issue_number` を Phase 0.9.3 (Tasklist update) のため retain する
+2. accumulator (`SUB_ISSUE_NUMBERS` / `SUB_ISSUE_URLS`) に append する (Phase 0.9.4 が参照)
+3. Per-call failure は non-blocking で継続、Phase 0.9.6 で成功 / 失敗を集約報告
 
 ### 0.9.3 Add Tasklist to Parent Issue
 

--- a/plugins/rite/commands/issue/references/bulk-create-pattern.md
+++ b/plugins/rite/commands/issue/references/bulk-create-pattern.md
@@ -4,7 +4,7 @@
 >
 > **抽出経緯**: `create-decompose.md` Phase 0.9.2 (旧 lines 363-505、約 140 行) には Pre-amble bash block / Per-Sub-Issue body bash block / Critical guard 警告 / Sub-Issue body structure / Placeholder descriptions / Error handling が集約されており、本体ファイルの認知負荷を高めていた。これを Issue #773 (#768 P1-3) PR 8/8 で本 reference に移管し、`create-decompose.md` Phase 0.9.2 本体には **概要 + AC-1 critical 警告 (NFR-2 protected で本体に残す) + 本 reference への参照リンク** のみを残す形にスリム化する。
 >
-> **NFR-2 (本体保持)**: AC-1 enforcement boundary に関する critical 警告 (`single-Bash-invocation requirement` / `silent-skip risk` の 2 文) は **`create-decompose.md` 本体に残す**。理由: AC-3 grep 検証 4 phrase の同 turn 警告は本体読込時に LLM が認識できる位置にある必要がある。本 reference は **手順詳細とコードリテラル** を集約し、警告そのものは本体側 SoT を維持する。
+> **NFR-2 (本体保持)**: AC-1 enforcement boundary に関する critical 警告 (`single-Bash-invocation requirement` / `silent-skip risk` の 2 文) は **`create-decompose.md` 本体に残す**。理由: AC-1 enforcement boundary の同 turn 警告は Phase 0.9.4 空配列 fail-fast との因果関係を保つため、本体読込時に LLM が認識できる位置にある必要がある。本 reference は **手順詳細とコードリテラル** を集約し、警告そのものは本体側 SoT を維持する。
 
 ## 位置づけ
 
@@ -230,10 +230,6 @@ done
 
 ## Regression context
 
-本 pattern の AC-1 enforcement (Phase 0.9.4 空配列ガード + Per-Sub-Issue body 内の数値検証) は以下の incident を経て段階的に強化されてきた:
+本 pattern の AC-1 enforcement (Phase 0.9.4 空配列ガード + Per-Sub-Issue body 内の数値検証) と各防御層 (per-call non-blocking、`link-sub-issue.sh` 経由の linkage、数値検証ガード、Phase 0.9.4 空配列 fail-fast 等) は、`/rite:issue:create` workflow 周辺で発生した複数の incident を経て段階的に強化されてきた。
 
-- **Issue #444** — Sub-Issue creation の partial failure 時に親 Issue tasklist が部分的に更新される問題への対策として `link-sub-issue.sh` の per-call non-blocking + Phase 0.9.6 報告 pattern を確立
-- **Issue #475** — `sub_issue_number` が `"null"` 文字列になるエッジケース (jq parse 失敗時) で linkage が malformed リクエストを送る問題に対し、`[[ "$sub_issue_number" =~ ^[0-9]+$ ]]` 数値検証ガードを追加
-- **Issue #525 / #552** — single-Bash-invocation 要件の暗黙化により分割実装が再発した incident。Phase 0.9.4 に空配列 fail-fast を追加して final defense layer を確立
-
-詳細な incident → 防御層導入経緯の時系列は [`regression-history.md`](./regression-history.md) を参照。
+各 Issue 番号別の incident → 防御層導入経緯の時系列は [`regression-history.md`](./regression-history.md) を参照。本 reference では Issue 番号の個別引用は行わず、SoT との二重定義を避ける。

--- a/plugins/rite/commands/issue/references/bulk-create-pattern.md
+++ b/plugins/rite/commands/issue/references/bulk-create-pattern.md
@@ -1,0 +1,239 @@
+# Bulk Sub-Issue Creation Pattern — 単一 Bash invocation での Pre-amble + Per-Sub-Issue body + linkage 連結
+
+> **Source of Truth**: 本ファイルは `/rite:issue:create` ワークフローにおける **XL 分解パスでの bulk Sub-Issue creation** の **Pre-amble + Per-Sub-Issue body の連結パターン** の SoT である。`create-decompose.md` Phase 0.9.2 の bash literal の正規定義は本 reference に集約する。
+>
+> **抽出経緯**: `create-decompose.md` Phase 0.9.2 (旧 lines 363-505、約 140 行) には Pre-amble bash block / Per-Sub-Issue body bash block / Critical guard 警告 / Sub-Issue body structure / Placeholder descriptions / Error handling が集約されており、本体ファイルの認知負荷を高めていた。これを Issue #773 (#768 P1-3) PR 8/8 で本 reference に移管し、`create-decompose.md` Phase 0.9.2 本体には **概要 + AC-1 critical 警告 (NFR-2 protected で本体に残す) + 本 reference への参照リンク** のみを残す形にスリム化する。
+>
+> **NFR-2 (本体保持)**: AC-1 enforcement boundary に関する critical 警告 (`single-Bash-invocation requirement` / `silent-skip risk` の 2 文) は **`create-decompose.md` 本体に残す**。理由: AC-3 grep 検証 4 phrase の同 turn 警告は本体読込時に LLM が認識できる位置にある必要がある。本 reference は **手順詳細とコードリテラル** を集約し、警告そのものは本体側 SoT を維持する。
+
+## 位置づけ
+
+`create-decompose.md` Phase 0.9 (Bulk Sub-Issue Creation) は以下の 6 step で構成される:
+
+| Step | 役割 | SoT |
+|------|------|-----|
+| Phase 0.9.1 | Create the Parent Issue | `create-decompose.md` 本体 |
+| **Phase 0.9.2** | **Bulk Creation of Sub-Issues** (Pre-amble + Per-Sub-Issue body) | **本 reference** |
+| Phase 0.9.3 | Add Tasklist to Parent Issue | `create-decompose.md` 本体 |
+| Phase 0.9.4 | Sub-Issues API Linkage (Mandatory) | `create-decompose.md` 本体 + [`graphql-helpers.md`](../../../references/graphql-helpers.md#addsubissue-helper) |
+| Phase 0.9.5 | Projects Registration | `create-decompose.md` 本体 |
+| Phase 0.9.6 | Completion Report | `create-decompose.md` 本体 |
+
+本 reference は **Phase 0.9.2 (Pre-amble + Per-Sub-Issue body の連結 bash literal)** の正規定義を集約する。
+
+## なぜ単一 Bash invocation が要件か (AC-1 enforcement boundary)
+
+Phase 0.9.2 は **2 つの部分** から構成され、両者は **同一の Bash tool invocation** で実行されることが MUST 要件:
+
+1. **Pre-amble** (1 回のみ実行): accumulator arrays (`SUB_ISSUE_NUMBERS` / `SUB_ISSUE_URLS`) を宣言する
+2. **Per-Sub-Issue body** (Phase 0.8 分解 list の項目数 N 回繰り返し実行): Sub-Issue を作成し accumulator に append する
+
+**Bash 変数 (配列を含む) は別々の Bash tool 呼び出し境界で消失する**。これは Claude Code の Bash tool 仕様 — 各呼び出しで新規 shell process が起動するため、前の呼び出しで宣言した変数は次の呼び出しでは参照不可。
+
+このため:
+
+- Pre-amble + N 個の Per-Sub-Issue body のすべてを **1 回の Bash tool invocation 内で順次実行** する必要がある。
+- 分割すると Phase 0.9.4 (Sub-Issues API linkage) が空配列を参照することになり、**linkage が silent skip され AC-1 が違反される** (linkage 失敗は per-call で non-blocking なため、log を見落とすと silent regression になる)。
+- Phase 0.9.4 が AC-1 enforcement boundary であり、空配列ガードで `exit 1` する fail-fast が最終防御層として機能する。
+
+> **これは本コマンドにおける silent-skip リスク最大の箇所**。Bookkeeping (accumulator append) の省略 / script 分割は **いかなる事情でも許容されない**。
+
+## Pre-amble (1 回のみ)
+
+結合スクリプトの先頭に **1 回だけ** 配置する:
+
+```bash
+# === Loop pre-amble (このブロックは結合スクリプトの先頭で1回だけ実行) ===
+# SUB_ISSUE_NUMBERS / SUB_ISSUE_URLS は Per-Sub-Issue body の全反復で蓄積され、
+# 同一 Bash ツール呼び出し内の Phase 0.9.4 から参照される。
+SUB_ISSUE_NUMBERS=()
+SUB_ISSUE_URLS=()
+```
+
+## Per-Sub-Issue body (N 回複製)
+
+Phase 0.8 分解 list の各 Sub-Issue について、以下のブロックを **複製して同一スクリプトに連結** する。各複製ごとに `{sub_issue_title}` / `{sub_issue_body}` / `{estimated_complexity}` placeholder を **その反復の実値で置換** すること:
+
+```bash
+# === Per-Sub-Issue body (N 回複製して連結。各複製ごとに placeholder を実値で置換) ===
+# Generate body content from Phase 0.8 decomposition and the structure defined below (see "Sub-Issue body structure")
+# Note: Empty check is required because {sub_issue_body} is dynamically generated.
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+cat <<'BODY_EOF' > "$tmpfile"
+{sub_issue_body}
+BODY_EOF
+
+if [ ! -s "$tmpfile" ]; then
+  echo "ERROR: Issue body is empty for Sub-Issue '{sub_issue_title}'" >&2
+else
+  result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
+    --arg title "{sub_issue_title}" \
+    --arg body_file "$tmpfile" \
+    --argjson projects_enabled {projects_enabled} \
+    --argjson project_number {project_number} \
+    --arg owner "{owner}" \
+    --arg priority "{priority}" \
+    --arg complexity "{estimated_complexity}" \
+    --arg iter_mode "none" \
+    '{
+      issue: { title: $title, body_file: $body_file },
+      projects: {
+        enabled: $projects_enabled,
+        project_number: $project_number,
+        owner: $owner,
+        status: "Todo",
+        priority: $priority,
+        complexity: $complexity,
+        iteration: { mode: $iter_mode }
+      },
+      options: { source: "xl_decomposition", non_blocking_projects: true }
+    }'
+  )")
+
+  if [ -z "$result" ]; then
+    echo "ERROR: create-issue-with-projects.sh returned empty result for Sub-Issue '{sub_issue_title}'" >&2
+    # Skip accumulation for this Sub-Issue but continue to the next iteration block.
+    # NOTE: We intentionally do NOT use `continue` here because each per-Sub-Issue body
+    # is concatenated as a flat sequence (not wrapped in a for/while loop), and `continue`
+    # outside a loop is a bash syntax error. The else-branch below handles the skip.
+  else
+    sub_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
+    sub_issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
+    sub_project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
+    # project_id/item_id は XL 分解パスでは後続フェーズで使用しないため省略
+    printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+
+    # === MANDATORY: 配列に蓄積（Phase 0.9.4 が参照） ===
+    # 数値であることを検証してから追加（"null" や空文字を弾く）
+    if [[ "$sub_issue_number" =~ ^[0-9]+$ ]]; then
+      SUB_ISSUE_NUMBERS+=("$sub_issue_number")
+      SUB_ISSUE_URLS+=("$sub_issue_url")
+    else
+      echo "⚠️ Sub-Issue '{sub_issue_title}' の番号が不正のため linkage 配列に追加しません: '$sub_issue_number'" >&2
+    fi
+  fi
+fi
+# === Per-Sub-Issue body 終了。次の Sub-Issue があれば、ここに次の複製を連結する ===
+```
+
+> **Alternative (advanced)**: 明示的な loop 構造を好む場合、上記 Per-Sub-Issue body を `for sub_entry in ...; do ... done` で wrap し、Phase 0.8 分解 list を bash array entries として展開する形でも実装可能。その場合は else-branch skip ではなく `continue` が syntactically valid となる。**Pre-amble が 1 回だけ実行され、すべての反復が同一 Bash tool invocation で実行される** という contract を満たせばどちらの approach も許容。
+
+## Placeholder descriptions
+
+Per-Sub-Issue body の placeholder は以下の通り:
+
+| Placeholder | 値の source |
+|-------------|-------------|
+| `{sub_issue_title}` | Phase 0.8 分解 list の各エントリの title |
+| `{sub_issue_body}` | 下記「Sub-Issue body structure」を該当反復の値で埋めて生成 |
+| `{estimated_complexity}` | Phase 0.8 で見積もった complexity (XS / S / M / L / XL の per-Sub-Issue 値) |
+| `{priority}` | 親 Issue から継承 |
+| `{owner}` | `github.projects.owner` (`rite-config.yml`) または `gh repo view --json owner --jq '.owner.login'` |
+| `{repo}` | `gh repo view --json name --jq '.name'`。Phase 0.9.4 の `link-sub-issue.sh` 呼び出しで必須。これが欠落すると GraphQL `repository(owner:..., name:"{repo}")` lookup が常に "Could not resolve to a Repository" で失敗し、AC-1 が silent 違反される (per-call 失敗が non-blocking なため)。 |
+| `{parent_issue_number}` | Phase 0.9.1 で作成した親 Issue 番号 (Sub-Issues 作成対象) |
+| `{projects_enabled}` | `rite-config.yml` の `github.projects.enabled` が `true` なら `true`、それ以外 `false` |
+| `{project_number}` | `github.projects.project_number` (`rite-config.yml`) |
+| `{plugin_root}` | [Plugin Path Resolution](../../../references/plugin-path-resolution.md#resolution-script-full-version) で解決 |
+
+## Sub-Issue body structure
+
+Per-Sub-Issue body の `{sub_issue_body}` placeholder に展開する markdown:
+
+```markdown
+## 概要
+
+{この Sub-Issue で実装する内容}
+
+## 親 Issue
+
+#{parent_issue_number} - {parent_issue_title}
+
+## 設計ドキュメント
+
+詳細な仕様は [docs/designs/{slug}.md](docs/designs/{slug}.md) を参照してください。
+
+## 変更内容
+
+{具体的な変更内容}
+
+## 依存関係
+
+{依存する Sub-Issue があれば記載}
+
+## 複雑度
+
+{complexity}
+
+## チェックリスト
+
+- [ ] 実装完了
+- [ ] テスト追加/更新
+- [ ] ドキュメント更新（必要な場合）
+```
+
+## Error handling for partial failures
+
+- Sub-Issue creation がループ途中で失敗した場合、エラーを log して残りの Sub-Issue 作成を継続する (per-call non-blocking)。
+- ループ完了後、Phase 0.9.6 (Completion Report) で **どの Sub-Issue が成功し、どの Sub-Issue が失敗したか** を報告する。
+- 失敗した Sub-Issue は user が手動で `/rite:issue:create` で retry 可能。
+
+各 Sub-Issue 作成成功後の post-processing:
+
+1. `sub_issue_url` / `sub_issue_number` を Phase 0.9.3 (Tasklist update) のために retain する
+2. accumulator (`SUB_ISSUE_NUMBERS` / `SUB_ISSUE_URLS`) に append する (Phase 0.9.4 が参照)
+3. `create-issue-with-projects.sh` script が Projects 登録 + field 設定を内部で処理する
+
+## Anti-pattern: Pre-amble + Per-Sub-Issue body 分割
+
+❌ **以下の anti-pattern を絶対に行わないこと**:
+
+```
+# Bash tool 呼び出し 1 (Pre-amble のみ)
+SUB_ISSUE_NUMBERS=()
+SUB_ISSUE_URLS=()
+
+# Bash tool 呼び出し 2 (Sub-Issue 1 作成)
+... (SUB_ISSUE_NUMBERS は空配列にリセットされている)
+
+# Bash tool 呼び出し 3 (Sub-Issue 2 作成)
+... (依然として空配列)
+```
+
+Bash variable scope は tool invocation 境界で消失するため、上記分割では `SUB_ISSUE_NUMBERS` は常に空のままで、Phase 0.9.4 が空配列ガードで `exit 1` する。Phase 0.9.4 の fail-fast が無ければ、AC-1 (parent-child linkage) が silent 違反されたまま完了レポートまで到達する。
+
+✅ **正しい pattern**:
+
+```
+# Bash tool 呼び出し 1 (Pre-amble + Sub-Issue 1 + Sub-Issue 2 + ... + Sub-Issue N + Phase 0.9.4 を全部連結)
+SUB_ISSUE_NUMBERS=()
+SUB_ISSUE_URLS=()
+
+# (Sub-Issue 1 の Per-Sub-Issue body)
+tmpfile=$(mktemp); trap ...
+... SUB_ISSUE_NUMBERS+=("$sub_issue_number") ...
+
+# (Sub-Issue 2 の Per-Sub-Issue body)
+tmpfile=$(mktemp); trap ...
+... SUB_ISSUE_NUMBERS+=("$sub_issue_number") ...
+
+# ... (Sub-Issue N まで)
+
+# (Phase 0.9.4 linkage を同一スクリプトで実行)
+for issue_num in "${SUB_ISSUE_NUMBERS[@]}"; do
+  bash {plugin_root}/scripts/link-sub-issue.sh ...
+done
+```
+
+`create-decompose.md` 本体の AC-1 critical 警告で何度繰り返されているように、この single-Bash-invocation 要件は **本コマンドにおける silent-skip リスク最大の箇所** である。
+
+## Regression context
+
+本 pattern の AC-1 enforcement (Phase 0.9.4 空配列ガード + Per-Sub-Issue body 内の数値検証) は以下の incident を経て段階的に強化されてきた:
+
+- **Issue #444** — Sub-Issue creation の partial failure 時に親 Issue tasklist が部分的に更新される問題への対策として `link-sub-issue.sh` の per-call non-blocking + Phase 0.9.6 報告 pattern を確立
+- **Issue #475** — `sub_issue_number` が `"null"` 文字列になるエッジケース (jq parse 失敗時) で linkage が malformed リクエストを送る問題に対し、`[[ "$sub_issue_number" =~ ^[0-9]+$ ]]` 数値検証ガードを追加
+- **Issue #525 / #552** — single-Bash-invocation 要件の暗黙化により分割実装が再発した incident。Phase 0.9.4 に空配列 fail-fast を追加して final defense layer を確立
+
+詳細な incident → 防御層導入経緯の時系列は [`regression-history.md`](./regression-history.md) を参照。


### PR DESCRIPTION
## 概要

Issue #773 (#768 P1-3) の最終 PR (8/8)。`create-decompose.md` Phase 0.9.2 (Bulk Sub-Issue Creation) の Pre-amble + Per-Sub-Issue body の bash literal を新規 reference [`bulk-create-pattern.md`](plugins/rite/commands/issue/references/bulk-create-pattern.md) に抽出し、本体をスリム化する。

これにより、計画していた 8 references ファイルすべてが完了 (8/8)。

## 関連 Issue

Closes #773 (の 8 references 抽出計画。残るチェックリスト項目 `create.md` 本体 ≤250 行スリム化は別 Issue 推奨)

親 Issue: #768

## 主な変更

### 新規ファイル

- `plugins/rite/commands/issue/references/bulk-create-pattern.md` (239 行)
  - Pre-amble bash literal (1 回のみ実行する accumulator 宣言)
  - Per-Sub-Issue body bash literal (N 回複製で連結)
  - Placeholder descriptions
  - Sub-Issue body structure (markdown skeleton)
  - Error handling for partial failures
  - Anti-pattern (Pre-amble + Per-Sub-Issue body の split 禁止) と correct pattern
  - Regression context (Issue #444 / #475 / #525 / #552 経緯)

### 本体スリム化

- `plugins/rite/commands/issue/create-decompose.md`: 781 → 661 行 (120 行削減)
  - Phase 0.9.2 の bash literal / Sub-Issue body structure / Error handling 等の詳細を references に移管
  - **NFR-2 protected**: AC-1 enforcement boundary に関する critical 警告 (single-Bash-invocation requirement / silent-skip risk) は本体に維持
  - 本体には: 概要 + critical 警告 + references 参照リンク + post-processing 手順 のみ残置

## PR 8 全体の進捗

8 references 抽出計画 (8/8 完了):

| # | PR | reference | 状態 |
|---|----|-----------|------|
| 1 | sub-skill-handoff-contract.md | マージ済み |
| 2 | pre-check-routing.md (P3-9) | マージ済み |
| 3 | edge-cases-create.md | マージ済み |
| 4 | complexity-gate.md | マージ済み |
| 5 | slug-generation.md | マージ済み |
| 6 | regression-history.md (P1-5) | マージ済み |
| 7 | contract-section-mapping.md | マージ済み (#801) |
| 8 | bulk-create-pattern.md | 本 PR |

## 未完了の Issue チェック項目

以下のチェック項目が Issue #773 本文で未完了です。Phase 3 計画段階で「PR 8 スコープ外、別 PR 推奨」と確認済み:

- [ ] `create.md` 本体スリム化 (≤250 行) — 本 Issue 内では未達成。references 抽出のみで本体重複削除は未実施。別 Issue 推奨。
- [ ] `create-interview.md` / `create-decompose.md` / `create-register.md` 本体スリム化 — PR 1-8 で `create-interview.md` 641→511 行 / `create-register.md` 650→615 行 / `create-decompose.md` 781→661 行 部分着手。≤250 行 ターゲットは別 PR で対応。

これらは後続作業で対応予定 (別 Issue で扱う)。

## テスト

- `/rite:lint` 実行: PR 8 で追加した `bulk-create-pattern.md` / 修正した `create-decompose.md` には新規 lint warning なし
- `verify-terminal-output.sh`: pass
- `bang-backtick-check.sh`: pass (Phase 1.0 PR 作成 gate)
- 既存 hooks tests: 影響なし (本 PR は markdown 抽出のみ)

## レビューポイント

1. **NFR-2 (本体保持) の境界**: `create-decompose.md` 本体に残した critical 警告 (4 つの bullet) が AC-1 enforcement に必要十分か
2. **Pre-amble + Per-Sub-Issue body の説明完全性**: `bulk-create-pattern.md` だけで XL 分解パスの bulk creation を理解・実行できるか
3. **Anti-pattern セクションの明示性**: split 禁止 anti-pattern が「✅ 正しい pattern」と並列表示されており、LLM が誤った実装に分岐しない構造になっているか
4. **既存 references の Source of Truth note との整合**: `position-table` で 0.9.2 のみ「本 reference」、他は本体・他 references を指す形式が他 7 references と一致

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
