### PR TITLE
refactor(create-interview): #805 本体を 511→331 行 (-35%) にスリム化

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -18,30 +18,18 @@ Execute the adaptive interview for Issue creation. This sub-command is invoked f
 
 ## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
 
-> **Issue #622 (regression of #552)**: This section was historically placed at the end of the file (titled "Defense-in-Depth: Flow State Update (Before Return)"). In the Bug Fix / Chore preset path (Phase 0.4.1 → skip Phase 0.5), the LLM running this sub-skill sometimes skipped the Defense-in-Depth bash block and jumped directly to the return output. The result: flow state の `.phase` stayed at `create_interview`, which had no dedicated `stop-guard.sh` case arm in versions prior to #622 fix, so the orchestrator's implicit stop after `<!-- [interview:skipped] -->` was not blocked and the user had to type `continue` manually. Moving the flow-state write to the **absolute beginning** of the sub-skill guarantees it runs regardless of interview scope.
+> **Issue #622 (regression of #552)**: 旧版では本ロジックがファイル末尾の Defense-in-Depth section に配置されていたが、Bug Fix / Chore preset path (Phase 0.4.1 → skip Phase 0.5) で sub-skill が末尾 bash block を skip して return output に直行する failure mode が再発した結果、flow state `.phase` が `create_interview` に残存し orchestrator implicit stop で `continue` 手入力が必要となった。本 Pre-flight を sub-skill **先頭** に配置することで interview scope に関係なく flow-state write を保証する。
 >
-> **DRIFT-CHECK ANCHOR (semantic)**: This section is mirrored by `stop-guard.sh` `create_interview` case arm (Issue #622) and `phase-transition-whitelist.sh` `create_interview → create_post_interview` edge. The three sites form a 3-site symmetry — when updating any one, update the others.
+> **DRIFT-CHECK ANCHOR (semantic)**: 本セクションは `stop-guard.sh` `create_interview` case arm (Issue #622) と `phase-transition-whitelist.sh` `create_interview → create_post_interview` edge と 3-site symmetry を成す。一方を更新したら他方も同期更新する。
 >
-> **DRIFT-CHECK ANCHOR (semantic, bash 引数 symmetry)** — 本 Pre-flight bash block は **3 site 対称契約 (現状)** に属する。bash 引数 (`--phase` / `--active` / `--next` / `--preserve-error-count`) symmetry / `--if-exists` の意図的非対称性 / pair 同期契約 / 関連 Issue history (#636 / #651 / #660 / #771 / #773) の **正規定義は [`references/sub-skill-handoff-contract.md`](./references/sub-skill-handoff-contract.md)** を参照。本セクションは canonical SoT における site (2) `create-interview.md` 🚨 MANDATORY Pre-flight に該当し、site (1) `create.md` Step 0/Step 1 / site (3) Return Output re-patch (本ファイル末尾) と pair 同期する。旧 site (4) `stop-guard.sh` WORKFLOW_HINT は撤去済み (commit `e2dfae0`、2026-04-26) のため pair 同期対象に含めない。symmetry 破壊は `hooks/tests/4-site-symmetry.test.sh` で検出される。
+> **DRIFT-CHECK ANCHOR (semantic, bash 引数 symmetry)** — 本 Pre-flight bash block は **3 site 対称契約 (現状)** に属し、bash 引数 (`--phase` / `--active` / `--next` / `--preserve-error-count`) symmetry / `--if-exists` 意図的非対称性 / pair 同期契約 / 関連 Issue history (#636 / #651 / #660 / #771 / #773) の **正規定義は [`references/sub-skill-handoff-contract.md`](./references/sub-skill-handoff-contract.md)** を参照。本セクションは site (2) `create-interview.md` 🚨 MANDATORY Pre-flight、site (1) `create.md` Step 0/Step 1 / site (3) Return Output re-patch と pair 同期する。symmetry 破壊は `hooks/tests/4-site-symmetry.test.sh` で検出。
 
-**MUST run before any interview logic** (Phase 0.4.1 scope evaluation, Phase 0.5 deep-dive, or return-output emission). This bash block is **not optional** and **not conditional on interview scope**. Execute it even when Phase 0.4.1 determines the Bug Fix / Chore preset (interview scope = "skip"):
+**MUST run before any interview logic** (Phase 0.4.1 scope evaluation / Phase 0.5 deep-dive / return-output emission)。**not optional**、**interview scope に conditional でない** — Bug Fix / Chore preset (scope = "skip") でも実行:
 
 ```bash
-# verified-review cycle 3 F-06 / #636: Pre-flight は create.md コメントで「primary 防御層」と
-# 位置付けられており、Step 0/Step 1 と同格の idempotent write。exit-code check を対称に
-# 入れることで persistent な disk full / permission denied 障害下でも silent に通過せず、
-# [CONTEXT] PREFLIGHT_PATCH_FAILED=1 retained flag を残す。layered defense は
-# stop-guard の create_interview case arm が routing する safety net がある。
-#
-# verified-review cycle 4 F-01 / #636: --preserve-error-count を create.md Step 0/Step 1 と
-# 対称に付与。本 Pre-flight bash block は sub-skill 再入時に同一 phase self-patch
-# (create_post_interview → create_post_interview) となるため、flag がないと
-# flow-state-update.sh patch mode の JQ_FILTER が `.error_count = 0` でリセットし、
-# stop-guard.sh の RE-ENTRY DETECTED escalation + THRESHOLD=3 bail-out 層が永久に fire しない。
-# create mode (file 不在時の初回書き込み) は phase transition ではないため flag は実質 no-op
-# だが、drift 防止の consistency で対称に付与する。
-# state file の正しい path を解決 (schema_version=2 は per-session file、
-# legacy は single-file 形式)。helper が空文字列を返す異常ケースは create branch に進む。
+# bash 引数 / exit-code check / --preserve-error-count rationale は references/sub-skill-handoff-contract.md (canonical SoT) と
+# references/regression-history.md (#636 / #660 累積経緯) に集約。本ブロックは canonical bash 引数 symmetry を保持し、
+# state-path-resolve.sh + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then
@@ -51,8 +39,7 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
       --next "rite:issue:create-interview Pre-flight completed. Proceed to Phase 0.4.1/0.5 if applicable, then return to caller. Caller MUST proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop." \
       --preserve-error-count; then
     echo "[CONTEXT] PREFLIGHT_PATCH_FAILED=1" >&2
-    # 非 blocking: create.md Step 0/Step 1 の redundant patch が 2 段目防御として存在し、
-    # stop-guard の create_interview case arm が routing する safety net でも間接検出される。
+    # 非 blocking: create.md Step 0/Step 1 の redundant patch + stop-guard create_interview case arm が safety net。
   fi
 else
   if ! bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -64,9 +51,9 @@ else
 fi
 ```
 
-**Why `create_post_interview` (not `create_interview_running`) at Pre-flight time**: The caller (`create.md` Delegation to Interview Pre-write) has already written `create_interview` to signal that delegation is in flight. The Pre-flight advances the phase to `create_post_interview` **before** the interview runs so that, no matter at which point the sub-skill exits (normal completion, early exit via Bug Fix preset, or unexpected stop), the stop-guard routes to the `create_post_interview` WORKFLOW_HINT which correctly tells the orchestrator to run the 🚨 Mandatory After Interview section and proceed to Phase 0.6. This is safe because `create_post_interview → create_delegation` is the only whitelisted forward transition — the orchestrator must still execute Delegation Routing to advance past it.
+**Why `create_post_interview` (not `create_interview_running`)**: caller (`create.md` Delegation to Interview Pre-write) は既に `create_interview` を書込済 (delegation in flight signal)。本 Pre-flight が **interview 実行前** に `create_post_interview` へ進めることで、normal completion / Bug Fix preset early exit / unexpected stop のいずれの exit point でも stop-guard が `create_post_interview` WORKFLOW_HINT へ routing し orchestrator を Phase 0.6 へ誘導する。`create_post_interview → create_delegation` のみが whitelisted forward transition のため、orchestrator は Delegation Routing を必ず実行する必要がある。
 
-**Idempotence**: Running this multiple times within a single sub-skill invocation is safe; each call refreshes the timestamp and `next_action` but does not regress the phase (patch mode sets `previous_phase` from the pre-update `.phase`, which stays `create_post_interview` on re-entry).
+**Idempotence**: 単一 sub-skill invocation 内で複数回実行されても safe — patch mode は pre-update `.phase` から `previous_phase` を設定し、re-entry で `create_post_interview` のまま phase regression しない。
 
 ---
 
@@ -90,107 +77,65 @@ After Phase 0.4 completes, determine the interview scope for Phase 0.5 based on 
 
 ### Task Type Presets
 
-Override the complexity-based scope when task type provides a stronger signal:
+Task type が complexity-based scope より強い signal となる場合、以下で override（task type が ambiguous なら complexity-based に fallback、user は scope に関係なく追加質問を要求可能）:
 
 | Task Type | Detection Method | Interview Override |
 |-----------|-----------------|-------------------|
-| **Bug Fix** | Phase 0.4 goal = "既存機能のバグ修正" or labels contain `bug` | Phase 0.4 → 0.6 direct (skip deep-dive) |
-| **Chore** | Phase 0.4 goal = "その他" with maintenance context (e.g., 依存関係更新, CI修正, リネーム, cleanup, linter設定, ツール更新), or labels contain `chore` | Phase 0.4 → 0.6 direct (skip deep-dive) |
-| **Feature** | Phase 0.4 goal = "新機能の追加" | Apply complexity-based scope above |
-| **Refactor** | Phase 0.4 goal = "リファクタリング" | Apply complexity-based scope above |
-| **Documentation** | Phase 0.4 goal = "ドキュメントの更新" or labels contain `documentation` | Abbreviated Phase 0.5 (perspectives 2, 4, 6 only) |
-
-**Notes**:
-- Task type presets take precedence over complexity-based scope
-- When task type is ambiguous, fall back to complexity-based scope
-- Users can always request additional questions regardless of the determined scope
+| **Bug Fix** | goal = "既存機能のバグ修正" or labels contain `bug` | Phase 0.4 → 0.6 direct (skip deep-dive) |
+| **Chore** | goal = "その他" + maintenance context (依存更新 / CI修正 / リネーム / cleanup / linter設定 / ツール更新) or labels `chore` | Phase 0.4 → 0.6 direct (skip deep-dive) |
+| **Feature** | goal = "新機能の追加" | complexity-based scope を適用 |
+| **Refactor** | goal = "リファクタリング" | complexity-based scope を適用 |
+| **Documentation** | goal = "ドキュメントの更新" or labels `documentation` | Abbreviated Phase 0.5 (perspectives 2, 4, 6 only) |
 
 ### Applying the Scope
 
 After determining the interview scope:
 
-1. **If scope is "skip"** (XS, Bug Fix, Chore): Skip Phase 0.5 entirely and proceed to Phase 0.6
-2. **If scope is "limited"** (S, Documentation): Enter Phase 0.5 but only ask questions from the specified perspectives
-3. **If scope is "standard" or "full"** (M, L, XL): Enter Phase 0.5 with the full interview flow, applying perspective filtering as specified
+1. **skip** (XS, Bug Fix, Chore): Skip Phase 0.5, proceed to Phase 0.6
+2. **limited** (S, Documentation): Enter Phase 0.5 with the specified perspectives only
+3. **standard / full** (M, L, XL): Enter Phase 0.5 with the full interview flow + perspective filtering
 
-When entering Phase 0.5 with limited scope, display (select based on `language` setting):
+When entering Phase 0.5, display the scope to the user. Select language per `language` setting (`ja` / `en` / `auto` based on input language):
 
-**Japanese** (`ja` or `auto` with Japanese input):
-```
-複雑度 {complexity} / タスク種別 {task_type} に基づき、以下の視点に絞って確認します:
-- {perspective_list}
-追加の確認が必要な場合はお知らせください。
-```
-
-**English** (`en` or `auto` with English input):
-```
-Based on complexity {complexity} / task type {task_type}, focusing on the following perspectives:
-- {perspective_list}
-Let me know if you need additional confirmation.
-```
-
-When entering Phase 0.5 with standard or full scope, display:
-
-**Japanese** (`ja` or `auto` with Japanese input):
-```
-複雑度 {complexity} に基づき、{standard の場合: 標準 / full の場合: フル}の深堀インタビューを実施します。
-```
-
-**English** (`en` or `auto` with English input):
-```
-Based on complexity {complexity}, conducting a {standard: standard / full: full} deep-dive interview.
-```
+| Scope | Japanese | English |
+|-------|----------|---------|
+| limited | `複雑度 {complexity} / タスク種別 {task_type} に基づき、以下の視点に絞って確認します:\n- {perspective_list}\n追加の確認が必要な場合はお知らせください。` | `Based on complexity {complexity} / task type {task_type}, focusing on the following perspectives:\n- {perspective_list}\nLet me know if you need additional confirmation.` |
+| standard / full | `複雑度 {complexity} に基づき、{standard:標準 / full:フル}の深堀インタビューを実施します。` | `Based on complexity {complexity}, conducting a {standard / full} deep-dive interview.` |
 
 ---
 
 ## Phase 0.5: Deep-Dive Interview
 
-**Boundary with Phase 0.4**: Phase 0.4 is a **quick confirmation** that fills gaps in basic information (What/Why/Where) and classifies the task type — it should complete in 0-1 AskUserQuestion calls. Phase 0.5 is a **deep-dive interview** that explores implementation details across multiple perspectives — it may require multiple rounds of questions depending on complexity.
+- **Boundary with Phase 0.4**: Phase 0.4 は **quick confirmation** (What/Why/Where ギャップ充填 + task type 分類、0-1 AskUserQuestion calls)。Phase 0.5 は **deep-dive interview** (実装詳細を multiple perspective から探求、complexity に応じ複数 round)
+- **Purpose**: 実装詳細を明確化（surface requirements ではない）。decision-divergence point と easily-overlooked aspect に focus
+- **Prerequisite**: Phase 0.4.1 の interview scope を確認。"skip" なら本 phase を完全 skip、limited なら perspective filtering を適用
 
-**Purpose**: Clarify the details needed for implementation, not just surface-level requirements. Avoid asking obvious questions; focus on points where decisions diverge or aspects easily overlooked.
+### EDGE-5: Context Window Pressure Mitigation
 
-**Prerequisite**: Check the interview scope determined in Phase 0.4.1. If the scope is "skip", do not execute this phase. If the scope specifies limited perspectives, only ask questions from those perspectives.
-
-#### EDGE-5: Context Window Pressure Mitigation
-
-> **Moved (Issue #773 P1-3 PR 3/8)**: 本セクションの定義は [`references/edge-cases-create.md#edge-5-context-window-pressure-mitigation`](./references/edge-cases-create.md#edge-5-context-window-pressure-mitigation) に移動しました。Phase 0.5 開始前に context pressure を heuristics (tool calls / read lines / AskUserQuestion calls) で評価し、High pressure 時は auto-shortening mode (perspectives 削減 + batching + 早期 exit option) を発動するロジックを定義します。
+> **Moved (Issue #773 P1-3 PR 3/8)**: 本セクションの定義は [`references/edge-cases-create.md#edge-5-context-window-pressure-mitigation`](./references/edge-cases-create.md#edge-5-context-window-pressure-mitigation) に移動しました。Phase 0.5 開始前に context pressure を heuristics で評価し、High pressure 時は auto-shortening mode (perspectives 削減 + batching + 早期 exit option) を発動します。
 
 ---
 
-> **Important**: Read the user's request and use the AskUserQuestion tool to conduct a detailed interview. Ask questions from the perspectives determined in Phase 0.4.1 (interview scope). Continue until the user explicitly states "no more points to confirm". Then write the final specifications to the Issue.
->
-> **Note**: See the "Quality Standards for Questions" section below for quality criteria. When in doubt, ask. There is no harm in asking too many questions.
+> **Important**: AskUserQuestion でインタビューを実施し、user が明示的に「no more points to confirm」と回答するまで継続。当て推量で打ち切らない。迷ったら質問する（聞きすぎは無害、品質基準は下記）。
 
 ### Basic Interview Guidelines
 
-**Principle of Continuous Interviewing**:
+**Principle of Continuous Interviewing**: User 明示終了まで継続。AI 判断 (`enough information gathered`) での打ち切りは禁止 (canonical: [Termination Logic > Phase 0.5](#phase-05-interview-termination))。Phase 0.4.1 scope の perspective を確認し、user が「任せる」「skip」と言うまで終了せず、各 perspective を掘り下げ回答から follow-up を導出する。
 
-- **Continue until the user explicitly ends the interview**
-- Confirm perspectives included in the interview scope from Phase 0.4.1, and do not end until the user explicitly says "leave the details to you" or "I want to skip"
-- Do not end the interview based solely on AI judgment that "enough information has been gathered" (canonical rule: see [Termination Logic > Phase 0.5](#phase-05-interview-termination))
-- Dig deep into each perspective and ask follow-up questions derived from answers
+**Quality Standards**: 自明な質問 (Yes/No 即答可、選択肢が 1 つ) は避ける。tradeoff を伴う複数選択肢の質問を優先。見落としやすい edge case / concern を能動的に確認。
 
-**Quality Standards for Questions**:
-- Avoid questions that are too obvious (can be answered immediately with Yes/No, have only one possible answer)
-- Prioritize questions where multiple options exist with tradeoffs
-- Actively confirm edge cases and concerns that are easily overlooked
+### Tentative Complexity & Interview Perspectives
 
-### Tentative Complexity
-
-The tentative complexity was estimated in Phase 0.4.1. Refer to [`references/complexity-gate.md#tentative-complexity-estimation`](./references/complexity-gate.md#tentative-complexity-estimation) for criteria and the complexity table. The estimated value drives the interview scope (Phase 0.4.1) and the task decomposition decision (Phase 0.6).
-
-### Interview Perspectives
-
-**Filtering rule**: Apply the interview scope from Phase 0.4.1. Only ask questions from perspectives included in the determined scope. For perspectives outside the scope, skip them silently unless the user explicitly requests them.
-
-> **Template reference**: Read `{plugin_root}/templates/issue/interview-perspectives.md` for the full perspective definitions, confirmation conditions, and question templates.
+- **Tentative Complexity**: Phase 0.4.1 で推定。詳細は [`references/complexity-gate.md#tentative-complexity-estimation`](./references/complexity-gate.md#tentative-complexity-estimation) 参照。Phase 0.4.1 interview scope と Phase 0.6 task decomposition decision に使われる
+- **Filtering rule**: Phase 0.4.1 で決定された scope に含まれる perspective のみ質問。scope 外は user 明示要求がない限り silent skip
+- **Template reference**: Perspective 定義・confirmation 条件・question template は `{plugin_root}/templates/issue/interview-perspectives.md` を参照
 
 ### Interview Flow
 
-1. **First question**: Start with the most important decision point
-2. **Deep-dive based on answers**: Ask follow-up questions derived from answers
-3. **End confirmation**: **After confirming all applicable perspectives**, present the end confirmation dialog (see [Termination Logic > Phase 0.5](#phase-05-interview-termination))
-4. **Specification summary**: When the user answers "no", reflect the interview results in the Issue body
+1. **First question**: 最重要 decision point から開始
+2. **Deep-dive**: 回答から follow-up を導出
+3. **End confirmation**: 全 applicable perspective 確認後、必ず end confirmation dialog を提示 ([Termination Logic > Phase 0.5](#phase-05-interview-termination))
+4. **Specification summary**: user が "no" と回答したら interview results を Issue body に反映
 
 **End confirmation question format**:
 ```
@@ -202,35 +147,28 @@ The tentative complexity was estimated in Phase 0.4.1. Refer to [`references/com
 - 残りの詳細は任せる
 ```
 
-#### EDGE-2: Re-entry After Exit Confirmation
+### EDGE-2: Re-entry After Exit Confirmation
 
 > **Moved (Issue #773 P1-3 PR 3/8)**: 本セクションの定義は [`references/edge-cases-create.md#edge-2-re-entry-after-exit-confirmation`](./references/edge-cases-create.md#edge-2-re-entry-after-exit-confirmation) に移動しました。Phase 0.5 終了確認後にユーザーが新規情報を追加入力した場合の re-entry trigger 検出基準と、再開・spec 追加・無視の 3 分岐挙動 (1 セッション 1 回 limit 付き) を定義します。
 
 ### AskUserQuestion Batch Optimization
 
-**Applies to**: This optimization modifies the Interview Flow above. When executing Phase 0.5, apply the batching rules below instead of asking each perspective independently.
-
-**Purpose**: Reduce the number of AskUserQuestion round-trips by grouping related perspectives into batched calls. This minimizes context pressure from multiple small interactions.
+**Applies to**: Modifies the Interview Flow above. Apply the batching rules below instead of asking each perspective independently to minimize context pressure from many small interactions.
 
 #### Batching Rules
 
-Group perspectives into **1-2 AskUserQuestion calls** instead of asking each perspective independently:
+Group perspectives into **1-2 AskUserQuestion calls** (use `multiSelect: true` when multi-select is appropriate):
 
-| Interview Scope | Batch Strategy | Max AskUserQuestion Calls |
-|-----------------|---------------|--------------------------|
-| **S** (Perspectives 1, 3) | Single batch: combine Technical + Edge Cases | 1 + follow-ups |
-| **M** (Perspectives 1, 2, 3, 4) | Batch 1: Technical + Edge Cases. Batch 2: UX + Consistency | 2 + follow-ups |
-| **L/XL** (All 6) | Batch 1: Technical + Edge Cases + NFR. Batch 2: UX + Consistency + Tradeoffs | 2 + follow-ups |
-| **Documentation** (Perspectives 2, 4, 6) | Single batch: combine all 3 perspectives | 1 + follow-ups |
+| Interview Scope | Batch Strategy | Max Calls |
+|-----------------|---------------|-----------|
+| **S** (Perspectives 1, 3) | Single batch: Technical + Edge Cases | 1 + follow-ups |
+| **M** (1, 2, 3, 4) | B1: Technical + Edge Cases. B2: UX + Consistency | 2 + follow-ups |
+| **L/XL** (All 6) | B1: Technical + Edge Cases + NFR. B2: UX + Consistency + Tradeoffs | 2 + follow-ups |
+| **Documentation** (2, 4, 6) | Single batch: all 3 perspectives | 1 + follow-ups |
 
-#### Batching Technique
-
-Compose a single AskUserQuestion prompt that includes multiple questions in the text body with consolidated options. Use `multiSelect: true` when the user may need to select more than one option:
-
-**Example — S scope (Batch 1: Technical + Edge Cases)**:
+**Example (S scope, Batch 1)**:
 ```
 以下の点について確認させてください:
-
 1. {機能} の実装アプローチはどちらを想定していますか？
 2. 以下のエッジケースへの対応は必要ですか？
 
@@ -241,127 +179,37 @@ Compose a single AskUserQuestion prompt that includes multiple questions in the 
 - 判断を任せる
 ```
 
-> **Note**: When the pre-defined option combinations don't cover the user's intent (e.g., "アプローチA + 正常系のみ"), the user can select "Other" to provide a free-text answer specifying each question independently.
-
-**Example — M scope (Batch 1: Technical + Edge Cases)**:
-```
-技術的な実装とエッジケースについて確認します:
-
-1. {機能} の実装アプローチ: {A} vs {B}
-2. エッジケース対応: {ケース1}, {ケース2}
-
-オプション:
-- {アプローチA} / 主要なエッジケースに対応
-- {アプローチB} / 正常系のみ
-- 要件を説明するので提案してほしい
-```
+> **Note**: 組み合わせがオプションに該当しない場合（例: "A + 正常系のみ"）はユーザーが "Other" で自由記述で回答できる。M/L/XL スコープでも同形式で「技術 + エッジケース」「UX + 一貫性」等を Batch 化する。
 
 #### Pre-condition Evaluation
 
-Before asking each perspective's questions, evaluate whether the question is necessary based on information already gathered:
+Before asking, evaluate whether the question is necessary:
 
 | Pre-condition | Action |
 |--------------|--------|
-| Implementation approach is uniquely determined (only one option) | Skip Technical Implementation question |
-| No UI/UX changes involved | Skip UX question |
-| Input is well-constrained (enum values, fixed format) | Skip Edge Cases question |
-| No existing features affected | Skip Consistency question |
-| No performance/security concerns | Skip NFR question (unless L/XL) |
+| Implementation approach is uniquely determined | Skip Technical Implementation |
+| No UI/UX changes | Skip UX |
+| Input well-constrained (enum, fixed format) | Skip Edge Cases |
+| No existing features affected | Skip Consistency |
+| No performance/security concerns | Skip NFR (unless L/XL) |
 
-**Important**: Pre-condition evaluation reduces questions within a batch, but does NOT replace user confirmation. If pre-conditions eliminate all questions in a batch, skip that batch entirely.
+**Important**: Pre-condition は batch 内の質問を減らすが user 確認を代替しない。batch 内の全質問が排除された場合は batch 全体を skip する。
 
 #### Follow-up Questions
 
-After batch responses, derive follow-up questions from answers. Follow-ups are asked individually (not batched) as they require specific context from prior answers. After **2 rounds** of follow-ups, present the end confirmation dialog. If the user requests additional follow-ups, continue — user judgment is the final decision (consistent with UX-2: No AI auto-termination).
+After batch responses, follow-ups are asked individually (not batched) as they require specific context from prior answers. After **2 rounds** of follow-ups, present the end confirmation dialog. User judgment is final — continue if requested (UX-2: No AI auto-termination).
 
 ### Deep-Dive Examples
 
-#### Example 1: User Authentication Feature
+各ユースケースの representative な質問パターンを示す（実際の質問は要件に応じて perspective filtering に従い導出）:
 
-**Initial input**: "I want to add user authentication"
+| Use Case | First Question | Representative Options | Follow-up Examples |
+|----------|----------------|----------------------|---------------------|
+| **User Authentication** | 認証方式は？ | メール/パスワード, ソーシャルログイン, 両方, 提案要 | (email/password 選択時) パスワードリセット機能の要否 / 認証状態の保持期間 (セッション/永続/期限付き) |
+| **UI Component (Data Table)** | 必要な機能は？ | ソート, フィルタ, ページネーション, 全部 | 想定データ量 (少量100件以下 / 中量1000件 / 大量1万件以上) → クライアント or サーバーサイド処理判断 |
+| **Refactoring (API Client)** | 主目的は？ | 可読性, テスタビリティ, パフォーマンス, 新機能準備 | インターフェース影響 (破壊的変更 / インターフェース維持 / 段階的移行) |
 
-**Deep-dive question 1**:
-```
-質問: 認証方式はどれを想定していますか？
-
-オプション:
-- メール/パスワード認証
-- ソーシャルログイン（Google, GitHub等）
-- 両方対応
-- 要件を説明するので提案してほしい
-```
-
-**Deep-dive question 2** (when the answer is "email/password"):
-```
-質問: パスワードリセット機能は必要ですか？
-
-オプション:
-- 必要（メールでリセットリンク送信）
-- 不要（管理者が手動リセット）
-- 将来的に必要（今回は対象外）
-```
-
-**Deep-dive question 3**:
-```
-質問: 認証状態の保持期間は？
-
-オプション:
-- ブラウザを閉じるまで（セッション）
-- 明示的にログアウトするまで（永続）
-- 一定期間（例: 7日間）で自動ログアウト
-- 要件に応じて提案してほしい
-```
-
-#### Example 2: UI Component Addition
-
-**Initial input**: "I want to add a data table component"
-
-**Deep-dive question 1**:
-```
-質問: テーブルに必要な機能はどれですか？
-
-オプション:
-- ソート機能
-- フィルタリング機能
-- ページネーション
-- すべて必要
-```
-
-**Deep-dive question 2**:
-```
-質問: データ量はどの程度を想定していますか？
-
-オプション:
-- 少量（100件以下）- 全件クライアント側で処理
-- 中量（1000件程度）- 仮想スクロール検討
-- 大量（1万件以上）- サーバーサイドページネーション必須
-- 不明（要件に応じて提案してほしい）
-```
-
-#### Example 3: Refactoring
-
-**Initial input**: "I want to refactor the API client"
-
-**Deep-dive question 1**:
-```
-質問: リファクタリングの主な目的は？
-
-オプション:
-- コードの可読性向上
-- テスタビリティの改善
-- パフォーマンス改善
-- 新機能追加への準備
-```
-
-**Deep-dive question 2**:
-```
-質問: 既存の API 呼び出し箇所への影響は許容しますか？
-
-オプション:
-- 破壊的変更 OK（すべて書き換え）
-- インターフェースは維持（内部実装のみ変更）
-- 段階的移行（新旧並存期間あり）
-```
+> **Pattern**: 第一質問はユースケースの最も重要な分岐点を提示し、follow-up は回答に応じて edge case / NFR / tradeoff を掘り下げる。option には常に「提案してほしい」「判断を任せる」を含めて user の judgment escape hatch を残す。
 
 ### Interview Termination Conditions
 
@@ -371,22 +219,9 @@ After batch responses, derive follow-up questions from answers. Follow-ups are a
 
 > **Moved (Issue #773 P1-3 PR 7/8)**: Interview Perspective → Target Sections の正規 mapping table は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) に移動しました。Phase 0.5 では本 reference の mapping に従って interview results を Section 1-9 に割り当てること。
 
-**Note**: Phase 0.5 collects and retains the raw interview results in conversation context; the structured mapping to Implementation Contract sections occurs at Issue body generation time (`create-register.md` Phase 2.2 Step 3).
+**Note**: Phase 0.5 は raw interview results を会話コンテキストに保持するのみ。Implementation Contract Section 1-9 への構造化 mapping は Issue body 生成時 (`create-register.md` Phase 2.2 Step 3) に実施する。
 
-**Retention format** (in conversation context, not in Issue body):
-
-```json
-{
-  "interview_results": {
-    "technical_implementation": ["認証方式: JWT ベース", "トークン保存: HttpOnly Cookie"],
-    "user_experience": ["ログイン失敗時: エラーメッセージを表示"],
-    "edge_cases": ["同一アカウントの複数デバイスログイン: 許可"],
-    "existing_feature_impact": [],
-    "non_functional_requirements": ["セッション期間: 7日間"],
-    "tradeoffs": ["ソーシャルログイン: スコープ外"]
-  }
-}
-```
+**Retention format** (会話コンテキスト保持、Issue body には書き込まない): JSON object `interview_results` に 6 perspective キー (`technical_implementation` / `user_experience` / `edge_cases` / `existing_feature_impact` / `non_functional_requirements` / `tradeoffs`) を持ち、各キーは「<項目>: <選択値>」形式の string array を保持する（例: `"technical_implementation": ["認証方式: JWT", "トークン保存: HttpOnly Cookie"]`）。スコープ外 perspective は空配列。
 
 ---
 
@@ -394,49 +229,32 @@ After batch responses, derive follow-up questions from answers. Follow-ups are a
 
 ### Phase 0.5 Interview Termination
 
-> **UX-2: Exit Condition Enforcement**
+> **UX-2: Exit Condition Enforcement** — 全 applicable perspective 確認後、end confirmation dialog の提示は **MUST**（無条件、AI 判断 skip 禁止）。
 
-**Mandatory exit confirmation dialog**: After confirming all applicable perspectives (determined by Phase 0.4.1 interview scope), the end confirmation dialog **MUST always be presented**. This is not optional.
-
-**Rules**:
-
-| Rule | Description |
-|------|-------------|
-| **Always present end confirmation** | After covering all perspectives in scope, always present the end confirmation dialog — no exceptions |
-| **No AI auto-termination** | Do NOT end the interview based on AI judgment that "enough information has been gathered". Only the user decides when the interview is complete |
-| **Skip only by user request** | The interview can only be skipped when the user explicitly selects "skip" or equivalent |
-| **Scope-based behavior** | The interview scope from Phase 0.4.1 determines which perspectives to cover before presenting the exit dialog |
+**Rules**: (1) scope 内 perspective 完了後は無条件で end confirmation dialog 提示、(2) 「enough information gathered」AI 自己判断での終了禁止（終了判断は user のみ）、(3) user が明示的に "skip" を選択した場合のみ skip 可能、(4) Phase 0.4.1 scope が対象 perspective を決定。
 
 **Scope-specific termination**:
 
 | Interview Scope | Termination Rule |
 |----------------|-----------------|
-| **Skip** (XS, Bug Fix, Chore) | Phase 0.5 is not entered; no termination needed |
-| **Limited** (S, Documentation) | After confirming all specified perspectives, present the end confirmation dialog. If user confirms no additional points, proceed to Phase 0.6 |
-| **Standard** (M) | After confirming perspectives 1-4, present the end confirmation dialog. Continue if user has more to add |
-| **Full** (L, XL) | After confirming all 6 perspectives, present the end confirmation dialog. Continue until user explicitly ends |
+| **Skip** (XS, Bug Fix, Chore) | Phase 0.5 不実行、終了処理不要 |
+| **Limited** (S, Documentation) | 指定 perspective 完了後 dialog 提示、追加なしなら Phase 0.6 へ |
+| **Standard** (M) | Perspective 1-4 完了後 dialog 提示、追加あれば継続 |
+| **Full** (L, XL) | 全 6 perspective 完了後 dialog 提示、user 明示終了まで継続 |
 
-**End confirmation dialog format**: Use the dialog template defined in the [Interview Flow > End confirmation question format](#interview-flow) section (mandatory after all applicable perspectives are covered).
+**Dialog format**: [Interview Flow > End confirmation question format](#interview-flow) を使用。
 
 ---
 
 ## Return Output Format (Before Return)
 
-> **Reference**: This pattern follows `start.md`'s sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0). The flow-state write was moved to the 🚨 MANDATORY Pre-flight section at the top of this file (Issue #622) so the post-interview phase is recorded regardless of interview scope. The idempotent re-patch below is retained as a defense-in-depth second write that refreshes the timestamp and `next_action` immediately before emitting the return output.
+> **Reference**: `start.md` の sub-skill defense-in-depth model (e.g., `lint.md` Phase 4.0, `review.md` Phase 8.0) に追従。flow-state write は Issue #622 で 🚨 MANDATORY Pre-flight (本ファイル冒頭) へ移動し interview scope に関係なく post-interview phase を記録。本 re-patch は defense-in-depth second write として timestamp / `next_action` を refresh する。
 
-Immediately before emitting the four-line return block, re-patch flow state to refresh the timestamp. This is idempotent with the 🚨 MANDATORY Pre-flight write (same phase, same transition target):
+Immediately before emitting the four-line return block, re-patch flow state (idempotent with Pre-flight write):
 
 ```bash
-# verified-review cycle 3 F-06 / #636: Return Output 直前 re-patch も Step 0/Step 1 と対称に
-# exit-code check を追加。primary Pre-flight 防御層の補強として silent failure を surface する。
-#
-# verified-review cycle 4 F-02 / #636: --preserve-error-count を create.md Step 0/Step 1 と
-# 対称に付与。本 re-patch は Pre-flight 後の確定的な同一 phase self-patch であり、
-# flag がないと sub-skill mid-execution で本 re-patch 通過時に error_count が 0 にリセットされ、
-# 直後の orchestrator implicit stop で escalation が再度 ERROR_COUNT=0 から始まり永久に
-# THRESHOLD bail-out 未到達。Pre-flight (F-01) と対称。
-# state file の正しい path を解決 (schema_version=2 は per-session file、
-# legacy は single-file 形式)。Pre-flight が保証した file 存在を再確認する。
+# bash 引数 / exit-code check / --preserve-error-count rationale は references/sub-skill-handoff-contract.md (canonical SoT) と
+# references/regression-history.md (#636 累積経緯) に集約。Pre-flight 後の同一 phase self-patch のため file 存在は保証済み。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then
@@ -451,15 +269,16 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
 fi
 ```
 
-> **Why patch mode only (no create fallback here)**: The 🚨 MANDATORY Pre-flight section at the top already handles the "file missing" branch (`create` mode). By the time execution reaches the return-output section, flow state file is guaranteed to exist with `.phase = create_post_interview`. A second `create` call here would reset `previous_phase` to an empty string and defeat the whitelist-based transition check in stop-guard — patch mode preserves the transition chain correctly.
+> **Why patch mode only (no create fallback)**: Pre-flight が "file missing" branch (`create` mode) を処理済。本 section 到達時は flow state file 存在 + `.phase = create_post_interview` が保証済。ここで `create` 呼出は `previous_phase` を空文字列にリセットし stop-guard whitelist transition check を defeat するため不可。patch mode で transition chain を preserve する。
 
-After the flow-state update above, output the appropriate result pattern. Emit the caller-continuation reminder **immediately before** the result pattern. The return block MUST be composed of four lines in the order below: (1) `[CONTEXT] INTERVIEW_DONE=1` grep marker, (2) plain-text blockquote continuation reminder, (3) HTML-commented caller instructions, (4) HTML-commented result sentinel. All four MUST be the last visible lines of this sub-skill's output.
+After the flow-state update, output the result pattern. Caller-continuation reminder を **immediately before** result pattern に emit。Return block は **4 line** 構成: (1) `[CONTEXT] INTERVIEW_DONE=1` grep marker / (2) plain-text blockquote continuation reminder / (3) HTML-commented caller instructions / (4) HTML-commented result sentinel。全 4 行が sub-skill の **last visible lines**。
 
-> **Issue #552 enhancement**: The caller continuation hint is emitted as **both** a plain-text line (visible in rendered Markdown) **and** an HTML comment (visible only in the LLM's raw context). The dual form ensures the reminder is robust against rendering modes where HTML comments are stripped before the LLM sees them. Rewriting this to HTML-comment-only is a regression.
+> **Cumulative regression strengthening** (詳細経緯は `references/sub-skill-handoff-contract.md` および `references/regression-history.md` 参照):
+> - **Issue #552**: caller continuation hint を plain-text line + HTML comment の **dual form** で emit（HTML comment が rendering で strip される場合への defense）
+> - **Issue #561**: result pattern を HTML comment 化 (`<!-- [interview:skipped] -->`) — sentinel は grep-matchable (`grep -F '[interview:'`) のまま AC-3 保持し、user-visible terminal token としての sentinel 出力を抑止して LLM turn-boundary heuristic 起因の `continue` 要求 stop を防ぐ
+> - **Issue #634**: `[CONTEXT] INTERVIEW_DONE=1` marker を return block の **FIRST line** に追加（not last）— orchestrator Pre-check Item 0 と Mandatory After Interview Step 0 が consume する grep signal、HTML strip rendering でも検出可能な plain-text 形式
 >
-> **Issue #561 UX fix**: The result pattern (`[interview:skipped]` / `[interview:completed]`) is now emitted as an HTML comment (`<!-- [interview:skipped] -->`). The string `[interview:skipped]` / `[interview:completed]` inside the HTML comment is still grep-matchable (`grep -F '[interview:'`) so the orchestrator's Pre-check Item 0 (routing dispatcher) and any hook/test contract remain intact (AC-3). The HTML comment form prevents the sentinel token from being the user-visible final line, weakening the LLM's turn-boundary heuristic that previously caused premature `continue`-requiring stops.
->
-> **Issue #634 enhancement**: `[CONTEXT] INTERVIEW_DONE=1` marker is added as the FIRST line of the return block (not the last). This establishes a grep-detectable signal `INTERVIEW_DONE=1` that the orchestrator's Pre-check list Item 0 and Mandatory After Interview Step 0 both consume. Placing the marker FIRST (not last) means the sub-skill's last line remains the sentinel HTML comment (preserving #561 ordering), while the context grep can still find `INTERVIEW_DONE=1` anywhere in recent context. The marker is a plain-text line (not HTML-commented) because Pre-check Item 0 uses context grep which may strip HTML comments in some rendering modes. DRIFT-CHECK ANCHOR (semantic, 3-site + historical 4th): create.md 🚨 Mandatory After Interview Step 0 Immediate Bash Action / create-interview.md 🚨 MANDATORY Pre-flight / create-interview.md Return Output re-patch (本セクション末尾) と **3 site 対称契約 (現状)** (Issue #651 PR #654 cycle 2 review F-NEW1 で 3-site → 4-site 拡張、その後 stop-guard.sh 撤去 commit `e2dfae0` で site (4) 無効化、本セクション末尾の DRIFT-CHECK ANCHOR (semantic, 3-site + historical 4th) と同一 scope)。
+> **DRIFT-CHECK ANCHOR (semantic, 3-site + historical 4th)**: create.md 🚨 Mandatory After Interview Step 0 Immediate Bash Action / create-interview.md 🚨 MANDATORY Pre-flight / create-interview.md Return Output re-patch (本セクション末尾) と **3 site 対称契約 (現状)** (Issue #651 PR #654 で 3→4-site 拡張、stop-guard.sh 撤去 commit `e2dfae0` で site (4) 無効化、後続 DRIFT-CHECK ANCHOR (semantic, 3-site + historical 4th) と同一 scope)。
 
 **Output format example (interview skipped)**:
 
@@ -496,16 +315,17 @@ This pattern is consumed by the orchestrator (`create.md`) to determine the next
 
 ## 🚨 Caller Return Protocol
 
-When this sub-skill completes (interview finished or skipped), control **MUST** return to the caller (`create.md`). The caller **MUST immediately** execute its 🚨 Mandatory After Interview section — proceeding to Phase 0.6 (Task Decomposition Decision) in the **same response turn**.
+Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** caller (`create.md`) へ戻る。caller は **同 response turn で MUST immediately** 🚨 Mandatory After Interview を実行し Phase 0.6 (Task Decomposition Decision) へ進む。
 
-**WARNING**: **No GitHub Issue has been created yet.** Stopping here abandons the workflow with no deliverable.
+**WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-**Output rules**:
-0. **FIRST**: Output `[CONTEXT] INTERVIEW_DONE=1; scope={skipped|completed}; next=phase_0_6` as a **plain-text line** (not HTML-commented). Position rules (#636 cycle 8 F-06 — Rule 1 absolute 位置規定との対称化、#636 cycle 9 F-02 — sub-bullet 分解で読解負荷軽減、#636 cycle 10 F-03/F-05 — canonical 規定の明示化 + routing dispatcher 表現の正確化):
-   - **0b (構造保証、canonical)**: the relative ordering of Rules 0-1 pins the full block structure as a **4-line return block**: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST). This 4-line invariant is the canonical structural rule — all other position descriptions derive from it
-   - **0a (絶対位置、0b から導出)**: derived from Rule 0b's 4-line block, this marker is the **4th-to-last visible line** of this sub-skill's output — i.e., 3 lines before the `<!-- [interview:*] -->` absolute-last sentinel defined in Rule 1. Note: this derived position assumes each of the other 3 lines is single-line; if Line 2 (plain-text reminder) or Line 3 (HTML comment) grows to multi-line in the future, Rule 0b's 4-line invariant is broken first and both rules need joint update
-   - **0c (目的)**: Issue #634 補強 — grep marker for orchestrator Pre-check Item 0 (routing dispatcher — the marker actively triggers routing at this site) and for Mandatory After Step 0 bash block comment reference (informational — Step 0 itself is an unconditional idempotent `flow-state-update.sh patch` and does not branch on the marker; the marker serves as documentation context); defense-in-depth against LLM turn-boundary heuristics
-1. Output the result pattern as an HTML comment (`<!-- [interview:completed] -->` or `<!-- [interview:skipped] -->`) as the **absolute last line** of this sub-skill's output (Issue #561 UX fix — the sentinel is grep-matchable but not user-visible)
-2. Do **NOT** emit the sentinel as a bare `[interview:*]` line (without HTML comment wrapping) — the bare form regressed in Issue #561 as the user-visible terminal token
-3. Do **NOT** output any narrative text (e.g., `→ Return to create.md`) after the result pattern — it creates a natural stopping point for the LLM
-4. The caller reads the result pattern via grep (the HTML comment contains the matchable string, plus the plain-text `[CONTEXT] INTERVIEW_DONE=1` marker) and immediately continues to Phase 0.6
+**Output rules** (#636 / #634 / #561 / #552 累積強化、詳細経緯は `references/sub-skill-handoff-contract.md` および `references/regression-history.md` を参照):
+
+0. **FIRST**: `[CONTEXT] INTERVIEW_DONE=1; scope={skipped|completed}; next=phase_0_6` を **plain-text line** で出力（HTML-commented 不可）。位置規定:
+   - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出
+   - **0a (絶対位置、0b から導出)**: 4-line block 構造より、本 marker は **4th-to-last visible line**（`<!-- [interview:*] -->` absolute-last sentinel の 3 行前）。各行が single-line である前提。Line 2/3 が multi-line 化した場合は 0b 4-line invariant が先に壊れるため両 Rule の joint update が必要
+   - **0c (目的)**: Issue #634 — grep marker for orchestrator Pre-check Item 0 (routing dispatcher、本 site で active routing 発火) and for Mandatory After Step 0 bash block comment reference (informational — Step 0 は unconditional idempotent `flow-state-update.sh patch` であり marker 分岐なし、marker は documentation context); LLM turn-boundary heuristic 対策の defense-in-depth
+1. Result pattern を HTML comment (`<!-- [interview:completed] -->` / `<!-- [interview:skipped] -->`) で **absolute last line** に出力 (Issue #561 UX fix: sentinel は grep-matchable だが user-visible でない)
+2. Bare `[interview:*]` 形式（HTML comment wrap なし）は **禁止**（Issue #561 で user-visible terminal token として regressed）
+3. Result pattern の **後ろに narrative text を出さない**（`→ Return to create.md` 等）— LLM の natural stopping point を生む
+4. Caller は HTML comment 内の grep-matchable 文字列と plain-text `[CONTEXT] INTERVIEW_DONE=1` marker を grep で読取り、即 Phase 0.6 へ継続


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/create-interview.md` 本体を **511 → 331 行 (-35%)** にスリム化。Umbrella Issue #804 (P1-3 follow-up) の Sub-Issue #1 として実施。

## 関連 Issue

Closes #805
- 親 Issue: #804 [Umbrella] refactor(create): create-interview/decompose/register.md 本体スリム化
- 兄弟参考: #803 (df564d5) で create.md は -55% 達成

## ⚠️ AC-1 緩和の経緯

- 当初目標 ≤200 行は SPEC-OUT-OF-SCOPE 制約 (新規 references 作成 / references 側 modify が禁止) と protected 区域 約 100 行 (Pre-flight 41 + Return Output 67) により構造的に達成困難
- user 承認のもと現実的着地点 **≤350 行** に緩和し、331 行 (-35%) で着地
- Issue body の AC-1 とチェックリストも本 PR で実態に合わせて更新済

## 変更内容

### 圧縮箇所
- **Phase 0.4.1 / Applying the Scope**: bilingual 表示テンプレートを `scope x lang` の compact table に統合
- **Phase 0.5 / AskUserQuestion Batch Optimization**: 冗長な S/M scope example を S 一例に統合
- **Phase 0.5 / Deep-Dive Examples**: 3 ユースケース 88 行を圧縮 table 化 (1 行/use case + pattern note)
- **Phase 0.5 / Reflecting Interview Results**: JSON example を semantic 説明に圧縮
- **Termination Logic**: Rules を bullet list から inline 4 項目に
- **Pre-flight / Return Output**: verified-review コメントを `references/sub-skill-handoff-contract.md` への semantic reference に集約 (canonical SoT 単一化、bash logic は完全保持)

### heading hierarchy 修正 (Wiki 経験則 PR #808 対応)
- Phase 0.5 直下の `EDGE-5` / Interview Flow 直下の `EDGE-2` を `h4 → h3` に格上げし `h2→h4 skip` を解消
- 元から存在した skip だが、大規模圧縮 refactor の機を捉えて修正 (Wiki 経験則: 大規模圧縮 refactor 時に heading skip が発生しやすい → 機械検証 gate を持つべき)

## NFR-2 protected 完全保持

- ✅ 4-site bash 引数 symmetry: `--phase` (count=7), `--active` (count=6), `--next` (count=7), `--preserve-error-count` (count=9) 各 ≥1
- ✅ DRIFT-CHECK ANCHOR (semantic): 4 occurrence
- ✅ Pre-flight bash block (state-path-resolve.sh): 3 occurrence
- ✅ caller HTML inline literal (Step 0 Immediate Bash Action): 3 occurrence
- ✅ skipped/completed example pair の caller HTML literal: 同一文字列 (pair 同期維持)

## Wiki 経験則の適用

- **PR #802** (References 抽出時 SoT verify): 引用先 4 anchor (`complexity-gate.md` / `edge-cases-create.md` / `contract-section-mapping.md` / `sub-skill-handoff-contract.md`) を Read で verify 済
- **PR #808** (heading hierarchy skip): 機械検証 gate を S7 として実装、本 PR の Self-Review で 1 violation 検出・修正
- **DRIFT-CHECK ANCHOR semantic name** (line 番号禁止): 維持
- **Asymmetric Fix Transcription**: skipped/completed example pair を同時更新

## verify 結果 (Phase 5.2)

- `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh`: **PASS=8 / FAIL=0**
- heading hierarchy: continuous (h2→h4 skip ゼロ、h3 連続性 OK)
- 内部 anchor link: 全件 resolved
- bang-backtick pre-PR gate: clean (rc=0)
- /rite:lint plugin-specific check: 全 success / pre-existing warning のみ (本 PR 範囲外)

## チェックリスト

- [x] 重複箇所を grep + diff で特定
- [x] references 参照リンクに置き換え
- [x] NFR-2 protected 項目を本体に残存することを grep verify
- [x] cross-file links 全件 verify
- [x] 4-site 対称化 grep test pass
- [x] 本体行数 ≤350 達成 (緩和済 AC-1)
- [x] /rite:lint pass

## Test plan

- [ ] `/rite:issue:create` を実 invoke し interview 経路 (Bug Fix / Chore preset / S / M / L scope) が機能することを確認 (AC-5)
- [ ] reviewer による NFR-2 protected 項目の最終 grep verify
- [ ] heading hierarchy 修正 (h4→h3) が rendered Markdown で正しく見えるか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
