### PR TITLE
docs(rite): #814 Phase A — simplification charter を新設

### DIFF
--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -9,6 +9,8 @@ description: |
 
 Create a new Issue and add it to GitHub Projects.
 
+> 生成する Issue body / commit message は [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) に従う（過去 PR / cycle 番号の本文引用を避け、経緯は git log に任せる）。
+
 ## Happy Path & Architecture
 
 1. **Phase 0.1**: ユーザ入力から What/Why/Where を抽出

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -10,6 +10,8 @@ description: ドラフト Pull Request を作成
 
 ドラフト PR を作成し、関連 Issue と連携する
 
+> 生成する PR description / commit message は [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) に従う（過去 PR / cycle 番号の本文引用を避け、経緯は git log に任せる）。
+
 ## E2E Output Minimization
 
 When called from the `/rite:issue:start` end-to-end flow, minimize output to reduce context window consumption:

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -156,7 +156,7 @@ See [references/coding-principles.md](./references/coding-principles.md) for the
 
 `plugins/rite/` 配下のファイルを編集する LLM・メンテナ、および rite workflow が生成する commit message / Issue body / PR description / review 指摘は、自己生成的に肥大化しないよう **Simplification Charter** に従う。runtime に効かない経緯記述は書かない / git log で代替できるものはコードに書かない / `Issue #` / `PR #` / `cycle #` の本文引用は禁止 / 重複 confirmation 禁止。
 
-See [references/simplification-charter.md](./references/simplification-charter.md) for the 5 self-questions, prohibited patterns, and recommended patterns.
+See [references/simplification-charter.md](./references/simplification-charter.md) for the 5 self-questions (5 つの自問) / prohibited patterns (禁止パターン) / recommended patterns (推奨パターン).
 
 ## Common Principles (AskUserQuestion Reduction)
 

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -152,6 +152,12 @@ Avoid common AI coding failure patterns: surface assumptions, manage confusion, 
 
 See [references/coding-principles.md](./references/coding-principles.md) for the full principle list and details.
 
+## Simplification Charter (rite plugin maintenance)
+
+`plugins/rite/` 配下のファイルを編集する LLM・メンテナ、および rite workflow が生成する commit message / Issue body / PR description / review 指摘は、自己生成的に肥大化しないよう **Simplification Charter** に従う。runtime に効かない経緯記述は書かない / git log で代替できるものはコードに書かない / `Issue #` / `PR #` / `cycle #` の本文引用は禁止 / 重複 confirmation 禁止。
+
+See [references/simplification-charter.md](./references/simplification-charter.md) for the 5 self-questions, prohibited patterns, and recommended patterns.
+
 ## Common Principles (AskUserQuestion Reduction)
 
 Reduce excessive questions: self-check necessity, use defaults when available, infer from context.

--- a/plugins/rite/skills/rite-workflow/references/simplification-charter.md
+++ b/plugins/rite/skills/rite-workflow/references/simplification-charter.md
@@ -4,6 +4,8 @@
 
 rite workflow 自体および rite workflow が生成する成果物（commit message / Issue body / PR description / reference ファイル）が、自己生成的に肥大化することを防ぐ。**「シンプル化」のための作業が新たな複雑性を生む** 自己言及ループを止めるための判断基準を本 charter に集約する。
 
+**「自己生成的肥大化」「自己言及ループ」とは**: rite workflow 自体を rite workflow で開発しているため (ドッグフーディング)、生成出力 (PR description / commit message / review 指摘) が次の入力に戻る構造を持つ。改善のための PR が新しい reference / 契約レイヤー / 経緯記述を生み、それを保護するためのテストや別の契約が増え、複雑性が雪だるま式に増えるリスクがある。
+
 ## 対象
 
 本 charter は以下を編集・生成する LLM および人間メンテナに適用される:
@@ -14,9 +16,9 @@ rite workflow 自体および rite workflow が生成する成果物（commit me
 
 ## 5 つの自問
 
-ファイル新規作成・セクション追加・段落追加の前に順に自問する。**1 つでも YES に該当したら、その記述は削除候補**。
+ファイル新規作成・セクション追加・段落追加の前に順に自問する。**1 つでも矢印の右側 (削除条件) に該当したら、その記述は削除候補**。
 
-1. **これを削除して、`/rite:*` の動作は変わるか? → 変わらないなら削除**
+1. **これは runtime に効くか? → 効かないなら削除**
    - runtime に効く: bash literal、MUST/MUST NOT 条文、decision tree、手順記述、設定スキーマ
    - runtime に効かない: 抽出経緯、対称化契約の散文、過去 incident の解説、cycle 番号付き review 記録
 
@@ -32,18 +34,20 @@ rite workflow 自体および rite workflow が生成する成果物（commit me
    - 親 skill が confirmation を取った直後に、子 skill で MANDATORY confirmation を再発火させない
    - 同一 phase に対する flow-state patch を複数 site で繰り返さない
 
-5. **この記述を読むのは LLM か、人間か?**
+5. **この記述は LLM が runtime で読むものか? → 人間向けの長文経緯なら削除**
    - LLM 向け: SoT として 1 箇所に集約
-   - 人間向けの長文経緯: コードベース外（git log / GitHub の close 済み Issue / `docs/decisions/`）に置く
+   - 人間向けの長文経緯: コードベース外（git log / GitHub の close 済み Issue / `docs/designs/` 配下の design / investigation）に置く
 
 ## 禁止パターン（コードベース内 .md / .yml / .sh に書かない）
 
-- `Issue #[0-9]+` / `PR #[0-9]+` / `cycle [0-9]+` の本文引用（セクション見出しでも最小限）
+- `Issue #[0-9]+` / `PR #[0-9]+` / `cycle [0-9]+` の本文引用
+  - **上限**: セクション見出し / 本文ともに 0 件を原則とし、どうしても必要な場合は 1 ファイル 1 件まで
+  - metavariable / regex (`Issue #N` / `Issue #[0-9]+` 等) として「禁止対象を明示する目的」での記述は許容
 - `Drift guard` / `DRIFT-CHECK ANCHOR` / `NFR-[0-9]+` 系の対称化契約の散文記述
-  - 対称化が必要な場合は **テストで担保**（例: `hooks/tests/4-site-symmetry.test.sh`）し、散文重複は書かない
+  - 対称化が必要な場合は **テストで担保**（例: `plugins/rite/hooks/tests/4-site-symmetry.test.sh`）し、散文重複は書かない
 - 「抽出経緯」「移管経緯」「Regression context」セクション
 - review cycle 番号付きの指摘記録（`cycle 3 F-NEW1` など）
-- `🚨` の濫用（1 ファイル 5 occurrence 以下）
+- `🚨` の濫用（**許容上限: 1 ファイル 5 occurrence、6 件以上は禁止**）
 
 ## 推奨パターン
 
@@ -68,3 +72,5 @@ rite workflow 自体および rite workflow が生成する成果物（commit me
 - `plugins/rite/hooks/` の hook 自体（runtime に効く）
 - decision tree 系の reference（`complexity-gate.md` / `slug-generation.md` / `pre-check-routing.md` 等）
 - bash literal そのもの（`create-decompose.md` の bulk-create block 等）
+
+ただし、これら適用範囲外のファイル**内でも上記『禁止パターン』は適用される** (`Issue #` 本文引用 / cycle # 記録 / 散文対称化契約 / `🚨` 濫用 等)。「適用範囲外」とは「ファイル丸ごと削除しない」の意味であり、ファイル内の歴史記述ノイズの整理は対象。

--- a/plugins/rite/skills/rite-workflow/references/simplification-charter.md
+++ b/plugins/rite/skills/rite-workflow/references/simplification-charter.md
@@ -1,0 +1,70 @@
+# rite workflow Simplification Charter
+
+## 目的
+
+rite workflow 自体および rite workflow が生成する成果物（commit message / Issue body / PR description / reference ファイル）が、自己生成的に肥大化することを防ぐ。**「シンプル化」のための作業が新たな複雑性を生む** 自己言及ループを止めるための判断基準を本 charter に集約する。
+
+## 対象
+
+本 charter は以下を編集・生成する LLM および人間メンテナに適用される:
+
+- `plugins/rite/` 配下の全 .md / .yml / .sh ファイル（commands / skills / references / hooks / agents / templates / scripts）
+- rite workflow が生成する commit message / Issue body / PR description
+- review cycle で生成される指摘リスト
+
+## 5 つの自問
+
+ファイル新規作成・セクション追加・段落追加の前に順に自問する。**1 つでも YES に該当したら、その記述は削除候補**。
+
+1. **これを削除して、`/rite:*` の動作は変わるか? → 変わらないなら削除**
+   - runtime に効く: bash literal、MUST/MUST NOT 条文、decision tree、手順記述、設定スキーマ
+   - runtime に効かない: 抽出経緯、対称化契約の散文、過去 incident の解説、cycle 番号付き review 記録
+
+2. **これは git log / commit message / close 済み Issue で代替できるか? → できるなら削除**
+   - 「なぜこの設計になったか」は commit message に書く
+   - 「Issue #N で何が起きたか」は close 済み Issue を見れば良い
+
+3. **これは『なぜこうなっているか』の説明か、『何をすべきか』か? → 説明だけなら削除**
+   - LLM は「現在のコードがどう書かれているか」と「これから何をすべきか」だけ必要
+   - 歴史的経緯はメンテナの好奇心を満たすだけで、LLM の挙動に影響しない
+
+4. **既に承認された判断を再確認しているか? → 重複なら除去**
+   - 親 skill が confirmation を取った直後に、子 skill で MANDATORY confirmation を再発火させない
+   - 同一 phase に対する flow-state patch を複数 site で繰り返さない
+
+5. **この記述を読むのは LLM か、人間か?**
+   - LLM 向け: SoT として 1 箇所に集約
+   - 人間向けの長文経緯: コードベース外（git log / GitHub の close 済み Issue / `docs/decisions/`）に置く
+
+## 禁止パターン（コードベース内 .md / .yml / .sh に書かない）
+
+- `Issue #[0-9]+` / `PR #[0-9]+` / `cycle [0-9]+` の本文引用（セクション見出しでも最小限）
+- `Drift guard` / `DRIFT-CHECK ANCHOR` / `NFR-[0-9]+` 系の対称化契約の散文記述
+  - 対称化が必要な場合は **テストで担保**（例: `hooks/tests/4-site-symmetry.test.sh`）し、散文重複は書かない
+- 「抽出経緯」「移管経緯」「Regression context」セクション
+- review cycle 番号付きの指摘記録（`cycle 3 F-NEW1` など）
+- `🚨` の濫用（1 ファイル 5 occurrence 以下）
+
+## 推奨パターン
+
+- **commit message** で経緯を説明し、コードベースには現在の動作仕様だけを書く
+- **README / docs/** で「設計判断」を書く（コードに散らさない）
+- **対称化契約は test で担保**、散文 SoT は 1 箇所のみ
+- **sub-skill 分離は最小限**、重複 confirmation や重複 flow-state patch を必要とするなら統合を検討
+
+## レビュー指摘の扱い
+
+- **当該 PR 内で全て解消する**。次 PR に「対応経緯」として持ち越さない
+- 持ち越す場合は **新しい Issue を起票**し、対応経緯ではなく要件として書き直す
+- レビューラウンド数を ID 付きで記録しない（cycle 1 / cycle 2 / cycle 3 などは git log で十分）
+
+## 自己観察
+
+本 charter 自体および本 charter に基づく simplification 作業も、自己言及性を持つ。**作業中に新しい reference / sub-skill / 契約レイヤーを追加したくなったら、まず charter の自問を適用する**。追加が本当に必要な場合のみ実施し、可能なら **既存 SoT を更新する** か **削除する**。
+
+## 適用範囲外（runtime に効くため現状維持）
+
+- `plugins/rite/scripts/` 配下の .sh（実装契約として必要）
+- `plugins/rite/hooks/` の hook 自体（runtime に効く）
+- decision tree 系の reference（`complexity-gate.md` / `slug-generation.md` / `pre-check-routing.md` 等）
+- bash literal そのもの（`create-decompose.md` の bulk-create block 等）


### PR DESCRIPTION
## Summary
- `plugins/rite/skills/rite-workflow/references/simplification-charter.md` を新設（5 つの自問・禁止パターン・推奨パターン・自己観察）
- `SKILL.md` および `commands/issue/create.md` / `commands/pr/create.md` から短く参照
- 本体修正は伴わない（charter SoT のみ追加）

## 背景
#814 の Phase A。次の PR から charter に従い、既存 references の一括削除 (Phase B) → 本体内の経緯記述削除 (Phase C) → 二重 confirmation 解消 (Phase D) を順次進める。

## Test plan
- [ ] charter 参照リンクが SKILL.md / create commands から解決されることを目視確認
- [ ] `/rite:issue:create` を 1 回実行して runtime regression がないこと
- [ ] `/rite:lint` でリンクチェックが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)