### PR TITLE
refactor(rite): #814 Phase D — pr/ready Phase 2.1 の二重 confirmation を解消

### DIFF
--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -196,25 +196,35 @@ End processing.
 
 ## Phase 2: Execution Confirmation
 
-### 2.1 Confirm with User (Standalone Only)
+### 2.1 Confirm with User (Standalone Path)
 
-> **End-to-end flow からの呼び出し時は本 confirmation を skip する**: orchestrator (`start.md` Phase 5.5) が user に Ready 移行を確認済みのため二重確認は不要 ([Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) の「重複 confirmation 禁止」原則)。本 sub-skill が flow state の `.phase` を確認し、`phase5_post_review` / `phase5_post_fix` のいずれかなら e2e 内の Ready 移行と判定。
+> **End-to-end flow の主経路から呼び出された場合は本 confirmation を skip する**: orchestrator (`start.md` Phase 5.5) が user に Ready 移行を確認済みのため二重確認は不要 ([Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) 5 つの自問の 4 番目「既に承認された判断を再確認しているか? → 重複なら除去」原則)。本 sub-skill が flow state の `.phase` を確認し、`phase5_post_review` / `phase5_post_fix` (review→ready / fix→ready の主経路) のいずれかなら confirmation を skip。
 >
-> **Standalone 実行時のみ** `AskUserQuestion` で確認 (`/rite:pr:ready` 直接呼び出し時の誤実行防止 safety net)。
+> **副次経路は fail-safe に standalone 経路 (旧挙動) で退行**: 主経路以外 (例: `/rite:resume` 経由 / 同 session 内 e2e 中断後の standalone 再呼び出し / 想定外の phase 値) で本 sub-skill に到達した場合、`*)` 分岐で `in_e2e_flow=false` に倒し confirmation を表示する (silent skip ではなく silent confirm 方向への退行で UX harm なし)。
+>
+> **Standalone 実行時** (`/rite:pr:ready` 直接呼び出し) は `AskUserQuestion` で確認 (誤実行防止 safety net)。
 
-**E2E flow detection**:
+**E2E flow detection** (canonical pattern: helper 起動失敗時は WARNING + sentinel emit してから fail-safe 退行):
 
 ```bash
-phase=$(bash {plugin_root}/hooks/state-read.sh --field phase --default "" 2>/dev/null || echo "")
+if phase=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
+  :
+else
+  rc=$?
+  echo "WARNING: state-read.sh failed (rc=$rc) for --field phase in pr/ready Phase 2.1 — falling back to standalone confirmation" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=pr_ready_phase_2_1; rc=$rc" >&2
+  phase=""
+fi
+# Whitelist approach: 主経路 (review→ready / fix→ready) のみ confirmation skip。
+# 想定外値 (phase5_post_ready 以降 / 空文字 / その他) は fail-safe に standalone 扱い。
 case "$phase" in
   phase5_post_review|phase5_post_fix) in_e2e_flow=true ;;
   *) in_e2e_flow=false ;;
 esac
+echo "in_e2e_flow=$in_e2e_flow"
 ```
 
-`$in_e2e_flow == "true"` の場合は本 sub-section の AskUserQuestion を skip して Phase 3 へ direct。
-
-`$in_e2e_flow == "false"` (standalone) の場合のみ `AskUserQuestion` で確認:
+LLM は本 bash の stdout (`in_e2e_flow=...`) を読み取り、`in_e2e_flow=true` の場合は本 sub-section の AskUserQuestion を skip して Phase 3 へ direct。`in_e2e_flow=false` の場合のみ `AskUserQuestion` で確認:
 
 ```
 PR #{number} を Ready for review に変更します。
@@ -229,7 +239,7 @@ URL: {pr_url}
 - キャンセル: 処理を中止します
 ```
 
-**If "Cancel" is selected (standalone only):**
+**If "Cancel" is selected:**
 
 ```
 処理を中止しました。

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -196,11 +196,25 @@ End processing.
 
 ## Phase 2: Execution Confirmation
 
-### 2.1 Confirm with User
+### 2.1 Confirm with User (Standalone Only)
 
-> **⚠️ MANDATORY**: This `AskUserQuestion` confirmation MUST be executed even within the `/rite:issue:start` end-to-end flow. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review. Identity: [workflow-identity.md](../../skills/rite-workflow/references/workflow-identity.md) の `no_step_omission` / `no_context_introspection` principle 参照。
+> **End-to-end flow からの呼び出し時は本 confirmation を skip する**: orchestrator (`start.md` Phase 5.5) が user に Ready 移行を確認済みのため二重確認は不要 ([Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) の「重複 confirmation 禁止」原則)。本 sub-skill が flow state の `.phase` を確認し、`phase5_post_review` / `phase5_post_fix` のいずれかなら e2e 内の Ready 移行と判定。
+>
+> **Standalone 実行時のみ** `AskUserQuestion` で確認 (`/rite:pr:ready` 直接呼び出し時の誤実行防止 safety net)。
 
-Confirm using `AskUserQuestion`:
+**E2E flow detection**:
+
+```bash
+phase=$(bash {plugin_root}/hooks/state-read.sh --field phase --default "" 2>/dev/null || echo "")
+case "$phase" in
+  phase5_post_review|phase5_post_fix) in_e2e_flow=true ;;
+  *) in_e2e_flow=false ;;
+esac
+```
+
+`$in_e2e_flow == "true"` の場合は本 sub-section の AskUserQuestion を skip して Phase 3 へ direct。
+
+`$in_e2e_flow == "false"` (standalone) の場合のみ `AskUserQuestion` で確認:
 
 ```
 PR #{number} を Ready for review に変更します。
@@ -215,7 +229,7 @@ URL: {pr_url}
 - キャンセル: 処理を中止します
 ```
 
-**If "Cancel" is selected:**
+**If "Cancel" is selected (standalone only):**
 
 ```
 処理を中止しました。


### PR DESCRIPTION
## Summary
- `/rite:pr:ready` Phase 2.1 の `AskUserQuestion` を E2E flow 主経路 (review→ready / fix→ready) からの呼び出し時に skip する
- Standalone 実行 / 副次経路 (resume / 想定外 phase 値) は従来通り confirmation を実行 (safety net)
- state-read.sh canonical pattern に整合させ、helper 起動失敗時は WARNING + sentinel emit してから fail-safe 退行
- 1 file changed, +33 / -13

## 背景
`/rite:issue:start` Phase 5.5 で user が「Ready for review に変更」を選択して `rite:pr:ready` を起動した直後、`ready.md` Phase 2.1 が再度「PR を Ready for review に変更します。よろしいですか?」と AskUserQuestion を発火していた。これが #814 当初提起の「一度 OK しているのに、なぜか再度問い合わせている」状況。

charter (#815)「既に承認された判断を再確認しているか?」原則 (5 つの自問の 4 番目) 違反であり、UX 上の無駄。

## 修正方針
- **E2E flow detection**: flow state の `.phase` が `phase5_post_review` / `phase5_post_fix` のいずれか → orchestrator (start.md Phase 5.5) で user 確認済の主経路と判定
- 主経路時は `AskUserQuestion` を skip して Phase 3 へ direct
- Standalone (`/rite:pr:ready` 直接) / 副次経路 (resume 等 / 想定外 phase) は従来通り confirmation 実行 (fail-safe 退行)

### 検出ロジック (canonical pattern)

```bash
if phase=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
  :
else
  rc=$?
  echo "WARNING: state-read.sh failed (rc=$rc) ..." >&2
  echo "[CONTEXT] STATE_READ_FAILED=1; phase=pr_ready_phase_2_1; rc=$rc" >&2
  phase=""
fi
case "$phase" in
  phase5_post_review|phase5_post_fix) in_e2e_flow=true ;;
  *) in_e2e_flow=false ;;
esac
echo "in_e2e_flow=$in_e2e_flow"
```

既存 7 箇所 (`start.md` / `implement.md` / `review.md` / `resume.md`) の canonical pattern と統一。helper 起動失敗時に `STATE_READ_FAILED` sentinel を emit するため operator triage 可能。

## `no_step_omission` 原則との関係
旧ガード文「MUST be executed even within the /rite:issue:start end-to-end flow」は `no_step_omission` principle を引用していたが、本原則は **時間/context 圧力による省略禁止** が本旨であり、アーキテクチャレベルでの redundancy 解消は別軸。本 PR は LLM の実行時判断による省略ではなく、設計上の重複定義を消す変更であり、原則と整合。

## スコープ外 (本 PR では touch しない)
- `pr/review.md:1279` の MANDATORY confirmation: reviewer 構成確認で別概念 (Ready confirmation の重複ではない)
- `phase` AND `active=true` AND 条件による堅牢化: 別 Issue 推奨 (本 PR は state-read.sh の cross-session guard で大半吸収できる前提)
- 言語スタイル一貫性 (英日混在の整理): 別 Issue 推奨
- review.md MANDATORY との style drift 予防: 別 Issue 推奨

## Test plan
- [ ] `/rite:issue:start` で E2E flow を 1 周し、Phase 5.5 で「Ready」選択後に追加の確認なしで Ready 移行されること (主経路、`phase5_post_review` / `phase5_post_fix` 経由)
- [ ] `/rite:pr:ready {pr_number}` を直接呼び出し、従来通り confirmation が出ること (standalone)
- [ ] flow state file が存在しない場合 standalone と判定され confirmation が出ること
- [ ] `/rite:issue:start` で Phase 5.5 まで進めた後、`/clear` して同 repo で `/rite:pr:ready {pr_number}` を直接実行 → confirmation が表示されること (cross-session guard により foreign:* → DEFAULT 空文字 → in_e2e_flow=false)
- [ ] state-read.sh が異常終了した場合に `[CONTEXT] STATE_READ_FAILED=1` sentinel が stderr に出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)