### PR TITLE
refactor(rite): #822 撤去済み stop-guard.sh への現在形参照 7 occurrence を歴史注記化

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -37,7 +37,7 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
       --next "rite:issue:create-interview Pre-flight completed. Proceed to Phase 0.4.1/0.5 if applicable, then return to caller. Caller MUST proceed to Phase 0.6 (Task Decomposition Decision). Issue has NOT been created yet. Do NOT stop." \
       --preserve-error-count; then
     echo "[CONTEXT] PREFLIGHT_PATCH_FAILED=1" >&2
-    # 非 blocking: create.md Step 0/Step 1 の redundant patch + stop-guard create_interview case arm が safety net。
+    # 非 blocking: create.md Step 0/Step 1 の redundant patch + phase-transition-whitelist.sh の create_interview case arm (pre-tool-bash-guard.sh / session-end.sh が source、stop-guard.sh は撤去済み) が safety net。
   fi
 else
   if ! bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -49,7 +49,7 @@ else
 fi
 ```
 
-**Why `create_post_interview` (not `create_interview_running`)**: caller (`create.md` Delegation to Interview Pre-write) は既に `create_interview` を書込済 (delegation in flight signal)。本 Pre-flight が **interview 実行前** に `create_post_interview` へ進めることで、normal completion / Bug Fix preset early exit / unexpected stop のいずれの exit point でも stop-guard が `create_post_interview` WORKFLOW_HINT へ routing し orchestrator を Phase 0.6 へ誘導する。`create_post_interview → create_delegation` のみが whitelisted forward transition のため、orchestrator は Delegation Routing を必ず実行する必要がある。
+**Why `create_post_interview` (not `create_interview_running`)**: caller (`create.md` Delegation to Interview Pre-write) は既に `create_interview` を書込済 (delegation in flight signal)。本 Pre-flight が **interview 実行前** に `create_post_interview` へ進めることで、normal completion / Bug Fix preset early exit / unexpected stop のいずれの exit point でも orchestrator が flow state の `.phase = create_post_interview` を読んで Phase 0.6 へ進む経路に切り替わる (`stop-guard.sh` 撤去済み — 撤去前は同 hook が `WORKFLOW_HINT` 経由で routing していた)。`phase-transition-whitelist.sh` が `create_post_interview → create_delegation` を唯一の whitelisted forward transition として graph 定義するため、orchestrator は Delegation Routing を必ず実行する必要がある。
 
 **Idempotence**: 単一 sub-skill invocation 内で複数回実行されても safe — patch mode は pre-update `.phase` から `previous_phase` を設定し、re-entry で `create_post_interview` のまま phase regression しない。
 
@@ -267,7 +267,7 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
 fi
 ```
 
-> **Why patch mode only (no create fallback)**: Pre-flight が "file missing" branch (`create` mode) を処理済。本 section 到達時は flow state file 存在 + `.phase = create_post_interview` が保証済。ここで `create` 呼出は `previous_phase` を空文字列にリセットし stop-guard whitelist transition check を defeat するため不可。patch mode で transition chain を preserve する。
+> **Why patch mode only (no create fallback)**: Pre-flight が "file missing" branch (`create` mode) を処理済。本 section 到達時は flow state file 存在 + `.phase = create_post_interview` が保証済。ここで `create` 呼出は `previous_phase` を空文字列にリセットし `phase-transition-whitelist.sh` whitelist transition check を defeat する (`pre-tool-bash-guard.sh` / `session-end.sh` が source、`stop-guard.sh` は撤去済み) ため不可。patch mode で transition chain を preserve する。
 
 After the flow-state update, output the result pattern. Caller-continuation reminder を **immediately before** result pattern に emit。Return block は **4 line** 構成: (1) `[CONTEXT] INTERVIEW_DONE=1` grep marker / (2) plain-text blockquote continuation reminder / (3) HTML-commented caller instructions / (4) HTML-commented result sentinel。全 4 行が sub-skill の **last visible lines**。
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -160,7 +160,7 @@ echo "$result"
 | # | MUST execute | Why |
 |---|--------------|-----|
 | 1 | Phase 0.4.1 goal classification (Phase 0.1 から推定) | Phase 0.5 interview scope 決定で必要 |
-| 2 | Delegation to Interview (Pre-write + Skill 起動) | `create_interview` write がないと stop-guard が enforce できない |
+| 2 | Delegation to Interview (Pre-write + Skill 起動) | `create_interview` write がないと `phase-transition-whitelist.sh` の case arm が enforce できない (`pre-tool-bash-guard.sh` / `session-end.sh` が source、`stop-guard.sh` は撤去済み) |
 | 3 | Mandatory After Interview | flow state を `create_post_interview` に進める |
 | 4 | Phase 0.6 | `create-register` vs `create-decompose` 選択 |
 | 5 | Delegation Routing (Pre-write + terminal sub-skill) | `create_delegation` を書き whitelist を進める |
@@ -198,7 +198,7 @@ Invoke `skill: "rite:issue:create-interview"`.
 
 ### 🚨 Mandatory After Interview
 
-> **⚠️ 同 turn 内連続実行する (MUST execute in the SAME response turn)**: `[interview:*]` return tag は turn 境界ではなく継続トリガ — turn を閉じると workflow が停止し Issue は作成されない。No GitHub Issue has been created yet。flow state の `.phase = create_post_interview` (sub-skill 内製)。stop-guard は active の間 stop を block — `create_delegation` (Delegation Routing Pre-write) または `create_completed` (terminal sub-skill) に進むまで unblock しない。
+> **⚠️ 同 turn 内連続実行する (MUST execute in the SAME response turn)**: `[interview:*]` return tag は turn 境界ではなく継続トリガ — turn を閉じると workflow が停止し Issue は作成されない。No GitHub Issue has been created yet。flow state の `.phase = create_post_interview` (sub-skill 内製)。`phase-transition-whitelist.sh` の whitelist transition graph により、active の間は `create_delegation` (Delegation Routing Pre-write) または `create_completed` (terminal sub-skill) への transition のみが許可される — `pre-tool-bash-guard.sh` / `session-end.sh` が enforce 経路 (`stop-guard.sh` は撤去済み)。
 
 **Step 0: Immediate Bash Action**: sub-skill return 直後の **very first tool call** として実行し turn-boundary 感を bash invocation に置換。失敗時は stderr に `[CONTEXT] STEP_0_PATCH_FAILED=1` retained flag を emit (非 blocking、Step 1 が idempotent patch として再試行):
 
@@ -234,7 +234,7 @@ fi
 
 **Step 3**: **→ Proceed to Phase 0.6 (Task Decomposition Decision) now. Do NOT stop.**
 
-> **Continuation trigger reminder**: `[interview:*]` return tag は continuation trigger であり turn 境界ではない。implicit stop は protocol violation で stop-guard が `workflow_incident` (`type=manual_fallback_adopted`) を emit する。
+> **Continuation trigger reminder**: `[interview:*]` return tag は continuation trigger であり turn 境界ではない。implicit stop は protocol violation で `hooks/workflow-incident-emit.sh` ヘルパー経由で `workflow_incident` (`type=manual_fallback_adopted`) を emit する (`stop-guard.sh` 撤去前は同 hook が auto emit していた)。
 
 ## Phase 0.6: Task Decomposition Decision
 
@@ -328,7 +328,7 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 
 Concrete output 例は `create-register.md` Phase 4.2-4.4 / `create-decompose.md` Phase 1.0.2-1.0.3。HTML コメント sentinel は grep-matchable を維持しつつ user-visible 末尾を `✅` メッセージに固定。
 
-**Step 4 (terminal gate)**: Pre-check list を場面 (b) mode で再実行 — Item 1-3 全 `YES` なら停止可、`NO` 残存時は manual 停止して stop-guard 経由で `workflow_incident` を emit。
+**Step 4 (terminal gate)**: Pre-check list を場面 (b) mode で再実行 — Item 1-3 全 `YES` なら停止可、`NO` 残存時は manual 停止して `hooks/workflow-incident-emit.sh` ヘルパー経由で `workflow_incident` を emit (`stop-guard.sh` 撤去前は同 hook が auto emit していた)。
 
 ## Termination Logic
 


### PR DESCRIPTION
## 概要

`commands/issue/create.md` (4 箇所) と `commands/issue/create-interview.md` (3 箇所) に残存していた撤去済み `stop-guard.sh` への現在形機能記述を、現存代替機構 (`phase-transition-whitelist.sh` / `pre-tool-bash-guard.sh` / `session-end.sh` / `workflow-incident-emit.sh`) への参照 + 歴史注記化で整理。

LLM が誤った mental model に基づいて改修判断を下す risk を解消する。

## 関連 Issue

Closes #822

## 変更内容

### 整理対象 (7 occurrence)

| ファイル | 行 | 整理方針 |
|---------|-----|----------|
| `create.md` | 163 | `phase-transition-whitelist.sh` の case arm への置換 + 撤去注記 |
| `create.md` | 201 | `phase-transition-whitelist.sh` の whitelist transition graph 説明への置換 + 撤去注記 |
| `create.md` | 237 | `hooks/workflow-incident-emit.sh` ヘルパー経路への置換 + 撤去前後の対比注記 |
| `create.md` | 331 | 同上 (Step 4 terminal gate) |
| `create-interview.md` | 40 | `phase-transition-whitelist.sh` の create_interview case arm への置換 + 撤去注記 |
| `create-interview.md` | 52 | orchestrator が flow state を直接読む経路の説明 + WORKFLOW_HINT 撤去注記 |
| `create-interview.md` | 270 | `phase-transition-whitelist.sh` whitelist check への置換 + 撤去注記 |

### 不変項

- bash literal は不変 (markdown 散文のみ修正)
- 機能契約 (3 site 対称契約 / 4 引数 symmetry / Bypass block) は維持
- `phase-transition-whitelist.sh` 自体の comment は Out of Scope (機能ファイル)

### Issue body との occurrence 数差分

Issue 本文は「8 occurrence」と記載だが `grep` 実測は 7 件。Issue 作成時から差分があったと推測される。AC-1 は件数ではなく「0 件 OR 歴史注記化」が状態要件のため、実測 7 件すべて整理で達成。

## 検証

| AC | 検証方法 | 結果 |
|----|---------|------|
| AC-1 | `grep 'stop-guard'` が 0 件 OR 全て歴史注記形式 | ✅ 全 7 occurrence が `(stop-guard.sh は撤去済み)` / `(stop-guard.sh 撤去前は...)` 形式 |
| AC-2 | 機能契約 (`pre-tool-bash-guard.sh` / `4-site-symmetry.test.sh` / `3 site 対称契約`) への参照維持 | ✅ baseline 同等 |
| AC-3 | `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` pass | ✅ PASS: 8, FAIL: 0 |

## Test plan

- [x] AC-1 / T-01: `grep -n 'stop-guard'` で全件が歴史注記形式
- [x] AC-2 / T-02: `pre-tool-bash-guard\.sh` / `4-site-symmetry\.test\.sh` / `3 site 対称契約` の参照が維持
- [x] AC-3 / T-03: `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` PASS: 8, FAIL: 0
- [ ] **T-04 (manual verification)**: `/rite:issue:create` の e2e 動作確認 — markdown 散文のみの変更で bash literal 不変、機能契約維持のため runtime regression リスク極小だが、PR レビュー時に 1 回 `/rite:issue:create` を実行して動作確認することを推奨
