### PR TITLE
docs(rite): review.md MANDATORY ガード文に reviewer 構成確認固有の区別注記を追加

### DIFF
--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -1277,6 +1277,8 @@ When the reviewer count reaches 4 or more, recommend splitting the review execut
 ### 3.3 Confirm Reviewers
 
 > **⚠️ MANDATORY**: This `AskUserQuestion` confirmation MUST be executed even within the `/rite:issue:start` end-to-end flow. Do NOT skip this step for context optimization or any other reason. The user must always confirm the reviewer configuration before review execution begins.
+>
+> **Note (区別注記 — PR #818 / Issue #820)**: 本ガード文は **reviewer 構成確認に固有**であり、`pr/ready.md` の Ready 移行確認とは別概念です。Ready 移行確認は親 skill `start.md` Phase 5.5 の `AskUserQuestion`（「Ready for review に変更 / ドラフトのまま完了 / 追加の修正を行う」）で同等の確認が実施されているため PR #818 で `ready.md` 側の MANDATORY ガード文を撤廃しましたが、reviewer 構成確認は親 skill での代替確認が存在しないため本ガード文を保持します。本対応を `ready.md` と同様に削除しないこと。
 
 Confirm the reviewer configuration with `AskUserQuestion` (fallback: see Phase 1.4 note):
 


### PR DESCRIPTION
## 概要

PR #818 で `pr/ready.md` の MANDATORY ガード文を撤廃したが、`pr/review.md:1279` に同パターンが残存していた。reviewer 構成確認は別概念のため削除不要だが、書式が酷似しているため drift リスク (Asymmetric Fix Transcription pattern) がある。

L1279 MANDATORY blockquote 直後に区別注記を追加し、本対応が **reviewer 構成確認に固有**である旨と PR #818 で `ready.md` 側を撤廃した経緯（親 skill `start.md` Phase 5.5 の `AskUserQuestion` が代替確認として存在するため）を明記した。

## 関連 Issue

Closes #820

## 変更内容

- `plugins/rite/commands/pr/review.md` (+2): L1279 MANDATORY blockquote 直後に区別注記行を追加

## チェックリスト

- [x] AC-1: L1279 MANDATORY blockquote に「reviewer 構成確認に固有」の区別注記が追加されている
- [x] AC-2: 既存の MANDATORY ガード文本文 (`AskUserQuestion ... MUST be executed`) は維持
- [x] AC-3: PR #818 の判断根拠（ready.md 側は親 skill で代替確認が存在するため撤廃）が注記から読み取れる
- [x] T-01: `grep -nE '(reviewer 構成確認|Ready 移行確認とは別概念)' plugins/rite/commands/pr/review.md` が L1281 で hit
- [x] T-02: `grep -n 'MUST be executed' plugins/rite/commands/pr/review.md` が L1279 で維持されている

## 動作確認

```
$ grep -nE '(reviewer 構成確認|Ready 移行確認とは別概念)' plugins/rite/commands/pr/review.md
1281:> **Note (区別注記 — PR #818 / Issue #820)**: 本ガード文は **reviewer 構成確認に固有**であり、`pr/ready.md` の Ready 移行確認とは別概念です。...

$ grep -n 'MUST be executed' plugins/rite/commands/pr/review.md
1279:> **⚠️ MANDATORY**: This `AskUserQuestion` confirmation MUST be executed even within ...
```

両 grep が期待通りの結果を返し、AC-1 / AC-2 / AC-3 / T-01 / T-02 を全て満たすことを確認済み。
