### PR TITLE
style(rite): #819 ready.md Phase 2.1 の説明文を英語ベースに統一

### DIFF
--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -198,13 +198,13 @@ End processing.
 
 ### 2.1 Confirm with User (Standalone Path)
 
-> **End-to-end flow の主経路から呼び出された場合は本 confirmation を skip する**: orchestrator (`start.md` Phase 5.5) が user に Ready 移行を確認済みのため二重確認は不要 ([Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) 5 つの自問の 4 番目「既に承認された判断を再確認しているか? → 重複なら除去」原則)。本 sub-skill が flow state の `.phase` を確認し、`phase5_post_review` / `phase5_post_fix` (review→ready / fix→ready の主経路) のいずれかなら confirmation を skip。
+> **Skip this confirmation when invoked from the main end-to-end flow path**: the orchestrator (`start.md` Phase 5.5) has already confirmed the Ready transition with the user, so a second confirmation is duplicate (per [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) — fourth of the five self-questions: "Is this re-confirming an already-approved decision? → eliminate duplicates"). This sub-skill reads the flow state `.phase` and skips the confirmation when it is `phase5_post_review` / `phase5_post_fix` (the review→ready / fix→ready main paths).
 >
-> **副次経路は fail-safe に standalone 経路 (旧挙動) で退行**: 主経路以外 (例: `/rite:resume` 経由 / 同 session 内 e2e 中断後の standalone 再呼び出し / 想定外の phase 値) で本 sub-skill に到達した場合、`*)` 分岐で `in_e2e_flow=false` に倒し confirmation を表示する (silent skip ではなく silent confirm 方向への退行で UX harm なし)。
+> **Side paths fall back fail-safe to the standalone path (legacy behavior)**: when this sub-skill is reached via any non-main path (e.g., via `/rite:resume`, a standalone re-invocation after an in-session e2e interruption, or an unexpected `.phase` value), the `*)` branch sets `in_e2e_flow=false` and the confirmation is shown. Erring on the side of "silent confirm" rather than "silent skip" preserves UX safety.
 >
-> **Standalone 実行時** (`/rite:pr:ready` 直接呼び出し) は `AskUserQuestion` で確認 (誤実行防止 safety net)。
+> **Standalone execution** (direct `/rite:pr:ready` invocation): always confirm via `AskUserQuestion` as a misuse safety net.
 
-**E2E flow detection** (canonical pattern: helper 起動失敗時は WARNING + sentinel emit してから fail-safe 退行):
+**E2E flow detection** (canonical pattern: on helper invocation failure, emit a WARNING + sentinel and fall back fail-safe):
 
 ```bash
 if phase=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
@@ -215,8 +215,8 @@ else
   echo "[CONTEXT] STATE_READ_FAILED=1; phase=pr_ready_phase_2_1; rc=$rc" >&2
   phase=""
 fi
-# Whitelist approach: 主経路 (review→ready / fix→ready) のみ confirmation skip。
-# 想定外値 (phase5_post_ready 以降 / 空文字 / その他) は fail-safe に standalone 扱い。
+# Whitelist approach: only the main paths (review→ready / fix→ready) skip the confirmation.
+# Unexpected values (phase5_post_ready and beyond / empty / other) fall back fail-safe to standalone.
 case "$phase" in
   phase5_post_review|phase5_post_fix) in_e2e_flow=true ;;
   *) in_e2e_flow=false ;;
@@ -224,7 +224,7 @@ esac
 echo "in_e2e_flow=$in_e2e_flow"
 ```
 
-LLM は本 bash の stdout (`in_e2e_flow=...`) を読み取り、`in_e2e_flow=true` の場合は本 sub-section の AskUserQuestion を skip して Phase 3 へ direct。`in_e2e_flow=false` の場合のみ `AskUserQuestion` で確認:
+The LLM reads the bash stdout (`in_e2e_flow=...`): when `in_e2e_flow=true`, skip the AskUserQuestion in this sub-section and proceed directly to Phase 3; only when `in_e2e_flow=false`, confirm via `AskUserQuestion`:
 
 ```
 PR #{number} を Ready for review に変更します。


### PR DESCRIPTION
## Summary

Closes #819

ready.md Phase 2.1 (`### 2.1 Confirm with User (Standalone Path)`) の説明文を英語ベース + 必要箇所のみ日本語に書き直し、ready.md 他 phase (Phase 0.1 / 1.0 / 4.6 等) との言語スタイルを統一しました。PR #818 (Phase D — pr/ready Phase 2.1 二重 confirmation 解消) review で指摘された style 不整合への対応です。

## Changes

- `plugins/rite/commands/pr/ready.md` (Phase 2.1 のみ、+7/-7 lines)
  - 3 つの blockquote 説明文 (旧 L201-205) を英語ベース化
  - bash block 内のコメント 2 箇所 (`# Whitelist approach: ...` / `# 想定外値 ...`) を英語化
  - 周辺 prose (E2E flow detection 説明 / LLM routing 指示) も同 scope の context synonym group として一括統一

## What Stays Unchanged (機能契約として保持)

- bash detection logic (case statement / `phase5_post_review|phase5_post_fix` / `echo "in_e2e_flow=$in_e2e_flow"` / `state-read.sh --field phase` 呼び出し) — 1 行も変更なし (`git diff` で機能行 0 確認済み)
- charter (`Simplification Charter`) への参照リンク — `[Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md)` 維持
- 「重複確認禁止」原則の引用 — 英訳した上で原意保持: `"Is this re-confirming an already-approved decision? → eliminate duplicates"`
- AskUserQuestion 内 prompt 文言 — UI 文言として日本語維持

## Wiki 経験則 (PR #617) の適用

「reference document の用語統一は『単語 X』ではなく『文脈類義語群全体』を対象にする」原則を適用し、L201-205 の 3 blockquote だけでなく、E2E flow detection 周辺 prose (`**E2E flow detection** ...` / `LLM は本 bash の stdout ...`) も同 scope の context synonym group として一括処理しました。これにより部分翻訳→残存日本語の drift を構造的に予防しています。

## Acceptance Criteria

- [x] AC-1: Phase 2.1 blockquote 説明文 (旧 L201-205) が英語ベースに書き直されている
- [x] AC-2: bash block 内のコメント (`# Whitelist approach: ...` など) が英語化されている
- [x] AC-3: charter (`simplification-charter.md`) への参照リンクと「重複 confirmation 禁止」(英訳) の引用は維持
- [x] AC-4: bash detection logic (case statement / `echo "in_e2e_flow=$in_e2e_flow"` / `state-read.sh` 呼び出し) は変更なし

## Test plan

- [x] T-01: Phase 2.1 説明文を目視確認、英日比率が他 phase と同等
- [x] T-02: `grep simplification-charter.md plugins/rite/commands/pr/ready.md` → 1 hit (line 201)
- [x] T-03: `git diff plugins/rite/commands/pr/ready.md | grep -cE '^[+-][[:space:]]*(case "\$phase" in|phase5_post_review|echo "in_e2e_flow|state-read.sh --field phase)'` → 0

## Lint Status

`/rite:lint` は `[lint:success]` を返却。変更ファイル (`plugins/rite/commands/pr/ready.md`) に対する warning は **0 件**。他ファイルの warning (distributed-fix-drift / comment-journal / wiki-growth / comment-line-ref) は本 PR の変更範囲外の pre-existing technical debt のため scope 外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
