### PR TITLE
refactor(create): /rite:issue:create AskUserQuestion 削減 (PR-E3 of #823)

### DIFF
--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -92,7 +92,9 @@ The type determines which Type Core Section (Section 3) is used in the Issue bod
 | "API エンドポイントを追加する" | Japanese (contains "エ", "追加") | "API エンドポイントの追加" |
 | "Add new API endpoint" | English (no Japanese characters) | "Add new API endpoint" |
 
-**Confirmation Dialog**: Confirm with AskUserQuestion before creation:
+**Pre-creation Preview & Ambiguity Gate**: Issue 作成前に preview を表示し、ambiguity が検出されない場合は auto-create する。ambiguity 検出時のみ AskUserQuestion で user に judgement を委ねる (charter 5 自問 #4「既に承認された判断を再確認しない」適用 — Phase 1 interview と Phase 0.5 confirmation で全要素が確定済みのケースで再度「よろしいですか？」を聞かない)。
+
+**Preview format** (常に表示):
 
 ```
 以下の内容で Issue を作成します:
@@ -104,14 +106,28 @@ The type determines which Type Core Section (Section 3) is used in the Issue bod
 
 説明:
 {generated-body}
+```
 
-よろしいですか？
+**Ambiguity detection** (any → AskUserQuestion で確認):
+
+| Trigger | 理由 |
+|---------|------|
+| Phase 0.4 で類似 Issue が title 完全一致 / 90%+ 類似度 | 重複 Issue 作成リスク |
+| Projects 設定が `enabled: true` だが `project_number` 未取得 / API エラー | Projects 登録失敗の silent missing risk |
+| Complexity = XL かつ Implementation Contract Section 4 (Implementation Details) が空 | spec 不足 PR を生む risk |
+| Title が 200 文字超 | GitHub 制限近接、編集機会必要 |
+
+Ambiguity 検出時の AskUserQuestion:
+
+```
 オプション:
 - はい、作成する
 - タイトルを変更
 - 説明を編集
 - キャンセル
 ```
+
+**Ambiguity 未検出時の auto-create**: Preview 表示後、直接 Issue Body Generation and Creation の `create-issue-with-projects.sh` 起動に進む。中断が必要なら user は次の tool invocation 前に Ctrl+C で介入可能。
 
 #### Issue Body Generation and Creation
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -115,9 +115,11 @@ create.md (orchestrator)
 | Selection | Action |
 |-----------|--------|
 | はい、分解 / Yes, decompose | Phase 0.4-0.5 を skip、Phase 2 へ direct (`force_decompose: true`、Phase 2.1/2.2 confirmation も skip し Phase 3 (decompose path) へ) |
-| いいえ、単一 / No, single | Phase 0.4 へ通常進行 |
+| いいえ、単一 / No, single | context flag `decomposition_decision_finalized: true` を保持し、Phase 0.4 へ通常進行 (Phase 2.2 confirmation は本 flag により skip される) |
 
 **⚠️ Phase 0.4 skip notice**: 「はい、分解」時は Phase 0.4 (重複検出) を skip — 大型タスクは exact duplicate が稀で、Phase 3 の sub-Issue 個別作成時に重複検出される。重複懸念があれば「いいえ」を選択。
+
+**Context flag `decomposition_decision_finalized`**: Phase 0.3 で user が「いいえ、単一」を明示選択した時点で、分解要否の判断は確定済み。Phase 2.2 で同じ問いを再発火させない (charter 5 自問 #4「既に承認された判断を再確認しない」)。本 flag は Phase 1 で tentative complexity が XL に上昇したケースでも保持され、Phase 2.2 は skip される (Phase 0.3 の user 明示選択を尊重)。
 
 ### 0.4 Search for Similar Issues
 
@@ -246,7 +248,9 @@ fi
 
 ### 2.2 Decomposition Confirmation
 
-`AskUserQuestion` で「Sub-Issue に分解する（推奨） / 単一 Issue として作成」を確認 (language-aware)。詳細 routing は [Termination Logic > Phase 2 Decomposition Decision Termination](#phase-2-decomposition-decision-termination) を参照。
+**Fast-path** (`decomposition_decision_finalized: true`): Phase 0.3 で user が「いいえ、単一」を明示選択していた場合、本 confirmation を skip して single Issue path (Phase 3 register) へ進む。skip notice として「Phase 0.3 の選択 (`いいえ、単一`) に従い Phase 2.2 確認を skip しました」を表示する。Phase 1 で tentative complexity が XL に上昇したケースでも user の明示選択を尊重する (charter 5 自問 #4「既に承認された判断を再確認しない」適用)。
+
+**通常 path** (Phase 0.3 を skip した / Phase 0.3 で「いいえ」を選んでいない場合): `AskUserQuestion` で「Sub-Issue に分解する（推奨） / 単一 Issue として作成」を確認 (language-aware)。詳細 routing は [Termination Logic > Phase 2 Decomposition Decision Termination](#phase-2-decomposition-decision-termination) を参照。
 
 **「単一 Issue として作成」時の context carryover**: Phase 1.1 interview 結果は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) 経由で Implementation Contract Section 1-9 に mapping。What/Why/Where → Section 1/2、tentative complexity XL → Phase 3 (Single Issue path) で最終確定 (cancel 時も XL 記録)、Out-of-scope → Section 2 (Out of Scope) / Section 1 (Non-goal)。
 
@@ -336,7 +340,8 @@ What / Why / Where がすべて clear なら完了。不足があれば clarifyi
 
 ### Phase 2 Decomposition Decision Termination
 
-| User Selection | Next Phase |
-|----------------|------------|
+| User Selection / Path | Next Phase |
+|----------------------|------------|
+| (fast-path) Phase 0.3 で「いいえ、単一」明示選択 → Phase 2.2 skip | `skill: "rite:issue:create-register"` (`decomposition_decision_finalized: true` 経由、interview 結果 → Implementation Contract sections は下記 single Issue 行と同 mapping) |
 | Sub-Issue に分解する（推奨） | `skill: "rite:issue:create-decompose"` |
 | 単一 Issue として作成 | `skill: "rite:issue:create-register"` (interview 結果 → Implementation Contract sections は [`references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping`](./references/contract-section-mapping.md#step-3-interview-perspective--target-sections-mapping) で mapping) |


### PR DESCRIPTION
## 概要

`/rite:issue:create` workflow 内の AskUserQuestion を 2 箇所削減した。Issue #823 (Phase E ゼロベース再設計) の PR-E3 として、charter 5 自問 #4「既に承認された判断を再確認しない」を直接適用する。

## 変更内容

- **`commands/issue/create.md` Phase 0.3**: 「いいえ、単一」選択時に context flag `decomposition_decision_finalized: true` を保持
- **`commands/issue/create.md` Phase 2.2**: flag を読み取り confirmation を skip する fast-path 追加。Phase 1 で tentative complexity が XL に上昇したケースでも user の明示選択を尊重 (保守的設計)
- **`commands/issue/create.md` Termination Logic > Phase 2 table**: fast-path 経路の row 追加
- **`commands/issue/create-register.md` Phase 3 Confirmation Dialog**: preview-only に変更。validation pass + ambiguity 未検出時は auto-create、ambiguity (title 衝突 / Projects 設定不備 / XL spec 不足 / title 200+ 文字) 検出時のみ従来の AskUserQuestion fallback を維持

## 効果 (Bug Fix preset 経路)

| Phase | 現状 | 本 PR 後 |
|-------|------|---------|
| 0.3 (大型タスク確認) | 通常 trigger しない | (変化なし) |
| 0.5 (Goal classification / 不足要素) | 推定可能なら 0 回 | (変化なし) |
| 2.2 (decomposition) | complexity != XL なら trigger しない | (変化なし) |
| 3 register (Confirmation Dialog) | 1 回 | **0 回 (auto-create)** |
| 合計 | 1-3 回 | **0-1 回 (AC-3 達成見込み)** |

## 設計の方向性 (Issue #823 Phase E)

- charter 5 自問 #4 適用: Phase 0.3 で承認された判断を Phase 2.2 で再確認しない
- 機能契約 (Bypass block / Terminal Completion / sentinel emit) は保持
- decision tree references / scripts / hooks は touch せず charter「適用範囲外」を尊重
- sub-skill 統合は本 PR scope 外、別 PR (PR-E4 等) で扱う

## 関連 Issue

Refs #823

## Test plan
- [ ] `commands/issue/create.md` の grep `decomposition_decision_finalized` が Phase 0.3 と Phase 2.2 と Termination Logic の 3 箇所で hits
- [ ] `commands/issue/create-register.md` の grep `(preview|auto-create)` が Phase 3 area で hits
- [ ] Bug Fix preset 経路で `/rite:issue:create` を実機検証し、AskUserQuestion 数が削減されていることを確認 (本 PR で 1 経路、残り 2 経路は PR-E5)
- [ ] Plugin-specific lint checks (drift / bang-backtick / comment-journal 等) で本 PR 変更分の新規 finding 0 件 (既存 legacy lines は warning のまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
