### PR TITLE
docs(rite): state-read.sh boolean caveat docstring の caller 列挙を最新化 (#827 follow-up)

### DIFF
--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -215,9 +215,14 @@ fi
 # ⚠️ Boolean field caveat: jq の `// $default` は null と false の両方を $default に
 # 置換するため、本 helper は boolean field の読み取りには使ってはいけない
 # (例: `{"active": false}` を `--default true` で読むと結果が "true"、stored false が
-# silent に default に置換される)。現状の caller (`parent_issue_number` / `phase` /
-# `loop_count` / `implementation_round` / `pr_number`) はすべて非 boolean。将来 boolean
-# field を読む場合は `--default empty` + caller 側分岐、または inline jq を使うこと。
+# silent に default に置換される)。
+# 現状の caller のうち boolean field を読むのは `commands/pr/ready.md` Phase 2.1 の
+# `active` のみ (binary AND check `[ "$active" = "true" ]` + `--default ""` 経路、
+# stored false / 不在 → 共に `else` 分岐の fail-safe pattern)。
+# それ以外 (`parent_issue_number` / `phase` / `loop_count` / `implementation_round` /
+# `pr_number`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
+# (binary AND check + `--default ""`) を採用するか、`--default empty` + caller 側分岐
+# を使うこと。
 #
 # Mechanical guard: WARNING on `--default true|false` flags erroneous boolean reads.
 case "$DEFAULT" in


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/state-read.sh` の boolean field caveat docstring (lines 215-220) を更新し、PR #827 で追加された `commands/pr/ready.md` Phase 2.1 の `active` boolean field 読み出し caller を反映する。本変更は **コメントのみ** で runtime behavior には完全に無影響。

## 背景

PR #827 (Issue #821) で `commands/pr/ready.md` Phase 2.1 が、e2e flow 検出のため `state-read.sh --field active --default ""` で boolean field を読み出す pattern を導入した。これにより docstring が記述する「現状の caller はすべて非 boolean」という前提が stale になり、後続 reviewer や新規 caller 追加者が helper 規約と整合しない読み出しパターンを採用するリスクが生じていた。

## 変更内容

`plugins/rite/hooks/state-read.sh:218-225` の docstring を以下のように更新:

- **boolean caller の唯一の事例を明記**: `commands/pr/ready.md` Phase 2.1 の `active` のみ
- **採用 pattern を docstring 化**: binary AND check `[ "$active" = "true" ]` + `--default ""` 経路、stored false / 不在 → 共に `else` 分岐の fail-safe pattern
- **非 boolean caller を明示的に区別**: `parent_issue_number` / `phase` / `loop_count` / `implementation_round` / `pr_number`
- **新規 boolean caller 追加時の推奨 2 パターン**: 本 pattern (binary AND check + `--default ""`) または `--default empty` + caller 側分岐

## 影響

- **runtime behavior**: 完全に無影響 (コメントのみ)
- **SoT helper 規約の整合性**: caller (`ready.md` lines 218-223) と helper (`state-read.sh` docstring) の 2 layer 同期契約を回復

## テスト

- `bash plugins/rite/hooks/state-read.sh --field active --default ""` が exit 0 を返すこと確認 (regression check pass)
- Plugin-specific lint check (bang-backtick / hardcoded-line-number / backlink-format / 等) は本 PR diff に対して 0 findings

## 関連

Closes #828
- 元 Issue: #821
- 元 PR: #827

## チェックリスト

- [x] docstring lines 218-225 が Issue 推奨内容で更新されている
- [x] `commands/pr/ready.md` Phase 2.1 active caller が事例として明記されている
- [x] 採用 pattern (binary AND check + `--default ""`) が docstring 内にある
- [x] 非 boolean caller 5 件の列挙が保持されている
- [x] Conventional Commits 形式のコミット (`docs(rite):` + `#828` 参照)
- [x] runtime behavior 無影響 (regression check pass)
