### PR TITLE
docs(rite): state-read.sh Mechanical guard WARNING に許容 pattern を追記 (#839 follow-up)

### DIFF
--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -227,7 +227,7 @@ fi
 # Mechanical guard: WARNING on `--default true|false` flags erroneous boolean reads.
 case "$DEFAULT" in
   true|false)
-    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル値です。boolean field の読み取りには本 helper を使わないでください (jq の \`// \$default\` 演算子が JSON null と false の両方を default に置換するため、stored false が silent に true に置換される regression を起こします)。non-boolean field (parent_issue_number / phase / loop_count / pr_number 等) のみが現状サポート対象です。boolean field が必要な場合は \`--default empty\` を使い caller 側で明示分岐するか、inline jq を使ってください。" >&2
+    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル値です。boolean field の読み取りには本 helper を使わないでください (jq の \`// \$default\` 演算子が JSON null と false の両方を default に置換するため、stored false が silent に true に置換される regression を起こします)。non-boolean field (parent_issue_number / phase / loop_count / pr_number 等) のみが現状サポート対象です。boolean field が必要な場合は \`--default empty\` を使い caller 側で明示分岐するか、inline jq を使ってください。ただし \`--default \"\"\` + binary AND check \`[ \"\$value\" = \"true\" ]\` 経路 (例: commands/pr/ready.md Phase 2.1 の \`active\` field) は、stored false / 不在 → 共に else 分岐の fail-safe pattern として許容されます (上の caveat docstring 参照)。" >&2
     ;;
 esac
 


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/state-read.sh:230` の Mechanical guard WARNING message に「`--default ""` + binary AND check 経路は許容」の補足を追記し、PR #839 で更新した boolean field caveat docstring (lines 215-225) との semantic 整合を完成させる。

## 背景

PR #839 で docstring に `commands/pr/ready.md` Phase 2.1 の `active` field を boolean caller として明記したが、Mechanical guard (line 230) の WARNING は依然として「boolean field の読み取りには本 helper を使わないでください」と blanket 禁止しており、operator が WARNING 文言だけ読むと「ready.md は禁則違反」と誤読する余地が残っていた。

## 変更内容

`plugins/rite/hooks/state-read.sh:230` の WARNING 末尾に以下を追記:

> ただし `--default ""` + binary AND check `[ "$value" = "true" ]` 経路 (例: commands/pr/ready.md Phase 2.1 の `active` field) は、stored false / 不在 → 共に else 分岐の fail-safe pattern として許容されます (上の caveat docstring 参照)。

## 影響

- **runtime behavior 完全に無影響**: WARNING は `case "$DEFAULT" in true|false)` ガードに到達したときのみ発火する。`--default ""` 経路はガードを trip しないため、本 WARNING 自体に到達しない。文言追記は operator の認識的整合性のみを目的とする
- **helper / docstring / guard の 3 layer semantic 整合**: PR #839 で完成した helper / caller (ready.md) docstring との整合に、guard WARNING の表現も統一

## テスト

- `grep -F "binary AND check" plugins/rite/hooks/state-read.sh` の WARNING 行 hit を確認
- `bash plugins/rite/hooks/state-read.sh --field active --default ""` が exit 0 (regression check pass)
- `bash plugins/rite/hooks/state-read.sh --field foo --default true 2>&1 | grep -c "binary AND check"` で WARNING 発火経路から「binary AND check」表現が取得できることを確認

## 関連

Closes #840

- 元の PR: #839 (累積 22 回目: helper / caller / prose 3 layer 同期契約の helper 側完了)
- 元の Issue: #828 (#827 follow-up)

## チェックリスト

- [x] WARNING 末尾に許容 pattern 補足が追加されている
- [x] caveat docstring (lines 215-225) との semantic 整合が完成
- [x] `case "$DEFAULT" in true|false)` ガードの literal trip 条件は不変 (`--default ""` 経路は WARNING に到達しない)
- [x] regression check pass (`state-read.sh --field active --default ""` が exit 0)
