### PR TITLE
docs(rite): state-read.sh docstring caller 列挙に next_action を追加

### DIFF
--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -220,7 +220,7 @@ fi
 # `active` のみ (binary AND check `[ "$active" = "true" ]` + `--default ""` 経路、
 # stored false / 不在 → 共に `else` 分岐の fail-safe pattern)。
 # それ以外 (`parent_issue_number` / `phase` / `loop_count` / `implementation_round` /
-# `pr_number`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
+# `pr_number` / `next_action`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
 # (binary AND check + `--default ""`) を採用するか、`--default empty` + caller 側分岐
 # を使うこと。
 #


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/state-read.sh` の "Boolean field caveat" docstring (lines 218-225) の non-boolean caller 列挙に `next_action` を追加し、caller 完全列挙化を達成する。

PR #839 (Issue #828) の同型 helper docstring 修正 follow-up。

## 関連 Issue

Closes #841
- 検出元 PR: #839 (code-quality reviewer 指摘)
- 元 docstring: Issue #828

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/state-read.sh` (line 222-224) | non-boolean caller 列挙に `next_action` を追加 |

### Diff (要旨)

```diff
- # `pr_number`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
+ # `pr_number` / `next_action`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
```

### 根拠 (実 caller 検証)

`grep -rn "state-read.sh --field"` で全 caller を列挙し、`next_action` field の caller が `plugins/rite/hooks/resume-active-flag-restore.sh:92` (`--default "Resume continuation."`) で実際に存在することを確認した。これまでの docstring caller 列挙はこの 1 caller を漏らしていた pre-existing omission。

| Field | Caller |
|-------|--------|
| `phase` | start.md / implement.md / ready.md / resume-active-flag-restore.sh / work-memory-update.sh |
| `parent_issue_number` | start.md / implement.md / resume.md |
| `implementation_round` | start.md |
| `loop_count` | review.md / work-memory-update.sh |
| `pr_number` | work-memory-update.sh |
| `next_action` | resume-active-flag-restore.sh ← **本 PR で追加** |
| `active` | ready.md (boolean — caveat 別経路) |

## scope 外 (本 PR で対応しない)

- **line 230 mechanical guard WARNING の例示部分** (`pr_number 等`): 別 docstring ブロックで「等」付き非完全列挙のため scope 外。Wiki Asymmetric Fix Transcription pattern を踏まえ別 Issue 候補。

## テスト

- [x] `bash plugins/rite/hooks/tests/caller-markdown-block.test.sh` → 23/23 PASS (回帰なし)
- [x] `grep -n 'next_action' plugins/rite/hooks/state-read.sh` で line 223 (caveat ブロック内) に出現確認

## チェックリスト

- [x] docstring caller 列挙に `next_action` を追加
- [x] caller-markdown-block.test.sh で回帰なし確認
- [x] line 行数変化なし (in-line edit、249 行のまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
