### PR TITLE
docs(rite): #842 state-read.sh alternative pattern 表記の SoT 統一

### DIFF
--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -51,7 +51,7 @@ if [ ! -x "$SCRIPT_DIR/_validate-helpers.sh" ]; then
 fi
 bash "$SCRIPT_DIR/_validate-helpers.sh" "$SCRIPT_DIR" || exit $?
 
-# Resolve repository root via the existing helper (single SoT).
+# Resolve repository root via the existing helper (single source of truth).
 # `||` fallback is a defensive guard for future non-zero return; stderr is
 # pass-through so any helper-emitted WARNING/ERROR remains observable.
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$(pwd)") || STATE_ROOT="$(pwd)"

--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -212,7 +212,7 @@ fi
 # JSON null/false — caller default semantics are matched natively, no
 # post-processing needed.
 #
-# ⚠️ Boolean field caveat (canonical SoT for caller patterns):
+# ⚠️ Boolean field caveat (single source of truth for caller patterns):
 #
 # jq の `// $default` は null と false の両方を $default に置換するため、本 helper は
 # boolean field の読み取りには使ってはいけない (例: `{"active": false}` を
@@ -220,10 +220,12 @@ fi
 #
 # 現状の caller のうち boolean field を読むのは `commands/pr/ready.md` Phase 2.1 の
 # `active` のみ。それ以外 (`parent_issue_number` / `phase` / `loop_count` /
-# `implementation_round` / `pr_number` / `next_action`) はすべて非 boolean field
-# (本 helper の通常用途)。
+# `implementation_round` / `pr_number` / `next_action` 等) は非 boolean field
+# (本 helper の通常用途)。`pr_number` / `next_action` 等は helper script 経由で間接的に
+# 読まれる (例: `work-memory-update.sh` / `resume-active-flag-restore.sh`) ため、
+# 列挙は documented-supported field を示し、現状全 caller を網羅するものではない。
 #
-# Approved caller pattern (canonical, the only supported boolean read path):
+# Approved caller pattern (the only supported boolean read path through this helper):
 #   `--default ""` + binary AND check `[ "$value" = "true" ]`
 #     stored false / 不在 → 共に空文字列 → else 分岐の fail-safe pattern。
 #   `commands/pr/ready.md` Phase 2.1 の `active` field がこの典型 (false と missing を
@@ -231,19 +233,21 @@ fi
 # 上記 pattern で要件を満たせない場合は本 helper を経由せず inline jq を使うこと
 # (例: `jq -r '.active' .rite-flow-state`)。
 #
-# Note (deprecated alternative): 旧 docstring が `--default empty` + caller 側分岐
-# を alternative として推奨していたが、`empty` は jq builtin ではなく literal string
-# `"empty"` として `--arg default "$DEFAULT"` 経由で渡されるため、機能的には
-# `--default ""` と等価 (stored false → `"empty"`、missing → `"empty"` で caller 側
-# で false / missing を区別不能)。新規 caller では採用しないこと。
+# Note (deprecated alternative): `--default empty` + caller 側分岐 alternative は
+# 採用不可 — `empty` は jq builtin ではなく literal string `"empty"` として
+# `--arg default "$DEFAULT"` 経由で渡されるため `--default ""` と機能的等価で、
+# stored false / missing が caller 側で disambiguate 不能。新規 caller では Approved
+# pattern のみ使用すること。
 #
 # Mechanical guard (below): WARNING on `--default true|false` flags erroneous boolean
 # reads. The WARNING message is intentionally short and delegates to this caveat
 # block as the single source of truth — do not duplicate caller-pattern guidance
-# inside the WARNING text (Issue #842).
+# inside the WARNING text (Issue #842). WARNING の文言を改訂する際は
+# `plugins/rite/hooks/tests/state-read.test.sh` TC-14.3 の grep pattern と同期させること
+# (mutation kill power 維持のため)。
 case "$DEFAULT" in
   true|false)
-    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル。jq の \`// \$default\` が null/false を default に silent 置換し stored false を失います。詳細は docstring \"Boolean field caveat\" 節を参照。" >&2
+    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル値です。jq の \`// \$default\` が null/false を default に silent 置換し stored false を失います。詳細は docstring \"Boolean field caveat\" 節を参照。" >&2
     ;;
 esac
 

--- a/plugins/rite/hooks/state-read.sh
+++ b/plugins/rite/hooks/state-read.sh
@@ -212,22 +212,38 @@ fi
 # JSON null/false — caller default semantics are matched natively, no
 # post-processing needed.
 #
-# ⚠️ Boolean field caveat: jq の `// $default` は null と false の両方を $default に
-# 置換するため、本 helper は boolean field の読み取りには使ってはいけない
-# (例: `{"active": false}` を `--default true` で読むと結果が "true"、stored false が
-# silent に default に置換される)。
-# 現状の caller のうち boolean field を読むのは `commands/pr/ready.md` Phase 2.1 の
-# `active` のみ (binary AND check `[ "$active" = "true" ]` + `--default ""` 経路、
-# stored false / 不在 → 共に `else` 分岐の fail-safe pattern)。
-# それ以外 (`parent_issue_number` / `phase` / `loop_count` / `implementation_round` /
-# `pr_number` / `next_action`) はすべて非 boolean。boolean field を新しく読みたい場合は本 pattern
-# (binary AND check + `--default ""`) を採用するか、`--default empty` + caller 側分岐
-# を使うこと。
+# ⚠️ Boolean field caveat (canonical SoT for caller patterns):
 #
-# Mechanical guard: WARNING on `--default true|false` flags erroneous boolean reads.
+# jq の `// $default` は null と false の両方を $default に置換するため、本 helper は
+# boolean field の読み取りには使ってはいけない (例: `{"active": false}` を
+# `--default true` で読むと結果が "true"、stored false が silent に default に置換される)。
+#
+# 現状の caller のうち boolean field を読むのは `commands/pr/ready.md` Phase 2.1 の
+# `active` のみ。それ以外 (`parent_issue_number` / `phase` / `loop_count` /
+# `implementation_round` / `pr_number` / `next_action`) はすべて非 boolean field
+# (本 helper の通常用途)。
+#
+# Approved caller pattern (canonical, the only supported boolean read path):
+#   `--default ""` + binary AND check `[ "$value" = "true" ]`
+#     stored false / 不在 → 共に空文字列 → else 分岐の fail-safe pattern。
+#   `commands/pr/ready.md` Phase 2.1 の `active` field がこの典型 (false と missing を
+#   区別しないが、「true なときだけ何かする」用途では十分)。
+# 上記 pattern で要件を満たせない場合は本 helper を経由せず inline jq を使うこと
+# (例: `jq -r '.active' .rite-flow-state`)。
+#
+# Note (deprecated alternative): 旧 docstring が `--default empty` + caller 側分岐
+# を alternative として推奨していたが、`empty` は jq builtin ではなく literal string
+# `"empty"` として `--arg default "$DEFAULT"` 経由で渡されるため、機能的には
+# `--default ""` と等価 (stored false → `"empty"`、missing → `"empty"` で caller 側
+# で false / missing を区別不能)。新規 caller では採用しないこと。
+#
+# Mechanical guard (below): WARNING on `--default true|false` flags erroneous boolean
+# reads. The WARNING message is intentionally short and delegates to this caveat
+# block as the single source of truth — do not duplicate caller-pattern guidance
+# inside the WARNING text (Issue #842).
 case "$DEFAULT" in
   true|false)
-    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル値です。boolean field の読み取りには本 helper を使わないでください (jq の \`// \$default\` 演算子が JSON null と false の両方を default に置換するため、stored false が silent に true に置換される regression を起こします)。non-boolean field (parent_issue_number / phase / loop_count / pr_number 等) のみが現状サポート対象です。boolean field が必要な場合は \`--default empty\` を使い caller 側で明示分岐するか、inline jq を使ってください。ただし \`--default \"\"\` + binary AND check \`[ \"\$value\" = \"true\" ]\` 経路 (例: commands/pr/ready.md Phase 2.1 の \`active\` field) は、stored false / 不在 → 共に else 分岐の fail-safe pattern として許容されます (上の caveat docstring 参照)。" >&2
+    echo "WARNING: state-read.sh: --default '$DEFAULT' は boolean リテラル。jq の \`// \$default\` が null/false を default に silent 置換し stored false を失います。詳細は docstring \"Boolean field caveat\" 節を参照。" >&2
     ;;
 esac
 


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/state-read.sh` 内の Mechanical guard WARNING (line 246) と docstring (lines 215-225) で、boolean field 読み取り時の alternative pattern が二重記述されていた問題を解消する。docstring を single source of truth として整理し、WARNING は逸脱検知のみの責務に簡素化する。

## 関連 Issue

Closes #842

## 変更内容

### docstring (`state-read.sh:215-247`)

- single source of truth として再構成
- approved caller pattern (`--default ""` + binary AND check `[ "$value" = "true" ]`) を **the only supported boolean read path through this helper** として明示
- `--default empty` を **deprecated alternative** として注記（pre-existing 問題を併合）。`empty` は jq builtin ではなく literal string `"empty"` として `--arg default "$DEFAULT"` 経由で渡されるため `--default ""` と機能的に等価で、boolean false / missing を caller 側で disambiguate できない
- Mechanical guard と docstring の責務分離を文末に明記
- WARNING 改訂時の test 同期義務 (tests/state-read.test.sh TC-14.3 grep pattern) を Mechanical guard 段落に追加

### Mechanical guard WARNING (`state-read.sh:248`)

- 593 chars → 220 chars (37%) に短縮
- 削除した内容: alternative pattern 詳細 (`--default empty` 推奨)、non-boolean field 列挙、canonical pattern with example、`commands/pr/ready.md` Phase 2.1 の例示
- 残した内容: regression 説明（boolean リテラル → silent 置換）と docstring "Boolean field caveat" 節へのポインタ
- `boolean リテラル値です。` 表現を維持して既存 test pin (`tests/state-read.test.sh:448/462` の `grep -q "boolean リテラル値"`) との互換性を保つ

## 動作不変

- `case "$DEFAULT" in true|false)` のトリガー条件は維持
- 既存 caller (`commands/pr/ready.md` Phase 2.1 の `active` field、`--default ""` 経路) には影響なし
- 動作検証: `--default true` / `--default false` で WARNING 出力、`--default ""` / `--default 0` で WARNING 非出力を確認
- テスト確認: `bash plugins/rite/hooks/tests/state-read.test.sh` で PASS=50 / FAIL=0

## レビュー対応履歴

- cycle 1 review: 6 findings 検出 (CRITICAL test regression × 1, HIGH × 1, MEDIUM × 2, LOW × 2)
  - cross-validated CRITICAL を含む主要 4 件を fix commit `064dd28` で解決
  - LOW 2 件のうち 1 件 (caller list の hedge 表現) を併せて吸収
- cycle 2 review: 残 LOW 1 件 (line 54 SoT 表記統一の取りこぼし) を fix commit `97a1a70` で解決

## Known Issues (本 PR スコープ外、別 Issue にて段階対応)

本 PR の変更スコープ外で lint が以下の pre-existing warning を検出（変更ファイル `state-read.sh` 自体には新規 finding なし）:

- Distributed fix drift: 32 findings (`pr/fix.md` / `pr/review.md` の reason / eval-table 同期 drift)
- Comment journal narration: 211 findings (`state-read-evolution.md` 等の verified-review cycle / 旧実装 narration、Issue #702 系で段階的解消中)
- Comment line-number reference: 21 findings (他ファイルから `state-read.sh:NN` への hardcoded reference、Issue #666 系で段階的に structural reference 化中)

これらはすべて本 PR スコープ外。

## 補足: caller への影響ゼロ確認

`grep -rn "default empty" plugins/rite/` で `state-read.sh` の Note 自身を除き **0 件**確認済み。`--default empty` 表記を deprecated alternative に降格しても、現存 caller への silent regression リスクなし。

## チェックリスト

- [x] docstring を single source of truth として整理
- [x] WARNING を簡素化（alternative pattern 詳細削除、SoT 参照に統一）
- [x] `--default empty` を deprecated alternative と注記
- [x] 動作検証 (boolean リテラル → WARNING、`--default ""` → 非出力)
- [x] テスト確認 (PASS=50 / FAIL=0)
- [x] Conventional Commits 形式でコミット
- [x] レビュー指摘対応 (cycle 1: 主要 4 件 + LOW 1 件、cycle 2: LOW 1 件)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
