### PR TITLE
test(rite): #832 caller HTML inline literal 対称性検証 lint script を新設

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,7 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-**Output rules** (本セクションが marker 形式の SoT。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保):
+**Output rules** (本セクションが marker 形式の SoT。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保。`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保):
 
 0. **FIRST**: `[CONTEXT] INTERVIEW_DONE=1; scope={skipped|completed}; next=phase_2` を **plain-text line** で出力（HTML-commented 不可）。位置規定:
    - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出

--- a/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# caller-html-literal-symmetry.test.sh
+#
+# Tests for caller HTML inline literal symmetry across the
+# create-interview.md example output blocks.
+#
+# Issue #832 — split out from the 4-site-symmetry concern as a
+# dedicated lint script (option B in the Issue's three-way decision).
+# Background: PR #830 removed the prose that documented this 2-site
+# symmetry; this test restores machine-verifiable drift detection.
+#
+# Purpose:
+#   The /rite:issue:create-interview sub-skill emits a return block
+#   ending in one of two HTML-commented sentinels:
+#     <!-- [interview:skipped] -->   (XS / Bug Fix / Chore preset)
+#     <!-- [interview:completed] --> (S / M / L / XL after deep-dive)
+#
+#   Both example blocks (Output format example sections in
+#   create-interview.md) must contain an *identical*
+#   `<!-- caller: ... -->` line that instructs the orchestrator to
+#   run a Step 0 Immediate Bash Action. The bash literal embedded in
+#   that comment must match across both examples so that an LLM
+#   reading either example sees the same contract.
+#
+#   This test verifies:
+#     1. There are exactly 2 occurrences of `<!-- caller:` in
+#        create-interview.md (one per example block).
+#     2. The 2 occurrences are byte-equal (full-line equality).
+#     3. The literal contains all 6 required elements:
+#          bash plugins/rite/hooks/flow-state-update.sh patch
+#          --phase create_post_interview
+#          --active true
+#          --next 'Step 0 Immediate Bash Action fired ...'
+#          --if-exists
+#          --preserve-error-count
+#
+# When this test fails:
+#   The 2 example blocks have drifted, typically because someone
+#   updated one block but missed the symmetric update in the other.
+#   Restore symmetry by replicating the change across both blocks.
+#   Do NOT relax this test — symmetry restoration is the correct fix.
+#
+# Relationship with `4-site-symmetry.test.sh`:
+#   That test guards CLI-arg PRESENCE (--phase / --active / --next /
+#   --preserve-error-count) at file-level grep granularity for the 2
+#   files commands/issue/create.md and commands/issue/create-interview.md.
+#   This test is narrower and stricter: full-line byte equality of the
+#   2 caller HTML inline literals within create-interview.md alone.
+#   The two are complementary; neither subsumes the other.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+TARGET="$REPO_ROOT/plugins/rite/commands/issue/create-interview.md"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  ❌ $1"; }
+
+if [ ! -f "$TARGET" ]; then
+  echo "  ❌ FILE NOT FOUND: $TARGET"
+  exit 1
+fi
+
+echo "=== caller HTML inline literal occurrence count ==="
+caller_count=$(grep -cF '<!-- caller:' "$TARGET" 2>/dev/null || true)
+caller_count=${caller_count:-0}
+if [ "$caller_count" -eq 2 ]; then
+  pass "expected 2 caller-comment lines, found 2"
+else
+  fail "expected exactly 2 caller-comment lines, found $caller_count"
+fi
+
+echo
+echo "=== caller HTML inline literal byte equality ==="
+mapfile -t caller_lines < <(grep -F '<!-- caller:' "$TARGET")
+if [ "${#caller_lines[@]}" -ge 2 ]; then
+  if [ "${caller_lines[0]}" = "${caller_lines[1]}" ]; then
+    pass "caller HTML inline literals are byte-identical across the 2 example blocks"
+  else
+    fail "caller HTML inline literals diverge between [interview:skipped] and [interview:completed] example blocks"
+    echo "  --- skipped block caller literal ---" >&2
+    echo "    ${caller_lines[0]}" >&2
+    echo "  --- completed block caller literal ---" >&2
+    echo "    ${caller_lines[1]}" >&2
+  fi
+else
+  fail "fewer than 2 caller-comment lines extracted; cannot compare"
+fi
+
+echo
+echo "=== required-element presence within the caller literal ==="
+REQUIRED_ELEMENTS=(
+  "bash plugins/rite/hooks/flow-state-update.sh patch"
+  "--phase create_post_interview"
+  "--active true"
+  "--next 'Step 0 Immediate Bash Action fired"
+  "--if-exists"
+  "--preserve-error-count"
+)
+if [ "${#caller_lines[@]}" -ge 1 ]; then
+  for needle in "${REQUIRED_ELEMENTS[@]}"; do
+    if [[ "${caller_lines[0]}" == *"$needle"* ]]; then
+      pass "caller literal contains: $needle"
+    else
+      fail "caller literal missing required element: $needle"
+    fi
+  done
+else
+  fail "no caller-comment line extracted; cannot verify required elements"
+fi
+
+echo
+echo "─── $(basename "$0") summary ──────────────────────"
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "Failed assertions:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  echo
+  echo "⚠️ caller HTML inline literal symmetry drift detected."
+  echo "   The 2 example output blocks in create-interview.md"
+  echo "   ([interview:skipped] and [interview:completed]) must contain"
+  echo "   an identical <!-- caller: ... --> line. Restore symmetry by"
+  echo "   replicating the change across both example blocks."
+  echo "   Do NOT relax this test."
+  exit 1
+fi
+
+echo "OK: caller HTML inline literal symmetry verified"
+exit 0


### PR DESCRIPTION
## 概要

`/rite:issue:create-interview` の Output format example 2 ブロック（`[interview:skipped]` / `[interview:completed]`）に含まれる `<!-- caller: ... -->` HTML inline literal の byte-equality を検証する dedicated lint script を追加した。

PR #830 で削除された 2 site 内対称性散文の test 担保を、4-site-symmetry test の SCOPE を拡げず（concern を分離）、`bang-backtick-edit-hook.test.sh` と同型の独立 lint として実装。

Closes #832

## 変更内容

- `plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh` (新規 139 行)
  - 2 example block 内 caller HTML literal の出現数（exactly 2）と byte-equality を assert
  - literal 内の必須 6 要素（`bash plugins/rite/hooks/flow-state-update.sh patch` / `--phase create_post_interview` / `--active true` / `--next` / `--if-exists` / `--preserve-error-count`）の存在確認
  - failure 時は両 literal を stderr に diff 形式で出力
  - `run-tests.sh` が `*.test.sh` 命名で自動検出するため orchestration 変更不要
- `plugins/rite/commands/issue/create-interview.md` (1 行更新)
  - Caller Return Protocol の `**Output rules**` 行（SoT）に新 test への参照を追記

## なぜ option B（別 lint script 新設）を採択したか

Issue #832 の三者択一:

| Option | 採否 | 理由 |
|--------|------|------|
| A: 既存 4-site-symmetry test を拡張 | × | test 名 `4-site-symmetry` の射程が CLI-arg + HTML literal の混合となり semantic ambiguity |
| **B: 別 lint script を新設** | **○** | Single Responsibility / clear naming、`bang-backtick-edit-hook.test.sh` 等の precedent と整合 |
| C: 決定記録のみ (wontfix) | × | drift LOW だが実 detection 機構なし、wiki 経験則「Asymmetric Fix Transcription」予防に反する |

## ドリフト検出能力の検証

`--if-exists` を片側 1 箇所のみ書き換えた負例で test 実行 → exit 1 + 両 literal を stderr に full-line diff として出力することを確認。

## テスト結果

`bash plugins/rite/hooks/tests/run-tests.sh` 全 40 件 pass、新 test 単独で 8 assertion pass、regression なし。

## レビュー観点

- 新 test 自身が対称性違反 / bang-backtick adjacency を導入していないか（self-violation cascade、PR #765 教訓）
- `<!-- caller:` リテラルの一致判定が将来の caller literal 変更（例: 引数追加・並び替え）で false positive を起こさないか
- `4-site-symmetry.test.sh` との責務分離が文書化されているか（test ヘッダの "Relationship with 4-site-symmetry.test.sh" セクション参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
