### PR TITLE
fix(create): #835 Context handoff に decomposition_decision_finalized flag を登録

### DIFF
--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -16,6 +16,7 @@ Classify, confirm, create, and register a single Issue. This sub-command is invo
 - Goal classification from Phase 0.5 — available if conducted; `null` if skipped (Phase 0.3 early decomposition path)
 - Language setting from Preparation phase — **always available**
 - `phases_skipped` flag — `"0.4-0.5"` when Phase 0.3 triggered early decomposition; `null` otherwise
+- `decomposition_decision_finalized` flag — `true` when Phase 0.3 で user が「いいえ、単一」を明示選択した fast-path 経由で呼び出された (Phase 2.2 confirmation skip); `null` otherwise. Conversation context 内で保持され (flow-state file には persist しない)、`create-register` 側では path 認識への影響はないが、Phase 0.3 fast-path 由来であることを示す context として handoff される
 - Specification document path — available when invoked from `create-decompose.md` cancel (Phase 3.1 Specification Document Confirmation)
 
 **Fallback rules for missing prerequisites**:

--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -16,7 +16,7 @@ Classify, confirm, create, and register a single Issue. This sub-command is invo
 - Goal classification from Phase 0.5 — available if conducted; `null` if skipped (Phase 0.3 early decomposition path)
 - Language setting from Preparation phase — **always available**
 - `phases_skipped` flag — `"0.4-0.5"` when Phase 0.3 triggered early decomposition; `null` otherwise
-- `decomposition_decision_finalized` flag — `true` when Phase 0.3 で user が「いいえ、単一」を明示選択した fast-path 経由で呼び出された (Phase 2.2 confirmation skip); `null` otherwise. Conversation context 内で保持され (flow-state file には persist しない)、`create-register` 側では path 認識への影響はないが、Phase 0.3 fast-path 由来であることを示す context として handoff される
+- `decomposition_decision_finalized` flag — `true` when Phase 0.3 で user が「いいえ、単一」を明示選択した fast-path 経由で呼び出された (Phase 2.2 confirmation を skip); `null` otherwise. Phase 0.3 fast-path 由来であることを示す traceability context として handoff される (`create-register` 側の path 認識への影響なし、retention 仕様は `create.md` Phase 0.3 の Retention mechanism 段落参照)
 - Specification document path — available when invoked from `create-decompose.md` cancel (Phase 3.1 Specification Document Confirmation)
 
 **Fallback rules for missing prerequisites**:

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -121,6 +121,8 @@ create.md (orchestrator)
 
 **Context flag `decomposition_decision_finalized`**: Phase 0.3 で user が「いいえ、単一」を明示選択した時点で、分解要否の判断は確定済み。Phase 2.2 で同じ問いを再発火させない (charter 5 自問 #4「既に承認された判断を再確認しない」)。本 flag は Phase 1 で tentative complexity が XL に上昇したケースでも保持され、Phase 2.2 は skip される (Phase 0.3 の user 明示選択を尊重)。
 
+**Retention mechanism**: 本 flag は **conversation context** 内で保持される (flow-state file には persist しない)。`create.md` Phase 0.3 → Phase 1 → Phase 2.2 → Phase 3 handoff は同一セッション内の一気通貫実行を前提としているため、`/clear` で context が破棄された場合 flag は失われる (再開時は通常 path が走り、Phase 2.2 で再確認が発生する)。これは意図的設計 (`/clear` 後は user の判断状況が変わっている可能性があり、再確認が安全な default)。
+
 ### 0.4 Search for Similar Issues
 
 **Purpose**: 重複検出 / context gathering / extension 候補検出 (parent Issue 検出は `start.md` 担当)。
@@ -297,6 +299,7 @@ fi
 | Interview results | Phase 1.1 | **N/A** — EDGE-3 row 4 適用 (MUST sections に placeholder) |
 | Tentative slug | [Phase 0.2](./references/slug-generation.md) | 常に available |
 | `phases_skipped` flag | Phase 0.3 | `"0.4-0.5"` (Phase 0.3 早期分解時) または `null` |
+| `decomposition_decision_finalized` flag | Phase 0.3 | `true` (Phase 0.3 で「いいえ、単一」明示選択時) または `null`。conversation context で保持 (flow-state file には persist しない)。`create-register` Phase 3 の path 認識には影響しないが、create.md Phase 2.2 fast-path 経由で create-register が呼ばれた根拠を context として handoff する |
 
 **🚨 Immediate after delegation returns**: sub-skill が `[create:completed:{N}]` を出力したら同 turn 内で Mandatory After Delegation を実行。
 

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -299,7 +299,7 @@ fi
 | Interview results | Phase 1.1 | **N/A** — EDGE-3 row 4 適用 (MUST sections に placeholder) |
 | Tentative slug | [Phase 0.2](./references/slug-generation.md) | 常に available |
 | `phases_skipped` flag | Phase 0.3 | `"0.4-0.5"` (Phase 0.3 早期分解時) または `null` |
-| `decomposition_decision_finalized` flag | Phase 0.3 | `true` (Phase 0.3 で「いいえ、単一」明示選択時) または `null`。conversation context で保持 (flow-state file には persist しない)。`create-register` Phase 3 の path 認識には影響しないが、create.md Phase 2.2 fast-path 経由で create-register が呼ばれた根拠を context として handoff する |
+| `decomposition_decision_finalized` flag | Phase 0.3 | `true` (Phase 0.3 で「いいえ、単一」明示選択時) または `null`。Phase 0.3 fast-path 由来であることを示す traceability context として handoff (詳細・retention 仕様は Phase 0.3 の Retention mechanism 段落参照、`create-register` 側 path 認識への影響なし) |
 
 **🚨 Immediate after delegation returns**: sub-skill が `[create:completed:{N}]` を出力したら同 turn 内で Mandatory After Delegation を実行。
 


### PR DESCRIPTION
## 概要

PR #834 で導入した `decomposition_decision_finalized` flag が `commands/issue/create.md` → `create-register.md` の handoff documentation に未登録だった drift を解消する。

## 関連 Issue

Closes #835

## 変更内容

- `commands/issue/create.md` Phase 3 handoff table に flag row を追加 (Phase 0.3 由来、`true` または `null`、conversation context で保持)
- `commands/issue/create.md` Phase 0.3 の flag 説明に **Retention mechanism** 段落を追加 (conversation context 内保持・`/clear` で失効する意図的設計を明記)
- `commands/issue/create-register.md` Prerequisites bullet list に `decomposition_decision_finalized` flag entry を追加

## チェックリスト

- [x] プロジェクト規約に準拠（マークダウン編集のみ、行数追加 4 行）
- [x] 関連箇所を一括更新（create.md / create-register.md 双方の handoff documentation）
- [x] `/rite:lint` 通過（plugin-specific check warnings は pre-existing baseline、本 PR 編集起因ではない）

## Known Issues

`/rite:lint` の warnings (distributed-fix-drift 32 / comment-journal 211 / comment-line-ref 21) はすべて pre-existing baseline で本 PR の編集（4 行のマークダウン追加）とは無関係。develop ブランチでも検出される warnings であり、本 PR では解消対象外。

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
