### PR TITLE
fix(create): #836 Phase 0.4 と Phase 3 ambiguity gate の二重確認矛盾を解消

### DIFF
--- a/plugins/rite/commands/issue/create-register.md
+++ b/plugins/rite/commands/issue/create-register.md
@@ -113,7 +113,6 @@ The type determines which Type Core Section (Section 3) is used in the Issue bod
 
 | Trigger | 理由 |
 |---------|------|
-| Phase 0.4 で類似 Issue が title 完全一致 / 90%+ 類似度 | 重複 Issue 作成リスク |
 | Projects 設定が `enabled: true` だが `project_number` 未取得 / API エラー | Projects 登録失敗の silent missing risk |
 | Complexity = XL かつ Implementation Contract Section 4 (Implementation Details) が空 | spec 不足 PR を生む risk |
 | Title が 200 文字超 | GitHub 制限近接、編集機会必要 |


### PR DESCRIPTION
## 概要

`commands/issue/create-register.md` Phase 3 「Pre-creation Preview & Ambiguity Gate」の Ambiguity detection table 1 行目（Phase 0.4 で類似 Issue が title 完全一致 / 90%+ 類似度）を削除。`commands/issue/create.md` Phase 0.4 で既に user に類似 Issue 拡張/関連なし/別 Issue 等を確認している判断と二重確認になっていた。

## 関連 Issue

Closes #836

## 背景

PR #834 (PR-E3 of #823) で導入された Ambiguity gate が、charter 5 自問 #4「既に承認された判断を再確認しない」違反を含んでいた self-referential な問題。reviewer (prompt-engineer + code-quality 両者) で重複検出された high-confidence 指摘。

Phase 0.4 で「(c) 関連なし」を選んだ user に対し、Phase 3 ambiguity gate で「90%+ 類似があるが本当に新規作成して良いか」を再度聞く経路は redundant。

## 採用方針

選択肢 1（trigger 1 行削除）を採用。

理由:
- Phase 0.6 (Skip Semantics / Mode B Defense) で Phase 0.4 は MUST execute と明示されている
- `pre-tool-bash-guard.sh` で `gh issue create` 直接呼出も block されるため、Phase 0.4 が skip されるケースは存在しない
- 選択肢 2（context flag による条件分岐）は防御過剰でシンプル化原則違反
- Wiki 経験則 Asymmetric Fix Transcription: 同型 trigger 列挙が他 doc / CHANGELOG にミラーされていないことを grep verify 済み

## 変更内容

- `plugins/rite/commands/issue/create-register.md`: Ambiguity detection table から 「Phase 0.4 で類似 Issue が title 完全一致 / 90%+ 類似度」trigger 1 行を削除（残 3 trigger: Projects 設定 / Complexity XL / Title 200 文字超 は維持）

## テストプラン

- [x] grep `^\| Phase 0\.4 で類似 Issue` で 0 件確認
- [x] 残 3 trigger（Projects / XL / Title）が drift なく保持されることを確認
- [x] `grep -rn "Phase 0.4 で類似 Issue" plugins/ CHANGELOG*.md` で他 doc にミラーがないこと確認
- [ ] `/rite:issue:create` の Phase 3 動作確認（ambiguity 未検出時の auto-create 経路が変わらないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
