### PR TITLE
docs(create-interview): line 307 を両 test の hub として明示

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,7 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-**Output rules** (本セクションが marker 形式の SoT。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保。`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保):
+**Output rules** (本セクションが marker 形式の SoT、かつ **両 test の hub**: bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持):
 
 0. **FIRST**: `[CONTEXT] INTERVIEW_DONE=1; scope={skipped|completed}; next=phase_2` を **plain-text line** で出力（HTML-commented 不可）。位置規定:
    - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/create-interview.md` の line 307 (Output rules SoT 行) に `caller-html-literal-symmetry.test.sh` への参照を追加した PR #850 で、line 27 / 247 の bash block コメントは既存の `4-site-symmetry.test.sh` 単独参照のままで非対称な状態が残存していた。Issue #851 が指摘する hub-spoke 関係の対称性回復を行う。

責務分離を保つため Option B (line 307 を「両 test の hub」と明示) を採用:

- **line 27/247 の bash block コメント**: `bash 引数 symmetry` 担保が責務 → `4-site-symmetry.test.sh` 単独参照のまま (現状維持)
- **line 307 SoT 行**: 「marker 形式の SoT、かつ両 test の hub」と明示。`HTML literal symmetry` は本セクションを single source として参照する責務分離方針を併記

これにより以下が成立:

- 両 test の hub 関係が文言上明示される (Issue #851 解消)
- bash block 側コメントは bash 引数 symmetry のみ inline 言及する責務範囲が文書化される
- 将来 `caller-html-literal-symmetry.test.sh` への参照を bash block に追加しようとする drift 提案が SoT 行を通じて構造的に retract される

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/commands/issue/create-interview.md` | line 307 の Output rules 文言を「両 test の hub」明示形に書き換え (1 line edit) |

## 検証

- ✅ `4-site-symmetry.test.sh`: PASS 8 / FAIL 0 (`--phase` / `--active` / `--next` / `--preserve-error-count` の 4 site symmetry 維持)
- ✅ `caller-html-literal-symmetry.test.sh`: PASS 8 / FAIL 0 (2 example block 間の HTML literal byte-equality 維持)
- ✅ grep drift check: `(4-site-symmetry|caller-html-literal-symmetry)\.test\.sh` の hit が line 27 / 247 / 307 の 3 箇所のみ、意図しない伝播 drift なし
- ✅ `/rite:lint` plugin-specific checks: bang-backtick 0 / doc-heavy-drift 0 / wiki-growth 0 / gitignore-health 0 / backlink-format 0 / hardcoded-line 0 / terminal-output success
  - 既存 baseline warnings (drift 32 / comment-journal 211 / comment-line-ref 21) は本変更とは無関係で create-interview.md には 1 件も hit しない

## 関連

Closes #851

参考:
- 元 PR: #850 (line 307 への新 test 参照追加で非対称が発生した経緯)
- 元 Issue: #832 (4-site-symmetry test SCOPE caller HTML literal 拡張)

## チェックリスト

- [x] line 307 の hub 明示文言を追加
- [x] 既存 test (`4-site-symmetry.test.sh`, `caller-html-literal-symmetry.test.sh`) の回帰なし
- [x] 文書内 drift なし (grep verify)
- [x] hardcoded line-number reference / self-drift なし
