### PR TITLE
docs(create-interview): line 307 の Output rules parenthetical を style 統一形式に分解

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,9 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-**Output rules** (本セクションが marker 形式の SoT、かつ **両 test の hub**: bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持):
+本セクションは marker 形式の SoT であり、かつ **両 test の hub** として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する。
+
+**Output rules**:
 
 0. **FIRST**: `[CONTEXT] INTERVIEW_DONE=1; scope={skipped|completed}; next=phase_2` を **plain-text line** で出力（HTML-commented 不可）。位置規定:
    - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -692,7 +692,8 @@ Generate structured action lines in the commit body following the Contextual Com
 4. **Apply mapping table**: Map each extracted item to action types using the [Work Memory → Action Line Mapping](../../skills/rite-workflow/references/contextual-commits.md#work-memory--action-line-mapping) table
 5. **Filter to 10-line limit**: If action lines exceed 10, trim in order: `learned` → `constraint` → `rejected` → `decision` → `root-cause` → `intent` (intent is preserved last as the core "why"; `comment-update` is out of scope — single-purpose commits do not exceed 10 lines)
 
-**Output rules:**
+**Output rules**:
+
 - Action type names are always in English (`intent`, `decision`, `root-cause`, `rejected`, `constraint`, `learned`, `comment-update`)
 - Description follows the `language` setting in `rite-config.yml`
 - Do not repeat information already visible in the diff


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/create-interview.md` line 307 の `**Output rules** (...):` parenthetical 構造を、説明段落 + 独立行 `**Output rules**:` 形式に分解しました。

PR #858 で「両 test の hub」明示を追加した結果、parenthetical 末尾の `):` が「半角 `)` + 半角 `:`」と「list 始端 colon」を兼ねる二重役割となっており、将来別の編集者が paren 構造を解釈し損ねるリスクがありました。他の Output rules 記述箇所（`create-register.md:550` / `create-decompose.md:457` / `implement.md:695`）と style を統一しました。

## 変更内容

### Before (line 307, 1 行)

```
**Output rules** (本セクションが marker 形式の SoT、かつ **両 test の hub**: bash 引数 symmetry は ... で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は ... で test 担保。bash block 側コメント (...) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持):
```

### After (説明段落 + 独立行 `**Output rules**:`)

```
本セクションは marker 形式の SoT であり、かつ **両 test の hub** として機能する。bash 引数 symmetry は ... で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は ... で test 担保する。bash block 側コメント (...) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する。

**Output rules**:
```

## 設計判断

- Issue #859 の推奨案 1（parenthetical を文末で完結させ、改行後に `**Output rules**:` を独立した行として再掲する 2 文構成）を採用
- 推奨案 2（「両 test の hub」セマンティクスを直前段落に移動）は不採用 — `**Output rules**:` ヘッダーから「両 test の hub」明示が離れるため、PR #858 の意図（rule list 直前で hub 性を明示）が薄まる懸念
- 後続 Rule 0/0a/0b/0c/1/2/3/4 と「4-line return block」「absolute last line」記述は変更なし

## test 影響確認

- `4-site-symmetry.test.sh` / `caller-html-literal-symmetry.test.sh` が line 307 の prose 文字列を grep で pin していないことを事前確認（Wiki 経験則「Wording-revision drift」予防）
- 本 PR は文言の構造変更のみで bash 引数 symmetry / caller HTML inline literal byte equality の test 対象には影響なし

## 関連

- Closes #859
- 元 PR: #858（「両 test の hub」明示を追加）
- 元 Issue: #851（create-interview.md 全体の test references を整理）

## チェックリスト

- [x] line 307 の parenthetical 構造を `**Output rules**:` 独立行スタイルに分解
- [x] 「両 test の hub」セマンティクスを新形式でも保持
- [x] 後続 Rule 0/1/2/3/4 と周辺記述（4-line return block / absolute last line）が変更なし
- [x] test pin 影響なしを pre-check
- [x] `grep -c '^\*\*Output rules\*\*:$' create-interview.md` ≥ 1
- [x] `grep -c '\*\*Output rules\*\* (' create-interview.md` = 0
