### PR TITLE
docs(create-interview): line 307 hub 概念に inline gloss を追加

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,7 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-本セクションは marker 形式の SoT であり、かつ **両 test の hub** として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する。
+本セクションは marker 形式の SoT であり、かつ **両 test の hub** (= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT) として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する。
 
 **Output rules**:
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/create-interview.md` line 307 の「両 test の hub」用語に inline gloss `(= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT)` を追加しました。

PR #858 で導入された hub 概念は本体内に用語定義がなく semantic 推測に依存していました。Issue #860 の prompt-engineer-reviewer 推奨 (LOW) に従い、line 307 内 short gloss として hub の意味を SoT 化することで、将来の編集者の解釈ぶれを防ぎます。

## 変更内容

### Before (line 307)

```
本セクションは marker 形式の SoT であり、かつ **両 test の hub** として機能する。bash 引数 symmetry は ...
```

### After (line 307)

```
本セクションは marker 形式の SoT であり、かつ **両 test の hub** (= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT) として機能する。bash 引数 symmetry は ...
```

## 設計判断

- Issue #860 の推奨案 2 案のうち **(b) line 307 内 short gloss 追加** を採用
  - (a) `references/hub-pattern.md` 新設は scope 拡大かつ参照箇所 1 か所のみのため過剰設計
  - (b) inline gloss は first-paragraph で hub の意味を即時伝達でき、PR #858 / #862 の minimal-diff doc PR pattern と整合
- 後続 prose (test references の説明) は変更なし。subsequent context での重複説明とのバランスは「TL;DR 定義 + 詳細展開」の典型構造
- bash block 側コメントの責務分離記述 (`bash block 側コメントは bash 引数 symmetry のみ ... HTML literal symmetry は本セクションを single source として参照する責務分離を維持`) も変更なし

## test 影響確認

- `4-site-symmetry.test.sh`: PASS 8/0 (修正後実行済み)
- `caller-html-literal-symmetry.test.sh`: PASS 8/0 (修正後実行済み)
- 両 test とも line 307 の prose 文字列を grep pin していないことを事前確認 (Wiki 経験則「Wording-revision drift」予防)

## 関連

- Closes #860
- 元 PR: #858 (「両 test の hub」用語導入)
- 元 Issue: #851 (Asymmetric Fix Transcription pattern follow-up)
- 兄弟 PR: #862 (line 307 parenthetical 構造分解、style 統一)

## チェックリスト

- [x] line 307 に inline gloss `(= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT)` を追加
- [x] 後続 prose (test references の説明) は変更なし
- [x] 4-site-symmetry.test.sh PASS
- [x] caller-html-literal-symmetry.test.sh PASS
- [x] test pin 影響なしを pre-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)