### PR TITLE
test(rite): #861 責務分離 invariant の machine-verifiable enforcement

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,7 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-本セクションは marker 形式の SoT であり、かつ **両 test の hub** (= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT) として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する。
+本セクションは marker 形式の SoT であり、かつ **両 test の hub** (= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT) として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する（この責務分離 invariant 自体は [`hooks/tests/create-interview-responsibility-separation.test.sh`](../../hooks/tests/create-interview-responsibility-separation.test.sh) で machine-verifiable に enforce される — bash block 内に `caller-html-literal-symmetry` reference が紛れ込んだ場合に lint failure として検出される）。
 
 **Output rules**:
 

--- a/plugins/rite/hooks/tests/create-interview-responsibility-separation.test.sh
+++ b/plugins/rite/hooks/tests/create-interview-responsibility-separation.test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# create-interview-responsibility-separation.test.sh
+#
+# Negative test guarding the responsibility separation invariant
+# declared in commands/issue/create-interview.md (Caller Return
+# Protocol section, around line 307):
+#
+#   "bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format)
+#    は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は
+#    本セクションを single source として参照する責務分離を維持する。"
+#
+# Issue #861 — machine-verifiable enforcement of the invariant declared at
+# create-interview.md line 307. Without this test, the line 307 declaration
+# could silently drift if a future commit added an HTML-literal-symmetry
+# test reference to a bash block comment, defeating the SoT structure.
+#
+# What this test verifies:
+#   1. NEGATIVE: bash fenced blocks (```bash ... ```) in create-interview.md
+#      MUST NOT contain the string `caller-html-literal-symmetry` —
+#      the HTML literal symmetry test reference belongs only in the prose
+#      Caller Return Protocol section, not in bash block comments.
+#   2. POSITIVE: prose sections (outside bash fenced blocks) MUST contain
+#      at least one reference to `caller-html-literal-symmetry` —
+#      this guards against accidental deletion of the SoT reference.
+#
+# When this test fails:
+#   The responsibility separation between bash block comments and the
+#   prose hub (line ~307) has drifted. Restore by either (a) removing
+#   the HTML-literal-symmetry reference from the bash block, or (b)
+#   restoring the missing SoT reference in the prose Caller Return
+#   Protocol section. Do NOT relax this test — the invariant exists to
+#   keep bash block comments focused on bash arg symmetry only.
+#
+# Relationship with sibling tests:
+#   - `4-site-symmetry.test.sh` guards CLI-arg PRESENCE across sites.
+#   - `caller-html-literal-symmetry.test.sh` guards byte equality of
+#     the 2 HTML literal example blocks.
+#   - This test guards the *meta-invariant* that wires the two above
+#     into a single SoT hub at line 307.
+#   The three are complementary; none subsumes the others.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+TARGET="$REPO_ROOT/plugins/rite/commands/issue/create-interview.md"
+NEEDLE="caller-html-literal-symmetry"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  ❌ $1"; }
+
+if [ ! -f "$TARGET" ]; then
+  echo "  ❌ FILE NOT FOUND: $TARGET"
+  exit 1
+fi
+
+echo "=== bash fenced block content extraction ==="
+# Extract content inside ```bash ... ``` fences (exclusive of fence lines).
+bash_block_content=$(awk '
+  /^```bash$/      { in_bash=1; next }
+  /^```$/ && in_bash { in_bash=0; next }
+  in_bash          { print }
+' "$TARGET")
+
+if [ -z "$bash_block_content" ]; then
+  fail "no bash fenced blocks found in $TARGET (file may have been restructured)"
+else
+  pass "bash fenced blocks extracted"
+fi
+
+echo
+echo "=== NEGATIVE: bash blocks must NOT reference $NEEDLE ==="
+if printf '%s\n' "$bash_block_content" | grep -qF "$NEEDLE"; then
+  fail "bash block comments contain '$NEEDLE' reference (responsibility separation drift)"
+  echo "  --- offending lines ---" >&2
+  printf '%s\n' "$bash_block_content" | grep -nF "$NEEDLE" >&2
+else
+  pass "bash blocks do not reference $NEEDLE (responsibility separation preserved)"
+fi
+
+echo
+echo "=== POSITIVE: prose sections MUST reference $NEEDLE (SoT preserved) ==="
+prose_content=$(awk '
+  /^```bash$/      { in_bash=1; next }
+  /^```$/ && in_bash { in_bash=0; next }
+  !in_bash         { print }
+' "$TARGET")
+
+if printf '%s\n' "$prose_content" | grep -qF "$NEEDLE"; then
+  pass "prose sections retain the SoT reference to $NEEDLE"
+else
+  fail "prose sections missing $NEEDLE reference (Caller Return Protocol hub broken)"
+fi
+
+echo
+echo "─── $(basename "$0") summary ──────────────────────"
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "Failed assertions:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  echo
+  echo "⚠️ Responsibility separation drift detected at create-interview.md."
+  echo "   bash block comments must not reference $NEEDLE — the HTML"
+  echo "   literal symmetry hub is the prose Caller Return Protocol"
+  echo "   section (around line 307). Restore symmetry by removing"
+  echo "   the bash-block reference or restoring the prose SoT reference."
+  exit 1
+fi
+
+echo "OK: responsibility separation invariant preserved"
+exit 0


### PR DESCRIPTION
## Summary

`commands/issue/create-interview.md` line 307 の責務分離 invariant（bash block コメントは bash 引数 symmetry のみ inline 言及、HTML literal symmetry は line 307 を SoT として参照）を machine-verifiable に enforce する negative test を追加。

これまで line 307 の責務分離宣言が drift しても bash block 側からは検出不能だったため、将来 bash block コメントが HTML literal test reference を追加した場合に line 307 の主張だけが silently 古くなる経路があった（Issue #861）。

## 変更内容

- **`plugins/rite/hooks/tests/create-interview-responsibility-separation.test.sh`** を新設
  - **Negative**: bash fenced ブロック（``` ```bash ... ``` ```）内に `caller-html-literal-symmetry` 文字列が出現しないこと
  - **Positive**: prose セクション側に `caller-html-literal-symmetry` reference が存在すること（SoT 削除防止）
- **`plugins/rite/commands/issue/create-interview.md`** line 307 に新テストへの reference を追加し、3 test (4-site-symmetry / caller-html-literal-symmetry / responsibility-separation) の hub 構造を明文化

## 関連

Closes #861
元の PR: #858
元の Issue: #851

## テスト

- 新規テスト単独: PASS (3/3 assertions)
- `bash plugins/rite/hooks/tests/run-tests.sh`: 41/41 PASS
- 既存 `4-site-symmetry.test.sh` / `caller-html-literal-symmetry.test.sh` も継続 PASS

## Test plan

- [ ] 新規テストが drift を検出することを確認（手動で bash block に caller-html-literal-symmetry 文字列を仕込んで test fail することを検証）
- [ ] line 307 の SoT 宣言が削除された場合に positive assertion が fail することを確認
