### PR TITLE
refactor(tests): _test-helpers.sh に PASS/FAIL/SCRIPT_DIR pattern を集約 (#852)

### DIFF
--- a/plugins/rite/hooks/tests/4-site-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/4-site-symmetry.test.sh
@@ -81,7 +81,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 
 SITES=(
   "plugins/rite/commands/issue/create.md"
@@ -95,22 +97,15 @@ REQUIRED_ARGS=(
   "--preserve-error-count"
 )
 
-PASS=0
-FAIL=0
-FAILED_NAMES=()
-
 assert_arg_present() {
   local site="$1" arg="$2"
   local count
   count=$(grep -cE -- "$arg" "$REPO_ROOT/$site" 2>/dev/null || true)
   count=${count:-0}
   if [ "$count" -ge 1 ]; then
-    echo "  ✅ $site: $arg (count=$count)"
-    PASS=$((PASS + 1))
+    pass "$site: $arg (count=$count)"
   else
-    echo "  ❌ $site: $arg (count=0, expected >= 1)"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$site|$arg")
+    fail "$site|$arg (count=0, expected >= 1)"
   fi
 }
 
@@ -118,32 +113,21 @@ for arg in "${REQUIRED_ARGS[@]}"; do
   echo "=== Checking: $arg present in all sites ==="
   for site in "${SITES[@]}"; do
     if [ ! -f "$REPO_ROOT/$site" ]; then
-      echo "  ❌ $site: FILE NOT FOUND"
-      FAIL=$((FAIL + 1))
-      FAILED_NAMES+=("$site|FILE_NOT_FOUND")
+      fail "$site|FILE_NOT_FOUND"
       continue
     fi
     assert_arg_present "$site" "$arg"
   done
 done
 
-echo
-echo "─── $(basename "$0") summary ──────────────────────"
-echo "PASS: $PASS"
-echo "FAIL: $FAIL"
+DRIFT_HINT='⚠️ 4-site bash literal symmetry drift detected.
+   Locate the failing (file, arg) pair above and inspect the
+   '\''DRIFT-CHECK ANCHOR (semantic, 4-site)'\'' comments in
+   commands/issue/create.md and commands/issue/create-interview.md.
+   Restore the missing --phase / --active / --next / --preserve-error-count
+   argument so the canonical bash literals stay in lockstep.'
 
-if [ "$FAIL" -ne 0 ]; then
-  echo "Failed assertions:"
-  for n in "${FAILED_NAMES[@]}"; do
-    echo "  - $n"
-  done
-  echo
-  echo "⚠️ 4-site bash literal symmetry drift detected."
-  echo "   Locate the failing (file, arg) pair above and inspect the"
-  echo "   'DRIFT-CHECK ANCHOR (semantic, 4-site)' comments in"
-  echo "   commands/issue/create.md and commands/issue/create-interview.md."
-  echo "   Restore the missing --phase / --active / --next / --preserve-error-count"
-  echo "   argument so the canonical bash literals stay in lockstep."
+if ! print_summary "$(basename "$0")" "$DRIFT_HINT"; then
   exit 1
 fi
 

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Common test helpers for plugins/rite/hooks/tests/*.test.sh (Issue #852)
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/_test-helpers.sh"
+#   REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
+#   # ...assertions using pass / fail / assert / assert_grep / assert_not_grep...
+#   if ! print_summary "$(basename "$0")" "drift hint text"; then
+#     exit 1
+#   fi
+#
+# Why this file is named `_test-helpers.sh` (no `.test.sh` suffix):
+#   `run-tests.sh` globs `*.test.sh`. A `_test-helpers.sh` filename is
+#   intentionally excluded so this helper is sourced only when callers
+#   `source` it explicitly. Each caller test still runs standalone
+#   (`bash 4-site-symmetry.test.sh`) because it defines its own SCRIPT_DIR
+#   before sourcing this file.
+#
+# Provided variables (initialized to 0 / empty array on source):
+#   PASS, FAIL, FAILED_NAMES
+#
+# Provided functions:
+#   _helpers_resolve_plugin_root <script_dir>
+#   _helpers_resolve_repo_root   <script_dir>
+#   pass <label>
+#   fail <label>
+#   assert <label> <expected> <actual>
+#   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
+#   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
+#   print_summary [test_name] [drift_hint_text]  # returns 1 if FAIL > 0
+
+# Resolve PLUGIN_ROOT from the test's SCRIPT_DIR (tests/ is 2 levels below).
+# plugins/rite/hooks/tests/<test>.sh -> plugins/rite (2 up)
+_helpers_resolve_plugin_root() {
+  local script_dir="${1:?script_dir required}"
+  (cd "$script_dir/../.." && pwd)
+}
+
+# Resolve REPO_ROOT from the test's SCRIPT_DIR (tests/ is 4 levels below repo root).
+# plugins/rite/hooks/tests/<test>.sh -> repo root (4 up)
+_helpers_resolve_repo_root() {
+  local script_dir="${1:?script_dir required}"
+  (cd "$script_dir/../../../.." && pwd)
+}
+
+# Counters — declared here so callers can rely on them existing after `source`.
+# Callers may reassign to 0 if re-running within a long-lived shell, but the
+# normal pattern (run-tests.sh forks a fresh `bash` per test) makes that unnecessary.
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ✅ $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("$1")
+  echo "  ❌ $1"
+}
+
+# Generic equality assertion.
+assert() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$label"
+  else
+    fail "$label (expected='$expected' actual='$actual')"
+  fi
+}
+
+# Pattern presence assertion (ERE via grep -E).
+assert_grep() {
+  local label="$1"
+  local file="$2"
+  local pattern="$3"
+  if grep -qE "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label (pattern not found in $file: $pattern)"
+  fi
+}
+
+# Pattern absence assertion (ERE via grep -E).
+assert_not_grep() {
+  local label="$1"
+  local file="$2"
+  local pattern="$3"
+  if grep -qE "$pattern" "$file"; then
+    fail "$label (anti-pattern found in $file: $pattern)"
+  else
+    pass "$label"
+  fi
+}
+
+# Print summary block and return non-zero when any assertion failed.
+# When FAILED_NAMES is non-empty, lists them so callers don't need to duplicate
+# the "Failed assertions:" loop in every test file.
+# drift_hint_text (optional) is echoed verbatim after the failure list — used by
+# tests like 4-site-symmetry that point readers at canonical anchor docs.
+print_summary() {
+  local test_name="${1:-summary}"
+  local drift_hint="${2:-}"
+  echo
+  echo "─── $test_name summary ──────────────────────"
+  echo "PASS: $PASS"
+  echo "FAIL: $FAIL"
+  if [ "$FAIL" -ne 0 ]; then
+    if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+      echo "Failed assertions:"
+      local n
+      for n in "${FAILED_NAMES[@]}"; do
+        echo "  - $n"
+      done
+    fi
+    if [ -n "$drift_hint" ]; then
+      echo
+      printf '%s\n' "$drift_hint"
+    fi
+    return 1
+  fi
+  return 0
+}

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -75,10 +75,15 @@ assert() {
 }
 
 # Pattern presence assertion (ERE via grep -E).
+# File-existence check distinguishes "file missing" (grep exit 2) from "pattern absent" (grep exit 1).
 assert_grep() {
   local label="$1"
   local file="$2"
   local pattern="$3"
+  if [ ! -f "$file" ]; then
+    fail "$label (file not found: $file)"
+    return
+  fi
   if grep -qE "$pattern" "$file"; then
     pass "$label"
   else
@@ -87,10 +92,15 @@ assert_grep() {
 }
 
 # Pattern absence assertion (ERE via grep -E).
+# File-existence check distinguishes "file missing" (grep exit 2) from "pattern absent" (grep exit 1).
 assert_not_grep() {
   local label="$1"
   local file="$2"
   local pattern="$3"
+  if [ ! -f "$file" ]; then
+    fail "$label (file not found: $file)"
+    return
+  fi
   if grep -qE "$pattern" "$file"; then
     fail "$label (anti-pattern found in $file: $pattern)"
   else

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -127,6 +127,25 @@ else
   outer_fail "TC-4.1: expected PASS=2 FAIL=2 got PASS=$gp FAIL=$gf"
 fi
 
+# TC-4.2 / TC-4.3: file-not-found path emits "file not found" diagnostic
+missing_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep     'missing-grep'     '/nonexistent/path/xyz' 'pattern' 2>&1
+  assert_not_grep 'missing-not-grep' '/nonexistent/path/xyz' 'pattern' 2>&1
+  echo \"FAIL=\$FAIL\"
+")
+mfail=$(echo "$missing_state" | grep '^FAIL=' | cut -d= -f2)
+if [ "$mfail" = "2" ]; then
+  outer_pass "TC-4.2: file-not-found increments FAIL for both assert_grep and assert_not_grep"
+else
+  outer_fail "TC-4.2: expected FAIL=2 got FAIL=$mfail"
+fi
+if echo "$missing_state" | grep -q 'file not found'; then
+  outer_pass "TC-4.3: file-not-found diagnostic message is emitted"
+else
+  outer_fail "TC-4.3: 'file not found' diagnostic missing in output"
+fi
+
 # === TC-5: print_summary return code ===
 echo
 echo "TC-5: print_summary return code"

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Self-test for _test-helpers.sh (Issue #852)
+#
+# Each test case runs in a subshell that re-sources _test-helpers.sh,
+# so we can observe how the helpers mutate the PASS / FAIL / FAILED_NAMES
+# counters in isolation without polluting our own outer counters.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS="$SCRIPT_DIR/_test-helpers.sh"
+
+# Outer-test counters (use plain integers to avoid colliding with helper counters
+# loaded inside subshells under test).
+OUTER_PASS=0
+OUTER_FAIL=0
+OUTER_FAILED=()
+
+outer_pass() { OUTER_PASS=$((OUTER_PASS + 1)); echo "  ✅ $1"; }
+outer_fail() { OUTER_FAIL=$((OUTER_FAIL + 1)); OUTER_FAILED+=("$1"); echo "  ❌ $1"; }
+
+if [ ! -f "$HELPERS" ]; then
+  echo "FATAL: $HELPERS not found"
+  exit 1
+fi
+
+# === TC-1: path resolvers ===
+echo "TC-1: _helpers_resolve_plugin_root / _helpers_resolve_repo_root"
+
+expected_plugin_root=$(cd "$SCRIPT_DIR/../.." && pwd)
+expected_repo_root=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+
+actual_plugin_root=$(bash -c "source '$HELPERS' && _helpers_resolve_plugin_root '$SCRIPT_DIR'")
+if [ "$actual_plugin_root" = "$expected_plugin_root" ]; then
+  outer_pass "TC-1.1: _helpers_resolve_plugin_root returns plugins/rite"
+else
+  outer_fail "TC-1.1: expected='$expected_plugin_root' actual='$actual_plugin_root'"
+fi
+
+actual_repo_root=$(bash -c "source '$HELPERS' && _helpers_resolve_repo_root '$SCRIPT_DIR'")
+if [ "$actual_repo_root" = "$expected_repo_root" ]; then
+  outer_pass "TC-1.2: _helpers_resolve_repo_root returns repo root"
+else
+  outer_fail "TC-1.2: expected='$expected_repo_root' actual='$actual_repo_root'"
+fi
+
+# === TC-2: pass / fail mutate counters ===
+echo
+echo "TC-2: pass / fail counter mutation"
+
+# capture inner PASS / FAIL / FAILED_NAMES state in subshell
+inner_state=$(bash -c "
+  source '$HELPERS'
+  pass 'sample-pass'   >/dev/null
+  pass 'sample-pass-2' >/dev/null
+  fail 'sample-fail'   >/dev/null
+  echo \"PASS=\$PASS\"
+  echo \"FAIL=\$FAIL\"
+  echo \"FAILED_COUNT=\${#FAILED_NAMES[@]}\"
+  echo \"FAILED_HEAD=\${FAILED_NAMES[0]:-}\"
+")
+
+inner_pass=$(echo "$inner_state" | grep '^PASS=' | cut -d= -f2)
+inner_fail=$(echo "$inner_state" | grep '^FAIL=' | cut -d= -f2)
+inner_failed_count=$(echo "$inner_state" | grep '^FAILED_COUNT=' | cut -d= -f2)
+inner_failed_head=$(echo "$inner_state" | grep '^FAILED_HEAD=' | cut -d= -f2)
+
+if [ "$inner_pass" = "2" ]; then
+  outer_pass "TC-2.1: pass() increments PASS to 2"
+else
+  outer_fail "TC-2.1: expected PASS=2 got PASS=$inner_pass"
+fi
+
+if [ "$inner_fail" = "1" ]; then
+  outer_pass "TC-2.2: fail() increments FAIL to 1"
+else
+  outer_fail "TC-2.2: expected FAIL=1 got FAIL=$inner_fail"
+fi
+
+if [ "$inner_failed_count" = "1" ] && [ "$inner_failed_head" = "sample-fail" ]; then
+  outer_pass "TC-2.3: fail() appends label to FAILED_NAMES"
+else
+  outer_fail "TC-2.3: expected count=1 head='sample-fail' got count=$inner_failed_count head='$inner_failed_head'"
+fi
+
+# === TC-3: assert ===
+echo
+echo "TC-3: assert (equality)"
+
+assert_state=$(bash -c "
+  source '$HELPERS'
+  assert 'eq-match'  'foo' 'foo' >/dev/null
+  assert 'eq-mismatch' 'foo' 'bar' >/dev/null
+  echo \"PASS=\$PASS\"
+  echo \"FAIL=\$FAIL\"
+")
+ap=$(echo "$assert_state" | grep '^PASS=' | cut -d= -f2)
+af=$(echo "$assert_state" | grep '^FAIL=' | cut -d= -f2)
+if [ "$ap" = "1" ] && [ "$af" = "1" ]; then
+  outer_pass "TC-3.1: assert passes on equal, fails on unequal"
+else
+  outer_fail "TC-3.1: expected PASS=1 FAIL=1 got PASS=$ap FAIL=$af"
+fi
+
+# === TC-4: assert_grep / assert_not_grep ===
+echo
+echo "TC-4: assert_grep / assert_not_grep"
+
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+printf 'hello world\nfoo bar\n' > "$tmpfile"
+
+grep_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep     'present'   '$tmpfile' 'hello'   >/dev/null
+  assert_grep     'absent'    '$tmpfile' 'missing' >/dev/null
+  assert_not_grep 'absent-ok' '$tmpfile' 'missing' >/dev/null
+  assert_not_grep 'present-bad' '$tmpfile' 'hello' >/dev/null
+  echo \"PASS=\$PASS\"
+  echo \"FAIL=\$FAIL\"
+")
+gp=$(echo "$grep_state" | grep '^PASS=' | cut -d= -f2)
+gf=$(echo "$grep_state" | grep '^FAIL=' | cut -d= -f2)
+if [ "$gp" = "2" ] && [ "$gf" = "2" ]; then
+  outer_pass "TC-4.1: assert_grep / assert_not_grep route correctly"
+else
+  outer_fail "TC-4.1: expected PASS=2 FAIL=2 got PASS=$gp FAIL=$gf"
+fi
+
+# === TC-5: print_summary return code ===
+echo
+echo "TC-5: print_summary return code"
+
+# All-pass case → exit 0
+if bash -c "source '$HELPERS'; pass 'x' >/dev/null; print_summary 'self-test' >/dev/null"; then
+  outer_pass "TC-5.1: print_summary returns 0 when FAIL=0"
+else
+  outer_fail "TC-5.1: print_summary returned non-zero on all-pass"
+fi
+
+# Any-fail case → exit 1
+if bash -c "source '$HELPERS'; fail 'x' >/dev/null; print_summary 'self-test' >/dev/null"; then
+  outer_fail "TC-5.2: print_summary returned 0 on FAIL>0 (expected non-zero)"
+else
+  outer_pass "TC-5.2: print_summary returns non-zero when FAIL>0"
+fi
+
+# === TC-6: drift hint is echoed in summary ===
+echo
+echo "TC-6: print_summary drift hint propagation"
+
+summary_output=$(bash -c "source '$HELPERS'; fail 'sample' >/dev/null; print_summary 'self-test' 'CUSTOM-DRIFT-HINT' || true")
+if echo "$summary_output" | grep -q 'CUSTOM-DRIFT-HINT'; then
+  outer_pass "TC-6.1: drift hint text appears in summary output"
+else
+  outer_fail "TC-6.1: drift hint not found in: $summary_output"
+fi
+
+# === Summary ===
+echo
+echo "─── $(basename "$0") summary ──────────────────────"
+echo "PASS: $OUTER_PASS"
+echo "FAIL: $OUTER_FAIL"
+
+if [ "$OUTER_FAIL" -ne 0 ]; then
+  echo "Failed assertions:"
+  for n in "${OUTER_FAILED[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
@@ -51,16 +51,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 
 TARGET="$REPO_ROOT/plugins/rite/commands/issue/create-interview.md"
-
-PASS=0
-FAIL=0
-FAILED_NAMES=()
-
-pass() { PASS=$((PASS + 1)); echo "  ✅ $1"; }
-fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  ❌ $1"; }
 
 if [ ! -f "$TARGET" ]; then
   echo "  ❌ FILE NOT FOUND: $TARGET"
@@ -115,23 +110,14 @@ else
   fail "no caller-comment line extracted; cannot verify required elements"
 fi
 
-echo
-echo "─── $(basename "$0") summary ──────────────────────"
-echo "PASS: $PASS"
-echo "FAIL: $FAIL"
+DRIFT_HINT='⚠️ caller HTML inline literal symmetry drift detected.
+   The 2 example output blocks in create-interview.md
+   ([interview:skipped] and [interview:completed]) must contain
+   an identical <!-- caller: ... --> line. Restore symmetry by
+   replicating the change across both example blocks.
+   Do NOT relax this test.'
 
-if [ "$FAIL" -ne 0 ]; then
-  echo "Failed assertions:"
-  for n in "${FAILED_NAMES[@]}"; do
-    echo "  - $n"
-  done
-  echo
-  echo "⚠️ caller HTML inline literal symmetry drift detected."
-  echo "   The 2 example output blocks in create-interview.md"
-  echo "   ([interview:skipped] and [interview:completed]) must contain"
-  echo "   an identical <!-- caller: ... --> line. Restore symmetry by"
-  echo "   replicating the change across both example blocks."
-  echo "   Do NOT relax this test."
+if ! print_summary "$(basename "$0")" "$DRIFT_HINT"; then
   exit 1
 fi
 

--- a/plugins/rite/hooks/tests/caller-markdown-block.test.sh
+++ b/plugins/rite/hooks/tests/caller-markdown-block.test.sh
@@ -38,50 +38,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
 COMMANDS_DIR="$PLUGIN_ROOT/commands"
-
-PASS=0
-FAIL=0
-
-assert() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "  ✅ PASS: $label"
-    PASS=$((PASS + 1))
-  else
-    echo "  ❌ FAIL: $label (expected='$expected' actual='$actual')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-assert_grep() {
-  local label="$1"
-  local file="$2"
-  local pattern="$3"
-  if grep -qE "$pattern" "$file"; then
-    echo "  ✅ PASS: $label"
-    PASS=$((PASS + 1))
-  else
-    echo "  ❌ FAIL: $label (pattern not found in $file: $pattern)"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-assert_not_grep() {
-  local label="$1"
-  local file="$2"
-  local pattern="$3"
-  if grep -qE "$pattern" "$file"; then
-    echo "  ❌ FAIL: $label (anti-pattern found in $file: $pattern)"
-    FAIL=$((FAIL + 1))
-  else
-    echo "  ✅ PASS: $label"
-    PASS=$((PASS + 1))
-  fi
-}
 
 START_MD="$COMMANDS_DIR/issue/start.md"
 IMPLEMENT_MD="$COMMANDS_DIR/issue/implement.md"
@@ -166,11 +126,9 @@ assert_2line_validation() {
   local next_line
   next_line=$(grep -A 1 "case \"\\\$${var_name}\" in\$" "$file" | grep -E "^\s*''\|\*\[!0-9\]\*\)" || true)
   if [ -n "$next_line" ]; then
-    echo "  ✅ PASS: $label"
-    PASS=$((PASS + 1))
+    pass "$label"
   else
-    echo "  ❌ FAIL: $label (case \"\$${var_name}\" in の直後行に \`''|*[!0-9]*)\` が存在しない: $file)"
-    FAIL=$((FAIL + 1))
+    fail "$label (case \"\$${var_name}\" in の直後行に \`''|*[!0-9]*)\` が存在しない: $file)"
   fi
 }
 
@@ -243,12 +201,7 @@ assert_grep "TC-6.3: start.md の implementation_round inline form が canonical
   'if val=\$\(bash \{plugin_root\}/hooks/state-read\.sh --field implementation_round.*then :; else rc=\$\?'
 
 # === Summary ===
-echo ""
-echo "=== Summary ==="
-echo "  PASS: $PASS"
-echo "  FAIL: $FAIL"
-
-if [ "$FAIL" -gt 0 ]; then
+if ! print_summary "$(basename "$0")"; then
   exit 1
 fi
 exit 0


### PR DESCRIPTION
## 概要

3 つの caller test (`4-site-symmetry.test.sh` / `caller-markdown-block.test.sh` / `caller-html-literal-symmetry.test.sh`) で繰り返されていた **SCRIPT_DIR / PLUGIN_ROOT / REPO_ROOT 解決、PASS/FAIL/FAILED_NAMES カウンタ、pass()/fail()/assert/assert_grep/assert_not_grep/print_summary** を新規 `_test-helpers.sh` に集約しました。

## 変更内容

- `plugins/rite/hooks/tests/_test-helpers.sh` を新規追加（共通ヘルパー、128 行）
  - `_helpers_resolve_plugin_root` / `_helpers_resolve_repo_root`
  - `PASS=0; FAIL=0; FAILED_NAMES=()` 初期化
  - `pass <label>` / `fail <label>`
  - `assert <label> <expected> <actual>`
  - `assert_grep <label> <file> <pattern>` / `assert_not_grep`
  - `print_summary [test_name] [drift_hint]`
- `plugins/rite/hooks/tests/_test-helpers.test.sh` を新規追加（自己テスト、172 行 / 10 PASS）
- `4-site-symmetry.test.sh` / `caller-html-literal-symmetry.test.sh` / `caller-markdown-block.test.sh` を更新
- 差し引き約 77 行削減（5 files changed, +329 / -106 だが新規 helpers + 自己テスト 300 行を除いた caller 3 ファイルだけで -77）

## 設計判断

- ファイル名 `_test-helpers.sh` は run-tests.sh の `*.test.sh` glob 対象外（ヘルパー専用）
- 各 caller test は `SCRIPT_DIR` を caller 側で定義してから `source "$SCRIPT_DIR/_test-helpers.sh"` で取り込み、**test 独立性 (run-tests.sh glob 直接実行 + 単独 `bash <test>.test.sh` 実行) の両方を維持**
- `_helpers_resolve_plugin_root` (../..) と `_helpers_resolve_repo_root` (../../../..) を分離（caller-markdown は plugin_root、4-site / caller-html は repo_root を必要とする差異を吸収）
- caller-markdown 固有の `assert_2line_validation` はローカル定義のまま維持（pass / fail 経由に統一）
- `print_summary` は drift hint テキストを第 2 引数で受け取り、4-site / caller-html の drift detection ヒントメッセージを保持

## テスト結果

```
$ bash plugins/rite/hooks/tests/run-tests.sh
Results: 42/42 passed, 0 failed
All tests passed!
```

個別実行:

| Test | 結果 |
|------|------|
| `_test-helpers.test.sh` (新規・自己テスト) | 10 PASS / 0 FAIL |
| `4-site-symmetry.test.sh` | 8 PASS / 0 FAIL |
| `caller-html-literal-symmetry.test.sh` | 8 PASS / 0 FAIL |
| `caller-markdown-block.test.sh` | 23 PASS / 0 FAIL |

## 関連 Issue

Closes #852

## チェックリスト

- [x] 3 ファイルから重複パターンを抽出して `_test-helpers.sh` に集約
- [x] `_test-helpers.test.sh` で自己テストを追加（10/10 pass）
- [x] 既存テスト全 42/42 pass
- [x] test 独立性（run-tests.sh glob + 単独 bash 実行）を維持
