### PR TITLE
chore(tests): #853 lint scripts の pass/fail/diff 出力先 convention を整理

### DIFF
--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -18,11 +18,13 @@
 #   before sourcing this file.
 #
 # Output convention (Issue #853):
-#   Scope: applies to tests that `source` this helper (e.g., 4-site-symmetry,
-#   caller-html-literal-symmetry, caller-markdown-block, _test-helpers self-test).
-#   Tests that define `pass()` / `fail()` inline (e.g.,
-#   create-interview-responsibility-separation.test.sh) are migration candidates
-#   but are NOT covered by this convention until they switch to sourcing this file.
+#   Scope: applies to tests that `source` this helper. Enumerate the current
+#   set with:
+#     grep -l 'source.*_test-helpers.sh' plugins/rite/hooks/tests/*.test.sh
+#   Tests that define `pass()` / `fail()` inline (enumerate with the inverse
+#   `grep -L 'source.*_test-helpers.sh' plugins/rite/hooks/tests/*.test.sh`)
+#   are migration candidates but are NOT covered by this convention until
+#   they switch to sourcing this file.
 #
 #   Tests sourcing this helper follow a single canonical convention so the
 #   pass/fail stream and any supporting failure detail stay together for

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -17,18 +17,45 @@
 #   (`bash 4-site-symmetry.test.sh`) because it defines its own SCRIPT_DIR
 #   before sourcing this file.
 #
+# Output convention (Issue #853):
+#   Tests sourcing this helper follow a single canonical convention so the
+#   pass/fail stream and any supporting failure detail stay together for
+#   readers and downstream tooling.
+#
+#   stdout (canonical for test-result stream):
+#     - pass / fail / assert / assert_grep / assert_not_grep markers
+#     - print_summary block (PASS/FAIL counts, Failed assertions list,
+#       optional drift_hint_text)
+#     - test phase headers (e.g., `echo "=== ... ==="`)
+#     - failure detail context (expected/actual diffs, "--- block ---"
+#       dumps that immediately follow a fail() line). Keep these on
+#       stdout so the failure marker and its diff render in the same
+#       stream — splitting them across stdout/stderr makes the diff
+#       hard to correlate when callers redirect only one stream.
+#
+#   stderr (>&2 — reserved for environment errors only):
+#     - Hard preconditions that prevent the test from running
+#       (missing executable, mktemp/jq failure, malformed config).
+#       These are NOT test failures; they are infrastructure problems
+#       that callers may want to handle separately from PASS/FAIL.
+#
+#   `run-tests.sh` does not split stdout/stderr (each test inherits the
+#   parent shell's streams), so this convention is observable rather
+#   than enforced — but downstream consumers that grep for `❌` or
+#   `PASS:` benefit from a single source stream.
+#
 # Provided variables (initialized to 0 / empty array on source):
 #   PASS, FAIL, FAILED_NAMES
 #
 # Provided functions:
 #   _helpers_resolve_plugin_root <script_dir>
 #   _helpers_resolve_repo_root   <script_dir>
-#   pass <label>
-#   fail <label>
-#   assert <label> <expected> <actual>
+#   pass <label>                                 # writes to stdout
+#   fail <label>                                 # writes to stdout
+#   assert <label> <expected> <actual>           # writes to stdout (via pass/fail)
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
-#   print_summary [test_name] [drift_hint_text]  # returns 1 if FAIL > 0
+#   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0
 
 # Resolve PLUGIN_ROOT from the test's SCRIPT_DIR (tests/ is 2 levels below).
 # plugins/rite/hooks/tests/<test>.sh -> plugins/rite (2 up)
@@ -51,11 +78,16 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
+# Pass marker — writes to stdout (see "Output convention" in the file header).
 pass() {
   PASS=$((PASS + 1))
   echo "  ✅ $1"
 }
 
+# Fail marker — writes to stdout (see "Output convention" in the file header).
+# Any failure-detail context the caller emits afterwards (expected/actual,
+# block dumps, etc.) MUST also go to stdout so it stays adjacent to this
+# marker in the result stream.
 fail() {
   FAIL=$((FAIL + 1))
   FAILED_NAMES+=("$1")
@@ -113,6 +145,7 @@ assert_not_grep() {
 # the "Failed assertions:" loop in every test file.
 # drift_hint_text (optional) is echoed verbatim after the failure list — used by
 # tests like 4-site-symmetry that point readers at canonical anchor docs.
+# Writes everything to stdout (see "Output convention" in the file header).
 print_summary() {
   local test_name="${1:-summary}"
   local drift_hint="${2:-}"

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -18,6 +18,12 @@
 #   before sourcing this file.
 #
 # Output convention (Issue #853):
+#   Scope: applies to tests that `source` this helper (e.g., 4-site-symmetry,
+#   caller-html-literal-symmetry, caller-markdown-block, _test-helpers self-test).
+#   Tests that define `pass()` / `fail()` inline (e.g.,
+#   create-interview-responsibility-separation.test.sh) are migration candidates
+#   but are NOT covered by this convention until they switch to sourcing this file.
+#
 #   Tests sourcing this helper follow a single canonical convention so the
 #   pass/fail stream and any supporting failure detail stay together for
 #   readers and downstream tooling.
@@ -39,10 +45,13 @@
 #       These are NOT test failures; they are infrastructure problems
 #       that callers may want to handle separately from PASS/FAIL.
 #
-#   `run-tests.sh` does not split stdout/stderr (each test inherits the
-#   parent shell's streams), so this convention is observable rather
-#   than enforced — but downstream consumers that grep for `❌` or
-#   `PASS:` benefit from a single source stream.
+#   The convention exists so downstream consumers (CI log parsers, grep
+#   filters scanning for `❌` / `PASS:`) can rely on a single source stream
+#   to capture the full test-result narrative without losing failure
+#   detail context. `run-tests.sh` currently inherits the parent shell's
+#   streams (no per-test split), so the rule is observable rather than
+#   enforced — if the runner grows per-stream capture in the future,
+#   tests honoring this convention will continue to work without change.
 #
 # Provided variables (initialized to 0 / empty array on source):
 #   PASS, FAIL, FAILED_NAMES

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -20,7 +20,8 @@ outer_pass() { OUTER_PASS=$((OUTER_PASS + 1)); echo "  ✅ $1"; }
 outer_fail() { OUTER_FAIL=$((OUTER_FAIL + 1)); OUTER_FAILED+=("$1"); echo "  ❌ $1"; }
 
 if [ ! -f "$HELPERS" ]; then
-  echo "FATAL: $HELPERS not found"
+  # Output convention (Issue #853): Hard precondition (missing executable) → stderr
+  echo "FATAL: $HELPERS not found" >&2
   exit 1
 fi
 

--- a/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
@@ -58,7 +58,8 @@ REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 TARGET="$REPO_ROOT/plugins/rite/commands/issue/create-interview.md"
 
 if [ ! -f "$TARGET" ]; then
-  echo "  ❌ FILE NOT FOUND: $TARGET"
+  # Output convention (Issue #853): Hard precondition (missing target file) → stderr
+  echo "  ❌ FILE NOT FOUND: $TARGET" >&2
   exit 1
 fi
 

--- a/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh
@@ -79,10 +79,13 @@ if [ "${#caller_lines[@]}" -ge 2 ]; then
     pass "caller HTML inline literals are byte-identical across the 2 example blocks"
   else
     fail "caller HTML inline literals diverge between [interview:skipped] and [interview:completed] example blocks"
-    echo "  --- skipped block caller literal ---" >&2
-    echo "    ${caller_lines[0]}" >&2
-    echo "  --- completed block caller literal ---" >&2
-    echo "    ${caller_lines[1]}" >&2
+    # Output convention (Issue #853): failure detail context stays on stdout so it
+    # appears adjacent to the fail() marker above in a single result stream.
+    # See _test-helpers.sh "Output convention" section.
+    echo "  --- skipped block caller literal ---"
+    echo "    ${caller_lines[0]}"
+    echo "  --- completed block caller literal ---"
+    echo "    ${caller_lines[1]}"
   fi
 else
   fail "fewer than 2 caller-comment lines extracted; cannot compare"


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/` 配下の helper を使う lint test 群で、`pass()` / `fail()` / `print_summary()` は stdout に出力する一方、`caller-html-literal-symmetry.test.sh` の failure diff context だけが stderr (`>&2`) に分散していた convention 不統一を整理する。

run-tests.sh は両ストリームを capture するため動作上の実害はないが、convention が文書化されていないと将来 test 群を拡張する際の混乱の元になる。Issue #853 で起票された scope 外推奨事項への対応。

## 変更内容

### `plugins/rite/hooks/tests/_test-helpers.sh`
- ヘッダーコメントに「Output convention」セクションを新設し、stdout (test-result stream) と stderr (環境エラー専用) の canonical を明文化
- `pass()` / `fail()` / `print_summary()` の前に「writes to stdout」コメントを追加
- `fail()` の docstring に「failure-detail context は同じ stream に出力すること」を明記

### `plugins/rite/hooks/tests/caller-html-literal-symmetry.test.sh`
- line 82-85 の failure diff context (`>&2`) を削除して stdout に統一
- 統一根拠を示すコメント (`Output convention (Issue #853)`) を追加

## 動作確認

helper 使用 4 テストを実行し、いずれも全 pass:

| テスト | PASS | FAIL |
|--------|------|------|
| `caller-html-literal-symmetry.test.sh` | 8 | 0 |
| `4-site-symmetry.test.sh` | 8 | 0 |
| `caller-markdown-block.test.sh` | 23 | 0 |
| `_test-helpers.test.sh` | 12 | 0 |

## 関連 Issue

Closes #853

## 関連

- 元 PR: #850 (4-site-symmetry test SCOPE caller HTML literal 拡張)
- 元 Issue: #832

## チェックリスト

- [x] `_test-helpers.sh` ヘッダーに canonical output convention を文書化
- [x] `pass()` / `fail()` / `print_summary()` の前に「writes to stdout」を明記
- [x] `caller-html-literal-symmetry.test.sh` の `>&2` を stdout に統一
- [x] helper 使用 4 テストが全 pass
