### PR TITLE
docs(issue): #854 create-interview.md line 307 SoT 行を bullet list 化

### DIFF
--- a/plugins/rite/commands/issue/create-interview.md
+++ b/plugins/rite/commands/issue/create-interview.md
@@ -304,7 +304,13 @@ Sub-skill 完了 (interview finished or skipped) 時、control は **MUST** call
 
 **WARNING**: **GitHub Issue は未作成**。本セクションで停止すると deliverable なしで workflow 放棄。
 
-本セクションは marker 形式の SoT であり、かつ **両 test の hub** (= bash 引数 symmetry / HTML literal byte equality 両 test の参照 SoT) として機能する。bash 引数 symmetry は [`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh) で test 担保、`[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal の byte equality は [`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh) で test 担保する。bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) は bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を維持する（この責務分離 invariant 自体は [`hooks/tests/create-interview-responsibility-separation.test.sh`](../../hooks/tests/create-interview-responsibility-separation.test.sh) で machine-verifiable に enforce される — bash block 内に `caller-html-literal-symmetry` reference が紛れ込んだ場合に lint failure として検出される）。
+本セクションは marker 形式の SoT であり、かつ **複数 test の参照 hub** として機能する。本セクションが変更された場合、以下の test が drift detection として連動する:
+
+- **bash 引数 symmetry** ([`hooks/tests/4-site-symmetry.test.sh`](../../hooks/tests/4-site-symmetry.test.sh)): bash block 側コメント (🚨 MANDATORY Pre-flight / Return Output Format) で `flow-state-update.sh patch` の CLI 引数 (`--phase` / `--active` / `--next` / `--preserve-error-count`) の presence を 4 site 横断で pin する。
+- **caller HTML inline literal byte equality** ([`hooks/tests/caller-html-literal-symmetry.test.sh`](../../hooks/tests/caller-html-literal-symmetry.test.sh)): `[interview:skipped]` / `[interview:completed]` 2 example block 間の caller HTML inline literal が byte equal であることを担保する。
+- **責務分離 invariant** ([`hooks/tests/create-interview-responsibility-separation.test.sh`](../../hooks/tests/create-interview-responsibility-separation.test.sh)): bash block 側コメントは bash 引数 symmetry のみを inline 言及し、HTML literal symmetry は本セクションを single source として参照する責務分離を machine-verifiable に enforce する (bash block 内に `caller-html-literal-symmetry` reference が紛れ込んだ場合に lint failure として検出される)。
+
+> **Bullet list 化基準** (将来の symmetry / invariant test 追加時): 本 SoT 行が参照する test が **3 件以上** になった時点で、可読性のため inline 連結ではなく bullet list 形式で列挙する (本 list がその移行例)。test 追加時は (a) 本 bullet list に該当 test を追加し、(b) 当該 test ファイル冒頭コメントから本 SoT 行への back-reference を維持すること。**判断基準の根拠**: inline 連結は 2 test 程度までは許容されるが、3 test 以上になると 1 段落が約 280 字を超え、各 test の責務境界が読み取りづらくなるため (Issue #854)。
 
 **Output rules**:
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/create-interview.md` line 307 の SoT 行を bullet list 化し、bullet list 化の判断基準を inline blockquote として明記しました。

これまで 3 つの test 参照 (`4-site-symmetry` / `caller-html-literal-symmetry` / `responsibility-separation`) が約 280 字の単一段落に inline 連結されており、各 test の責務境界が読み取りづらい状態でした。3 つの bullet 項目に分解し、各 test の役割を 1 行で説明できる構造に整えています。

## 関連 Issue

Closes #854

## 変更内容

- `plugins/rite/commands/issue/create-interview.md`
  - line 307 を 3 項目 bullet list (bash 引数 symmetry / caller HTML inline literal byte equality / 責務分離 invariant) に展開
  - bullet list 化基準を blockquote callout として追加: 「test 参照が 3 件以上になった時点で inline 連結ではなく bullet 形式で列挙する」
  - 判断基準の根拠 (約 280 字 / 責務境界の可読性) を併記

## 検証

bullet 化後も責務分離 test の POSITIVE check (prose 内に `caller-html-literal-symmetry` reference が残ること) は維持されることを 3 test の手元実行で確認:

| Test | 結果 |
|------|------|
| `hooks/tests/4-site-symmetry.test.sh` | PASS (8/8) |
| `hooks/tests/caller-html-literal-symmetry.test.sh` | PASS (8/8) |
| `hooks/tests/create-interview-responsibility-separation.test.sh` | PASS (3/3) |

## 経緯

PR #850 のレビューで検出されたスコープ外推奨事項として #854 で起票。元の Issue 本文は 2 test 想定だが、PR #850 で 3 つ目の test (`responsibility-separation`) 参照が parenthetical で追加されており、現時点で 3 test に到達済みのため事前 bullet list 化を採用しました。
