### PR TITLE
refactor(rite): pr/references/archive-procedures.md から charter 違反引用 4 件を削除

### DIFF
--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -17,7 +17,7 @@ github:
 
 ### 3.2 Update Status via Shared Script
 
-> **Source of truth**: This phase delegates to `plugins/rite/scripts/projects-status-update.sh` — the same shared script used by `commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2 (Issue #496 / PR #531). Direct inline `gh api graphql` + `gh project field-list` + `gh project item-edit` calls have been removed because LLM attention loss / partial-failure paths through the 3-stage inline pipeline produced silent skips that left Issue Status stuck at the previous value (Issue #658 — observed on #593 stuck at "In Review" and #652 stuck at "In Progress").
+> **Source of truth**: This phase delegates to `plugins/rite/scripts/projects-status-update.sh` — the same shared script used by `commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2. Direct inline `gh api graphql` + `gh project field-list` + `gh project item-edit` calls have been removed because LLM attention loss / partial-failure paths through the 3-stage inline pipeline produced silent skips that left Issue Status stuck at the previous value.
 
 Skip Phase 3.2 if `github.projects.enabled: false` in `rite-config.yml` or if no related Issue was identified in `cleanup.md` Phase 1.5, and proceed to Phase 3.5 (work memory update). Otherwise, invoke the shared script to transition the Issue Status to **Done**:
 
@@ -99,7 +99,7 @@ If a work memory comment exists on the Issue, automatically append a completion 
 
 ```bash
 # ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること（クロスプロセス変数参照を防止）
-# comment_data の取得・追記内容の heredoc 定義・PATCH を分割すると変数が失われる（Issue #693）
+# comment_data の取得・追記内容の heredoc 定義・PATCH を分割すると変数が失われる
 comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
   --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
 comment_id=$(echo "$comment_data" | jq -r '.id // empty')
@@ -142,7 +142,7 @@ NEW_SECTION_EOF
 fi
 ```
 
-**Note for Claude**: ⚠️ このブロック全体を**1つの Bash ツール呼び出し**で実行すること。`current_body` 取得・追記内容の heredoc 定義・PATCH を別の Bash ツール呼び出しに分割すると、前の呼び出しのシェル変数（`current_body` 等）が失われてヘッダーが消失する（Issue #693）。`{3.5.2の内容を実際の値で置換して記述}` を 3.5.2 のテンプレートから生成した実際の追記内容で置換し、**すべてを1ブロックで**実行する。
+**Note for Claude**: ⚠️ このブロック全体を**1つの Bash ツール呼び出し**で実行すること。`current_body` 取得・追記内容の heredoc 定義・PATCH を別の Bash ツール呼び出しに分割すると、前の呼び出しのシェル変数（`current_body` 等）が失われてヘッダーが消失する。`{3.5.2の内容を実際の値で置換して記述}` を 3.5.2 のテンプレートから生成した実際の追記内容で置換し、**すべてを1ブロックで**実行する。
 
 #### 3.5.2 Update Content
 
@@ -424,7 +424,7 @@ If all child Issues are complete, auto-close the parent Issue without user confi
 
 ##### 3.7.2.1 Update Parent Issue's Projects Status to "Done"
 
-Skip this substep if `github.projects.enabled: false` in `rite-config.yml` and proceed to 3.7.2.2 (close processing). Otherwise, invoke the shared script to transition the parent Issue Status to **Done** (same delegate pattern as Phase 3.2 — see Issue #658 for rationale):
+Skip this substep if `github.projects.enabled: false` in `rite-config.yml` and proceed to 3.7.2.2 (close processing). Otherwise, invoke the shared script to transition the parent Issue Status to **Done** (same delegate pattern as Phase 3.2):
 
 ```bash
 bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \


### PR DESCRIPTION
## 概要

simplification-charter.md で禁止されている `Issue #[0-9]+` の本文引用パターンを `plugins/rite/commands/pr/references/archive-procedures.md` から削除する。L20 の SoT 説明段落 / L102 の bash heredoc 内コメント / L145 の Note for Claude / L427 の rationale 引用の 4 箇所を一般化し、reasoning prose は維持する。

親 Issue #843 Phase 0a の sibling (#869 / #870 / #871 / #872 / #874 に続く 6 件目)。

## 関連 Issue

Closes #875

## 変更ファイル

- `plugins/rite/commands/pr/references/archive-procedures.md` - 変更 (+4/-4)

## AC 検証結果

| AC | 検証内容 | 結果 |
|----|---------|------|
| AC-1 | `grep -E "cycle [0-9]+\|verified-review cycle" archive-procedures.md` が 0 件 | ✅ pass |
| AC-2 | `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` が pass | ✅ pass (PASS=8 / FAIL=0) |
| AC-3 | bash literal 内 runtime 必須引用の保持 | ✅ pass (Issue #N 本文引用 0 件、bash literal の意味論を維持) |

## 未完了の Issue チェック項目

以下のチェック項目が Issue 本文で未完了です:

- [ ] PR が develop にマージされる
- [ ] 親 Issue #843 の Sub-Issues tasklist で本 Issue が check 済みになる

これらの項目は本 PR マージおよび後続の cleanup 処理で自動達成されます。

## Test plan

- [x] grep ベースで charter 禁止 3 種 regex (`cycle [0-9]+` / `verified-review cycle` / `Issue #[0-9]+ で.*対応`) が 0 件であることを確認
- [x] `4-site-symmetry.test.sh` を手動実行し pass を確認
- [x] bash literal 内の runtime 必須コメントを誤削除していないことを目視レビュー
- [x] 削除後も文意が通ることを確認 (reasoning prose を保持し review-history journal のみ除去)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
