### PR TITLE
feat(rite): commit-msg charter-lint case arm を pre-tool-bash-guard.sh に追加

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -424,82 +424,129 @@ fi
 # Exclusions:
 #   (a) commits whose staged files are ALL under docs/designs/
 #   (b) message ranges enclosed by triple-backtick Markdown fences
-# Independent of $BLOCKED_PATTERN: charter-lint emits its own JSON deny on BLOCK
-# rather than feeding into the result section below.
-charter_check=0
-case "$COMMAND" in
-  *"git commit"*) charter_check=1 ;;
-esac
+#       (only when fence pairs are balanced — odd fence count disables exclusion)
+# Independent of $BLOCKED_PATTERN: when set by Pattern 1-5 (gh-pr-diff / jq != null /
+# create-lifecycle / reviewer subagent state-mutating git), Pattern 6 is skipped so the
+# more specific block reason takes precedence.
+#
+# Known limitations (acknowledged false negatives):
+#   - HEREDOC subshell form (`-m "$(cat <<EOF ... EOF)"`) is not parsed; the regex captures
+#     up to the first `"` of `$(cat <<EOF`, leaving the body unchecked. Project canonical
+#     commit patterns that use this form bypass the lint.
+#   - `--message=...` long-form, `--file=...` long-form, multiple `-m` flags
+#     (`-m title -m body`), and editor mode (no `-m`/`-F`) are not parsed.
+# Pattern matching is heredoc-aware via the heredoc-stripped $CMD_CHECK at line ~70.
+if [ -z "$BLOCKED_PATTERN" ]; then
+  CHARTER_CHECK=0
+  # Detect `git commit` with word boundaries (Pattern 4/5 normalization style):
+  # normalize shell meta-chars + whitespace to single space, then match space-padded
+  # `git commit ` to avoid false positives on `git commit-tree`, `echo "git commit"`,
+  # function definitions, and comment lines.
+  CHARTER_NORM="${COMMAND//$'\t'/ }"
+  CHARTER_NORM="${CHARTER_NORM//$'\n'/ }"
+  CHARTER_NORM="${CHARTER_NORM//$'\r'/ }"
+  CHARTER_NORM="${CHARTER_NORM//;/ }"
+  CHARTER_NORM="${CHARTER_NORM//&/ }"
+  CHARTER_NORM="${CHARTER_NORM//|/ }"
+  CHARTER_NORM="${CHARTER_NORM//(/ }"
+  CHARTER_NORM="${CHARTER_NORM//)/ }"
+  CHARTER_NORM="${CHARTER_NORM//\{/ }"
+  CHARTER_NORM="${CHARTER_NORM//\}/ }"
+  CHARTER_NORM="${CHARTER_NORM//\`/ }"
+  CHARTER_NORM="${CHARTER_NORM//\$/ }"
+  while [[ "$CHARTER_NORM" == *"  "* ]]; do
+    CHARTER_NORM="${CHARTER_NORM//  / }"
+  done
+  CHARTER_PADDED=" $CHARTER_NORM "
+  case "$CHARTER_PADDED" in
+    *" git commit "*) CHARTER_CHECK=1 ;;
+  esac
 
-CHARTER_MSG=""
-if [ "$charter_check" = "1" ]; then
-  if [[ "$COMMAND" =~ -m[[:space:]]+\"([^\"]*)\" ]]; then
-    CHARTER_MSG="${BASH_REMATCH[1]}"
-  elif [[ "$COMMAND" =~ -m[[:space:]]+\'([^\']*)\' ]]; then
-    CHARTER_MSG="${BASH_REMATCH[1]}"
-  elif [[ "$COMMAND" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
-    CHARTER_FILE="${BASH_REMATCH[1]}"
-    if [ -f "$CHARTER_FILE" ] && [ -r "$CHARTER_FILE" ]; then
-      CHARTER_MSG=$(cat "$CHARTER_FILE" 2>/dev/null) || CHARTER_MSG=""
+  CHARTER_MSG=""
+  if [ "$CHARTER_CHECK" = "1" ]; then
+    if [[ "$COMMAND" =~ -m[[:space:]]+\"([^\"]*)\" ]]; then
+      CHARTER_MSG="${BASH_REMATCH[1]}"
+    elif [[ "$COMMAND" =~ -m[[:space:]]+\'([^\']*)\' ]]; then
+      CHARTER_MSG="${BASH_REMATCH[1]}"
+    elif [[ "$COMMAND" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
+      CHARTER_FILE="${BASH_REMATCH[1]}"
+      if [ -f "$CHARTER_FILE" ] && [ -r "$CHARTER_FILE" ]; then
+        CHARTER_MSG=$(cat "$CHARTER_FILE" 2>/dev/null) || CHARTER_MSG=""
+      else
+        echo "[charter-lint] WARN: -F file path unresolvable: $CHARTER_FILE (charter check skipped)" >&2
+        CHARTER_CHECK=0
+      fi
     else
-      echo "[charter-lint] WARN: -F file path unresolvable: $CHARTER_FILE (charter check skipped)" >&2
-      charter_check=0
+      CHARTER_CHECK=0
     fi
-  else
-    charter_check=0
   fi
-fi
 
-if [ "$charter_check" = "1" ] && [ -n "$CHARTER_MSG" ]; then
-  STAGED_FILES=$(git diff --cached --name-only 2>/dev/null) || STAGED_FILES=""
-  if [ -n "$STAGED_FILES" ]; then
-    all_designs=1
-    while IFS= read -r f; do
-      [ -z "$f" ] && continue
-      case "$f" in
-        docs/designs/*) ;;
-        *) all_designs=0; break ;;
+  if [ "$CHARTER_CHECK" = "1" ] && [ -n "$CHARTER_MSG" ]; then
+    STAGED_FILES=$(git diff --cached --name-only 2>/dev/null) || STAGED_FILES=""
+    if [ -n "$STAGED_FILES" ]; then
+      ALL_DESIGNS=1
+      while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        case "$f" in
+          docs/designs/*) ;;
+          *) ALL_DESIGNS=0; break ;;
+        esac
+      done <<< "$STAGED_FILES"
+      if [ "$ALL_DESIGNS" = "1" ]; then
+        CHARTER_CHECK=0
+      fi
+    fi
+  fi
+
+  if [ "$CHARTER_CHECK" = "1" ] && [ -n "$CHARTER_MSG" ]; then
+    # Code block exclusion is only safe when fence pairs are balanced. An unclosed
+    # fence (odd fence count) would make the awk toggle consume everything after the
+    # opening fence and silently drop a real charter pattern. Count fences first; if
+    # odd, fall back to the raw message.
+    CHARTER_FENCE_COUNT=$(grep -c '^[[:space:]]*```' <<< "$CHARTER_MSG" 2>/dev/null) || CHARTER_FENCE_COUNT=0
+    if [ $((CHARTER_FENCE_COUNT % 2)) -eq 0 ]; then
+      CHARTER_MSG_STRIPPED=$(awk '
+        BEGIN { in_block = 0 }
+        /^[[:space:]]*```/ { in_block = !in_block; next }
+        !in_block { print }
+      ' <<< "$CHARTER_MSG") || CHARTER_MSG_STRIPPED="$CHARTER_MSG"
+    else
+      CHARTER_MSG_STRIPPED="$CHARTER_MSG"
+    fi
+
+    CHARTER_HIT=""
+    if [[ "$CHARTER_MSG_STRIPPED" =~ verified-review[[:space:]]+cycle ]]; then
+      CHARTER_HIT="verified-review cycle"
+    elif [[ "$CHARTER_MSG_STRIPPED" =~ cycle[[:space:]]+[0-9]+ ]]; then
+      CHARTER_HIT="cycle [0-9]+"
+    elif [[ "$CHARTER_MSG_STRIPPED" =~ Issue[[:space:]]+#[0-9]+[[:space:]]+で.*対応 ]]; then
+      CHARTER_HIT="Issue #[0-9]+ で.*対応"
+    fi
+
+    if [ -n "$CHARTER_HIT" ]; then
+      STRICT_MODE="${RITE_COMMIT_LINT_STRICT:-false}"
+      case "$STRICT_MODE" in
+        true|yes|1|TRUE|YES) STRICT_MODE="true" ;;
+        *) STRICT_MODE="false" ;;
       esac
-    done <<< "$STAGED_FILES"
-    if [ "$all_designs" = "1" ]; then
-      charter_check=0
-    fi
-  fi
-fi
 
-if [ "$charter_check" = "1" ] && [ -n "$CHARTER_MSG" ]; then
-  CHARTER_MSG_STRIPPED=$(awk '
-    BEGIN { in_block = 0 }
-    /^[[:space:]]*```/ { in_block = !in_block; next }
-    !in_block { print }
-  ' <<< "$CHARTER_MSG")
-
-  CHARTER_HIT=""
-  if [[ "$CHARTER_MSG_STRIPPED" =~ verified-review[[:space:]]+cycle ]]; then
-    CHARTER_HIT="verified-review cycle"
-  elif [[ "$CHARTER_MSG_STRIPPED" =~ cycle[[:space:]]+[0-9]+ ]]; then
-    CHARTER_HIT="cycle [0-9]+"
-  elif [[ "$CHARTER_MSG_STRIPPED" =~ Issue[[:space:]]+#[0-9]+[[:space:]]+で.*対応 ]]; then
-    CHARTER_HIT="Issue #[0-9]+ で.*対応"
-  fi
-
-  if [ -n "$CHARTER_HIT" ]; then
-    STRICT_MODE="${RITE_COMMIT_LINT_STRICT:-false}"
-    case "$STRICT_MODE" in
-      true|yes|1|TRUE|YES) STRICT_MODE="true" ;;
-      *) STRICT_MODE="false" ;;
-    esac
-
-    if [ "$STRICT_MODE" = "true" ]; then
-      echo "[charter-lint] BLOCK: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
-      echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
-      jq -n --arg reason "BLOCKED (commit-msg-charter-violation): commit message contains charter-forbidden pattern: $CHARTER_HIT. Rewrite without literal cycle numbers / Issue references / verified-review cycle text. See plugins/rite/skills/rite-workflow/references/simplification-charter.md." \
-        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
-      exit 2
-    else
-      echo "[charter-lint] WARN: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
-      echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
-      echo "[charter-lint] Set RITE_COMMIT_LINT_STRICT=true to block this commit." >&2
+      if [ "$STRICT_MODE" = "true" ]; then
+        echo "[charter-lint] BLOCK: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
+        echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
+        # jq must succeed; if it fails the script's `set -e` + `trap 'exit 0' ERR` would
+        # silently downgrade the BLOCK to allow. Force fail-closed by emitting a minimal
+        # JSON deny inline and exiting 2 explicitly.
+        if ! jq -n --arg reason "BLOCKED (commit-msg-charter-violation): commit message contains charter-forbidden pattern: $CHARTER_HIT. Rewrite without literal cycle numbers / Issue references / verified-review cycle text. See plugins/rite/skills/rite-workflow/references/simplification-charter.md." \
+          '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'; then
+          echo "[charter-lint] FATAL: jq invocation failed; emitting fallback deny" >&2
+          printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED (commit-msg-charter-violation): jq unavailable; failing closed."}}\n'
+        fi
+        exit 2
+      else
+        echo "[charter-lint] WARN: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
+        echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
+        echo "[charter-lint] Set RITE_COMMIT_LINT_STRICT=true to block this commit." >&2
+      fi
     fi
   fi
 fi

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -417,6 +417,93 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   fi
 fi
 
+# Pattern 6 (charter-lint): commit message charter pattern enforcement.
+# Scope: `git commit -m "..."` / `git commit -F <file>` invocations.
+# Default: WARN to stderr (exit 0 — commit passes).
+# RITE_COMMIT_LINT_STRICT=true: BLOCK via JSON deny + exit 2.
+# Exclusions:
+#   (a) commits whose staged files are ALL under docs/designs/
+#   (b) message ranges enclosed by triple-backtick Markdown fences
+# Independent of $BLOCKED_PATTERN: charter-lint emits its own JSON deny on BLOCK
+# rather than feeding into the result section below.
+charter_check=0
+case "$COMMAND" in
+  *"git commit"*) charter_check=1 ;;
+esac
+
+CHARTER_MSG=""
+if [ "$charter_check" = "1" ]; then
+  if [[ "$COMMAND" =~ -m[[:space:]]+\"([^\"]*)\" ]]; then
+    CHARTER_MSG="${BASH_REMATCH[1]}"
+  elif [[ "$COMMAND" =~ -m[[:space:]]+\'([^\']*)\' ]]; then
+    CHARTER_MSG="${BASH_REMATCH[1]}"
+  elif [[ "$COMMAND" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
+    CHARTER_FILE="${BASH_REMATCH[1]}"
+    if [ -f "$CHARTER_FILE" ] && [ -r "$CHARTER_FILE" ]; then
+      CHARTER_MSG=$(cat "$CHARTER_FILE" 2>/dev/null) || CHARTER_MSG=""
+    else
+      echo "[charter-lint] WARN: -F file path unresolvable: $CHARTER_FILE (charter check skipped)" >&2
+      charter_check=0
+    fi
+  else
+    charter_check=0
+  fi
+fi
+
+if [ "$charter_check" = "1" ] && [ -n "$CHARTER_MSG" ]; then
+  STAGED_FILES=$(git diff --cached --name-only 2>/dev/null) || STAGED_FILES=""
+  if [ -n "$STAGED_FILES" ]; then
+    all_designs=1
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      case "$f" in
+        docs/designs/*) ;;
+        *) all_designs=0; break ;;
+      esac
+    done <<< "$STAGED_FILES"
+    if [ "$all_designs" = "1" ]; then
+      charter_check=0
+    fi
+  fi
+fi
+
+if [ "$charter_check" = "1" ] && [ -n "$CHARTER_MSG" ]; then
+  CHARTER_MSG_STRIPPED=$(awk '
+    BEGIN { in_block = 0 }
+    /^[[:space:]]*```/ { in_block = !in_block; next }
+    !in_block { print }
+  ' <<< "$CHARTER_MSG")
+
+  CHARTER_HIT=""
+  if [[ "$CHARTER_MSG_STRIPPED" =~ verified-review[[:space:]]+cycle ]]; then
+    CHARTER_HIT="verified-review cycle"
+  elif [[ "$CHARTER_MSG_STRIPPED" =~ cycle[[:space:]]+[0-9]+ ]]; then
+    CHARTER_HIT="cycle [0-9]+"
+  elif [[ "$CHARTER_MSG_STRIPPED" =~ Issue[[:space:]]+#[0-9]+[[:space:]]+で.*対応 ]]; then
+    CHARTER_HIT="Issue #[0-9]+ で.*対応"
+  fi
+
+  if [ -n "$CHARTER_HIT" ]; then
+    STRICT_MODE="${RITE_COMMIT_LINT_STRICT:-false}"
+    case "$STRICT_MODE" in
+      true|yes|1|TRUE|YES) STRICT_MODE="true" ;;
+      *) STRICT_MODE="false" ;;
+    esac
+
+    if [ "$STRICT_MODE" = "true" ]; then
+      echo "[charter-lint] BLOCK: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
+      echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
+      jq -n --arg reason "BLOCKED (commit-msg-charter-violation): commit message contains charter-forbidden pattern: $CHARTER_HIT. Rewrite without literal cycle numbers / Issue references / verified-review cycle text. See plugins/rite/skills/rite-workflow/references/simplification-charter.md." \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+      exit 2
+    else
+      echo "[charter-lint] WARN: commit message contains charter-forbidden pattern: $CHARTER_HIT" >&2
+      echo "[charter-lint] See: plugins/rite/skills/rite-workflow/references/simplification-charter.md" >&2
+      echo "[charter-lint] Set RITE_COMMIT_LINT_STRICT=true to block this commit." >&2
+    fi
+  fi
+fi
+
 # --- Result ---
 
 if [ -z "$BLOCKED_PATTERN" ]; then

--- a/plugins/rite/hooks/tests/commit-msg-lint.test.sh
+++ b/plugins/rite/hooks/tests/commit-msg-lint.test.sh
@@ -29,21 +29,31 @@ fi
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
 
-# Setup a fresh temporary git repo with one staged file. Cleans previous one.
+# Setup a fresh temporary git repo with one or more staged files.
+# Each argument is a relative path to stage. Defaults to a single src/foo.txt.
+# Cleans previous TEST_REPO before creating a new one.
 setup_git_repo() {
-  local staged_path="${1:-src/foo.txt}"
   if [ -n "$TEST_REPO" ] && [ -d "$TEST_REPO" ]; then
     rm -rf "$TEST_REPO"
   fi
   TEST_REPO=$(mktemp -d)
+  local paths
+  if [ "$#" -eq 0 ]; then
+    paths=("src/foo.txt")
+  else
+    paths=("$@")
+  fi
   (
     cd "$TEST_REPO"
     git init -q
     git config user.email "test@example.com"
     git config user.name "Test"
-    mkdir -p "$(dirname "$staged_path")"
-    echo "content" > "$staged_path"
-    git add "$staged_path"
+    local p
+    for p in "${paths[@]}"; do
+      mkdir -p "$(dirname "$p")"
+      echo "content" > "$p"
+      git add "$p"
+    done
   )
 }
 
@@ -192,6 +202,61 @@ if [ "$rc" -ne 0 ] \
   pass "-F file BLOCK in STRICT mode"
 else
   fail "Expected exit !=0 + BLOCK, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-07: mixed staging (docs/designs/* + src/*) + STRICT + pattern → BLOCK
+# (boundary case: NOT all-designs, so exclusion does NOT apply)
+# --------------------------------------------------------------------------
+echo "T-07: mixed (docs/designs/* + src/*) + STRICT + pattern → BLOCK (no exclusion)"
+setup_git_repo "docs/designs/example.md" "src/foo.txt"
+rc=0
+output=$(run_guard "git commit -m \"refactor: cycle 5 mixed change\"" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" -ne 0 ] \
+   && [ "$decision" = "deny" ] \
+   && [[ "$stderr_log" == *"[charter-lint] BLOCK:"* ]]; then
+  pass "mixed staging: exclusion does NOT apply, BLOCK fires"
+else
+  fail "Expected exit !=0 + BLOCK (mixed exclusion not applied), got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-08: pattern outside fenced code block + STRICT → BLOCK
+# (symmetric counterpart to T-04: fence inside should NOT mask outside hits)
+# --------------------------------------------------------------------------
+echo "T-08: fence inside + pattern outside fence + STRICT → BLOCK"
+setup_git_repo
+fenced_msg2=$'fix: cycle 99 outside\n\n```\nverified-review cycle 3\n```\n'
+rc=0
+output=$(run_guard "git commit -m \"$fenced_msg2\"" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" -ne 0 ] \
+   && [ "$decision" = "deny" ] \
+   && [[ "$stderr_log" == *"[charter-lint] BLOCK:"* ]] \
+   && [[ "$stderr_log" == *"cycle [0-9]+"* ]]; then
+  pass "fence-outside pattern detected (cycle [0-9]+ pattern)"
+else
+  fail "Expected exit !=0 + BLOCK + cycle [0-9]+ in stderr, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-09: empty -m "" message → no-op (charter check skips empty body)
+# --------------------------------------------------------------------------
+echo "T-09: empty -m \"\" message → no charter check (no warn/block)"
+setup_git_repo
+rc=0
+output=$(run_guard "git commit -m \"\"") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+if [ "$rc" = "0" ] && [[ "$stderr_log" != *"[charter-lint]"* ]]; then
+  pass "empty message: no charter-lint output"
+else
+  fail "Expected clean pass, got rc=$rc stderr=$stderr_log"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/commit-msg-lint.test.sh
+++ b/plugins/rite/hooks/tests/commit-msg-lint.test.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Tests for charter-lint commit-msg detection in pre-tool-bash-guard.sh
+# Test fixtures intentionally contain charter-forbidden patterns as
+# regex/metavariable input — these are excluded from charter §禁止パターン
+# scope (test inputs, not document statements).
+# Usage: bash plugins/rite/hooks/tests/commit-msg-lint.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../pre-tool-bash-guard.sh"
+PASS=0
+FAIL=0
+STDERR_FILE=$(mktemp)
+TEST_REPO=""
+
+cleanup() {
+  rm -f "$STDERR_FILE"
+  if [ -n "$TEST_REPO" ] && [ -d "$TEST_REPO" ]; then
+    rm -rf "$TEST_REPO"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# Setup a fresh temporary git repo with one staged file. Cleans previous one.
+setup_git_repo() {
+  local staged_path="${1:-src/foo.txt}"
+  if [ -n "$TEST_REPO" ] && [ -d "$TEST_REPO" ]; then
+    rm -rf "$TEST_REPO"
+  fi
+  TEST_REPO=$(mktemp -d)
+  (
+    cd "$TEST_REPO"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    mkdir -p "$(dirname "$staged_path")"
+    echo "content" > "$staged_path"
+    git add "$staged_path"
+  )
+}
+
+# Run the hook with the given command. Optional second arg "true" enables
+# RITE_COMMIT_LINT_STRICT. Hook is invoked from within $TEST_REPO so
+# `git diff --cached` reflects the staged file.
+run_guard() {
+  local cmd="$1"
+  local strict="${2:-}"
+  local rc=0
+  local output
+  if [ "$strict" = "true" ]; then
+    output=$(cd "$TEST_REPO" && jq -n --arg cmd "$cmd" --arg cwd "$TEST_REPO" \
+      '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}' \
+      | RITE_COMMIT_LINT_STRICT=true bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  else
+    output=$(cd "$TEST_REPO" && jq -n --arg cmd "$cmd" --arg cwd "$TEST_REPO" \
+      '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}' \
+      | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  fi
+  echo "$output"
+  return $rc
+}
+
+# Safe extraction of permissionDecision: empty string when stdout is not JSON.
+get_decision() {
+  local output="$1"
+  if [ -z "$output" ]; then
+    echo ""
+    return
+  fi
+  if echo "$output" | jq empty 2>/dev/null; then
+    echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null
+  else
+    echo ""
+  fi
+}
+
+echo "=== commit-msg-lint.test.sh ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# T-01: charter pattern in -m + STRICT unset → WARN (exit 0, stderr only)
+# --------------------------------------------------------------------------
+echo "T-01: charter pattern + RITE_COMMIT_LINT_STRICT unset → WARN (exit 0)"
+setup_git_repo
+rc=0
+output=$(run_guard "git commit -m \"fix: handle cycle 3 retry path\"") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" = "0" ] \
+   && [ "$decision" != "deny" ] \
+   && [[ "$stderr_log" == *"[charter-lint] WARN:"* ]] \
+   && [[ "$stderr_log" != *"[charter-lint] BLOCK:"* ]]; then
+  pass "WARN emitted, exit 0, no JSON deny"
+else
+  fail "Expected exit 0 + WARN, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-02: charter pattern + STRICT=true → BLOCK (exit non-zero, JSON deny)
+# --------------------------------------------------------------------------
+echo "T-02: charter pattern + RITE_COMMIT_LINT_STRICT=true → BLOCK (exit non-zero)"
+setup_git_repo
+rc=0
+output=$(run_guard "git commit -m \"refactor: cycle 5 cleanup\"" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" -ne 0 ] \
+   && [ "$decision" = "deny" ] \
+   && [[ "$stderr_log" == *"[charter-lint] BLOCK:"* ]]; then
+  pass "BLOCK emitted, exit non-zero, JSON deny"
+else
+  fail "Expected exit !=0 + BLOCK + deny, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-03: docs/designs/* only commit + STRICT + pattern → exclusion (no warn/block)
+# --------------------------------------------------------------------------
+echo "T-03: docs/designs/* only + STRICT + pattern → exclusion"
+setup_git_repo "docs/designs/example.md"
+rc=0
+output=$(run_guard "git commit -m \"docs: cycle 1 example for design notes\"" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" = "0" ] \
+   && [ "$decision" != "deny" ] \
+   && [[ "$stderr_log" != *"[charter-lint]"* ]]; then
+  pass "docs/designs/ exclusion: no charter-lint output"
+else
+  fail "Expected exclusion, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-04: pattern only inside fenced code block + STRICT → exclusion
+# --------------------------------------------------------------------------
+echo "T-04: code block exclusion + STRICT + pattern inside fence → exclusion"
+setup_git_repo
+fenced_msg=$'docs: refactor\n\n```\nverified-review cycle 3\n```\n\nNo violations outside the fence.'
+rc=0
+output=$(run_guard "git commit -m \"$fenced_msg\"" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+if [ "$rc" = "0" ] \
+   && [ "$decision" != "deny" ] \
+   && [[ "$stderr_log" != *"[charter-lint]"* ]]; then
+  pass "code block exclusion: no charter-lint output"
+else
+  fail "Expected exclusion, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-05: normal Conventional Commits message → pass through (non-regression)
+# --------------------------------------------------------------------------
+echo "T-05: normal commit message (no charter pattern) → pass through"
+setup_git_repo
+rc=0
+output=$(run_guard "git commit -m \"feat(rite): add new feature\"") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+if [ "$rc" = "0" ] && [[ "$stderr_log" != *"[charter-lint]"* ]]; then
+  pass "no charter-lint output for normal Conventional Commits message"
+else
+  fail "Expected clean pass, got rc=$rc stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# T-06: -F file with pattern + STRICT → BLOCK
+# --------------------------------------------------------------------------
+echo "T-06: -F file with charter pattern + STRICT → BLOCK"
+setup_git_repo
+msg_file=$(mktemp)
+printf 'fix: cycle 7 trailing newlines\n' > "$msg_file"
+rc=0
+output=$(run_guard "git commit -F $msg_file" "true") || rc=$?
+stderr_log=$(cat "$STDERR_FILE")
+decision=$(get_decision "$output")
+rm -f "$msg_file"
+if [ "$rc" -ne 0 ] \
+   && [ "$decision" = "deny" ] \
+   && [[ "$stderr_log" == *"[charter-lint] BLOCK:"* ]]; then
+  pass "-F file BLOCK in STRICT mode"
+else
+  fail "Expected exit !=0 + BLOCK, got rc=$rc decision=$decision stderr=$stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Bash tool 経由の `git commit -m` / `git commit -F` で渡される commit message を simplification charter の禁止パターン (3 種) で検査する commit-msg lint hook を `pre-tool-bash-guard.sh` に追加する。デフォルトは WARN (commit 通過)、`RITE_COMMIT_LINT_STRICT=true` で BLOCK に切り替わる opt-in 設計。

親 Issue #843 の Phase 0b に対応するセーフティネット。Phase 0a (#869〜#875) のマージ完了後にマージすることで、charter 違反引用の本文への混入を再発防止する。

Closes #876

## Changes

- `plugins/rite/hooks/pre-tool-bash-guard.sh`: 既存 Pattern 1-5 の後ろに独立した case arm を additive で追加 (87 行追加)
- `plugins/rite/hooks/tests/commit-msg-lint.test.sh` (新規): T-01〜T-06 の 6 TC を網羅 (208 行)

## Detection Patterns

検出対象 (charter §禁止パターンのうち初期 3 種):

| ID | 正規表現 | 説明 |
|----|---------|------|
| 1 | `cycle [0-9]+` | レビューラウンド番号 literal |
| 2 | `verified-review cycle` | レビュー世代 phrase |
| 3 | `Issue #[0-9]+ で.*対応` | Issue 参照 + 対応プローズ |

`DRIFT-CHECK` / `4-site` / `🚨` 濫用は false positive リスクが高いため後続 Issue で段階的検討。

## Behavior

- **デフォルト** (`RITE_COMMIT_LINT_STRICT` 未設定): 検出時 stderr に `[charter-lint] WARN:` を出力 + exit 0 (commit は通る)
- **STRICT mode** (`RITE_COMMIT_LINT_STRICT=true`): 検出時 stderr に `[charter-lint] BLOCK:` を出力 + JSON deny (`permissionDecision: "deny"`) + exit 2 (commit が block される)

## False Positive Suppression

- **Path 除外**: `git diff --cached --name-only` の結果が全て `docs/designs/` 配下なら検査をスキップ (design doc は metavariable / regex 引用が必要なため)
- **コードブロック除外**: commit message 内の Markdown ` ``` ` で囲まれた範囲を awk で削除してから pattern match を実行
- **`-F` ファイル解決失敗**: warn のみ出力して通過 (block しない)
- **未対応構文** (`-am`, `--message=`, editor mode, heredoc subshell): 静かにスキップ (false negative 許容)

## Compatibility

- additive: 既存 Pattern 1-5 (gh pr diff / jq != null / reviewer subagent git / create-lifecycle direct gh issue) の検査ロジックは無変更
- デフォルト warn のため既存 commit flow に破壊的影響なし
- STRICT mode は opt-in、デフォルト false

## Test plan

- [x] `bash plugins/rite/hooks/tests/commit-msg-lint.test.sh` を実行し T-01〜T-06 が全て pass する (実測 6/6 pass)
- [x] `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` が pass する (実測 PASS 8 / FAIL 0)
- [x] `bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` が pass する (134 件 pass / 0 件 fail、non-regression 確認)
- [x] `bash -n plugins/rite/hooks/pre-tool-bash-guard.sh` で構文 OK
- [x] 本 PR の commit message が charter 禁止パターンを含まない (STRICT モードでもパスする)

## Acceptance Criteria

| AC | 検証方法 | 結果 |
|----|---------|------|
| AC-1: warn デフォルト | T-01 (commit-msg-lint.test.sh) | ✅ |
| AC-2: strict block | T-02 | ✅ |
| AC-3: docs/designs/ 除外 | T-03 | ✅ |
| AC-4: コードブロック除外 | T-04 | ✅ |
| AC-5: 通常 commit non-regression | T-05 | ✅ |
| AC-6: 機能契約 non-regression | 4-site-symmetry.test.sh + pre-tool-bash-guard.test.sh | ✅ |
| AC-7: hook テストスイート | T-01〜T-06 全 pass | ✅ |

## Merge Order Constraint

charter pattern を含む引用が本文に残っている状態で本 hook を STRICT で運用すると Phase 0a 系統 (Sub-Issue #869〜#875) の cleanup commit を block する経路があるため、本 PR は **Phase 0a 完了後** にマージする。

## 未完了の Issue チェック項目

以下のチェック項目は本 PR のマージ・受説タイミングに依存する未来イベントのため未完了:

- [ ] PR が develop にマージされる
- [ ] 親 Issue #843 の Sub-Issues tasklist で本 Issue が check 済みになる
- [ ] Phase 0a (#869〜#875) のマージ完了後にマージする

これらは PR マージ後 / `/rite:pr:cleanup` 等の後続フローで自然に解決する。
