### PR TITLE
feat(rite): start.md に Charter 宣言と symmetry test を追加 (PR A)

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -4,6 +4,8 @@ description: Issue の作業を開始（ブランチ作成 → 実装 → PR 作
 
 # /rite:issue:start
 
+> **Charter**: This command and its `references/` are subject to the [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md). Runtime に効かない経緯記述・cycle 番号引用・重複 confirmation は書かない。
+
 ## Contract
 **Input**: Issue number (required), optionally a flow state record from a previous interrupted session
 **Output**: `## 完了報告` (completion report with Issue/PR details and phase progress table)

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# start-md-charter.test.sh — Simplification Charter assertions for start.md
+#
+# Issue #897 / PR A: 後続 PR (B-H) の slim 進捗を機械的に保護するドリフト検出ゲート。
+#
+# Run modes:
+#   STRICT_CHARTER 未設定 (default): skip して exit 0 (CI red 化しない)
+#   STRICT_CHARTER=1                : 全 assert 実行 (上限超過時は fail = ratchet)
+#
+# Assertions:
+#   上限 (Charter 違反パターン上限):
+#     - `Issue #[0-9]+` ≤ 1   metavariable `Issue #N` は数字でないため自動除外
+#     - `cycle [0-9]+`  ≤ 1
+#     - `🚨`            ≤ 5
+#   下限 (現状値の保護):
+#     - `AskUserQuestion` ≥ 30
+#     - `Mandatory After` ≥ 30
+#   対称性:
+#     - `flow-state-update.sh create` 各呼び出しが
+#       --phase / --issue / --branch / --pr / --next の 5 種すべてを含む
+#
+# Note (PR C 以降):
+#   `MUST execute in the SAME response turn` ≥ 30 / `DO NOT stop` ≥ 30 の追加 assert は
+#   PR C で 2 文 contract phrase が導入された後に別 PR で追加する。本 PR では実装しない。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+START_MD="$PLUGIN_ROOT/commands/issue/start.md"
+
+# Env gate: opt-in via STRICT_CHARTER=1
+if [ "${STRICT_CHARTER:-}" != "1" ]; then
+  echo "[start-md-charter] skip (STRICT_CHARTER not set; opt-in only)"
+  exit 0
+fi
+
+if [ ! -f "$START_MD" ]; then
+  echo "ERROR: start.md not found at $START_MD" >&2
+  exit 1
+fi
+
+echo "=== start-md-charter (STRICT_CHARTER=1) ==="
+echo "target: $START_MD"
+echo ""
+
+# === 上限 assert: Charter 違反パターン上限 ===
+echo "--- Upper bounds (Charter limits) ---"
+
+# `grep -oE 'Issue #[0-9]+'` は数字限定のため `Issue #N` placeholder は自動除外される
+issue_count=$(grep -oE 'Issue #[0-9]+' "$START_MD" | wc -l | tr -d ' ')
+if [ "$issue_count" -le 1 ]; then
+  pass "Upper: \`Issue #[0-9]+\` count <= 1 (actual=$issue_count)"
+else
+  fail "Upper: \`Issue #[0-9]+\` count <= 1 (actual=$issue_count, expected <=1)"
+fi
+
+cycle_count=$(grep -oE 'cycle [0-9]+' "$START_MD" | wc -l | tr -d ' ')
+if [ "$cycle_count" -le 1 ]; then
+  pass "Upper: \`cycle [0-9]+\` count <= 1 (actual=$cycle_count)"
+else
+  fail "Upper: \`cycle [0-9]+\` count <= 1 (actual=$cycle_count, expected <=1)"
+fi
+
+bell_count=$(grep -c '🚨' "$START_MD" || true)
+if [ "$bell_count" -le 5 ]; then
+  pass "Upper: \`🚨\` count <= 5 (actual=$bell_count)"
+else
+  fail "Upper: \`🚨\` count <= 5 (actual=$bell_count, expected <=5)"
+fi
+
+# === 下限 assert: 現状値の保護 ===
+echo ""
+echo "--- Lower bounds (current-state protection) ---"
+
+ask_count=$(grep -c 'AskUserQuestion' "$START_MD" || true)
+if [ "$ask_count" -ge 30 ]; then
+  pass "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count)"
+else
+  fail "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count, expected >=30)"
+fi
+
+# `Mandatory After` (markdown heading 内) または `🚨 After ` (review/fix の after section) を集計
+mandatory_count=$(grep -cE 'Mandatory After|🚨 After ' "$START_MD" || true)
+if [ "$mandatory_count" -ge 30 ]; then
+  pass "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count)"
+else
+  fail "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count, expected >=30)"
+fi
+
+# === 対称性 assert: flow-state-update.sh create の 5 引数 ===
+echo ""
+echo "--- Symmetry (flow-state-update.sh create 5-arg invariant) ---"
+
+# bash code block 内 (```bash ... ```) の `flow-state-update.sh create` 呼び出しのみ対象。
+# markdown 散文 (table cell / prose mention) の言及は対象外。
+total=0
+asymmetric=0
+while IFS= read -r line_no; do
+  [ -z "$line_no" ] && continue
+  total=$((total + 1))
+  end=$((line_no + 7))
+  block=$(sed -n "${line_no},${end}p" "$START_MD")
+  missing=""
+  for flag in '--phase' '--issue' '--branch' '--pr' '--next'; do
+    if ! printf '%s\n' "$block" | grep -qE -- "${flag}([[:space:]]|$)"; then
+      missing="${missing} ${flag}"
+    fi
+  done
+  if [ -n "$missing" ]; then
+    asymmetric=$((asymmetric + 1))
+    echo "  ⚠️ asymmetric (line ${line_no}, missing:${missing})"
+  fi
+done < <(awk '
+  /^```bash/ { in_block=1; next }
+  /^```$/    { in_block=0; next }
+  in_block && /flow-state-update\.sh create/ { print NR }
+' "$START_MD")
+
+if [ "$asymmetric" -eq 0 ]; then
+  pass "Symmetry: all ${total} \`flow-state-update.sh create\` invocations have 5 args (--phase/--issue/--branch/--pr/--next)"
+else
+  fail "Symmetry: ${asymmetric}/${total} invocations missing required args"
+fi
+
+# === Summary ===
+if ! print_summary "start-md-charter" \
+  "後続 PR (B-H) の slim 進捗で上限超過パターンを削減してください。STRICT_CHARTER=1 での fail は ratchet として設計されています。"; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -50,21 +50,23 @@ echo ""
 echo "--- Upper bounds (Charter limits) ---"
 
 # `grep -oE 'Issue #[0-9]+'` は数字限定のため `Issue #N` placeholder は自動除外される
-issue_count=$(grep -oE 'Issue #[0-9]+' "$START_MD" | wc -l | tr -d ' ')
+# 注: `set -euo pipefail` 配下では grep 0 マッチ (exit 1) で pipeline 全体が abort するため、
+# `{ grep ... || true; }` で 0 マッチを exit 0 に正規化する (ratchet ideal 達成時の silent abort 防止)
+issue_count=$({ grep -oE 'Issue #[0-9]+' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$issue_count" -le 1 ]; then
   pass "Upper: \`Issue #[0-9]+\` count <= 1 (actual=$issue_count)"
 else
   fail "Upper: \`Issue #[0-9]+\` count <= 1 (actual=$issue_count, expected <=1)"
 fi
 
-cycle_count=$(grep -oE 'cycle [0-9]+' "$START_MD" | wc -l | tr -d ' ')
+cycle_count=$({ grep -oE 'cycle [0-9]+' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$cycle_count" -le 1 ]; then
   pass "Upper: \`cycle [0-9]+\` count <= 1 (actual=$cycle_count)"
 else
   fail "Upper: \`cycle [0-9]+\` count <= 1 (actual=$cycle_count, expected <=1)"
 fi
 
-bell_count=$(grep -oE '🚨' "$START_MD" | wc -l | tr -d ' ')
+bell_count=$({ grep -oE '🚨' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$bell_count" -le 5 ]; then
   pass "Upper: \`🚨\` count <= 5 (actual=$bell_count)"
 else
@@ -78,15 +80,18 @@ echo "--- Lower bounds (current-state protection) ---"
 # 上限 assert と単位を揃えるため `grep -oE | wc -l` (occurrence 単位) に統一する。
 # `grep -c` (line 単位) では 1 行に複数出現する phrase を 1 とカウントしてしまい、後続 PR で
 # 1 行集約 slim を行った際に行数 30 を満たしつつ実出現が 30 未満になる ratchet 漏れリスクがある。
-ask_count=$(grep -oE 'AskUserQuestion' "$START_MD" | wc -l | tr -d ' ')
+# 注: 0 マッチ時の pipefail abort 回避は `{ ... || true; }` で実装 (上限 assert と同パターン)。
+ask_count=$({ grep -oE 'AskUserQuestion' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$ask_count" -ge 30 ]; then
   pass "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count)"
 else
   fail "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count, expected >=30)"
 fi
 
-# `Mandatory After` (markdown heading 内) または `🚨 After ` (review/fix の after section) を集計
-mandatory_count=$(grep -oE 'Mandatory After|🚨 After ' "$START_MD" | wc -l | tr -d ' ')
+# `Mandatory After` (markdown heading 内) または `🚨 After ` (review/fix の after section) を集計。
+# 注: 別 Issue #907 で heading-anchor 限定への変更を検討中。本 PR では現状仕様 (occurrence 単位、
+# heading + prose mention 合算) を維持する。
+mandatory_count=$({ grep -oE 'Mandatory After|🚨 After ' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$mandatory_count" -ge 30 ]; then
   pass "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count)"
 else
@@ -144,7 +149,7 @@ else
 fi
 
 # === Summary ===
-if ! print_summary "$(basename "$0" .test.sh)" \
+if ! print_summary "$(basename "$0")" \
   "後続 PR (B-H) の slim 進捗で上限超過パターンを削減してください。STRICT_CHARTER=1 での fail は ratchet として設計されています。"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -75,7 +75,10 @@ fi
 echo ""
 echo "--- Lower bounds (current-state protection) ---"
 
-ask_count=$(grep -c 'AskUserQuestion' "$START_MD" || true)
+# 上限 assert と単位を揃えるため `grep -oE | wc -l` (occurrence 単位) に統一する。
+# `grep -c` (line 単位) では 1 行に複数出現する phrase を 1 とカウントしてしまい、後続 PR で
+# 1 行集約 slim を行った際に行数 30 を満たしつつ実出現が 30 未満になる ratchet 漏れリスクがある。
+ask_count=$(grep -oE 'AskUserQuestion' "$START_MD" | wc -l | tr -d ' ')
 if [ "$ask_count" -ge 30 ]; then
   pass "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count)"
 else
@@ -83,7 +86,7 @@ else
 fi
 
 # `Mandatory After` (markdown heading 内) または `🚨 After ` (review/fix の after section) を集計
-mandatory_count=$(grep -cE 'Mandatory After|🚨 After ' "$START_MD" || true)
+mandatory_count=$(grep -oE 'Mandatory After|🚨 After ' "$START_MD" | wc -l | tr -d ' ')
 if [ "$mandatory_count" -ge 30 ]; then
   pass "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count)"
 else
@@ -96,14 +99,18 @@ echo "--- Symmetry (flow-state-update.sh create 5-arg invariant) ---"
 
 # bash code block 内 (```bash ... ```) の `flow-state-update.sh create` 呼び出しのみ対象。
 # markdown 散文 (table cell / prose mention) の言及は対象外。
+# 各 create 呼び出しに対して、bash block 終端 ``` までを動的に block として抽出する
+# (固定 +7 行 window では line continuation の長さに依存して block を取り損ねるリスクがある)。
+# awk でファイル全体を 1 度走査し、各 block を `\0` 区切りで出力 → bash の read -d '' で受ける。
 total=0
 asymmetric=0
-while IFS= read -r line_no; do
-  [ -z "$line_no" ] && continue
+while IFS= read -r -d '' block; do
+  [ -z "$block" ] && continue
   total=$((total + 1))
-  end=$((line_no + 7))
-  block=$(sed -n "${line_no},${end}p" "$START_MD")
+  first_line=$(printf '%s' "$block" | head -1 | sed 's/^[[:space:]]*//' | cut -c1-80)
   missing=""
+  # 引数検出 regex は `--flag value` (space 区切り) 形式を前提とする。`--flag=value` 形式は
+  # 現状 start.md では使われていないが、将来書式変更時はこの regex を拡張する必要がある。
   for flag in '--phase' '--issue' '--branch' '--pr' '--next'; do
     if ! printf '%s\n' "$block" | grep -qE -- "${flag}([[:space:]]|$)"; then
       missing="${missing} ${flag}"
@@ -111,12 +118,20 @@ while IFS= read -r line_no; do
   done
   if [ -n "$missing" ]; then
     asymmetric=$((asymmetric + 1))
-    echo "  ⚠️ asymmetric (line ${line_no}, missing:${missing})"
+    echo "  ⚠️ asymmetric (block starting: ${first_line}, missing:${missing})"
   fi
 done < <(awk '
-  /^```bash/ { in_block=1; next }
-  /^```$/    { in_block=0; next }
-  in_block && /flow-state-update\.sh create/ { print NR }
+  /^```bash/      { in_block=1; in_create=0; block=""; next }
+  /^```$/         {
+                    if (in_create) { printf "%s%c", block, 0 }
+                    in_block=0; in_create=0; block=""; next
+                  }
+  in_block && /flow-state-update\.sh create/ {
+                    in_create=1
+                    block = (block == "" ? $0 : block "\n" $0)
+                    next
+                  }
+  in_block && in_create { block = block "\n" $0 }
 ' "$START_MD")
 
 if [ "$asymmetric" -eq 0 ]; then

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -64,7 +64,7 @@ else
   fail "Upper: \`cycle [0-9]+\` count <= 1 (actual=$cycle_count, expected <=1)"
 fi
 
-bell_count=$(grep -c '🚨' "$START_MD" || true)
+bell_count=$(grep -oE '🚨' "$START_MD" | wc -l | tr -d ' ')
 if [ "$bell_count" -le 5 ]; then
   pass "Upper: \`🚨\` count <= 5 (actual=$bell_count)"
 else
@@ -127,8 +127,11 @@ done < <(awk '
                     in_block=0; in_create=0; block=""; next
                   }
   in_block && /flow-state-update\.sh create/ {
+                    # 同一 bash block 内に複数 create 呼び出しがある場合、前 block を先に flush
+                    # してから新 block を開始する (multi-create-per-block blind spot 防止)
+                    if (in_create) { printf "%s%c", block, 0 }
                     in_create=1
-                    block = (block == "" ? $0 : block "\n" $0)
+                    block=$0
                     next
                   }
   in_block && in_create { block = block "\n" $0 }
@@ -141,7 +144,7 @@ else
 fi
 
 # === Summary ===
-if ! print_summary "start-md-charter" \
+if ! print_summary "$(basename "$0" .test.sh)" \
   "後続 PR (B-H) の slim 進捗で上限超過パターンを削減してください。STRICT_CHARTER=1 での fail は ratchet として設計されています。"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

start.md 冒頭に Simplification Charter 宣言を追加し、新規テスト
`start-md-charter.test.sh` で charter 違反パターンの上限と保護 phrase の
下限を機械検証する基盤を整備する。後続 PR (B-H) のドリフト検出ゲートとして
機能する (Issue #896 ハイブリッド方針の PR A)。

## 関連 Issue

Closes #897 (parent: #896)

## 変更内容

- `plugins/rite/commands/issue/start.md` 冒頭に cleanup.md 同型の Charter 宣言を追加
- `plugins/rite/hooks/tests/start-md-charter.test.sh` を新規作成
  - **上限 assert**: `Issue #[0-9]+` ≤ 1 / `cycle [0-9]+` ≤ 1 / `🚨` ≤ 5
    / `flow-state-update.sh create` の 5 引数対称性
  - **下限 assert (現状値の保護)**: `AskUserQuestion` ≥ 30 (現状 34)
    / `Mandatory After` ≥ 30 (現状 49)
  - `STRICT_CHARTER=1` env gate で opt-in 化 (default skip で CI red 化しない)
- `run-tests.sh` は `*.test.sh` glob で自動拾うため明示的登録は不要

## 設計上の注意

- **上限 assert は ratchet として fail 想定**: 現状値 (13/39/35) は上限 (1/1/5) を
  超過しているため `STRICT_CHARTER=1` で実行すると上限 assert は意図的に fail する。
  これは PR B-H で違反値を段階的に削減するための機械的進捗指標として機能する
- **下限 assert は現状値の保護**: 削減作業中に運用上必要な phrase が脱落しないよう、
  現状値より低い閾値 (30) で固定。これは pass する想定
- **対称性 assert は 32/32 pass を確認済み**: bash code block 内の create 呼び出しのみ
  対象 (markdown 散文の言及は除外)。markdown table cell や prose の `flow-state-update.sh create`
  への参照は対象外

## PR C 後の追加 assert (本 PR スコープ外)

`MUST execute in the SAME response turn` ≥ 30 / `DO NOT stop` ≥ 30 の追加 assert は
PR C で 2 文 contract phrase が導入された後に別 PR で追加する。本 PR では実装しない。

## テスト

- `STRICT_CHARTER=` 未設定: `bash plugins/rite/hooks/tests/start-md-charter.test.sh`
  → exit 0 + skip ログ出力 ✅
- `STRICT_CHARTER=1`: 下限 2/2 pass、対称性 32/32 pass、上限 3/3 fail (ratchet 想定) ✅
- `bash plugins/rite/hooks/tests/run-tests.sh` → 45/45 passed (新 test は env 未設定 skip) ✅

## チェックリスト

- [x] 実装完了
- [x] テスト追加/更新
- [x] ドキュメント更新（必要な場合）
