### PR TITLE
test(rite): #907 Mandatory After 下限 assert を heading-anchor 限定に変更

### DIFF
--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -88,14 +88,16 @@ else
   fail "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count, expected >=30)"
 fi
 
-# `Mandatory After` (markdown heading 内) または `🚨 After ` (review/fix の after section) を集計。
-# 注: 別 Issue #907 で heading-anchor 限定への変更を検討中。本 PR では現状仕様 (occurrence 単位、
-# heading + prose mention 合算) を維持する。
-mandatory_count=$({ grep -oE 'Mandatory After|🚨 After ' "$START_MD" || true; } | wc -l | tr -d ' ')
-if [ "$mandatory_count" -ge 30 ]; then
-  pass "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count)"
+# heading-anchor 限定: `### 🚨 Mandatory After …` (h3) と `#### N.N.N 🚨 After …` (h4) を行頭マッチで集計。
+# 散文 mention (`**🚨 Immediate after …**`) や table cell の参照 (`| 🚨 After Review |`) は除外する。
+# occurrence 単位の旧 regex (`Mandatory After|🚨 After `) は heading 14 件 + prose mention 30 件超 = 51 件
+# となり、後続 slim PR が prose mention を削減すると heading 数が無傷でも閾値割れする false-positive
+# ratchet を生んだ。本 assert は heading 自体の削除のみを catch する真正な構造保護として機能する。
+mandatory_count=$({ grep -oE '^#+ .*🚨 (Mandatory After|After )' "$START_MD" || true; } | wc -l | tr -d ' ')
+if [ "$mandatory_count" -ge 17 ]; then
+  pass "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count)"
 else
-  fail "Lower: \`Mandatory After\` count >= 30 (actual=$mandatory_count, expected >=30)"
+  fail "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count, expected >=17)"
 fi
 
 # === 対称性 assert: flow-state-update.sh create の 5 引数 ===

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -88,12 +88,18 @@ else
   fail "Lower: \`AskUserQuestion\` count >= 30 (actual=$ask_count, expected >=30)"
 fi
 
-# heading-anchor 限定: `### 🚨 Mandatory After …` (h3) と `#### N.N.N 🚨 After …` (h4) を行頭マッチで集計。
+# heading-anchor 限定: 行頭の `#+ … 🚨 (Mandatory After|After <Word>)` のみを集計する。
+# 現状の構造:
+#   - h3: `### 🚨 Mandatory After N.N` 14 件
+#   - h4: `#### N.N.N 🚨 (After Review|After Fix|Mandatory After …)` 3 件
+#   - 合計: 17 件 (実測値、本 assert の閾値根拠)
 # 散文 mention (`**🚨 Immediate after …**`) や table cell の参照 (`| 🚨 After Review |`) は除外する。
-# occurrence 単位の旧 regex (`Mandatory After|🚨 After `) は heading 14 件 + prose mention 30 件超 = 51 件
+# 旧 regex (`Mandatory After|🚨 After `) は occurrence 単位で heading 17 件 + prose mention 等 34 件 = 51 件
 # となり、後続 slim PR が prose mention を削減すると heading 数が無傷でも閾値割れする false-positive
 # ratchet を生んだ。本 assert は heading 自体の削除のみを catch する真正な構造保護として機能する。
-mandatory_count=$({ grep -oE '^#+ .*🚨 (Mandatory After|After )' "$START_MD" || true; } | wc -l | tr -d ' ')
+# `After ` 側を `After [A-Za-z]` (単語境界) として `Mandatory After` 側との trailing-space 非対称性を解消し、
+# 将来 `### 🚨 After-Review` (hyphen) など想定外の heading 命名が混入した場合の取りこぼしも防ぐ。
+mandatory_count=$({ grep -oE '^#+ .*🚨 (Mandatory After|After [A-Za-z])' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$mandatory_count" -ge 17 ]; then
   pass "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count)"
 else

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -14,7 +14,7 @@
 #     - `🚨`            ≤ 5
 #   下限 (現状値の保護):
 #     - `AskUserQuestion` ≥ 30
-#     - `Mandatory After` ≥ 30
+#     - `Mandatory After` heading-anchor (h3+h4) ≥ 17 (実測: h3 14 + h4 3)
 #   対称性:
 #     - `flow-state-update.sh create` 各呼び出しが
 #       --phase / --issue / --branch / --pr / --next の 5 種すべてを含む
@@ -97,8 +97,11 @@ fi
 # 旧 regex (`Mandatory After|🚨 After `) は occurrence 単位で heading 17 件 + prose mention 等 34 件 = 51 件
 # となり、後続 slim PR が prose mention を削減すると heading 数が無傷でも閾値割れする false-positive
 # ratchet を生んだ。本 assert は heading 自体の削除のみを catch する真正な構造保護として機能する。
-# `After ` 側を `After [A-Za-z]` (単語境界) として `Mandatory After` 側との trailing-space 非対称性を解消し、
-# 将来 `### 🚨 After-Review` (hyphen) など想定外の heading 命名が混入した場合の取りこぼしも防ぐ。
+# `After ` 側を `After [A-Za-z]` として `Mandatory After` 側との trailing-space 非対称性を解消する
+# (旧 regex で `🚨 After<EOL>` 等が誤マッチする潜在問題の予防)。なお、`After-Review` 等のハイフン形は
+# いずれの regex でも対象外であり、必要になった時点で `After[ -][A-Za-z]` 等への拡張を検討する。
+# 更新ルール: 本 assert 対象の heading を追加/削除する PR では上記内訳 (h3 N 件 / h4 M 件 / 合計 K 件)
+# と本ブロック直下の閾値 `-ge K` / `>=K` を同期更新すること (内訳と閾値の drift 防止)。
 mandatory_count=$({ grep -oE '^#+ .*🚨 (Mandatory After|After [A-Za-z])' "$START_MD" || true; } | wc -l | tr -d ' ')
 if [ "$mandatory_count" -ge 17 ]; then
   pass "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count)"


### PR DESCRIPTION
## Summary

- `Mandatory After` 下限 assert を occurrence 単位 (51 件) → heading-anchor 限定 (17 件) に変更
- 閾値を 30 → 17 (実測 heading 数: h3 14 件 + h4 3 件) に再定義
- 旧 regex は prose mention 削減時に false-positive ratchet を生む構造的欠陥があった

## 関連 Issue

Closes #907

## 変更内容

- `plugins/rite/hooks/tests/start-md-charter.test.sh`:
  - line 91-93: コメントを heading-anchor 採用説明に書き換え (rationale 追記)
  - line 94: regex を `^#+ .*🚨 (Mandatory After|After )` (heading-anchor 限定) に変更
  - line 95: 閾値を 30 → 17 に変更
  - line 96, 98: pass/fail メッセージを `heading-anchor count >= 17` に更新

## Verification

- `STRICT_CHARTER=1 bash plugins/rite/hooks/tests/start-md-charter.test.sh` で target assert pass (actual=17)
- Mutation test: regex を h3 only に縮小すると actual=14 で fail → identification power 確認

## 関連

- Issue #897 の本文「下限 assert (現状値の保護)」記述を更新済み

## Test plan

- [x] `STRICT_CHARTER=1` で `Mandatory After` heading-anchor count >= 17 が pass
- [x] Mutation test (h3 only に縮小 → actual=14 で fail) で identification power 検証
- [x] Issue #897 本文の整合性確認 (#907 への参照追記)

## Known Issues

- 上限 assert (`Issue #N` / `cycle N` / `🚨`) の fail は本 Issue 範囲外 (後続 slim PR で削減予定)。下限 assert の改善には影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
