### PR TITLE
test(rite): #908 start-md-charter.test.sh の latent edge case 3 件対応

### DIFF
--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -124,7 +124,8 @@ echo "--- Symmetry (flow-state-update.sh create 5-arg invariant) ---"
 # Issue #908 finding 1: indented fence (`   ```bash` 等、リスト項目内 block) も含めるため
 # `^[[:space:]]*` を許容する。fence 開始/終了を対称適用 (Asymmetric Fix Transcription 防止)。
 # Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
-# false positive 検出してしまう問題に対し `^[[:space:]]*[^#]` 先頭ガードで除外。
+# false positive 検出してしまう問題に対し `^[[:space:]]*[^[:space:]#]` 先頭ガードで除外。
+# (詳細な regex 設計理由は line 161 付近の inline コメント参照)
 # 各 create 呼び出しに対して、bash block 終端 ``` までを動的に block として抽出する
 # (固定 +7 行 window では line continuation の長さに依存して block を取り損ねるリスクがある)。
 # awk でファイル全体を 1 度走査し、各 block を `\0` 区切りで出力 → bash の read -d '' で受ける。
@@ -157,8 +158,14 @@ done < <(awk '
                   }
   # Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
   # false positive で検出してしまう問題に対し、行頭 (任意空白後) の最初の非空白文字が
-  # `#` でないことを要求する `[^#]` 先頭ガードを追加。
-  in_block && /^[[:space:]]*[^#].*flow-state-update\.sh create/ {
+  # `#` でないことを要求する `[^[:space:]#]` 先頭ガードを追加。
+  # `[^#]` ではなく `[^[:space:]#]` を使う理由: awk POSIX ERE の貪欲マッチで `[[:space:]]*` が
+  # leading whitespace をゼロ文字消費した後 `[^#]` が space 文字にマッチし、続く `.*` が `#` 以降を
+  # 消費して indented shell comment (`    # ... flow-state-update.sh create ...`) を誤検出する
+  # backtracking 経路があった (PR #911 review で empirical mutation test で再現確認済み)。
+  # negative class に whitespace を含めることで leading whitespace consume 後の最初の非空白文字が
+  # `#` でないことを保証する (bash/awk regex の確立されたイディオム)。
+  in_block && /^[[:space:]]*[^[:space:]#].*flow-state-update\.sh create/ {
                     # 同一 bash block 内に複数 create 呼び出しがある場合、前 block を先に flush
                     # してから新 block を開始する (multi-create-per-block blind spot 防止)
                     if (in_create) { printf "%s%c", block, 0 }

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -18,6 +18,11 @@
 #   対称性:
 #     - `flow-state-update.sh create` 各呼び出しが
 #       --phase / --issue / --branch / --pr / --next の 5 種すべてを含む
+#     - 検出対象は bash code block 内 (indented fence `   ```bash` も含む) の
+#       コードのみ。shell コメント (`# ... flow-state-update.sh create ...`) は除外。
+#   対称性-下限 (Issue #908 finding 3):
+#     - `flow-state-update.sh create` の (上記検出対象内) 呼び出し数 ≥ 1
+#       (全削除 regression を catch する真正な保護)
 #
 # Note (PR C 以降):
 #   `MUST execute in the SAME response turn` ≥ 30 / `DO NOT stop` ≥ 30 の追加 assert は
@@ -29,7 +34,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_test-helpers.sh
 source "$SCRIPT_DIR/_test-helpers.sh"
 PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
-START_MD="$PLUGIN_ROOT/commands/issue/start.md"
+# Issue #908: START_MD を env override 可能にする (mutation test fixture を渡せるように)
+START_MD="${START_MD:-$PLUGIN_ROOT/commands/issue/start.md}"
 
 # Env gate: opt-in via STRICT_CHARTER=1
 if [ "${STRICT_CHARTER:-}" != "1" ]; then
@@ -115,6 +121,10 @@ echo "--- Symmetry (flow-state-update.sh create 5-arg invariant) ---"
 
 # bash code block 内 (```bash ... ```) の `flow-state-update.sh create` 呼び出しのみ対象。
 # markdown 散文 (table cell / prose mention) の言及は対象外。
+# Issue #908 finding 1: indented fence (`   ```bash` 等、リスト項目内 block) も含めるため
+# `^[[:space:]]*` を許容する。fence 開始/終了を対称適用 (Asymmetric Fix Transcription 防止)。
+# Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
+# false positive 検出してしまう問題に対し `^[[:space:]]*[^#]` 先頭ガードで除外。
 # 各 create 呼び出しに対して、bash block 終端 ``` までを動的に block として抽出する
 # (固定 +7 行 window では line continuation の長さに依存して block を取り損ねるリスクがある)。
 # awk でファイル全体を 1 度走査し、各 block を `\0` 区切りで出力 → bash の read -d '' で受ける。
@@ -137,12 +147,18 @@ while IFS= read -r -d '' block; do
     echo "  ⚠️ asymmetric (block starting: ${first_line}, missing:${missing})"
   fi
 done < <(awk '
-  /^```bash/      { in_block=1; in_create=0; block=""; next }
-  /^```$/         {
+  # Issue #908 finding 1: indented bash code fence (e.g., リスト項目内の `   ```bash`) も検出
+  # するため `^[[:space:]]*` を許容する。fence 開始/終了の対称適用が必須
+  # (Asymmetric Fix Transcription 防止)。
+  /^[[:space:]]*```bash/      { in_block=1; in_create=0; block=""; next }
+  /^[[:space:]]*```$/         {
                     if (in_create) { printf "%s%c", block, 0 }
                     in_block=0; in_create=0; block=""; next
                   }
-  in_block && /flow-state-update\.sh create/ {
+  # Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
+  # false positive で検出してしまう問題に対し、行頭 (任意空白後) の最初の非空白文字が
+  # `#` でないことを要求する `[^#]` 先頭ガードを追加。
+  in_block && /^[[:space:]]*[^#].*flow-state-update\.sh create/ {
                     # 同一 bash block 内に複数 create 呼び出しがある場合、前 block を先に flush
                     # してから新 block を開始する (multi-create-per-block blind spot 防止)
                     if (in_create) { printf "%s%c", block, 0 }
@@ -157,6 +173,16 @@ if [ "$asymmetric" -eq 0 ]; then
   pass "Symmetry: all ${total} \`flow-state-update.sh create\` invocations have 5 args (--phase/--issue/--branch/--pr/--next)"
 else
   fail "Symmetry: ${asymmetric}/${total} invocations missing required args"
+fi
+
+# Issue #908 finding 3: total=0 (= 1 つも `flow-state-update.sh create` を含む bash block が無い) でも
+# 上の `pass` が成功扱いになる false-positive を防ぐ。後続 PR で誤って create 呼び出しを全削除した場合の
+# regression 検出能力を保護する下限 (`-ge 1`)。具体的な現状値 (32 等) を pin すると後続 slim PR の
+# 正当な減少と衝突するため、「呼び出しが消滅していないこと」のみを保護する。
+if [ "$total" -ge 1 ]; then
+  pass "Symmetry-bound: \`flow-state-update.sh create\` invocations >= 1 (actual=$total)"
+else
+  fail "Symmetry-bound: \`flow-state-update.sh create\` invocations >= 1 (actual=$total, expected >=1)"
 fi
 
 # === Summary ===

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -124,8 +124,9 @@ echo "--- Symmetry (flow-state-update.sh create 5-arg invariant) ---"
 # Issue #908 finding 1: indented fence (`   ```bash` 等、リスト項目内 block) も含めるため
 # `^[[:space:]]*` を許容する。fence 開始/終了を対称適用 (Asymmetric Fix Transcription 防止)。
 # Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
-# false positive 検出してしまう問題に対し `^[[:space:]]*[^[:space:]#]` 先頭ガードで除外。
-# (詳細な regex 設計理由は line 161 付近の inline コメント参照)
+# false positive 検出してしまう問題に対し、shell コメント開始行を前置 not-match `!/^[[:space:]]*#/`
+# で除外する形式を採用 (前置 not-match で除外 → create 含有を別 regex で判定)。
+# (詳細な regex 設計理由は直下 awk block の inline コメント参照)
 # 各 create 呼び出しに対して、bash block 終端 ``` までを動的に block として抽出する
 # (固定 +7 行 window では line continuation の長さに依存して block を取り損ねるリスクがある)。
 # awk でファイル全体を 1 度走査し、各 block を `\0` 区切りで出力 → bash の read -d '' で受ける。
@@ -157,15 +158,16 @@ done < <(awk '
                     in_block=0; in_create=0; block=""; next
                   }
   # Issue #908 finding 2: shell コメント行 (`# ... flow-state-update.sh create ...`) を
-  # false positive で検出してしまう問題に対し、行頭 (任意空白後) の最初の非空白文字が
-  # `#` でないことを要求する `[^[:space:]#]` 先頭ガードを追加。
-  # `[^#]` ではなく `[^[:space:]#]` を使う理由: awk POSIX ERE の貪欲マッチで `[[:space:]]*` が
-  # leading whitespace をゼロ文字消費した後 `[^#]` が space 文字にマッチし、続く `.*` が `#` 以降を
-  # 消費して indented shell comment (`    # ... flow-state-update.sh create ...`) を誤検出する
-  # backtracking 経路があった (PR #911 review で empirical mutation test で再現確認済み)。
-  # negative class に whitespace を含めることで leading whitespace consume 後の最初の非空白文字が
-  # `#` でないことを保証する (bash/awk regex の確立されたイディオム)。
-  in_block && /^[[:space:]]*[^[:space:]#].*flow-state-update\.sh create/ {
+  # false positive で検出してしまう問題に対し、shell コメント開始行 (行頭が任意空白後 `#` で始まる行)
+  # を **前置 not-match で除外** してから create 含有を判定する形式を採用。
+  # 設計上の選択理由 (前置 not-match vs `[^[:space:]#]` 先頭ガード):
+  #   1. `^[[:space:]]*[^[:space:]#].*X` 形式は、X が行頭から始まる行 (例: `flow-state-update.sh create ...`)
+  #      を `[^[:space:]#]` で先頭の `f` を消費した結果、続く literal `X` が行内に再発見できず
+  #      silent miss する backtracking trap がある (PR #911 cycle 2 で empirical 再現確認済み)。
+  #   2. 前置 not-match `!/^[[:space:]]*#/` は「shell コメント開始行のみ除外」と意図が直接的で、
+  #      X の行頭出現有無に影響を受けない。これは bash/awk regex の確立されたイディオム。
+  # 仕様: shell コメント開始行 (`^[[:space:]]*#`) を除外したうえで `flow-state-update.sh create` を含む行を検出。
+  in_block && !/^[[:space:]]*#/ && /flow-state-update\.sh create/ {
                     # 同一 bash block 内に複数 create 呼び出しがある場合、前 block を先に flush
                     # してから新 block を開始する (multi-create-per-block blind spot 防止)
                     if (in_create) { printf "%s%c", block, 0 }


### PR DESCRIPTION
## 概要

`start-md-charter.test.sh` の robustness を向上させる latent edge case 3 件への対応。PR #906 cycle 3 review で検出された finding (現状 start.md には未顕在化だが、後続 PR B-H の slim 進捗で発生し得るリスク) を別途処置。

Closes #908

## 変更内容

- **finding 1 (indented bash block)**: awk fence regex (`/^```bash/`, `/^```$/`) を `^[[:space:]]*` 対応に拡張。リスト項目内の indented fence (4-space indent 等) もカバー。
- **finding 2 (shell comment 除外)**: `flow-state-update.sh create` 検出 regex に `^[[:space:]]*[^#]` 先頭ガードを追加。bash block 内の shell コメント行 (`# ... flow-state-update.sh create ...`) の false positive を排除。
- **finding 3 (total=0 ガード)**: `Symmetry-bound: invocations >= 1` 下限 assert を追加し、後続 PR で create 呼び出しが全削除された場合の regression 検出能力を保護。
- `START_MD` を env override 可能化 (`${START_MD:-...}`) し、mutation test fixture を渡せるようにした。
- 冒頭 Assertions 一覧と awk inline コメントを修正後の挙動と sync (Same-file 3-site sync 防止)。

## 検証

- `STRICT_CHARTER=1` で全 assert 実行 → 本 PR で導入した assert (Symmetry / Symmetry-bound) は全て pass。Upper bounds の fail (Issue#/cycle/🚨) は本 PR の対象外で、後続 PR (B-H) の slim 進捗で削減予定の ratchet。
- Mutation test 3 種で identification power を empirical 検証:
  - **S7** 全削除 fixture → `Symmetry-bound` が `actual=0` で fail (dead code 検出能力確認)
  - **S8** indented fence + create を含む fixture → `total=1` で正しくカウント
  - **S9** shell comment-only fixture → `total=0` で除外確認 (false positive 排除)
- 修正前後で本物の start.md に対する `total` は 32 で regression なし。

## 影響範囲

- 変更ファイル: `plugins/rite/hooks/tests/start-md-charter.test.sh` (1 ファイル、+30/-4 行)
- 既存挙動への影響: なし (本対応は latent risk 対策、現状 start.md には該当パターン未存在)

## チェックリスト

- [x] `STRICT_CHARTER=1` で動作確認 (本 PR assert は全 pass、regression なし)
- [x] Mutation test 3 種実施 (S7 dead code / S8 indented fence / S9 comment 除外)
- [x] Issue body チェックリスト 4 項目すべて完了
