### PR TITLE
docs(workflow): start.md の英文+コード span 後の Japanese full-stop 整形

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1728,7 +1728,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 **Owner**: `/rite:issue:start` (defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow).
 
-**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`。`ready.md` Phase 4.2 も同じく `projects-status-update.sh` delegate に統一済み。本 Phase 5.5.1 は defense-in-depth の二重実行であり、ready.md 失敗時の補完として機能する。
+**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`. `ready.md` Phase 4.2 も同じく `projects-status-update.sh` delegate に統一済み。本 Phase 5.5.1 は defense-in-depth の二重実行であり、ready.md 失敗時の補完として機能する。
 
 Skip if `projects.enabled: false` in rite-config.yml. Otherwise invoke the shared script to transition the Issue Status to **In Review**:
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/start.md` L1731 で、英文 + コード span 直後に Japanese full-stop `。` が来る箇所を整形した（読み味改善）。

## 変更内容

L1731 の `**Note**: Delegates to \`plugins/rite/scripts/projects-status-update.sh\`。\`ready.md\` Phase 4.2 ...` を、英文を `.` で締めて空白を挟む形式に変更:

```diff
-**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`。`ready.md` Phase 4.2 ...
+**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`. `ready.md` Phase 4.2 ...
```

これにより、英文セクションと日本語セクションの境界が明示的になり、読み味が改善される。

## 対象範囲

`start.md` 全体を以下の grep パターンで走査し、本箇所が唯一の該当パターンであることを確認:

```bash
grep -nE '[a-zA-Z][a-zA-Z0-9_ )(]*`[^`]*`。' plugins/rite/commands/issue/start.md
```

修正後、同 grep の結果は 0 件。

## 関連 Issue

Closes #922

## Test plan

- [x] grep で同パターンの残存が 0 件であることを確認
- [x] `/rite:lint` (plugin-specific checks) で新規 finding が start.md に追加されていないことを確認 (pre-existing warnings は別件、本 PR 由来 0 件)
- [x] diff が単一行変更（1 file changed, 1 insertion(+), 1 deletion(-)）であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
