### PR TITLE
refactor(rite): #899 Mandatory After を 2 文 contract 標準化 + flow-state-scaffolding/pre-condition-gate references 抽出 [PR C]

### DIFF
--- a/plugins/rite/commands/issue/references/flow-state-scaffolding.md
+++ b/plugins/rite/commands/issue/references/flow-state-scaffolding.md
@@ -1,0 +1,119 @@
+# Flow State Scaffolding — Pre-write + Mandatory After 契約 SoT
+
+> **Source of Truth**: 本ファイルは `/rite:issue:start` ワークフローにおける **`flow-state-update.sh create` の Pre-write + Mandatory After 契約** の SoT である。`start.md` 内の各 phase Pre-write block と Mandatory After section は本ファイルへ semantic 参照する。サブスキル (`parent-routing.md` / `child-issue-selection.md` / `branch-setup.md` / `work-memory-init.md` / `implementation-plan.md` の Defense-in-Depth 1 回目書き込み) と orchestrator (`start.md` の 2 回目 atomic 書き込み) の二段構造、5 引数 canonical literal、second-write rationale を 1 ファイルに閉じ込めることで、本体の認知負荷を下げる。
+>
+> **抽出経緯**: `start.md` 2303 行のうち約 17 箇所の Mandatory After section が「`Do **NOT** stop after ... returns.` + `The sub-skill has already updated to ... via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:` + 5 引数 bash literal + `**Step 2**: → Proceed to ...`」という同型構造を散文と bash literal で 17 回繰り返していた。これを Issue #899 (PR C — #896 親 Issue) で 2 文 contract phrase に標準化し、本 reference に SoT として集約する。
+
+## 2 文 contract phrase（標準化形式）
+
+すべての Mandatory After section の rationale 散文は以下の 2 文に統一する:
+
+```
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+```
+
+- 第 1 文: 本 reference への semantic anchor。LLM は本ファイルを読み「なぜ second write が必要か」「なぜ stop してはいけないか」を理解できる。
+- 第 2 文: 不変条件の宣言。`MUST execute in the SAME response turn` は「sub-skill return 直後に同一 turn 内で続行」を、`DO NOT stop, do NOT re-invoke` は「停止せず、また同じ sub-skill を再起動しない」を意味する。
+
+bash literal (5 引数 `flow-state-update.sh create` invocation) は **本体に残す**。これは runtime contract であり references 集約の対象外。
+
+## Pre-write の役割
+
+各 phase の Pre-write block は、**sub-skill 起動前** に flow state を更新する。目的:
+
+1. **stop-guard の resume 経路保証**: コンテキスト消失 / セッション中断時、`flow-state-update.sh create` で書き込まれた `phase` / `issue` / `branch` / `pr` / `next` フィールドを `/rite:resume` が読み取り、適切な phase に復帰する。
+2. **whitelist 整合**: `phase-transition-whitelist.sh` は隣接 phase 間の遷移のみを許可するため、Pre-write で正しい phase を記録しないと whitelist が遷移を reject し永久 block する。
+3. **next フィールドによる継続指示**: `next` 文字列は「sub-skill 返却後の次行動」を natural language で記述し、LLM が `/rite:resume` 経由で復帰した際の routing hint として機能する。
+
+## Mandatory After の役割（second write）
+
+各 sub-skill は Defense-in-Depth として自身の Phase 末尾で `flow-state-update.sh create --phase <skill_name>_post_*` を 1 回目書き込みする。orchestrator (`start.md`) はその後 **同一 turn 内**で `Mandatory After` block の **2 回目 atomic 書き込み**を実行する。
+
+### なぜ 2 回必要か
+
+| 1 回目 (sub-skill 内) | 2 回目 (orchestrator) |
+|-----------------------|----------------------|
+| sub-skill 自身の完了マーカ | orchestrator が「次の phase に進む」意思表示 |
+| sub-skill 単独で停止しても resume 可能にする safety net | 隣接 phase の whitelist 遷移を 1 hop で進める |
+| Defense-in-Depth (sub-skill が orchestrator の制御外で stop されても state 整合性を保つ) | stop-guard が「次の phase」を判定する根拠 |
+| `--next` は「sub-skill 単体の return まで」 | `--next` は「次の phase の continuation hint」 |
+
+両者が無いと、sub-skill が return 直後に stop された場合、`previous_phase = pre-write 時の phase`, `phase = sub-skill 内 1 回目 write の phase` のままで、whitelist の許可エッジが「pre-write phase → post phase」ではなく「sub-skill 1 回目 phase → 次の phase」を期待する経路で routing できず block する。
+
+## 5 引数 canonical literal
+
+`flow-state-update.sh create` 呼び出しは **必ず以下の 5 引数**を含む:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "{phase_name}" \
+  --issue {issue_number} \
+  --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "{next_action_hint}"
+```
+
+| 引数 | 型 | 意味 |
+|------|----|----|
+| `--phase` | string | 現 phase 名 (例: `phase2_post_branch`)。`phase-transition-whitelist.sh` の許可エッジで使われる |
+| `--issue` | int | 対象 Issue 番号。session 識別子の一部 |
+| `--branch` | string | 作業ブランチ名。Phase 2.3 前は空文字列 `""` (まだブランチ未作成のため) |
+| `--pr` | int | PR 番号。Phase 5.3 前は `0` (まだ PR 未作成のため) |
+| `--next` | string | 次行動の natural language hint。stop-guard / resume が LLM に渡す continuation 指示 |
+
+この 5 引数構造は `plugins/rite/hooks/tests/start-md-charter.test.sh` の Symmetry assertion で機械検証されている。1 つでも欠けると test fail。
+
+## stop-guard 通称と実体
+
+> **重要**: `start.md` 本体および本 reference 内で散見される「stop-guard」「stop-guard が flow を resume する」等の表現は **通称** である。`develop` ブランチでは `plugins/rite/hooks/stop-guard.sh` は実体不在となり、機能は **`pre-tool-bash-guard.sh`** (574 行) および `phase-transition-whitelist.sh` (source-only helper) に統合・移管されている。同期更新時はこれらのファイルを編集すること。本体の `stop-guard` 通称言及の整理は後続 PR の射程に委ねる。
+
+歴史的経緯:
+
+- `main` ブランチには旧 `stop-guard.sh` (blob `d26a4e0d`) が残存し、`hooks.json` に Stop hook として登録されている。
+- `develop` では Stop hook 経路ごと撤去され、`pre-tool-bash-guard.sh` の `PreToolUse(Bash)` matcher 経由で同等の防御機能を提供する設計に移管。
+- `start.md` 内 29 箇所の `stop-guard` 言及は通称として残置されており、PR C では reference 集約と 2 文 contract 標準化を通じて副次的に削減される（完全な置換は後続 PR）。
+
+## 適用箇所（start.md）
+
+PR C 時点で本 reference を参照する Mandatory After section（h3/h4 含む 17 箇所）:
+
+| section | location | sub-skill |
+|---------|----------|-----------|
+| Mandatory After 1.5 | `rite:issue:parent-routing` 後 | parent-routing.md |
+| Mandatory After 1.6 | `rite:issue:child-issue-selection` 後 | child-issue-selection.md |
+| Mandatory After 2.3 | `rite:issue:branch-setup` 後 | branch-setup.md |
+| Mandatory After 2.4 | Projects Status 更新後 | (inline) |
+| Mandatory After 2.5 | Iteration assignment 後 | (inline) |
+| Mandatory After 2.6 | `rite:issue:work-memory-init` 後 | work-memory-init.md |
+| Mandatory After 3 | `rite:issue:implementation-plan` 後 | implementation-plan.md |
+| Mandatory After 5.0 | Stop hook verification 後 | (inline) |
+| Mandatory After 5.2 | `rite:lint` 後 | lint.md |
+| Mandatory After 5.3 | `rite:pr:create` 後 | pr/create.md |
+| Mandatory After 5.4.3 (After Review) | `rite:pr:review` 後 | pr/review.md |
+| Mandatory After 5.4.6 (After Fix) | `rite:pr:fix` 後 | pr/fix.md |
+| Mandatory After 5.5 / 5.5.0.1 | `rite:pr:ready` 後 | pr/ready.md |
+| Mandatory After 5.5.1 | Issue Status In Review 更新後 | (inline) |
+| Mandatory After 5.5.2 | Metrics recording 後 | (inline) |
+| Mandatory After 5.7.2 | `rite:issue:close` 後（parent close） | issue/close.md |
+| Mandatory After 5.7 | Parent completion 全体 | (inline) |
+
+各 section の `**Step 1**` で 5 引数 bash literal を実行し、`**Step 2**` で次 phase への遷移を宣言する。
+
+## アンチパターン
+
+以下は本契約違反であり禁止:
+
+1. **同 turn 内で stop する**: sub-skill return 直後に LLM が turn を終了するパターン。stop-guard が detect して stderr に diagnose を残すが、結果として workflow が中断する。
+2. **sub-skill を再起動する**: return 直後に同じ sub-skill を `skill:` 経由で再 invoke。state は 2 重書きされ whitelist が reject する。
+3. **second write を skip する**: sub-skill 内 1 回目書き込みだけで次 phase に進むと、whitelist 期待エッジから外れて resume 時に block する。
+4. **5 引数のうちどれかを省略する**: 例えば Phase 2.3 前で `--branch ""` を省略すると state file の `branch` フィールドが残り、後続 phase が古い branch を参照するリスクがある。
+
+## 関連
+
+- [`pre-condition-gate.md`](./pre-condition-gate.md) — pre-condition の `state-read.sh` fail-fast pattern
+- `plugins/rite/hooks/flow-state-update.sh` — `create` / `patch` / `increment` modes の実装
+- `plugins/rite/hooks/phase-transition-whitelist.sh` — 隣接 phase 遷移の許可エッジ定義
+- `plugins/rite/hooks/state-read.sh` — per-session flow-state 読み出し
+- `plugins/rite/hooks/tests/start-md-charter.test.sh` — Charter assertions (`MUST execute` / `DO NOT stop` 下限、5 引数 Symmetry)
+- `plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh` — 5 引数対称性の機械検証 (PR C 新規)

--- a/plugins/rite/commands/issue/references/flow-state-scaffolding.md
+++ b/plugins/rite/commands/issue/references/flow-state-scaffolding.md
@@ -64,9 +64,11 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 この 5 引数構造は `plugins/rite/hooks/tests/start-md-charter.test.sh` の Symmetry assertion で機械検証されている。1 つでも欠けると test fail。
 
-## patch mode の例外 (Workflow Termination 直前)
+## patch mode の例外 (Workflow Termination 直前の 2 site)
 
-Mandatory After 5.7 (Parent Issue Completion 完了直後) のみ、`flow-state-update.sh` を **`create` ではなく `patch` mode** で呼び出す。3 引数 (`--phase` / `--active` / `--next`) の異形:
+`start.md` 内には **2 site** だけ `flow-state-update.sh` を **`create` ではなく `patch` mode** で呼び出す箇所がある: Mandatory After 5.7 (Parent Issue Completion 完了直後) と Workflow Termination block (terminal state へ遷移)。3 引数 (`--phase` / `--active` / `--next`) の異形を使う。両 site の bash literal を SoT として掲載する:
+
+### Form 1: Mandatory After 5.7 (`phase5_post_parent_completion` 完了マーカ)
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
@@ -74,25 +76,37 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
   --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
 ```
 
-### なぜ patch mode か (Workflow Termination 直前のみ)
+### Form 2: Workflow Termination block (`completed` terminal state)
 
-| 属性 | `create` mode (通常 16 箇所) | `patch` mode (Mandatory After 5.7 のみ) |
-|------|------------------------------|------------------------------------------|
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "completed" \
+  --next "none" --active false
+```
+
+> **使い分け**: Mandatory After 5.7 (Form 1) は parent close 直後の完了マーカ、Workflow Termination block (Form 2) は workflow 終了の terminal state 書き込み。両者は別 phase で順に発火する (5.7 → Termination)。Parent-skip 経路 (parent 不在で 5.7 を skip する場合) は Form 1 を経由せず直接 Form 2 を実行する。
+
+### なぜ patch mode か (Workflow Termination 直前の 2 site のみ)
+
+| 属性 | `create` mode (通常 17 sections / 32 bash literal) | `patch` mode (Workflow Termination 直前の 2 site) |
+|------|------------------------------------------------------|---------------------------------------------------|
 | `previous_phase` シフト | 旧 `.phase` を `.previous_phase` に書き込み | 旧 `.phase` をそのまま保持 |
 | `active` 制御 | 常に `active: true` | `--active false` で workflow 終了をマーク |
 | `--issue` / `--branch` / `--pr` | 必須 (5 引数) | 不要 (既存値を保持) |
-| 使用タイミング | 各 phase の post-marker 書き込み | Workflow Termination 直前の終了マーカー |
+| 使用タイミング | 各 phase の post-marker 書き込み | Workflow Termination 直前 (Form 1: 5.7 完了 / Form 2: terminal state) |
 | Symmetry test 対象 | YES (`start-md-charter.test.sh` で 5 引数検証) | NO (patch mode は Symmetry test の対象外) |
 
-### 5.7 patch mode が `create` mode 5 引数 contract に違反しない理由
+> **「通常 17 sections / 32 bash literal」の集計**: Mandatory After heading-anchor 数は **17 sections** (本 reference の「適用箇所」テーブル参照、h3 14 + h4 3)。bash code block 内の `flow-state-update.sh create` invocation 総数は **32 箇所** (`start-md-charter.test.sh` Symmetry assert 実行値)。後者は各 section が複数 create を持つ場合 (Pre-write + Mandatory After Step 1 等) を反映する。1 ファイル内で両単位が混在するため両方明示する。
 
-- `create` mode の 5 引数 contract は **「新規 phase marker を書き込む契機」専用**。Mandatory After 5.7 は workflow 終了の **terminal state** を書くため、phase progression としては「次の phase に進まず active を false にして session を閉じる」操作であり、create の semantics と異なる。
+### Workflow Termination 直前の 2 site が `create` mode 5 引数 contract に違反しない理由
+
+- `create` mode の 5 引数 contract は **「新規 phase marker を書き込む契機」専用**。Mandatory After 5.7 / Workflow Termination は workflow 終了の **terminal state** を書くため、phase progression としては「次の phase に進まず active を false にして session を閉じる」操作であり、create の semantics と異なる。
 - `patch` mode は既存 state file の一部 field のみを更新する preserving operation。`previous_phase` を維持することで、stop-guard whitelist が `phase5_post_parent_completion → phase5_post_parent_completion` のような無限ループ風遷移を誤検出しないようにする。
 - `Symmetry test` は `flow-state-update.sh create` invocation のみを対象とする (`start-md-charter.test.sh` Symmetry assert の awk regex で `create` literal にマッチする bash block のみ抽出)。patch mode は test の判定対象外であり、5 引数欠落 fail にはならない。
 
 ### LLM 向け注意
 
-Mandatory After 5.7 の bash literal を読んで「5 引数 contract 違反」と誤判定しないこと。本セクション (`patch mode の例外`) が異形を正規化し、 `start.md` 内 唯一の `patch` 呼び出し箇所 (Mandatory After 5.7 + Workflow Termination block) を SoT として認める。後続 PR で本体 `start.md` の rationale 散文 (`patch preserves previous_phase` 等) を完全削除する際は、本 reference の本セクションが LLM 向け唯一の説明源となる。
+Mandatory After 5.7 および Workflow Termination block の bash literal を読んで「5 引数 contract 違反」と誤判定しないこと。本セクション (`patch mode の例外`) が両 site の異形を SoT として正規化する。後続 PR で本体 `start.md` の rationale 散文 (`patch preserves previous_phase` 等) を完全削除する際は、本 reference の本セクションが LLM 向け唯一の説明源となる。
 
 ## stop-guard 通称と実体
 

--- a/plugins/rite/commands/issue/references/flow-state-scaffolding.md
+++ b/plugins/rite/commands/issue/references/flow-state-scaffolding.md
@@ -64,6 +64,36 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 この 5 引数構造は `plugins/rite/hooks/tests/start-md-charter.test.sh` の Symmetry assertion で機械検証されている。1 つでも欠けると test fail。
 
+## patch mode の例外 (Workflow Termination 直前)
+
+Mandatory After 5.7 (Parent Issue Completion 完了直後) のみ、`flow-state-update.sh` を **`create` ではなく `patch` mode** で呼び出す。3 引数 (`--phase` / `--active` / `--next`) の異形:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "phase5_post_parent_completion" --active false \
+  --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
+```
+
+### なぜ patch mode か (Workflow Termination 直前のみ)
+
+| 属性 | `create` mode (通常 16 箇所) | `patch` mode (Mandatory After 5.7 のみ) |
+|------|------------------------------|------------------------------------------|
+| `previous_phase` シフト | 旧 `.phase` を `.previous_phase` に書き込み | 旧 `.phase` をそのまま保持 |
+| `active` 制御 | 常に `active: true` | `--active false` で workflow 終了をマーク |
+| `--issue` / `--branch` / `--pr` | 必須 (5 引数) | 不要 (既存値を保持) |
+| 使用タイミング | 各 phase の post-marker 書き込み | Workflow Termination 直前の終了マーカー |
+| Symmetry test 対象 | YES (`start-md-charter.test.sh` で 5 引数検証) | NO (patch mode は Symmetry test の対象外) |
+
+### 5.7 patch mode が `create` mode 5 引数 contract に違反しない理由
+
+- `create` mode の 5 引数 contract は **「新規 phase marker を書き込む契機」専用**。Mandatory After 5.7 は workflow 終了の **terminal state** を書くため、phase progression としては「次の phase に進まず active を false にして session を閉じる」操作であり、create の semantics と異なる。
+- `patch` mode は既存 state file の一部 field のみを更新する preserving operation。`previous_phase` を維持することで、stop-guard whitelist が `phase5_post_parent_completion → phase5_post_parent_completion` のような無限ループ風遷移を誤検出しないようにする。
+- `Symmetry test` は `flow-state-update.sh create` invocation のみを対象とする (`start-md-charter.test.sh` Symmetry assert の awk regex で `create` literal にマッチする bash block のみ抽出)。patch mode は test の判定対象外であり、5 引数欠落 fail にはならない。
+
+### LLM 向け注意
+
+Mandatory After 5.7 の bash literal を読んで「5 引数 contract 違反」と誤判定しないこと。本セクション (`patch mode の例外`) が異形を正規化し、 `start.md` 内 唯一の `patch` 呼び出し箇所 (Mandatory After 5.7 + Workflow Termination block) を SoT として認める。後続 PR で本体 `start.md` の rationale 散文 (`patch preserves previous_phase` 等) を完全削除する際は、本 reference の本セクションが LLM 向け唯一の説明源となる。
+
 ## stop-guard 通称と実体
 
 > **重要**: `start.md` 本体および本 reference 内で散見される「stop-guard」「stop-guard が flow を resume する」等の表現は **通称** である。`develop` ブランチでは `plugins/rite/hooks/stop-guard.sh` は実体不在となり、機能は **`pre-tool-bash-guard.sh`** (574 行) および `phase-transition-whitelist.sh` (source-only helper) に統合・移管されている。同期更新時はこれらのファイルを編集すること。本体の `stop-guard` 通称言及の整理は後続 PR の射程に委ねる。

--- a/plugins/rite/commands/issue/references/pre-condition-gate.md
+++ b/plugins/rite/commands/issue/references/pre-condition-gate.md
@@ -72,7 +72,7 @@ if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --d
 
 ### 共通禁止事項
 
-> **NG パターン**: `if ! curr=$(...); then rc=$?; ... fi` は bash 仕様上、`!` が pipeline 全体を反転するため `rc` には常に 0 が入る。 helper 起動失敗 (state-read.sh の exit 非 0) と pre-condition 失敗 (state-read.sh は exit 0 で値を返したが `curr` が期待値と不一致) を区別できなくなる。 **`if cmd; then :; else rc=$?; fi`** 形式を form A / B のいずれでも必ず使うこと。
+> **NG パターン**: `if ! curr=$(...); then rc=$?; ... fi` は bash 仕様上、「!」 が pipeline 全体を反転するため `rc` には常に 0 が入る。 helper 起動失敗 (state-read.sh の exit 非 0) と pre-condition 失敗 (state-read.sh は exit 0 で値を返したが `curr` が期待値と不一致) を区別できなくなる。 **`if cmd; then :; else rc=$?; fi`** 形式を form A / B のいずれでも必ず使うこと。
 
 > **capture を伴わない `if ! cmd; then ...`** (例: `if ! mapfile ...` / `if ! gh ...`) は本 guard の適用範囲外。capture と exit code を両方取る場合のみ if/else 形式が必須。
 
@@ -121,7 +121,7 @@ Pre-condition (phase / parent_issue_number) は **複数行 form (Form A)**、me
 ## アンチパターン
 
 1. **直接 `jq` で legacy state file を読む**: `cat .rite/flow-state.json | jq -r .phase` 形式は禁止。`state-read.sh` 経由のみ許可。
-2. **`!` 反転で capture**: `if ! val=$(cmd); then rc=$?; fi` は `rc` に常に 0 が入る。
+2. **「!」 反転で capture**: `if ! val=$(cmd); then rc=$?; fi` は `rc` に常に 0 が入る (bang inversion を pipeline 全体に適用するため)。
 3. **`.previous_phase` を expected と比較**: 1 hop 前を見るため normal entry で毎回 fail。
 4. **silent 0 降格**: `state-read.sh` 起動失敗時に `val=0` 等で fallback すると、`implementation_round=0` が「乖離なし」と誤分類される (silent partial corruption)。空文字列 `val=""` を保持し、METRICS_SKIPPED sentinel を別途 emit して下流 step を skip させる。
 5. **form の混同**: Pre-condition (`^if .*then$` で複数行 form を expect) を inline 1 行に圧縮すると TC-3 が fail。逆に inline 1 行 form (`if val=...; then :; else rc=$?` で 1 行 canonical を expect) を複数行に展開すると TC-6 が fail。site ごとの canonical form を保つこと。

--- a/plugins/rite/commands/issue/references/pre-condition-gate.md
+++ b/plugins/rite/commands/issue/references/pre-condition-gate.md
@@ -41,9 +41,9 @@ Pre-condition check は **`state-read.sh` で `.phase` を読み、期待する 
 
 `state-read.sh` 起動失敗と pre-condition 失敗を**区別**するため、以下の if/else 形式を使う。 form は site の用途に応じて 2 種類を使い分ける。
 
-### Form A: 複数行 form (Pre-condition 用)
+### Form A: 複数行 form (Pre-condition + 値取得 用)
 
-Phase 3 / 5.5.1 / 5.6 の pre-condition check + Phase 5.7 parent close (`parent_issue_number` 取得) の **4 site** はこの form を使う。 `ERROR:` 行と `ACTION:` 行を後続 if 文で複数行に渡って出力するため、可読性のため複数行 form が canonical:
+Phase 3 / 5.5.1 / 5.6 の pre-condition check (3 site) + Phase 5.7 parent close (`parent_issue_number` 取得、pre-condition ではないが Form A canonical を共有する 1 site) の **start.md 内 4 箇所** はこの form を使う。 `ERROR:` 行と `ACTION:` 行を後続 if 文で複数行に渡って出力するため、可読性のため複数行 form が canonical:
 
 ```bash
 if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
@@ -60,13 +60,15 @@ fi
 
 ### Form B: inline 1 行 form (metrics step 用)
 
-Phase 5.5.2 内 `implementation_round` 取得 (`plan_deviation_count` 算出) は単純な capture (失敗時 warning 出力 + 値 default 化) のため、1 行 form が canonical:
+Phase 5.5.2 内 `implementation_round` 取得 (`plan_deviation_count` 算出) は単純な capture (失敗時 warning 出力 + 値 default 化) のため、1 行 form が canonical。Form A と同様に **`[CONTEXT] STATE_READ_FAILED=1` sentinel を emit する**ことで downstream observability (cross-session-incident 集計 / workflow-incident-emit-protocol grep) に統一形式で通知する:
 
 ```bash
-if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
+if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_2_metrics; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
 ```
 
 `caller-markdown-block.test.sh` TC-6 は本 inline form を `if val=...; then :; else rc=$?` の 1 行 canonical で grep pin している (Issue #908 で確立)。
+
+> **Form A と Form B の sentinel emit 共通化**: 両 form ともに `[CONTEXT] STATE_READ_FAILED=1; phase={site}; rc=$rc` を必ず emit する。両者の唯一の差異は (a) **severity prefix** (Form A: `ERROR:` で `exit 1`、Form B: `WARNING:` で値 default 化して fall-through)、(b) **行展開** (Form A: 複数行 / Form B: 1 行) のみ。downstream observability tooling は単一 sentinel pattern (`STATE_READ_FAILED`) を grep するだけで Form A / B の両経路を捕捉できる。
 
 ### 共通禁止事項
 
@@ -76,11 +78,13 @@ if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --d
 
 ## Phase 別の期待値テーブル
 
-| Phase | Pre-condition expected `.phase` | Resume re-entry も accept する代替値 | Skip 検出時の指示 |
-|-------|--------------------------------|--------------------------------------|------------------|
-| **Phase 3** (implementation-plan) | `phase2_post_work_memory` | `phase3_post_plan` (`/rite:resume` re-entry) | Phase 2.4 / 2.5 / 2.6 の missing step に return |
-| **Phase 5.5.1** (Issue Status In Review) | `phase5_post_ready` | なし | Phase 5.5 (Ready for Review) に return |
-| **Phase 5.6** (Completion Report) | `phase5_post_metrics` | なし | Phase 5.5.1 (Status) / 5.5.2 (Metrics) に return |
+| Phase | Pre-condition expected `.phase` | Resume re-entry も accept する代替値 | 対応する whitelist edge | Skip 検出時の指示 |
+|-------|--------------------------------|--------------------------------------|-------------------------|------------------|
+| **Phase 3** (implementation-plan) | `phase2_post_work_memory` | `phase3_post_plan` (`/rite:resume` re-entry) | `phase2_post_work_memory → phase3_plan`、resume 経路は `phase3_post_plan → phase3_plan` | Phase 2.4 / 2.5 / 2.6 の missing step に return |
+| **Phase 5.5.1** (Issue Status In Review) | `phase5_post_ready` | なし | `phase5_post_ready → phase5_status_in_review` | Phase 5.5 (Ready for Review) に return |
+| **Phase 5.6** (Completion Report) | `phase5_post_metrics` | なし | `phase5_post_metrics → phase5_completion` | Phase 5.5.1 (Status) / 5.5.2 (Metrics) に return |
+
+> **Pre-condition と whitelist の二重防御**: 各 Pre-condition check は LLM 向け enforcement (本 reference 後段の "Enforcement note") で routing を駆動するが、 **`phase-transition-whitelist.sh` も独立に許可エッジを検証**する。例: Phase 5.6 の pre-condition が `phase5_post_status_in_review` 等を誤って受容しても、whitelist が `phase5_post_metrics → phase5_completion` 以外の source を reject するため、defense-in-depth として silent skip が阻止される。両層の整合性は `phase-transition-whitelist.sh` の許可エッジ定義を SoT として参照すること。
 
 ### Resume re-entry の `phase3_post_plan` 受容
 
@@ -100,9 +104,9 @@ bash の `exit 1` は **shell process を終わらせるだけで、Claude Code 
 
 これら 3 行は **LLM 向け enforcement** であり、シェル制御フローではなく LLM の routing 判断を駆動する。
 
-## 4 site canonical (capture pattern 共有)
+## 5 site canonical (capture pattern 共有)
 
-Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$(cmd); then :; else rc=$?; fi` capture pattern を共有する:
+Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$(cmd); then :; else rc=$?; fi` capture pattern を共有する (start.md 内合計 **5 site** が `state-read.sh` capture 共通形式)。 Form A (4 site: Pre-condition 3 + Phase 5.7 parent close) と Form B (1 site: Phase 5.5.2 metrics) の使い分けは上記 [Canonical capture pattern (2 forms)](#canonical-capture-pattern-2-forms) を参照:
 
 | Site | Field | 用途 |
 |------|-------|------|

--- a/plugins/rite/commands/issue/references/pre-condition-gate.md
+++ b/plugins/rite/commands/issue/references/pre-condition-gate.md
@@ -1,0 +1,132 @@
+# Pre-condition Gate — `state-read.sh` fail-fast Pattern SoT
+
+> **Source of Truth**: 本ファイルは `/rite:issue:start` ワークフローにおける **pre-condition check (#490 AC-5)** の `state-read.sh` fail-fast pattern の SoT である。`start.md` の Phase 3 / Phase 5.5.1 / Phase 5.6 の pre-condition block、および Phase 5.5.2 内 metrics step (`plan_deviation_count` 取得) と Phase 5.7 (`parent_issue_number` 取得) で同型の capture pattern を共有する。本 reference は **5 site で重複していた if/else capture pattern**、 **`.phase` vs `.previous_phase` の使い分け根拠**、 **`state-read.sh` を使う理由 (per-session vs legacy state file)** を 1 ファイルに集約する。
+>
+> **抽出経緯**: `start.md` の Pre-condition check 3 箇所 (Phase 3: L484-540 / Phase 5.5.1: L1697-1758 / Phase 5.6: L1992-2050、合計約 178 行) が同型の散文 + bash block で書かれていた。加えて Phase 5.5.2 内 metrics step の `plan_deviation_count` 取得 (L1795-1840) と Phase 5.7 の `parent_issue_number` 取得もまた同一 capture pattern を inline で再掲していた。Issue #899 (PR C — #896 親 Issue) で本 reference に集約し、各 caller は anchor reference + 5 引数 bash literal のみに圧縮する。
+
+## なぜ pre-condition check が必要か (#490 AC-5)
+
+`/rite:issue:start` の workflow は phase 単位の sequential transition で構成され、各 phase の Mandatory After block が次 phase 向けの flow state を書き込む。LLM が **意図的または事故で intermediate phase を skip した**場合、後段の phase は「期待する事前状態」を満たさない state で実行され、silent skip による partial corruption (e.g., `metrics.enabled: false` で Metrics body を skip しつつ Mandatory After marker も skip → Phase 5.6 が `phase5_post_status_in_review` で誤起動) が発生しうる。
+
+Pre-condition check は **`state-read.sh` で `.phase` を読み、期待する post-marker と一致しない場合は ERROR と ACTION 指示を出して abort する** ことで、silent skip を fail-fast に変換する防御層である。
+
+## `.phase` vs `.previous_phase`
+
+| 評価対象 | 意味 |
+|----------|------|
+| `.phase` | **直前に完了した phase の post-marker** (例: `phase2_post_work_memory`) |
+| `.previous_phase` | `.phase` の predecessor (1 hop 前の phase) |
+
+`flow-state-update.sh create` mode は新 phase を `.phase` に書き込む際、 **旧 `.phase` を `.previous_phase` にシフトする** 設計 (`hooks/flow-state-update.sh` の create branch 実装)。したがって:
+
+- **Pre-condition check は `.phase` を読む**: 期待値は「直前 Mandatory After が書き込んだ post-marker」であり、これは `.phase` に格納されている。
+- **`.previous_phase` を読むのは誤り**: predecessor を比較すると normal entry でも常に 1 hop 前を expected と認識し、毎回 ERROR を発火する false-positive となる (prompt-engineer cycle-3 CRITICAL で検出済みの過去 regression)。
+
+## `state-read.sh` を使う理由 (per-session vs legacy state file)
+
+`flow_state.schema_version=2` 以降、active state は **per-session file** (`.rite/sessions/{session_id}.flow-state`) に書き込まれる。一方、legacy state file (`.rite/flow-state.json`) は schema_version=1 の互換のために残置されており、別 session の残骸が混在する可能性がある。
+
+```
+.rite/
+├── flow-state.json                    ← legacy snapshot (互換用、他 session の residue を含む)
+└── sessions/
+    └── {session_id}.flow-state         ← 現 session 固有 state (authoritative)
+```
+
+`state-read.sh` は **per-session file を優先解決し、存在しない場合のみ legacy にフォールバック** する。Pre-condition check で legacy を直接 `jq` で読むと、別 session の `phase5_post_stop_hook` 等が leak して **fresh Phase 3 check で誤 ERROR** を出すリスクがある (Issue #680 で実際に発生したケース)。
+
+したがって Pre-condition check は **必ず `state-read.sh` 経由**で `.phase` を読むこと。`cat .rite/flow-state.json | jq -r .phase` 形式は禁止。
+
+## Canonical capture pattern (2 forms)
+
+`state-read.sh` 起動失敗と pre-condition 失敗を**区別**するため、以下の if/else 形式を使う。 form は site の用途に応じて 2 種類を使い分ける。
+
+### Form A: 複数行 form (Pre-condition 用)
+
+Phase 3 / 5.5.1 / 5.6 の pre-condition check + Phase 5.7 parent close (`parent_issue_number` 取得) の **4 site** はこの form を使う。 `ERROR:` 行と `ACTION:` 行を後続 if 文で複数行に渡って出力するため、可読性のため複数行 form が canonical:
+
+```bash
+if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
+  :
+else
+  rc=$?
+  echo "ERROR: state-read.sh failed (rc=$rc) for --field phase in {Phase X} pre-condition" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase={phase_X_pre_condition}; rc=$rc" >&2
+  exit 1
+fi
+```
+
+`caller-markdown-block.test.sh` TC-3 は本 form を `^if .*then$` (行末 `then`) で grep pin している (start.md 4 箇所、implement.md 1 箇所、review.md 1 箇所、resume.md 1 箇所)。
+
+### Form B: inline 1 行 form (metrics step 用)
+
+Phase 5.5.2 内 `implementation_round` 取得 (`plan_deviation_count` 算出) は単純な capture (失敗時 warning 出力 + 値 default 化) のため、1 行 form が canonical:
+
+```bash
+if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
+```
+
+`caller-markdown-block.test.sh` TC-6 は本 inline form を `if val=...; then :; else rc=$?` の 1 行 canonical で grep pin している (Issue #908 で確立)。
+
+### 共通禁止事項
+
+> **NG パターン**: `if ! curr=$(...); then rc=$?; ... fi` は bash 仕様上、`!` が pipeline 全体を反転するため `rc` には常に 0 が入る。 helper 起動失敗 (state-read.sh の exit 非 0) と pre-condition 失敗 (state-read.sh は exit 0 で値を返したが `curr` が期待値と不一致) を区別できなくなる。 **`if cmd; then :; else rc=$?; fi`** 形式を form A / B のいずれでも必ず使うこと。
+
+> **capture を伴わない `if ! cmd; then ...`** (例: `if ! mapfile ...` / `if ! gh ...`) は本 guard の適用範囲外。capture と exit code を両方取る場合のみ if/else 形式が必須。
+
+## Phase 別の期待値テーブル
+
+| Phase | Pre-condition expected `.phase` | Resume re-entry も accept する代替値 | Skip 検出時の指示 |
+|-------|--------------------------------|--------------------------------------|------------------|
+| **Phase 3** (implementation-plan) | `phase2_post_work_memory` | `phase3_post_plan` (`/rite:resume` re-entry) | Phase 2.4 / 2.5 / 2.6 の missing step に return |
+| **Phase 5.5.1** (Issue Status In Review) | `phase5_post_ready` | なし | Phase 5.5 (Ready for Review) に return |
+| **Phase 5.6** (Completion Report) | `phase5_post_metrics` | なし | Phase 5.5.1 (Status) / 5.5.2 (Metrics) に return |
+
+### Resume re-entry の `phase3_post_plan` 受容
+
+`/rite:resume` でフローを再開した場合、Phase 3 (implementation-plan) は既に完了している可能性がある。その状態で再度 Phase 3 を通過させると plan が重複生成される。これを避けるため、Phase 3 pre-condition は `phase3_post_plan` を **追加 accept value** として受け入れる (normal first-entry では `phase2_post_work_memory` のみ accept、resume 経路でのみ `phase3_post_plan` が現れる)。 `phase3_post_plan → phase3_plan` の whitelist エッジが対応する retry edge を許可する。
+
+Phase 5.5.1 / 5.6 は resume re-entry でも skip 不可なので追加 accept は不要。
+
+## Enforcement note (LLM 向け)
+
+bash の `exit 1` は **shell process を終わらせるだけで、Claude Code の LLM 駆動 turn を halt しない**。Pre-condition check が ERROR を出した場合、 **LLM は stderr の `ERROR:` / `ACTION:` 行を認識して、指示された missing phase に return する責務**を負う。silent に「次の Pre-write block を実行する」経路は禁止。
+
+各 pre-condition block の bash literal は以下の 3 種類の echo を必ず emit する:
+
+1. `ERROR: {Phase X} pre-condition failed. .phase=$curr (expected: {expected_marker})` — diagnostic
+2. `ACTION: Return to the missing {Phase Y} step and execute its Pre-write + main procedure + Mandatory After before entering {Phase X}.` — recovery instruction
+3. `⚠️ LLM MUST NOT proceed to {Phase X} Pre-write below. Re-invoke the missing phase first.` — anti-silent-continue guard
+
+これら 3 行は **LLM 向け enforcement** であり、シェル制御フローではなく LLM の routing 判断を駆動する。
+
+## 4 site canonical (capture pattern 共有)
+
+Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$(cmd); then :; else rc=$?; fi` capture pattern を共有する:
+
+| Site | Field | 用途 |
+|------|-------|------|
+| Phase 3 pre-condition | `phase` | Phase 2 完了確認 |
+| Phase 5.5.1 pre-condition | `phase` | Phase 5.5 完了確認 |
+| Phase 5.6 pre-condition | `phase` | Phase 5.5.2 完了確認 |
+| Phase 5.5.2 Metrics Step 1 | `implementation_round` | `plan_deviation_count` 算出 (non-numeric は 0 降格、空文字列は METRICS_SKIPPED sentinel emit) |
+| Phase 5.7 parent close | `parent_issue_number` | parent Issue の auto-close 判定 (non-numeric は 0 降格 = "no parent" 扱い) |
+
+Pre-condition (phase / parent_issue_number) は **複数行 form (Form A)**、metrics step (implementation_round) は **inline 1 行 form (Form B)** を使う。 numeric type validation (非数値 → 0 降格) は metrics / parent_issue_number 等の数値 field で同型対応する: writer / reader / resume の 3 layer 対称化 doctrine (詳細は `implement.md` / `pr/review.md` / `resume.md` の同 pattern site を参照)。
+
+## アンチパターン
+
+1. **直接 `jq` で legacy state file を読む**: `cat .rite/flow-state.json | jq -r .phase` 形式は禁止。`state-read.sh` 経由のみ許可。
+2. **`!` 反転で capture**: `if ! val=$(cmd); then rc=$?; fi` は `rc` に常に 0 が入る。
+3. **`.previous_phase` を expected と比較**: 1 hop 前を見るため normal entry で毎回 fail。
+4. **silent 0 降格**: `state-read.sh` 起動失敗時に `val=0` 等で fallback すると、`implementation_round=0` が「乖離なし」と誤分類される (silent partial corruption)。空文字列 `val=""` を保持し、METRICS_SKIPPED sentinel を別途 emit して下流 step を skip させる。
+5. **form の混同**: Pre-condition (`^if .*then$` で複数行 form を expect) を inline 1 行に圧縮すると TC-3 が fail。逆に inline 1 行 form (`if val=...; then :; else rc=$?` で 1 行 canonical を expect) を複数行に展開すると TC-6 が fail。site ごとの canonical form を保つこと。
+
+## 関連
+
+- [`flow-state-scaffolding.md`](./flow-state-scaffolding.md) — Pre-write + Mandatory After 契約 SoT
+- `plugins/rite/hooks/state-read.sh` — per-session flow-state 読み出し (legacy フォールバック含む)
+- `plugins/rite/hooks/_resolve-flow-state-path.sh` — per-session vs legacy path 解決ロジック
+- `plugins/rite/hooks/flow-state-update.sh` — `create` mode の `.previous_phase` シフト実装
+- `plugins/rite/hooks/tests/caller-markdown-block.test.sh` — TC-6 で 1 行 capture pattern を grep pin
+- `plugins/rite/commands/issue/start.md` Phase 3 / 5.5.1 / 5.6 — 3 site の caller

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -199,11 +199,10 @@ Invoke `skill: "rite:issue:parent-routing"`.
 
 ### 🚨 Mandatory After 1.5
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-Do **NOT** stop after `rite:issue:parent-routing` returns. The parent routing sub-skill only performs detection — branch creation and implementation have NOT started yet.
-
-**Step 1**: Update flow state to post-parent-routing phase (atomic). The sub-skill has already updated to `phase1_5_post_parent` via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:
+**Step 1**: Update flow state to post-parent-routing phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -232,11 +231,10 @@ Invoke `skill: "rite:issue:child-issue-selection"`.
 
 ### 🚨 Mandatory After 1.6
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-Do **NOT** stop after `rite:issue:child-issue-selection` returns. Branch creation and implementation have NOT started yet.
-
-**Step 1**: Update flow state to post-child-selection phase (atomic). The sub-skill has already updated to `phase1_6_post_child` via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:
+**Step 1**: Update flow state to post-child-selection phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -304,11 +302,10 @@ Invoke `skill: "rite:issue:branch-setup"`.
 
 ### 🚨 Mandatory After 2.3
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-Do **NOT** stop after `rite:issue:branch-setup` returns. Projects status update and work memory initialization are still pending.
-
-**Step 1**: Update flow state to post-branch phase (atomic). The sub-skill has already updated to `phase2_post_branch` via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:
+**Step 1**: Update flow state to post-branch phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -384,9 +381,8 @@ The script is the single source of truth for Projects Status updates. See [proje
 
 ### 🚨 Mandatory After 2.4
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
-
-Do **NOT** stop after the Projects Status update. Phase 2.5 (Iteration) and 2.6 (Work Memory) are still pending.
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Step 1**: Update flow state to post-projects phase. If Phase 2.4.7 detected a parent Issue (`{parent_issue_number}` is non-empty and non-zero), persist it via `--parent-issue` so it survives context compaction and session restarts (#497):
 
@@ -424,6 +420,9 @@ Otherwise, execute the Module procedure: field info (2.5.1), current iteration d
 
 ### 🚨 Mandatory After 2.5
 
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
 **Step 1**: Update flow state to post-iteration phase:
 
 ```bash
@@ -452,9 +451,10 @@ Invoke `skill: "rite:issue:work-memory-init"`.
 
 ### 🚨 Mandatory After 2.6
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-**Step 1**: Update flow state to post-work-memory phase (atomic). The sub-skill has already updated to `phase2_post_work_memory` via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:
+**Step 1**: Update flow state to post-work-memory phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -477,23 +477,13 @@ fi
 
 > **Note**: `{plugin_root}` が未解決の場合は、[Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) に従い事前に解決すること。このコードブロックは Phase 4.1 よりも前に実行されるため、Phase 4.1 での解決に依存できない。相対パス `plugins/rite/hooks/` は、マーケットプレイスインストール環境ではスクリプトが見つからないため使用不可。
 
-**Step 3**: Do **NOT** stop after `rite:issue:work-memory-init` returns. **→ Proceed to Phase 3 now**.
+**Step 3**: **→ Proceed to Phase 3 now**.
 
 ## Phase 3: Implementation Plan
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 2 completed in full. If the current `.phase` is not `phase2_post_work_memory`, the workflow has silently skipped one of Phase 2.4/2.5/2.6 — **abort with an ERROR** and return to the missing phase. `phase3_post_plan` is additionally accepted only for `/rite:resume` re-entry after Phase 3 already completed (not for normal first-entry).
-
-> **⚠️ Why `.phase`, not `.previous_phase`**: `flow-state-update.sh` `create` mode assigns the outgoing `.phase` value to `.previous_phase` (see `hooks/flow-state-update.sh` create branch). Therefore the **expected post-phase marker** appears in `.phase`, and `.previous_phase` holds the *predecessor*. Checking `.previous_phase` here would always compare against the phase *one step behind* the expected marker and would ERROR on every normal entry (prompt-engineer cycle-3 CRITICAL).
-
-> **⚠️ Why `state-read.sh`, not direct `jq` on the legacy state file**: When `flow_state.schema_version=2`, the active state is written to `.rite/sessions/{session_id}.flow-state`, while the legacy state file may retain another session's residue. Reading the legacy file inline returns stale residue (e.g., `phase5_post_stop_hook` from a prior session leaking into a fresh Phase 3 check). `state-read.sh` resolves the per-session file first and falls back to legacy only when per-session is absent.
+**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase2_post_work_memory` (resume re-entry also accepts `phase3_post_plan`).
 
 ```bash
-# `if ! var=$(cmd); then rc=$?` パターンは bash 仕様上 `$?` が常に 0 になる (「!」 が pipeline 全体を反転し、
-# then 節は否定結果 = 0 を見るため)。capture と exit code を両方取る場合は `if cmd; then :; else rc=$?; fi`
-# の if/else 形式を使う。helper 起動失敗と pre-condition 失敗の区別を維持する不変条件。
-# capture を伴わない `if ! cmd; then ...` (例: mapfile / gh) は本ガードの適用範囲外。
-# 詳細な canonical 説明: _emit-cross-session-incident.sh、update_local_work_memory 関数の
-# `_phase` / `pr_num` / `loop_cnt` capture も同 pattern。
 if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
   :
 else
@@ -502,7 +492,6 @@ else
   echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase3_pre_condition; rc=$rc" >&2
   exit 1
 fi
-# Accept phase3_post_plan only for /rite:resume re-entry (plan already completed in a prior session).
 if [ "$curr" != "phase2_post_work_memory" ] && [ "$curr" != "phase3_post_plan" ]; then
   echo "ERROR: Phase 3 pre-condition failed. .phase=$curr (expected: phase2_post_work_memory)" >&2
   echo "ACTION: Return to the missing Phase 2 step (2.4 Projects / 2.5 Iteration / 2.6 Work Memory) and execute its Pre-write + main procedure + Mandatory After before entering Phase 3." >&2
@@ -510,8 +499,6 @@ if [ "$curr" != "phase2_post_work_memory" ] && [ "$curr" != "phase3_post_plan" ]
   exit 1
 fi
 ```
-
-> **Enforcement note**: bash `exit 1` does NOT halt the LLM from proceeding. On ERROR output, the LLM MUST recognise the failure text and return to the named phase. Do NOT silently continue to the Pre-write below.
 
 **Pre-write** (before invoking `rite:issue:implementation-plan`): Update flow state so stop-guard can resume flow if interrupted:
 
@@ -528,11 +515,10 @@ Invoke `skill: "rite:issue:implementation-plan"`.
 
 ### 🚨 Mandatory After 3
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-Do **NOT** stop after `rite:issue:implementation-plan` returns. Implementation has NOT started yet — the plan is just a plan.
-
-**Step 1**: Update flow state to post-plan phase (atomic). The sub-skill has already updated to `phase3_post_plan` via its Defense-in-Depth section; this second write ensures stop-guard routes to the correct next branch:
+**Step 1**: Update flow state to post-plan phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
@@ -707,6 +693,9 @@ Retain `workflow_incident_enabled` in conversation context. Phase 5.4.4.1 reads 
 
 ### 🚨 Mandatory After 5.0
 
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
 **Step 1**: Update flow state to post-stop-hook phase:
 
 ```bash
@@ -836,7 +825,8 @@ printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do ec
 
 ### 🚨 Mandatory After 5.2
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Ignore** `/rite:lint` "Next steps" (standalone only). **Immediately** update flow state and execute 5.2.1.
 
@@ -989,7 +979,8 @@ bash {plugin_root}/hooks/workflow-incident-emit.sh --type manual_fallback_adopte
 
 ### 🚨 Mandatory After 5.3
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Verify**: `[pr:created:{number}]`, number saved. Review has NOT started yet.
 
@@ -1183,7 +1174,8 @@ Invoke `skill: "rite:pr:review"`.
 
 #### 5.4.3 🚨 After Review
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Verify**: Pattern confirmed, parsed.
 
@@ -1568,7 +1560,8 @@ It is also triggered when an `AskUserQuestion` fallback option that emits a sent
 
 #### 5.4.6 🚨 After Fix
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Verify**: Pattern confirmed, parsed.
 
@@ -1662,7 +1655,8 @@ bash {plugin_root}/hooks/workflow-incident-emit.sh --type manual_fallback_adopte
 
 #### 5.5.0.1 🚨 Mandatory After 5.5
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Verify**: `[ready:completed]` pattern confirmed. `rite:pr:ready` returned successfully. Status update, metrics recording, and completion report are still pending — these are the **primary deliverables** of the e2e flow that the user expects to see.
 
@@ -1694,11 +1688,9 @@ WM_SOURCE="ready" \
 
 #### 5.5.1 Update Issue Status to "In Review"
 
-**Pre-condition check** (#490 AC-5): Verify that Phase 5.5 (Ready) completed. The current `.phase` must be `phase5_post_ready` (the Mandatory After 5.5 marker). See the "Why `.phase`, not `.previous_phase`" explanation in Phase 3 pre-condition above. The pre-condition reads `.phase` via `state-read.sh` so per-session state is consulted instead of the legacy state file snapshot which may hold another session's residue.
+**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_ready`.
 
 ```bash
-# `if ! var=$(cmd); then rc=$?` は bash 仕様上 `$?` が常に 0 になるため、capture と exit code を
-# 両方取る場合は if/else 形式にする (capture-less `if ! cmd; then ...` は対象外)。
 if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
   :
 else
@@ -1714,8 +1706,6 @@ if [ "$curr" != "phase5_post_ready" ]; then
   exit 1
 fi
 ```
-
-> **Enforcement note**: bash `exit 1` does NOT halt the LLM. On ERROR, the LLM MUST recognise the failure and return to Phase 5.5 rather than proceeding.
 
 **Pre-write**:
 
@@ -1755,6 +1745,9 @@ Inspect the script's stdout JSON:
 See [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) for the underlying API calls.
 
 ### 🚨 Mandatory After 5.5.1
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Step 1**: Update flow state to post-status-in-review phase:
 
@@ -1974,6 +1967,9 @@ Present options via `AskUserQuestion`:
 
 ### 🚨 Mandatory After 5.5.2
 
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
 **Step 1**: Update flow state to post-metrics phase:
 
 ```bash
@@ -1989,13 +1985,9 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 > **Historical note (informational only — no action required)**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed between Mandatory After 5.5.2 and this heading. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition. The terminal state update now runs at the end of Phase 5.7 or, when no parent is identified, immediately after this Phase 5.6 — see the "Workflow Termination" block below. This note is purely historical context for future maintainers and contains no executable instructions.
 
-**Pre-condition check** (#490 AC-5): Verify that both Phase 5.5.1 (Status) and 5.5.2 (Metrics) completed. The current `.phase` must be `phase5_post_metrics` — the earlier `phase5_post_status_in_review` alternative was removed because it let Metrics silently skip (AC-5 violation). See the "Why `.phase`, not `.previous_phase`" explanation in Phase 3 pre-condition above. The pre-condition reads `.phase` via `state-read.sh` so per-session state is consulted instead of the legacy state file snapshot.
-
-If `metrics.enabled: false` in rite-config.yml, Phase 5.5.2 must still write the `phase5_post_metrics` marker (the phase body may short-circuit Steps 1-5 below, but the Mandatory After block must run unconditionally — see Phase 5.5.2 Skip Steps note).
+**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_metrics`. When `metrics.enabled: false`, Phase 5.5.2 must still write the `phase5_post_metrics` marker via its Mandatory After block (body skip allowed; marker required).
 
 ```bash
-# `if ! var=$(cmd); then rc=$?` は bash 仕様上 `$?` が常に 0 になるため、capture と exit code を
-# 両方取る場合は if/else 形式にする (capture-less `if ! cmd; then ...` は対象外)。
 if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
   :
 else
@@ -2011,8 +2003,6 @@ if [ "$curr" != "phase5_post_metrics" ]; then
   exit 1
 fi
 ```
-
-> **Enforcement note** (prompt-engineer HIGH): bash `exit 1` does NOT stop the LLM from proceeding to the Pre-write block below. On ERROR, the LLM MUST recognise the failure text in stderr and return to the missing phase. Do NOT silently continue. The stop-guard whitelist (`["phase5_post_metrics"]="phase5_completion"`) will also reject any other source (e.g., `phase5_post_ready`, `phase5_post_status_in_review`) as a defense-in-depth layer.
 
 **Pre-write**:
 
@@ -2222,9 +2212,8 @@ Invoke `skill: "rite:issue:close", args: "{parent_issue_number}"`.
 
 ### 🚨 Mandatory After 5.7.2
 
-> See [Sub-skill Return Protocol (Global)](#sub-skill-return-protocol-global).
-
-Do **NOT** stop after `rite:issue:close` returns. Phase 5.7.3 (Next Child) and Workflow Termination are still pending.
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Step 1**: Update flow state to post-parent-close phase:
 
@@ -2242,6 +2231,9 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 Display remaining children, guide `/rite:issue:start`. No auto-start.
 
 ### 🚨 Mandatory After 5.7
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
 **Step 1**: Update flow state to post-parent-completion phase. Use **patch mode** — patch preserves `previous_phase` automatically from the outgoing `.phase` field, whereas `create` mode would overwrite the entire state and risk tripping the session-ownership check (prompt-engineer cycle-2 MEDIUM #5):
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -377,7 +377,7 @@ The script is the single source of truth for Projects Status updates. See [proje
 
 **Step 3** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
 
-> **Regression guard**: Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident: a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature.
+> **Regression guard** (Issue #513 regression guard): Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident (Issue #513): a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature. `parent-child-sync-static.test.sh` pins this literal to prevent silent re-introduction.
 
 ### 🚨 Mandatory After 2.4
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -1796,7 +1796,7 @@ Otherwise:
 # silent default 0 (= "no deviation") に降格せず、metrics output を skip する。
 # 注意: inline 1 行 form を維持 (caller-markdown-block.test.sh TC-6 が
 # `if val=...; then :; else rc=$?` の 1 行 canonical capture pattern を grep で pin する)。
-if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
+if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_2_metrics; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
 # numeric type validation (writer/reader/resume 3 layer 対称化 doctrine): 他 caller (Phase 5.7
 # parent_issue_number / implement.md parent_issue_number / pr/review.md loop_count /
 # resume.md parent_issue_number_raw) と同様に non-numeric 値を 0 に降格して partial corruption

--- a/plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Tests for 5-arg symmetry of `flow-state-update.sh create` invocations
+# across the rite workflow (Issue #899 / parent #896).
+#
+# Purpose:
+#   Every `flow-state-update.sh create` invocation in command markdown files
+#   MUST include all 5 canonical arguments (--phase / --issue / --branch /
+#   --pr / --next). Missing any one of them breaks the Pre-write + Mandatory
+#   After contract documented in
+#   `plugins/rite/commands/issue/references/flow-state-scaffolding.md`.
+#
+#   `start.md` symmetry is already verified by `start-md-charter.test.sh`'s
+#   Symmetry assert (single-target). This test complements it by scanning
+#   the **remaining caller files** so that drift in a sub-skill or sibling
+#   command does not slip through.
+#
+# Scope:
+#   - plugins/rite/commands/issue/implement.md      (Phase 5.1 sub-skill)
+#   - plugins/rite/commands/issue/create.md         (Phase X.X handoff)
+#   - plugins/rite/commands/issue/create-interview.md (Pre-flight)
+#   - plugins/rite/commands/pr/cleanup.md           (Post-merge hand-off)
+#
+# Out of scope (documented elsewhere):
+#   - `commands/issue/start.md` — covered by `start-md-charter.test.sh`
+#   - `commands/issue/references/*.md` — documentation only (illustrative
+#     literals must NOT be executed; the references explain the contract)
+#   - `commands/resume.md` — references `flow-state-update.sh create` only in
+#     prose (documentation of what the invoked command will do); contains no
+#     executable bash block invoking create. Including it would yield a false-
+#     positive NO_CREATE_BLOCK_FOUND fail.
+#
+# Detection logic:
+#   For each SITE, find every bash code block (``` fence) containing
+#   `flow-state-update.sh create` and assert that the block contains all
+#   5 required `--<flag>` tokens. The block-aware extraction (vs naive
+#   line grep) matches the canonical implementation in
+#   `start-md-charter.test.sh::compute_symmetry_for()` so that line
+#   continuations (`\`) and multi-line literals are handled identically.
+#
+# When this test fails:
+#   The 5-arg contract has drifted in one of the caller files. Restore
+#   the missing flag rather than relaxing the assert. The contract is
+#   the runtime invariant — the test is its mirror.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
+
+SITES=(
+  "plugins/rite/commands/issue/implement.md"
+  "plugins/rite/commands/issue/create.md"
+  "plugins/rite/commands/issue/create-interview.md"
+  "plugins/rite/commands/pr/cleanup.md"
+)
+
+REQUIRED_ARGS=(
+  "--phase"
+  "--issue"
+  "--branch"
+  "--pr"
+  "--next"
+)
+
+# Extract bash blocks containing `flow-state-update.sh create` and emit one
+# `null`-delimited record per block. Mirrors the awk pipeline in
+# `start-md-charter.test.sh::compute_symmetry_for()` to share the same
+# block-extraction semantics (indented fences, inline shell comment strip,
+# trailing whitespace fence end).
+extract_create_blocks() {
+  local target="$1"
+  awk '
+    /^[[:space:]]*```[[:space:]]*bash[[:space:]]*$/ { in_block=1; block=""; next }
+    /^[[:space:]]*```[[:space:]]*$/ {
+      if (in_block) {
+        if (block ~ /flow-state-update\.sh create/) {
+          printf "%s%c", block, 0
+        }
+        in_block=0; block=""
+      }
+      next
+    }
+    in_block {
+      line=$0
+      # strip whitespace-preceded inline shell comment so `# ... create ...` does not
+      # contaminate the matcher (mirrors compute_symmetry_for finding #2)
+      sub(/[[:space:]]+#.*$/, "", line)
+      # skip pure shell comment lines
+      if (line ~ /^[[:space:]]*#/) next
+      block = block line "\n"
+    }
+  ' "$target"
+}
+
+assert_block_has_arg() {
+  local site="$1" arg="$2" block="$3" block_id="$4"
+  if printf '%s\n' "$block" | grep -qE -- "${arg}([[:space:]]|$)"; then
+    return 0
+  fi
+  fail "${site}|block#${block_id}|${arg} missing"
+  return 1
+}
+
+total_blocks=0
+total_failures=0
+
+for site in "${SITES[@]}"; do
+  full_path="$REPO_ROOT/$site"
+  if [ ! -f "$full_path" ]; then
+    fail "${site}|FILE_NOT_FOUND"
+    total_failures=$((total_failures + 1))
+    continue
+  fi
+
+  echo "=== ${site} ==="
+
+  block_id=0
+  any_block=0
+  while IFS= read -r -d '' block; do
+    [ -z "$block" ] && continue
+    block_id=$((block_id + 1))
+    any_block=1
+    total_blocks=$((total_blocks + 1))
+    block_failures=0
+    for arg in "${REQUIRED_ARGS[@]}"; do
+      if ! assert_block_has_arg "$site" "$arg" "$block" "$block_id"; then
+        block_failures=$((block_failures + 1))
+      fi
+    done
+    if [ "$block_failures" -eq 0 ]; then
+      pass "${site}|block#${block_id} all 5 args present"
+    else
+      total_failures=$((total_failures + 1))
+    fi
+  done < <(extract_create_blocks "$full_path")
+
+  if [ "$any_block" -eq 0 ]; then
+    fail "${site}|NO_CREATE_BLOCK_FOUND (regression — caller previously contained flow-state-update.sh create)"
+    total_failures=$((total_failures + 1))
+  fi
+done
+
+# Lower bound: at least one block must be found across all SITES. If every
+# block disappears, the test silently passes which would mask a wholesale
+# removal regression. This mirrors `start-md-charter.test.sh` Symmetry-bound
+# assertion (Issue #908 finding 3).
+if [ "$total_blocks" -ge 1 ]; then
+  pass "lower-bound: total \`flow-state-update.sh create\` blocks across SITES = ${total_blocks} (>= 1)"
+else
+  fail "lower-bound: zero create blocks found across ${#SITES[@]} SITES (regression — all callers removed?)"
+fi
+
+DRIFT_HINT='⚠️ 5-arg flow-state-update.sh create symmetry drift detected.
+   Locate the failing (site, block, arg) tuple above and restore the
+   missing --phase / --issue / --branch / --pr / --next argument.
+   The 5-arg contract is documented in
+   plugins/rite/commands/issue/references/flow-state-scaffolding.md.
+   Do NOT relax the test — restore the missing flag instead.'
+
+if ! print_summary "$(basename "$0")" "$DRIFT_HINT"; then
+  exit 1
+fi
+
+echo "OK: 5-arg flow-state-update.sh create symmetry verified across ${#SITES[@]} sites (${total_blocks} blocks)"
+exit 0

--- a/plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh
@@ -65,10 +65,41 @@ REQUIRED_ARGS=(
 )
 
 # Extract bash blocks containing `flow-state-update.sh create` and emit one
-# `null`-delimited record per block. Mirrors the awk pipeline in
-# `start-md-charter.test.sh::compute_symmetry_for()` to share the same
-# block-extraction semantics (indented fences, inline shell comment strip,
-# trailing whitespace fence end).
+# `null`-delimited record per block. Block-extraction semantics are
+# **partially aligned** with `start-md-charter.test.sh::compute_symmetry_for()`,
+# but the following 3 divergences are **intentional** and documented below.
+# In the future, refactoring `compute_symmetry_for()` into `_test-helpers.sh`
+# would let both tests share a single canonical implementation.
+#
+# Intentional divergences from `compute_symmetry_for()`:
+#
+#   1. Fence-open regex: `^[[:space:]]*```[[:space:]]*bash[[:space:]]*$` (strict, anchored)
+#      vs `compute_symmetry_for`: `^[[:space:]]*```bash` (lenient, info-string accepting).
+#      Intent: this test targets 4 specific caller files (implement.md /
+#      create.md / create-interview.md / cleanup.md) which all use plain
+#      ```bash without info-string suffixes. The strict form prevents false
+#      positives if a future caller introduces ```bash {info-string} (which
+#      may or may not warrant inclusion in symmetry check — re-evaluate at
+#      that time). If info-string callers become common, relax to match.
+#
+#   2. Multi-`create`-per-block flush logic: `compute_symmetry_for()` emits
+#      one record per `create` invocation (`if (in_create) printf ...`), but
+#      this test concatenates all lines in a fence block into a single record.
+#      Intent: SITES (4 caller files) currently have at most 1 `create` per
+#      fence block. If a future caller writes 2 creates in one fence block,
+#      this test would treat them as a single block (assertion still works:
+#      `--phase` etc. would appear at least once). When per-`create` granularity
+#      becomes necessary, port the flush logic from compute_symmetry_for.
+#
+#   3. Block content: this test stores stripped lines (post inline-comment-strip)
+#      vs `compute_symmetry_for` stores original `$0`. Intent: stripped lines
+#      simplify downstream `grep -qE` matching. The original-line preservation in
+#      compute_symmetry_for is needed for diagnostic output (which this test
+#      doesn't produce). When quoted `#` in --arg values appears in real callers
+#      (none currently), revisit this decision.
+#
+# When refactoring: extract `compute_symmetry_for()` into `_test-helpers.sh` and
+# parameterize the 3 divergences as function arguments. See Issue #899 / #896.
 extract_create_blocks() {
   local target="$1"
   awk '
@@ -84,8 +115,7 @@ extract_create_blocks() {
     }
     in_block {
       line=$0
-      # strip whitespace-preceded inline shell comment so `# ... create ...` does not
-      # contaminate the matcher (mirrors compute_symmetry_for finding #2)
+      # strip whitespace-preceded inline shell comment (intentional divergence #3 above)
       sub(/[[:space:]]+#.*$/, "", line)
       # skip pure shell comment lines
       if (line ~ /^[[:space:]]*#/) next
@@ -103,14 +133,15 @@ assert_block_has_arg() {
   return 1
 }
 
+# Note: pass/fail counts are tracked by the global FAIL/PASS counters in
+# `_test-helpers.sh` via the `pass`/`fail` functions. `print_summary` consumes
+# those globals — no local counter is needed in this driver.
 total_blocks=0
-total_failures=0
 
 for site in "${SITES[@]}"; do
   full_path="$REPO_ROOT/$site"
   if [ ! -f "$full_path" ]; then
     fail "${site}|FILE_NOT_FOUND"
-    total_failures=$((total_failures + 1))
     continue
   fi
 
@@ -131,14 +162,11 @@ for site in "${SITES[@]}"; do
     done
     if [ "$block_failures" -eq 0 ]; then
       pass "${site}|block#${block_id} all 5 args present"
-    else
-      total_failures=$((total_failures + 1))
     fi
   done < <(extract_create_blocks "$full_path")
 
   if [ "$any_block" -eq 0 ]; then
     fail "${site}|NO_CREATE_BLOCK_FOUND (regression — caller previously contained flow-state-update.sh create)"
-    total_failures=$((total_failures + 1))
   fi
 done
 

--- a/plugins/rite/hooks/tests/start-md-charter.test.sh
+++ b/plugins/rite/hooks/tests/start-md-charter.test.sh
@@ -41,9 +41,10 @@
 #     - META_FIXTURES counter == 6 (drift 検出アンカー)
 #     - identification power の regression (mutation 実装が壊れた場合) を CI で機械検出
 #
-# Note (PR C 以降):
-#   `MUST execute in the SAME response turn` ≥ 30 / `DO NOT stop` ≥ 30 の追加 assert は
-#   PR C で 2 文 contract phrase が導入された後に別 PR で追加する。本 PR では実装しない。
+# Note (PR C 実装済み, Issue #899):
+#   `MUST execute in the SAME response turn` ≥ 17 / `DO NOT stop, do NOT re-invoke` ≥ 17 の
+#   下限 assert を PR C で有効化済み (Mandatory After heading 17 件 + 各 1 件導入による現状値を ratchet)。
+#   設計ドキュメント上の最終目標 ≥ 30 は Pre-write block への展開を含む後続 PR で引き上げる予定。
 
 set -euo pipefail
 
@@ -338,6 +339,29 @@ if [ "$mandatory_count" -ge 17 ]; then
   pass "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count)"
 else
   fail "Lower: \`Mandatory After\` heading-anchor count >= 17 (actual=$mandatory_count, expected >=17)"
+fi
+
+# Issue #899 (PR C) で導入された 2 文 contract phrase の下限 assert。
+# 設計ドキュメント L52-53 では「標準化 phrase ≥ 30」と記述されているが、PR C 直接の射程では
+# Mandatory After heading 17 件 + 各 heading に 1 件ずつ 2 文 contract を導入したため、現状値は
+# `MUST execute in the SAME response turn` 17 / `DO NOT stop, do NOT re-invoke` 17 となる。
+# 30 件への引き上げは後続 PR (D/E/F/G1/G2/H) で Pre-write block へも phrase を展開してから別 PR で
+# 行う。本 PR ではまず 17 件 (= Mandatory After heading 数) を保護する ratchet 下限として pin する
+# (PR C 完了の現状値 ≤ 後続 PR の追加分、で削除のみを catch)。
+# 旧コメント (本ファイル冒頭 L45-46) の「PR C で 2 文 contract phrase が導入された後に別 PR で
+# 追加する」記述に従い、本 PR C で 17 ≥ assert を有効化する。
+must_execute_count=$({ grep -oE 'MUST execute in the SAME response turn' "$START_MD" || true; } | wc -l | tr -d ' ')
+if [ "$must_execute_count" -ge 17 ]; then
+  pass "Lower: \`MUST execute in the SAME response turn\` count >= 17 (actual=$must_execute_count)"
+else
+  fail "Lower: \`MUST execute in the SAME response turn\` count >= 17 (actual=$must_execute_count, expected >=17)"
+fi
+
+do_not_stop_count=$({ grep -oE 'DO NOT stop, do NOT re-invoke' "$START_MD" || true; } | wc -l | tr -d ' ')
+if [ "$do_not_stop_count" -ge 17 ]; then
+  pass "Lower: \`DO NOT stop, do NOT re-invoke\` count >= 17 (actual=$do_not_stop_count)"
+else
+  fail "Lower: \`DO NOT stop, do NOT re-invoke\` count >= 17 (actual=$do_not_stop_count, expected >=17)"
 fi
 
 # === 対称性 assert: flow-state-update.sh create の 5 引数 ===


### PR DESCRIPTION
## 概要

親 Issue #896 (XL 分解) の Sub-Issue #899 (PR C) を実装。Mandatory After 17 箇所の
rationale 散文を 2 文 contract phrase に標準化し、Pre-write + Mandatory After 契約と
`state-read.sh` fail-fast pattern を 2 つの new reference に集約する。

Closes #899
Refs #896 (parent)

## 変更内容

### 新規 references
- `plugins/rite/commands/issue/references/flow-state-scaffolding.md` (119 行)
  - Pre-write + Mandatory After 契約 SoT、5 引数 canonical literal、second-write
    rationale、stop-guard 通称＝実体 `pre-tool-bash-guard.sh` 注記、17 箇所適用先
    テーブル、アンチパターン
- `plugins/rite/commands/issue/references/pre-condition-gate.md` (132 行)
  - `state-read.sh` fail-fast pattern SoT、`.phase` vs `.previous_phase` 使い分け、
    Form A 複数行 form (Pre-condition) と Form B inline 1 行 form (metrics step) の
    使い分け (TC-3 と TC-6 の grep pin 整合)、4 site canonical、アンチパターン

### 本体編集
- `plugins/rite/commands/issue/start.md` (2303 → 2295 行、本体 -8 行)
  - Mandatory After section (h3 14 件 + h4 3 件 = 17 件) の rationale 散文を 2 文
    contract phrase に統一:
    ```
    > See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
    > MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
    ```
  - Pre-condition check 3 箇所 (Phase 3 / 5.5.1 / 5.6) の散文 rationale 三層を
    pre-condition-gate.md anchor + 複数行 form bash literal に圧縮
  - bash literal (5 引数 `flow-state-update.sh create`) は runtime contract のため
    本体維持。Mandatory After heading-anchor count は 17 件で不変

### テスト
- `plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh` 新規 (167 行)
  - start.md 以外の caller (implement.md / create.md / create-interview.md /
    cleanup.md = 4 site, 5 block) で `flow-state-update.sh create` の 5 引数対称性を
    機械検証。`compute_symmetry_for()` と同型の awk fence-aware ブロック抽出
- `plugins/rite/hooks/tests/start-md-charter.test.sh` に PR C 後の下限 assert 2 件を
  有効化:
  - `MUST execute in the SAME response turn` ≥ 17
  - `DO NOT stop, do NOT re-invoke` ≥ 17

## 検証

| Test | 結果 |
|------|------|
| `caller-markdown-block.test.sh` | 23/23 ✅ (TC-3 複数行 form + TC-6 inline 1 行 form 両 pin 整合) |
| `flow-state-create-symmetry.test.sh` (新規) | 6/6 ✅ (4 site 5 block 全 pass) |
| `4-site-symmetry.test.sh` | 8/8 ✅ (regression なし) |
| `start-md-charter.test.sh` (default) | 8/8 ✅ |
| `start-md-charter.test.sh` STRICT_CHARTER=1 | 16/17 ⚠️ |

STRICT_CHARTER=1 で残る 1 件 fail は `🚨 ≤ 5 (actual=17)` で、Mandatory After
heading 17 件 (heading-anchor 構造保護) によるもの。PR A の設計通り後続 PR (D-H)
での slim 進捗 ratchet として継続。本 PR C で新規に増加させた違反ではない (PR B
後と同じ 17 件)。

## metrics

| 項目 | 変化 |
|------|------|
| start.md 行数 | 2303 → 2295 (-8) |
| contract phrase (各) | 0 → 17 |
| `Issue #[0-9]+` | 1 → 1 (上限 ≤1 維持) |
| `cycle [0-9]+` | 0 → 0 (上限 ≤1 維持) |
| Mandatory After heading | 17 → 17 (下限 ≥17 維持) |
| `flow-state-update.sh create` 5-arg Symmetry | 32/32 (asymmetric 0) |

## Test plan

- [x] `caller-markdown-block.test.sh` 23/23 pass
- [x] `flow-state-create-symmetry.test.sh` 6/6 pass (新規)
- [x] `4-site-symmetry.test.sh` 8/8 pass (regression なし)
- [x] `start-md-charter.test.sh` default 8/8 pass
- [x] `STRICT_CHARTER=1` で 16/17 (既存 🚨 ≤5 fail のみ、新規 regression なし)
- [ ] e2e: `/rite:resume` 復帰経路の軽量確認 (Mandatory After 後の routing 整合)
- [ ] verified-review サイクル / マルチレビュアー review

## 補足: stop-guard 通称について

develop ブランチでは `plugins/rite/hooks/stop-guard.sh` は実体不在。機能は
`pre-tool-bash-guard.sh` (574 行) および `phase-transition-whitelist.sh` に統合・
移管されている。本 PR C で flow-state-scaffolding.md にこの通称関係を明文化した
(本体 start.md 内の `stop-guard` 言及 29 箇所の整理は後続 PR の射程)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)