### PR TITLE
fix(wiki): page-template.md のソースリンク relative path 修正

### DIFF
--- a/plugins/rite/templates/wiki/page-template.md
+++ b/plugins/rite/templates/wiki/page-template.md
@@ -26,4 +26,4 @@ confidence: medium
 
 ## ソース
 
-- [{source_description}]({source_ref})
+- [{source_description}](../../{source_ref})


### PR DESCRIPTION
## 概要

`plugins/rite/templates/wiki/page-template.md` line 29 の `## ソース` セクションのリンク URL を `{source_ref}` → `../../{source_ref}` に変更。新規 Wiki page (`.rite/wiki/pages/{domain}/{slug}.md`) から wiki root への相対 path 計算が正しくなり、lint で broken_refs として検出されなくなる。

Closes #938

## 変更内容

- `plugins/rite/templates/wiki/page-template.md` line 29
  - Before: `- [{source_description}]({source_ref})`
  - After: `- [{source_description}](../../{source_ref})`

## Root Cause

`{source_ref}` placeholder は 2 用途で再利用されていた:

1. frontmatter `sources[].ref` (line 8) — 識別子目的、bare path で OK
2. `## ソース` セクションのリンク URL (line 29) — Markdown link resolution の対象、相対 path 計算が必要

後者では page 深度 (`pages/{domain}/`) から wiki root への `../../` prefix が必要だが template に含まれていなかった。本 PR は line 29 のみに prefix を追加し、line 8 (frontmatter) はそのまま維持する。

## Scope

**In Scope**:
- `plugins/rite/templates/wiki/page-template.md` line 29 の 1 行修正

**Out of Scope**:
- 既存 wiki page (`.rite/wiki/pages/**`) — PR #936 cleanup フローで wiki branch HEAD=9990280c に既に修正済み
- `{related_page_path}` placeholder — 同型の relative path 問題があるかもしれないが本 Issue では扱わない（別途検証要）
- `ingest.md` / その他参照ドキュメント — template 修正のみで動作する

## Acceptance Criteria

- **AC-1 (Happy path)**: 修正後の template で `/rite:wiki:ingest` 実行 → 生成された page の `## ソース` リンク URL が `../../raw/{type}/{filename}.md` 形式
- **AC-2 (Non-regression)**: 修正後の新規 page が `/rite:wiki:lint` の broken_refs に含まれない（lint 検出 0 件）

## Test Plan

- [x] line 29 が `[{source_description}](../../{source_ref})` に変更されていること（grep 確認済み）
- [x] line 8 の frontmatter `ref: "{source_ref}"` が不変であること（grep 確認済み）
- [ ] レビュー時: template substitution ロジック (`ingest.md`) が `{source_ref}` に bare path を渡し続けることを確認

## Known Issues

- 通常 lint コマンド (`commands.lint`) は本リポジトリで未設定 (null) のためスキップ
- Plugin-specific checks の warning は全て **pre-existing baseline**（本 PR の 1 行変更とは無関係）:
  - distributed-fix-drift: 32 findings
  - wiki-growth: 1 finding
  - comment-journal: 172 findings
  - comment-line-ref: 21 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
