### PR TITLE
docs(wiki): #940 ingest.md F-15 注釈で source_ref と URL prefix 分担を明示

### DIFF
--- a/plugins/rite/commands/wiki/ingest.md
+++ b/plugins/rite/commands/wiki/ingest.md
@@ -778,6 +778,8 @@ fi
 > **`{source_type}` から `manual` を削除** (F-15 fix): `wiki-ingest-trigger.sh` は `reviews|retrospectives|fixes` の 3 値のみを受理するため、本 placeholder で `manual` を許容すると drift 源になります。手動投入経路を導入する場合は trigger.sh 側のバリデーションも同時に拡張すること。
 >
 > **`{source_ref}` のセマンティクス分離** (F-15 fix): page-template.md は frontmatter の `sources[].ref` と「## ソース」セクションのリンク URL の 2 箇所で `{source_ref}` を参照しますが、両方とも **ファイル相対パス** (例: `raw/reviews/20260413T...md`) を使用します。リンクの**表示テキスト**には `{source_description}` を使い、URL には `{source_ref}` を使うことで両者を分離してください。`wiki-ingest-trigger.sh` の frontmatter 内 `source_ref` フィールド (例: `pr-123`) は識別子であり、ここで参照される `{source_ref}` (ファイル相対パス) とは別物です。
+>
+> **設計意図** (#940 fix): `{source_ref}` placeholder の値は wiki-root 相対の bare path (例: `raw/reviews/foo.md`) のまま使用する。`## ソース` セクションのリンク URL には、新規 page 格納位置 `.rite/wiki/pages/{domain}/{slug}.md` から wiki root への 2 階層上昇を表す `../../` prefix を template リテラル側で hardcode する (page-template.md L29 参照)。placeholder 値自体に URL prefix を含めないことで、frontmatter `sources[].ref` (識別子目的) と Markdown link URL (resolution 対象) の semantics 分離を維持する。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #940 対応。`plugins/rite/commands/wiki/ingest.md` L780 の F-15 fix 注釈の直後に「設計意図」段落を追記し、`{source_ref}` placeholder の値と template literal 側の URL prefix の役割分担を明示する。

## 関連 Issue

Closes #940

関連:
- PR #939 (page-template.md `../../` prefix 追加の元 PR)
- Issue #938 (URL prefix 重複の original incident)

## 変更内容

- `plugins/rite/commands/wiki/ingest.md` L780-782 周辺:
  既存の `{source_ref}` のセマンティクス分離注釈の後ろに、Issue #940 で提案された「設計意図」段落を追加。
    - `{source_ref}` placeholder の値は wiki-root 相対の bare path (例: `raw/reviews/foo.md`) のまま
    - `## ソース` セクションのリンク URL の `../../` prefix は template リテラル側で hardcode (page-template.md L29 参照)
    - frontmatter `sources[].ref` (識別子) と Markdown link URL (resolution 対象) の semantics 分離を維持

## 背景・Why

PR #939 のレビューで tech-writer reviewer が検出した LOW severity findings。PR #939 自体は page-template.md L29 を `[{source_description}]({source_ref})` → `[{source_description}](../../{source_ref})` に修正したが、ingest.md L780 の既存注釈は「URL も `raw/...` をそのまま使う」と誤読され得る表現になっていた。

読者が「placeholder 値そのものが `../../raw/...` を持つ」と誤解した場合、Issue #938 と同種の URL prefix 重複/欠落バグを再導入する可能性があるため、設計意図を明文化する。

## 変更ファイル

- `plugins/rite/commands/wiki/ingest.md` - 変更 (2 行追記)

## チェックリスト

- [x] ドキュメント追記のみ (コード変更なし)
- [x] lint 実行 (commands.lint 未設定、plugin-specific checks は baseline 維持)
- [x] 変更箇所 L780-790 に新規 warning 発生なし
- [ ] レビュー対応
- [ ] Ready for review に変更

## 影響範囲

ドキュメントのみ。runtime 動作・既存テストへの影響なし。

