### PR TITLE
fix(wiki): #941 related_page_path placeholder の page-dir 相対 path 起点を明示

### DIFF
--- a/plugins/rite/commands/wiki/ingest.md
+++ b/plugins/rite/commands/wiki/ingest.md
@@ -780,6 +780,8 @@ fi
 > **`{source_ref}` のセマンティクス分離** (F-15 fix): page-template.md は frontmatter の `sources[].ref` と「## ソース」セクションのリンク URL の 2 箇所で `{source_ref}` を参照しますが、両方とも **ファイル相対パス** (例: `raw/reviews/20260413T...md`) を使用します。リンクの**表示テキスト**には `{source_description}` を使い、URL には `{source_ref}` を使うことで両者を分離してください。`wiki-ingest-trigger.sh` の frontmatter 内 `source_ref` フィールド (例: `pr-123`) は識別子であり、ここで参照される `{source_ref}` (ファイル相対パス) とは別物です。
 >
 > **設計意図** (#940 fix): `{source_ref}` placeholder の値は wiki-root 相対の bare path (例: `raw/reviews/foo.md`) のまま使用する。`## ソース` セクションのリンク URL には、新規 page 格納位置 `.rite/wiki/pages/{domain}/{slug}.md` から wiki root への 2 階層上昇を表す `../../` prefix を template リテラル側で hardcode する (page-template.md L29 参照)。placeholder 値自体に URL prefix を含めないことで、frontmatter `sources[].ref` (識別子目的) と Markdown link URL (resolution 対象) の semantics 分離を維持する。
+>
+> **設計意図** (#941 fix): `{related_page_path}` placeholder の値は **page-dir 相対** の path を substitute する (例: 同ドメイン内 `./other-page.md` または `other-page.md`、別ドメイン `../{domain}/other-page.md`)。新規 page 格納位置は `.rite/wiki/pages/{domain}/{slug}.md` であり、`## 関連ページ` セクションのリンク URL はその page-dir (`.rite/wiki/pages/{domain}/`) 起点で resolve される。`{source_ref}` (wiki-root 起点、template 側で `../../` prefix を hardcode) とは **起点が異なる** ため、`{related_page_path}` には template リテラル側で prefix を付けず、placeholder 値そのものに page-dir 相対 path を入れる方針を採る。Phase 4 で関連ページを特定する際は、対象ページの格納パスから新規 page 格納パスへの相対 path を計算して substitute する (実装サンプル: `.rite/wiki/pages/anti-patterns/asymmetric-fix-transcription.md` 等が `../heuristics/foo.md` / `./bar.md` 形式で記述されている)。
 
 ---
 

--- a/plugins/rite/references/wiki-patterns.md
+++ b/plugins/rite/references/wiki-patterns.md
@@ -217,7 +217,7 @@ Wiki 初期化時にテンプレートを `.rite/wiki/` に展開します。
 | `{summary}` | ページ概要（1-2文、Ingest 時） |
 | `{details}` | 詳細説明（Ingest 時） |
 | `{related_page_title}` | 関連ページのタイトル（Ingest 時） |
-| `{related_page_path}` | 関連ページの相対パス（Ingest 時） |
+| `{related_page_path}` | 関連ページへの **page-dir 相対パス**（Ingest 時）。新規 page 格納位置 `.rite/wiki/pages/{domain}/{slug}.md` の格納ディレクトリ `.rite/wiki/pages/{domain}/` を起点として resolve される。同ドメイン内は `./other.md` または `other.md`、別ドメインは `../{other_domain}/other.md` の形式で substitute する。`{source_ref}` (wiki-root 起点、template 側で `../../` prefix を hardcode) とは **起点が異なる** 点に注意。詳細は `plugins/rite/commands/wiki/ingest.md` Phase 5.3 の「設計意図 (#941 fix)」を参照 |
 | `{source_description}` | ソースの説明文（Ingest 時） |
 
 > **confidence フィールド**: page-template.md の `confidence: medium` はリテラル値であり `{confidence}` プレースホルダーではない。Write 後に Edit で Phase 4 の判定値 (`high` / `medium` / `low`) に置換する。


### PR DESCRIPTION
## 概要

`{related_page_path}` placeholder の起点が ingest.md / wiki-patterns.md に明示されていなかった gap を埋める documentation clarification。実 wiki page (`asymmetric-fix-transcription.md` 等多数) の実測により page-dir 相対 path で機能していることを確認した上で、`{source_ref}` (wiki-root 起点 + `../../` prefix) との semantics 対比を文書化。

## 背景

PR #939 / Issue #938 で `{source_ref}` の relative path 起点を修正した後、tech-writer reviewer + code-quality reviewer が `{related_page_path}` も同種の問題を潜在している可能性を Issue #941 として LOW で指摘した。本 PR で逆引き調査を行い、結論として:

- 実 wiki page 30+ 件中 8 件 sample で `./foo.md` / `../{domain}/bar.md` 形式を確認 → **page-dir 起点で機能している**
- `{source_ref}` (wiki-root 起点) とは異なる起点
- broken_refs は現時点で発生していない
- ただし、起点規約が ingest.md / wiki-patterns.md に未明示だった

## 変更内容

- `plugins/rite/commands/wiki/ingest.md` Phase 5.3: `{source_ref}` 設計意図段落 (PR #940 で確立、L780-782) の直後に `{related_page_path}` 用設計意図 blockquote を追加。page-dir 起点・例 (`./other.md` / `../{domain}/other.md`)・`{source_ref}` との対比軸を明示
- `plugins/rite/references/wiki-patterns.md` L220: `{related_page_path}` 行を「page-dir 相対パス」明示版に更新し、詳細は ingest.md Phase 5.3 を参照する案内を追記

**page-template.md L25 は触らない**: 現状の `- [{related_page_title}]({related_page_path})` リテラルは page-dir 起点 placeholder 値とそのまま整合しており修正不要。

## 関連 Issue

Closes #941

関連 PR:
- #939 (`{source_ref}` 側修正、`../../` prefix 追加)
- #942 (ingest.md F-15 注釈に `{source_ref}` 設計意図段落を追加)

## 検証

- Grep で `{related_page_path}` 関連の page-dir / ページディレクトリ 言及が両ファイルに hit することを確認
- 実 wiki page の `## 関連ページ` link が現状動作している事実は既存 wiki 30+ ページの構造で実証済み
- 本 PR は documentation clarification のみで実行コード変更なし

## Known Issues

`/rite:lint` で 225 件の警告を検出。すべて本 PR 外のファイルで develop に既存:
- distributed-fix-drift-check: 32 件 (pr/fix.md の P2/P3/P5 patterns)
- comment-journal: 172 件 (issue/close.md, pr/fix.md 等の P1/P2 patterns)
- comment-line-ref: 21 件 (hooks/*.sh の comment line-number references)

これらは pre-existing で本 PR の変更とは無関係。スコープ外のため別途プロジェクト全体のクリーンアップで対応推奨。

## チェックリスト

- [x] 調査: 既存 wiki page の `## 関連ページ` 起点を逆引き確認 (page-dir 起点)
- [x] ingest.md: `{related_page_path}` 設計意図 blockquote 追加
- [x] wiki-patterns.md: placeholder 説明を「page-dir 相対」明示版に更新
- [x] lint: `[lint:success]` (本 PR 0 件追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
