### PR TITLE
refactor(issue): start.md Phase 5.5.2 / 5.2.1 / 2.4 を 3 references に抽出 [PR E]

### DIFF
--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -1,0 +1,113 @@
+# Checklist Auto-Check — Phase 5.2.1 + 5.2.1.1 SoT
+
+> **Source of Truth**: 本ファイルは `/rite:issue:start` Phase 5.2.1 (Checklist Confirmation) および Phase 5.2.1.1 (Auto-Check Evaluation) の **bash literal + 評価ロジック の SoT** である。`start.md` 本体の Phase 5.2.1 / 5.2.1.1 は本ファイルへ semantic 参照する anchor stub のみ保持する。
+>
+> **抽出経緯**: `start.md` Phase 5.2.1 + 5.2.1.1 は ~100 行で、Issue body checklist の grep 確認 + auto-check evaluation + uncertain handling + re-check の 4 layer logic を 1 reference に集約することで、本体の認知負荷を下げる。Issue #901 (PR E — #896 親 Issue) で抽出。
+>
+> **caller**: `start.md` Phase 5.2.1 (唯一の caller、`/rite:lint` returns 直後に呼び出される)。
+
+## Phase 5.2.1: Checklist Confirmation
+
+**Owner**: `/rite:issue:start` after `/rite:lint` returns. **Condition**: Execute only if checklist retained in Phase 3.6. **Purpose**: Block PR until all items complete.
+
+Use `grep -E` (not `-P`). Pattern per [gh-cli-patterns.md](../../../references/gh-cli-patterns.md#safe-checklist-operation-patterns).
+
+```bash
+issue_body=$(gh issue view {issue_number} --json body --jq '.body')
+[ -z "$issue_body" ] && echo "ERROR: Issue body の取得に失敗" >&2 && exit 1
+echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' || true
+echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true
+```
+
+**Determine**: `grep -c` output `0`→all complete→5.3. `≥1`→incomplete→proceed to 5.2.1.1 (auto-check). Empty body→retry 5.1. **Mandatory**, cannot skip.
+
+## Phase 5.2.1.1: Auto-Check Evaluation
+
+When incomplete checklist items are detected, evaluate each item's fulfillment status based on the current implementation state before returning to Phase 5.1.
+
+**Purpose**: Prevent infinite loops where implementation is complete but Definition of Done checklist items remain unchecked because no process updates them to `- [x]`.
+
+### Evaluation procedure
+
+1. **Collect evidence**: Use `git diff origin/{base_branch}...HEAD --name-only` and `git log --oneline origin/{base_branch}...HEAD` to understand what was implemented.
+
+2. **Evaluate each incomplete item**: For each `- [ ]` item, assess whether the item is satisfied based on the implementation evidence:
+
+   | Assessment | Criteria | Action |
+   |-----------|----------|--------|
+   | **Satisfied** | Implementation evidence clearly fulfills the item | Mark as `- [x]` |
+   | **Not satisfied** | No evidence of fulfillment, or clearly incomplete | Keep as `- [ ]` |
+   | **Uncertain** | Cannot confidently determine | Present to user via `AskUserQuestion` |
+
+3. **Update Issue body**: If any items are newly marked as satisfied, update the Issue body via `gh issue edit`:
+
+   Follow the "Checkbox Update" pattern in [gh-cli-patterns.md](../../../references/gh-cli-patterns.md#safe-checklist-operation-patterns). Use Python for safe `- [ ]` → `- [x]` replacement (do NOT use `sed`).
+
+   ```bash
+   # Step 1: Retrieve current body and validate
+   tmpfile_read=$(mktemp)
+   tmpfile_write=$(mktemp)
+   trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
+   gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"
+
+   if [ ! -s "$tmpfile_read" ]; then
+     echo "ERROR: Issue body の取得に失敗" >&2
+     exit 1
+   fi
+
+   # Output paths for subsequent Read/Write tool calls
+   echo "tmpfile_read=$tmpfile_read"
+   echo "tmpfile_write=$tmpfile_write"
+   ```
+
+   Then use the Read tool to read `$tmpfile_read` (the path output above), apply `- [ ]` → `- [x]` replacements for satisfied items using the Write tool to `$tmpfile_write`, and apply:
+
+   **Note**: Shell variables do not carry over between Bash tool calls. Use the literal paths output by `echo "tmpfile_read=..."` in Step 1 directly in the command below.
+
+   ```bash
+   # Replace with actual paths from Step 1 output (e.g., /tmp/tmp.XXXXXXXXXX)
+   tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Step 1 の出力値に置換
+
+   if [ ! -s "$tmpfile_write" ]; then
+     echo "ERROR: Updated content is empty" >&2
+     exit 1
+   fi
+
+   gh issue edit {issue_number} --body-file "$tmpfile_write"
+   ```
+
+4. **Re-check**: After updating, re-run the checklist check:
+
+   ```bash
+   issue_body=$(gh issue view {issue_number} --json body --jq '.body')
+   [ -z "$issue_body" ] && echo "ERROR: Issue body の取得に失敗" >&2 && exit 1
+   echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true
+   ```
+
+   - `0` (all complete) → Proceed to Phase 5.3
+   - `≥1` (still incomplete) → Display remaining incomplete items and return to Phase 5.1
+   - Empty body → retry Phase 5.1
+
+### User confirmation for uncertain items
+
+When items are assessed as "Uncertain", use `AskUserQuestion`:
+
+```
+以下のチェックリスト項目の充足状態を確認してください:
+
+- [ ] {item_text}
+
+オプション:
+- 充足済みとしてチェック（推奨）: この項目を完了とマークします
+- 未充足: Phase 5.1 に戻って対応します
+```
+
+### Constraints
+
+- Already checked items (`- [x]`) are never modified (AC-3 non-regression)
+- Issue reference items (`- [ ] #XX`) are excluded from evaluation (parent-child tracking)
+- Auto-check is executed **at most once per 5.2.1 invocation** to prevent evaluation loops
+
+## 関連
+
+- [`../../../references/gh-cli-patterns.md`](../../../references/gh-cli-patterns.md#safe-checklist-operation-patterns) — Safe Checklist Operation Patterns / Checkbox Update pattern

--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -41,7 +41,7 @@ When incomplete checklist items are detected, evaluate each item's fulfillment s
 
 3. **Update Issue body**: If any items are newly marked as satisfied, update the Issue body via `gh issue edit`:
 
-   Follow the "Checkbox Update" pattern in [gh-cli-patterns.md](../../../references/gh-cli-patterns.md#safe-checklist-operation-patterns). Use Python for safe `- [ ]` → `- [x]` replacement (do NOT use `sed`).
+   Follow the "Checkbox Update" pattern in [gh-cli-patterns.md](../../../references/gh-cli-patterns.md#safe-checklist-operation-patterns). Use Read+Write tools for safe `- [ ]` → `- [x]` replacement (do NOT use `sed`).
 
    ```bash
    # Step 1: Retrieve current body and validate

--- a/plugins/rite/commands/issue/references/metrics-recording.md
+++ b/plugins/rite/commands/issue/references/metrics-recording.md
@@ -1,0 +1,218 @@
+# Metrics Recording — Phase 5.5.2 SoT
+
+> **Source of Truth**: 本ファイルは `/rite:issue:start` Phase 5.5.2 (Metrics Recording) の **bash literal + LLM 制御指示の SoT** である。`start.md` 本体の Phase 5.5.2 は本ファイルへ semantic 参照する anchor stub のみ保持する。
+>
+> **抽出経緯**: `start.md` Phase 5.5.2 は ~200 行で本体の最大 inline section の一つだった。Step 1 (collect metrics + plan_deviation_count bash block) / Step 2 (threshold evaluation) / Step 3 (failure classification) / Step 4 (heredoc PATCH 本体) / Step 5 (repeated failure) を 1 reference に集約することで、`start.md` 本体の認知負荷を下げる。Issue #901 (PR E — #896 親 Issue) で抽出。
+>
+> **caller**: `start.md` Phase 5.5.2 (唯一の caller)。本 reference の bash literal および LLM 指示はこの caller でのみ使用される。
+
+## Skip Steps note (Phase 5.6 pre-condition)
+
+`metrics.enabled: false` in rite-config.yml の場合、Step 1-5 を skip する。**ただし Mandatory After 5.5.2 は無条件実行する。** `phase5_post_metrics` marker は Phase 5.6 pre-condition で要求されるため、Mandatory After を skip すると `.phase = phase5_post_status_in_review` のままで Phase 5.6 ERROR gate が hard abort する。
+
+Otherwise:
+
+## Step 1: Collect metrics
+
+Collect metrics from the current workflow execution:
+
+| Metric | Source | How to Obtain |
+|--------|--------|---------------|
+| `plan_deviation_rate` | Issue body checklist items (Phase 3.6) vs completed items | `planned_steps` = total checklist items added in Phase 3.6. `actual_steps` = checked items at completion. Formula: `abs(actual - planned) / planned * 100`. If `planned = 0`, set judgment to `skip` |
+| `test_pass_rate` | From Phase 5.2 lint results | 100% if tests passed or no tests configured |
+| `review_critical_high` | Phase 5.4 review results | Count of CRITICAL+HIGH findings from the last `📜 rite レビュー結果` PR comment |
+| `review_fix_loops` | PR comments | Count `📜 rite レビュー結果` comments on the PR: `gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '[.[] | select(.body | contains("📜 rite レビュー結果"))] | length'` |
+| `plan_deviation_count` | flow-state | Read `implementation_round` field (set by Phase 5.1.3) via `state-read.sh`. **Use the same fail-fast pattern documented at the Phase 3 pre-condition** (canonical `if cmd; then :; else rc=$?; fi` form). state-read.sh launch failure 時は metrics output を skip し、silent に `"0"` 扱い (= "no deviation" の誤分類) しないこと。per-session state を参照 (legacy state file snapshot ではない)。Phase 5.1 への re-entry 数 (checklist failure 由来) を計測。詳細な bash literal は本ファイルの「`plan_deviation_count` 取得 bash block」セクション参照 |
+
+> **Note**: bash literal は table cell 内に埋め込まず、独立 code block として下に分離している。これは LLM が table を読んで値を提示する際に、cell 内 literal を正規の Bash tool 呼び出しと誤認するリスクを避けるため。table cell 内の prose は Phase 3 pre-condition への semantic reference にとどめる。
+
+### `plan_deviation_count` 取得 bash block
+
+canonical capture pattern を維持し `caller-markdown-block.test.sh` G-03 metatest が pass することを保証:
+
+```bash
+# canonical fail-fast pattern (Phase 3 pre-condition と同型): state-read.sh 起動失敗時は
+# silent default 0 (= "no deviation") に降格せず、metrics output を skip する。
+# 注意: inline 1 行 form を維持 (caller-markdown-block.test.sh TC-6 が
+# `if val=...; then :; else rc=$?` の 1 行 canonical capture pattern を grep で pin する)。
+if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_2_metrics; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
+# numeric type validation (writer/reader/resume 3 layer 対称化 doctrine): 他 caller (Phase 5.7
+# parent_issue_number / implement.md parent_issue_number / pr/review.md loop_count /
+# resume.md parent_issue_number_raw) と同様に non-numeric 値を 0 に降格して partial corruption
+# (`| 計画逸脱回数 | abc回 |` 等) を防ぐ。空文字列 (state-read.sh 失敗) は下記 if-z で別途
+# METRICS_SKIPPED 経路へ流すため、ここでは非空かつ非数値のみ 0 に降格する。
+case "$val" in
+  '') ;;
+  *[!0-9]*)
+    echo "WARNING: implementation_round is not numeric ('$val'), defaulting to 0 (partial corruption 防止)" >&2
+    val=0
+    ;;
+esac
+plan_deviation_count="$val"
+# state-read.sh 失敗時 (`val=""`) は METRICS_SKIPPED sentinel を emit し、後続 Step 2/3/4
+# (threshold evaluation + failure classification + PATCH heredoc generation) を skip させる。
+# silent に空文字列 `{plan_deviation_count}` substitute が下流 heredoc (Phase 5.5.2 完了レポート)
+# に流入し `| 計画逸脱回数 | 回 | ...` の partial corruption が発生する経路
+# を遮断する。Claude は本 sentinel を会話履歴で grep し、検出時は **Phase 5.5.2 metrics body 生成を skip** すること
+# (= metrics PATCH を実行せず、ただし Mandatory After 5.5.2 の `phase5_post_metrics` marker は必ず書き込み、Phase 5.6 へ進む)。
+#
+# 成功経路では PLAN_DEVIATION_COUNT sentinel を emit し、Claude が会話履歴を grep して
+# Step 4 heredoc の `{plan_deviation_count}` placeholder に literal substitute する。シェル変数
+# `$plan_deviation_count` は Bash tool 境界で消失するため、stdout/stderr に明示的に emit しない限り
+# Claude は値を読み取れない。同型の cross-boundary state transfer は resume.md Phase 2.1 Step 1
+# / start.md Phase 5.7 で確立済みの canonical pattern。
+#
+# Emit channel policy: cross-boundary state transfer の sentinel は **stdout / stderr のいずれでも会話コンテキストに記録される**。
+# Claude Code の Bash tool は stdout/stderr 両方を会話コンテキストに取り込む仕様のため、emit channel の
+# 統一は機能要件ではない。本箇所は METRICS_SKIPPED と PLAN_DEVIATION_COUNT を一貫して stderr に emit する
+# (両者を観測値ストリームとして揃える設計選択)。PARENT_ISSUE / PARENT_ISSUE_DISPLAY は stdout 側で emit する
+# 既存の canonical pattern を維持しつつ、本箇所の stderr 採用は **observability ログ専用ストリームを stderr に集約する** 一貫性のための設計選択。
+if [ -z "$val" ]; then
+  echo "[CONTEXT] METRICS_SKIPPED=1; reason=state_read_failed" >&2
+else
+  echo "[CONTEXT] PLAN_DEVIATION_COUNT=$plan_deviation_count" >&2
+fi
+```
+
+### Claude への指示 (METRICS_SKIPPED 検出時の挙動)
+
+上記 bash block 実行後、stderr に `[CONTEXT] METRICS_SKIPPED=1; reason=state_read_failed` が emit された場合、Claude は **Step 2 (threshold evaluation)、Step 3 (failure classification)、Step 4 (PATCH heredoc generation) の 3 step すべてを skip** し、`Phase 5.5.2: state-read.sh 失敗のため metrics 更新を skip しました (manual intervention で次回計測してください)` を stderr に出力する。その後、**Mandatory After 5.5.2 (`flow-state-update.sh create --phase phase5_post_metrics` の marker 書き込み) を unconditional に実行してから Phase 5.6 へ進む** (AC-5 により body skip 時も marker 書き込みは必須。これを skip すると Phase 5.6 pre-condition `expected: phase5_post_metrics` で hard abort する)。Phase 5.5.2 の実 heading 構造は Step 1=collect / Step 2=threshold / Step 3=failure classification / **Step 4=Append metrics section to work memory (= heredoc PATCH 本体)** / Step 5=repeated failure であり、Step 4 が PATCH heredoc 本体のため、Step 4 を skip 対象に含めないと空 placeholder の partial corruption が再発する self-defeating defense になる。
+
+## Step 2: Evaluate thresholds
+
+Read `metrics.baseline_issues` from rite-config.yml (default: 3).
+
+### Step 2a: Count completed Issues with metrics
+
+Search the 10 most recently closed Issues for work memory comments containing `📊 メトリクス`:
+
+```bash
+# 直近の closed Issue 番号を取得（最大10件）
+recent_issues=$(gh api "repos/{owner}/{repo}/issues?state=closed&per_page=10&sort=updated&direction=desc" --jq '.[].number')
+
+# 各 Issue のメトリクスセクションを検索
+for issue_num in $recent_issues; do
+  metrics=$(gh api "repos/{owner}/{repo}/issues/${issue_num}/comments" \
+    --jq '[.[] | select(.body | contains("📊 メトリクス"))] | last | .body' 2>/dev/null)
+  if [ -n "$metrics" ] && [ "$metrics" != "null" ]; then
+    echo "FOUND:${issue_num}"
+  fi
+done
+```
+
+### Step 2b: Determine baseline status
+
+- **Baseline period** (completed Issues with metrics < `baseline_issues`): Set all judgments to `skip`. Display: `📊 Baseline 収集中 ({n}/{baseline_issues}) — 閾値判定はスキップします`
+- **Post-baseline**: Proceed to Step 2c
+
+### Step 2c: Evaluate thresholds (post-baseline only)
+
+1. **Per-Issue thresholds** (from Step 1 values): `plan_deviation_rate <= 30`, `test_pass_rate == 100`, `review_fix_loops <= 3`. Set `pass` or `warn`.
+2. **MA thresholds**: Parse `📊 メトリクス` sections from the 5 most recent completed Issues (found in Step 2a). Extract each metric value, calculate the moving average, and compare against `baseline_ma5 * improvement_factor`. Set `pass`, `warn`, or `skip` (if fewer than `baseline_issues` completed).
+
+## Step 3: Determine failure classification
+
+If any threshold is `warn`: classify each violation per the [Metric-to-Failure-Class Mapping](../../../references/execution-metrics.md#metric-to-failure-class-mapping) table. Select primary failure class (most frequent; tie-break: last occurring).
+
+## Step 4: Append metrics section to work memory
+
+Update the Issue work memory comment by appending the metrics table per [Execution Metrics recording format](../../../references/execution-metrics.md#recording-format).
+
+> **Reference**: Apply [Work Memory Update Safety Patterns](../../../references/gh-cli-patterns.md#work-memory-update-safety-patterns).
+
+```bash
+# ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること（クロスプロセス変数参照を防止）
+# comment_data の取得・追記内容の heredoc 定義・PATCH を分割すると変数が失われる
+comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
+  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
+comment_id=$(echo "$comment_data" | jq -r '.id // empty')
+current_body=$(echo "$comment_data" | jq -r '.body // empty')
+
+if [ -z "$comment_id" ]; then
+  # comment not found: skip metrics recording entirely (non-fatal; metrics are optional)
+  echo "ERROR: Work memory comment not found. Skipping metrics recording." >&2
+  exit 0
+fi
+
+# 1. Backup before update
+backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
+printf '%s' "$current_body" > "$backup_file"
+
+if [[ -z "$current_body" ]]; then
+  echo "ERROR: Updated body is empty or too short. Aborting PATCH." >&2
+  echo "Backup saved at: $backup_file" >&2
+  exit 1
+fi
+
+# 2. Append metrics section
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+printf '%s\n\n' "$current_body" > "$tmpfile"
+# ⚠️ 以下の heredoc 内の {…} プレースホルダーを Step 1-3 の実測値で置換してから実行すること
+cat >> "$tmpfile" << 'METRICS_EOF'
+### 📊 メトリクス
+
+| メトリクス | 値 | 閾値 | 判定 |
+|-----------|-----|------|------|
+| 計画乖離率 | {plan_deviation_rate}% | ≤30% | {judgment} |
+| テスト通過率 | {test_pass_rate}% | 100% | {judgment} |
+| レビュー指摘(CRITICAL+HIGH) | {review_critical_high}件 | MA5≤{threshold} | {judgment} |
+| review-fixループ | {review_fix_loops}回 | ≤3 | {judgment} |
+| 計画逸脱回数 | {plan_deviation_count}回 | MA5≤{threshold} | {judgment} |
+
+**Baseline**: {baseline_status}
+**失敗分類**: {primary_failure_class} ({corrective_action_pointer})
+METRICS_EOF
+
+# 3. Empty body guard
+if [ ! -s "$tmpfile" ] || [[ "$(wc -c < "$tmpfile")" -lt 10 ]]; then
+  echo "ERROR: Updated body is empty or too short. Aborting PATCH." >&2
+  echo "Backup saved at: $backup_file" >&2
+  exit 1
+fi
+
+# 4. Header validation
+if grep -q -- '📜 rite 作業メモリ' "$tmpfile"; then
+  : # Header present, proceed
+else
+  echo "ERROR: Updated body missing work memory header. Restoring from backup." >&2
+  cp "$backup_file" "$tmpfile"
+  exit 1
+fi
+
+# 5. PATCH
+jq -n --rawfile body "$tmpfile" '{"body": $body}' \
+  | gh api repos/{owner}/{repo}/issues/comments/"$comment_id" \
+    -X PATCH --input -
+patch_status=$?
+if [[ "${patch_status:-1}" -ne 0 ]]; then
+  echo "ERROR: PATCH failed (exit code: $patch_status). Backup saved at: $backup_file" >&2
+  exit 1
+fi
+```
+
+### Placeholder descriptions
+
+`{plan_deviation_rate}`, `{test_pass_rate}`, `{review_critical_high}`, `{review_fix_loops}`, `{plan_deviation_count}` are the values collected in Step 1. **`{plan_deviation_count}` の source**: Step 1 bash block の stderr に emit される `[CONTEXT] PLAN_DEVIATION_COUNT=<N>` 行を Claude が会話履歴で first-match で grep し、`<N>` 部分を literal substitute する (state-read.sh 失敗時は `[CONTEXT] METRICS_SKIPPED=1` が代わりに emit され、本 heredoc 全体が skip される — 上記「Claude への指示 (METRICS_SKIPPED 検出時の挙動)」段落を参照)。`{judgment}` is `pass`/`warn`/`skip` from Step 2. `{threshold}` is the MA5 threshold. `{baseline_status}`, `{primary_failure_class}`, `{corrective_action_pointer}` are from Steps 2-3. Before executing this bash block, replace all `{...}` placeholders in the heredoc body with actual values computed in Steps 1-3. The heredoc uses a single-quoted delimiter (`'METRICS_EOF'`) so shell variables are NOT expanded; Claude must substitute the placeholder text directly in the template before passing it to the Bash tool.
+
+## Step 5: Check repeated failure
+
+If `safety.auto_stop_on_repeated_failure: true` and the same primary failure class has occurred `safety.repeated_failure_threshold` times consecutively (across recent Issues), trigger fail-closed:
+
+```
+⚠️ 安全装置が発動しました（繰り返し失敗検出）
+分類: {failure_class} が {count} 回連続
+是正アクション: {corrective_action_pointer}
+```
+
+Present options via `AskUserQuestion`:
+- 続行（制限を引き上げ）→ Proceed to 5.6
+- 中止（作業メモリに状態保存）→ Phase 5.6
+- 手動介入（ユーザーが直接対応）→ terminate
+
+## 関連
+
+- [`../../../references/execution-metrics.md`](../../../references/execution-metrics.md) — メトリクス定義 / 閾値 / failure classification
+- [`../../../references/gh-cli-patterns.md`](../../../references/gh-cli-patterns.md#work-memory-update-safety-patterns) — Work Memory Update Safety Patterns
+- [`./pre-condition-gate.md`](./pre-condition-gate.md) — Phase 5.6 pre-condition の `state-read.sh` fail-fast pattern
+- `plugins/rite/hooks/tests/caller-markdown-block.test.sh` TC-6 — `implementation_round` inline form pin (本 reference の bash block を grep 対象とする)

--- a/plugins/rite/commands/issue/references/pre-condition-gate.md
+++ b/plugins/rite/commands/issue/references/pre-condition-gate.md
@@ -1,8 +1,8 @@
 # Pre-condition Gate — `state-read.sh` fail-fast Pattern SoT
 
-> **Source of Truth**: 本ファイルは `/rite:issue:start` ワークフローにおける **pre-condition check (#490 AC-5)** の `state-read.sh` fail-fast pattern の SoT である。`start.md` の Phase 3 / Phase 5.5.1 / Phase 5.6 の pre-condition block、および Phase 5.5.2 内 metrics step (`plan_deviation_count` 取得) と Phase 5.7 (`parent_issue_number` 取得) で同型の capture pattern を共有する。本 reference は **5 site で重複していた if/else capture pattern**、 **`.phase` vs `.previous_phase` の使い分け根拠**、 **`state-read.sh` を使う理由 (per-session vs legacy state file)** を 1 ファイルに集約する。
+> **Source of Truth**: 本ファイルは `/rite:issue:start` ワークフローにおける **pre-condition check (#490 AC-5)** の `state-read.sh` fail-fast pattern の SoT である。`start.md` の Phase 3 / Phase 5.5.1 / Phase 5.6 の pre-condition block、Phase 5.5.2 内 metrics step (`plan_deviation_count` 取得、Issue #901 PR E で `commands/issue/references/metrics-recording.md` へ SoT 移管済み) と Phase 5.7 (`parent_issue_number` 取得) で同型の capture pattern を共有する。本 reference は **`/rite:issue:start` workflow 全体で合計 5 site (start.md 内 4 site + metrics-recording.md 1 site) で重複していた if/else capture pattern**、 **`.phase` vs `.previous_phase` の使い分け根拠**、 **`state-read.sh` を使う理由 (per-session vs legacy state file)** を 1 ファイルに集約する。
 >
-> **抽出経緯**: `start.md` の Pre-condition check 3 箇所 (Phase 3: L484-540 / Phase 5.5.1: L1697-1758 / Phase 5.6: L1992-2050、合計約 178 行) が同型の散文 + bash block で書かれていた。加えて Phase 5.5.2 内 metrics step の `plan_deviation_count` 取得 (L1795-1840) と Phase 5.7 の `parent_issue_number` 取得もまた同一 capture pattern を inline で再掲していた。Issue #899 (PR C — #896 親 Issue) で本 reference に集約し、各 caller は anchor reference + 5 引数 bash literal のみに圧縮する。
+> **抽出経緯**: `start.md` の Pre-condition check 3 箇所 (Phase 3 / Phase 5.5.1 / Phase 5.6 — 合計約 178 行) が同型の散文 + bash block で書かれていた。加えて Phase 5.5.2 内 metrics step の `plan_deviation_count` 取得 (Issue #901 PR E で `metrics-recording.md` へ SoT 移管) と Phase 5.7 の `parent_issue_number` 取得もまた同一 capture pattern を inline で再掲していた。Issue #899 (PR C — #896 親 Issue) で本 reference に集約し、各 caller は anchor reference + 5 引数 bash literal のみに圧縮する。Issue #901 PR E で Phase 5.5.2 を `metrics-recording.md` へ抽出した結果、5 site のうち 4 site が start.md、1 site が metrics-recording.md に分散した。
 
 ## なぜ pre-condition check が必要か (#490 AC-5)
 
@@ -60,13 +60,17 @@ fi
 
 ### Form B: inline 1 行 form (metrics step 用)
 
-Phase 5.5.2 内 `implementation_round` 取得 (`plan_deviation_count` 算出) は単純な capture (失敗時 warning 出力 + 値 default 化) のため、1 行 form が canonical。Form A と同様に **`[CONTEXT] STATE_READ_FAILED=1` sentinel を emit する**ことで downstream observability (cross-session-incident 集計 / workflow-incident-emit-protocol grep) に統一形式で通知する:
+Phase 5.5.2 内 `implementation_round` 取得 (`plan_deviation_count` 算出) は単純な capture (失敗時 warning 出力 + 値 default 化) のため、1 行 form が canonical。Form A と同様に **`[CONTEXT] STATE_READ_FAILED=1` sentinel を emit する**ことで downstream observability (cross-session-incident 集計 / workflow-incident-emit-protocol grep) に統一形式で通知する。
 
-```bash
-if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_2_metrics; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
+**Form B の構造 (pseudo-code)**:
+
+```
+if <var>=$(bash {plugin_root}/hooks/state-read.sh --field <field> --default <default_value>); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=<site_phase>; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — <metric_name> skipped" >&2; <var>=""; fi
 ```
 
-`caller-markdown-block.test.sh` TC-6 は本 inline form を `if val=...; then :; else rc=$?` の 1 行 canonical で grep pin している (Issue #908 で確立)。
+実 caller (`commands/issue/references/metrics-recording.md` Step 1) では `<var>=val`、`<field>=implementation_round`、`<default_value>=0`、`<site_phase>=phase5_5_2_metrics`、`<metric_name>=metrics for plan_deviation_count` で展開される。
+
+`caller-markdown-block.test.sh` TC-6 は metrics-recording.md の実 caller を `if val=...; then :; else rc=$?` の 1 行 canonical で grep pin している (Issue #908 で確立、Issue #901 PR E で対象を `START_MD → METRICS_RECORDING_MD` に切替)。本 reference の Form B 例 (上記 pseudo-code) は **field 名を placeholder 化することで literal 重複を解消** している (Issue #901 PR E で適用、Wiki PR #936 経験則「SoT 一本化」遵守)。
 
 > **Form A と Form B の sentinel emit 共通化**: 両 form ともに `[CONTEXT] STATE_READ_FAILED=1; phase={site}; rc=$rc` を必ず emit する。両者の唯一の差異は (a) **severity prefix** (Form A: `ERROR:` で `exit 1`、Form B: `WARNING:` で値 default 化して fall-through)、(b) **行展開** (Form A: 複数行 / Form B: 1 行) のみ。downstream observability tooling は単一 sentinel pattern (`STATE_READ_FAILED`) を grep するだけで Form A / B の両経路を捕捉できる。
 
@@ -106,15 +110,15 @@ bash の `exit 1` は **shell process を終わらせるだけで、Claude Code 
 
 ## 5 site canonical (capture pattern 共有)
 
-Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$(cmd); then :; else rc=$?; fi` capture pattern を共有する (start.md 内合計 **5 site** が `state-read.sh` capture 共通形式)。 Form A (4 site: Pre-condition 3 + Phase 5.7 parent close) と Form B (1 site: Phase 5.5.2 metrics) の使い分けは上記 [Canonical capture pattern (2 forms)](#canonical-capture-pattern-2-forms) を参照:
+Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$(cmd); then :; else rc=$?; fi` capture pattern を共有する (`/rite:issue:start` workflow 全体で合計 **5 site** が `state-read.sh` capture 共通形式 — start.md 内 4 site + `commands/issue/references/metrics-recording.md` 1 site)。 Form A (4 site: Pre-condition 3 + Phase 5.7 parent close) と Form B (1 site: Phase 5.5.2 metrics) の使い分けは上記 [Canonical capture pattern (2 forms)](#canonical-capture-pattern-2-forms) を参照:
 
-| Site | Field | 用途 |
-|------|-------|------|
-| Phase 3 pre-condition | `phase` | Phase 2 完了確認 |
-| Phase 5.5.1 pre-condition | `phase` | Phase 5.5 完了確認 |
-| Phase 5.6 pre-condition | `phase` | Phase 5.5.2 完了確認 |
-| Phase 5.5.2 Metrics Step 1 | `implementation_round` | `plan_deviation_count` 算出 (non-numeric は 0 降格、空文字列は METRICS_SKIPPED sentinel emit) |
-| Phase 5.7 parent close | `parent_issue_number` | parent Issue の auto-close 判定 (non-numeric は 0 降格 = "no parent" 扱い) |
+| Site | 所在ファイル | Field | 用途 |
+|------|-------------|-------|------|
+| Phase 3 pre-condition | `commands/issue/start.md` | `phase` | Phase 2 完了確認 |
+| Phase 5.5.1 pre-condition | `commands/issue/start.md` | `phase` | Phase 5.5 完了確認 |
+| Phase 5.6 pre-condition | `commands/issue/start.md` | `phase` | Phase 5.5.2 完了確認 |
+| Phase 5.5.2 Metrics Step 1 | `commands/issue/references/metrics-recording.md` (Issue #901 PR E で SoT 移管) | `implementation_round` | `plan_deviation_count` 算出 (non-numeric は 0 降格、空文字列は METRICS_SKIPPED sentinel emit) |
+| Phase 5.7 parent close | `commands/issue/start.md` | `parent_issue_number` | parent Issue の auto-close 判定 (non-numeric は 0 降格 = "no parent" 扱い) |
 
 Pre-condition (phase / parent_issue_number) は **複数行 form (Form A)**、metrics step (implementation_round) は **inline 1 行 form (Form B)** を使う。 numeric type validation (非数値 → 0 降格) は metrics / parent_issue_number 等の数値 field で同型対応する: writer / reader / resume の 3 layer 対称化 doctrine (詳細は `implement.md` / `pr/review.md` / `resume.md` の同 pattern site を参照)。
 

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -1,0 +1,139 @@
+# Projects Status Update — 3 Callsite Delegation SoT
+
+> **Source of Truth**: 本ファイルは `/rite:issue:start` 内で `plugins/rite/scripts/projects-status-update.sh` を invoke する **3 callsite (Phase 2.4 / 5.5.1 / 5.7.2) の bash literal SoT** である。`start.md` 本体の各 callsite は本ファイルへ semantic 参照する anchor stub のみ保持する。
+>
+> **抽出経緯**: 3 callsite はすべて同一の `bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n ...)"` 構造を持つが、`status_name` (In Progress / In Review / Done) と `auto_add` フラグ (true / false) のみ異なる。bash literal を 1 reference に集約することで drift を防止し、本体の認知負荷を下げる。Issue #901 (PR E — #896 親 Issue) で抽出。
+>
+> **API レベル仕様 SoT との役割分担**: `references/projects-integration.md` §2.4 は GraphQL projectItems / item-add / field-list / item-edit の **API 動作仕様** SoT。本ファイルは **caller bash literal** の SoT。両 reference は補完関係 (semantically orthogonal、重複契約なし)。
+>
+> **caller**: `start.md` の 3 sites (Phase 2.4 / 5.5.1 / 5.7.2) すべてが本 reference の対応セクションへ delegate する。
+
+## Common contract
+
+すべての callsite は以下の共通 contract を満たす:
+
+1. **Skip if `projects.enabled: false`** in rite-config.yml — non-blocking, continue workflow
+2. **Delegate to `projects-status-update.sh`** via `bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n ...)"` (single source of truth for Projects Status updates)
+3. **Inspect script stdout JSON**: `.result == "updated"` → success / `.result == "skipped_not_in_project"` or `"failed"` → display `.warnings[]` and continue (non-blocking)
+4. **DO NOT inline GraphQL queries** — past incident (Issue #513) caused AC-1 failure when `trackedInIssues`-only inline simplification was introduced; `parent-child-sync-static.test.sh` Group 4 pins this regression guard
+
+詳細な API レベル動作 (GraphQL projectItems query / auto-add / field-list / item-edit) は [`projects-integration.md §2.4.2-2.4.5`](../../../references/projects-integration.md#242-check-issue-project-registration-status) を参照。
+
+## Callsite 1 — Phase 2.4 (Issue Status → In Progress)
+
+**Step 1** — Read config and emit a skip marker on stdout (the LLM reads the marker, not a bash variable; shell state does not persist across Bash tool invocations):
+
+```bash
+projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
+project_number=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    project_number:/{print $2; exit}' rite-config.yml 2>/dev/null)
+project_owner=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    owner:/{gsub(/"/,"",$2); print $2; exit}' rite-config.yml 2>/dev/null)
+if [ "$projects_enabled" != "true" ]; then
+  echo "[CONTEXT] PHASE_2_4_STATE=skip; reason=projects_disabled"
+else
+  echo "[CONTEXT] PHASE_2_4_STATE=execute; project_number=$project_number owner=$project_owner"
+fi
+```
+
+**LLM routing rule** (Bash tool shell state does not persist): the LLM reads the `[CONTEXT] PHASE_2_4_STATE=` marker from the bash block's stdout in the conversation context:
+
+| `PHASE_2_4_STATE` value | LLM action |
+|------------------------|-----------|
+| `skip` | Skip Step 2 and Step 3 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the two whitelist transitions stay valid (the skip is recorded, not silent). |
+| `execute` | Proceed to Step 2-3 using the emitted `project_number` / `owner` values. |
+
+Do NOT rely on a bash variable (`SKIP_2_4=1`) that persists only within a single Bash tool call — each `echo`/`gh api` in the following steps is a separate invocation and the variable is lost. The `[CONTEXT]` marker travels via the conversation context and is authoritative.
+
+**Step 2** — Update Issue Status to "In Progress" via the shared script:
+
+```bash
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "In Progress" \
+  --argjson auto_add true \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+```
+
+The script executes: GraphQL `projectItems` query → auto-add if not registered → `field-list` retrieval → Status `item-edit`. Inspect its stdout JSON:
+
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` or `"failed"` → display `.warnings[]` and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
+
+The script is the single source of truth for Projects Status updates. See [projects-integration.md §2.4.2-2.4.5](../../../references/projects-integration.md#242-check-issue-project-registration-status) for API-level documentation.
+
+**Step 3** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
+
+> **Issue #513 regression guard**: Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident (Issue #513): a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature. `parent-child-sync-static.test.sh` pins this literal to prevent silent re-introduction.
+
+## Callsite 2 — Phase 5.5.1 (Issue Status → In Review)
+
+**Owner**: `/rite:issue:start` (defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow).
+
+**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`. `ready.md` Phase 4.2 も同じく `projects-status-update.sh` delegate に統一済み。本 Phase 5.5.1 は defense-in-depth の二重実行であり、ready.md 失敗時の補完として機能する。
+
+Skip if `projects.enabled: false` in rite-config.yml. Otherwise invoke the shared script to transition the Issue Status to **In Review**:
+
+```bash
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "In Review" \
+  --argjson auto_add false \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+```
+
+`auto_add: false` because at this point the Issue is already registered in the Project (Phase 2.4 auto-added it if missing).
+
+Inspect the script's stdout JSON:
+
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking).
+- `.result == "failed"` → display `.warnings[]` and continue (non-blocking).
+
+See [projects-integration.md §2.4](../../../references/projects-integration.md#24-github-projects-status-update) for the underlying API calls.
+
+## Callsite 3 — Phase 5.7.2 (Parent Issue Status → Done)
+
+**Step 1**: Update parent Issue Status to "Done" via the shared script.
+
+Skip if `projects.enabled: false` in rite-config.yml. Otherwise:
+
+```bash
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {parent_issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "Done" \
+  --argjson auto_add false \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+```
+
+Inspect the script's stdout JSON:
+
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` → display `警告: Issue #{parent_issue_number} は Project に登録されていません` and proceed to Step 2 (non-blocking).
+- `.result == "failed"` → display `.warnings[]` and proceed to Step 2 (non-blocking).
+
+**Step 2** (Phase 5.7.2 specific): Close the parent Issue via `/rite:issue:close` Skill invocation — see `start.md` Phase 5.7.2 本体の Step 2 invocation block。本 reference は Step 1 (Status update) の bash literal SoT のみ提供する。
+
+## 差分 summary (3 callsite 比較)
+
+| Callsite | `status` | `auto_add` | `--argjson issue` 引数 | 補足 |
+|----------|----------|------------|------------------------|------|
+| Phase 2.4 | `In Progress` | `true` | `{issue_number}` | 当該 Issue 自身。未登録なら auto-add (true) |
+| Phase 5.5.1 | `In Review` | `false` | `{issue_number}` | 既に Phase 2.4 で auto-add 済みのため `false` |
+| Phase 5.7.2 | `Done` | `false` | `{parent_issue_number}` | 親 Issue 対象。auto-add 不要 |
+
+## 関連
+
+- [`../../../references/projects-integration.md`](../../../references/projects-integration.md#24-github-projects-status-update) — API レベル動作仕様 SoT (GraphQL queries / item-add / field-list / item-edit)
+- `plugins/rite/scripts/projects-status-update.sh` — Single source of truth (delegated by all 3 callsites)
+- `plugins/rite/hooks/tests/parent-child-sync-static.test.sh` Group 4 — `Issue #513 regression guard` literal pin (本 reference の Callsite 1 Step 3 が grep 対象)

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -327,57 +327,11 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 2.4 (Projects Status → In Progress). Skipping to Phase 2.5/2.6/3 without running Projects update is PROHIBITED. Do NOT stop."
 ```
 
-> **Module**: [Projects Integration](../../references/projects-integration.md#24-github-projects-status-update). Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh`, which is the single source of truth for Projects Status updates across Phase 2.4, 5.5.1, and 5.7.2. `projects-integration.md` §2.4 documents the underlying API calls for reference and debugging, but callers MUST NOT re-inline those bash blocks here — always delegate to the script.
-<!-- Do not re-inline Step 2-3. -->
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-1--phase-24-issue-status--in-progress) — Phase 2.4 / 5.5.1 / 5.7.2 共通 delegation の bash literal SoT (Callsite 1 = Phase 2.4)。Runtime execution delegates to `plugins/rite/scripts/projects-status-update.sh`. API レベル動作仕様は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
 
+> **Issue #513 regression guard**: Step 3 (Parent Issue Status Update via 3-method detection) は本 Module 内 Callsite 1 Step 3 に SoT として移管。inline `trackedInIssues`-only simplification (Issue #513 incident で AC-1 失敗を引き起こした anti-pattern) への revert は禁止。詳細な 3-method procedure と regression guard 全文は Module を参照。`parent-child-sync-static.test.sh` Group 4 が両ファイル ([projects-integration.md#247](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) リンク + Issue #513 literal) を pin する。
 
-
-**Step 1** — Read config and emit a skip marker on stdout (the LLM reads the marker, not a bash variable; shell state does not persist across Bash tool invocations):
-
-```bash
-projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
-project_number=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    project_number:/{print $2; exit}' rite-config.yml 2>/dev/null)
-project_owner=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    owner:/{gsub(/"/,"",$2); print $2; exit}' rite-config.yml 2>/dev/null)
-if [ "$projects_enabled" != "true" ]; then
-  echo "[CONTEXT] PHASE_2_4_STATE=skip; reason=projects_disabled"
-else
-  echo "[CONTEXT] PHASE_2_4_STATE=execute; project_number=$project_number owner=$project_owner"
-fi
-```
-
-**LLM routing rule** (prompt-engineer CRITICAL — Bash tool shell state does not persist): the LLM reads the `[CONTEXT] PHASE_2_4_STATE=` marker from the bash block's stdout in the conversation context:
-
-| `PHASE_2_4_STATE` value | LLM action |
-|------------------------|-----------|
-| `skip` | Skip Step 2 and Step 3 below. Go directly to Mandatory After 2.4. The post-projects marker is still written so the two whitelist transitions (`phase2_post_branch → phase2_projects` and `phase2_projects → phase2_post_projects`) stay valid (the skip is recorded, not silent). |
-| `execute` | Proceed to Step 2-3 using the emitted `project_number` / `owner` values. |
-
-Do NOT rely on a bash variable (`SKIP_2_4=1`) that persists only within a single Bash tool call — each `echo`/`gh api` in the following steps is a separate invocation and the variable is lost. The `[CONTEXT]` marker travels via the conversation context and is authoritative.
-
-**Step 2** — Update Issue Status to "In Progress" via the shared script:
-
-```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
-  --argjson issue {issue_number} \
-  --arg owner "{owner}" \
-  --arg repo "{repo}" \
-  --argjson project_number {project_number} \
-  --arg status "In Progress" \
-  --argjson auto_add true \
-  --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
-```
-
-The script executes: GraphQL `projectItems` query → auto-add if not registered → `field-list` retrieval → Status `item-edit`. Inspect its stdout JSON:
-
-- `.result == "updated"` → success.
-- `.result == "skipped_not_in_project"` or `"failed"` → display `.warnings[]` and continue (non-blocking). The scaffolding-failure itself is recorded by stop-guard via the whitelist on the next transition attempt.
-
-The script is the single source of truth for Projects Status updates. See [projects-integration.md §2.4.2-2.4.5](../../references/projects-integration.md#242-check-issue-project-registration-status) for API-level documentation.
-
-**Step 3** — Parent Issue Status Update (2.4.7): **always execute** this substep regardless of whether the current Issue was identified as a parent in Phase 0.3 (Phase 0.3 detects children, not parents). **Execute the full 3-method detection and Status update procedure from [projects-integration.md §2.4.7](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues)** (Method 1: `## 親 Issue` body meta PRIMARY → Method 2: Sub-Issues API → Method 3: tasklist search → 2.4.7.2 Retrieve → 2.4.7.3 Status Condition → 2.4.7.4 Update). When all three methods fail, the referenced procedure emits a debug log and skips silently — this is the normal path for standalone Issues (AC-4).
-
-> **Regression guard** (Issue #513 regression guard): Do NOT replace this delegation with an inline simplification (e.g., querying only `trackedInIssues` or only one detection method). Past incident (Issue #513): a `trackedInIssues`-only inline version in this file caused AC-1 failure in repositories that manage parent-child links via body tasklist and `## 親 Issue` meta rather than GitHub's native Sub-Issues feature. `parent-child-sync-static.test.sh` pins this literal to prevent silent re-introduction.
+Execute the Module procedure: Callsite 1 Step 1 (config read + skip marker emit) → Callsite 1 Step 2 (Status In Progress update) → Callsite 1 Step 3 (parent Issue Status update via 3-method detection)。On `[CONTEXT] PHASE_2_4_STATE=skip`, skip Step 2-3 but still execute Mandatory After 2.4 unconditionally。
 
 ### 🚨 Mandatory After 2.4
 
@@ -821,104 +775,11 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 ### 5.2.1 Checklist Confirmation
 
+> **Module**: [Checklist Auto-Check](./references/checklist-auto-check.md) — Phase 5.2.1 (grep ベースの完了確認) + Phase 5.2.1.1 (Auto-Check Evaluation: evidence collection / per-item assessment / Issue body update / re-check / uncertain handling) の SoT。
+
 **Owner**: `/rite:issue:start` after `/rite:lint` returns. **Condition**: Execute only if checklist retained in Phase 3.6. **Purpose**: Block PR until all items complete.
 
-Use `grep -E` (not `-P`). Pattern per [gh-cli-patterns.md](../../references/gh-cli-patterns.md#safe-checklist-operation-patterns).
-
-```bash
-issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-[ -z "$issue_body" ] && echo "ERROR: Issue body の取得に失敗" >&2 && exit 1
-echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' || true
-echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true
-```
-
-**Determine**: `grep -c` output `0`→all complete→5.3. `≥1`→incomplete→proceed to 5.2.1.1 (auto-check). Empty body→retry 5.1. **Mandatory**, cannot skip.
-
-#### 5.2.1.1 Auto-Check Evaluation
-
-When incomplete checklist items are detected, evaluate each item's fulfillment status based on the current implementation state before returning to Phase 5.1.
-
-**Purpose**: Prevent infinite loops where implementation is complete but Definition of Done checklist items remain unchecked because no process updates them to `- [x]`.
-
-**Evaluation procedure**:
-
-1. **Collect evidence**: Use `git diff origin/{base_branch}...HEAD --name-only` and `git log --oneline origin/{base_branch}...HEAD` to understand what was implemented.
-
-2. **Evaluate each incomplete item**: For each `- [ ]` item, assess whether the item is satisfied based on the implementation evidence:
-
-   | Assessment | Criteria | Action |
-   |-----------|----------|--------|
-   | **Satisfied** | Implementation evidence clearly fulfills the item | Mark as `- [x]` |
-   | **Not satisfied** | No evidence of fulfillment, or clearly incomplete | Keep as `- [ ]` |
-   | **Uncertain** | Cannot confidently determine | Present to user via `AskUserQuestion` |
-
-3. **Update Issue body**: If any items are newly marked as satisfied, update the Issue body via `gh issue edit`:
-
-   Follow the "Checkbox Update" pattern in [gh-cli-patterns.md](../../references/gh-cli-patterns.md#safe-checklist-operation-patterns). Use Python for safe `- [ ]` → `- [x]` replacement (do NOT use `sed`).
-
-   ```bash
-   # Step 1: Retrieve current body and validate
-   tmpfile_read=$(mktemp)
-   tmpfile_write=$(mktemp)
-   trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
-   gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"
-
-   if [ ! -s "$tmpfile_read" ]; then
-     echo "ERROR: Issue body の取得に失敗" >&2
-     exit 1
-   fi
-
-   # Output paths for subsequent Read/Write tool calls
-   echo "tmpfile_read=$tmpfile_read"
-   echo "tmpfile_write=$tmpfile_write"
-   ```
-
-   Then use the Read tool to read `$tmpfile_read` (the path output above), apply `- [ ]` → `- [x]` replacements for satisfied items using the Write tool to `$tmpfile_write`, and apply:
-
-   **Note**: Shell variables do not carry over between Bash tool calls. Use the literal paths output by `echo "tmpfile_read=..."` in Step 1 directly in the command below.
-
-   ```bash
-   # Replace with actual paths from Step 1 output (e.g., /tmp/tmp.XXXXXXXXXX)
-   tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Step 1 の出力値に置換
-
-   if [ ! -s "$tmpfile_write" ]; then
-     echo "ERROR: Updated content is empty" >&2
-     exit 1
-   fi
-
-   gh issue edit {issue_number} --body-file "$tmpfile_write"
-   ```
-
-4. **Re-check**: After updating, re-run the checklist check:
-
-   ```bash
-   issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-   [ -z "$issue_body" ] && echo "ERROR: Issue body の取得に失敗" >&2 && exit 1
-   echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true
-   ```
-
-   - `0` (all complete) → Proceed to Phase 5.3
-   - `≥1` (still incomplete) → Display remaining incomplete items and return to Phase 5.1
-   - Empty body → retry Phase 5.1
-
-**User confirmation for uncertain items**:
-
-When items are assessed as "Uncertain", use `AskUserQuestion`:
-
-```
-以下のチェックリスト項目の充足状態を確認してください:
-
-- [ ] {item_text}
-
-オプション:
-- 充足済みとしてチェック（推奨）: この項目を完了とマークします
-- 未充足: Phase 5.1 に戻って対応します
-```
-
-**Constraints**:
-- Already checked items (`- [x]`) are never modified (AC-3 non-regression)
-- Issue reference items (`- [ ] #XX`) are excluded from evaluation (parent-child tracking)
-- Auto-check is executed **at most once per 5.2.1 invocation** to prevent evaluation loops
+Execute the Module procedure: grep `- [ ]` pattern (Phase 5.2.1) → if `≥1` incomplete, run Auto-Check Evaluation (Phase 5.2.1.1) → re-check → all complete → Phase 5.3, otherwise return to Phase 5.1. **Mandatory**, cannot skip.
 
 ### 5.3 PR Creation
 
@@ -1294,33 +1155,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 5.5.1 (Issue Status → In Review). Skipping to Phase 5.5.2/5.6 without running the Status update is PROHIBITED. Do NOT stop."
 ```
 
-**Owner**: `/rite:issue:start` (defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow).
-
-**Note**: Delegates to `plugins/rite/scripts/projects-status-update.sh`. `ready.md` Phase 4.2 も同じく `projects-status-update.sh` delegate に統一済み。本 Phase 5.5.1 は defense-in-depth の二重実行であり、ready.md 失敗時の補完として機能する。
-
-Skip if `projects.enabled: false` in rite-config.yml. Otherwise invoke the shared script to transition the Issue Status to **In Review**:
-
-```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
-  --argjson issue {issue_number} \
-  --arg owner "{owner}" \
-  --arg repo "{repo}" \
-  --argjson project_number {project_number} \
-  --arg status "In Review" \
-  --argjson auto_add false \
-  --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
-```
-
-`auto_add: false` because at this point the Issue is already registered in the Project (Phase 2.4 auto-added it if missing).
-
-Inspect the script's stdout JSON:
-
-- `.result == "updated"` → success.
-- `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking).
-- `.result == "failed"` → display `.warnings[]` and continue (non-blocking).
-
-See [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) for the underlying API calls.
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-2--phase-551-issue-status--in-review) — Callsite 2 (Phase 5.5.1) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "In Review", `auto_add: false` since Phase 2.4 already auto-added if missing). Defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow. API レベル動作は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
 
 ### 🚨 Mandatory After 5.5.1
 
@@ -1349,199 +1184,11 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
   --next "Execute Phase 5.5.2 (Metrics Recording). Skipping to Phase 5.6 without running metrics is PROHIBITED. Do NOT stop."
 ```
 
-> **Reference**: [Execution Metrics](../../references/execution-metrics.md)
+> **Reference**: [Execution Metrics](../../references/execution-metrics.md). **Module**: [Metrics Recording](./references/metrics-recording.md) — Phase 5.5.2 全体 (Step 1-5 + `implementation_round` inline metrics capture + METRICS_SKIPPED 経路 + heredoc PATCH 本体) の SoT。
 
-**Skip Steps note** (referenced by Phase 5.6 pre-condition): When `metrics.enabled: false` in rite-config.yml, skip Steps 1-5 below **but unconditionally execute Mandatory After 5.5.2**. The `phase5_post_metrics` marker is required for Phase 5.6 pre-condition to pass. Skipping the Mandatory After would leave `.phase = phase5_post_status_in_review` and trip the Phase 5.6 ERROR gate (prompt-engineer cycle-4 HIGH / code-quality cycle-4 MEDIUM).
+**Skip Steps note** (referenced by Phase 5.6 pre-condition): When `metrics.enabled: false` in rite-config.yml, skip Steps 1-5 (per Module) **but unconditionally execute Mandatory After 5.5.2**. The `phase5_post_metrics` marker is required for Phase 5.6 pre-condition to pass. Skipping the Mandatory After would leave `.phase = phase5_post_status_in_review` and trip the Phase 5.6 ERROR gate.
 
-Otherwise:
-
-**Step 1**: Collect metrics from the current workflow execution:
-
-| Metric | Source | How to Obtain |
-|--------|--------|---------------|
-| `plan_deviation_rate` | Issue body checklist items (Phase 3.6) vs completed items | `planned_steps` = total checklist items added in Phase 3.6. `actual_steps` = checked items at completion. Formula: `abs(actual - planned) / planned * 100`. If `planned = 0`, set judgment to `skip` |
-| `test_pass_rate` | From Phase 5.2 lint results | 100% if tests passed or no tests configured |
-| `review_critical_high` | Phase 5.4 review results | Count of CRITICAL+HIGH findings from the last `📜 rite レビュー結果` PR comment |
-| `review_fix_loops` | PR comments | Count `📜 rite レビュー結果` comments on the PR: `gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '[.[] | select(.body | contains("📜 rite レビュー結果"))] | length'` |
-| `plan_deviation_count` | flow-state | Read `implementation_round` field (set by Phase 5.1.3) via `state-read.sh`. **Use the same fail-fast pattern documented at the Phase 3 pre-condition** (canonical `if cmd; then :; else rc=$?; fi` form). state-read.sh launch failure 時は metrics output を skip し、silent に `"0"` 扱い (= "no deviation" の誤分類) しないこと。per-session state を参照 (legacy state file snapshot ではない)。Phase 5.1 への re-entry 数 (checklist failure 由来) を計測。詳細な bash literal は本ファイル Phase 3 pre-condition の bash block を参照 |
-
-> **Note**: bash literal は table cell 内に埋め込まず、独立 code block として下に分離している。これは LLM が table を読んで値を提示する際に、cell 内 literal を正規の Bash tool 呼び出しと誤認するリスクを避けるため。table cell 内の prose は Phase 3 pre-condition への semantic reference にとどめる。
-
-**`plan_deviation_count` 取得 bash block** (canonical capture pattern を維持し caller-markdown-block.test.sh G-03 metatest が pass することを保証):
-
-```bash
-# canonical fail-fast pattern (Phase 3 pre-condition と同型): state-read.sh 起動失敗時は
-# silent default 0 (= "no deviation") に降格せず、metrics output を skip する。
-# 注意: inline 1 行 form を維持 (caller-markdown-block.test.sh TC-6 が
-# `if val=...; then :; else rc=$?` の 1 行 canonical capture pattern を grep で pin する)。
-if val=$(bash {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then :; else rc=$?; echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_2_metrics; rc=$rc" >&2; echo "WARNING: state-read.sh failed (rc=$rc) — metrics for plan_deviation_count skipped" >&2; val=""; fi
-# numeric type validation (writer/reader/resume 3 layer 対称化 doctrine): 他 caller (Phase 5.7
-# parent_issue_number / implement.md parent_issue_number / pr/review.md loop_count /
-# resume.md parent_issue_number_raw) と同様に non-numeric 値を 0 に降格して partial corruption
-# (`| 計画逸脱回数 | abc回 |` 等) を防ぐ。空文字列 (state-read.sh 失敗) は下記 if-z で別途
-# METRICS_SKIPPED 経路へ流すため、ここでは非空かつ非数値のみ 0 に降格する。
-case "$val" in
-  '') ;;
-  *[!0-9]*)
-    echo "WARNING: implementation_round is not numeric ('$val'), defaulting to 0 (partial corruption 防止)" >&2
-    val=0
-    ;;
-esac
-plan_deviation_count="$val"
-# state-read.sh 失敗時 (`val=""`) は METRICS_SKIPPED sentinel を emit し、後続 Step 2/3/4
-# (threshold evaluation + failure classification + PATCH heredoc generation) を skip させる。
-# silent に空文字列 `{plan_deviation_count}` substitute が下流 heredoc (Phase 5.5.2 完了レポート)
-# に流入し `| 計画逸脱回数 | 回 | ...` の partial corruption が発生する経路
-# を遮断する。Claude は本 sentinel を会話履歴で grep し、検出時は **Phase 5.5.2 metrics body 生成を skip** すること
-# (= metrics PATCH を実行せず、ただし Mandatory After 5.5.2 の `phase5_post_metrics` marker は必ず書き込み、Phase 5.6 へ進む)。
-#
-# 成功経路では PLAN_DEVIATION_COUNT sentinel を emit し、Claude が会話履歴を grep して
-# Step 4 heredoc の `{plan_deviation_count}` placeholder に literal substitute する。シェル変数
-# `$plan_deviation_count` は Bash tool 境界で消失するため、stdout/stderr に明示的に emit しない限り
-# Claude は値を読み取れない。同型の cross-boundary state transfer は resume.md Phase 2.1 Step 1
-# / start.md Phase 5.7 で確立済みの canonical pattern。
-#
-# Emit channel policy: cross-boundary state transfer の sentinel は **stdout / stderr のいずれでも会話コンテキストに記録される**。
-# Claude Code の Bash tool は stdout/stderr 両方を会話コンテキストに取り込む仕様のため、emit channel の
-# 統一は機能要件ではない。本箇所は METRICS_SKIPPED と PLAN_DEVIATION_COUNT を一貫して stderr に emit する
-# (両者を観測値ストリームとして揃える設計選択)。PARENT_ISSUE / PARENT_ISSUE_DISPLAY は stdout 側で emit する
-# 既存の canonical pattern を維持しつつ、本箇所の stderr 採用は **observability ログ専用ストリームを stderr に集約する** 一貫性のための設計選択。
-if [ -z "$val" ]; then
-  echo "[CONTEXT] METRICS_SKIPPED=1; reason=state_read_failed" >&2
-else
-  echo "[CONTEXT] PLAN_DEVIATION_COUNT=$plan_deviation_count" >&2
-fi
-```
-
-**Claude への指示 (METRICS_SKIPPED 検出時の挙動)**: 上記 bash block 実行後、stderr に `[CONTEXT] METRICS_SKIPPED=1; reason=state_read_failed` が emit された場合、Claude は **Step 2 (threshold evaluation)、Step 3 (failure classification)、Step 4 (PATCH heredoc generation) の 3 step すべてを skip** し、`Phase 5.5.2: state-read.sh 失敗のため metrics 更新を skip しました (manual intervention で次回計測してください)` を stderr に出力する。その後、**Mandatory After 5.5.2 (`flow-state-update.sh create --phase phase5_post_metrics` の marker 書き込み) を unconditional に実行してから Phase 5.6 へ進む** (AC-5 により body skip 時も marker 書き込みは必須。これを skip すると Phase 5.6 pre-condition `expected: phase5_post_metrics` で hard abort する)。Phase 5.5.2 の実 heading 構造は Step 1=collect / Step 2=threshold / Step 3=failure classification / **Step 4=Append metrics section to work memory (= heredoc PATCH 本体)** / Step 5=repeated failure であり、Step 4 が PATCH heredoc 本体のため、Step 4 を skip 対象に含めないと空 placeholder の partial corruption が再発する self-defeating defense になる。
-
-**Step 2**: Evaluate thresholds.
-
-Read `metrics.baseline_issues` from rite-config.yml (default: 3).
-
-**Step 2a**: Count completed Issues with metrics. Search the 10 most recently closed Issues for work memory comments containing `📊 メトリクス`:
-
-```bash
-# 直近の closed Issue 番号を取得（最大10件）
-recent_issues=$(gh api "repos/{owner}/{repo}/issues?state=closed&per_page=10&sort=updated&direction=desc" --jq '.[].number')
-
-# 各 Issue のメトリクスセクションを検索
-for issue_num in $recent_issues; do
-  metrics=$(gh api "repos/{owner}/{repo}/issues/${issue_num}/comments" \
-    --jq '[.[] | select(.body | contains("📊 メトリクス"))] | last | .body' 2>/dev/null)
-  if [ -n "$metrics" ] && [ "$metrics" != "null" ]; then
-    echo "FOUND:${issue_num}"
-  fi
-done
-```
-
-**Step 2b**: Determine baseline status:
-
-- **Baseline period** (completed Issues with metrics < `baseline_issues`): Set all judgments to `skip`. Display: `📊 Baseline 収集中 ({n}/{baseline_issues}) — 閾値判定はスキップします`
-- **Post-baseline**: Proceed to Step 2c
-
-**Step 2c**: Evaluate thresholds (post-baseline only):
-
-1. **Per-Issue thresholds** (from Step 1 values): `plan_deviation_rate <= 30`, `test_pass_rate == 100`, `review_fix_loops <= 3`. Set `pass` or `warn`.
-2. **MA thresholds**: Parse `📊 メトリクス` sections from the 5 most recent completed Issues (found in Step 2a). Extract each metric value, calculate the moving average, and compare against `baseline_ma5 * improvement_factor`. Set `pass`, `warn`, or `skip` (if fewer than `baseline_issues` completed).
-
-**Step 3**: Determine failure classification.
-
-If any threshold is `warn`: classify each violation per the [Metric-to-Failure-Class Mapping](../../references/execution-metrics.md#metric-to-failure-class-mapping) table. Select primary failure class (most frequent; tie-break: last occurring).
-
-**Step 4**: Append metrics section to work memory.
-
-Update the Issue work memory comment by appending the metrics table per [Execution Metrics recording format](../../references/execution-metrics.md#recording-format).
-
-> **Reference**: Apply [Work Memory Update Safety Patterns](../../references/gh-cli-patterns.md#work-memory-update-safety-patterns).
-
-```bash
-# ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること（クロスプロセス変数参照を防止）
-# comment_data の取得・追記内容の heredoc 定義・PATCH を分割すると変数が失われる
-comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
-comment_id=$(echo "$comment_data" | jq -r '.id // empty')
-current_body=$(echo "$comment_data" | jq -r '.body // empty')
-
-if [ -z "$comment_id" ]; then
-  # comment not found: skip metrics recording entirely (non-fatal; metrics are optional)
-  echo "ERROR: Work memory comment not found. Skipping metrics recording." >&2
-  exit 0
-fi
-
-# 1. Backup before update
-backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
-printf '%s' "$current_body" > "$backup_file"
-
-if [[ -z "$current_body" ]]; then
-  echo "ERROR: Updated body is empty or too short. Aborting PATCH." >&2
-  echo "Backup saved at: $backup_file" >&2
-  exit 1
-fi
-
-# 2. Append metrics section
-tmpfile=$(mktemp)
-trap 'rm -f "$tmpfile"' EXIT
-printf '%s\n\n' "$current_body" > "$tmpfile"
-# ⚠️ 以下の heredoc 内の {…} プレースホルダーを Step 1-3 の実測値で置換してから実行すること
-cat >> "$tmpfile" << 'METRICS_EOF'
-### 📊 メトリクス
-
-| メトリクス | 値 | 閾値 | 判定 |
-|-----------|-----|------|------|
-| 計画乖離率 | {plan_deviation_rate}% | ≤30% | {judgment} |
-| テスト通過率 | {test_pass_rate}% | 100% | {judgment} |
-| レビュー指摘(CRITICAL+HIGH) | {review_critical_high}件 | MA5≤{threshold} | {judgment} |
-| review-fixループ | {review_fix_loops}回 | ≤3 | {judgment} |
-| 計画逸脱回数 | {plan_deviation_count}回 | MA5≤{threshold} | {judgment} |
-
-**Baseline**: {baseline_status}
-**失敗分類**: {primary_failure_class} ({corrective_action_pointer})
-METRICS_EOF
-
-# 3. Empty body guard
-if [ ! -s "$tmpfile" ] || [[ "$(wc -c < "$tmpfile")" -lt 10 ]]; then
-  echo "ERROR: Updated body is empty or too short. Aborting PATCH." >&2
-  echo "Backup saved at: $backup_file" >&2
-  exit 1
-fi
-
-# 4. Header validation
-if grep -q -- '📜 rite 作業メモリ' "$tmpfile"; then
-  : # Header present, proceed
-else
-  echo "ERROR: Updated body missing work memory header. Restoring from backup." >&2
-  cp "$backup_file" "$tmpfile"
-  exit 1
-fi
-
-# 5. PATCH
-jq -n --rawfile body "$tmpfile" '{"body": $body}' \
-  | gh api repos/{owner}/{repo}/issues/comments/"$comment_id" \
-    -X PATCH --input -
-patch_status=$?
-if [[ "${patch_status:-1}" -ne 0 ]]; then
-  echo "ERROR: PATCH failed (exit code: $patch_status). Backup saved at: $backup_file" >&2
-  exit 1
-fi
-```
-
-**Placeholder descriptions**: `{plan_deviation_rate}`, `{test_pass_rate}`, `{review_critical_high}`, `{review_fix_loops}`, `{plan_deviation_count}` are the values collected in Step 1. **`{plan_deviation_count}` の source**: Step 1 bash block の stderr に emit される `[CONTEXT] PLAN_DEVIATION_COUNT=<N>` 行を Claude が会話履歴で first-match で grep し、`<N>` 部分を literal substitute する (state-read.sh 失敗時は `[CONTEXT] METRICS_SKIPPED=1` が代わりに emit され、本 heredoc 全体が skip される — 上記「Claude への指示 (METRICS_SKIPPED 検出時の挙動)」段落を参照)。`{judgment}` is `pass`/`warn`/`skip` from Step 2. `{threshold}` is the MA5 threshold. `{baseline_status}`, `{primary_failure_class}`, `{corrective_action_pointer}` are from Steps 2-3. Before executing this bash block, replace all `{...}` placeholders in the heredoc body with actual values computed in Steps 1-3. The heredoc uses a single-quoted delimiter (`'METRICS_EOF'`) so shell variables are NOT expanded; Claude must substitute the placeholder text directly in the template before passing it to the Bash tool.
-
-**Step 5**: Check repeated failure (if `safety.auto_stop_on_repeated_failure: true`).
-
-If the same primary failure class has occurred `safety.repeated_failure_threshold` times consecutively (across recent Issues), trigger fail-closed:
-
-```
-⚠️ 安全装置が発動しました（繰り返し失敗検出）
-分類: {failure_class} が {count} 回連続
-是正アクション: {corrective_action_pointer}
-```
-
-Present options via `AskUserQuestion`:
-- 続行（制限を引き上げ）→ Proceed to 5.6
-- 中止（作業メモリに状態保存）→ Phase 5.6
-- 手動介入（ユーザーが直接対応）→ terminate
+Otherwise: execute the Module procedure (Step 1 collect → Step 2 thresholds → Step 3 failure classification → Step 4 PATCH → Step 5 repeated failure check). On `[CONTEXT] METRICS_SKIPPED=1` sentinel emission (state-read.sh failure), skip Steps 2-4 but still execute Mandatory After 5.5.2 unconditionally (per Module's "Claude への指示" section).
 
 ### 🚨 Mandatory After 5.5.2
 
@@ -1747,27 +1394,9 @@ Use [Basic Query](../../references/epic-detection.md#basic-query). All `CLOSED`�
 
 Confirm via `AskUserQuestion`. If "No", display message and proceed to 5.7.3 (no auto-close). If yes, update Projects Status to "Done" and then close the Issue.
 
-Skip Step 1 if `projects.enabled: false` in rite-config.yml. Otherwise:
+**Step 1**: Update parent Issue Status to "Done".
 
-**Step 1**: Update parent Issue Status to "Done" via the shared script:
-
-```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
-  --argjson issue {parent_issue_number} \
-  --arg owner "{owner}" \
-  --arg repo "{repo}" \
-  --argjson project_number {project_number} \
-  --arg status "Done" \
-  --argjson auto_add false \
-  --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
-```
-
-Inspect the script's stdout JSON:
-
-- `.result == "updated"` → success.
-- `.result == "skipped_not_in_project"` → display `警告: Issue #{parent_issue_number} は Project に登録されていません` and proceed to Step 2 (non-blocking).
-- `.result == "failed"` → display `.warnings[]` and proceed to Step 2 (non-blocking).
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-3--phase-572-parent-issue-status--done) — Callsite 3 (Phase 5.7.2) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "Done" for `{parent_issue_number}`, `auto_add: false` for parent Issue). On `skipped_not_in_project` / `failed` result, display `.warnings[]` and proceed to Step 2 (non-blocking).
 
 **Step 2**: Close the parent Issue via `/rite:issue:close` Skill invocation.
 

--- a/plugins/rite/hooks/tests/caller-markdown-block.test.sh
+++ b/plugins/rite/hooks/tests/caller-markdown-block.test.sh
@@ -21,16 +21,20 @@
 #   対象ではない (markdown を grep するメタテスト)。手動レビュー依存だった部分を機械化する。
 #
 # Caller sites covered (8 箇所、verified-review F11-10 で resume.md を追加):
-#   - commands/issue/start.md (5 箇所): Phase 3 (phase) / Phase 5.5.1 (phase) /
-#     Phase 5.5.2 (implementation_round inline metrics capture, cycle 41 II-1 確立) /
+#   - commands/issue/start.md (4 箇所): Phase 3 (phase) / Phase 5.5.1 (phase) /
 #     Phase 5.6 (phase) + Phase 5.7 (parent_issue_number)
+#   - commands/issue/references/metrics-recording.md (1 箇所): Phase 5.5.2
+#     (implementation_round inline metrics capture, cycle 41 II-1 確立 → Issue #901 PR E で
+#     start.md から本 reference に SoT 移管)
 #   - commands/issue/implement.md (1 箇所): Phase 5.1.2 (parent_issue_number)
 #   - commands/pr/review.md (1 箇所): Phase 5.3.8 (loop_count)
 #   - commands/resume.md (1 箇所): Phase 2.1 Step 1 (parent_issue_number_raw) — F11-10 で追加
-# 注: 数値の真実の源は本ファイル内 TC-1.1〜TC-1.4 の grep count。docstring drift 防止のため
+# 注: 数値の真実の源は本ファイル内 TC-1.1〜TC-1.5 の grep count。docstring drift 防止のため
 # verified-review cycle 44 F-07 で 6→7 に更新、verified-review F-14 で start.md Phase 5.1.2 表記を
 # Phase 5.5.2 (implementation_round inline metrics capture) へ正確化 (cycle 43 F-12 + cycle 41 II-1 の
-# semantic 整合)。F11-10 で 7→8 (resume.md F-02 caller 追加に伴う metatest 拡張)。
+# semantic 整合)。F11-10 で 7→8 (resume.md F-02 caller 追加に伴う metatest 拡張)。Issue #901 PR E で
+# start.md Phase 5.5.2 の implementation_round inline 形式を metrics-recording.md へ SoT 移管 (caller
+# 数 5→4 に減少、新たに METRICS_RECORDING_MD constant を追加し TC-1.5 / TC-6 を当該ファイル対象に変更)。
 #
 # Type validation only applies to numeric fields (parent_issue_number / loop_count).
 # `phase` は文字列のため type validation は不要 (3 箇所は本テストの type validation 対象外)。
@@ -47,16 +51,19 @@ START_MD="$COMMANDS_DIR/issue/start.md"
 IMPLEMENT_MD="$COMMANDS_DIR/issue/implement.md"
 REVIEW_MD="$COMMANDS_DIR/pr/review.md"
 RESUME_MD="$COMMANDS_DIR/resume.md"
+# Issue #901 PR E: implementation_round inline form を metrics-recording.md へ SoT 移管
+METRICS_RECORDING_MD="$COMMANDS_DIR/issue/references/metrics-recording.md"
 
 # === Test 1: caller bash block の存在確認 (regression 対策の前提) ===
 echo "TC-1: state-read.sh 呼出 caller bash block の存在確認"
 
-# start.md は 5 箇所
+# start.md は 4 箇所 (Phase 3 / 5.5.1 / 5.6 / 5.7 Workflow Termination)
 # cycle 43 F-12 LOW 対応: Phase 5.5.2 の plan_deviation_count metric capture を table cell から
-# 別 bash code block へ分離した結果、caller 数が 4 → 5 に増えた (Phase 3 / 5.1.2 / 5.5.1 / 5.7
-# Workflow Termination + Phase 5.5.2 metric)。
+# 別 bash code block へ分離した結果、caller 数が 4 → 5 に増えた。
+# Issue #901 PR E: Phase 5.5.2 implementation_round inline 形式を metrics-recording.md へ SoT 移管
+# した結果、start.md の caller 数が 5 → 4 に減った (TC-1.5 で metrics-recording.md の 1 箇所を別途検証)。
 start_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$START_MD" || true)
-assert "TC-1.1: start.md の caller bash block は 5 箇所" "5" "$start_count"
+assert "TC-1.1: start.md の caller bash block は 4 箇所" "4" "$start_count"
 
 # implement.md は 1 箇所
 implement_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$IMPLEMENT_MD" || true)
@@ -69,6 +76,11 @@ assert "TC-1.3: review.md の caller bash block は 1 箇所" "1" "$review_count
 # resume.md は 1 箇所 (F11-10 で追加: Phase 2.1 Step 1 parent_issue_number_raw)
 resume_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$RESUME_MD" || true)
 assert "TC-1.4: resume.md の caller bash block は 1 箇所" "1" "$resume_count"
+
+# metrics-recording.md は 1 箇所 (Issue #901 PR E で start.md Phase 5.5.2 から SoT 移管:
+# implementation_round inline form は本 reference の Step 1 セクション内に唯一存在)
+metrics_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$METRICS_RECORDING_MD" || true)
+assert "TC-1.5: metrics-recording.md の caller bash block は 1 箇所" "1" "$metrics_count"
 
 # === Test 2: G-02 — `if !` anti-pattern revert 検出 ===
 # cycle 35 F-04 で empirical に bash spec 違反と判明した形式が caller markdown に revert されないこと。
@@ -174,31 +186,39 @@ assert_grep "TC-5.4: resume.md の parent_issue_number_raw validation が defaul
   'parent_issue_number_raw=0'
 
 # === Test 6: G-03 — inline form pin (verified-review cycle 41 II-1) ===
-# Background: TC-1 / TC-2 / TC-3 は `^if` (行頭) に限定して caller block を pin するが、
-# start.md L1805 周辺の metrics 表内に inline 形式の caller (`| Brief inline form: \`if val=$(bash
-# {plugin_root}/hooks/state-read.sh --field implementation_round --default 0); then ...\`` 列内 inline)
-# が存在し、`^if` 限定 grep では捕捉できない (行頭が `|` で始まる markdown table cell のため)。
-# start.md の verified-review cycle 38 F-02 prose に「previous '6 / 7 caller sites' prose
-# self-undercount-drifted twice」と明記されている通り、`implementation_round` field は過去 2 回
-# self-undercount drift を起こした履歴があり、再発確率が高い field。inline 形式が anti-pattern
-# (`if !` 形式) に revert された場合に TC-2 が素通りする盲点を本 TC で塞ぐ。
+# Background: TC-1 / TC-2 / TC-3 は `^if` (行頭) に限定して caller block を pin する。
+# 当初は start.md L1805 周辺の metrics 表内に inline 形式の caller が存在し、`^if` 限定 grep では
+# 捕捉できない盲点を本 TC で塞いでいた。
+# verified-review cycle 38 F-02 prose に「previous '6 / 7 caller sites' prose self-undercount-drifted
+# twice」と明記されている通り、`implementation_round` field は過去 2 回 self-undercount drift を起こした
+# 履歴があり、再発確率が高い field。
+# Issue #901 PR E (refactor): start.md Phase 5.5.2 を metrics-recording.md へ SoT 移管。implementation_round
+# inline form は本 reference の Step 1 セクション内に存続するため、TC-6 の対象を METRICS_RECORDING_MD に
+# 切り替え (TC-1.5 と対をなす形で SoT 移管後の存続を検証する)。anti-pattern revert 検出 (`if !` 形式) と
+# canonical capture pattern (`then :; else rc=$?`) の維持確認は SoT 移管後も同じく機能する。
 echo ""
-echo "TC-6: G-03 — start.md inline form (implementation_round) pin (cycle 41 II-1)"
+echo "TC-6: G-03 — metrics-recording.md inline form (implementation_round) pin (cycle 41 II-1, Issue #901 PR E で SoT 移管)"
 
-# 6.1: inline form の caller が start.md に存在すること (markdown table cell 内も検出)
-inline_count=$(grep -cE 'if val=\$\(bash \{plugin_root\}/hooks/state-read\.sh --field implementation_round' "$START_MD" || true)
-assert "TC-6.1: start.md の implementation_round inline form (1 箇所) が存続" "1" "$inline_count"
+# 6.1: inline form の caller が metrics-recording.md に存在すること
+inline_count=$(grep -cE 'if val=\$\(bash \{plugin_root\}/hooks/state-read\.sh --field implementation_round' "$METRICS_RECORDING_MD" || true)
+assert "TC-6.1: metrics-recording.md の implementation_round inline form (1 箇所) が存続" "1" "$inline_count"
 
 # 6.2: inline form に `if !` anti-pattern が含まれていないこと (anti-pattern revert 検出)
-assert_not_grep "TC-6.2: start.md の implementation_round inline form に \`if !\` anti-pattern が無い" \
-  "$START_MD" \
+assert_not_grep "TC-6.2: metrics-recording.md の implementation_round inline form に \`if !\` anti-pattern が無い" \
+  "$METRICS_RECORDING_MD" \
   'if !\s+val=\$\(bash\s+\{plugin_root\}/hooks/state-read\.sh --field implementation_round'
 
 # 6.3: inline form の canonical capture pattern が `; then :; else rc=$?;` を含むこと
 # (else 節の rc capture が削除された場合に検出)
-assert_grep "TC-6.3: start.md の implementation_round inline form が canonical capture pattern を維持" \
-  "$START_MD" \
+assert_grep "TC-6.3: metrics-recording.md の implementation_round inline form が canonical capture pattern を維持" \
+  "$METRICS_RECORDING_MD" \
   'if val=\$\(bash \{plugin_root\}/hooks/state-read\.sh --field implementation_round.*then :; else rc=\$\?'
+
+# 6.4: SoT 移管後の drift guard — start.md に implementation_round inline form が再度 introduce
+# されていないこと (Issue #901 PR E で剥がした SoT を将来の編集で誤って再 inline 化する経路を遮断)
+assert_not_grep "TC-6.4: start.md に implementation_round inline form が再 inline 化されていない (SoT drift guard)" \
+  "$START_MD" \
+  'if val=\$\(bash \{plugin_root\}/hooks/state-read\.sh --field implementation_round'
 
 # === Summary ===
 if ! print_summary "$(basename "$0")"; then


### PR DESCRIPTION
## 概要

`/rite:issue:start` ハイブリッド再設計 (#896) の **PR E**。Phase 5.5.2 (Metrics Recording) / Phase 5.2.1 + 5.2.1.1 (Checklist Auto-Check) / Phase 2.4 + 5.5.1 + 5.7.2 (Projects Status Update 3 callsites) を新規 references に SoT 移管し、本体は anchor stub のみに圧縮した。

## 関連 Issue

Closes #901

## 変更内容

### 新規 references (3 ファイル、合計 470 行)

| ファイル | 行数 | 内容 |
|---------|------|------|
| `plugins/rite/commands/issue/references/metrics-recording.md` | 218 | Phase 5.5.2 全体 (Step 1-5 + `implementation_round` inline metrics capture + METRICS_SKIPPED 経路 + heredoc PATCH 本体) |
| `plugins/rite/commands/issue/references/checklist-auto-check.md` | 113 | Phase 5.2.1 + 5.2.1.1 (grep 確認 + Auto-Check Evaluation + uncertain handling + re-check) |
| `plugins/rite/commands/issue/references/projects-status-update-callsites.md` | 139 | Phase 2.4 / 5.5.1 / 5.7.2 共通 delegation の bash literal SoT (3 callsite 比較表) |

### 本体側の anchor 化

- `plugins/rite/commands/issue/start.md`: 1873 → 1502 行 (**-371 行、-19.8%**)
- 各 anchor stub は Pre-write / Mandatory After / Module link のみ保持
- `Skip Steps note` (Phase 5.6 pre-condition で参照) と `Issue #513 regression guard` (test pin) は本体に保持

### テスト更新

- `caller-markdown-block.test.sh`:
  - TC-1.1 caller count `5 → 4` (start.md の implementation_round inline form 移動)
  - TC-1.5 新規追加 (metrics-recording.md = 1 箇所)
  - TC-6 を `METRICS_RECORDING_MD` 対象に切り替え
  - TC-6.4 SoT drift guard 新規追加 (start.md への再 inline 化を検出)
- 全 49/49 テスト PASS

## 期待効果

- **本体行数 -371 行** (目標 -300 を 23.7% 上回る)
- **SoT 一本化** (Wiki 経験則 PR #936): 3 callsite delegation の bash literal を 1 reference に集約
- **既存 anchor sweep** (Wiki 経験則 PR #801): test fixture 経由で SoT 移動を機械検証
- **heading hierarchy 維持** (Wiki 経験則 PR #808): 圧縮後も h2/h3/h4 の連続性を保持

## 検証

- [x] 関連テスト全 49/49 PASS (`bash plugins/rite/hooks/tests/run-tests.sh`)
- [x] 既存 test pin 文字列 retention 確認 (`projects-integration.md#247` / `Issue #513 regression guard` / canonical `if curr=...; then` 4 箇所)
- [x] `caller-markdown-block.test.sh` TC-1.5 / TC-6.1-6.4 で metrics-recording.md の inline form 維持を検証
- [x] 新規 references の `implementation_round` inline form が canonical capture pattern (`then :; else rc=$?`) を維持

## 設計ドキュメント

詳細仕様は [docs/designs/redesign-issue-start-hybrid.md](https://github.com/B16B1RD/cc-rite-workflow/blob/develop/docs/designs/redesign-issue-start-hybrid.md) (PR E セクション) を参照。

## 親 Issue

#896 — `/rite:issue:start` 再設計ハイブリッド方針 (9 PR 段階的 slim・Phase 5 分割)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
