### PR TITLE
refactor(issue): start.md Phase 5.3/5.4 を start-publish.md sub-skill に抽出 [PR G1]

### DIFF
--- a/docs/designs/redesign-issue-start-hybrid.md
+++ b/docs/designs/redesign-issue-start-hybrid.md
@@ -1,0 +1,203 @@
+# refactor(rite): /rite:issue:start を再設計 — ハイブリッド方針で 9 PR 段階的 slim・Phase 5 分割
+
+<!-- Section ID: SPEC-OVERVIEW -->
+## 概要
+
+`plugins/rite/commands/issue/start.md` (現 2303 行) を再設計する。Phase 5 (line 564 以降 1740 行) を 3 sub-skill (`start-execute` / `start-publish` / `start-finalize`) に分割し、charter 駆動 slim と references 抽出 (6-8 件) を組み合わせて適用、本体を約 600-700 行に圧縮する。9 PR で段階的に進行し、完全後方互換を維持する。
+
+最終形:
+- 本体 `start.md`: 600-700 行 (現 2303 から -70%)
+- 新規 sub-skill: 3 ファイル (合計 750 行)
+- 新規 references: 6-8 ファイル (合計 1250 行)
+- 新規 charter test: 2 ファイル (機械検証)
+- runtime 動作不変
+
+<!-- Section ID: SPEC-BACKGROUND -->
+## 背景・目的
+
+start.md は現在、以下の構造的な肥大化を抱えている:
+
+- **行数**: 2303 行 (create.md 350 行の 6.6 倍、cleanup.md 1496 行の 1.5 倍)
+- **Phase 5 のモノリシック構造**: line 564 以降 1740 行で全体の 75% を占める
+- **状態管理の散在**: `Mandatory After` セクション 42 個、各 phase の状態書込み・遷移検証が散文と bash literal で散らばる
+- **Charter 違反の多発**: `Issue #` 引用 13 件 / `cycle N` 引用 26 件 / `🚨` 35 件で Simplification Charter 上限 (`Issue #` 1 件 / `🚨` 5 件) を大幅超過
+
+過去の同種再設計で蓄積された 2 つの成功パターンを継承する:
+
+1. **`/rite:issue:create` の sub-skill 分割** (734→334 行): orchestrator + interview/decompose/register という責務分割
+2. **`/rite:pr:cleanup` の charter 駆動 slim** (1810→1496 行): Simplification Charter 先行適用 + references 集約
+
+start は規模・性質的に両者の中間以上にあり、片方だけのアプローチでは効果不足。サブスキル分割と charter slim を統合する **ハイブリッド方針** を採用することで、最大の slim 効果と responsibility 明確化を両立する。
+
+## 要件
+
+<!-- Section ID: SPEC-REQ-FUNC -->
+### 機能要件
+
+1. **本体 slim**: `start.md` を 600-700 行に圧縮する (-70%)
+2. **Phase 5 分割**: Phase 5.0-5.7 を 3 sub-skill に垂直分割する
+   - `start-execute.md` (約 250 行): Phase 5.0 (Stop Hook) + 5.1 (implement) + 5.2 (lint) + 5.2.1 (checklist)
+   - `start-publish.md` (約 220 行): Phase 5.3 (PR create) + 5.4 (review-fix loop + fingerprint cycling)
+   - `start-finalize.md` (約 280 行): Phase 5.5 (ready) + 5.5.1/5.5.2 (status/metrics) + 5.6 (completion) + 5.7 (parent close) + Workflow Termination
+3. **References 抽出**: 6-8 ファイルを `commands/issue/references/` 配下に新設
+   - `flow-state-scaffolding.md`: Pre-write + Mandatory After 契約の SoT
+   - `pre-condition-gate.md`: state-read.sh fail-fast pattern の SoT
+   - `workflow-incident-detection.md`: Phase 5.4.4.1 全体の SoT
+   - `workflow-incident-emit-pattern.md`: orchestrator-direct emit pattern の SoT
+   - `fingerprint-cycling.md`: Phase 5.4.1.0 + Quality Signal 検出の SoT
+   - `checklist-auto-check.md`: Phase 5.2.1 + Auto-Check Evaluation の SoT
+   - `metrics-recording.md`: Phase 5.5.2 全体の SoT
+   - `projects-status-update-callsites.md`: Phase 2.4 / 5.5.1 / 5.7.2 delegation の SoT
+4. **Charter 適用**: 機械的禁止パターン (`Issue #` 引用 / `cycle N` 引用 / `🚨` 濫用) を機械的に削除し、標準化された 2 文 contract phrase (`MUST execute in the SAME response turn` / `DO NOT stop`) を Mandatory After に導入する
+5. **HTML sentinel 名前空間**: `[start:execute:completed]` / `[start:publish:completed]` / `[start:finalize:completed]` を新設し、orchestrator が継続トリガとして観測する
+6. **Charter test**: `start-md-charter.test.sh` で上限 (`Issue #` ≤ 1 / `cycle N` ≤ 1 / `🚨` ≤ 5) と下限 (`AskUserQuestion` ≥ 30 / `Mandatory After` ≥ 30 / 標準化 phrase ≥ 30) を機械検証する
+7. **Symmetry test**: `flow-state-create-symmetry.test.sh` で `flow-state-update.sh create` の 5 引数対称性を検証する
+
+<!-- Section ID: SPEC-REQ-NFR -->
+### 非機能要件
+
+1. **完全後方互換**: `/rite:issue:start <N>` の引数・挙動は不変。既存ユーザーは何も変更不要
+2. **resume.md routing 互換**: line 199-208, 496-504, 523-531 で参照される phase 名 (`phase5_implementation` / `phase5_lint` / `phase5_post_lint` / `phase5_pr` / `phase5_review` / `phase5_post_review` / `phase5_fix` / `phase5_post_fix` / `phase5_post_ready`) は維持し、サブスキル境界には新しい `*_post_*` marker のみ追加する
+3. **whitelist 整合**: `phase-transition-whitelist.sh` の新エッジは sub-skill 切出 PR (F / G1 / G2) で同 PR 内に追加する
+4. **ドッグフーディング維持**: 各 sub-skill 切出 PR で e2e 必須 (CLAUDE.md 「ドッグフーディング中の作者を破壊しない」要件)
+5. **revert 可能性**: PR A の charter test は `STRICT_CHARTER=1` env gate で opt-in 化し、A 単独 revert で B 以降の CI が落ちない設計とする
+6. **runtime 動作不変**: bash literal や MUST/MUST NOT 条文は維持し、散文の rationale 集約のみで slim を達成する
+
+<!-- Section ID: SPEC-TECH-DECISIONS -->
+## 技術的決定事項
+
+1. **ハイブリッド方針採用**: charter slim だけでは Phase 5 のモノリシック構造が残り、サブスキル分割だけでは散文肥大が解消しない。両者を統合することで最大効果
+2. **Phase 5 を 3 分割**: create.md と対称な命名 (interview/decompose/register) ではなく、Phase 5 の責務単位 (execute/publish/finalize) で命名する。これは start の lifecycle (準備済み実装 → 公開 → 完結) と一致するため
+3. **Sentinel 終端責務マトリクス**: `[start:finalize:completed]` のみが workflow 終端。`[start:execute:completed]` / `[start:publish:completed]` は continuation trigger
+4. **2 文 contract 標準化**: 各 Mandatory After の rationale を以下の 2 文に統一する
+   ```
+   > See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+   > MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+   ```
+5. **Charter test の `STRICT_CHARTER` env gate**: PR A の test は CI で ON、ローカル revert 時は OFF にすることで、A 単独 revert 時の CI 失敗を防ぐ
+6. **PR 順序**: A → B → C → D → E → F → G1 → G2 → H、各 sub-skill 切出は 1 PR 1 sub-skill 原則
+7. **FSM 化は射程外**: phase 名 SoT 一本化や `--auto/--until/--resume` flag、コマンド分割は本プランでは扱わない (将来 Issue 候補)
+
+## アーキテクチャ
+
+<!-- Section ID: SPEC-ARCH-COMPONENTS -->
+### コンポーネント構成
+
+```
+plugins/rite/commands/issue/start.md (orchestrator, ~700 行)
+  ├── Phase 0/1 (Detection / Quality Validation)
+  ├── Phase 1.5/1.6 (Parent / Child routing)
+  ├── Phase 2 (Branch / Projects / Iteration / WM init)
+  ├── Phase 3 (Implementation Plan dispatcher)
+  ├── Phase 4 (Work Start Guidance)
+  └── Phase 5 (dispatcher のみ)
+      ├── start-execute.md (~250 行)
+      │   ├── Phase 5.0: Stop Hook registration
+      │   ├── Phase 5.1: implement.md 呼び出し
+      │   ├── Phase 5.2: rite:lint 呼び出し
+      │   └── Phase 5.2.1: checklist auto-check
+      │   └── sentinel: [start:execute:completed]  (continuation trigger)
+      │
+      ├── start-publish.md (~220 行)
+      │   ├── Phase 5.3: rite:pr:create 呼び出し
+      │   ├── Phase 5.4.1: rite:pr:review 呼び出し
+      │   ├── Phase 5.4.4: rite:pr:fix 呼び出し
+      │   ├── Phase 5.4.6 routing (mergeable / fix-needed / replied-only / error)
+      │   └── Phase 5.4.1.0: fingerprint cycling dispatcher
+      │   └── sentinel: [start:publish:completed]  (continuation trigger)
+      │
+      └── start-finalize.md (~280 行)
+          ├── Phase 5.5: rite:pr:ready 呼び出し
+          ├── Phase 5.5.1: Issue Status In Review
+          ├── Phase 5.5.2: metrics recording
+          ├── Phase 5.6: completion-report 呼び出し
+          ├── Phase 5.7: parent Issue close (rite:issue:close)
+          └── Workflow Termination
+          └── sentinel: [start:finalize:completed]  (workflow 終端)
+
+新規 references (commands/issue/references/):
+  ├ flow-state-scaffolding.md  (Pre-write + Mandatory After 契約 SoT)
+  ├ pre-condition-gate.md      (state-read.sh fail-fast SoT)
+  ├ workflow-incident-detection.md      (Phase 5.4.4.1 SoT)
+  ├ workflow-incident-emit-pattern.md   (5 caller 用 emit pattern SoT)
+  ├ fingerprint-cycling.md     (Phase 5.4.1.0 + Quality Signal SoT)
+  ├ checklist-auto-check.md    (Phase 5.2.1 + Auto-Check SoT)
+  ├ metrics-recording.md       (Phase 5.5.2 SoT)
+  └ projects-status-update-callsites.md (Phase 2.4/5.5.1/5.7.2 SoT)
+```
+
+<!-- Section ID: SPEC-ARCH-DATAFLOW -->
+### データフロー
+
+1. ユーザーが `/rite:issue:start <N>` を起動
+2. orchestrator が Phase 0/1/1.5/1.6/2/3/4 を逐次実行 (現状とほぼ同じ)
+3. Phase 5 dispatcher が以下の順で sub-skill 連鎖 dispatch:
+   - `rite:issue:start-execute` → 完了時に `<!-- [start:execute:completed] -->` emit
+   - orchestrator が sentinel 観測 → `rite:issue:start-publish` dispatch
+   - `rite:issue:start-publish` → 完了時に `<!-- [start:publish:completed] -->` emit
+   - orchestrator が sentinel 観測 → `rite:issue:start-finalize` dispatch
+   - `rite:issue:start-finalize` → 完了時に `<!-- [start:finalize:completed] -->` emit (workflow 終端)
+4. 各 sub-skill 内では Phase 内の各 step boundary で `flow-state-update.sh` patch、Mandatory After で 2 文 contract に従い continuation を保証
+5. resume / compact / interrupt 時は orchestrator が flow-state を読み込み、対応する sub-skill から再開
+
+## 実装ガイドライン
+
+<!-- Section ID: SPEC-IMPL-FILES -->
+### 変更が必要なファイル/領域
+
+#### 編集対象
+- `plugins/rite/commands/issue/start.md` (本体、2303 → ~700 行)
+
+#### 新規作成
+- `plugins/rite/commands/issue/start-execute.md` (sub-skill)
+- `plugins/rite/commands/issue/start-publish.md` (sub-skill)
+- `plugins/rite/commands/issue/start-finalize.md` (sub-skill)
+- `plugins/rite/commands/issue/references/flow-state-scaffolding.md`
+- `plugins/rite/commands/issue/references/pre-condition-gate.md`
+- `plugins/rite/commands/issue/references/workflow-incident-detection.md`
+- `plugins/rite/commands/issue/references/workflow-incident-emit-pattern.md`
+- `plugins/rite/commands/issue/references/fingerprint-cycling.md`
+- `plugins/rite/commands/issue/references/checklist-auto-check.md`
+- `plugins/rite/commands/issue/references/metrics-recording.md`
+- `plugins/rite/commands/issue/references/projects-status-update-callsites.md`
+- `plugins/rite/hooks/tests/start-md-charter.test.sh`
+- `plugins/rite/hooks/tests/flow-state-create-symmetry.test.sh`
+
+#### 同期更新が必要 (Critical Files に昇格)
+- `plugins/rite/commands/resume.md`: phase routing 表 (line 199-208, 496-504, 523-531) の verify、必要なら sub-skill 境界 marker を追加
+- `plugins/rite/skills/rite-workflow/SKILL.md`: sub-skill 名追記
+- `plugins/rite/skills/rite-workflow/references/phase-mapping.md`: Phase 5 図の更新
+- `plugins/rite/i18n/{ja,en}/{common,issue,other,pr}.yml`: i18n キー owner 移転確認
+- `plugins/rite/hooks/phase-transition-whitelist.sh`: 新エッジ追加 (PR F/G1/G2)
+- `plugins/rite/hooks/pre-tool-bash-guard.sh`: sentinel detection regex 同期 (PR F/G1/G2)
+- `plugins/rite/hooks/verify-terminal-output.sh`: `[start:finalize:completed]` allow-list 追加 (PR G2)
+- `plugins/rite/hooks/tests/run-tests.sh`: 新 test 登録 (PR A)
+- `docs/SPEC.md`: Plugin Structure 節の更新 (PR H)
+- `CHANGELOG.md` / `CHANGELOG.ja.md`: リリース履歴 (PR H)
+
+<!-- Section ID: SPEC-IMPL-CONSIDERATIONS -->
+### 考慮事項
+
+1. **`stop-guard.sh` は実体不在**: 既存ドキュメントで通称として残るが、リポジトリの実体は `pre-tool-bash-guard.sh` (574 行)。同期更新時はこちらを編集する
+2. **`phase5_implementation` の latent unaligned state**: resume.md は line 199, 496, 523 で hard-code 参照するが、whitelist には存在しない既存問題。本プランでは触らず、将来 Issue として分離
+3. **Revert 互換性チェーン**: PR C (scaffolding/pre-condition references) を revert すると D-G2 が anchor リンク切れ → revert 単位は {C, D, E, F, G1, G2} セット。各 PR は独立 mergeable だが revert 時はセット扱い
+4. **develop 並列開発の merge conflict**: 8 PR 中 7 PR が start.md を編集、他 Issue の start.md PR と高頻度競合。各 PR で develop 最新へ rebase 後 charter test を再実行し、機械的削除が rebase で復活していないか自動検証
+5. **Silent regression リスク**: 散文の中に紛れた runtime contract を消す可能性。各 sub-skill 切出 PR で e2e 必須化 (PR F / G1 / G2 / H + B / D / E で計 7 回)
+6. **Dogfooding recovery 手順**: 実装中に runtime regression を踏んだ場合、`~/.claude/settings.json` の `rite@rite-marketplace: true` 一時切替で marketplace 版に fallback (cache クリア後、修正完了後に false に戻す)
+7. **HTML sentinel 名前空間衝突**: 既存 sentinel (`[interview:*]` `[create:*]` `[ingest:*]` `[cleanup:*]` `[review:*]` `[fix:*]` `[pr:*]` `[lint:*]` `[plan:*]` `[ready:*]`) と grep 確認で 0 件衝突を確認済み
+8. **i18n キー owner 移転**: Phase 5 内の AskUserQuestion / ユーザー向けメッセージが sub-skill に移管された場合、参照キーの所有者 (caller-side or sub-skill-side) を明示的に決定する必要あり
+
+<!-- Section ID: SPEC-OUT-OF-SCOPE -->
+## スコープ外
+
+以下は本プランでは扱わず、将来 Issue として分離する:
+
+- **FSM yml 外部化** (`references/issue-start-fsm.yml`): phase 名 SoT 一本化
+- **detection framework 統一** (`hooks/detect/*.sh`): 4 自動検出機能 (parent / out-of-scope / workflow-incident / fingerprint) の共通契約化
+- **`--auto` flag**: AskUserQuestion 自動 resolve (sprint:execute / team-execute からの呼び出し安定化)
+- **`--until` / `--resume` flag**: flag 化したライフサイクル制御
+- **コマンド分割** (`/rite:issue:work` / `/rite:issue:finish`): 完全 lifecycle 分離
+- **`implement.md` slim** (1001 行): TDD Light / Parallel impl / Adaptive re-eval の references 化
+- **latent unaligned state の解消**: `phase5_implementation` を resume.md は要求するが whitelist にない問題
+
+これらは本プラン完了後に効果測定し、必要があれば別 Issue として起票する。

--- a/plugins/rite/commands/issue/start-publish.md
+++ b/plugins/rite/commands/issue/start-publish.md
@@ -21,7 +21,7 @@ Execute the publish phase for an Issue. This sub-skill is invoked from `start.md
 
 ## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
 
-> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも post-publish phase / next_action が記録されるよう、sub-skill 先頭で Pre-flight write を保証する (defense-in-depth: caller の delegation pre-write は upstream で先行書き込み済みだが、本 Pre-flight が timestamp と next_action を refresh する)。
+> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも、`phase5_publish_running` phase + sub-skill 由来の `next_action` が必ず記録されるよう (caller の delegation pre-write を上書きせず timestamp / `next_action` を refresh)、sub-skill 先頭で Pre-flight write を保証する。`phase5_post_publish` への遷移は Return Output Format (line 318-) の re-patch が担う。
 
 **MUST run before any publish logic** (Phase 5.3 PR creation / Phase 5.4 review-fix loop / return-output emission)。**not optional**:
 
@@ -66,7 +66,7 @@ Run [Preflight Protocol](./start.md#preflight-protocol) before creating PR.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->emit aborted sentinel and return to caller (start.md routes to Phase 5.6). Do NOT stop."
+  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->ask user via AskUserQuestion (3 options: 再試行 / Edit ツールで PR 作成して continue / Phase 5.6 へ); 再試行 と continue は sub-skill 内 loop、Phase 5.6 へ のみ emit aborted sentinel and return to caller. Do NOT stop."
 ```
 
 > **Data Handoff**: When invoking `rite:pr:create`, include the Issue information retrieved in Phase 0.1 (`number`, `title`, `body`, `labels`) in the Skill prompt to avoid redundant `gh issue view` calls in the child command.
@@ -80,7 +80,7 @@ Invoke `skill: "rite:pr:create"`.
 - `[pr:created:{number}]` → extract `{pr_number}`, proceed to Phase 5.4 (Review-Fix Loop).
 - `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel and ask user via `AskUserQuestion`** with 3 options (`再試行` / `Edit ツールで PR 作成して continue` / `Phase 5.6 へ`):
   - **「再試行」**: Phase 5.3 (rite:pr:create) を再呼出する (network blip / 一時的な auth エラー等の transient failure 回復用)。
-  - **「Edit ツールで PR 作成して continue」**: §B SoT Step 2 (`manual_fallback_adopted`) を emit し、ユーザーが手動で PR を作成した後 `{pr_number}` を context に確認してから Phase 5.4 (Review-Fix Loop) へ進む。
+  - **「Edit ツールで PR 作成して continue (incident 記録)」**: §B SoT Step 2 (`manual_fallback_adopted`) を emit し、ユーザーが手動で PR を作成した後 `{pr_number}` を context に確認してから Phase 5.4 (Review-Fix Loop) へ進む。
   - **「Phase 5.6 へ」**: emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。
 
 > **Emit canonical literal**: See [§B — Phase 5.3 `[pr:create-failed]`](./references/workflow-incident-emit-pattern.md#b--phase-53-prcreate-failed) (SoT) for both emit steps (Step 1 `skill_load_failure` is emitted **before** the AskUserQuestion; Step 2 `manual_fallback_adopted` is emitted **only when** user selects 「Edit ツールで PR 作成して continue」), `|| true` non-blocking guarantee, and `--pr-number 0` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
@@ -360,7 +360,7 @@ abort path (Phase 5.3 `[pr:create-failed]` / Phase 5.4.6 `[fix:error]` user-term
 Result pattern (grep-matchable string inside HTML comment):
 
 - **Publish completed (success)**: `<!-- [start:publish:completed] -->` (matches `grep -F '[start:publish:completed]'`) — emitted when review-fix loop converges via `[review:mergeable]` or `[fix:replied-only]`. Caller routes to Phase 5.5 (Ready for Review).
-- **Publish aborted**: `<!-- [start:publish:aborted] -->` (matches `grep -F '[start:publish:aborted]'`) — emitted when `rite:pr:create` returns `[pr:create-failed]`, or when `rite:pr:fix` returns `[fix:error]` and user selects 「Phase 5.6 にスキップ」/「Edit ツールで手動 fallback」/「terminate」. Caller routes to Phase 5.6 (Completion Report), **skipping** Phase 5.5.
+- **Publish aborted**: `<!-- [start:publish:aborted] -->` (matches `grep -F '[start:publish:aborted]'`) — emitted when `rite:pr:create` returns `[pr:create-failed]` **and user selects 「Phase 5.6 へ」** (3-option AskUserQuestion 経由、「再試行」「Edit ツールで PR 作成して continue (incident 記録)」 を選択した場合は abort されず sub-skill 内 loop 継続)、または `rite:pr:fix` returns `[fix:error]` and user selects 「Phase 5.6 にスキップ」/「Edit ツールで手動 fallback (incident 記録)」/「terminate」. Caller routes to Phase 5.6 (Completion Report), **skipping** Phase 5.5.
 
 Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.3-5.4 — Step 3) to determine the next action.
 

--- a/plugins/rite/commands/issue/start-publish.md
+++ b/plugins/rite/commands/issue/start-publish.md
@@ -21,7 +21,7 @@ Execute the publish phase for an Issue. This sub-skill is invoked from `start.md
 
 ## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
 
-> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも、`phase5_publish_running` phase + sub-skill 由来の `next_action` が必ず記録されるよう (caller の delegation pre-write を上書きせず timestamp / `next_action` を refresh)、sub-skill 先頭で Pre-flight write を保証する。`phase5_post_publish` への遷移は Return Output Format (line 318-) の re-patch が担う。
+> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも、`phase5_publish_running` phase + sub-skill 由来の `next_action` が必ず記録されるよう (caller の delegation pre-write を上書きせず timestamp / `next_action` を refresh)、sub-skill 先頭で Pre-flight write を保証する。`phase5_post_publish` への遷移は本 sub-skill 末尾の [Return Output Format](#return-output-format-before-return) section の re-patch が担う。
 
 **MUST run before any publish logic** (Phase 5.3 PR creation / Phase 5.4 review-fix loop / return-output emission)。**not optional**:
 
@@ -66,7 +66,7 @@ Run [Preflight Protocol](./start.md#preflight-protocol) before creating PR.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->ask user via AskUserQuestion (3 options: 再試行 / Edit ツールで PR 作成して continue / Phase 5.6 へ); 再試行 と continue は sub-skill 内 loop、Phase 5.6 へ のみ emit aborted sentinel and return to caller. Do NOT stop."
+  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->ask user via AskUserQuestion (3 options: 再試行 / Edit ツールで PR 作成して continue (incident 記録) / Phase 5.6 へ); 再試行 と continue は sub-skill 内 loop、Phase 5.6 へ のみ emit aborted sentinel and return to caller. Do NOT stop."
 ```
 
 > **Data Handoff**: When invoking `rite:pr:create`, include the Issue information retrieved in Phase 0.1 (`number`, `title`, `body`, `labels`) in the Skill prompt to avoid redundant `gh issue view` calls in the child command.
@@ -78,7 +78,7 @@ Invoke `skill: "rite:pr:create"`.
 **Patterns**:
 
 - `[pr:created:{number}]` → extract `{pr_number}`, proceed to Phase 5.4 (Review-Fix Loop).
-- `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel and ask user via `AskUserQuestion`** with 3 options (`再試行` / `Edit ツールで PR 作成して continue` / `Phase 5.6 へ`):
+- `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel and ask user via `AskUserQuestion`** with 3 options (`再試行` / `Edit ツールで PR 作成して continue (incident 記録)` / `Phase 5.6 へ`):
   - **「再試行」**: Phase 5.3 (rite:pr:create) を再呼出する (network blip / 一時的な auth エラー等の transient failure 回復用)。
   - **「Edit ツールで PR 作成して continue (incident 記録)」**: §B SoT Step 2 (`manual_fallback_adopted`) を emit し、ユーザーが手動で PR を作成した後 `{pr_number}` を context に確認してから Phase 5.4 (Review-Fix Loop) へ進む。
   - **「Phase 5.6 へ」**: emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。
@@ -304,7 +304,7 @@ bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
 
 ## Return Output Format (Before Return)
 
-> **Reference**: `start-execute.md` Return Output Format と対称な設計。flow-state write は 🚨 MANDATORY Pre-flight (本ファイル冒頭) で publish scope に関係なく post-publish phase を記録。本 re-patch は defense-in-depth second write として timestamp / `next_action` を refresh する。
+> **Reference**: `start-execute.md` Return Output Format と対称な設計。flow-state write は 🚨 MANDATORY Pre-flight (本ファイル冒頭) で publish scope に関係なく `phase5_publish_running` phase + sub-skill 由来の `next_action` を記録。本 re-patch は defense-in-depth second write として `phase5_post_publish` への遷移と timestamp / `next_action` の refresh を担う。
 
 Immediately before emitting the four-line return block, re-patch flow state (idempotent with Pre-flight write):
 

--- a/plugins/rite/commands/issue/start-publish.md
+++ b/plugins/rite/commands/issue/start-publish.md
@@ -21,7 +21,7 @@ Execute the publish phase for an Issue. This sub-skill is invoked from `start.md
 
 ## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
 
-> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。末尾配置だと Phase 5.3 PR create で早期 error return した場合に flow-state write が抜けるため、先頭配置が必須。
+> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも post-publish phase / next_action が記録されるよう、sub-skill 先頭で Pre-flight write を保証する (defense-in-depth: caller の delegation pre-write は upstream で先行書き込み済みだが、本 Pre-flight が timestamp と next_action を refresh する)。
 
 **MUST run before any publish logic** (Phase 5.3 PR creation / Phase 5.4 review-fix loop / return-output emission)。**not optional**:
 
@@ -50,7 +50,7 @@ else
 fi
 ```
 
-**Why `phase5_publish_running`**: caller (`start.md` Phase 5.3 Delegation Pre-write) は既に `phase5_publish_running` を書込済 (delegation in flight signal)。本 Pre-flight は patch mode で timestamp / `next_action` を refresh し、re-entry / interrupt 時にも sub-skill scope を識別できるようにする。`phase-transition-whitelist.sh` が `phase5_publish_running → phase5_pr` (forward) / `phase5_publish_running → phase5_post_publish` (terminal — abort) を whitelist 化する。
+**Why `phase5_publish_running`**: caller (`start.md` Phase 5.3-5.4 Delegation Pre-write) は既に `phase5_publish_running` を書込済 (delegation in flight signal)。本 Pre-flight は patch mode で timestamp / `next_action` を refresh し、re-entry / interrupt 時にも sub-skill scope を識別できるようにする。`phase-transition-whitelist.sh` が `phase5_publish_running → phase5_pr` (forward) / `phase5_publish_running → phase5_post_publish` (terminal) を whitelist 化する。success path は `phase5_publish_running → phase5_pr → ... → phase5_post_publish` の間接経路を辿り、direct edge `phase5_publish_running → phase5_post_publish` は sub-skill 早期 stop / abort 時の direct return path として使われる。
 
 **Idempotence**: 単一 sub-skill invocation 内で複数回実行されても safe — patch mode は pre-update `.phase` から `previous_phase` を設定し、re-entry で `phase5_publish_running` のまま phase regression しない。
 
@@ -78,11 +78,14 @@ Invoke `skill: "rite:pr:create"`.
 **Patterns**:
 
 - `[pr:created:{number}]` → extract `{pr_number}`, proceed to Phase 5.4 (Review-Fix Loop).
-- `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel + abort return block, then return to caller** (caller orchestrator routes to Phase 5.6).
+- `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel and ask user via `AskUserQuestion`** with 3 options (`再試行` / `Edit ツールで PR 作成して continue` / `Phase 5.6 へ`):
+  - **「再試行」**: Phase 5.3 (rite:pr:create) を再呼出する (network blip / 一時的な auth エラー等の transient failure 回復用)。
+  - **「Edit ツールで PR 作成して continue」**: §B SoT Step 2 (`manual_fallback_adopted`) を emit し、ユーザーが手動で PR を作成した後 `{pr_number}` を context に確認してから Phase 5.4 (Review-Fix Loop) へ進む。
+  - **「Phase 5.6 へ」**: emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。
 
-> **Emit canonical literal**: See [§B — Phase 5.3 `[pr:create-failed]`](./references/workflow-incident-emit-pattern.md#b--phase-53-prcreate-failed) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで PR 作成して continue」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number 0` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
+> **Emit canonical literal**: See [§B — Phase 5.3 `[pr:create-failed]`](./references/workflow-incident-emit-pattern.md#b--phase-53-prcreate-failed) (SoT) for both emit steps (Step 1 `skill_load_failure` is emitted **before** the AskUserQuestion; Step 2 `manual_fallback_adopted` is emitted **only when** user selects 「Edit ツールで PR 作成して continue」), `|| true` non-blocking guarantee, and `--pr-number 0` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
 
-**On `[pr:create-failed]` — abort return**: After emitting the §B canonical bash literal (WORKFLOW_INCIDENT sentinel), emit the abort return block (see [Return Output Format](#return-output-format-before-return) — abort variant) and return control to caller. Do NOT proceed to Phase 5.4. The caller (`start.md` Mandatory After 5.3 Delegation — Step 3) detects `[start:publish:aborted]` sentinel and routes directly to Phase 5.6.
+**On `[pr:create-failed]` — abort routing**: After the AskUserQuestion completes, route per the user's selection: 再試行 → re-invoke `rite:pr:create` (loop within Phase 5.3) / continue → §B Step 2 emit + Phase 5.4 progression / Phase 5.6 へ → emit `[start:publish:aborted]` abort return block (see [Return Output Format](#return-output-format-before-return) — abort variant) and return control to caller. Only the 「Phase 5.6 へ」 path triggers the abort return; the other two paths continue within the sub-skill scope. The caller (`start.md` Mandatory After 5.3-5.4 — Step 3) detects `[start:publish:aborted]` sentinel and routes directly to Phase 5.6.
 
 ---
 
@@ -202,7 +205,7 @@ After the review result is received, verify that the review was properly execute
 
 4. **When `reviewer_sections >= 1`**: Review quality verified. Proceed to Step 3.
 
-**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3 Delegation に委譲)。sub-skill 内部で emit された `[CONTEXT] WORKFLOW_INCIDENT=1` sentinel (`[pr:create-failed]` / `[fix:error]` 経路の §B/§C canonical bash literal、または `review.md` sub-skill の Sentinel Visibility Rule 経由) は会話コンテキストに残り、caller の Phase 5.4.4.1 が grep 検出・処理 (parse → dedupe → AskUserQuestion → create-issue / skip → mark processed) する責務を負う。
+**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3-5.4 に委譲)。sub-skill 内部で emit された `[CONTEXT] WORKFLOW_INCIDENT=1` sentinel (`[pr:create-failed]` / `[fix:error]` 経路の §B/§C canonical bash literal、または `review.md` sub-skill の Sentinel Visibility Rule 経由) は会話コンテキストに残り、caller の Phase 5.4.4.1 が grep 検出・処理 (parse → dedupe → AskUserQuestion → create-issue / skip → mark processed) する責務を負う。
 
 **Step 3.1 (Quality Signal 3 & 4 Detection)**: After review returns, detect Quality Signal 3 (cross-validation disagreement) and Signal 4 (reviewer self-degraded).
 
@@ -277,7 +280,7 @@ bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
   2>/dev/null || true
 ```
 
-**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3 Delegation に委譲)。
+**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3-5.4 に委譲)。
 
 > **Note (v0.4.0 #557)**: The review-fix loop has no cycle-count-based hard limit. Non-convergence is detected exclusively via the four quality signals (see `commands/pr/references/fix-relaxation-rules.md#four-quality-signals-for-escalation`):
 > 1. Fingerprint cycling → Phase 5.4.1.0 (before every re-review)
@@ -293,7 +296,7 @@ bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
 | `[fix:pushed-wm-stale]` | **Work memory が stale です。手動介入が必要かを `AskUserQuestion` でユーザーに確認** (推奨: stale 警告ログを残した上で `skill: "rite:pr:review", args: "{pr_number}"` を起動して再レビューに進む / 中断して手動で work memory を修復する)。silent に `[fix:pushed]` 扱いしてはならない (fix.md Phase 8.1 caller semantics 参照)。 |
 | `[fix:issues-created:{n}]` | **Invoke `skill: "rite:pr:review", args: "{pr_number}"`** via the Skill tool (re-review, Phase 5.4.1). |
 | `[fix:replied-only]` | **→ Emit `[start:publish:completed]` and return to caller** (caller routes to Phase 5.5 Ready for Review). |
-| `[fix:error]` | Ask the user how to proceed via `AskUserQuestion` with options: 「再試行」/「Edit ツールで手動 fallback (incident 記録)」/「Phase 5.6 にスキップ」/「terminate」. If user selects 「Edit ツールで手動 fallback」, **emit sentinel** per [§C — Phase 5.4.4 `[fix:error]`](./references/workflow-incident-emit-pattern.md#c--phase-544-fixerror) (SoT) then emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6). If user selects 「Phase 5.6 にスキップ」 or 「terminate」, emit `[start:publish:aborted]` and return to caller. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literal here. |
+| `[fix:error]` | Ask the user how to proceed via `AskUserQuestion` with 4 options and execute the corresponding action: <br>**「再試行」**: Phase 5.4.4 に戻り `skill: "rite:pr:fix"` を再呼出 (fix.md 内の error 詳細を踏まえて再試行)。<br>**「Edit ツールで手動 fallback (incident 記録)」**: **emit sentinel** per [§C — Phase 5.4.4 `[fix:error]`](./references/workflow-incident-emit-pattern.md#c--phase-544-fixerror) (SoT) then emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。<br>**「Phase 5.6 にスキップ」**: emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。<br>**「terminate」**: emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6)。The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literal here. |
 
 > **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。再レビューは必ず `skill: "rite:pr:review"` を Skill ツールで呼び出すこと。
 
@@ -318,7 +321,7 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
       --next "rite:issue:start-publish completed. Proceed to Phase 5.5 (Ready for Review). Do NOT stop." \
       --preserve-error-count; then
     echo "[CONTEXT] PUBLISH_RETURN_PATCH_FAILED=1" >&2
-    # 非 blocking: start.md Mandatory After 5.3 Delegation の redundant patch が続行する。
+    # 非 blocking: start.md Mandatory After 5.3-5.4 の redundant patch が続行する。
   fi
 fi
 ```
@@ -330,7 +333,7 @@ After the flow-state update, output the result pattern. Caller-continuation remi
 > **Return block design rationale**:
 > - caller continuation hint を plain-text line + HTML comment の **dual form** で emit（HTML comment が rendering で strip される場合への defense）
 > - result pattern を HTML comment 化 (`<!-- [start:publish:completed] -->` / `<!-- [start:publish:aborted] -->`) — sentinel は grep-matchable (`grep -F '[start:publish:'`) のまま AC 保持し、user-visible terminal token としての sentinel 出力を抑止して LLM turn-boundary heuristic 起因の `continue` 要求 stop を防ぐ
-> - `[CONTEXT] PUBLISH_DONE=1` marker を return block の **FIRST line** に追加（not last）— orchestrator Pre-check Item 0 と Mandatory After 5.3 Delegation Step 0 が consume する grep signal、HTML strip rendering でも検出可能な plain-text 形式
+> - `[CONTEXT] PUBLISH_DONE=1` marker を return block の **FIRST line** に追加（not last）— orchestrator Pre-check Item 0 と Mandatory After 5.3-5.4 Step 0 が consume する grep signal、HTML strip rendering でも検出可能な plain-text 形式
 
 **Output format example (success — `[start:publish:completed]`)**:
 
@@ -359,13 +362,13 @@ Result pattern (grep-matchable string inside HTML comment):
 - **Publish completed (success)**: `<!-- [start:publish:completed] -->` (matches `grep -F '[start:publish:completed]'`) — emitted when review-fix loop converges via `[review:mergeable]` or `[fix:replied-only]`. Caller routes to Phase 5.5 (Ready for Review).
 - **Publish aborted**: `<!-- [start:publish:aborted] -->` (matches `grep -F '[start:publish:aborted]'`) — emitted when `rite:pr:create` returns `[pr:create-failed]`, or when `rite:pr:fix` returns `[fix:error]` and user selects 「Phase 5.6 にスキップ」/「Edit ツールで手動 fallback」/「terminate」. Caller routes to Phase 5.6 (Completion Report), **skipping** Phase 5.5.
 
-Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.3 Delegation — Step 3) to determine the next action.
+Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.3-5.4 — Step 3) to determine the next action.
 
 ---
 
 ## 🚨 Caller Return Protocol
 
-Sub-skill 完了時、control は **MUST** caller (`start.md`) へ戻る。caller は **同 response turn で MUST immediately** 🚨 Mandatory After 5.3 Delegation を実行し、sentinel に応じて Phase 5.5 (Ready for Review — success path) または Phase 5.6 (Completion Report — abort path) へ進む。
+Sub-skill 完了時、control は **MUST** caller (`start.md`) へ戻る。caller は **同 response turn で MUST immediately** 🚨 Mandatory After 5.3-5.4 を実行し、sentinel に応じて Phase 5.5 (Ready for Review — success path) または Phase 5.6 (Completion Report — abort path) へ進む。
 
 **WARNING (success path)**: Success path で本セクションで停止すると Ready for Review 化されず PR が draft のまま放置される。
 
@@ -376,10 +379,10 @@ Sub-skill 完了時、control は **MUST** caller (`start.md`) へ戻る。calle
 0. **FIRST**: `[CONTEXT] PUBLISH_DONE=1; next=phase_5_5` (success) または `[CONTEXT] PUBLISH_DONE=1; next=phase_5_6` (abort) を **plain-text line** で出力（HTML-commented 不可）。位置規定:
    - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出
    - **0a (絶対位置、0b から導出)**: 4-line block 構造より、本 marker は **4th-to-last visible line**（`<!-- [start:publish:completed] -->` / `<!-- [start:publish:aborted] -->` absolute-last sentinel の 3 行前）
-   - **0c (目的)**: grep marker for orchestrator Pre-check Item 0 (routing dispatcher) and for Mandatory After 5.3 Delegation Step 0 bash block comment reference (informational — Step 0 は unconditional idempotent `flow-state-update.sh patch` であり marker 分岐なし); LLM turn-boundary heuristic 対策の defense-in-depth
+   - **0c (目的)**: grep marker for orchestrator Pre-check Item 0 (routing dispatcher) and for Mandatory After 5.3-5.4 Step 0 bash block comment reference (informational — Step 0 は unconditional idempotent `flow-state-update.sh patch` であり marker 分岐なし); LLM turn-boundary heuristic 対策の defense-in-depth
 1. Result pattern を HTML comment (`<!-- [start:publish:completed] -->` または `<!-- [start:publish:aborted] -->`) で **absolute last line** に出力 (sentinel は grep-matchable だが user-visible でない)
 2. Bare `[start:publish:completed]` / `[start:publish:aborted]` 形式（HTML comment wrap なし）は **禁止**（user-visible terminal token として regressed）
 3. Result pattern の **後ろに narrative text を出さない**（`→ Return to start.md` 等）— LLM の natural stopping point を生む
 4. Caller は HTML comment 内の grep-matchable 文字列 (`grep -F '[start:publish:completed]'` / `grep -F '[start:publish:aborted]'`) と plain-text `[CONTEXT] PUBLISH_DONE=1` marker を grep で読取り、success path は即 Phase 5.5 へ、abort path は即 Phase 5.6 へ継続
 
-> **Caller responsibility note**: 上記 Rules 0-3 は本 sub-skill (`start-publish.md`) の出力に関する MUST/MUST NOT 制約。Rule 4 は subject = Caller の **Caller-side expectation** (本 sub-skill が caller に期待する後続動作の documentation)。本 sub-skill が emit する return block の構造健全性は必要条件であって十分条件ではなく、caller (`start.md`) 側の 🚨 Mandatory After 5.3 Delegation Step 0 が sub-skill return 直後の **VERY FIRST tool call** として bash literal を fire することが MUST。
+> **Caller responsibility note**: 上記 Rules 0-3 は本 sub-skill (`start-publish.md`) の出力に関する MUST/MUST NOT 制約。Rule 4 は subject = Caller の **Caller-side expectation** (本 sub-skill が caller に期待する後続動作の documentation)。本 sub-skill が emit する return block の構造健全性は必要条件であって十分条件ではなく、caller (`start.md`) 側の 🚨 Mandatory After 5.3-5.4 Step 0 が sub-skill return 直後の **VERY FIRST tool call** として bash literal を fire することが MUST。

--- a/plugins/rite/commands/issue/start-publish.md
+++ b/plugins/rite/commands/issue/start-publish.md
@@ -1,0 +1,385 @@
+---
+description: |
+  (Internal sub-skill — invoked by /rite:issue:start only. Do NOT invoke directly.)
+  Issue 公開フェーズの実行 sub-skill。
+  Phase 5.3 (PR Creation) + 5.4 (Review-Fix Loop: 5.4.1 review / 5.4.1.0 fingerprint dispatcher / 5.4.4 fix / 5.4.6 routing) を担当。
+---
+
+# /rite:issue:start-publish
+
+Execute the publish phase for an Issue. This sub-skill is invoked from `start.md` after Phase 5.0-5.2.1 (`rite:issue:start-execute`) has completed with `[start:execute:completed]` sentinel.
+
+**Prerequisites**: Phase 0-5.2.1 of `start.md` and `start-execute` sub-skill have completed. The following information is available in conversation context:
+- `{issue_number}` — target Issue number
+- `{branch_name}` — created/checked-out branch
+- `{pr_number}` — initialized to `0`; populated after Phase 5.3 `[pr:created:{N}]`
+- `{plugin_root}` — resolved per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version)
+- `{owner}`, `{repo}` — from `gh repo view`
+- Implementation completed + linted
+
+---
+
+## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
+
+> 本 Pre-flight は sub-skill の **先頭** で実行し publish scope に関係なく flow-state write を保証する。末尾配置だと Phase 5.3 PR create で早期 error return した場合に flow-state write が抜けるため、先頭配置が必須。
+
+**MUST run before any publish logic** (Phase 5.3 PR creation / Phase 5.4 review-fix loop / return-output emission)。**not optional**:
+
+```bash
+# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
+# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。state-path-resolve.sh
+# + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
+state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
+state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
+if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+  if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
+      --phase "phase5_publish_running" \
+      --active true \
+      --next "rite:issue:start-publish Pre-flight completed. Proceed to Phase 5.3 (PR creation) → 5.4 (Review-Fix Loop), then return to caller. Caller MUST proceed to Phase 5.5 (Ready for Review). Do NOT stop." \
+      --preserve-error-count; then
+    echo "[CONTEXT] PREFLIGHT_PATCH_FAILED=1" >&2
+    # 非 blocking: start.md delegation pre-write が safety net。
+  fi
+else
+  if ! bash {plugin_root}/hooks/flow-state-update.sh create \
+      --phase "phase5_publish_running" --issue {issue_number} --branch "{branch_name}" --pr 0 \
+      --next "rite:issue:start-publish Pre-flight completed. Proceed to Phase 5.3 (PR creation) → 5.4 (Review-Fix Loop), then return to caller. Caller MUST proceed to Phase 5.5 (Ready for Review). Do NOT stop." \
+      --preserve-error-count; then
+    echo "[CONTEXT] PREFLIGHT_CREATE_FAILED=1" >&2
+  fi
+fi
+```
+
+**Why `phase5_publish_running`**: caller (`start.md` Phase 5.3 Delegation Pre-write) は既に `phase5_publish_running` を書込済 (delegation in flight signal)。本 Pre-flight は patch mode で timestamp / `next_action` を refresh し、re-entry / interrupt 時にも sub-skill scope を識別できるようにする。`phase-transition-whitelist.sh` が `phase5_publish_running → phase5_pr` (forward) / `phase5_publish_running → phase5_post_publish` (terminal — abort) を whitelist 化する。
+
+**Idempotence**: 単一 sub-skill invocation 内で複数回実行されても safe — patch mode は pre-update `.phase` から `previous_phase` を設定し、re-entry で `phase5_publish_running` のまま phase regression しない。
+
+---
+
+## Phase 5.3: PR Creation
+
+Run [Preflight Protocol](./start.md#preflight-protocol) before creating PR.
+
+**Pre-write** (before invoking `rite:pr:create`):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
+  --pr 0 \
+  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->emit aborted sentinel and return to caller (start.md routes to Phase 5.6). Do NOT stop."
+```
+
+> **Data Handoff**: When invoking `rite:pr:create`, include the Issue information retrieved in Phase 0.1 (`number`, `title`, `body`, `labels`) in the Skill prompt to avoid redundant `gh issue view` calls in the child command.
+
+Invoke `skill: "rite:pr:create"`.
+
+**Immediate after pr:create returns**: When `rite:pr:create` outputs a result pattern (`[pr:created:{N}]` or `[pr:create-failed]`) and returns control, do **NOT** churn or pause — **immediately** proceed to the routing below. The review-fix loop has NOT started yet — you MUST continue to Phase 5.4.
+
+**Patterns**:
+
+- `[pr:created:{number}]` → extract `{pr_number}`, proceed to Phase 5.4 (Review-Fix Loop).
+- `[pr:create-failed]` → **emit WORKFLOW_INCIDENT sentinel + abort return block, then return to caller** (caller orchestrator routes to Phase 5.6).
+
+> **Emit canonical literal**: See [§B — Phase 5.3 `[pr:create-failed]`](./references/workflow-incident-emit-pattern.md#b--phase-53-prcreate-failed) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで PR 作成して continue」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number 0` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
+
+**On `[pr:create-failed]` — abort return**: After emitting the §B canonical bash literal (WORKFLOW_INCIDENT sentinel), emit the abort return block (see [Return Output Format](#return-output-format-before-return) — abort variant) and return control to caller. Do NOT proceed to Phase 5.4. The caller (`start.md` Mandatory After 5.3 Delegation — Step 3) detects `[start:publish:aborted]` sentinel and routes directly to Phase 5.6.
+
+---
+
+## Phase 5.4: Review-Fix Loop
+
+`rite:issue:start-publish` orchestrates the review-fix loop. The loop is **internal** to this sub-skill — re-invocations of `rite:pr:review` / `rite:pr:fix` happen within this sub-skill's execution scope and do NOT return control to the caller until the loop converges (mergeable / replied-only) or aborts (fix:error user-terminate).
+
+**Local work memory sync rule**: At each phase transition within the review-fix loop (5.4.1, 5.4.3, 5.4.4, 5.4.6), after updating flow state, also sync phase to the local work memory file (`.rite-work-memory/issue-{n}.md`). Use the self-resolving wrapper `local-wm-update.sh` with appropriate `WM_*` env vars. See [Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands) for the recommended pattern.
+
+**Issue comment backup sync rule**: After each review cycle completes (at 5.4.3 and 5.4.6), sync local work memory to the Issue comment as a backup. Use `issue-comment-wm-sync.sh` which handles owner/repo resolution internally, backup creation, safety checks, and PATCH atomically (#204).
+
+### 5.4.1 Review
+
+Run [Preflight Protocol](./start.md#preflight-protocol) before each review cycle.
+
+**Pre-write** (atomic):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "After rite:pr:review returns: [review:mergeable]->emit [start:publish:completed] and return to caller. [review:fix-needed:{N}]->Phase 5.4.4 (fix). Do NOT stop."
+```
+
+> **Data Handoff**: When invoking `rite:pr:review`, the PR number is passed as an argument. Issue information from Phase 0.1 is available in work memory (loaded by `rite:pr:review` Phase 0), avoiding additional `gh issue view` calls.
+
+#### 5.4.1.0 Fingerprint Cycling Detection
+
+When `review.loop.convergence_monitoring` is enabled (default: `true`) and a prior `📜 rite レビュー結果` comment exists on the PR, compute finding fingerprints and detect the "same-finding cycling" quality signal (Signal 1 of 4).
+
+> **Reference**: [Fingerprint Cycling Detection](./references/fingerprint-cycling.md) for the full procedure — Step 1 (fetch 2 most recent review comments via `gh api --paginate --slurp`), Step 2 (fingerprint specification + similarity matching + portable SHA-1 helper), Step 3 (fingerprint-set intersection signal), Step 4 (escalate via the **common 4-option `AskUserQuestion`** shared with Quality Signal 3 / 4), and Step 5 (proceed to `rite:pr:review` invocation when routing is "本 PR 内で再試行" or "別 Issue として切り出す").
+
+When Step 4 routes to `rite:pr:review` invocation, invoke `skill: "rite:pr:review"` from here.
+
+**Immediate after review returns**: When `rite:pr:review` outputs a result pattern and returns control, do **NOT** churn or pause — **immediately** proceed to 5.4.3 After Review below. The review sub-skill has already updated flow state to `phase5_post_review` via Phase 8.0 (defense-in-depth); execute the 5.4.3 steps without delay.
+
+### 5.4.2 Review Patterns
+
+`[review:mergeable]` → emit `[start:publish:completed]` and return to caller (caller routes to Phase 5.5). `[review:fix-needed:{n}]` → 5.4.4.
+
+### 5.4.3 🚨 After Review
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Verify**: Pattern confirmed, parsed.
+
+**Step 1**: Update flow state to post-review phase (atomic). This second write (after the Phase 5.4.1 pre-write) transitions from `phase5_review` to `phase5_post_review`, ensuring stop-guard routes to the correct next branch rather than repeatedly blocking and incrementing `error_count`:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "rite:pr:review completed. Check recent result pattern in context: [review:mergeable]->emit [start:publish:completed] and return to caller. [review:fix-needed:{N}]->Phase 5.4.4 (fix). Do NOT stop."
+```
+
+**Step 2**: Sync to local work memory:
+
+```bash
+WM_SOURCE="review" \
+  WM_PHASE="phase5_post_review" \
+  WM_PHASE_DETAIL="レビュー完了" \
+  WM_NEXT_ACTION="レビュー結果に基づき次アクションを実行" \
+  WM_BODY_TEXT="Post-review sync." \
+  WM_ISSUE_NUMBER="{issue_number}" \
+  WM_READ_FROM_FLOW_STATE="true" \
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+```
+
+**Step 2.5**: Sync local work memory to Issue comment (backup):
+
+```bash
+# ⚠️ このパターンは 5.4.6 (After Fix) と同一構造。変更時は両方を更新すること
+bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform update-phase \
+  --phase "phase5_post_review" --phase-detail "レビュー完了" \
+  2>/dev/null || true
+```
+
+**Step 2.8: Review Quality Verification (defense-in-depth)**
+
+After the review result is received, verify that the review was properly executed with sub-agents by checking the PR comment structure:
+
+1. Retrieve the latest review comment:
+   ```bash
+   latest_review=$(gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+     --jq '[.[] | select(.body | contains("📜 rite レビュー結果"))] | last | .body')
+   ```
+
+2. Check for per-reviewer sections (`#### ` under `### 全指摘事項`):
+   ```bash
+   has_reviewer_sections=$(echo "$latest_review" | grep -c '^#### ' || true)
+   echo "reviewer_sections=$has_reviewer_sections"
+   ```
+
+3. **When `reviewer_sections == 0`**: The review was performed inline without sub-agents (rubber-stamp review detected).
+
+   **Circuit breaker guard** (check FIRST, before re-invoke): If this is already a re-invoked review cycle (i.e., Step 2.8 has already triggered a re-invoke earlier in this conversation turn), do NOT re-invoke again. Instead, display the fallback message and proceed to Step 3:
+
+   ```
+   ⚠️ 再試行後もサブエージェント未使用のレビューが検出されました。
+   現在のレビュー結果をそのまま使用して続行します。
+   ```
+
+   **Note**: Track re-invocation in conversation context, NOT via flow state fields (flow-state fields are destroyed by `create` mode in Phase 5.4.3 Step 1). The LLM executing this step retains conversation history and can determine whether it already performed a Step 2.8 re-invoke in the current review cycle.
+
+   **Re-invoke** (only when circuit breaker guard passes — first occurrence):
+
+   ```
+   ⚠️ レビュー品質検証: サブエージェント未使用のレビューを検出しました。
+   PR コメントにレビュアー別セクション（#### {Reviewer Type}）が含まれていません。
+   サブエージェントによるフルレビューを再実行します。
+   ```
+
+   Invoke `skill: "rite:pr:review", args: "{pr_number}"`. This re-invocation counts as a new review cycle and is allowed **at most once** per review cycle.
+
+4. **When `reviewer_sections >= 1`**: Review quality verified. Proceed to Step 3.
+
+**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3 Delegation に委譲)。sub-skill 内部で emit された `[CONTEXT] WORKFLOW_INCIDENT=1` sentinel (`[pr:create-failed]` / `[fix:error]` 経路の §B/§C canonical bash literal、または `review.md` sub-skill の Sentinel Visibility Rule 経由) は会話コンテキストに残り、caller の Phase 5.4.4.1 が grep 検出・処理 (parse → dedupe → AskUserQuestion → create-issue / skip → mark processed) する責務を負う。
+
+**Step 3.1 (Quality Signal 3 & 4 Detection)**: After review returns, detect Quality Signal 3 (cross-validation disagreement) and Signal 4 (reviewer self-degraded).
+
+> **Reference**: [Fingerprint Cycling Detection §2](./references/fingerprint-cycling.md#2--phase-543-step-31-quality-signal-3--4-detection) for the canonical marker list (`[CONTEXT] QUALITY_SIGNAL=3_cross_validation_disagreement` for Signal 3, `### Reviewer self-assessment` + `Status: degraded` for Signal 4), the detection bash for Signal 4, and the **common 4-option `AskUserQuestion`** shared with Phase 5.4.1.0 Signal 1. When neither signal fires, proceed directly to Step 4.
+
+**Step 4**: Based on the review result pattern from `rite:pr:review`, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly — always invoke the appropriate Skill tool.
+
+| Result Pattern | Action |
+|----------------|--------|
+| `[review:mergeable]` | **→ Emit `[start:publish:completed]` and return to caller** (caller routes to Phase 5.5 Ready for Review). Skip fix entirely. |
+| `[review:fix-needed:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4). After it returns, proceed to After Fix (5.4.6). |
+
+> **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。
+
+### 5.4.4 Fix
+
+**Pre-write** (atomic):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_fix" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "After rite:pr:fix returns: [fix:pushed]->Phase 5.4.1 (re-review). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (AskUserQuestion). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->emit [start:publish:completed] and return to caller. [fix:error]->ask user. Do NOT stop."
+```
+
+> **Data Handoff**: When invoking `rite:pr:fix`, PR number and review results are passed via work memory. Issue information from Phase 0.1 is available in work memory, avoiding redundant `gh issue view` calls.
+
+Invoke `skill: "rite:pr:fix"`.
+
+**Immediate after fix returns**: When `rite:pr:fix` outputs a result pattern (`[fix:pushed]`, `[fix:pushed-wm-stale]`, `[fix:issues-created:{N}]`, `[fix:replied-only]`, or `[fix:error]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 5.4.6 After Fix below.
+
+### 5.4.5 Fix Patterns
+
+`[fix:pushed]` → 5.4.1. `[fix:pushed-wm-stale]` → AskUserQuestion (WM stale warning) → 5.4.1. `[fix:issues-created:{n}]` → 5.4.1. `[fix:replied-only]` → emit `[start:publish:completed]` and return to caller. `[fix:error]` → error, ask user.
+
+### 5.4.6 🚨 After Fix
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Verify**: Pattern confirmed, parsed.
+
+**Step 1**: Update flow state to post-fix phase (atomic):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_fix" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (re-review). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning. [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->emit [start:publish:completed] and return to caller. Do NOT stop."
+```
+
+**Step 2**: Sync to local work memory:
+
+```bash
+WM_SOURCE="fix" \
+  WM_PHASE="phase5_post_fix" \
+  WM_PHASE_DETAIL="修正完了" \
+  WM_NEXT_ACTION="修正結果に基づき次アクションを実行" \
+  WM_BODY_TEXT="Post-fix sync." \
+  WM_ISSUE_NUMBER="{issue_number}" \
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+```
+
+**Step 2.5**: Sync local work memory to Issue comment (backup):
+
+```bash
+# ⚠️ このパターンは 5.4.3 (After Review) と同一構造。変更時は両方を更新すること
+bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform update-phase \
+  --phase "phase5_post_fix" --phase-detail "修正完了" \
+  2>/dev/null || true
+```
+
+**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.3 Delegation に委譲)。
+
+> **Note (v0.4.0 #557)**: The review-fix loop has no cycle-count-based hard limit. Non-convergence is detected exclusively via the four quality signals (see `commands/pr/references/fix-relaxation-rules.md#four-quality-signals-for-escalation`):
+> 1. Fingerprint cycling → Phase 5.4.1.0 (before every re-review)
+> 2. Root-cause-missing fix → `fix.md` Phase 3.2.1 (before every commit)
+> 3. Cross-validation disagreement → `review.md` Phase 5.2 + debate (during every review)
+> 4. Finding quality gate failure → `_reviewer-base.md` Finding Quality Guardrail (during every reviewer run)
+
+**Step 4**: Based on the fix result pattern from `rite:pr:fix`, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly.
+
+| Fix Result Pattern | Action |
+|--------------------|--------|
+| `[fix:pushed]` | **Invoke `skill: "rite:pr:review", args: "{pr_number}"`** via the Skill tool (re-review, Phase 5.4.1). |
+| `[fix:pushed-wm-stale]` | **Work memory が stale です。手動介入が必要かを `AskUserQuestion` でユーザーに確認** (推奨: stale 警告ログを残した上で `skill: "rite:pr:review", args: "{pr_number}"` を起動して再レビューに進む / 中断して手動で work memory を修復する)。silent に `[fix:pushed]` 扱いしてはならない (fix.md Phase 8.1 caller semantics 参照)。 |
+| `[fix:issues-created:{n}]` | **Invoke `skill: "rite:pr:review", args: "{pr_number}"`** via the Skill tool (re-review, Phase 5.4.1). |
+| `[fix:replied-only]` | **→ Emit `[start:publish:completed]` and return to caller** (caller routes to Phase 5.5 Ready for Review). |
+| `[fix:error]` | Ask the user how to proceed via `AskUserQuestion` with options: 「再試行」/「Edit ツールで手動 fallback (incident 記録)」/「Phase 5.6 にスキップ」/「terminate」. If user selects 「Edit ツールで手動 fallback」, **emit sentinel** per [§C — Phase 5.4.4 `[fix:error]`](./references/workflow-incident-emit-pattern.md#c--phase-544-fixerror) (SoT) then emit `[start:publish:aborted]` and return to caller (caller routes to Phase 5.6). If user selects 「Phase 5.6 にスキップ」 or 「terminate」, emit `[start:publish:aborted]` and return to caller. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literal here. |
+
+> **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。再レビューは必ず `skill: "rite:pr:review"` を Skill ツールで呼び出すこと。
+
+---
+
+## Return Output Format (Before Return)
+
+> **Reference**: `start-execute.md` Return Output Format と対称な設計。flow-state write は 🚨 MANDATORY Pre-flight (本ファイル冒頭) で publish scope に関係なく post-publish phase を記録。本 re-patch は defense-in-depth second write として timestamp / `next_action` を refresh する。
+
+Immediately before emitting the four-line return block, re-patch flow state (idempotent with Pre-flight write):
+
+```bash
+# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
+# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。Pre-flight 後の
+# self-patch のため file 存在は保証済み。
+state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
+state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
+if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+  if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
+      --phase "phase5_post_publish" \
+      --active true \
+      --next "rite:issue:start-publish completed. Proceed to Phase 5.5 (Ready for Review). Do NOT stop." \
+      --preserve-error-count; then
+    echo "[CONTEXT] PUBLISH_RETURN_PATCH_FAILED=1" >&2
+    # 非 blocking: start.md Mandatory After 5.3 Delegation の redundant patch が続行する。
+  fi
+fi
+```
+
+> **Why patch mode only (no create fallback)**: Pre-flight が "file missing" branch (`create` mode) を処理済。本 section 到達時は flow state file 存在 + `.phase = phase5_publish_running` (Pre-flight 書込後の base) または内部 phase (`phase5_pr` / `phase5_post_review` / `phase5_post_fix` 等) が保証済。ここで `create` 呼出は `previous_phase` を空文字列にリセットし `phase-transition-whitelist.sh` whitelist transition check を defeat するため不可。patch mode で transition chain を preserve する。
+
+After the flow-state update, output the result pattern. Caller-continuation reminder を **immediately before** result pattern に emit。Return block は **4 line** 構成: (1) `[CONTEXT] PUBLISH_DONE=1` grep marker / (2) plain-text blockquote continuation reminder / (3) HTML-commented caller instructions / (4) HTML-commented result sentinel。全 4 行が sub-skill の **last visible lines**。
+
+> **Return block design rationale**:
+> - caller continuation hint を plain-text line + HTML comment の **dual form** で emit（HTML comment が rendering で strip される場合への defense）
+> - result pattern を HTML comment 化 (`<!-- [start:publish:completed] -->` / `<!-- [start:publish:aborted] -->`) — sentinel は grep-matchable (`grep -F '[start:publish:'`) のまま AC 保持し、user-visible terminal token としての sentinel 出力を抑止して LLM turn-boundary heuristic 起因の `continue` 要求 stop を防ぐ
+> - `[CONTEXT] PUBLISH_DONE=1` marker を return block の **FIRST line** に追加（not last）— orchestrator Pre-check Item 0 と Mandatory After 5.3 Delegation Step 0 が consume する grep signal、HTML strip rendering でも検出可能な plain-text 形式
+
+**Output format example (success — `[start:publish:completed]`)**:
+
+```
+[CONTEXT] PUBLISH_DONE=1; next=phase_5_5
+> ⏭ MUST continue (turn を閉じない): Phase 5.5 Ready for Review → terminal — review-fix loop は収束 (mergeable または replied-only) Ready 化未起動のため停止禁止。
+<!-- caller: MUST execute the following bash command as your VERY FIRST tool call BEFORE any text output, narrative, or response generation (Step 0 Immediate Bash Action — bash command literal in backticks): `bash plugins/rite/hooks/flow-state-update.sh patch --phase phase5_post_publish --active true --next 'Step 0 Immediate Bash Action fired; proceeding to Phase 5.5. Do NOT stop.' --if-exists --preserve-error-count` IMMEDIATELY AFTER bash success, continue with Phase 5.5 (Ready for Review) in the SAME response turn. DO NOT end the turn. DO NOT output any narrative text before this bash call. The PR is created and review-fix loop converged — Ready for Review has not yet been confirmed. -->
+<!-- [start:publish:completed] -->
+```
+
+**Output format example (abort — `[start:publish:aborted]`)**:
+
+abort path (Phase 5.3 `[pr:create-failed]` / Phase 5.4.6 `[fix:error]` user-terminate) では `next=phase_5_6` marker に切替え、caller-instruction HTML comment 内の next-phase 指示を Phase 5.6 へ変更する:
+
+```
+[CONTEXT] PUBLISH_DONE=1; next=phase_5_6
+> ⏭ MUST continue (turn を閉じない): Phase 5.6 Completion Report → terminal — publish aborted ([pr:create-failed] または [fix:error] user-terminate) Ready 化は skip、完了報告のみ。
+<!-- caller: MUST execute the following bash command as your VERY FIRST tool call BEFORE any text output, narrative, or response generation (Step 0 Immediate Bash Action — bash command literal in backticks): `bash plugins/rite/hooks/flow-state-update.sh patch --phase phase5_post_publish --active true --next 'Publish aborted; routing to Phase 5.6 (Completion Report). Skip Ready for Review.' --if-exists --preserve-error-count` IMMEDIATELY AFTER bash success, route to Phase 5.6 (Completion Report) in the SAME response turn — skip Phase 5.5 (Ready for Review) entirely. DO NOT end the turn. DO NOT output any narrative text before this bash call. -->
+<!-- [start:publish:aborted] -->
+```
+
+> **Plain-text form rationale**: 短く user-friendly な Markdown blockquote (`> ⏭ MUST continue (turn を閉じない):`) にすることで (a) rendered Markdown で視覚的に「停止禁止・継続必須」の文脈が明確、(b) HTML コメント (LLM 向け詳細) との責任分担が明確。詳細な caller 向け instruction は HTML コメント側に残し、plain-text 行は user 向けの短い imperative status indicator として機能する。user-visible な最終コンテンツは `⏭ MUST continue` blockquote となり、sentinel token は HTML コメント化されレンダリング時に不可視。`継続中` (現状報告) ではなく `MUST continue` (命令形) を採用するのは、reminder 文言が現状報告的に解釈されると LLM の turn-boundary heuristic implicit stop を防げない事象への対策。
+
+Result pattern (grep-matchable string inside HTML comment):
+
+- **Publish completed (success)**: `<!-- [start:publish:completed] -->` (matches `grep -F '[start:publish:completed]'`) — emitted when review-fix loop converges via `[review:mergeable]` or `[fix:replied-only]`. Caller routes to Phase 5.5 (Ready for Review).
+- **Publish aborted**: `<!-- [start:publish:aborted] -->` (matches `grep -F '[start:publish:aborted]'`) — emitted when `rite:pr:create` returns `[pr:create-failed]`, or when `rite:pr:fix` returns `[fix:error]` and user selects 「Phase 5.6 にスキップ」/「Edit ツールで手動 fallback」/「terminate」. Caller routes to Phase 5.6 (Completion Report), **skipping** Phase 5.5.
+
+Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.3 Delegation — Step 3) to determine the next action.
+
+---
+
+## 🚨 Caller Return Protocol
+
+Sub-skill 完了時、control は **MUST** caller (`start.md`) へ戻る。caller は **同 response turn で MUST immediately** 🚨 Mandatory After 5.3 Delegation を実行し、sentinel に応じて Phase 5.5 (Ready for Review — success path) または Phase 5.6 (Completion Report — abort path) へ進む。
+
+**WARNING (success path)**: Success path で本セクションで停止すると Ready for Review 化されず PR が draft のまま放置される。
+
+**WARNING (abort path)**: Abort path で Phase 5.5 へ誤進すると、PR 未作成 (pr:create-failed) または review 未収束 (fix:error) の状態で Ready 化を試みて gh CLI が失敗する。caller 側 sentinel routing が誤動作した場合の最終 fallback は user による手動介入。
+
+**Output rules**:
+
+0. **FIRST**: `[CONTEXT] PUBLISH_DONE=1; next=phase_5_5` (success) または `[CONTEXT] PUBLISH_DONE=1; next=phase_5_6` (abort) を **plain-text line** で出力（HTML-commented 不可）。位置規定:
+   - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)。この 4-line invariant が canonical で、他の位置記述はここから導出
+   - **0a (絶対位置、0b から導出)**: 4-line block 構造より、本 marker は **4th-to-last visible line**（`<!-- [start:publish:completed] -->` / `<!-- [start:publish:aborted] -->` absolute-last sentinel の 3 行前）
+   - **0c (目的)**: grep marker for orchestrator Pre-check Item 0 (routing dispatcher) and for Mandatory After 5.3 Delegation Step 0 bash block comment reference (informational — Step 0 は unconditional idempotent `flow-state-update.sh patch` であり marker 分岐なし); LLM turn-boundary heuristic 対策の defense-in-depth
+1. Result pattern を HTML comment (`<!-- [start:publish:completed] -->` または `<!-- [start:publish:aborted] -->`) で **absolute last line** に出力 (sentinel は grep-matchable だが user-visible でない)
+2. Bare `[start:publish:completed]` / `[start:publish:aborted]` 形式（HTML comment wrap なし）は **禁止**（user-visible terminal token として regressed）
+3. Result pattern の **後ろに narrative text を出さない**（`→ Return to start.md` 等）— LLM の natural stopping point を生む
+4. Caller は HTML comment 内の grep-matchable 文字列 (`grep -F '[start:publish:completed]'` / `grep -F '[start:publish:aborted]'`) と plain-text `[CONTEXT] PUBLISH_DONE=1` marker を grep で読取り、success path は即 Phase 5.5 へ、abort path は即 Phase 5.6 へ継続
+
+> **Caller responsibility note**: 上記 Rules 0-3 は本 sub-skill (`start-publish.md`) の出力に関する MUST/MUST NOT 制約。Rule 4 は subject = Caller の **Caller-side expectation** (本 sub-skill が caller に期待する後続動作の documentation)。本 sub-skill が emit する return block の構造健全性は必要条件であって十分条件ではなく、caller (`start.md`) 側の 🚨 Mandatory After 5.3 Delegation Step 0 が sub-skill return 直後の **VERY FIRST tool call** として bash literal を fire することが MUST。

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -62,10 +62,8 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 | 2.6 (Work Memory) | `rite:issue:work-memory-init` | 3 | **No** |
 | 3 (Plan) | `rite:issue:implementation-plan` | 4 | **No** |
 | 4 (Guidance) | — | 5 or terminate | Yes (user choice) |
-| 5.0-5.2.1 (Execute) | `rite:issue:start-execute` | 5.3 | **No** |
-| 5.3 (PR) | `rite:pr:create` | 5.4 | **No** |
-| 5.4.1 (Review) | `rite:pr:review` | 5.4.3→5.4.4 or 5.5 | **No** |
-| 5.4.4 (Fix) | `rite:pr:fix` | 5.4.6→5.4.1 or 5.5 | **No** |
+| 5.0-5.2.1 (Execute) | `rite:issue:start-execute` | 5.3-5.4 or 5.6 | **No** |
+| 5.3-5.4 (Publish) | `rite:issue:start-publish` | 5.5 or 5.6 | **No** |
 | 5.5 (Ready) | `rite:pr:ready` | 5.5.0.1→5.5.1 | **No** |
 | 5.5.1 (Status In Review) | — | 5.5.2 | **No** |
 | 5.5.2 (Metrics) | — | 5.6 | **No** |
@@ -531,15 +529,10 @@ The e2e flow must minimize context consumption to complete within a single sessi
 ### Flow
 
 ```
-5.0 Stop Hook 確認 → 5.1
-5.1 実装・コミット・プッシュ → 5.1.3 安全チェック → rite:lint
-5.2 品質チェック → 5.2.1
-5.2.1 チェックリスト完了確認 → 全完了なら 5.3 / 未完了なら 5.1
-5.3 PR 作成 → 5.4
-5.4 レビュー・修正ループ:
-  5.4.1 rite:pr:review → [mergeable]→5.5 / [fix-needed]→fix→5.4.1
-  (5.4.2-5.4.3 review routing/after, 5.4.5-5.4.6 fix routing/after)
-  5.4.4 rite:pr:fix → [pushed]→5.4.1 / [pushed-wm-stale]→AskUserQuestion→5.4.1 (WM stale 警告) / [issues-created]→5.4.1 / [replied-only]→5.5 / [error]→処理
+5.0-5.2.1 rite:issue:start-execute (sub-skill: Stop Hook + 実装 + lint + checklist)
+  → [start:execute:completed]→5.3-5.4 / [start:execute:aborted]→5.6
+5.3-5.4 rite:issue:start-publish (sub-skill: PR create + review-fix loop)
+  → [start:publish:completed]→5.5 / [start:publish:aborted]→5.6
 5.5 Ready for Review 確認 → rite:pr:ready → [ready:completed]→5.5.0.1→5.5.1 Status 更新 → 5.5.2
 5.5.2 メトリクス記録 → 5.6
 5.6 完了報告
@@ -570,7 +563,7 @@ Invocation: `skill: "rite:lint"` or `skill: "rite:pr:review", args: "67"`
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_execute_running" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "After rite:issue:start-execute returns: proceed to Phase 5.3 (PR creation). Do NOT stop."
+  --next "After rite:issue:start-execute returns: proceed to Phase 5.3-5.4 (Publish Phase) via rite:issue:start-publish. Do NOT stop."
 ```
 
 > **Module**: [Execute Phase](./start-execute.md) - Handles Phase 5.0 (Stop Hook Verification), 5.1 (Implementation invoking implement.md), 5.2 (Lint via rite:lint), 5.2.1 (Checklist Confirmation).
@@ -590,206 +583,59 @@ Invoke `skill: "rite:issue:start-execute"`.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_execute" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "rite:issue:start-execute completed. Proceed to Phase 5.3 (PR creation) on [start:execute:completed]. Skip to Phase 5.6 on [start:execute:aborted]. Do NOT stop."
+  --next "rite:issue:start-execute completed. Proceed to Phase 5.3-5.4 (Publish Phase via rite:issue:start-publish) on [start:execute:completed]. Skip to Phase 5.6 on [start:execute:aborted]. Do NOT stop."
 ```
 
 **Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-execute` sub-skill — e.g., `[lint:aborted]` orchestrator-direct emit per §A, or by `lint.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.
 
 **Step 3 (Sentinel-based routing)**: Grep the recent conversation context for `<!-- [start:execute:completed] -->` or `<!-- [start:execute:aborted] -->`:
 
-- `[start:execute:completed]` detected → **→ Proceed to Phase 5.3 (PR creation) now**.
+- `[start:execute:completed]` detected → **→ Proceed to Phase 5.3-5.4 (Publish Phase) now** (invoke `rite:issue:start-publish` sub-skill).
 - `[start:execute:aborted]` detected → **→ Skip to Phase 5.6 (Completion Report) now**. PR creation is intentionally skipped because the execute phase was aborted by user choice (5.1.3 Safety Check) or `[lint:aborted]`. The completion report MUST display the abort reason to the user.
-- Neither detected → fail-safe: treat as `[start:execute:completed]` (proceed to Phase 5.3); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
+- Neither detected → fail-safe: treat as `[start:execute:completed]` (proceed to Phase 5.3-5.4); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
 
-### 5.3 PR Creation
+### 5.3-5.4 Publish Phase (delegated to start-publish sub-skill)
 
-Run [Preflight Protocol](#preflight-protocol) before creating PR.
-
-After 5.2.1, update flow state (atomic):
+**Pre-write** (before invoking `rite:issue:start-publish`):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_pr" --issue {issue_number} --branch "{branch_name}" \
+  --phase "phase5_publish_running" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "After rite:pr:create returns: [pr:created:{N}]->save pr_number, Phase 5.4 (review loop). [pr:create-failed]->Phase 5.6. Do NOT stop."
+  --next "After rite:issue:start-publish returns: proceed to Phase 5.5 (Ready for Review) on [start:publish:completed]. Skip to Phase 5.6 (Completion Report) on [start:publish:aborted]. Do NOT stop."
 ```
 
-> **Data Handoff**: When invoking `rite:pr:create`, include the Issue information retrieved in Phase 0.1 (`number`, `title`, `body`, `labels`) in the Skill prompt to avoid redundant `gh issue view` calls in the child command.
+> **Module**: [Publish Phase](./start-publish.md) - Handles Phase 5.3 (PR creation via rite:pr:create), 5.4 (Review-Fix Loop with internal 5.4.1/5.4.1.0/5.4.4/5.4.6 routing, fingerprint cycling dispatcher).
 
-Invoke `skill: "rite:pr:create"`.
+Invoke `skill: "rite:issue:start-publish"`.
 
-**Immediate after pr:create returns**: When `rite:pr:create` outputs a result pattern (`[pr:created:{N}]` or `[pr:create-failed]`) and returns control, do **NOT** churn or pause — **immediately** proceed to Mandatory After 5.3 below. The review-fix loop has NOT started yet — you MUST continue to Phase 5.4.
+**Immediate after start-publish returns**: When `start-publish` outputs `<!-- [start:publish:completed] -->` (success — review-fix loop converged via `[review:mergeable]` or `[fix:replied-only]`) or `<!-- [start:publish:aborted] -->` (abort — `[pr:create-failed]` or `[fix:error]` user-terminate) sentinel and returns control, do **NOT** stop — **immediately** proceed to Mandatory After 5.3-5.4 below.
 
-**Patterns**: `[pr:created:{number}]`→extract number, proceed 5.4. `[pr:create-failed]`→**emit sentinel and ask user** (#366).
-
-> **Emit canonical literal**: See [§B — Phase 5.3 `[pr:create-failed]`](./references/workflow-incident-emit-pattern.md#b--phase-53-prcreate-failed) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで PR 作成して continue」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number 0` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
-
-### 🚨 Mandatory After 5.3
+### 🚨 Mandatory After 5.3-5.4
 
 > See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
 > MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-**Verify**: `[pr:created:{number}]`, number saved. Review has NOT started yet.
-
-**Run Phase 5.4.4.1 (Workflow Incident Detection)**. Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `[pr:create-failed]` orchestrator-direct emit, or by pr/create.md sub-skill if applicable). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue regardless of detection result.
-
-**→ Proceed to 5.4 now**.
-
-### 5.4 Review-Fix Loop
-
-`/rite:issue:start` orchestrates the review-fix loop.
-
-**Local work memory sync rule**: At each phase transition within the review-fix loop (5.4.1, 5.4.3, 5.4.4, 5.4.6), after updating flow state, also sync phase to the local work memory file (`.rite-work-memory/issue-{n}.md`). Use the self-resolving wrapper `local-wm-update.sh` with appropriate `WM_*` env vars. See [Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands) for the recommended pattern.
-
-**Issue comment backup sync rule**: After each review cycle completes (at 5.4.3 and 5.4.6), sync local work memory to the Issue comment as a backup. Use the existing `gh api` PATCH pattern from `fix.md` Phase 4.5.2. This ensures the Issue comment reflects the latest phase for recovery after context compaction.
-
-#### 5.4.1 Review
-
-Run [Preflight Protocol](#preflight-protocol) before each review cycle.
-
-Update flow state (atomic):
+**Step 1**: Update flow state to post-publish phase (atomic):
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_review" --issue {issue_number} --branch "{branch_name}" \
+  --phase "phase5_post_publish" --issue {issue_number} --branch "{branch_name}" \
   --pr {pr_number} \
-  --next "After rite:pr:review returns: [review:mergeable]->Phase 5.5. [review:fix-needed:{N}]->Phase 5.4.4. Do NOT stop."
+  --next "rite:issue:start-publish completed. Proceed to Phase 5.5 (Ready for Review) on [start:publish:completed]. Skip to Phase 5.6 on [start:publish:aborted]. Do NOT stop."
 ```
 
-> **Note**: `{pr_number}` in the `--arg next` is a document placeholder that Claude replaces with the actual PR number at execution time (same as `--argjson pr {pr_number}` above). The `{N}` in result patterns refers to a count value returned by the sub-skill.
+**Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-publish` sub-skill — e.g., `[pr:create-failed]` / `[fix:error]` orchestrator-direct emit per §B/§C, or by `pr/create.md` / `pr/review.md` / `pr/fix.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.
 
-> **Data Handoff**: When invoking `rite:pr:review`, the PR number is passed as an argument. Issue information from Phase 0.1 is available in work memory (loaded by `rite:pr:review` Phase 0), avoiding additional `gh issue view` calls.
+**Step 3 (Sentinel-based routing)**: Grep the recent conversation context for `<!-- [start:publish:completed] -->` or `<!-- [start:publish:aborted] -->`:
 
-##### 5.4.1.0 Fingerprint Cycling Detection
+- `[start:publish:completed]` detected → **→ Proceed to Phase 5.5 (Ready for Review) now**.
+- `[start:publish:aborted]` detected → **→ Skip to Phase 5.6 (Completion Report) now**. Ready for Review is intentionally skipped because the publish phase was aborted by `[pr:create-failed]` (PR was never created) or `[fix:error]` user-terminate (review-fix loop did not converge). The completion report MUST display the abort reason to the user.
+- Neither detected → fail-safe: treat as `[start:publish:completed]` (proceed to Phase 5.5); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
 
-When `review.loop.convergence_monitoring` is enabled (default: `true`) and a prior `📜 rite レビュー結果` comment exists on the PR, compute finding fingerprints and detect the "same-finding cycling" quality signal (Signal 1 of 4).
+### 5.4.4.1 Workflow Incident Detection (Contract Summary)
 
-> **Reference**: [Fingerprint Cycling Detection](./references/fingerprint-cycling.md) for the full procedure — Step 1 (fetch 2 most recent review comments via `gh api --paginate --slurp`), Step 2 (fingerprint specification + similarity matching + portable SHA-1 helper), Step 3 (fingerprint-set intersection signal), Step 4 (escalate via the **common 4-option `AskUserQuestion`** shared with Quality Signal 3 / 4), and Step 5 (proceed to `rite:pr:review` invocation when routing is "本 PR 内で再試行" or "別 Issue として切り出す").
-
-When Step 4 routes to `rite:pr:review` invocation, invoke `skill: "rite:pr:review"` from here.
-
-**Immediate after review returns**: When `rite:pr:review` outputs a result pattern and returns control, do **NOT** churn or pause — **immediately** proceed to 5.4.3 After Review below. The review sub-skill has already updated flow state to `phase5_post_review` via Phase 8.0 (defense-in-depth, #719); execute the 5.4.3 steps without delay.
-
-#### 5.4.2 Review Patterns
-
-`[review:mergeable]`→5.5, `[review:fix-needed:{n}]`→5.4.4.
-
-#### 5.4.3 🚨 After Review
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Verify**: Pattern confirmed, parsed.
-
-**Step 1**: Update flow state to post-review phase (atomic). This second write (after the Phase 5.4.1 pre-write) transitions from `phase5_review` to `phase5_post_review`, ensuring stop-guard routes to the correct next branch rather than repeatedly blocking and incrementing `error_count` (fixes #719):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_review" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "rite:pr:review completed. Check recent result pattern in context: [review:mergeable]->Phase 5.5 (ready). [review:fix-needed:{N}]->Phase 5.4.4 (fix). Do NOT stop."
-```
-
-**Step 2**: Sync to local work memory:
-
-```bash
-WM_SOURCE="review" \
-  WM_PHASE="phase5_post_review" \
-  WM_PHASE_DETAIL="レビュー完了" \
-  WM_NEXT_ACTION="レビュー結果に基づき次アクションを実行" \
-  WM_BODY_TEXT="Post-review sync." \
-  WM_ISSUE_NUMBER="{issue_number}" \
-  WM_READ_FROM_FLOW_STATE="true" \
-  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
-```
-
-**Step 2.5**: Sync local work memory to Issue comment (backup):
-
-> **Reference**: Uses `issue-comment-wm-sync.sh` which handles owner/repo resolution internally, backup creation, safety checks, and PATCH atomically (#204).
-
-```bash
-# ⚠️ このパターンは 5.4.6 (After Fix) と同一構造。変更時は両方を更新すること
-bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
-  --issue {issue_number} \
-  --transform update-phase \
-  --phase "phase5_post_review" --phase-detail "レビュー完了" \
-  2>/dev/null || true
-```
-
-**Step 2.8: Review Quality Verification (defense-in-depth)**
-
-After the review result is received, verify that the review was properly executed with sub-agents by checking the PR comment structure:
-
-1. Retrieve the latest review comment:
-   ```bash
-   latest_review=$(gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
-     --jq '[.[] | select(.body | contains("📜 rite レビュー結果"))] | last | .body')
-   ```
-
-2. Check for per-reviewer sections (`#### ` under `### 全指摘事項`):
-   ```bash
-   has_reviewer_sections=$(echo "$latest_review" | grep -c '^#### ' || true)
-   echo "reviewer_sections=$has_reviewer_sections"
-   ```
-
-3. **When `reviewer_sections == 0`**: The review was performed inline without sub-agents (rubber-stamp review detected).
-
-   **Circuit breaker guard** (check FIRST, before re-invoke): If this is already a re-invoked review cycle (i.e., Step 2.8 has already triggered a re-invoke earlier in this conversation turn), do NOT re-invoke again. Instead, display the fallback message and proceed to Step 3:
-
-   ```
-   ⚠️ 再試行後もサブエージェント未使用のレビューが検出されました。
-   現在のレビュー結果をそのまま使用して続行します。
-   ```
-
-   **Note**: Track re-invocation in conversation context, NOT via flow state fields (flow-state fields are destroyed by `create` mode in Phase 5.4.3 Step 1). The LLM executing this step retains conversation history and can determine whether it already performed a Step 2.8 re-invoke in the current review cycle.
-
-   **Re-invoke** (only when circuit breaker guard passes — first occurrence):
-
-   ```
-   ⚠️ レビュー品質検証: サブエージェント未使用のレビューを検出しました。
-   PR コメントにレビュアー別セクション（#### {Reviewer Type}）が含まれていません。
-   サブエージェントによるフルレビューを再実行します。
-   ```
-
-   Invoke `skill: "rite:pr:review", args: "{pr_number}"`. This re-invocation counts as a new review cycle and is allowed **at most once** per review cycle.
-
-4. **When `reviewer_sections >= 1`**: Review quality verified. Proceed to Step 3.
-
-**Step 3 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines emitted by the review.md sub-skill (per Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3.1 regardless of detection result.
-
-**Step 3.1 (Quality Signal 3 & 4 Detection)**: After review returns, detect Quality Signal 3 (cross-validation disagreement) and Signal 4 (reviewer self-degraded).
-
-> **Reference**: [Fingerprint Cycling Detection §2](./references/fingerprint-cycling.md#2--phase-543-step-31-quality-signal-3--4-detection) for the canonical marker list (`[CONTEXT] QUALITY_SIGNAL=3_cross_validation_disagreement` for Signal 3, `### Reviewer self-assessment` + `Status: degraded` for Signal 4), the detection bash for Signal 4, and the **common 4-option `AskUserQuestion`** shared with Phase 5.4.1.0 Signal 1. When neither signal fires, proceed directly to Step 4.
-
-**Step 4**: Based on the review result pattern from `rite:pr:review`, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly — always invoke the appropriate Skill tool.
-
-| Result Pattern | Action |
-|----------------|--------|
-| `[review:mergeable]` | **→ Proceed to Phase 5.5** (Ready for Review). Skip fix entirely. |
-| `[review:fix-needed:{n}]` | **Invoke `skill: "rite:pr:fix"`** via the Skill tool (Phase 5.4.4). After it returns, proceed to After Fix (5.4.6). |
-
-> **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。
-
-#### 5.4.4 Fix
-
-Update flow state (atomic):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_fix" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "After rite:pr:fix returns: [fix:pushed]->Phase 5.4.1 (re-review). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (AskUserQuestion). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. [fix:error]->ask user. Do NOT stop."
-```
-
-> **Data Handoff**: When invoking `rite:pr:fix`, PR number and review results are passed via work memory. Issue information from Phase 0.1 is available in work memory, avoiding redundant `gh issue view` calls.
-
-Invoke `skill: "rite:pr:fix"`.
-
-**Immediate after fix returns**: When `rite:pr:fix` outputs a result pattern (`[fix:pushed]`, `[fix:pushed-wm-stale]`, `[fix:issues-created:{N}]`, `[fix:replied-only]`, or `[fix:error]`) and returns control, do **NOT** churn or pause — **immediately** proceed to 5.4.6 After Fix below. The fix sub-skill has already updated flow state to `phase5_post_fix` via its defense-in-depth mechanism (fixes #709); execute the 5.4.6 steps without delay.
-
-#### 5.4.4.1 Workflow Incident Detection
-
-> **Reference**: This section detects **workflow blockers** (Skill load failure, hook abnormal exit, manual fallback adoption, Wiki ingest skip / failure, Gitignore drift) and auto-registers them as Issues to prevent silent loss. See [docs/SPEC.md](../../../../docs/SPEC.md#workflow-incident-detection) and [Workflow Incident Detection](./references/workflow-incident-detection.md) for the full specification.
+> **Reference**: This section documents the **本体 contract** for workflow incident detection. The detailed Step 1-7 processing flow lives in [Workflow Incident Detection](./references/workflow-incident-detection.md); emit pattern canonical bash literals live in [Workflow Incident Emit Pattern](./references/workflow-incident-emit-pattern.md); fingerprint cycling / Quality Signal 3 & 4 detail lives in [Fingerprint Cycling Detection](./references/fingerprint-cycling.md). The orchestrator (`/rite:issue:start`) invokes detection at three boundaries (Mandatory After 5.0-5.2.1 / 5.3-5.4 / 5.5 — see "When to execute" table below).
 
 **Detection scope** — recognised sentinel `type` values:
 
@@ -803,91 +649,21 @@ Invoke `skill: "rite:pr:fix"`.
 | `wiki_ingest_push_failed` | review/fix/close Phase X.X.W when `wiki-ingest-commit.sh` exits 4 — commit landed locally on the wiki branch but origin push failed | AskUserQuestion → register Issue / skip — recommended to **register**. Manual recovery: `git push origin wiki` |
 | `gitignore_drift` | `/rite:lint` Phase 3.9 when `gitignore-health-check.sh` detects missing `.rite/wiki/` rule (last-line-of-defense) | AskUserQuestion → register Issue / skip — recommended to **register**. Manual recovery: restore `.rite/wiki/` to `.gitignore` |
 
-The processing flow applies uniformly to all seven types — there is no per-type branching beyond the table above. See [Workflow Incident Detection](./references/workflow-incident-detection.md) for the complete Step 1-7 procedure (sentinel detection / parse / dedupe / AskUserQuestion / Issue creation bash literal / context-local list management), the **Workflow Incident Sentinel Visibility Rule** for sub-skill emit pattern, and the [Workflow Incident Emit Pattern](./references/workflow-incident-emit-pattern.md) for orchestrator-direct emit invocations (Phase 5.2 / 5.3 / 5.4.4 / 5.5).
-
 **When to execute** (explicit routing):
 
-This phase runs **after every Skill invocation in Phase 5** at the following explicit invocation points:
+This phase runs **after every Skill invocation in Phase 5** at the following explicit invocation points. With PR F/G1 sub-skill extraction, the orchestrator's Skill boundaries are 3 — `start-execute` (5.0-5.2.1) / `start-publish` (5.3-5.4) / `pr:ready` (5.5). Internal `pr:create` / `pr:review` / `pr:fix` invocations happen inside `start-publish` and are detected by the same context-grep at the publish delegation boundary.
 
 | Caller | Invocation point | Trigger |
 |--------|------------------|---------|
 | Phase 5.0-5.2.1 (execute) | Mandatory After 5.0-5.2.1 — Step 2 | Always after `[start:execute:*]` pattern |
-| Phase 5.3 (pr:create) | Mandatory After 5.3 — between "Verify" and "Proceed to 5.4 now" | Always after `[pr:created:{N}]` or `[pr:create-failed]` |
-| Phase 5.4.3 (pr:review) | After Review — Step 3 | Always after `[review:*]` pattern |
-| Phase 5.4.6 (pr:fix) | After Fix — Step 3 | Always after `[fix:*]` pattern |
+| Phase 5.3-5.4 (publish) | Mandatory After 5.3-5.4 — Step 2 | Always after `[start:publish:*]` pattern (covers internal `[pr:created:{N}]` / `[pr:create-failed]` / `[review:*]` / `[fix:*]` emits via context grep) |
 | Phase 5.5.0.1 (pr:ready) | Mandatory After 5.5 — Step 3 | Always after `[ready:*]` pattern |
 
-Each Mandatory After section MUST include a **"Run Phase 5.4.4.1 detection"** step that directs the orchestrator to grep the recent conversation context for sentinel lines BEFORE proceeding to the next phase. It is also triggered when an `AskUserQuestion` fallback option that emits a sentinel (e.g., "manual fallback") is selected.
+Each Mandatory After section MUST include a **"Run Phase 5.4.4.1 detection"** step that directs the orchestrator to grep the recent conversation context for sentinel lines BEFORE proceeding to the next phase.
 
-**Skip condition**: If `workflow_incident.enabled: false` is set in `rite-config.yml`, skip this entire phase. Read the value once at Phase 5.0 and cache for the rest of the flow.
+**Skip condition**: If `workflow_incident.enabled: false` is set in `rite-config.yml`, skip this entire phase. Read the value once at Phase 5.0 (delegated to `start-execute`) and cache for the rest of the flow.
 
 **Invariants**: Issue creation failure is non-blocking (workflow MUST NOT halt). The codepath is independent of Phase 7 (Issue creation from review recommendations). Default-on behavior: when `workflow_incident:` section is absent from `rite-config.yml`, treat as `enabled: true`.
-
-#### 5.4.5 Fix Patterns
-
-`[fix:pushed]`→5.4.1. `[fix:pushed-wm-stale]`→AskUserQuestion (WM stale warning)→5.4.1. `[fix:issues-created:{n}]`→5.4.1. `[fix:replied-only]`→5.5. `[fix:error]`→error, ask user.
-
-#### 5.4.6 🚨 After Fix
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Verify**: Pattern confirmed, parsed.
-
-**Step 1**: Update flow state to post-fix phase (atomic). This second write (after the Phase 5.4.4 pre-write) transitions from `phase5_fix` to `phase5_post_fix`, ensuring stop-guard routes to the correct next branch rather than repeatedly blocking and incrementing `error_count` (fixes #709):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_fix" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "rite:pr:fix completed. Check recent result pattern in context: [fix:pushed]->Phase 5.4.1 (re-review). [fix:pushed-wm-stale]->Phase 5.4.1 with WM stale warning (AskUserQuestion). [fix:issues-created]->Phase 5.4.1. [fix:replied-only]->Phase 5.5. Do NOT stop."
-```
-
-**Step 2**: Sync to local work memory:
-
-```bash
-WM_SOURCE="fix" \
-  WM_PHASE="phase5_post_fix" \
-  WM_PHASE_DETAIL="修正完了" \
-  WM_NEXT_ACTION="修正結果に基づき次アクションを実行" \
-  WM_BODY_TEXT="Post-fix sync." \
-  WM_ISSUE_NUMBER="{issue_number}" \
-  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
-```
-
-**Step 2.5**: Sync local work memory to Issue comment (backup):
-
-> **Reference**: Uses `issue-comment-wm-sync.sh` which handles owner/repo resolution internally, backup creation, safety checks, and PATCH atomically (#204).
-
-```bash
-# ⚠️ このパターンは 5.4.3 (After Review) と同一構造。変更時は両方を更新すること
-bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
-  --issue {issue_number} \
-  --transform update-phase \
-  --phase "phase5_post_fix" --phase-detail "修正完了" \
-  2>/dev/null || true
-```
-
-**Step 3 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines emitted by the fix.md sub-skill (per Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 4 regardless of detection result.
-
-> **Note (v0.4.0 #557)**: The former Step 3.5 (Review-Fix Loop Hard Limit Check) was removed. The review-fix loop no longer has a cycle-count-based hard limit. Non-convergence is now detected exclusively via the four quality signals (see `commands/pr/references/fix-relaxation-rules.md#four-quality-signals-for-escalation`):
-> 1. Fingerprint cycling → Phase 5.4.1.0 (before every re-review)
-> 2. Root-cause-missing fix → `fix.md` Phase 3.2.1 (before every commit)
-> 3. Cross-validation disagreement → `review.md` Phase 5.2 + debate (during every review)
-> 4. Finding quality gate failure → `_reviewer-base.md` Finding Quality Guardrail (during every reviewer run)
-> **Design intent (#557 D-02)**: There is intentionally no cycle-count safety limit. The 4 quality signals are the sole termination mechanism; if they fire correctly, convergence on 0 findings is reached, and if they don't, the user is escalated via `AskUserQuestion` and chooses manually. Hardening this with an additional iteration counter would reintroduce the cycle-count-based degradation that #557 explicitly removed.
-
-**Step 4**: Based on the fix result pattern from `rite:pr:fix` **and** the preceding review result pattern, execute the corresponding action **immediately**. Do **NOT** use the Edit tool to fix code directly — always invoke the appropriate Skill tool.
-
-| Fix Result Pattern | Preceding Review Pattern | Action |
-|--------------------|--------------------------|--------|
-| `[fix:pushed]` | _(any)_ | **Invoke `skill: "rite:pr:review", args: "{pr_number}"`** via the Skill tool (re-review, Phase 5.4.1). |
-| `[fix:pushed-wm-stale]` | _(any)_ | **Work memory が stale です。手動介入が必要かを `AskUserQuestion` でユーザーに確認** (推奨: stale 警告ログを残した上で `skill: "rite:pr:review", args: "{pr_number}"` を起動して再レビューに進む / 中断して手動で work memory を修復する)。silent に `[fix:pushed]` 扱いしてはならない (fix.md Phase 8.1 caller semantics 参照)。 |
-| `[fix:issues-created:{n}]` | _(any)_ | **Invoke `skill: "rite:pr:review", args: "{pr_number}"`** via the Skill tool (re-review, Phase 5.4.1). |
-| `[fix:replied-only]` | _(any)_ | **→ Proceed to Phase 5.5** (Ready for Review). |
-| `[fix:error]` | _(any)_ | Ask the user how to proceed via `AskUserQuestion` with options: 「再試行」/「Edit ツールで手動 fallback (incident 記録)」/「Phase 5.6 にスキップ」/「terminate」. If user selects 「Edit ツールで手動 fallback」, **emit sentinel** per [§C — Phase 5.4.4 `[fix:error]`](./references/workflow-incident-emit-pattern.md#c--phase-544-fixerror) (SoT). The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). The sentinel will be picked up by Phase 5.4.4.1 in the next cycle. Do NOT inline the bash literal here. |
-
-> **禁止**: Edit ツールや Bash ツールでコードを直接修正してはならない。修正は必ず `skill: "rite:pr:fix"` を Skill ツールで呼び出して実行すること。再レビューは必ず `skill: "rite:pr:review"` を Skill ツールで呼び出すこと。
 
 ### 5.5 Ready for Review
 
@@ -1041,15 +817,15 @@ else
   echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_6_pre_condition; rc=$rc" >&2
   exit 1
 fi
-if [ "$curr" != "phase5_post_metrics" ] && [ "$curr" != "phase5_post_execute" ]; then
-  echo "ERROR: Phase 5.6 pre-condition failed. .phase=$curr (expected: phase5_post_metrics or phase5_post_execute for abort path)" >&2
+if [ "$curr" != "phase5_post_metrics" ] && [ "$curr" != "phase5_post_execute" ] && [ "$curr" != "phase5_post_publish" ]; then
+  echo "ERROR: Phase 5.6 pre-condition failed. .phase=$curr (expected: phase5_post_metrics or phase5_post_execute/phase5_post_publish for abort path)" >&2
   echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
   echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1
 fi
-# Note: phase5_post_execute は abort path (start-execute.md が [start:execute:aborted] sentinel
-# emit 後に Phase 5.6 へ直接 skip する経路、Workflow Termination 用) を accept する。
-# success path は phase5_post_metrics 経由が正規路。
+# Note: phase5_post_execute / phase5_post_publish は abort path (start-execute.md が [start:execute:aborted]
+# または start-publish.md が [start:publish:aborted] sentinel emit 後に Phase 5.6 へ直接 skip する経路、
+# Workflow Termination 用) を accept する。success path は phase5_post_metrics 経由が正規路。
 ```
 
 **Pre-write**:

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -92,7 +92,18 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # [start:execute:completed] sentinel (success path), or to phase5_completion after
   # [start:execute:aborted] sentinel (abort path — 5.1.3 中止 / [lint:aborted]).
   ["phase5_execute_running"]="phase5_stop_hook phase5_post_execute"
-  ["phase5_post_execute"]="phase5_pr phase5_completion"
+
+  # /rite:issue:start-publish sub-skill (PR G1 #903)
+  # start.md Phase 5.3/5.4 delegation: orchestrator writes phase5_publish_running before invoke,
+  # sub-skill writes phase5_post_publish when done. Orchestrator routes to phase5_ready /
+  # phase5_post_ready after [start:publish:completed] sentinel (success path — mergeable or
+  # replied-only), or to phase5_completion after [start:publish:aborted] sentinel (abort path —
+  # pr:create-failed / fix:error user-terminate).
+  # phase5_post_execute (PR F terminal) → phase5_publish_running (PR G1 delegation entry) を
+  # 新規 edge として許容する。
+  ["phase5_post_execute"]="phase5_pr phase5_publish_running phase5_completion"
+  ["phase5_publish_running"]="phase5_pr phase5_post_publish"
+  ["phase5_post_publish"]="phase5_ready phase5_post_ready phase5_ready_error phase5_completion"
 
   # Phase 5.3: PR create
   # start.md Phase 5.3 Mandatory After transitions directly from phase5_pr to phase5_review
@@ -105,10 +116,12 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # `rite:pr:ready` defense-in-depth directly writes phase5_post_ready from phase5_post_review /
   # phase5_post_fix, bypassing phase5_ready. Allow that transition to avoid invalid-transition
   # blocks on the mergeable path (devops-reviewer CRITICAL #1).
+  # phase5_post_review / phase5_post_fix → phase5_post_publish は start-publish sub-skill 終端
+  # (sub-skill が review-fix loop の最終 internal phase から caller-write の post_publish へ抜ける) edge (PR G1 #903)。
   ["phase5_review"]="phase5_post_review"
-  ["phase5_post_review"]="phase5_fix phase5_ready phase5_post_ready phase5_ready_error"
+  ["phase5_post_review"]="phase5_fix phase5_ready phase5_post_ready phase5_ready_error phase5_post_publish"
   ["phase5_fix"]="phase5_post_fix"
-  ["phase5_post_fix"]="phase5_review phase5_ready phase5_post_ready phase5_ready_error"
+  ["phase5_post_fix"]="phase5_review phase5_ready phase5_post_ready phase5_ready_error phase5_post_publish"
 
   # Phase 5.5: ready → status → metrics → completion
   # phase5_ready_error is a terminal error state emitted by ready.md Phase 3.1 when skill errors.

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -109,7 +109,10 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # start.md Phase 5.3 Mandatory After transitions directly from phase5_pr to phase5_review
   # (no intermediate phase5_post_pr write). Allow both the direct path and the legacy
   # post_pr marker for backward compat (devops cycle-2 CRITICAL).
-  ["phase5_pr"]="phase5_post_pr phase5_review"
+  # phase5_pr → phase5_post_publish は [pr:create-failed] abort path 用 (PR G1)。
+  # start-publish.md の Return Output Format Self-patch が previous_phase=phase5_pr のまま
+  # phase5_post_publish へ patch する経路を whitelist 化する (runtime BLOCKED 防止)。
+  ["phase5_pr"]="phase5_post_pr phase5_review phase5_post_publish"
   ["phase5_post_pr"]="phase5_review"
 
   # Phase 5.4: review-fix loop

--- a/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
+++ b/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
@@ -2,8 +2,9 @@
 # sentinel-visibility-rule.test.sh — Workflow Incident Sentinel Visibility Rule の構造保護
 #
 # 本 test は PR D で抽出した 3 references (workflow-incident-detection.md /
-# workflow-incident-emit-pattern.md / fingerprint-cycling.md) と本体 start.md
-# 側の anchor reference が以下不変条件を満たすことを保証する:
+# workflow-incident-emit-pattern.md / fingerprint-cycling.md) と本体 start.md /
+# start-execute.md / start-publish.md (PR F/G1 抽出後の 3-way split) 側の anchor
+# reference が以下不変条件を満たすことを保証する:
 #
 # 1. workflow-incident-detection.md が Phase 5.4.4.1 Processing flow Step 1-7
 #    と Phase 5.0 Step 6 (workflow_incident.enabled parser) を含む
@@ -15,7 +16,10 @@
 # 4. 本体 start.md 側に 3 references への anchor reference が存在し、orchestrator
 #    が圧縮済み phase から正しい SoT に到達可能であること
 # 5. 本体 start.md 側に Detection scope table (7 sentinel type) と When to execute
-#    table (5 caller) が残されていること (これらは本体 contract として保持)
+#    table (3 caller — PR G1 で start-publish 抽出後、5.0-5.2.1 / 5.3-5.4 / 5.5.0.1)
+#    が残されていること (これらは本体 contract として保持)
+# 6. start-publish.md 内の rite:pr:* Skill invocation contract が破壊されていないこと
+#    (PR G1 で内部 routing が sub-skill 内に閉じた drift 防止)
 #
 # Run mode: 常時実行 (Charter assertion ではなく構造保護のため STRICT_CHARTER 不要)
 # Exit code: 不変条件違反時に non-zero
@@ -294,6 +298,26 @@ assert_grep "start: Skip condition retained" \
 assert_grep "start: Invariants statement retained (non-blocking)" \
   "$START_MD" \
   'workflow MUST NOT halt'
+
+# === 5.5. start-publish.md 内の rite:pr:* Skill invocation contract ===
+# PR G1 で Phase 5.3-5.4 が start-publish.md sub-skill 内に閉じたため、
+# start.md からは「Phase 5.4.3 (pr:review) / 5.4.6 (pr:fix) row」の assert が削除された。
+# 代わりに「start-publish.md 内に rite:pr:create / rite:pr:review / rite:pr:fix の Skill invocation が
+# 必ず存在する」ことを pin することで、内部 Skill 呼出が誤削除される drift を検出する。
+echo ""
+echo "--- 5.5. start-publish.md 内の rite:pr:* Skill invocation contract (PR G1) ---"
+
+assert_grep "start-publish: rite:pr:create skill invocation retained" \
+  "$START_PUBLISH_MD" \
+  'skill: "rite:pr:create"'
+
+assert_grep "start-publish: rite:pr:review skill invocation retained" \
+  "$START_PUBLISH_MD" \
+  'skill: "rite:pr:review"'
+
+assert_grep "start-publish: rite:pr:fix skill invocation retained" \
+  "$START_PUBLISH_MD" \
+  'skill: "rite:pr:fix"'
 
 # === 6. start.md drift guard — inline emit literal must NOT reappear (#937) ===
 echo ""

--- a/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
+++ b/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
@@ -28,10 +28,14 @@ REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 
 START_MD="$REPO_ROOT/plugins/rite/commands/issue/start.md"
 # PR F (#902) extracted Phase 5.0-5.2.1 (incl. §A Phase 5.2 `[lint:aborted]` anchor reference)
-# into start-execute.md. The §A anchor now legitimately lives in start-execute.md, while
-# §B-§D and `## 不変条件` remain in start.md (Phase 5.3/5.4.4/5.5 references). Anchor
-# drift check scans both files.
+# into start-execute.md. PR G1 (#903) extracted Phase 5.3/5.4 (incl. §B Phase 5.3 `[pr:create-failed]`
+# / §C Phase 5.4.4 `[fix:error]` anchor references) into start-publish.md. The anchor ownership is:
+#   §A → start-execute.md
+#   §B / §C → start-publish.md
+#   §D + `## 不変条件` → start.md (Phase 5.5 stays in start.md)
+# Anchor drift check scans the owner file per anchor.
 START_EXECUTE_MD="$REPO_ROOT/plugins/rite/commands/issue/start-execute.md"
+START_PUBLISH_MD="$REPO_ROOT/plugins/rite/commands/issue/start-publish.md"
 REF_DETECTION="$REPO_ROOT/plugins/rite/commands/issue/references/workflow-incident-detection.md"
 REF_EMIT="$REPO_ROOT/plugins/rite/commands/issue/references/workflow-incident-emit-pattern.md"
 REF_FINGERPRINT="$REPO_ROOT/plugins/rite/commands/issue/references/fingerprint-cycling.md"
@@ -264,25 +268,19 @@ for sentinel_type in "skill_load_failure" \
     "\`$sentinel_type\`"
 done
 
-# When to execute 5-caller table 行が本体に残されている
+# When to execute 3-caller table 行が本体に残されている
 # PR F #951 F-05 fix: Phase 5.2 (lint) row が Mandatory After 5.0-5.2.1 統合により
 # 「Phase 5.0-5.2.1 (execute) | Mandatory After 5.0-5.2.1 — Step 2」へ変更された。
-# 新 delegation design (start.md → start-execute.md sub-skill) を反映する。
+# PR G1 #903 fix: Phase 5.3 / 5.4.3 / 5.4.6 rows が start-publish sub-skill 抽出により
+# 「Phase 5.3-5.4 (publish) | Mandatory After 5.3-5.4」へ統合された。internal pr:create /
+# pr:review / pr:fix 呼出は start-publish 内に閉じ、orchestrator 視点では 3 boundary。
 assert_grep "start: When to execute table — Phase 5.0-5.2.1 execute row" \
   "$START_MD" \
   'Phase 5\.0-5\.2\.1 \(execute\).*Mandatory After 5\.0-5\.2\.1'
 
-assert_grep "start: When to execute table — Phase 5.3 pr:create row" \
+assert_grep "start: When to execute table — Phase 5.3-5.4 publish row" \
   "$START_MD" \
-  'Phase 5\.3 \(pr:create\).*Mandatory After 5\.3'
-
-assert_grep "start: When to execute table — Phase 5.4.3 pr:review row" \
-  "$START_MD" \
-  'Phase 5\.4\.3 \(pr:review\).*After Review'
-
-assert_grep "start: When to execute table — Phase 5.4.6 pr:fix row" \
-  "$START_MD" \
-  'Phase 5\.4\.6 \(pr:fix\).*After Fix'
+  'Phase 5\.3-5\.4 \(publish\).*Mandatory After 5\.3-5\.4'
 
 assert_grep "start: When to execute table — Phase 5.5.0.1 pr:ready row" \
   "$START_MD" \
@@ -386,8 +384,8 @@ echo "--- 7. start.md → emit-pattern.md anchor 整合性 (github-slugger 互�
 # 妨げないため)。
 anchor_pairs=(
   '### §A — Phase 5.2 `[lint:aborted]`|a--phase-52-lintaborted|start-execute'
-  '### §B — Phase 5.3 `[pr:create-failed]`|b--phase-53-prcreate-failed|start'
-  '### §C — Phase 5.4.4 `[fix:error]`|c--phase-544-fixerror|start'
+  '### §B — Phase 5.3 `[pr:create-failed]`|b--phase-53-prcreate-failed|start-publish'
+  '### §C — Phase 5.4.4 `[fix:error]`|c--phase-544-fixerror|start-publish'
   '### §D — Phase 5.5 `[ready:error]`|d--phase-55-readyerror|start'
   '## 不変条件|不変条件|start'
 )
@@ -419,8 +417,12 @@ for pair in "${anchor_pairs[@]}"; do
       owner_file="$START_EXECUTE_MD"
       owner_label="start-execute.md"
       ;;
+    start-publish)
+      owner_file="$START_PUBLISH_MD"
+      owner_label="start-publish.md"
+      ;;
     *)
-      fail "anchor: unknown owner '$owner' in anchor_pairs (must be 'start' or 'start-execute')"
+      fail "anchor: unknown owner '$owner' in anchor_pairs (must be 'start', 'start-execute', or 'start-publish')"
       continue
       ;;
   esac

--- a/plugins/rite/skills/rite-workflow/references/work-memory-format.md
+++ b/plugins/rite/skills/rite-workflow/references/work-memory-format.md
@@ -462,7 +462,7 @@ bash {plugin_root}/hooks/preflight-check.sh --command-id "/rite:{command}" --cwd
 |----------|---------|-------------------|
 | **Write** | `pr/create`, `pr/review`, `pr/ready`, `pr/cleanup`†, `pr/fix`, `issue/close`, `issue/update`, `issue/implement`, `issue/work-memory-init`, `lint` | Read + Write (via `local-wm-update.sh`) |
 | **Read** | `issue/branch-setup`, `issue/implementation-plan`, `sprint/execute`, `sprint/team-execute` | Read only |
-| **Preflight only** | `issue/create`, `issue/list`, `issue/edit`, `issue/parent-routing`, `issue/child-issue-selection`, `issue/start-execute`, `workflow`, `getting-started`, `sprint/list`, `sprint/current`, `sprint/plan`, `skill/suggest`, `template/reset`, `init` | None |
+| **Preflight only** | `issue/create`, `issue/list`, `issue/edit`, `issue/parent-routing`, `issue/child-issue-selection`, `issue/start-execute`, `issue/start-publish`, `workflow`, `getting-started`, `sprint/list`, `sprint/current`, `sprint/plan`, `skill/suggest`, `template/reset`, `init` | None |
 | **Orchestrator** | `issue/start`, `resume` | Managed by flow state (these commands orchestrate other commands; they do not directly read/write local WM but control flow via flow state) |
 
 † `pr/cleanup` updates Issue comment directly in Phase 4.5 (final archival record) because local WM file is deleted earlier in Phase 3.

--- a/plugins/rite/skills/rite-workflow/references/work-memory-format.md
+++ b/plugins/rite/skills/rite-workflow/references/work-memory-format.md
@@ -460,9 +460,9 @@ bash {plugin_root}/hooks/preflight-check.sh --command-id "/rite:{command}" --cwd
 
 | Category | Commands | Local WM Operation |
 |----------|---------|-------------------|
-| **Write** | `pr/create`, `pr/review`, `pr/ready`, `pr/cleanup`†, `pr/fix`, `issue/close`, `issue/update`, `issue/implement`, `issue/work-memory-init`, `lint` | Read + Write (via `local-wm-update.sh`) |
+| **Write** | `pr/create`, `pr/review`, `pr/ready`, `pr/cleanup`†, `pr/fix`, `issue/close`, `issue/update`, `issue/implement`, `issue/work-memory-init`, `issue/start-publish`, `lint` | Read + Write (via `local-wm-update.sh`) |
 | **Read** | `issue/branch-setup`, `issue/implementation-plan`, `sprint/execute`, `sprint/team-execute` | Read only |
-| **Preflight only** | `issue/create`, `issue/list`, `issue/edit`, `issue/parent-routing`, `issue/child-issue-selection`, `issue/start-execute`, `issue/start-publish`, `workflow`, `getting-started`, `sprint/list`, `sprint/current`, `sprint/plan`, `skill/suggest`, `template/reset`, `init` | None |
+| **Preflight only** | `issue/create`, `issue/list`, `issue/edit`, `issue/parent-routing`, `issue/child-issue-selection`, `issue/start-execute`, `workflow`, `getting-started`, `sprint/list`, `sprint/current`, `sprint/plan`, `skill/suggest`, `template/reset`, `init` | None |
 | **Orchestrator** | `issue/start`, `resume` | Managed by flow state (these commands orchestrate other commands; they do not directly read/write local WM but control flow via flow state) |
 
 † `pr/cleanup` updates Issue comment directly in Phase 4.5 (final archival record) because local WM file is deleted earlier in Phase 3.


### PR DESCRIPTION
## Summary

- `plugins/rite/commands/issue/start-publish.md` 新規 (385 行): Phase 5.3 (PR Creation) + 5.4 (Review-Fix Loop) を移管。HTML sentinel `[start:publish:completed]` / `[start:publish:aborted]` 実装。review-fix loop の routing は本 sub-skill 内に閉じる。
- `plugins/rite/commands/issue/start.md`: 1318 → 1101 行 (-217 行 / -16.5%)。Phase 5.3-5.4 を delegation 呼び出しに置換。Phase 5.4.4.1 本体 contract (Detection scope / When to execute 3-row / Skip condition / Invariants) は保持。
- `phase-transition-whitelist.sh` / `sentinel-visibility-rule.test.sh` / `work-memory-format.md` を同 PR 内で同期更新。

ハイブリッド再設計 #896 の PR G1。PR F (#902, #951) で確立した sub-skill 抽出パターンに対称な構造で実装。

Closes #903

## Test plan

- [x] `bash plugins/rite/hooks/tests/run-tests.sh`: 49/49 PASS
- [x] `sentinel-visibility-rule.test.sh` で §B/§C anchor の start-publish.md 移管と When to execute table 3-row 化を pin
- [x] whitelist 新 edge 6 件 (`phase5_post_execute→phase5_publish_running`, `phase5_publish_running→phase5_pr/post_publish`, `phase5_post_review/phase5_post_fix→phase5_post_publish`, `phase5_post_publish→phase5_ready/post_ready/completion`) を bash 上で動作確認
- [ ] e2e 検証: review pass / fix-needed×N / replied-only / error の **4 経路すべて** (本 PR 自身で発火するレビュー指摘対応で確認予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)