### PR TITLE
refactor(issue): start.md Phase 5.5-Termination を start-finalize.md sub-skill に抽出 [PR G2]

### DIFF
--- a/plugins/rite/commands/issue/completion-report.md
+++ b/plugins/rite/commands/issue/completion-report.md
@@ -1,6 +1,6 @@
 # Completion Report (Phase 5.6)
 
-> **Source**: Extracted from `start.md` Phase 5.6. This file is the source of truth for the completion report procedure.
+> **Source**: Extracted from `start-finalize.md` Phase 5.6 (originally in `start.md` before PR G2 #904 moved Phase 5.5-Termination to the start-finalize sub-skill). This file is the source of truth for the completion report procedure.
 
 Execute the following steps **in order**. Do NOT skip any step. Always base your output on the template file read in Step 1 (or the inline fallback below if the Read tool fails).
 
@@ -44,11 +44,11 @@ Output the substituted template as your response. First determine which case app
 
 **Step 3.5 — Append Wiki ingest 状況 section (Issue #524 AC-5)**:
 
-**Output ordering** (must match `start.md` Phase 5.6.2 ordering note): After outputting the case-specific sections (項目テーブル + フェーズ進捗 + 次のステップ), **always** append the "Wiki ingest 状況" table **before** the Phase 5.6.1 (Workflow Incident Reporting) section. The runtime sequence is: standard completion sections → Phase 5.6.2 (Wiki ingest 状況, this Step 3.5) → Phase 5.6.1 (workflow incidents). The section numbers in `start.md` reflect introduction order (#366 first, #524 second) and are intentionally NOT in execution order.
+**Output ordering** (must match `start-finalize.md` Phase 5.6.2 ordering note): After outputting the case-specific sections (項目テーブル + フェーズ進捗 + 次のステップ), **always** append the "Wiki ingest 状況" table **before** the Phase 5.6.1 (Workflow Incident Reporting) section. The runtime sequence is: standard completion sections → Phase 5.6.2 (Wiki ingest 状況, this Step 3.5) → Phase 5.6.1 (workflow incidents). The section numbers in `start.md` reflect introduction order (#366 first, #524 second) and are intentionally NOT in execution order.
 
-The "Wiki ingest 状況" table is generated per `start.md` Phase 5.6.2 by aggregating `[CONTEXT] WIKI_INGEST_DONE/SKIPPED/FAILED=1` lines from the conversation context. This section is mandatory in both Case A and Case B and is **never** skipped — the absence of any signal is itself a reportable state (silent-skip detection).
+The "Wiki ingest 状況" table is generated per `start-finalize.md` Phase 5.6.2 by aggregating `[CONTEXT] WIKI_INGEST_DONE/SKIPPED/FAILED=1` lines from the conversation context. This section is mandatory in both Case A and Case B and is **never** skipped — the absence of any signal is itself a reportable state (silent-skip detection).
 
-See `start.md` Phase 5.6.2 for the full procedure (signal aggregation, output table format, conditional warnings).
+See `start-finalize.md` Phase 5.6.2 for the full procedure (signal aggregation, output table format, conditional warnings).
 
 **Step 4 — Self-verification**:
 

--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -12,11 +12,16 @@ Execute the finalize phase for an Issue. This sub-skill is invoked from `start.m
 **Prerequisites**: Phase 0-5.4 of `start.md` and `start-publish` sub-skill have completed. The following information is available in conversation context:
 - `{issue_number}` — target Issue number
 - `{branch_name}` — created/checked-out branch
-- `{pr_number}` — populated from Phase 5.3 `[pr:created:{N}]`
+- `{pr_number}` — populated from Phase 5.3 `[pr:created:{N}]` (success path) OR `0` (abort path — `[start:execute:aborted]` 経由で PR 未作成のまま invocation された場合)
 - `{plugin_root}` — resolved per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version)
-- `{owner}`, `{repo}` — from `gh repo view`
 - `{parent_issue_number}` — from flow-state via `state-read.sh` (Phase 5.7)
-- Review-fix loop converged (mergeable / replied-only)
+- Review-fix loop converged (mergeable / replied-only) **OR** abort context (`[start:execute:aborted]` / `[start:publish:aborted]` 経由 — Phase 5.5/5.5.1/5.5.2/5.7 を skip して直接 Phase 5.6 Completion Report へ進む)
+
+**Abort entry detection**: 本 sub-skill 起動直後、以下のいずれかが成立する場合は **abort entry** と判定し、Phase 5.5 AskUserQuestion / 5.5.1 / 5.5.2 / 5.7 を skip して **直接 Phase 5.6 Completion Report へ進む** (terminal state は caller の Mandatory After 5.5-Termination Step 1 が SoT として担う):
+1. `{pr_number}` が `0` (PR 未作成 — `[start:execute:aborted]` 経由)
+2. 会話履歴に `<!-- [start:execute:aborted] -->` または `<!-- [start:publish:aborted] -->` sentinel が直近の sub-skill return として存在する
+
+abort entry の場合、Phase 5.6 Completion Report の本文には abort 理由 (`[lint:aborted]` / 5.1.3 Safety Check user 中止 / `[pr:create-failed]` / `[fix:error]` user-terminate) を必ず明示する。
 
 ---
 
@@ -36,15 +41,17 @@ if [ -n "$state_file" ] && [ -f "$state_file" ]; then
   if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
       --phase "phase5_finalize_running" \
       --active true \
-      --next "rite:issue:start-finalize Pre-flight completed. Proceed to Phase 5.5 (Ready for Review) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination, then return to caller. Do NOT stop." \
+      --next "rite:issue:start-finalize Pre-flight completed. Success path: Phase 5.5 (Ready) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination. Abort entry path: skip Phase 5.5/5.5.1/5.5.2/5.7 and go directly to Phase 5.6 (Completion Report). Do NOT stop." \
       --preserve-error-count; then
     echo "[CONTEXT] PREFLIGHT_PATCH_FAILED=1" >&2
     # 非 blocking: start.md delegation pre-write が safety net。
+    # 注: Pre-flight 失敗自体は Phase 5.4.4.1 grep target の WORKFLOW_INCIDENT sentinel ではないが、
+    # caller の Mandatory After 5.5-Termination Step 1 idempotent patch が terminal を補填する。
   fi
 else
   if ! bash {plugin_root}/hooks/flow-state-update.sh create \
       --phase "phase5_finalize_running" --issue {issue_number} --branch "{branch_name}" --pr {pr_number} \
-      --next "rite:issue:start-finalize Pre-flight completed. Proceed to Phase 5.5 (Ready for Review) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination, then return to caller. Do NOT stop." \
+      --next "rite:issue:start-finalize Pre-flight completed. Success path: Phase 5.5 (Ready) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination. Abort entry path: skip Phase 5.5/5.5.1/5.5.2/5.7 and go directly to Phase 5.6. Do NOT stop." \
       --preserve-error-count; then
     echo "[CONTEXT] PREFLIGHT_CREATE_FAILED=1" >&2
   fi
@@ -58,6 +65,10 @@ fi
 ---
 
 ## Phase 5.5: Ready for Review
+
+**Abort-entry gate**: Pre-flight 完了後、Prerequisites section の「Abort entry detection」条件 (`{pr_number} == 0` OR 会話履歴に `[start:execute:aborted]` / `[start:publish:aborted]` sentinel) が成立する場合、Phase 5.5 AskUserQuestion / 5.5.0.1 / 5.5.1 / 5.5.2 を **すべて skip** し、直接 Phase 5.6 Completion Report へ進む。Phase 5.7 (parent close) も abort context では skip し、Workflow Termination も実行されず caller の Mandatory After 5.5-Termination Step 1 が terminal state SoT として担う。Phase 5.6 完了レポート本文には abort 理由を必ず明示する。
+
+success path (review-fix loop converged) では abort-entry gate を通過し、以下の通常 Phase 5.5 routing を実行する。
 
 > **⚠️ MANDATORY**: The following `AskUserQuestion` confirmation MUST be executed. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review.
 
@@ -82,10 +93,11 @@ On user selecting "Ready for review", invoke `skill: "rite:pr:ready", args: "{pr
 
 > **Emit canonical literal**: See [§D — Phase 5.5 `[ready:error]`](./references/workflow-incident-emit-pattern.md#d--phase-55-readyerror) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで手動 Ready 化」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number {pr_number}` semantics. The response-text-inclusion requirement that caller Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
 
-**On `[ready:error]` — routing**: After emitting §D canonical literal, present `AskUserQuestion` (3 options: `再試行` / `Edit ツールで手動 Ready 化 (incident 記録)` / `terminate`):
+**On `[ready:error]` — routing**: After emitting §D canonical literal, present `AskUserQuestion` (4 options matching SoT in [§D](./references/workflow-incident-emit-pattern.md#d--phase-55-readyerror)): `再試行` / `Edit ツールで手動 Ready 化 (incident 記録)` / `Phase 5.6 へスキップ` / `terminate`:
 - **「再試行」**: re-invoke `rite:pr:ready` (loop within Phase 5.5).
 - **「Edit ツールで手動 Ready 化 (incident 記録)」**: emit §D Step 2 (`manual_fallback_adopted`), then proceed to 5.5.0.1 (treat as `[ready:completed]`).
-- **「terminate」**: emit `[start:finalize:aborted]` abort return block and return to caller. Workflow Termination is skipped — caller's Mandatory After patches terminal state.
+- **「Phase 5.6 へスキップ」**: emit `[start:finalize:aborted]` abort return block and return to caller. Phase 5.5.1/5.5.2/5.7 are skipped; Workflow Termination は実行されず、terminal state への遷移は caller の Mandatory After 5.5-Termination Step 1 が担う。
+- **「terminate」**: emit `[start:finalize:aborted]` abort return block and return to caller. Workflow Termination は実行されず、caller's Mandatory After 5.5-Termination Step 1 が terminal state への遷移を担う。
 
 ### 5.5.0.1 🚨 Mandatory After 5.5
 
@@ -220,9 +232,14 @@ if [ "$curr" != "phase5_post_metrics" ] && [ "$curr" != "phase5_finalize_running
   echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
   exit 1
 fi
-# Note: phase5_finalize_running は abort path (Draft 化 or [ready:error] terminate 経路で
-# Phase 5.5.1/5.5.2 を skip して直接 Phase 5.6 へ進むケース) を accept する。
-# success path は phase5_post_metrics 経由が正規路。
+# Note: phase5_finalize_running は以下 2 経路を accept する:
+#   (a) Draft path: Phase 5.5 で user が「ドラフトのまま完了」を選択し Phase 5.5.0.1/5.5.1/5.5.2
+#       を skip して直接 Phase 5.6 完了レポートへ進む success-path 内 routing。
+#   (b) Abort entry path: caller (start.md Mandatory After 5.0-5.2.1 / 5.3-5.4 Step 3) で
+#       `[start:execute:aborted]` / `[start:publish:aborted]` 検出時に Pre-write `--pr 0` 等で
+#       sub-skill を invoke し、本 sub-skill が Phase 5.5 Abort-entry gate で Phase 5.5/5.5.1/5.5.2
+#       を skip して直接 Phase 5.6 へ進む経路。
+# success path (Ready 化選択) は phase5_post_metrics 経由が正規路。
 ```
 
 **Pre-write**:
@@ -452,12 +469,13 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 
 > **Why this routing relies on Phase 5.7 emit, not state re-read**: Phase 5.7 が `parent_issue_number` の **single source of truth for the read** であり、本 Workflow Termination block は state を re-read しない。本 sub-skill 内の branching decision は Phase 5.7 の `[CONTEXT] PARENT_ISSUE=none` echo (LLM-level routing signal、会話履歴で観測可能) で駆動され、bash 変数経由ではない (Bash tool invocation は shell state を境界を跨いで共有しない)。
 
-**Step 1**: Update flow state to the terminal state (patch mode, preserves `previous_phase`):
+**Step 1**: Update flow state to the terminal state (patch mode, preserves `previous_phase`). Use `--if-exists --preserve-error-count` for safety — if the Pre-flight failed to create the state file (rare), this patch becomes a no-op rather than failing terminal:
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "completed" \
-  --next "none" --active false
+  --next "none" --active false \
+  --if-exists --preserve-error-count
 ```
 
 **Step 2**: Clean up `.rite-compact-state` to prevent stale blocked state from affecting the next session (#756):
@@ -473,23 +491,13 @@ rm -rf .rite-compact-state.lockdir 2>/dev/null || true
 
 ## Return Output Format (Before Return)
 
-> **Reference**: `start-execute.md` / `start-publish.md` Return Output Format と異なり、本 sub-skill は **workflow terminal**。flow-state の terminal write (`phase="completed", active=false`) は Workflow Termination section が既に実行済みのため、Return Output Format では state file への re-patch は **不要**。sentinel 出力のみで caller に handoff する。abort path では Workflow Termination をスキップして本 sub-skill 内で直接 `completed, active=false` を patch する (下記 abort 経路で実行)。
+> **Reference**: `start-execute.md` / `start-publish.md` Return Output Format と異なり、本 sub-skill は **workflow terminal**。
+>
+> **Success path**: Workflow Termination section が terminal write (`phase="completed", active=false`) + `.rite-compact-state` cleanup を実行済み。Return Output Format では state file への re-patch は **不要** で、sentinel 出力のみで caller に handoff する。
+>
+> **Abort path** (Phase 5.5 user selects 「More fixes」or `[ready:error]` → 「terminate」 or 「Phase 5.6 へスキップ」 で abort sentinel emit): Workflow Termination は実行されない (Phase 5.7 へ進まないため)。terminal state への遷移は **caller (`start.md` Mandatory After 5.5-Termination Step 1) の idempotent patch (`--if-exists --preserve-error-count`) が SoT として担う**。本 sub-skill 内に bash variable guard 経由の terminal write は配置しない (Claude Code の Bash tool は invocation 間で shell state を共有しないため `FINALIZE_ABORT=1` 経路は構造的に dead code になる)。
 
-> **Why no defense-in-depth re-patch here**: start-execute.md / start-publish.md は中間 sub-skill のため `phase5_post_execute` / `phase5_post_publish` への遷移を defense-in-depth で保証する必要があるが、start-finalize.md は terminal sub-skill で `completed` は既に書込済。再度 `completed` を patch する idempotent 操作は意味がなく、`phase5_post_finalize` 等の間接 phase は design doc SPEC-TECH-DECISIONS #3 で否定された (`[start:finalize:completed]` IS the terminal sentinel)。**Abort path のみ** Workflow Termination 未実行のため、abort 経路では本 section 直前に terminal `completed, active=false` を direct patch する (下記 bash block)。
-
-**Abort path terminal write** (only when abort path: Phase 5.5 user selects 「More fixes」or `[ready:error]` AskUserQuestion → 「terminate」):
-
-```bash
-# abort path のみ実行 — success path は Workflow Termination が既に terminal を書き込み済み
-# `phase5_finalize_running → completed` direct edge を whitelist が許可している (phase-transition-whitelist.sh)
-if [ "${FINALIZE_ABORT:-0}" = "1" ]; then
-  bash {plugin_root}/hooks/flow-state-update.sh patch \
-    --phase "completed" \
-    --next "none" --active false
-  rm -f .rite-compact-state 2>/dev/null || true
-  rm -rf .rite-compact-state.lockdir 2>/dev/null || true
-fi
-```
+> **Why no defense-in-depth re-patch here**: start-execute.md / start-publish.md は中間 sub-skill のため `phase5_post_execute` / `phase5_post_publish` への遷移を defense-in-depth で保証する必要があるが、start-finalize.md は terminal sub-skill で success path では `completed` 書込済 / abort path では caller の idempotent patch が SoT。`phase5_post_finalize` 等の間接 phase は design doc SPEC-TECH-DECISIONS #3 で否定された (`[start:finalize:completed]` IS the terminal sentinel)。
 
 After the flow-state update, output the result pattern. Caller-continuation reminder を **immediately before** result pattern に emit。Return block は **4 line** 構成: (1) `[CONTEXT] FINALIZE_DONE=1` grep marker / (2) plain-text blockquote continuation reminder / (3) HTML-commented caller instructions / (4) HTML-commented result sentinel。全 4 行が sub-skill の **last visible lines**。
 
@@ -518,12 +526,12 @@ abort path (Phase 5.5 `[ready:error]` user-terminate or "More fixes" selection) 
 <!-- [start:finalize:aborted] -->
 ```
 
-> **Plain-text form rationale**: 短く user-friendly な Markdown blockquote (`> ⏭ MUST continue (turn を閉じない):`) にすることで (a) rendered Markdown で視覚的に「停止禁止・継続必須」の文脈が明確、(b) HTML コメント (LLM 向け詳細) との責任分担が明確。詳細な caller 向け instruction は HTML コメント側に残し、plain-text 行は user 向けの短い imperative status indicator として機能する。user-visible な最終コンテンツは `⏭ MUST continue` blockquote となり、sentinel token は HTML コメント化されレンダリング時に不可視。
+> **Plain-text form rationale**: 短く user-friendly な Markdown blockquote (`> ⏭ MUST continue (turn を閉じない):`) にすることで (a) rendered Markdown で視覚的に「停止禁止・継続必須」の文脈が明確、(b) HTML コメント (LLM 向け詳細) との責任分担が明確。詳細な caller 向け instruction は HTML コメント側に残し、plain-text 行は user 向けの短い imperative status indicator として機能する。user-visible な最終コンテンツは `⏭ MUST continue` blockquote となり、sentinel token は HTML コメント化されレンダリング時に不可視。`継続中` (現状報告) ではなく `MUST continue` (命令形) を採用するのは、reminder 文言が現状報告的に解釈されると LLM の turn-boundary heuristic implicit stop を防げない事象への対策。
 
 Result pattern (grep-matchable string inside HTML comment):
 
 - **Finalize completed (success)**: `<!-- [start:finalize:completed] -->` (matches `grep -F '[start:finalize:completed]'`) — emitted when Phase 5.5/5.5.1/5.5.2/5.6/5.7/Workflow Termination all complete successfully. This is the **workflow terminal sentinel**: caller does no further phase work.
-- **Finalize aborted**: `<!-- [start:finalize:aborted] -->` (matches `grep -F '[start:finalize:aborted]'`) — emitted when Phase 5.5 user selects 「More fixes」(continue iterating, skip Ready) or `[ready:error]` AskUserQuestion → 「terminate」. Workflow Termination Step 1 (terminal `completed` write) is still executed by the sub-skill so the workflow does not remain in a half-finalized state.
+- **Finalize aborted**: `<!-- [start:finalize:aborted] -->` (matches `grep -F '[start:finalize:aborted]'`) — emitted when Phase 5.5 user selects 「More fixes」(continue iterating, skip Ready) or `[ready:error]` AskUserQuestion → 「terminate」 / 「Phase 5.6 へスキップ」. Workflow Termination は実行されず、terminal state への遷移は caller (`start.md` Mandatory After 5.5-Termination Step 1) の idempotent patch (`--if-exists --preserve-error-count`) が SoT として担う。これにより半完了状態が残らない。
 
 Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.5-Termination) to determine the next action — but since this is the **workflow terminal sub-skill**, caller routing is limited to the post-state cleanup and completion handoff display.
 

--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -1,0 +1,551 @@
+---
+description: |
+  (Internal sub-skill — invoked by /rite:issue:start only. Do NOT invoke directly.)
+  Issue 完結フェーズの実行 sub-skill。
+  Phase 5.5 (Ready for Review) + 5.5.1 (Status In Review) + 5.5.2 (Metrics) + 5.6 (Completion Report) + 5.7 (Parent Issue Completion) + Workflow Termination を担当。
+---
+
+# /rite:issue:start-finalize
+
+Execute the finalize phase for an Issue. This sub-skill is invoked from `start.md` after Phase 5.3-5.4 (`rite:issue:start-publish`) has completed with `[start:publish:completed]` sentinel.
+
+**Prerequisites**: Phase 0-5.4 of `start.md` and `start-publish` sub-skill have completed. The following information is available in conversation context:
+- `{issue_number}` — target Issue number
+- `{branch_name}` — created/checked-out branch
+- `{pr_number}` — populated from Phase 5.3 `[pr:created:{N}]`
+- `{plugin_root}` — resolved per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version)
+- `{owner}`, `{repo}` — from `gh repo view`
+- `{parent_issue_number}` — from flow-state via `state-read.sh` (Phase 5.7)
+- Review-fix loop converged (mergeable / replied-only)
+
+---
+
+## 🚨 MANDATORY Pre-flight: Flow State Update (MUST execute FIRST)
+
+> 本 Pre-flight は sub-skill の **先頭** で実行し finalize scope に関係なく flow-state write を保証する。Return Output Format 到達前に LLM stop / context truncation / interrupt が発生した場合でも、`phase5_finalize_running` phase + sub-skill 由来の `next_action` が必ず記録されるよう (caller の delegation pre-write を上書きせず timestamp / `next_action` を refresh)、sub-skill 先頭で Pre-flight write を保証する。terminal `completed, active=false` への遷移は本 sub-skill 末尾の Workflow Termination section が担う。
+
+**MUST run before any finalize logic** (Phase 5.5 ready / 5.5.1 status / 5.5.2 metrics / 5.6 completion / 5.7 parent close / Workflow Termination / return-output emission)。**not optional**:
+
+```bash
+# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
+# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。state-path-resolve.sh
+# + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
+state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
+state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
+if [ -n "$state_file" ] && [ -f "$state_file" ]; then
+  if ! bash {plugin_root}/hooks/flow-state-update.sh patch \
+      --phase "phase5_finalize_running" \
+      --active true \
+      --next "rite:issue:start-finalize Pre-flight completed. Proceed to Phase 5.5 (Ready for Review) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination, then return to caller. Do NOT stop." \
+      --preserve-error-count; then
+    echo "[CONTEXT] PREFLIGHT_PATCH_FAILED=1" >&2
+    # 非 blocking: start.md delegation pre-write が safety net。
+  fi
+else
+  if ! bash {plugin_root}/hooks/flow-state-update.sh create \
+      --phase "phase5_finalize_running" --issue {issue_number} --branch "{branch_name}" --pr {pr_number} \
+      --next "rite:issue:start-finalize Pre-flight completed. Proceed to Phase 5.5 (Ready for Review) → 5.5.1 → 5.5.2 → 5.6 → 5.7 → Workflow Termination, then return to caller. Do NOT stop." \
+      --preserve-error-count; then
+    echo "[CONTEXT] PREFLIGHT_CREATE_FAILED=1" >&2
+  fi
+fi
+```
+
+**Why `phase5_finalize_running`**: caller (`start.md` Phase 5.5-Termination Delegation Pre-write) は既に `phase5_finalize_running` を書込済 (delegation in flight signal)。本 Pre-flight は patch mode で timestamp / `next_action` を refresh し、re-entry / interrupt 時にも sub-skill scope を識別できるようにする。`phase-transition-whitelist.sh` が `phase5_finalize_running → phase5_ready` (forward) / `phase5_finalize_running → completed` (terminal abort direct) を whitelist 化する。success path は `phase5_finalize_running → phase5_ready → ... → phase5_completion → phase5_parent_completion → phase5_post_parent_completion → completed` の間接経路を辿り、direct edge `phase5_finalize_running → completed` は abort path の direct terminal write 用。`[start:finalize:completed]` IS the workflow terminal sentinel (design doc SPEC-TECH-DECISIONS #3)、別 `phase5_post_finalize` 間接層は意図的に作らない。
+
+**Idempotence**: 単一 sub-skill invocation 内で複数回実行されても safe — patch mode は pre-update `.phase` から `previous_phase` を設定し、re-entry で `phase5_finalize_running` のまま phase regression しない。
+
+---
+
+## Phase 5.5: Ready for Review
+
+> **⚠️ MANDATORY**: The following `AskUserQuestion` confirmation MUST be executed. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review.
+
+When loop completes, confirm via `AskUserQuestion`:
+
+```
+レビューが完了しました（一気通貫フロー）
+総合評価: {assessment}
+指摘件数: {total_findings}
+オプション: Ready for review に変更（推奨）/ ドラフトのまま完了 / 追加の修正を行う
+```
+
+> **Data Handoff**: When invoking `rite:pr:ready`, PR number is passed as an argument. Issue information from Phase 0.1 is available in work memory (loaded by `rite:pr:ready` Phase 0), avoiding redundant `gh issue view` calls.
+
+**Ready**→invoke `rite:pr:ready`→5.5.1. **Draft**→5.6 (no Ready, but completion report still required). **More fixes**→emit `[start:finalize:aborted]` and return to caller (user explicitly chose to continue iterating).
+
+On user selecting "Ready for review", invoke `skill: "rite:pr:ready", args: "{pr_number}"`.
+
+**Immediate after ready returns**: When `rite:pr:ready` outputs `[ready:completed]` and returns control, do **NOT** churn or pause — **immediately** proceed to 5.5.0.1 Mandatory After 5.5 below. The ready sub-skill has already updated flow state to `phase5_post_ready` via Phase 4.6 (defense-in-depth, fixes #17); execute the 5.5.0.1 steps without delay. The completion report (Phase 5.6) has NOT been output yet — `ready.md` intentionally skips it in e2e flow. You MUST continue to Phase 5.5.1, 5.5.2, and 5.6.
+
+**Results**: `[ready:completed]`→5.5.0.1→5.5.1→5.5.2→5.6. `[ready:error]`→**emit sentinel and ask user** (#366).
+
+> **Emit canonical literal**: See [§D — Phase 5.5 `[ready:error]`](./references/workflow-incident-emit-pattern.md#d--phase-55-readyerror) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで手動 Ready 化」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number {pr_number}` semantics. The response-text-inclusion requirement that caller Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
+
+**On `[ready:error]` — routing**: After emitting §D canonical literal, present `AskUserQuestion` (3 options: `再試行` / `Edit ツールで手動 Ready 化 (incident 記録)` / `terminate`):
+- **「再試行」**: re-invoke `rite:pr:ready` (loop within Phase 5.5).
+- **「Edit ツールで手動 Ready 化 (incident 記録)」**: emit §D Step 2 (`manual_fallback_adopted`), then proceed to 5.5.0.1 (treat as `[ready:completed]`).
+- **「terminate」**: emit `[start:finalize:aborted]` abort return block and return to caller. Workflow Termination is skipped — caller's Mandatory After patches terminal state.
+
+### 5.5.0.1 🚨 Mandatory After 5.5
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Verify**: `[ready:completed]` pattern confirmed. `rite:pr:ready` returned successfully. Status update, metrics recording, and completion report are still pending — these are the **primary deliverables** of the e2e flow that the user expects to see.
+
+**Step 1**: Update flow state to post-ready phase (atomic). This write transitions from `phase5_post_review`/`phase5_post_fix` to `phase5_post_ready`, ensuring stop-guard routes to Status update rather than re-invoking ready (fixes #781):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_ready" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Phase 5.5.1: Update Issue Status to In Review, then Phase 5.5.2 metrics, then Phase 5.6 completion report. Do NOT stop."
+```
+
+**Step 2**: Sync to local work memory:
+
+```bash
+WM_SOURCE="ready" \
+  WM_PHASE="phase5_post_ready" \
+  WM_PHASE_DETAIL="Ready処理後" \
+  WM_NEXT_ACTION="Issue Status を In Review に更新後、メトリクス記録、完了レポートを実行" \
+  WM_BODY_TEXT="Post-ready sync." \
+  WM_ISSUE_NUMBER="{issue_number}" \
+  WM_READ_FROM_FLOW_STATE="true" \
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+```
+
+**Step 3**: 本 sub-skill は Workflow Incident Detection 自体を実行しない (caller `start.md` Mandatory After 5.5-Termination に委譲)。sub-skill 内部で emit された `[CONTEXT] WORKFLOW_INCIDENT=1` sentinel (`[ready:error]` 経路の §D canonical bash literal、または `ready.md` sub-skill の Sentinel Visibility Rule 経由) は会話コンテキストに残り、caller の Phase 5.4.4.1 が grep 検出・処理する責務を負う。
+
+**Step 4**: **→ Proceed to 5.5.1 now**.
+
+## Phase 5.5.1: Update Issue Status to "In Review"
+
+**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_ready`.
+
+```bash
+if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
+  :
+else
+  rc=$?
+  echo "ERROR: state-read.sh failed (rc=$rc) for --field phase in Phase 5.5.1 pre-condition" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_1_pre_condition; rc=$rc" >&2
+  exit 1
+fi
+if [ "$curr" != "phase5_post_ready" ]; then
+  echo "ERROR: Phase 5.5.1 pre-condition failed. .phase=$curr (expected: phase5_post_ready)" >&2
+  echo "ACTION: Return to Phase 5.5 (Ready for Review) and execute its Pre-write + rite:pr:ready invocation + Mandatory After 5.5 before entering Phase 5.5.1." >&2
+  echo "⚠️ LLM MUST NOT proceed to Phase 5.5.1 Pre-write below. Re-invoke Phase 5.5 first." >&2
+  exit 1
+fi
+```
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_status_in_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.5.1 (Issue Status → In Review). Skipping to Phase 5.5.2/5.6 without running the Status update is PROHIBITED. Do NOT stop."
+```
+
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-2--phase-551-issue-status--in-review) — Callsite 2 (Phase 5.5.1) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "In Review", `auto_add: false` since Phase 2.4 already auto-added if missing). Defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow. API レベル動作は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
+
+### 🚨 Mandatory After 5.5.1
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Step 1**: Update flow state to post-status-in-review phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_status_in_review" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Phase 5.5.1 completed (Issue Status → In Review). Proceed to Phase 5.5.2 (Metrics Recording). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 5.5.2 now**.
+
+## Phase 5.5.2: Metrics Recording
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_metrics" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.5.2 (Metrics Recording). Skipping to Phase 5.6 without running metrics is PROHIBITED. Do NOT stop."
+```
+
+> **Reference**: [Execution Metrics](../../references/execution-metrics.md). **Module**: [Metrics Recording](./references/metrics-recording.md) — Phase 5.5.2 全体 (Step 1-5 + `implementation_round` inline metrics capture + METRICS_SKIPPED 経路 + heredoc PATCH 本体) の SoT。
+
+**Skip Steps note** (referenced by Phase 5.6 pre-condition): When `metrics.enabled: false` in rite-config.yml, skip Steps 1-5 (per Module) **but unconditionally execute Mandatory After 5.5.2**. The `phase5_post_metrics` marker is required for Phase 5.6 pre-condition to pass. Skipping the Mandatory After would leave `.phase = phase5_post_status_in_review` and trip the Phase 5.6 ERROR gate.
+
+Otherwise: execute the Module procedure (Step 1 collect → Step 2 thresholds → Step 3 failure classification → Step 4 PATCH → Step 5 repeated failure check). On `[CONTEXT] METRICS_SKIPPED=1` sentinel emission (state-read.sh failure), skip Steps 2-4 but still execute Mandatory After 5.5.2 unconditionally (per Module's "Claude への指示" section).
+
+### 🚨 Mandatory After 5.5.2
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Step 1**: Update flow state to post-metrics phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_metrics" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Phase 5.5.2 completed (metrics recorded). Proceed to Phase 5.6 (Completion Report). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to Phase 5.6 now**.
+
+## Phase 5.6: Completion Report
+
+**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_metrics`. When `metrics.enabled: false`, Phase 5.5.2 must still write the `phase5_post_metrics` marker via its Mandatory After block (body skip allowed; marker required).
+
+```bash
+if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
+  :
+else
+  rc=$?
+  echo "ERROR: state-read.sh failed (rc=$rc) for --field phase in Phase 5.6 pre-condition" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_6_pre_condition; rc=$rc" >&2
+  exit 1
+fi
+if [ "$curr" != "phase5_post_metrics" ] && [ "$curr" != "phase5_finalize_running" ]; then
+  echo "ERROR: Phase 5.6 pre-condition failed. .phase=$curr (expected: phase5_post_metrics or phase5_finalize_running for abort path)" >&2
+  echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
+  echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
+  exit 1
+fi
+# Note: phase5_finalize_running は abort path (Draft 化 or [ready:error] terminate 経路で
+# Phase 5.5.1/5.5.2 を skip して直接 Phase 5.6 へ進むケース) を accept する。
+# success path は phase5_post_metrics 経由が正規路。
+```
+
+**Pre-write**:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_completion" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.6 (Completion Report). Determine parent_issue_number routing in Phase 5.7. If parent_issue_number is non-zero, proceed to Phase 5.7; otherwise jump directly to the Workflow Termination block (bypass 5.7). Do NOT stop."
+```
+
+> See [completion-report.md](./completion-report.md) for the full procedure (template read, placeholder substitution, output cases, self-verification, and inline fallbacks).
+
+### 5.6.1 Workflow Incident Reporting (#366)
+
+> **Output ordering** (must match `completion-report.md` Step 3.5): Phase 5.6.1 is appended **after Phase 5.6.2 (Wiki Ingest Status Reporting)**, not directly after the standard completion report sections. The runtime sequence is: standard completion sections → Phase 5.6.2 (Wiki ingest 状況) → Phase 5.6.1 (workflow incidents). The section numbers (5.6.1 / 5.6.2) reflect introduction order (#366 first, #524 second) and are intentionally NOT in execution order — see Phase 5.6.2 ordering note for the canonical execution order.
+
+After Phase 5.6.2 (Wiki Ingest Status Reporting) is appended, append a "未処理 incident" section listing any workflow incidents that were skipped (user chose "skip" in Phase 5.4.4.1) or whose Issue creation failed (`create-issue-with-projects.sh` returned empty).
+
+**Source**: The context-local `workflow_incident_skipped` list maintained by caller's Phase 5.4.4.1. Each entry is `{type, details, root_cause_hint, iteration_id}`.
+
+**Output format** (only when the list is non-empty):
+
+```markdown
+### ⚠️ 未処理の workflow incident
+
+| # | Type | Details | Root cause hint | iteration_id |
+|---|------|---------|-----------------|--------------|
+| 1 | {type} | {details} | {root_cause_hint or "(none)"} | {iteration_id} |
+
+> これらの incident は workflow 実行中に検出されましたが、Issue として登録されませんでした (user skipped or registration failed)。手動で `/rite:issue:create` で記録することを推奨します。
+```
+
+**When the list is empty**: Skip this section entirely (do not display "no incidents" placeholder — minimize output).
+
+**Also report registered incidents** when `workflow_incident_registered` list is non-empty (auto-registered Issues from Phase 5.4.4.1 step 6):
+
+```markdown
+### ✅ 自動登録された workflow incident
+
+| # | Issue | Type | Details |
+|---|-------|------|---------|
+| 1 | #{new_issue_number} | {type} | {details} |
+```
+
+### 5.6.2 Wiki Ingest Status Reporting (#524)
+
+> **Source of truth**: `[CONTEXT] WIKI_INGEST_DONE=1` / `WIKI_INGEST_SKIPPED=1; reason=...` / `WIKI_INGEST_FAILED=1; reason=...` / `WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` lines emitted by `pr/review.md` Phase 6.5.W.2, `pr/fix.md` Phase 4.6.W.2, and `issue/close.md` Phase 4.4.W.2 throughout this `/rite:issue:start` invocation. These lines flow into the conversation context the same way caller's Phase 5.4.4.1 sentinels do.
+
+> **Output ordering** (must match `completion-report.md` Step 3.5): This section is appended **immediately after the case-specific sections (項目テーブル + フェーズ進捗 + 次のステップ)** of the completion report, **before** the workflow incident sections (5.6.1). Both 5.6.2 and 5.6.1 then together form the trailing report sections.
+
+Append a "Wiki ingest 状況" section so the user can confirm at a glance whether the Experience Wiki growth path actually executed during this Issue. This addresses Issue #524 AC-5 — the regression where Phase X.X.W was silently skipped and the user had no visibility into the missing growth.
+
+**Step 1 — Aggregate signals from conversation context**:
+
+Scan the recent conversation context for these patterns (the same context the caller's Phase 5.4.4.1 grep operates on):
+
+| Pattern | Counter |
+|---------|---------|
+| `[CONTEXT] WIKI_INGEST_DONE=1; ...` | `done_count` |
+| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=disabled` | `skipped_disabled_count` |
+| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=auto_ingest_off` | `skipped_auto_off_count` |
+| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=commit_branch_missing` | `skipped_commit_branch_missing_count` |
+| `[CONTEXT] WIKI_INGEST_FAILED=1; reason=commit_rc_*` or `reason=trigger_exit_*` | `failed_count` (all `commit_rc_*` values fold into `failed_count` except `commit_rc_4` which is segregated into `push_failed_count`) |
+| `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` | `push_failed_count` |
+
+Also retrieve the current wiki branch state (best-effort — never block on this):
+
+```bash
+wiki_branch=$(awk '/^wiki:/{h=1;next} h && /^[[:space:]]+branch_name:/{print;exit}' rite-config.yml 2>/dev/null \
+  | sed 's/[[:space:]]#.*//' | sed 's/.*branch_name:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+[ -z "$wiki_branch" ] && wiki_branch="wiki"
+last_wiki_commit=""
+if git rev-parse --verify "$wiki_branch" >/dev/null 2>&1; then
+  last_wiki_commit=$(git log -1 --format='%aI' "$wiki_branch" 2>/dev/null)
+elif git rev-parse --verify "origin/$wiki_branch" >/dev/null 2>&1; then
+  last_wiki_commit=$(git log -1 --format='%aI' "origin/$wiki_branch" 2>/dev/null)
+fi
+echo "[CONTEXT] WIKI_LAST_COMMIT=${last_wiki_commit:-}"
+```
+
+**Step 2 — Output format** (always render, even when all counters are 0 — the absence is itself a signal worth reporting per AC-5):
+
+```markdown
+### 📚 Wiki ingest 状況
+
+| シグナル | 件数 |
+|----------|------|
+| ✅ DONE (trigger + ingest 完了) | {done_count} |
+| ⚠️ SKIPPED (disabled) | {skipped_disabled_count} |
+| ⚠️ SKIPPED (auto_ingest_off) | {skipped_auto_off_count} |
+| ⚠️ SKIPPED (commit_branch_missing) | {skipped_commit_branch_missing_count} |
+| ❌ FAILED (trigger / commit エラー) | {failed_count} |
+| ❌ PUSH_FAILED (commit は成功、push が失敗) | {push_failed_count} |
+
+- **wiki branch 最終 commit**: {last_wiki_commit or "(wiki branch 未作成)"}
+```
+
+**Step 3 — Conditional warnings** (append below the table only when applicable):
+
+| Condition | Warning to append |
+|-----------|------------------|
+| All counters == 0 | `> ⚠️ Phase X.X.W が一度も実行されていません。silent skip の可能性があります。/rite:wiki:ingest を手動実行するか、caller の Phase 5.4.4.1 の sentinel を確認してください。` |
+| `failed_count >= 1` | `> ❌ Wiki ingest trigger が {failed_count} 回失敗しました。caller の Phase 5.4.4.1 で workflow incident として登録されているか確認してください。` |
+| `push_failed_count >= 1` | `> ❌ wiki-ingest-commit.sh が commit 成功後の push に {push_failed_count} 回失敗しました。local wiki branch に commit は保持されています。手動 recovery: \`git push origin wiki\` を実行してください。` |
+| `skipped_disabled_count >= 1` | `> ℹ️ wiki.enabled=false により Wiki 機能全体が無効化されています。意図的でない場合は rite-config.yml を確認してください。` |
+| `skipped_auto_off_count >= 1` | `> ℹ️ wiki.auto_ingest が無効化されています。意図的でない場合は rite-config.yml を確認してください。` |
+| `skipped_commit_branch_missing_count >= 1` | `> ℹ️ wiki-ingest-commit.sh が wiki ブランチ未作成により skip されました。/rite:wiki:init を実行するか、git fetch origin wiki を実行してください。` |
+| `done_count >= 1` AND no failures | `> ✅ Wiki branch が成長しました（{done_count} cycle 分の raw source が ingest されました）。` |
+
+> **Skip condition**: This section is **NEVER** skipped. AC-5 requires it to always be present in the completion report so the user has a definitive answer about whether the Wiki grew during this Issue.
+
+## Phase 5.7: Parent Issue Completion
+
+**Condition**: `parent_issue_number` is non-zero in flow-state. Read deterministically via `state-read.sh` so per-session state is consulted instead of the legacy state file snapshot:
+
+```bash
+# `if ! var=$(cmd); then rc=$?` は bash 仕様上 `$?` が常に 0 になるため、capture と exit code を
+# 両方取る場合は if/else 形式にする (capture-less `if ! cmd; then ...` は対象外)。
+if parent_issue_number=$(bash {plugin_root}/hooks/state-read.sh --field parent_issue_number --default 0); then
+  :
+else
+  rc=$?
+  echo "ERROR: state-read.sh failed (rc=$rc) for --field parent_issue_number in Phase 5.7" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_7_parent_issue; rc=$rc" >&2
+  exit 1
+fi
+# state-read.sh は jq の `// $default` で null/false → default 置換するが値の型は validate しない。
+# 攻撃者が `.rite/sessions/*.flow-state` を書き換えて parent_issue_number に non-numeric
+# (例: "true" / "../etc") を注入した場合、後続の `gh` 呼び出しに literal が流入する経路がある。
+# numeric pattern check で fail-safe に default 0 (parent なし扱い) に降格する。
+case "$parent_issue_number" in
+  ''|*[!0-9]*)
+    echo "WARNING: parent_issue_number is not numeric ('$parent_issue_number'), defaulting to 0 (no parent)" >&2
+    parent_issue_number=0
+    ;;
+esac
+if [ "$parent_issue_number" -eq 0 ] 2>/dev/null; then
+  echo "[CONTEXT] PARENT_ISSUE=none — skip Phase 5.7, proceed to Workflow Termination"
+else
+  echo "[CONTEXT] PARENT_ISSUE=$parent_issue_number — execute Phase 5.7"
+fi
+```
+
+Execute after 5.6. When `PARENT_ISSUE=none`, skip directly to Workflow Termination block.
+
+**Pre-write** (only when a parent was identified — otherwise skip directly to terminate):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_parent_completion" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "Execute Phase 5.7 (Parent Issue Completion). Ending the workflow without processing the parent is PROHIBITED when a parent was identified. Do NOT stop."
+```
+
+### 5.7.1 Child Check
+
+Use [Basic Query](../../references/epic-detection.md#basic-query). All `CLOSED`→5.7.2. Some `OPEN`→5.7.3.
+
+### 5.7.2 Auto-Close
+
+Confirm via `AskUserQuestion`. If "No", display message and proceed to 5.7.3 (no auto-close). If yes, update Projects Status to "Done" and then close the Issue.
+
+**Step 1**: Update parent Issue Status to "Done".
+
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-3--phase-572-parent-issue-status--done) — Callsite 3 (Phase 5.7.2) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "Done" for `{parent_issue_number}`, `auto_add: false` for parent Issue). On `skipped_not_in_project` / `failed` result, display `.warnings[]` and proceed to Step 2 (non-blocking).
+
+**Step 2**: Close the parent Issue via `/rite:issue:close` Skill invocation.
+
+> **Why Skill invoke (not `gh issue close`)**: `close.md` Phase 4.4.W.2 で Wiki raw source の蓄積（`wiki-ingest-commit.sh`）が発火する。直接 `gh issue close` を実行すると close.md を経由しないため、Wiki 経路が 100% silent skip になる。
+
+**Pre-write** (before invoking `rite:issue:close`):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_parent_close" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "After rite:issue:close returns: proceed to Mandatory After 5.7.2, then 5.7.3 (Next Child). Do NOT stop."
+```
+
+Invoke `skill: "rite:issue:close", args: "{parent_issue_number}"`.
+
+> **Note**: `close.md` receives `{parent_issue_number}` as its `{issue_number}` argument. Phase 4.1 executes `gh issue close`, Phase 4.4.W triggers Wiki ingest. The close.md `AskUserQuestion` (Phase 3) will present options to the user — since the user already confirmed "Close parent Issue" in Phase 5.7.2's own `AskUserQuestion`, they should select the manual close option when prompted by close.md.
+
+> **Note**: `close.md` does NOT output a machine-readable result pattern (unlike `[review:mergeable]` etc.). When it returns control, immediately proceed to Mandatory After 5.7.2.
+
+### 🚨 Mandatory After 5.7.2
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Step 1**: Update flow state to post-parent-close phase:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_post_parent_close" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "rite:issue:close completed. Proceed to 5.7.3 (Next Child display). Do NOT stop."
+```
+
+**Step 2**: **→ Proceed to 5.7.3** (display remaining children if any).
+
+### 5.7.3 Next Child
+
+Display remaining children, guide `/rite:issue:start`. No auto-start.
+
+### 🚨 Mandatory After 5.7
+
+> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
+> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
+
+**Step 1**: Update flow state to post-parent-completion phase. Use **patch mode** — patch preserves `previous_phase` automatically from the outgoing `.phase` field, whereas `create` mode would overwrite the entire state and risk tripping the session-ownership check:
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "phase5_post_parent_completion" --active true \
+  --next "Phase 5.7 completed. Proceed to Workflow Termination block. Do NOT stop."
+```
+
+**Step 2**: Proceed to the "Workflow Termination" block below.
+
+## Workflow Termination
+
+> **Placement**: This block runs **after** Phase 5.7 completes **or after Phase 5.6** when no parent Issue was identified (the Phase 5.7 skip branch). Both paths converge here so the terminal `phase="completed", active: false` state is set exactly once, with `previous_phase` pointing at a whitelist-valid source (`phase5_post_parent_completion` or `phase5_completion`).
+
+**Parent-skip routing**: When `parent_issue_number` is `0` in flow-state (determined in Phase 5.7 via `state-read.sh`), Phase 5.7 is skipped entirely. In that case, jump from the end of Phase 5.6 directly to this block (bypassing 5.7.1-5.7.3 and Mandatory After 5.7) — do **not** leave the workflow in `phase5_completion, active: true`, which would cause the next stop attempt to block indefinitely.
+
+> **Why this routing relies on Phase 5.7 emit, not state re-read**: Phase 5.7 が `parent_issue_number` の **single source of truth for the read** であり、本 Workflow Termination block は state を re-read しない。本 sub-skill 内の branching decision は Phase 5.7 の `[CONTEXT] PARENT_ISSUE=none` echo (LLM-level routing signal、会話履歴で観測可能) で駆動され、bash 変数経由ではない (Bash tool invocation は shell state を境界を跨いで共有しない)。
+
+**Step 1**: Update flow state to the terminal state (patch mode, preserves `previous_phase`):
+
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh patch \
+  --phase "completed" \
+  --next "none" --active false
+```
+
+**Step 2**: Clean up `.rite-compact-state` to prevent stale blocked state from affecting the next session (#756):
+
+```bash
+rm -f .rite-compact-state 2>/dev/null || true
+rm -rf .rite-compact-state.lockdir 2>/dev/null || true
+```
+
+**Note**: This cleanup is non-blocking. Failure to delete is silently ignored.
+
+---
+
+## Return Output Format (Before Return)
+
+> **Reference**: `start-execute.md` / `start-publish.md` Return Output Format と異なり、本 sub-skill は **workflow terminal**。flow-state の terminal write (`phase="completed", active=false`) は Workflow Termination section が既に実行済みのため、Return Output Format では state file への re-patch は **不要**。sentinel 出力のみで caller に handoff する。abort path では Workflow Termination をスキップして本 sub-skill 内で直接 `completed, active=false` を patch する (下記 abort 経路で実行)。
+
+> **Why no defense-in-depth re-patch here**: start-execute.md / start-publish.md は中間 sub-skill のため `phase5_post_execute` / `phase5_post_publish` への遷移を defense-in-depth で保証する必要があるが、start-finalize.md は terminal sub-skill で `completed` は既に書込済。再度 `completed` を patch する idempotent 操作は意味がなく、`phase5_post_finalize` 等の間接 phase は design doc SPEC-TECH-DECISIONS #3 で否定された (`[start:finalize:completed]` IS the terminal sentinel)。**Abort path のみ** Workflow Termination 未実行のため、abort 経路では本 section 直前に terminal `completed, active=false` を direct patch する (下記 bash block)。
+
+**Abort path terminal write** (only when abort path: Phase 5.5 user selects 「More fixes」or `[ready:error]` AskUserQuestion → 「terminate」):
+
+```bash
+# abort path のみ実行 — success path は Workflow Termination が既に terminal を書き込み済み
+# `phase5_finalize_running → completed` direct edge を whitelist が許可している (phase-transition-whitelist.sh)
+if [ "${FINALIZE_ABORT:-0}" = "1" ]; then
+  bash {plugin_root}/hooks/flow-state-update.sh patch \
+    --phase "completed" \
+    --next "none" --active false
+  rm -f .rite-compact-state 2>/dev/null || true
+  rm -rf .rite-compact-state.lockdir 2>/dev/null || true
+fi
+```
+
+After the flow-state update, output the result pattern. Caller-continuation reminder を **immediately before** result pattern に emit。Return block は **4 line** 構成: (1) `[CONTEXT] FINALIZE_DONE=1` grep marker / (2) plain-text blockquote continuation reminder / (3) HTML-commented caller instructions / (4) HTML-commented result sentinel。全 4 行が sub-skill の **last visible lines**。
+
+> **Return block design rationale**:
+> - caller continuation hint を plain-text line + HTML comment の **dual form** で emit
+> - result pattern を HTML comment 化 (`<!-- [start:finalize:completed] -->` / `<!-- [start:finalize:aborted] -->`) — sentinel は grep-matchable (`grep -F '[start:finalize:'`) のまま AC 保持し、user-visible terminal token としての sentinel 出力を抑止して LLM turn-boundary heuristic 起因の `continue` 要求 stop を防ぐ
+> - `[CONTEXT] FINALIZE_DONE=1` marker を return block の **FIRST line** に追加（not last）— orchestrator が consume する grep signal、HTML strip rendering でも検出可能な plain-text 形式
+
+**Output format example (success — `[start:finalize:completed]`)**:
+
+```
+[CONTEXT] FINALIZE_DONE=1; next=workflow_terminal
+> ⏭ MUST continue (turn を閉じない): caller Mandatory After 5.5-Termination → workflow terminal — finalize 完了 完了レポート出力済みのため caller 側は終端 cleanup のみ。
+<!-- caller: workflow terminal state ("completed", active=false) is ALREADY set by Workflow Termination section. As your VERY FIRST tool call BEFORE any text output, narrative, or response generation, idempotently confirm via `bash plugins/rite/hooks/flow-state-update.sh patch --phase completed --active false --next none --if-exists --preserve-error-count` (idempotent; no-op if already terminal). IMMEDIATELY AFTER bash success, output the final completion handoff message to the user in the SAME response turn. DO NOT end the turn before the user-visible completion message is displayed. No further phase work remains. -->
+<!-- [start:finalize:completed] -->
+```
+
+**Output format example (abort — `[start:finalize:aborted]`)**:
+
+abort path (Phase 5.5 `[ready:error]` user-terminate or "More fixes" selection) では `next=workflow_terminal_abort` marker に切替え、caller-instruction HTML comment 内の次フェーズ指示を terminal cleanup へ変更する:
+
+```
+[CONTEXT] FINALIZE_DONE=1; next=workflow_terminal_abort
+> ⏭ MUST continue (turn を閉じない): caller Mandatory After 5.5-Termination → workflow terminal — finalize aborted ([ready:error] user-terminate or "More fixes") Ready 化未完了 完了レポート省略。
+<!-- caller: workflow terminal state ("completed", active=false) was patched by sub-skill's Return Output Format abort-path block. As your VERY FIRST tool call BEFORE any text output, narrative, or response generation, idempotently confirm via `bash plugins/rite/hooks/flow-state-update.sh patch --phase completed --active false --next none --if-exists --preserve-error-count` (idempotent; no-op if already terminal). IMMEDIATELY AFTER bash success, output a short abort handoff message to the user explaining the aborted reason in the SAME response turn. DO NOT end the turn before the user-visible abort message is displayed. -->
+<!-- [start:finalize:aborted] -->
+```
+
+> **Plain-text form rationale**: 短く user-friendly な Markdown blockquote (`> ⏭ MUST continue (turn を閉じない):`) にすることで (a) rendered Markdown で視覚的に「停止禁止・継続必須」の文脈が明確、(b) HTML コメント (LLM 向け詳細) との責任分担が明確。詳細な caller 向け instruction は HTML コメント側に残し、plain-text 行は user 向けの短い imperative status indicator として機能する。user-visible な最終コンテンツは `⏭ MUST continue` blockquote となり、sentinel token は HTML コメント化されレンダリング時に不可視。
+
+Result pattern (grep-matchable string inside HTML comment):
+
+- **Finalize completed (success)**: `<!-- [start:finalize:completed] -->` (matches `grep -F '[start:finalize:completed]'`) — emitted when Phase 5.5/5.5.1/5.5.2/5.6/5.7/Workflow Termination all complete successfully. This is the **workflow terminal sentinel**: caller does no further phase work.
+- **Finalize aborted**: `<!-- [start:finalize:aborted] -->` (matches `grep -F '[start:finalize:aborted]'`) — emitted when Phase 5.5 user selects 「More fixes」(continue iterating, skip Ready) or `[ready:error]` AskUserQuestion → 「terminate」. Workflow Termination Step 1 (terminal `completed` write) is still executed by the sub-skill so the workflow does not remain in a half-finalized state.
+
+Both patterns are consumed by the orchestrator (`start.md` Mandatory After 5.5-Termination) to determine the next action — but since this is the **workflow terminal sub-skill**, caller routing is limited to the post-state cleanup and completion handoff display.
+
+---
+
+## 🚨 Caller Return Protocol
+
+Sub-skill 完了時、control は **MUST** caller (`start.md`) へ戻る。caller は **同 response turn で MUST immediately** 🚨 Mandatory After 5.5-Termination を実行し、user-visible completion handoff message を出力する。
+
+**WARNING (success path)**: Success path で本セクションで停止すると user は workflow 完了を認識できず「stalled」状態に見える。Workflow Termination が terminal state を書き込んでいても、user-facing handoff message が表示されないと UX が壊れる。
+
+**WARNING (abort path)**: Abort path で abort 理由を user に伝えないと、何が起きて workflow が中断したのか分からない。emitted sentinel に応じて caller は abort 理由を短く要約して user に表示する。
+
+**Output rules**:
+
+0. **FIRST**: `[CONTEXT] FINALIZE_DONE=1; next=workflow_terminal` (success) または `[CONTEXT] FINALIZE_DONE=1; next=workflow_terminal_abort` (abort) を **plain-text line** で出力（HTML-commented 不可）。位置規定:
+   - **0b (構造保証、canonical)**: Rules 0-1 の相対順序が **4-line return block** を pin する: Rule 0 (FIRST) → plain-text continuation reminder → HTML-commented caller instructions → Rule 1 (absolute LAST)
+   - **0a (絶対位置、0b から導出)**: 4-line block 構造より、本 marker は **4th-to-last visible line**（`<!-- [start:finalize:completed] -->` / `<!-- [start:finalize:aborted] -->` absolute-last sentinel の 3 行前）
+   - **0c (目的)**: grep marker for orchestrator (workflow terminal detection) and for Mandatory After 5.5-Termination bash block comment reference; LLM turn-boundary heuristic 対策の defense-in-depth
+1. Result pattern を HTML comment (`<!-- [start:finalize:completed] -->` または `<!-- [start:finalize:aborted] -->`) で **absolute last line** に出力 (sentinel は grep-matchable だが user-visible でない)
+2. Bare `[start:finalize:completed]` / `[start:finalize:aborted]` 形式（HTML comment wrap なし）は **禁止**（user-visible terminal token として regressed）
+3. Result pattern の **後ろに narrative text を出さない**（`→ Return to start.md` 等）— LLM の natural stopping point を生む
+4. Caller は HTML comment 内の grep-matchable 文字列 (`grep -F '[start:finalize:completed]'` / `grep -F '[start:finalize:aborted]'`) と plain-text `[CONTEXT] FINALIZE_DONE=1` marker を grep で読取り、workflow terminal handoff を実行
+
+> **Caller responsibility note**: 上記 Rules 0-3 は本 sub-skill (`start-finalize.md`) の出力に関する MUST/MUST NOT 制約。Rule 4 は subject = Caller の **Caller-side expectation** (本 sub-skill が caller に期待する後続動作の documentation)。本 sub-skill が emit する return block の構造健全性は必要条件であって十分条件ではなく、caller (`start.md`) 側の 🚨 Mandatory After 5.5-Termination が sub-skill return 直後の **VERY FIRST tool call** として bash literal を fire することが MUST。

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -62,13 +62,9 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 | 2.6 (Work Memory) | `rite:issue:work-memory-init` | 3 | **No** |
 | 3 (Plan) | `rite:issue:implementation-plan` | 4 | **No** |
 | 4 (Guidance) | — | 5 or terminate | Yes (user choice) |
-| 5.0-5.2.1 (Execute) | `rite:issue:start-execute` | 5.3-5.4 or 5.6 | **No** |
-| 5.3-5.4 (Publish) | `rite:issue:start-publish` | 5.5 or 5.6 | **No** |
-| 5.5 (Ready) | `rite:pr:ready` | 5.5.0.1→5.5.1 | **No** |
-| 5.5.1 (Status In Review) | — | 5.5.2 | **No** |
-| 5.5.2 (Metrics) | — | 5.6 | **No** |
-| 5.6 (Report) | — | 5.7 or Workflow Termination | Yes (only after completion handoff is displayed) |
-| 5.7 (Parent Completion) | — | Workflow Termination | Yes (only after completion handoff is displayed) |
+| 5.0-5.2.1 (Execute) | `rite:issue:start-execute` | 5.3-5.4 or 5.5-Termination | **No** |
+| 5.3-5.4 (Publish) | `rite:issue:start-publish` | 5.5-Termination | **No** |
+| 5.5-Termination (Finalize) | `rite:issue:start-finalize` | Workflow Termination | Yes (only after completion handoff is displayed) |
 
 ---
 
@@ -530,13 +526,11 @@ The e2e flow must minimize context consumption to complete within a single sessi
 
 ```
 5.0-5.2.1 rite:issue:start-execute (sub-skill: Stop Hook + 実装 + lint + checklist)
-  → [start:execute:completed]→5.3-5.4 / [start:execute:aborted]→5.6
+  → [start:execute:completed]→5.3-5.4 / [start:execute:aborted]→5.5-Termination
 5.3-5.4 rite:issue:start-publish (sub-skill: PR create + review-fix loop)
-  → [start:publish:completed]→5.5 / [start:publish:aborted]→5.6
-5.5 Ready for Review 確認 → rite:pr:ready → [ready:completed]→5.5.0.1→5.5.1 Status 更新 → 5.5.2
-5.5.2 メトリクス記録 → 5.6
-5.6 完了報告
-5.7 親 Issue 完了処理
+  → [start:publish:completed]→5.5-Termination / [start:publish:aborted]→5.5-Termination
+5.5-Termination rite:issue:start-finalize (sub-skill: ready + status + metrics + completion + parent close + termination)
+  → [start:finalize:completed] (workflow 終端) / [start:finalize:aborted] (User-terminate during finalize)
 ```
 
 ### Preflight Protocol
@@ -635,7 +629,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 ### 5.4.4.1 Workflow Incident Detection (Contract Summary)
 
-> **Reference**: This section documents the **本体 contract** for workflow incident detection. The detailed Step 1-7 processing flow lives in [Workflow Incident Detection](./references/workflow-incident-detection.md); emit pattern canonical bash literals live in [Workflow Incident Emit Pattern](./references/workflow-incident-emit-pattern.md); fingerprint cycling / Quality Signal 3 & 4 detail lives in [Fingerprint Cycling Detection](./references/fingerprint-cycling.md). The orchestrator (`/rite:issue:start`) invokes detection at three boundaries (Mandatory After 5.0-5.2.1 / 5.3-5.4 / 5.5 — see "When to execute" table below).
+> **Reference**: This section documents the **本体 contract** for workflow incident detection. The detailed Step 1-7 processing flow lives in [Workflow Incident Detection](./references/workflow-incident-detection.md); emit pattern canonical bash literals live in [Workflow Incident Emit Pattern](./references/workflow-incident-emit-pattern.md) (the response-text-inclusion requirement that grep detection below depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件)); fingerprint cycling / Quality Signal 3 & 4 detail lives in [Fingerprint Cycling Detection](./references/fingerprint-cycling.md). The orchestrator (`/rite:issue:start`) invokes detection at three boundaries (Mandatory After 5.0-5.2.1 / 5.3-5.4 / 5.5-Termination — see "When to execute" table below).
 
 **Detection scope** — recognised sentinel `type` values:
 
@@ -651,13 +645,13 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 
 **When to execute** (explicit routing):
 
-This phase runs **after every Skill invocation in Phase 5** at the following explicit invocation points. With PR F/G1 sub-skill extraction, the orchestrator's Skill boundaries are 3 — `start-execute` (5.0-5.2.1) / `start-publish` (5.3-5.4) / `pr:ready` (5.5). Internal `pr:create` / `pr:review` / `pr:fix` invocations happen inside `start-publish` and are detected by the same context-grep at the publish delegation boundary.
+This phase runs **after every Skill invocation in Phase 5** at the following explicit invocation points. With PR F/G1/G2 sub-skill extraction, the orchestrator's Skill boundaries are 3 — `start-execute` (5.0-5.2.1) / `start-publish` (5.3-5.4) / `start-finalize` (5.5-Termination). Internal `pr:create` / `pr:review` / `pr:fix` invocations happen inside `start-publish` and are detected by the same context-grep at the publish delegation boundary. Internal `pr:ready` / `issue:close` invocations happen inside `start-finalize` and are detected at the finalize delegation boundary.
 
 | Caller | Invocation point | Trigger |
 |--------|------------------|---------|
 | Phase 5.0-5.2.1 (execute) | Mandatory After 5.0-5.2.1 — Step 2 | Always after `[start:execute:*]` pattern |
 | Phase 5.3-5.4 (publish) | Mandatory After 5.3-5.4 — Step 2 | Always after `[start:publish:*]` pattern (covers internal `[pr:created:{N}]` / `[pr:create-failed]` / `[review:*]` / `[fix:*]` emits via context grep) |
-| Phase 5.5.0.1 (pr:ready) | Mandatory After 5.5 — Step 3 | Always after `[ready:*]` pattern |
+| Phase 5.5-Termination (finalize) | Mandatory After 5.5-Termination — Step 2 | Always after `[start:finalize:*]` pattern (covers internal `[ready:*]` emit via context grep) |
 
 Each Mandatory After section MUST include a **"Run Phase 5.4.4.1 detection"** step that directs the orchestrator to grep the recent conversation context for sentinel lines BEFORE proceeding to the next phase.
 
@@ -665,416 +659,45 @@ Each Mandatory After section MUST include a **"Run Phase 5.4.4.1 detection"** st
 
 **Invariants**: Issue creation failure is non-blocking (workflow MUST NOT halt). The codepath is independent of Phase 7 (Issue creation from review recommendations). Default-on behavior: when `workflow_incident:` section is absent from `rite-config.yml`, treat as `enabled: true`.
 
-### 5.5 Ready for Review
+### 5.5-Termination Finalize Phase (delegated to start-finalize sub-skill)
 
-> **⚠️ MANDATORY**: The following `AskUserQuestion` confirmation MUST be executed. Do NOT skip this step for context optimization or any other reason. The user must always confirm before changing the PR to Ready for review.
+**Pre-write** (before invoking `rite:issue:start-finalize`):
 
-When loop completes, confirm via `AskUserQuestion`:
-
-```
-レビューが完了しました（一気通貫フロー）
-総合評価: {assessment}
-指摘件数: {total_findings}
-オプション: Ready for review に変更（推奨）/ ドラフトのまま完了 / 追加の修正を行う
+```bash
+bash {plugin_root}/hooks/flow-state-update.sh create \
+  --phase "phase5_finalize_running" --issue {issue_number} --branch "{branch_name}" \
+  --pr {pr_number} \
+  --next "After rite:issue:start-finalize returns: workflow terminates (terminal state already written by sub-skill). Caller MUST output completion handoff message. Do NOT stop."
 ```
 
-> **Data Handoff**: When invoking `rite:pr:ready`, PR number is passed as an argument. Issue information from Phase 0.1 is available in work memory (loaded by `rite:pr:ready` Phase 0), avoiding redundant `gh issue view` calls.
+> **Module**: [Finalize Phase](./start-finalize.md) - Handles Phase 5.5 (Ready for Review via `rite:pr:ready`), 5.5.1 (Issue Status In Review), 5.5.2 (Metrics Recording), 5.6 (Completion Report incl. 5.6.1 Workflow Incident Reporting + 5.6.2 Wiki Ingest Status Reporting), 5.7 (Parent Issue Completion via `rite:issue:close`), Workflow Termination.
 
-**Ready**→invoke `rite:pr:ready`→5.5.1. **Draft**→5.6. **More fixes**→terminate.
+Invoke `skill: "rite:issue:start-finalize"`.
 
-**Immediate after ready returns**: When `rite:pr:ready` outputs `[ready:completed]` and returns control, do **NOT** churn or pause — **immediately** proceed to 5.5.0.1 Mandatory After 5.5 below. The ready sub-skill has already updated flow state to `phase5_post_ready` via Phase 4.6 (defense-in-depth, fixes #17); execute the 5.5.0.1 steps without delay. The completion report (Phase 5.6) has NOT been output yet — `ready.md` intentionally skips it in e2e flow. You MUST continue to Phase 5.5.1, 5.5.2, and 5.6.
+**Immediate after start-finalize returns**: When `start-finalize` outputs `<!-- [start:finalize:completed] -->` (success — workflow terminated normally) or `<!-- [start:finalize:aborted] -->` (abort — Phase 5.5 user selects 「More fixes」or `[ready:error]` user-terminate) sentinel and returns control, do **NOT** stop — **immediately** proceed to Mandatory After 5.5-Termination below.
 
-**Results**: `[ready:completed]`→5.5.0.1→5.5.1→5.5.2→5.6. `[ready:error]`→**emit sentinel and ask user** (#366).
-
-> **Emit canonical literal**: See [§D — Phase 5.5 `[ready:error]`](./references/workflow-incident-emit-pattern.md#d--phase-55-readyerror) (SoT) for both emit steps (Step 1 `skill_load_failure` + Step 2 `manual_fallback_adopted` after user selects 「Edit ツールで手動 Ready 化」 in the `AskUserQuestion`), `|| true` non-blocking guarantee, and `--pr-number {pr_number}` semantics. The response-text-inclusion requirement that Phase 5.4.4.1 grep detection depends on is documented in [§不変条件](./references/workflow-incident-emit-pattern.md#不変条件). Do NOT inline the bash literals here.
-
-#### 5.5.0.1 🚨 Mandatory After 5.5
+### 🚨 Mandatory After 5.5-Termination
 
 > See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
 > MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
 
-**Verify**: `[ready:completed]` pattern confirmed. `rite:pr:ready` returned successfully. Status update, metrics recording, and completion report are still pending — these are the **primary deliverables** of the e2e flow that the user expects to see.
-
-**Step 1**: Update flow state to post-ready phase (atomic). This write transitions from `phase5_post_review`/`phase5_post_fix` to `phase5_post_ready`, ensuring stop-guard routes to Status update rather than re-invoking ready (fixes #781):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_ready" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Phase 5.5.1: Update Issue Status to In Review, then Phase 5.5.2 metrics, then Phase 5.6 completion report. Do NOT stop."
-```
-
-**Step 2**: Sync to local work memory:
-
-```bash
-WM_SOURCE="ready" \
-  WM_PHASE="phase5_post_ready" \
-  WM_PHASE_DETAIL="Ready処理後" \
-  WM_NEXT_ACTION="Issue Status を In Review に更新後、メトリクス記録、完了レポートを実行" \
-  WM_BODY_TEXT="Post-ready sync." \
-  WM_ISSUE_NUMBER="{issue_number}" \
-  WM_READ_FROM_FLOW_STATE="true" \
-  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
-```
-
-**Step 3 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines emitted by `[ready:error]` orchestrator-direct emit. If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 4 regardless of detection result.
-
-**Step 4**: **→ Proceed to 5.5.1 now**.
-
-#### 5.5.1 Update Issue Status to "In Review"
-
-**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_ready`.
-
-```bash
-if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
-  :
-else
-  rc=$?
-  echo "ERROR: state-read.sh failed (rc=$rc) for --field phase in Phase 5.5.1 pre-condition" >&2
-  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_5_1_pre_condition; rc=$rc" >&2
-  exit 1
-fi
-if [ "$curr" != "phase5_post_ready" ]; then
-  echo "ERROR: Phase 5.5.1 pre-condition failed. .phase=$curr (expected: phase5_post_ready)" >&2
-  echo "ACTION: Return to Phase 5.5 (Ready for Review) and execute its Pre-write + rite:pr:ready invocation + Mandatory After 5.5 before entering Phase 5.5.1." >&2
-  echo "⚠️ LLM MUST NOT proceed to Phase 5.5.1 Pre-write below. Re-invoke Phase 5.5 first." >&2
-  exit 1
-fi
-```
-
-**Pre-write**:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_status_in_review" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Execute Phase 5.5.1 (Issue Status → In Review). Skipping to Phase 5.5.2/5.6 without running the Status update is PROHIBITED. Do NOT stop."
-```
-
-> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-2--phase-551-issue-status--in-review) — Callsite 2 (Phase 5.5.1) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "In Review", `auto_add: false` since Phase 2.4 already auto-added if missing). Defense-in-depth — `rite:pr:ready` Phase 4 also attempts this, but may not execute reliably within e2e flow. API レベル動作は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
-
-### 🚨 Mandatory After 5.5.1
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Step 1**: Update flow state to post-status-in-review phase:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_status_in_review" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Phase 5.5.1 completed (Issue Status → In Review). Proceed to Phase 5.5.2 (Metrics Recording). Do NOT stop."
-```
-
-**Step 2**: **→ Proceed to Phase 5.5.2 now**.
-
-### 5.5.2 Metrics Recording
-
-**Pre-write**:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_metrics" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Execute Phase 5.5.2 (Metrics Recording). Skipping to Phase 5.6 without running metrics is PROHIBITED. Do NOT stop."
-```
-
-> **Reference**: [Execution Metrics](../../references/execution-metrics.md). **Module**: [Metrics Recording](./references/metrics-recording.md) — Phase 5.5.2 全体 (Step 1-5 + `implementation_round` inline metrics capture + METRICS_SKIPPED 経路 + heredoc PATCH 本体) の SoT。
-
-**Skip Steps note** (referenced by Phase 5.6 pre-condition): When `metrics.enabled: false` in rite-config.yml, skip Steps 1-5 (per Module) **but unconditionally execute Mandatory After 5.5.2**. The `phase5_post_metrics` marker is required for Phase 5.6 pre-condition to pass. Skipping the Mandatory After would leave `.phase = phase5_post_status_in_review` and trip the Phase 5.6 ERROR gate.
-
-Otherwise: execute the Module procedure (Step 1 collect → Step 2 thresholds → Step 3 failure classification → Step 4 PATCH → Step 5 repeated failure check). On `[CONTEXT] METRICS_SKIPPED=1` sentinel emission (state-read.sh failure), skip Steps 2-4 but still execute Mandatory After 5.5.2 unconditionally (per Module's "Claude への指示" section).
-
-### 🚨 Mandatory After 5.5.2
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Step 1**: Update flow state to post-metrics phase:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_metrics" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Phase 5.5.2 completed (metrics recorded). Proceed to Phase 5.6 (Completion Report). Do NOT stop."
-```
-
-**Step 2**: **→ Proceed to Phase 5.6 now**.
-
-### 5.6 Completion Report
-
-> **Historical note (informational only — no action required)**: The `phase="completed", active: false` patch and `.rite-compact-state` cleanup were previously placed between Mandatory After 5.5.2 and this heading. That placement caused a **state flap** — the Phase 5.6 Pre-write (`create --phase phase5_completion`) re-activated the workflow and recorded `previous_phase="completed"`, which stop-guard then rejected as an invalid transition. The terminal state update now runs at the end of Phase 5.7 or, when no parent is identified, immediately after this Phase 5.6 — see the "Workflow Termination" block below. This note is purely historical context for future maintainers and contains no executable instructions.
-
-**Pre-condition check** (#490 AC-5): See [Pre-condition Gate](./references/pre-condition-gate.md). Expected `.phase`: `phase5_post_metrics`. When `metrics.enabled: false`, Phase 5.5.2 must still write the `phase5_post_metrics` marker via its Mandatory After block (body skip allowed; marker required).
-
-```bash
-if curr=$(bash {plugin_root}/hooks/state-read.sh --field phase --default ""); then
-  :
-else
-  rc=$?
-  echo "ERROR: state-read.sh failed (rc=$rc) for --field phase in Phase 5.6 pre-condition" >&2
-  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_6_pre_condition; rc=$rc" >&2
-  exit 1
-fi
-if [ "$curr" != "phase5_post_metrics" ] && [ "$curr" != "phase5_post_execute" ] && [ "$curr" != "phase5_post_publish" ]; then
-  echo "ERROR: Phase 5.6 pre-condition failed. .phase=$curr (expected: phase5_post_metrics or phase5_post_execute/phase5_post_publish for abort path)" >&2
-  echo "ACTION: Return to the missing phase (5.5.1 Status Update → 5.5.2 Metrics) and execute each Pre-write + main procedure + Mandatory After before entering Phase 5.6." >&2
-  echo "⚠️ LLM MUST NOT proceed to Phase 5.6 Pre-write below. Re-invoke the missing phase first." >&2
-  exit 1
-fi
-# Note: phase5_post_execute / phase5_post_publish は abort path (start-execute.md が [start:execute:aborted]
-# または start-publish.md が [start:publish:aborted] sentinel emit 後に Phase 5.6 へ直接 skip する経路、
-# Workflow Termination 用) を accept する。success path は phase5_post_metrics 経由が正規路。
-```
-
-**Pre-write**:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_completion" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Execute Phase 5.6 (Completion Report). Determine parent_issue_number routing in Phase 5.7 (\"Parent Issue Completion\"). If parent_issue_number is non-zero, proceed to Phase 5.7; otherwise jump directly to the Workflow Termination block (bypass 5.7). Do NOT stop."
-```
-
-> **Note**: `--next` 文字列に `state-read.sh` 等の helper 名や bash literal を埋め込まない。Phase 5.7 の actual caller (本ファイル末尾の `Parent Issue Completion` ブロック) と semantic 重複し、LLM が「state-read.sh を呼べ」と解釈する hallucination 経路を作る (caller 2 重起動 silent regression の根)。Phase 5.7 への semantic anchor reference のみを残すこと。
-
-> See [completion-report.md](./completion-report.md) for the full procedure (template read, placeholder substitution, output cases, self-verification, and inline fallbacks).
-
-#### 5.6.1 Workflow Incident Reporting (#366)
-
-> **Output ordering** (must match `completion-report.md` Step 3.5): Phase 5.6.1 is appended **after Phase 5.6.2 (Wiki Ingest Status Reporting)**, not directly after the standard completion report sections. The runtime sequence is: standard completion sections → Phase 5.6.2 (Wiki ingest 状況) → Phase 5.6.1 (workflow incidents). The section numbers (5.6.1 / 5.6.2) reflect introduction order (#366 first, #524 second) and are intentionally NOT in execution order — see Phase 5.6.2 ordering note for the canonical execution order.
-
-After Phase 5.6.2 (Wiki Ingest Status Reporting) is appended, append a "未処理 incident" section listing any workflow incidents that were skipped (user chose "skip" in Phase 5.4.4.1) or whose Issue creation failed (`create-issue-with-projects.sh` returned empty).
-
-**Source**: The context-local `workflow_incident_skipped` list maintained by Phase 5.4.4.1. Each entry is `{type, details, root_cause_hint, iteration_id}`.
-
-**Output format** (only when the list is non-empty):
-
-```markdown
-### ⚠️ 未処理の workflow incident
-
-| # | Type | Details | Root cause hint | iteration_id |
-|---|------|---------|-----------------|--------------|
-| 1 | {type} | {details} | {root_cause_hint or "(none)"} | {iteration_id} |
-
-> これらの incident は workflow 実行中に検出されましたが、Issue として登録されませんでした (user skipped or registration failed)。手動で `/rite:issue:create` で記録することを推奨します。
-```
-
-**When the list is empty**: Skip this section entirely (do not display "no incidents" placeholder — minimize output).
-
-**Also report registered incidents** when `workflow_incident_registered` list is non-empty (auto-registered Issues from Phase 5.4.4.1 step 6):
-
-```markdown
-### ✅ 自動登録された workflow incident
-
-| # | Issue | Type | Details |
-|---|-------|------|---------|
-| 1 | #{new_issue_number} | {type} | {details} |
-```
-
-#### 5.6.2 Wiki Ingest Status Reporting (#524)
-
-> **Source of truth**: `[CONTEXT] WIKI_INGEST_DONE=1` / `WIKI_INGEST_SKIPPED=1; reason=...` / `WIKI_INGEST_FAILED=1; reason=...` / `WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` lines emitted by `pr/review.md` Phase 6.5.W.2, `pr/fix.md` Phase 4.6.W.2, and `issue/close.md` Phase 4.4.W.2 throughout this `/rite:issue:start` invocation. These lines flow into the orchestrator's conversation context the same way Phase 5.4.4.1 sentinels do.
-
-> **Output ordering** (must match `completion-report.md` Step 3.5): This section is appended **immediately after the case-specific sections (項目テーブル + フェーズ進捗 + 次のステップ)** of the completion report, **before** the workflow incident sections (5.6.1). Both 5.6.2 and 5.6.1 then together form the trailing report sections. The `completion-report.md` Step 4 self-verification checklist confirms the presence of the `### 📚 Wiki ingest 状況` heading.
-
-Append a "Wiki ingest 状況" section so the user can confirm at a glance whether the Experience Wiki growth path actually executed during this Issue. This addresses Issue #524 AC-5 — the regression where Phase X.X.W was silently skipped and the user had no visibility into the missing growth.
-
-**Step 1 — Aggregate signals from conversation context**:
-
-Scan the recent conversation context for these patterns (the same context the Phase 5.4.4.1 grep operates on):
-
-| Pattern | Counter |
-|---------|---------|
-| `[CONTEXT] WIKI_INGEST_DONE=1; ...` | `done_count` (number of successful trigger + ingest cycles in this Issue) |
-| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=disabled` | `skipped_disabled_count` |
-| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=auto_ingest_off` | `skipped_auto_off_count` |
-| `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=commit_branch_missing` | `skipped_commit_branch_missing_count` (`wiki-ingest-commit.sh` exited 2 because the wiki branch does not exist locally — treated as a legitimate skip separate from `wiki.enabled=false`/`auto_ingest=false`) |
-| `[CONTEXT] WIKI_INGEST_FAILED=1; reason=commit_rc_*` or `reason=trigger_exit_*` | `failed_count` (all `commit_rc_*` values fold into `failed_count` — `commit_rc_3` = git stash/checkout/commit failure, `commit_rc_5+` = future exit codes. Only `commit_rc_4` is segregated into `push_failed_count` below because it represents the commit-landed-push-failed sub-case) |
-| `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4` | `push_failed_count` (`wiki-ingest-commit.sh` exited 4 — commit landed on local wiki branch but origin push failed. Local branch diverges from origin. Manual recovery: `git push origin wiki`) |
-
-Also retrieve the current wiki branch state (best-effort — never block on this):
-
-```bash
-wiki_branch=$(awk '/^wiki:/{h=1;next} h && /^[[:space:]]+branch_name:/{print;exit}' rite-config.yml 2>/dev/null \
-  | sed 's/[[:space:]]#.*//' | sed 's/.*branch_name:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
-[ -z "$wiki_branch" ] && wiki_branch="wiki"
-last_wiki_commit=""
-if git rev-parse --verify "$wiki_branch" >/dev/null 2>&1; then
-  last_wiki_commit=$(git log -1 --format='%aI' "$wiki_branch" 2>/dev/null)
-elif git rev-parse --verify "origin/$wiki_branch" >/dev/null 2>&1; then
-  last_wiki_commit=$(git log -1 --format='%aI' "origin/$wiki_branch" 2>/dev/null)
-fi
-# 空文字列で emit (Step 2 template の `{last_wiki_commit or "(wiki branch 未作成)"}` で日本語 fallback を render する)
-echo "[CONTEXT] WIKI_LAST_COMMIT=${last_wiki_commit:-}"
-```
-
-**Step 2 — Output format** (always render, even when all counters are 0 — the absence is itself a signal worth reporting per AC-5):
-
-```markdown
-### 📚 Wiki ingest 状況
-
-| シグナル | 件数 |
-|----------|------|
-| ✅ DONE (trigger + ingest 完了) | {done_count} |
-| ⚠️ SKIPPED (disabled) | {skipped_disabled_count} |
-| ⚠️ SKIPPED (auto_ingest_off) | {skipped_auto_off_count} |
-| ⚠️ SKIPPED (commit_branch_missing) | {skipped_commit_branch_missing_count} |
-| ❌ FAILED (trigger / commit エラー) | {failed_count} |
-| ❌ PUSH_FAILED (commit は成功、push が失敗) | {push_failed_count} |
-
-- **wiki branch 最終 commit**: {last_wiki_commit or "(wiki branch 未作成)"}
-```
-
-**Step 3 — Conditional warnings** (append below the table only when applicable):
-
-| Condition | Warning to append |
-|-----------|------------------|
-| `done_count == 0` AND `skipped_disabled_count == 0` AND `skipped_auto_off_count == 0` AND `skipped_commit_branch_missing_count == 0` AND `failed_count == 0` AND `push_failed_count == 0` | `> ⚠️ Phase X.X.W が一度も実行されていません。silent skip の可能性があります。/rite:wiki:ingest を手動実行するか、Phase 5.4.4.1 の sentinel を確認してください。` |
-| `failed_count >= 1` | `> ❌ Wiki ingest trigger が {failed_count} 回失敗しました。Phase 5.4.4.1 で workflow incident として登録されているか確認してください。` |
-| `push_failed_count >= 1` | `> ❌ wiki-ingest-commit.sh が commit 成功後の push に {push_failed_count} 回失敗しました。local wiki branch に commit は保持されています。Phase 5.4.4.1 で wiki_ingest_push_failed incident として登録されているか確認してください。手動 recovery: \`git push origin wiki\` を実行してください。` |
-| `skipped_disabled_count >= 1` | `> ℹ️ wiki.enabled=false により Wiki 機能全体が無効化されています。意図的でない場合は rite-config.yml を確認してください。` |
-| `skipped_auto_off_count >= 1` | `> ℹ️ wiki.auto_ingest が無効化されています。意図的でない場合は rite-config.yml を確認してください。` |
-| `skipped_commit_branch_missing_count >= 1` | `> ℹ️ wiki-ingest-commit.sh が wiki ブランチ未作成により skip されました（{skipped_commit_branch_missing_count} 件）。/rite:wiki:init を実行するか、git fetch origin wiki を実行してください。` |
-| `done_count >= 1` AND no failures | `> ✅ Wiki branch が成長しました（{done_count} cycle 分の raw source が ingest されました）。` |
-
-> **Skip condition**: This section is **NEVER** skipped. AC-5 requires it to always be present in the completion report so the user has a definitive answer about whether the Wiki grew during this Issue.
-
-### 5.7 Parent Issue Completion
-
-**Condition**: `parent_issue_number` is non-zero in flow-state. Read deterministically via `state-read.sh` so per-session state is consulted instead of the legacy state file snapshot:
-
-```bash
-# `if ! var=$(cmd); then rc=$?` は bash 仕様上 `$?` が常に 0 になるため、capture と exit code を
-# 両方取る場合は if/else 形式にする (capture-less `if ! cmd; then ...` は対象外)。
-if parent_issue_number=$(bash {plugin_root}/hooks/state-read.sh --field parent_issue_number --default 0); then
-  :
-else
-  rc=$?
-  echo "ERROR: state-read.sh failed (rc=$rc) for --field parent_issue_number in Phase 5.7" >&2
-  echo "[CONTEXT] STATE_READ_FAILED=1; phase=phase5_7_parent_issue; rc=$rc" >&2
-  exit 1
-fi
-# state-read.sh は jq の `// $default` で null/false → default 置換するが値の型は validate しない。
-# 攻撃者が `.rite/sessions/*.flow-state` を書き換えて parent_issue_number に non-numeric
-# (例: "true" / "../etc") を注入した場合、後続の `gh` 呼び出し (`gh issue close $parent_issue_number`)
-# に literal が流入する経路がある。numeric pattern check で fail-safe に default 0 (parent なし扱い)
-# に降格する。
-case "$parent_issue_number" in
-  ''|*[!0-9]*)
-    echo "WARNING: parent_issue_number is not numeric ('$parent_issue_number'), defaulting to 0 (no parent)" >&2
-    parent_issue_number=0
-    ;;
-esac
-if [ "$parent_issue_number" -eq 0 ] 2>/dev/null; then
-  echo "[CONTEXT] PARENT_ISSUE=none — skip Phase 5.7, proceed to Workflow Termination"
-else
-  echo "[CONTEXT] PARENT_ISSUE=$parent_issue_number — execute Phase 5.7"
-fi
-```
-
-Execute after 5.6. When `PARENT_ISSUE=none`, skip directly to Workflow Termination block.
-
-**Pre-write** (only when a parent was identified — otherwise skip directly to terminate):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_parent_completion" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "Execute Phase 5.7 (Parent Issue Completion). Ending the workflow without processing the parent is PROHIBITED when a parent was identified. Do NOT stop."
-```
-
-#### 5.7.1 Child Check
-
-Use [Basic Query](../../references/epic-detection.md#basic-query). All `CLOSED`→5.7.2. Some `OPEN`→5.7.3.
-
-#### 5.7.2 Auto-Close
-
-Confirm via `AskUserQuestion`. If "No", display message and proceed to 5.7.3 (no auto-close). If yes, update Projects Status to "Done" and then close the Issue.
-
-**Step 1**: Update parent Issue Status to "Done".
-
-> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-3--phase-572-parent-issue-status--done) — Callsite 3 (Phase 5.7.2) bash literal SoT。Skip if `projects.enabled: false` in rite-config.yml. Otherwise execute the Module procedure (Status update to "Done" for `{parent_issue_number}`, `auto_add: false` for parent Issue). On `skipped_not_in_project` / `failed` result, display `.warnings[]` and proceed to Step 2 (non-blocking).
-
-**Step 2**: Close the parent Issue via `/rite:issue:close` Skill invocation.
-
-> **Why Skill invoke (not `gh issue close`)**: `close.md` Phase 4.4.W.2 で Wiki raw source の蓄積（`wiki-ingest-commit.sh`）が発火する。直接 `gh issue close` を実行すると close.md を経由しないため、Wiki 経路が 100% silent skip になる。
-
-**Pre-write** (before invoking `rite:issue:close`): Update flow state so stop-guard can resume flow if interrupted:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_parent_close" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "After rite:issue:close returns: proceed to Mandatory After 5.7.2, then 5.7.3 (Next Child). Do NOT stop."
-```
-
-Invoke `skill: "rite:issue:close", args: "{parent_issue_number}"`.
-
-> **Note**: `close.md` receives `{parent_issue_number}` as its `{issue_number}` argument. Phase 4.1 executes `gh issue close`, Phase 4.4.W triggers Wiki ingest. The close.md `AskUserQuestion` (Phase 3) will present options to the user — since the user already confirmed "Close parent Issue" in Phase 5.7.2's own `AskUserQuestion`, they should select the manual close option when prompted by close.md.
-
-> **Note**: `close.md` does NOT output a machine-readable result pattern (unlike `[review:mergeable]` etc.). When it returns control, immediately proceed to Mandatory After 5.7.2.
-
-### 🚨 Mandatory After 5.7.2
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Step 1**: Update flow state to post-parent-close phase:
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh create \
-  --phase "phase5_post_parent_close" --issue {issue_number} --branch "{branch_name}" \
-  --pr {pr_number} \
-  --next "rite:issue:close completed. Proceed to 5.7.3 (Next Child display). Do NOT stop."
-```
-
-**Step 2**: **→ Proceed to 5.7.3** (display remaining children if any).
-
-#### 5.7.3 Next Child
-
-Display remaining children, guide `/rite:issue:start`. No auto-start.
-
-### 🚨 Mandatory After 5.7
-
-> See [Flow State Scaffolding](./references/flow-state-scaffolding.md).
-> MUST execute in the SAME response turn. DO NOT stop, do NOT re-invoke.
-
-**Step 1**: Update flow state to post-parent-completion phase. Use **patch mode** — patch preserves `previous_phase` automatically from the outgoing `.phase` field, whereas `create` mode would overwrite the entire state and risk tripping the session-ownership check (prompt-engineer cycle-2 MEDIUM #5):
+**Step 1**: Idempotent terminal state confirmation. Workflow terminal state (`phase="completed", active=false`) is already written by the sub-skill (Workflow Termination block in `start-finalize.md` for success path, or the abort-path terminal write in its Return Output Format for abort path). Re-patch idempotently to refresh timestamp and guard against the rare case where sub-skill terminal write was skipped due to interrupt:
 
 ```bash
 bash {plugin_root}/hooks/flow-state-update.sh patch \
-  --phase "phase5_post_parent_completion" --active false \
-  --next "Phase 5.7 completed. Workflow finished. Do NOT stop before the completion handoff is displayed to the user."
-```
-
-**Step 2**: Workflow terminates normally. Proceed to the "Workflow Termination" block below.
-
-### Workflow Termination
-
-> **Placement**: This block runs **after** Phase 5.7 completes **or after Phase 5.6** when no parent Issue was identified in Phase 1.6 / 2.4.7 (the Phase 5.7 skip branch). Both paths converge here so the terminal `phase="completed", active: false` state is set exactly once, with `previous_phase` pointing at a whitelist-valid source (`phase5_post_parent_completion` or `phase5_completion`).
-
-**Parent-skip routing**: When `parent_issue_number` is `0` in flow-state (determined in Phase 5.7 via `state-read.sh`), Phase 5.7 is skipped entirely. In that case, jump from the end of Phase 5.6 directly to this block (bypassing 5.7.1-5.7.3 and Mandatory After 5.7) — do **not** leave the workflow in `phase5_completion, active: true`, which would cause the next stop attempt to block indefinitely.
-
-> **Why this routing relies on Phase 5.7 emit, not state re-read**: Phase 5.7 が `parent_issue_number` の **single source of truth for the read** であり、本 Workflow Termination block は state を re-read しない。orchestrator の branching decision は Phase 5.7 の `[CONTEXT] PARENT_ISSUE=none` echo (LLM-level routing signal、会話履歴で観測可能) で駆動され、bash 変数経由ではない (Bash tool invocation は shell state を境界を跨いで共有しない)。
-
-**Step 1**: Update flow state to the terminal state (patch mode, preserves `previous_phase`):
-
-```bash
-bash {plugin_root}/hooks/flow-state-update.sh patch \
-  --phase "completed" \
-  --next "none" --active false
-```
-
-**Step 2**: Clean up `.rite-compact-state` to prevent stale blocked state from affecting the next session (#756):
-
-```bash
+  --phase "completed" --active false --next "none" \
+  --if-exists --preserve-error-count
 rm -f .rite-compact-state 2>/dev/null || true
 rm -rf .rite-compact-state.lockdir 2>/dev/null || true
 ```
 
-**Note**: This cleanup is non-blocking. Failure to delete is silently ignored.
+**Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-finalize` sub-skill — e.g., `[ready:error]` orchestrator-direct emit per §D, or by `ready.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.
+
+**Step 3 (Sentinel-based completion handoff)**: Grep the recent conversation context for `<!-- [start:finalize:completed] -->` or `<!-- [start:finalize:aborted] -->` and display a short user-facing completion handoff message:
+
+- `[start:finalize:completed]` detected → workflow terminated normally. The completion report was output by the sub-skill (Phase 5.6). Display a short user-facing confirmation summarizing PR URL, Issue URL, and next-step guidance (e.g., 「✅ Issue #{N} の作業が完了しました。 PR: {url}」).
+- `[start:finalize:aborted]` detected → workflow aborted during finalize. Display a short abort summary explaining the abort reason (Phase 5.5 user-terminate during ready confirmation or `[ready:error]` AskUserQuestion → terminate) and next-step guidance (e.g., 「⚠️ Phase 5.5 で中断されました。 PR: {url} は draft のままです」).
+- Neither detected → fail-safe: treat as `[start:finalize:completed]` (display normal completion); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
 
 ## Interruption/Resumption
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -48,7 +48,7 @@ Execute phases sequentially. **Do NOT stop between phases unless the user explic
 >
 > Every phase that writes to flow state is subject to the Pre-write + Mandatory After scaffolding contract (#490). Phases that only read state (0.x Detection, 1 Quality, 2.1/2.2 Branch-pattern detection, 4 User Guidance, 5.6.1 Incident Reporting, etc.) do not write markers and are therefore excluded from whitelist verification — they run inline and their transitions are verified indirectly by the surrounding write-phases. Every state-writing transition is tracked via flow state and verified by the stop-guard phase-transition whitelist (`plugins/rite/hooks/phase-transition-whitelist.sh`).
 >
-> The "Stop Allowed?" column marks whether the **user** may cancel at that phase (e.g., Phase 4 Guidance where the user chooses to work later, Phase 5.6/5.7 where the workflow naturally terminates after the completion handoff is displayed). Even for "Yes" rows, the scaffolding contract still applies — the user's stop action must be explicit, not a silent skip by the LLM.
+> The "Stop Allowed?" column marks whether the **user** may cancel at that phase (e.g., Phase 4 Guidance where the user chooses to work later, Phase 5.5-Termination where the workflow naturally terminates after the completion handoff is displayed — Phase 5.5/5.5.1/5.5.2/5.6/5.7/Workflow Termination はすべて start-finalize sub-skill 内)。Even for "Yes" rows, the scaffolding contract still applies — the user's stop action must be explicit, not a silent skip by the LLM.
 
 | Phase | Sub-skill Invoked | Next Phase | Stop Allowed? |
 |-------|-------------------|------------|---------------|
@@ -577,7 +577,7 @@ Invoke `skill: "rite:issue:start-execute"`.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_execute" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "rite:issue:start-execute completed. Proceed to Phase 5.3-5.4 (Publish Phase via rite:issue:start-publish) on [start:execute:completed]. Skip to Phase 5.6 on [start:execute:aborted]. Do NOT stop."
+  --next "rite:issue:start-execute completed. Proceed to Phase 5.3-5.4 (Publish Phase via rite:issue:start-publish) on [start:execute:completed]. Invoke rite:issue:start-finalize (abort context — PR 未作成のため pr=0 で delegation pre-write) on [start:execute:aborted]; sub-skill 内で abort entry を検出して Phase 5.5/5.5.1/5.5.2/5.7 を skip し直接 Phase 5.6 へ進む。 Do NOT stop."
 ```
 
 **Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-execute` sub-skill — e.g., `[lint:aborted]` orchestrator-direct emit per §A, or by `lint.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.
@@ -585,7 +585,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 **Step 3 (Sentinel-based routing)**: Grep the recent conversation context for `<!-- [start:execute:completed] -->` or `<!-- [start:execute:aborted] -->`:
 
 - `[start:execute:completed]` detected → **→ Proceed to Phase 5.3-5.4 (Publish Phase) now** (invoke `rite:issue:start-publish` sub-skill).
-- `[start:execute:aborted]` detected → **→ Skip to Phase 5.6 (Completion Report) now**. PR creation is intentionally skipped because the execute phase was aborted by user choice (5.1.3 Safety Check) or `[lint:aborted]`. The completion report MUST display the abort reason to the user.
+- `[start:execute:aborted]` detected → **→ Invoke `rite:issue:start-finalize` sub-skill (abort context) now**. Use Pre-write `--pr 0` to signal PR 未作成 状態; the sub-skill detects abort entry (`pr_number == 0` AND no prior `[pr:created:N]` sentinel) and skips Phase 5.5/5.5.1/5.5.2/5.7 entirely, proceeding directly to Phase 5.6 Completion Report. The completion report MUST display the abort reason ([lint:aborted] or 5.1.3 Safety Check user 中止) to the user.
 - Neither detected → fail-safe: treat as `[start:execute:completed]` (proceed to Phase 5.3-5.4); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
 
 ### 5.3-5.4 Publish Phase (delegated to start-publish sub-skill)
@@ -596,7 +596,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_publish_running" --issue {issue_number} --branch "{branch_name}" \
   --pr 0 \
-  --next "After rite:issue:start-publish returns: proceed to Phase 5.5 (Ready for Review) on [start:publish:completed]. Skip to Phase 5.6 (Completion Report) on [start:publish:aborted]. Do NOT stop."
+  --next "After rite:issue:start-publish returns: proceed to Phase 5.5-Termination (rite:issue:start-finalize) on [start:publish:completed]. Invoke rite:issue:start-finalize (abort context — pr exists but review-fix loop 未収束) on [start:publish:aborted]; sub-skill 内で abort entry を検出して Phase 5.5/5.5.1/5.5.2/5.7 を skip し直接 Phase 5.6 へ進む。 Do NOT stop."
 ```
 
 > **Module**: [Publish Phase](./start-publish.md) - Handles Phase 5.3 (PR creation via rite:pr:create), 5.4 (Review-Fix Loop with internal 5.4.1/5.4.1.0/5.4.4/5.4.6 routing, fingerprint cycling dispatcher).
@@ -616,7 +616,7 @@ Invoke `skill: "rite:issue:start-publish"`.
 bash {plugin_root}/hooks/flow-state-update.sh create \
   --phase "phase5_post_publish" --issue {issue_number} --branch "{branch_name}" \
   --pr {pr_number} \
-  --next "rite:issue:start-publish completed. Proceed to Phase 5.5 (Ready for Review) on [start:publish:completed]. Skip to Phase 5.6 on [start:publish:aborted]. Do NOT stop."
+  --next "rite:issue:start-publish completed. Invoke rite:issue:start-finalize on [start:publish:completed] (success path) or [start:publish:aborted] (abort context — sub-skill 内で abort entry を検出して Phase 5.5/5.5.1/5.5.2/5.7 を skip し直接 Phase 5.6 へ進む)。 Do NOT stop."
 ```
 
 **Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-publish` sub-skill — e.g., `[pr:create-failed]` / `[fix:error]` orchestrator-direct emit per §B/§C, or by `pr/create.md` / `pr/review.md` / `pr/fix.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.
@@ -624,7 +624,7 @@ bash {plugin_root}/hooks/flow-state-update.sh create \
 **Step 3 (Sentinel-based routing)**: Grep the recent conversation context for `<!-- [start:publish:completed] -->` or `<!-- [start:publish:aborted] -->`:
 
 - `[start:publish:completed]` detected → **→ Proceed to Phase 5.5 (Ready for Review) now**.
-- `[start:publish:aborted]` detected → **→ Skip to Phase 5.6 (Completion Report) now**. Ready for Review is intentionally skipped because the publish phase was aborted by `[pr:create-failed]` (PR was never created) or `[fix:error]` user-terminate (review-fix loop did not converge). The completion report MUST display the abort reason to the user.
+- `[start:publish:aborted]` detected → **→ Invoke `rite:issue:start-finalize` sub-skill (abort context) now**. The sub-skill detects abort entry (`[start:publish:aborted]` sentinel grep / review-fix loop 未収束) and skips Phase 5.5/5.5.1/5.5.2/5.7 entirely, proceeding directly to Phase 5.6 Completion Report. The completion report MUST display the abort reason (`[pr:create-failed]` or `[fix:error]` user-terminate) to the user.
 - Neither detected → fail-safe: treat as `[start:publish:completed]` (proceed to Phase 5.5); the sub-skill SHOULD always emit one of the two sentinels per its Return Output Format contract.
 
 ### 5.4.4.1 Workflow Incident Detection (Contract Summary)

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -111,13 +111,18 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # start.md Phase 5.5-Termination delegation: orchestrator writes phase5_finalize_running
   # before invoke, sub-skill writes terminal `completed` via Workflow Termination when done.
   # Workflow terminal sentinel is [start:finalize:completed] (no further phase work) or
-  # [start:finalize:aborted] (Phase 5.5 user selects 「More fixes」or [ready:error] terminate).
-  # success path: phase5_finalize_running → phase5_ready → ... → phase5_completion →
+  # [start:finalize:aborted] (Phase 5.5 user selects 「More fixes」/「Phase 5.6 へスキップ」/
+  # [ready:error] terminate, or abort entry from [start:execute:aborted] / [start:publish:aborted]).
+  # success path: phase5_finalize_running → phase5_post_ready (rite:pr:ready defense-in-depth
+  #   direct write, skipping phase5_ready middle phase) → phase5_status_in_review →
+  #   phase5_post_status_in_review → phase5_metrics → phase5_post_metrics → phase5_completion →
   #   phase5_parent_completion → phase5_post_parent_completion → completed
-  # abort path: phase5_finalize_running → completed (direct via terminal patch on abort)
+  # abort path: phase5_finalize_running → phase5_completion → completed (abort entry skips Phase
+  #   5.5/5.5.1/5.5.2/5.7 and goes directly to Phase 5.6 / Workflow Termination)
+  # phase5_ready_error: rite:pr:ready error path written by ready.md Phase 3.1.
   # Note: no separate phase5_post_finalize indirection — [start:finalize:completed] IS the
   # workflow terminal sentinel per design doc SPEC-TECH-DECISIONS #3.
-  ["phase5_finalize_running"]="phase5_ready phase5_completion completed"
+  ["phase5_finalize_running"]="phase5_ready phase5_post_ready phase5_ready_error phase5_completion completed"
 
   # Phase 5.3: PR create
   # start.md Phase 5.3 Mandatory After transitions directly from phase5_pr to phase5_review

--- a/plugins/rite/hooks/phase-transition-whitelist.sh
+++ b/plugins/rite/hooks/phase-transition-whitelist.sh
@@ -103,7 +103,21 @@ declare -gA _RITE_PHASE_TRANSITIONS=(
   # 新規 edge として許容する。
   ["phase5_post_execute"]="phase5_pr phase5_publish_running phase5_completion"
   ["phase5_publish_running"]="phase5_pr phase5_post_publish"
-  ["phase5_post_publish"]="phase5_ready phase5_post_ready phase5_ready_error phase5_completion"
+  # phase5_post_publish (PR G1 terminal) → phase5_finalize_running (PR G2 delegation entry) を
+  # 新規 edge として追加 (PR G2 #904)。
+  ["phase5_post_publish"]="phase5_ready phase5_post_ready phase5_ready_error phase5_completion phase5_finalize_running"
+
+  # /rite:issue:start-finalize sub-skill (PR G2 #904)
+  # start.md Phase 5.5-Termination delegation: orchestrator writes phase5_finalize_running
+  # before invoke, sub-skill writes terminal `completed` via Workflow Termination when done.
+  # Workflow terminal sentinel is [start:finalize:completed] (no further phase work) or
+  # [start:finalize:aborted] (Phase 5.5 user selects 「More fixes」or [ready:error] terminate).
+  # success path: phase5_finalize_running → phase5_ready → ... → phase5_completion →
+  #   phase5_parent_completion → phase5_post_parent_completion → completed
+  # abort path: phase5_finalize_running → completed (direct via terminal patch on abort)
+  # Note: no separate phase5_post_finalize indirection — [start:finalize:completed] IS the
+  # workflow terminal sentinel per design doc SPEC-TECH-DECISIONS #3.
+  ["phase5_finalize_running"]="phase5_ready phase5_completion completed"
 
   # Phase 5.3: PR create
   # start.md Phase 5.3 Mandatory After transitions directly from phase5_pr to phase5_review

--- a/plugins/rite/hooks/tests/caller-markdown-block.test.sh
+++ b/plugins/rite/hooks/tests/caller-markdown-block.test.sh
@@ -48,6 +48,8 @@ PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
 COMMANDS_DIR="$PLUGIN_ROOT/commands"
 
 START_MD="$COMMANDS_DIR/issue/start.md"
+# PR G2 #904: Phase 5.5.1 / 5.6 / 5.7 caller bash block を start-finalize.md sub-skill へ SoT 移管
+START_FINALIZE_MD="$COMMANDS_DIR/issue/start-finalize.md"
 IMPLEMENT_MD="$COMMANDS_DIR/issue/implement.md"
 REVIEW_MD="$COMMANDS_DIR/pr/review.md"
 RESUME_MD="$COMMANDS_DIR/resume.md"
@@ -57,13 +59,19 @@ METRICS_RECORDING_MD="$COMMANDS_DIR/issue/references/metrics-recording.md"
 # === Test 1: caller bash block の存在確認 (regression 対策の前提) ===
 echo "TC-1: state-read.sh 呼出 caller bash block の存在確認"
 
-# start.md は 4 箇所 (Phase 3 / 5.5.1 / 5.6 / 5.7 Workflow Termination)
+# start.md は 1 箇所 (Phase 3 のみ残存)
 # cycle 43 F-12 LOW 対応: Phase 5.5.2 の plan_deviation_count metric capture を table cell から
 # 別 bash code block へ分離した結果、caller 数が 4 → 5 に増えた。
 # Issue #901 PR E: Phase 5.5.2 implementation_round inline 形式を metrics-recording.md へ SoT 移管
 # した結果、start.md の caller 数が 5 → 4 に減った (TC-1.5 で metrics-recording.md の 1 箇所を別途検証)。
+# PR G2 #904: Phase 5.5.1 / 5.6 / 5.7 caller を start-finalize.md へ SoT 移管した結果、
+# start.md の caller 数が 4 → 1 に減った (TC-1.6 で start-finalize.md の 3 箇所を別途検証)。
 start_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$START_MD" || true)
-assert "TC-1.1: start.md の caller bash block は 4 箇所" "4" "$start_count"
+assert "TC-1.1: start.md の caller bash block は 1 箇所" "1" "$start_count"
+
+# start-finalize.md は 3 箇所 (Phase 5.5.1 / 5.6 / 5.7) — PR G2 #904 で SoT 移管
+start_finalize_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$START_FINALIZE_MD" || true)
+assert "TC-1.6: start-finalize.md の caller bash block は 3 箇所" "3" "$start_finalize_count"
 
 # implement.md は 1 箇所
 implement_count=$(grep -cE '^if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh' "$IMPLEMENT_MD" || true)
@@ -109,9 +117,13 @@ echo ""
 echo "TC-3: G-02 — canonical \`if cmd; then :; else rc=\$?; fi\` pattern の存在確認"
 
 # canonical 直後 (else 節) に `rc=$?` を持つこと
-# (start.md は phase / parent_issue_number で 4 箇所すべて、implement.md は 1 箇所、review.md は 1 箇所)
+# (start.md は phase で 1 箇所、start-finalize.md は 3 箇所、implement.md は 1 箇所、review.md は 1 箇所)
+# PR G2 #904: parent_issue_number caller を start-finalize.md へ SoT 移管した結果、start.md は 1 箇所に
 start_canonical=$(grep -cE 'if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh.*then$' "$START_MD" || true)
-assert "TC-3.1: start.md の canonical pattern (4 箇所) が存続" "4" "$start_canonical"
+assert "TC-3.1: start.md の canonical pattern (1 箇所) が存続" "1" "$start_canonical"
+
+start_finalize_canonical=$(grep -cE 'if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh.*then$' "$START_FINALIZE_MD" || true)
+assert "TC-3.1b: start-finalize.md の canonical pattern (3 箇所) が存続" "3" "$start_finalize_canonical"
 
 implement_canonical=$(grep -cE 'if [a-z_]+=\$\(bash \{plugin_root\}/hooks/state-read\.sh.*then$' "$IMPLEMENT_MD" || true)
 assert "TC-3.2: implement.md の canonical pattern (1 箇所) が存続" "1" "$implement_canonical"
@@ -144,9 +156,9 @@ assert_2line_validation() {
   fi
 }
 
-# start.md Phase 5.7: parent_issue_number
-assert_2line_validation "TC-4.1: start.md に parent_issue_number の type validation pattern が存在" \
-  "$START_MD" "parent_issue_number"
+# start-finalize.md Phase 5.7: parent_issue_number (PR G2 #904 で start.md から SoT 移管)
+assert_2line_validation "TC-4.1: start-finalize.md に parent_issue_number の type validation pattern が存在" \
+  "$START_FINALIZE_MD" "parent_issue_number"
 
 # implement.md Phase 5.1.2: parent_issue_number
 assert_2line_validation "TC-4.2: implement.md に parent_issue_number の type validation pattern が存在" \
@@ -168,8 +180,8 @@ assert_2line_validation "TC-4.4: resume.md に parent_issue_number_raw の type 
 echo ""
 echo "TC-5: type validation の default 値 pin (numeric field は 0 に降格)"
 
-assert_grep "TC-5.1: start.md の parent_issue_number validation が default 0 に降格する" \
-  "$START_MD" \
+assert_grep "TC-5.1: start-finalize.md の parent_issue_number validation が default 0 に降格する" \
+  "$START_FINALIZE_MD" \
   'parent_issue_number=0'
 
 assert_grep "TC-5.2: implement.md の parent_issue_number validation が default 0 に降格する" \

--- a/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
+++ b/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
@@ -33,13 +33,17 @@ REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 START_MD="$REPO_ROOT/plugins/rite/commands/issue/start.md"
 # PR F (#902) extracted Phase 5.0-5.2.1 (incl. §A Phase 5.2 `[lint:aborted]` anchor reference)
 # into start-execute.md. PR G1 (#903) extracted Phase 5.3/5.4 (incl. §B Phase 5.3 `[pr:create-failed]`
-# / §C Phase 5.4.4 `[fix:error]` anchor references) into start-publish.md. The anchor ownership is:
+# / §C Phase 5.4.4 `[fix:error]` anchor references) into start-publish.md. PR G2 (#904) extracted
+# Phase 5.5-Termination (incl. §D Phase 5.5 `[ready:error]` anchor reference) into start-finalize.md.
+# The anchor ownership is:
 #   §A → start-execute.md
 #   §B / §C → start-publish.md
-#   §D + `## 不変条件` → start.md (Phase 5.5 stays in start.md)
+#   §D → start-finalize.md (Phase 5.5 moved to start-finalize.md in PR G2)
+#   `## 不変条件` → start.md (本体 contract retains generic reference to emit-pattern.md#不変条件)
 # Anchor drift check scans the owner file per anchor.
 START_EXECUTE_MD="$REPO_ROOT/plugins/rite/commands/issue/start-execute.md"
 START_PUBLISH_MD="$REPO_ROOT/plugins/rite/commands/issue/start-publish.md"
+START_FINALIZE_MD="$REPO_ROOT/plugins/rite/commands/issue/start-finalize.md"
 REF_DETECTION="$REPO_ROOT/plugins/rite/commands/issue/references/workflow-incident-detection.md"
 REF_EMIT="$REPO_ROOT/plugins/rite/commands/issue/references/workflow-incident-emit-pattern.md"
 REF_FINGERPRINT="$REPO_ROOT/plugins/rite/commands/issue/references/fingerprint-cycling.md"
@@ -278,6 +282,8 @@ done
 # PR G1 #903 fix: Phase 5.3 / 5.4.3 / 5.4.6 rows が start-publish sub-skill 抽出により
 # 「Phase 5.3-5.4 (publish) | Mandatory After 5.3-5.4」へ統合された。internal pr:create /
 # pr:review / pr:fix 呼出は start-publish 内に閉じ、orchestrator 視点では 3 boundary。
+# PR G2 #904 fix: Phase 5.5.0.1 (pr:ready) row が start-finalize sub-skill 抽出により
+# 「Phase 5.5-Termination (finalize) | Mandatory After 5.5-Termination」へ変更。
 assert_grep "start: When to execute table — Phase 5.0-5.2.1 execute row" \
   "$START_MD" \
   'Phase 5\.0-5\.2\.1 \(execute\).*Mandatory After 5\.0-5\.2\.1'
@@ -286,9 +292,9 @@ assert_grep "start: When to execute table — Phase 5.3-5.4 publish row" \
   "$START_MD" \
   'Phase 5\.3-5\.4 \(publish\).*Mandatory After 5\.3-5\.4'
 
-assert_grep "start: When to execute table — Phase 5.5.0.1 pr:ready row" \
+assert_grep "start: When to execute table — Phase 5.5-Termination finalize row" \
   "$START_MD" \
-  'Phase 5\.5\.0\.1 \(pr:ready\).*Mandatory After 5\.5'
+  'Phase 5\.5-Termination \(finalize\).*Mandatory After 5\.5-Termination'
 
 # Skip condition + Invariants が本体に残されている (本体 contract)
 assert_grep "start: Skip condition retained" \
@@ -318,6 +324,27 @@ assert_grep "start-publish: rite:pr:review skill invocation retained" \
 assert_grep "start-publish: rite:pr:fix skill invocation retained" \
   "$START_PUBLISH_MD" \
   'skill: "rite:pr:fix"'
+
+# === 5.6. start-finalize.md 内の rite:pr:ready / rite:issue:close Skill invocation contract (PR G2) ===
+# PR G2 で Phase 5.5/5.7 が start-finalize.md sub-skill 内に閉じたため、
+# start.md からは「Phase 5.5 (pr:ready) row」「5.7.2 (rite:issue:close)」の assert が削除された。
+# 代わりに「start-finalize.md 内に rite:pr:ready / rite:issue:close の Skill invocation が
+# 必ず存在する」ことを pin することで、内部 Skill 呼出が誤削除される drift を検出する。
+echo ""
+echo "--- 5.6. start-finalize.md 内の rite:pr:ready / rite:issue:close Skill invocation contract (PR G2) ---"
+
+assert_grep "start-finalize: rite:pr:ready skill invocation retained" \
+  "$START_FINALIZE_MD" \
+  'skill: "rite:pr:ready"'
+
+assert_grep "start-finalize: rite:issue:close skill invocation retained" \
+  "$START_FINALIZE_MD" \
+  'skill: "rite:issue:close"'
+
+# start-finalize.md drift guard: inline workflow-incident-emit.sh literal が再混入しないこと
+assert_not_grep "start-finalize: no inline 'workflow-incident-emit.sh' bash literal (drift guard)" \
+  "$START_FINALIZE_MD" \
+  'bash \{plugin_root\}/hooks/workflow-incident-emit.sh'
 
 # === 6. start.md drift guard — inline emit literal must NOT reappear (#937) ===
 echo ""
@@ -410,7 +437,7 @@ anchor_pairs=(
   '### §A — Phase 5.2 `[lint:aborted]`|a--phase-52-lintaborted|start-execute'
   '### §B — Phase 5.3 `[pr:create-failed]`|b--phase-53-prcreate-failed|start-publish'
   '### §C — Phase 5.4.4 `[fix:error]`|c--phase-544-fixerror|start-publish'
-  '### §D — Phase 5.5 `[ready:error]`|d--phase-55-readyerror|start'
+  '### §D — Phase 5.5 `[ready:error]`|d--phase-55-readyerror|start-finalize'
   '## 不変条件|不変条件|start'
 )
 
@@ -428,10 +455,11 @@ for pair in "${anchor_pairs[@]}"; do
     fail "anchor: emit-pattern.md MISSING heading literal: $heading (heading が書き換えられた可能性)"
   fi
 
-  # (b) owner file に対応 anchor が存在することを検証 (PR F #902 ownership 契約):
+  # (b) owner file に対応 anchor が存在することを検証 (PR F/G1/G2 #902/#903/#904 ownership 契約):
   #   - §A → start-execute.md
-  #   - §B-§D + 不変条件 → start.md
-  # owner='start' なら $START_MD のみ、owner='start-execute' なら $START_EXECUTE_MD のみを grep。
+  #   - §B / §C → start-publish.md
+  #   - §D → start-finalize.md
+  #   - `## 不変条件` → start.md (本体 contract 内 generic reference)
   case "$owner" in
     start)
       owner_file="$START_MD"
@@ -445,8 +473,12 @@ for pair in "${anchor_pairs[@]}"; do
       owner_file="$START_PUBLISH_MD"
       owner_label="start-publish.md"
       ;;
+    start-finalize)
+      owner_file="$START_FINALIZE_MD"
+      owner_label="start-finalize.md"
+      ;;
     *)
-      fail "anchor: unknown owner '$owner' in anchor_pairs (must be 'start', 'start-execute', or 'start-publish')"
+      fail "anchor: unknown owner '$owner' in anchor_pairs (must be 'start', 'start-execute', 'start-publish', or 'start-finalize')"
       continue
       ;;
   esac

--- a/plugins/rite/hooks/tests/verify-terminal-output.test.sh
+++ b/plugins/rite/hooks/tests/verify-terminal-output.test.sh
@@ -39,9 +39,11 @@ setup_plugin_tree() {
   if [ "$html_comment" = "true" ]; then
     local sentinel_create='<!-- [create:completed:{N}] -->'
     local sentinel_interview='<!-- [interview:completed] --> / <!-- [interview:skipped] -->'
+    local sentinel_finalize='<!-- [start:finalize:completed] --> / <!-- [start:finalize:aborted] -->'
   else
     local sentinel_create='[create:completed:{N}]'
     local sentinel_interview='[interview:completed] / [interview:skipped]'
+    local sentinel_finalize='[start:finalize:completed] / [start:finalize:aborted]'
   fi
 
   cat > "$root/commands/issue/create-register.md" <<EOF
@@ -55,6 +57,10 @@ EOF
   cat > "$root/commands/issue/create-interview.md" <<EOF
 # create-interview
 Test fixture. Sentinel form: $sentinel_interview
+EOF
+  cat > "$root/commands/issue/start-finalize.md" <<EOF
+# start-finalize
+Test fixture. Sentinel form: $sentinel_finalize
 EOF
   cat > "$root/skills/rite-workflow/SKILL.md" <<'EOF'
 # rite-workflow SKILL
@@ -164,6 +170,10 @@ EOF
 cat > "$TEST_DIR/test7/commands/issue/create-interview.md" <<'EOF'
 # interview
 <!-- [interview:completed] --> <!-- [interview:skipped] -->
+EOF
+cat > "$TEST_DIR/test7/commands/issue/start-finalize.md" <<'EOF'
+# finalize
+<!-- [start:finalize:completed] --> <!-- [start:finalize:aborted] -->
 EOF
 cat > "$TEST_DIR/test7/skills/rite-workflow/SKILL.md" <<'EOF'
 workflow は途中で止まらない

--- a/plugins/rite/hooks/verify-terminal-output.sh
+++ b/plugins/rite/hooks/verify-terminal-output.sh
@@ -200,6 +200,32 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Check 3.5: start-finalize.md `[start:finalize:*]` HTML-comment form (PR G2 #904)
+# -----------------------------------------------------------------------------
+START_FINALIZE="${REPO_ROOT}${CHECK_PATHS_PREFIX:+/${CHECK_PATHS_PREFIX}}/commands/issue/start-finalize.md"
+
+if [ ! -f "$START_FINALIZE" ]; then
+  fail "start-finalize.md not found at $START_FINALIZE"
+else
+  # AC-3 non-regression: the raw sentinel string must still be present for grep contracts.
+  if grep -qE '\[start:finalize:(completed|aborted)\]' "$START_FINALIZE"; then
+    pass "start-finalize.md: contains [start:finalize:completed] / [start:finalize:aborted] string (AC-3 non-regression)"
+  else
+    fail "start-finalize.md: missing [start:finalize:*] string (AC-3 regression)"
+  fi
+
+  # AC-2 / AC-6: HTML-comment wrapped form must be present so the user-visible terminal
+  # line is the human-readable completion handoff, not a bare sentinel token. This is
+  # critical because [start:finalize:completed] is the workflow terminal sentinel —
+  # if it leaks as a bare line, the user sees a sentinel token as the final output.
+  if grep -qE '<!--[[:space:]]*\[start:finalize:(completed|aborted)\]' "$START_FINALIZE"; then
+    pass "start-finalize.md: [start:finalize:*] wrapped in HTML comment form (AC-2 / AC-6)"
+  else
+    fail "start-finalize.md: [start:finalize:*] NOT wrapped in HTML comment form; expected <!-- [start:finalize:completed] --> / <!-- [start:finalize:aborted] -->"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Check 4: SKILL.md / workflow-identity.md identity entries
 # -----------------------------------------------------------------------------
 SKILL_MD="${REPO_ROOT}${CHECK_PATHS_PREFIX:+/${CHECK_PATHS_PREFIX}}/skills/rite-workflow/SKILL.md"

--- a/plugins/rite/skills/rite-workflow/references/work-memory-format.md
+++ b/plugins/rite/skills/rite-workflow/references/work-memory-format.md
@@ -460,7 +460,7 @@ bash {plugin_root}/hooks/preflight-check.sh --command-id "/rite:{command}" --cwd
 
 | Category | Commands | Local WM Operation |
 |----------|---------|-------------------|
-| **Write** | `pr/create`, `pr/review`, `pr/ready`, `pr/cleanup`†, `pr/fix`, `issue/close`, `issue/update`, `issue/implement`, `issue/work-memory-init`, `issue/start-publish`, `lint` | Read + Write (via `local-wm-update.sh`) |
+| **Write** | `pr/create`, `pr/review`, `pr/ready`, `pr/cleanup`†, `pr/fix`, `issue/close`, `issue/update`, `issue/implement`, `issue/work-memory-init`, `issue/start-publish`, `issue/start-finalize`, `lint` | Read + Write (via `local-wm-update.sh`) |
 | **Read** | `issue/branch-setup`, `issue/implementation-plan`, `sprint/execute`, `sprint/team-execute` | Read only |
 | **Preflight only** | `issue/create`, `issue/list`, `issue/edit`, `issue/parent-routing`, `issue/child-issue-selection`, `issue/start-execute`, `workflow`, `getting-started`, `sprint/list`, `sprint/current`, `sprint/plan`, `skill/suggest`, `template/reset`, `init` | None |
 | **Orchestrator** | `issue/start`, `resume` | Managed by flow state (these commands orchestrate other commands; they do not directly read/write local WM but control flow via flow state) |


### PR DESCRIPTION
## 概要

`/rite:issue:start` ハイブリッド再設計 (#896) の PR G2。Phase 5.5 (Ready for Review) + 5.5.1 (Status In Review) + 5.5.2 (Metrics) + 5.6 (Completion Report incl. 5.6.1/5.6.2) + 5.7 (Parent Issue Completion) + Workflow Termination を新規 `start-finalize.md` sub-skill に移管し、本体 `start.md` は delegation 呼び出しに圧縮。

## 変更内容

- `plugins/rite/commands/issue/start-finalize.md` 新規 (~470 行) — Phase 5.5/5.5.1/5.5.2/5.6/5.7/Workflow Termination 移管 + HTML sentinel `<!-- [start:finalize:completed] -->` (**workflow terminal**) + abort path sentinel `<!-- [start:finalize:aborted] -->` + Pre-flight + Caller Return Protocol。Wiki 経験則「Success-only Sentinel Design (anti-pattern)」を回避し abort path sentinel も対称に定義。
- `plugins/rite/commands/issue/start.md`: 1101 → 724 行 (-377 行 / -34%) — Phase 5.5+ を sub-skill delegation + Mandatory After 5.5-Termination に置換。Phase 5.4.4.1 Contract Summary は本体 contract として保持。
- `plugins/rite/hooks/phase-transition-whitelist.sh`: 新 phase `phase5_finalize_running` を追加 (`phase5_post_publish` allowed list に追加)。`phase5_post_finalize` 間接層は意図的に作らず `[start:finalize:completed]` が workflow terminal sentinel。
- `plugins/rite/hooks/verify-terminal-output.sh`: Check 3.5 を新規追加 — start-finalize.md の HTML-comment sentinel を verify。terminal token leak を構造的に block。
- `plugins/rite/hooks/tests/{sentinel-visibility-rule,verify-terminal-output,caller-markdown-block}.test.sh`: §D anchor ownership を start → start-finalize に移管、start-finalize.md fixture / pin assert 追加、PR G2 caller bash block 数 (start.md: 4→1 / start-finalize.md: 0→3) を更新。
- `plugins/rite/skills/rite-workflow/references/work-memory-format.md`: start-finalize を Write カテゴリに登録。

## 期待効果

- 本体 start.md -377 行 (-34%) と sub-skill 分離による責務明確化。設計 doc 目標 (本体 ~600-700 行) を 724 行で概ね達成。
- HTML sentinel + abort path sentinel + caller continuation pattern (start-execute.md / start-publish.md と対称) で turn-boundary heuristic 起因の implicit stop を抑止。
- 既存 phase 名 (phase5_ready / phase5_post_ready / phase5_status_in_review / phase5_metrics / phase5_completion / phase5_parent_completion / completed) は維持し resume.md routing 互換性を保つ。

## 検証

- `bash plugins/rite/hooks/tests/run-tests.sh`: 49/49 PASS
- `bash plugins/rite/hooks/verify-terminal-output.sh`: 全 check PASS (Check 3.5 新規追加含む)
- start-finalize.md の HTML sentinel が absolute last line に配置 (verify-terminal-output.sh Check 3.5 で構造検証)
- whitelist 新 edge: `phase5_post_publish → phase5_finalize_running` 追加、`phase5_finalize_running → phase5_ready / phase5_completion / completed`

## 関連

Closes #904
親 Issue: #896 (Phase 5 ハイブリッド再設計 — PR F/G1/G2 連鎖の G2)

## チェックリスト

- [x] 実装完了
- [x] テスト追加/更新
- [x] ドキュメント更新（必要な場合）
