### PR TITLE
refactor(issue): PR #959 cycle 2 deferred MEDIUM 2 + LOW 2 (4 件) を対称化整理

### DIFF
--- a/plugins/rite/commands/issue/references/pre-condition-gate.md
+++ b/plugins/rite/commands/issue/references/pre-condition-gate.md
@@ -124,6 +124,7 @@ bash の `exit 1` は **shell process を終わらせるだけで、Claude Code 
 - これらの echo は **LLM 向け enforcement** であり、シェル制御フローではなく LLM の routing 判断を駆動する
 - **Branch I と Branch II は disjoint** — Pre-condition mismatch は state-read.sh が exit 0 で値を返した後の比較失敗、Launch failure は state-read.sh 自体の exit 非 0 で、同一実行内で両方が発火することはない (Form A の bash literal でも `else rc=$?; ...` branch が先に `exit 1` するため `if [ "$curr" != "..." ]` ブロックに到達しない)
 - RESUME_HINT 本文は **Form A / Form B / 全 caller で bit-identical** とし、`caller-markdown-block.test.sh` TC-7 が SoT (本 reference) と全 caller の同一性を **grep + 文字列等値比較** で機械検証する
+- RESUME_HINT 本文に **literal backtick (\`) と literal double-quote (")** を含めてはならない (Issue #960 MEDIUM-2 で明示化)。`caller-markdown-block.test.sh` の `extract_resume_hint_body` helper は本文を `["\`]RESUME_HINT: ...[^"\`]*["\`]` 形式の正規表現で抽出するため、本文に literal backtick / double-quote が含まれると `[^"\`]*` 否定文字クラスが本文の途中で切れて drift 検出が誤判定する (false positive または false negative)。本文内で path / 変数を参照する場合は `\$PLUGIN_ROOT` のような escape 形式に統一し、inline code (\` 囲み) や引用 (" 囲み) は使わない
 
 ## 5 site canonical (capture pattern 共有)
 
@@ -147,7 +148,7 @@ Pre-condition check (3 site) に加えて、以下 2 site も同一の `if val=$
 
 Pre-condition (phase / parent_issue_number) は **複数行 form (Form A)**、metrics step (implementation_round) は **inline 1 行 form (Form B)** を使う。 numeric type validation (非数値 → 0 降格) は metrics / parent_issue_number 等の数値 field で同型対応する: writer / reader / resume の 3 layer 対称化 doctrine (詳細は `implement.md` / `pr/review.md` / `resume.md` の同 pattern site を参照)。
 
-> **RESUME_HINT mirror 義務 (Issue #956)**: 上記 8 site (5 site canonical + 3 site 外延) すべてが `state-read.sh` 起動失敗 branch (`else rc=$?; ...`) で **bit-identical** な `RESUME_HINT:` echo を emit する義務を負う。`caller-markdown-block.test.sh` TC-7 が SoT (本 reference の Form A / Form B canonical block 内 `RESUME_HINT:` 行 + line 114 prose backtick form の 3 occurrence) と全 caller の同一性を **grep + 文字列等値比較** で機械検証する。drift は CI fail で即座に検出される (TC-7.0b で SoT 内 drift を、TC-7.1〜TC-7.6 で各 caller との drift を、TC-7.0c で SoT 占有数を pin する)。
+> **RESUME_HINT mirror 義務 (Issue #956)**: 上記 8 site (5 site canonical + 3 site 外延) すべてが `state-read.sh` 起動失敗 branch (`else rc=$?; ...`) で **bit-identical** な `RESUME_HINT:` echo を emit する義務を負う。`caller-markdown-block.test.sh` TC-7 が SoT (本 reference の Form A / Form B canonical block 内 `RESUME_HINT:` 行 + §[Enforcement note (LLM 向け)](#enforcement-note-llm-向け) Branch II 項目 3 prose backtick form の 3 occurrence) と全 caller の同一性を **grep + 文字列等値比較** で機械検証する。drift は CI fail で即座に検出される (TC-7.0b で SoT 内 drift を、TC-7.1〜TC-7.6 で各 caller との drift を、TC-7.0c で SoT 占有数を pin する)。
 
 ## アンチパターン
 

--- a/plugins/rite/hooks/tests/caller-markdown-block.test.sh
+++ b/plugins/rite/hooks/tests/caller-markdown-block.test.sh
@@ -248,8 +248,9 @@ echo "TC-7: G-04 — RESUME_HINT bit-identical drift detection (Issue #956)"
 PRECONDITION_GATE_MD="$COMMANDS_DIR/issue/references/pre-condition-gate.md"
 
 # 引用符 (double-quote " または backtick `) で囲まれた RESUME_HINT 本文を抽出する helper。
-# Form A (`  echo "..."`) / Form B (`; echo "..." >&2;`) / prose backtick (line 114 `RESUME_HINT: ...`) の
-# 3 形式すべてに対応する (PR #959 cycle 1 で line 114 backtick が drift detection 対象外だった指摘に対応)。
+# Form A (`  echo "..."`) / Form B (`; echo "..." >&2;`) / prose backtick (§Enforcement note Branch II 項目 3 `RESUME_HINT: ...`) の
+# 3 形式すべてに対応する (PR #959 cycle 1 で Branch II 項目 3 prose backtick が drift detection 対象外だった指摘に対応)。
+# 注: hardcoded 行番号は新セクション追加時の shift で容易に stale 化するため section-relative 参照を採用 (Issue #960 MEDIUM-1 対応)。
 # Stage 1 (本 helper): 引用符込みで全形式を捕捉。Stage 2 (_strip_outer_quote): 外側引用符を除去して
 # bit-identical 比較する。
 extract_resume_hint_body() {
@@ -274,19 +275,19 @@ else
   pass "TC-7.0: SoT 文字列が pre-condition-gate.md から抽出できた"
 fi
 
-# pre-condition-gate.md 自身: SoT 内部 (Form A + Form B + line 114 backtick prose の 3 occurrence) が
+# pre-condition-gate.md 自身: SoT 内部 (Form A + Form B + §Enforcement note Branch II 項目 3 backtick prose の 3 occurrence) が
 # drift していないことを assert。Stage 2 で外側引用符を除去してから unique 数をカウントすることで、
 # 「外側 quote は異なるが本文は同一」のケースを 1 種類として正しく集計する。
 gate_bodies_raw=$(extract_resume_hint_body "$PRECONDITION_GATE_MD")
 gate_bodies_stripped=$(printf '%s\n' "$gate_bodies_raw" | _strip_outer_quote)
 gate_unique=$(printf '%s\n' "$gate_bodies_stripped" | sort -u | wc -l | tr -d ' ')
-assert "TC-7.0b: pre-condition-gate.md 内 RESUME_HINT 本文が 1 種類 (Form A + Form B + line 114 backtick prose を含む 3 occurrence で drift なし)" "1" "$gate_unique"
+assert "TC-7.0b: pre-condition-gate.md 内 RESUME_HINT 本文が 1 種類 (Form A + Form B + §Enforcement note Branch II 項目 3 backtick prose を含む 3 occurrence で drift なし)" "1" "$gate_unique"
 
 # pre-condition-gate.md 内 RESUME_HINT 占有数の機械検証。
-# Form A (line 55 double-quote) + Form B (line 69 double-quote) + line 114 backtick prose = 3 occurrence。
+# Form A canonical block (double-quote) + Form B inline form (double-quote) + §Enforcement note Branch II 項目 3 backtick prose = 3 occurrence。
 # 占有数を pin することで、将来 SoT 拡張や撤回時に drift を即座に検出できる。
 gate_occurrence_count=$(printf '%s\n' "$gate_bodies_raw" | grep -c . || true)
-assert "TC-7.0c: pre-condition-gate.md 内 RESUME_HINT 占有数 (3 occurrence: Form A + Form B + line 114 backtick prose)" "3" "$gate_occurrence_count"
+assert "TC-7.0c: pre-condition-gate.md 内 RESUME_HINT 占有数 (3 occurrence: Form A + Form B + §Enforcement note Branch II 項目 3 backtick prose)" "3" "$gate_occurrence_count"
 
 # 各 caller の RESUME_HINT 本文を SoT と bit-identical 比較
 # CQ-HIGH-2 対応: grep の 2 段階分離 (count 確認と drift 検出を独立化) で
@@ -299,7 +300,7 @@ assert_caller_match() {
   local label="$1"
   local file="$2"
   local expected_count="$3"
-  local bodies_raw count drift_count=0 drift_report=""
+  local bodies_raw count drift_count=0 drift_report="" body_stripped
   bodies_raw=$(extract_resume_hint_body "$file" || true)
   # count: wc -l で簡素化 (bodies_raw が空なら 0 とする)
   if [ -z "$bodies_raw" ]; then
@@ -316,7 +317,6 @@ assert_caller_match() {
   while IFS= read -r body_raw; do
     idx=$((idx + 1))
     [ -z "$body_raw" ] && continue
-    local body_stripped
     body_stripped=$(printf '%s' "$body_raw" | _strip_outer_quote)
     if [ "$body_stripped" != "$sot_body" ]; then
       drift_count=$((drift_count + 1))
@@ -342,7 +342,7 @@ assert_caller_match "TC-7.5: resume.md (Phase 2.1 parent_issue_number_raw) RESUM
 assert_caller_match "TC-7.6: metrics-recording.md (Phase 5.5.2 Form B implementation_round) RESUME_HINT が SoT bit-identical" "$METRICS_RECORDING_MD" 1
 
 # Resume.md の「対処: helper の存在」legacy 形式が完全に消失していること (Issue #956 AC-3)
-assert_not_grep "TC-7.8: resume.md から「対処: helper の存在」legacy 形式が消失している (Issue #956 AC-3)" \
+assert_not_grep "TC-7.7: resume.md から「対処: helper の存在」legacy 形式が消失している (Issue #956 AC-3)" \
   "$RESUME_MD" \
   '対処: helper の存在'
 


### PR DESCRIPTION
## 概要

PR #959 cycle 2 で両 reviewer マージ可合意の上 deferred された 4 件 (MEDIUM 2 + LOW 2) の改善項目を対称化整理。Wiki 経験則「累積対策 PR の review-fix loop で fix 自体が drift を導入する」の典型例 (PR #959 cycle 1 fix が本 PR で対応する drift を生成した実例)。

## 変更内容

### MEDIUM-1: hardcoded 行番号を section-relative 参照に置換

`caller-markdown-block.test.sh` 6 箇所の `line 114` 表記 (line 251, 252, 277, 283, 286, 289) と line 286 内の補足的 `line 55` / `line 69` 表記、および `pre-condition-gate.md:150` の `line 114` 表記をすべて section-relative 参照 (`§Enforcement note Branch II 項目 3 prose backtick` 等) に置換。cycle 1 fix で `### Branch I/II` 見出しを追加した結果 6 行 shift し全 stale 化した silent drift を構造的に予防。

Wiki 経験則「Asymmetric Fix Transcription」に従い Issue 記載 6 箇所に加え grep で発見した line 283 (Issue で undercount) と line 286 内の line 55/69 も同時に section-relative 化することで対称性を担保。

### MEDIUM-2: RESUME_HINT 本文の backtick / double-quote 禁止契約を明示

`pre-condition-gate.md` の "Branch I / II 共通の不変条件" セクションに RESUME_HINT 本文には literal backtick (\`) と literal double-quote (") を含めない契約を追加。`extract_resume_hint_body` の `[^"\`]*` 否定文字クラスが本文の途中で切れて drift 検出が誤判定する future failure mode を future-proof 化。

### LOW-1: TC-7.7 gap 解消

`caller-markdown-block.test.sh:345` の TC-7.8 を TC-7.7 にリネーム (TC-7.7 gap 解消で TC-7.0 / 7.0b / 7.0c / 7.1〜7.7 の連番が完成)。

### LOW-2: `body_stripped` の local declare を関数先頭へ

`assert_caller_match` 関数内 line 319 の `local body_stripped` を line 302 の関数先頭 local declare にまとめ、他の local 変数 (`bodies_raw count drift_count drift_report`) と style 一貫化。

## 関連 Issue

Closes #960

関連 PR: #959 (元 PR、cycle 2 で deferred 合意の発端)
関連 Issue: #956 (元 Issue、RESUME_HINT SoT 化)

## 検証

- `bash plugins/rite/hooks/tests/caller-markdown-block.test.sh`: 全 37 TC pass (TC-7.7 改名後も含む)
- `/rite:lint`: plugin-specific checks 完了 (本 PR の hardcoded-line-number 修正で hardcoded-line-number-check 0 findings)

## チェックリスト

- [x] MEDIUM-1: line 114 hardcoded 6 箇所を section-relative 参照に置換
- [x] MEDIUM-2: RESUME_HINT 本文の backtick / double-quote 禁止契約を pre-condition-gate.md に明示
- [x] LOW-1: TC-7 numbering 連番化 (TC-7.7 gap 解消)
- [x] LOW-2: `body_stripped` の local declare を関数先頭に移動
- [x] caller-markdown-block.test.sh は引き続き全 TC pass
