### PR TITLE
refactor(observability): lockdir cleanup を 4 site 対称化 (#957)

### DIFF
--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -485,12 +485,23 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 
 ```bash
 rm -f .rite-compact-state 2>/dev/null || true
-rm -rf .rite-compact-state.lockdir 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1" >&2
+rm -rf .rite-compact-state.lockdir 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=start_finalize_termination" >&2
 ```
 
 **Note**: Cleanup は non-blocking。`.rite-compact-state` の削除失敗は silent skip (regular file の rm -f はほぼ permission denied のみで、次セッションでは上書き作成されるため)。
 
-`.rite-compact-state.lockdir` の削除失敗 (shared filesystem 上の stale lock 等) は `[CONTEXT] LOCKDIR_CLEANUP_FAILED=1` を stderr へ emit する。`session-start.sh` startup 時 hook で自動 cleanup する safety net はあるが、それまでの間に `pre-compact.sh acquire_wm_lock` が同 lockdir を取得しようとして work memory sync を silent skip する potential risk があるため observable signal を残す目的。なお現状この sentinel は `WORKFLOW_INCIDENT=1` 形式ではないため Phase 5.4.4.1 detection 経路では consume されず、stderr observability のみ (将来 incident pattern への昇格 / preflight 拡張時の interception 点として将来利用される想定)。
+`.rite-compact-state.lockdir` の削除失敗 (shared filesystem 上の stale lock 等) は `[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=<discriminator>` を stderr へ emit する。`from=` discriminator で emit 元を識別し、4 site (`start_md_termination` / `start_finalize_termination` / `session_start_cleanup` / `cleanup_work_memory`) で対称化されている。`session-start.sh` startup 時 hook で自動 cleanup する safety net はあるが、それまでの間に `pre-compact.sh acquire_wm_lock` が同 lockdir を取得しようとして work memory sync を silent skip する potential risk があるため observable signal を残す目的。
+
+**4 site 対称化マッピング** (Issue #957):
+
+| 呼出元 | ファイル | `from=` discriminator |
+|-------|---------|----------------------|
+| Workflow Termination (success path) | `start-finalize.md` Step 2 | `start_finalize_termination` |
+| Mandatory After 5.5-Termination (caller idempotent) | `start.md` Step 1 | `start_md_termination` |
+| Startup cleanup (stale state) | `hooks/session-start.sh` `_cleanup_stale_compact` | `session_start_cleanup` |
+| Close mode cleanup | `hooks/cleanup-work-memory.sh` Step 2 | `cleanup_work_memory` |
+
+caller (`start.md`) と sub-skill (`start-finalize.md`) の二重 rm は defense-in-depth: sub-skill が success path で primary cleanup を担い、caller が abort path / interrupt path での idempotent fallback を担う。なお現状この sentinel は `WORKFLOW_INCIDENT=1` 形式ではないため Phase 5.4.4.1 detection 経路では consume されず、stderr observability のみ (将来 incident pattern への昇格 / preflight 拡張時の interception 点として将来利用される想定)。
 
 ---
 

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -688,8 +688,14 @@ Invoke `skill: "rite:issue:start-finalize"`.
 bash {plugin_root}/hooks/flow-state-update.sh patch \
   --phase "completed" --active false --next "none" \
   --if-exists --preserve-error-count
+# Defense-in-depth dual cleanup: start-finalize.md Workflow Termination Step 2 が
+# success path での primary cleanup を担う。本 idempotent rm は abort path /
+# interrupt path で sub-skill cleanup が skip された場合の最終 fallback。
+# regular file (`.rite-compact-state`) は permission denied 以外で失敗しないため silent skip。
+# lockdir (`.rite-compact-state.lockdir`) は shared filesystem 上の stale lock 等で失敗する
+# potential があるため emit する。`from=` discriminator で emit 元 (4 site 対称) を識別。
 rm -f .rite-compact-state 2>/dev/null || true
-rm -rf .rite-compact-state.lockdir 2>/dev/null || true
+rm -rf .rite-compact-state.lockdir 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=start_md_termination" >&2
 ```
 
 **Step 2 (Workflow Incident Detection)**: Run Phase 5.4.4.1 (Workflow Incident Detection). Grep the recent conversation context for `[CONTEXT] WORKFLOW_INCIDENT=1` lines (emitted by `start-finalize` sub-skill — e.g., `[ready:error]` orchestrator-direct emit per §D, or by `ready.md` sub-skill via Sentinel Visibility Rule). If found, execute Phase 5.4.4.1 step 2-7. Phase 5.4.4.1 is **non-blocking** — continue to Step 3 regardless of detection result.

--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -83,7 +83,7 @@ if [ "$CLOSE_MODE" = false ]; then
 
   # Step 2: Clean up .rite-compact-state
   rm -f "$STATE_ROOT/.rite-compact-state" 2>/dev/null || true
-  rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || true
+  rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory" >&2
 
   # Step 3: Delete ALL work memory files
   if [ -d "$WM_DIR" ]; then

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -73,7 +73,7 @@ fi
 _cleanup_stale_compact() {
   if [ -f "$STATE_ROOT/.rite-compact-state" ]; then
     rm -f "$STATE_ROOT/.rite-compact-state" 2>/dev/null || true
-    rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || true
+    rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=session_start_cleanup" >&2
   fi
 }
 


### PR DESCRIPTION
## 概要

PR #955 (Issue #954) cycle 2 レビューで指摘された `LOCKDIR_CLEANUP_FAILED=1` emit の片肺問題を解消する。同一 path (`.rite-compact-state.lockdir`) を二重 rm する 4 site の cleanup observability を対称化し、`from=` discriminator で emit 元を機械的に区別可能にした。

Closes #957

## 変更内容

| ファイル | 変更 |
|---------|------|
| `plugins/rite/commands/issue/start.md` | L691-692 を emit + `from=start_md_termination` discriminator、直前に defense-in-depth dual cleanup の意図コメント追加 |
| `plugins/rite/commands/issue/start-finalize.md` | L488 emit に `from=start_finalize_termination` discriminator 追加、L491-493 Note を 4 site 対称化マッピングテーブルで更新 |
| `plugins/rite/hooks/session-start.sh` | L76 を emit + `from=session_start_cleanup` |
| `plugins/rite/hooks/cleanup-work-memory.sh` | L86 を emit + `from=cleanup_work_memory` |

## 設計判断

- **二重 rm は defense-in-depth として維持**: sub-skill (`start-finalize.md`) が success path の primary cleanup、caller (`start.md`) が abort path / interrupt path の idempotent fallback を担う責務分離。Issue で示された選択肢 (b) (cleanup 一本化) は採用せず、観測性を上げる方向 (選択肢 a) で対称化。
- **`from=` discriminator で emit 元を区別**: runtime evidence として 4 site (`start_md_termination` / `start_finalize_termination` / `session_start_cleanup` / `cleanup_work_memory`) を機械的に区別可能。
- **全 4 site 対称化を採用**: 選択肢 (c) (workflow-incident-emit.sh 経由格上げ) は将来の拡張に retain しつつ、現状は stderr observability に統一。session-start.sh / cleanup-work-memory.sh も含めることで drift 経路を構造的に塞ぐ (Wiki 経験則「N site 対称化 counter 宣言」)。

## Acceptance Criteria

- [x] start.md と start-finalize.md の lockdir cleanup observability が対称化されている
- [x] 二重 rm の意図が docstring または code コメントで明示されている
- [x] 関連 hook scripts (session-start / cleanup-work-memory) の方針も決定

## 検証

- `grep -rn "LOCKDIR_CLEANUP_FAILED=1" plugins/rite/` = 4 hits (canonical site) + 1 hit (start-finalize.md Note 内列挙)
- 4 discriminator (`from=start_md_termination` / `from=start_finalize_termination` / `from=session_start_cleanup` / `from=cleanup_work_memory`) が各 1 hit
- `session-start.test.sh`: 38 tests pass (lockdir cleanup の exit/file 状態 check で emit 変更による破壊なし)
- `/rite:lint` Phase 3.5-3.13: all checks ≤ warning (non-blocking、本 PR 変更による新規 finding なし)

## 関連

- 元 PR: #955
- 元 Issue: #954 (M-3 task の延長)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
