### PR TITLE
refactor(observability): work memory lockdir cleanup の observability を 2 site 対称化

### DIFF
--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -512,7 +512,7 @@ caller (`start.md`) と sub-skill (`start-finalize.md`) の二重 rm は defense
 | Full cleanup mode per-file loop | `hooks/cleanup-work-memory.sh` Step 3 | `cleanup_work_memory_wm_dir` |
 | Close mode single-issue cleanup | `hooks/cleanup-work-memory.sh` close-mode | `cleanup_work_memory_issue` |
 
-両系列とも emit の目的は `pre-compact.sh acquire_wm_lock` 等が stale lockdir を取得して work memory sync を silent skip する potential risk への observable signal。`.rite-compact-state.lockdir` は global state ゆえ 4 site で対称化、work memory lockdir は per-issue scope ゆえ 2 site で完結する。
+両系列とも emit の目的は `work-memory-update.sh:153 acquire_wm_lock "$lockdir"` (per-issue work memory `.lockdir` を取得、`$lockdir="${local_wm}.lockdir"`) 等が stale lockdir を取得して work memory sync を silent skip する potential risk への observable signal。global state の `.rite-compact-state.lockdir` 系列 (`pre-compact.sh:82` で取得) とは consumer が異なる別系列であり、`.rite-compact-state.lockdir` は global state ゆえ 4 site で対称化、work memory lockdir は per-issue scope ゆえ 2 site で完結する。
 
 ---
 

--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -503,6 +503,17 @@ rm -rf .rite-compact-state.lockdir 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANU
 
 caller (`start.md`) と sub-skill (`start-finalize.md`) の二重 rm は defense-in-depth: sub-skill が success path で primary cleanup を担い、caller が abort path / interrupt path での idempotent fallback を担う。なお現状この sentinel は `WORKFLOW_INCIDENT=1` 形式ではないため Phase 5.4.4.1 detection 経路では consume されず、stderr observability のみ (将来 incident pattern への昇格 / preflight 拡張時の interception 点として将来利用される想定)。
 
+**Work memory lockdir 別系統 2 site 対称化マッピング** (Issue #964):
+
+`.rite-compact-state.lockdir` (global compact state) とは別系統で、work memory file (`.rite-work-memory/issue-*.md`) 単位の `.lockdir` cleanup が `cleanup-work-memory.sh` 内に 2 site 存在する。同形の `from=cleanup_work_memory_<scope>` discriminator で対称化されている。
+
+| 呼出元 | ファイル | `from=` discriminator |
+|-------|---------|----------------------|
+| Full cleanup mode per-file loop | `hooks/cleanup-work-memory.sh` Step 3 | `cleanup_work_memory_wm_dir` |
+| Close mode single-issue cleanup | `hooks/cleanup-work-memory.sh` close-mode | `cleanup_work_memory_issue` |
+
+両系列とも emit の目的は `pre-compact.sh acquire_wm_lock` 等が stale lockdir を取得して work memory sync を silent skip する potential risk への observable signal。`.rite-compact-state.lockdir` は global state ゆえ 4 site で対称化、work memory lockdir は per-issue scope ゆえ 2 site で完結する。
+
 ---
 
 ## Return Output Format (Before Return)

--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -95,7 +95,7 @@ if [ "$CLOSE_MODE" = false ]; then
         echo "WARNING: 削除失敗: $f" >&2
         failed_count=$((failed_count + 1))
       fi
-      rm -rf "${f}.lockdir" 2>/dev/null || true
+      rm -rf "${f}.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory_wm_dir" >&2
     done
   fi
 
@@ -111,7 +111,7 @@ else
       failed_count=1
     fi
   fi
-  rm -rf "$WM_DIR/issue-${ISSUE_NUMBER}.md.lockdir" 2>/dev/null || true
+  rm -rf "$WM_DIR/issue-${ISSUE_NUMBER}.md.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory_issue" >&2
 fi
 
 # Step 4: Verify and report


### PR DESCRIPTION
## 概要

PR #963 (Issue #957) cycle 1 レビューで code-quality reviewer が指摘した follow-up を解消する。`cleanup-work-memory.sh` 内の `rm -rf <lockdir>` 3 site のうち、L86 (`.rite-compact-state.lockdir`) のみ `[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory` を emit し、L98 (per-file `${f}.lockdir`) と L114 (close-mode `issue-${N}.md.lockdir`) は `|| true` で silent skip だった observability 非対称を解消する。

## 変更内容

- `plugins/rite/hooks/cleanup-work-memory.sh` L98: silent skip → `from=cleanup_work_memory_wm_dir` emit
- `plugins/rite/hooks/cleanup-work-memory.sh` L114: silent skip → `from=cleanup_work_memory_issue` emit
- `plugins/rite/commands/issue/start-finalize.md`: `.rite-compact-state.lockdir` 4-site mapping 表の直後に「Work memory lockdir 別系統 2 site 対称化マッピング」を追記。per-issue scope の 2 discriminator (`_wm_dir` / `_issue`) を明示し、global state (4 site) と別系統である旨を documentation する

## 設計判断

Issue 推奨対応 (a) + (b) を統合採用:
- (a) start-finalize.md mapping 表に note 追加
- (b) `from=cleanup_work_memory_wm_dir` / `from=cleanup_work_memory_issue` で symmetric emit

理由: Wiki 経験則「state machine 1 箇所 canonical 宣言 + UX-positive 側統一」+「極小対称化 PR は sibling site Grep 照合で高確信レビュー」(PR #963 で実証) に従い、runtime symmetric emit を主、documentation を従とする統合アプローチ。

## スコープ厳守

- `.rite-compact-state.lockdir` の既存 4-site mapping (start_md_termination / start_finalize_termination / session_start_cleanup / cleanup_work_memory) は別系列のため未改変
- L92-96 の work memory file 削除 WARNING (regular file rm 失敗) は別 anti-pattern (permission issue 系統) のため本 PR scope 外

## 検証

- `grep -c "LOCKDIR_CLEANUP_FAILED" cleanup-work-memory.sh` == 3 (3 site すべて emit)
- `bash -n cleanup-work-memory.sh` syntax OK
- `4-site-symmetry.test.sh` PASS 8/8
- `cleanup-on-session-end.test.sh` PASS 8/8
- sentinel 文字列を pin する test 不在を `grep -rn` で確認済み (breakage risk なし)

## 関連 Issue

Closes #964

## 関連 PR

- 元 PR: #963 (Issue #957 = `.rite-compact-state.lockdir` 4-site 対称化)
- 元 Issue: #957

## チェックリスト

- [x] `cleanup-work-memory.sh` L98 emit 追加
- [x] `cleanup-work-memory.sh` L114 emit 追加
- [x] `start-finalize.md` mapping note 追加
- [x] 全 3 site が `LOCKDIR_CLEANUP_FAILED` emit を持つことを grep で確認
- [x] 既存 test 全件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
