### PR TITLE
fix(commands): start-finalize.md の test 担保宣言の scope drift を解消

### DIFF
--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -32,8 +32,9 @@ abort entry の場合、Phase 5.6 Completion Report の本文には abort 理由
 **MUST run before any finalize logic** (Phase 5.5 ready / 5.5.1 status / 5.5.2 metrics / 5.6 completion / 5.7 parent close / Workflow Termination / return-output emission)。**not optional**:
 
 ```bash
-# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill 固有の
-# Pre-flight pattern。plugins/rite/hooks/tests/4-site-symmetry.test.sh は create-interview
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill での
+# Pre-flight pattern (同 pattern は他 sub-skill / create-interview workflow でも使用される
+# 共有 pattern)。plugins/rite/hooks/tests/4-site-symmetry.test.sh は create-interview
 # workflow (create.md / create-interview.md) 専用で本 sub-skill は対象外。
 # state-path-resolve.sh + _resolve-flow-state-path.sh で per-session (schema_version=2) /
 # legacy 両形式に対応。

--- a/plugins/rite/commands/issue/start-finalize.md
+++ b/plugins/rite/commands/issue/start-finalize.md
@@ -32,9 +32,11 @@ abort entry の場合、Phase 5.6 Completion Report の本文には abort 理由
 **MUST run before any finalize logic** (Phase 5.5 ready / 5.5.1 status / 5.5.2 metrics / 5.6 completion / 5.7 parent close / Workflow Termination / return-output emission)。**not optional**:
 
 ```bash
-# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
-# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。state-path-resolve.sh
-# + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill 固有の
+# Pre-flight pattern。plugins/rite/hooks/tests/4-site-symmetry.test.sh は create-interview
+# workflow (create.md / create-interview.md) 専用で本 sub-skill は対象外。
+# state-path-resolve.sh + _resolve-flow-state-path.sh で per-session (schema_version=2) /
+# legacy 両形式に対応。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/start-finalize.md:35-37` の Pre-flight section コメントが「4 引数 symmetry は `plugins/rite/hooks/tests/4-site-symmetry.test.sh` で test 担保」と記述していたが、実 test SCOPE は **create-interview workflow 専用** (`create.md` / `create-interview.md`) で `start-finalize.md` は SITES に含まれず、test 担保宣言は虚偽記述だった。

コメントを「本 sub-skill 固有の Pre-flight pattern。test は create-interview workflow 専用で本 sub-skill は対象外」と scope 明示の表現に修正。test 本体 (`4-site-symmetry.test.sh`) は変更せず、test の design intent (create-interview workflow 限定の drift 検出) を保持。

## 関連 Issue

Closes #965

## 変更内容

- `plugins/rite/commands/issue/start-finalize.md` line 35-37 のコメント修正のみ
- test 本体 (`4-site-symmetry.test.sh`) は変更なし
- 既存 test の pass 確認済み（`PASS: 8 / FAIL: 0`）

## 採択方針

- **採用**: option (b) — コメント側で scope 明示
- **不採用**: option (a) — test SITES への `start-finalize.md` 追加
  - 不採用理由: `4-site-symmetry.test.sh` header (line 23-37) は test scope を「create-interview workflow 限定」と明示しており、start sub-skill 群への scope 拡張は別の drift contract と混合する設計違反になる

## チェックリスト

- [x] 仮想 test 担保宣言を解消
- [x] `4-site-symmetry.test.sh` の test scope を維持
- [x] 既存 test を破壊していないことを確認
- [x] grep 検証: `grep -c "start-finalize" plugins/rite/hooks/tests/4-site-symmetry.test.sh` = 0

## Out of Scope (別 Issue 候補)

同じ false claim が以下 4 箇所にも存在する。本 Issue scope 外:

- `plugins/rite/commands/issue/start-execute.md:29, 289`
- `plugins/rite/commands/issue/start-publish.md:30, 313`

これらは別 Issue として追跡推奨。

## 経緯

- 元 PR: #963 (Issue #957)
- 検出: code-quality-reviewer による pre-existing drift 指摘
