### PR TITLE
docs(start.md): コメント文言 hedge と SoT pointer 追加 (PR #963 LOW 3 件) (#966)

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -691,9 +691,9 @@ bash {plugin_root}/hooks/flow-state-update.sh patch \
 # Defense-in-depth dual cleanup: start-finalize.md Workflow Termination Step 2 が
 # success path での primary cleanup を担う。本 idempotent rm は abort path /
 # interrupt path で sub-skill cleanup が skip された場合の最終 fallback。
-# regular file (`.rite-compact-state`) は permission denied 以外で失敗しないため silent skip。
+# regular file (`.rite-compact-state`) はほぼ permission denied のみで失敗するため silent skip (rare 失敗時は次セッションで上書き作成されて自己治癒)。
 # lockdir (`.rite-compact-state.lockdir`) は shared filesystem 上の stale lock 等で失敗する
-# potential があるため emit する。`from=` discriminator で emit 元 (4 site 対称) を識別。
+# potential があるため emit する。`from=` discriminator で emit 元 (4 site 対称) を識別 (対称化マッピング表は start-finalize.md `4 site 対称化マッピング` 表 参照)。
 rm -f .rite-compact-state 2>/dev/null || true
 rm -rf .rite-compact-state.lockdir 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=start_md_termination" >&2
 ```


### PR DESCRIPTION
## 概要

PR #963 cycle 1 レビューで prompt-engineer / code-quality reviewer が指摘した LOW 3 件を一括対応。

- **prompt-engineer LOW #1**: `start.md` L694 のコメント文言を断定形から hedge 形へ変更し、`start-finalize.md` L494 の表現と技術的精度を揃える
- **prompt-engineer LOW #2 / code-quality LOW #3**: `start.md` L696 末尾に `4 site 対称化マッピング` 表への semantic name 参照 pointer を追加し、SoT が `start-finalize.md` 側にあることを明示

## 変更内容

`plugins/rite/commands/issue/start.md` (+2/-2)

### Before/After

**L694 hedge 表現**:

- Before: `# regular file (`.rite-compact-state`) は permission denied 以外で失敗しないため silent skip。`
- After: `# regular file (`.rite-compact-state`) はほぼ permission denied のみで失敗するため silent skip (rare 失敗時は次セッションで上書き作成されて自己治癒)。`

**L696 SoT pointer**:

- Before: `# potential があるため emit する。`from=` discriminator で emit 元 (4 site 対称) を識別。`
- After: `# potential があるため emit する。`from=` discriminator で emit 元 (4 site 対称) を識別 (対称化マッピング表は start-finalize.md `4 site 対称化マッピング` 表 参照)。`

## 設計判断

- **line 番号ではなく semantic name で参照**: Wiki 経験則「DRIFT-CHECK ANCHOR は semantic name 参照で記述する（line 番号禁止）」に従い、`4 site 対称化マッピング` という section heading 名で参照することで、行挿入/削除による drift 耐性を保つ
- **start-finalize.md の表現に寄せる**: Wiki 経験則「Asymmetric Fix Transcription」を踏まえ、2 ファイルに分散する同種のコメントは技術的精度を揃える

## 関連 Issue

Closes #966

## 関連リンク

- 元 PR: #963
- 元 Issue: #957

## チェックリスト

- [x] 実装
- [x] lint (plugin-specific checks — start.md に新規 finding なし)
- [x] 検証基準確認 (`grep -n "ほぼ permission denied のみで"` / `grep -nE "対称化マッピング表は.*start-finalize.md"` 両方 hit)
