### PR TITLE
fix(commands): 4-site-symmetry.test.sh 担保宣言の scope drift を解消 (#970)

### DIFF
--- a/plugins/rite/commands/issue/start-execute.md
+++ b/plugins/rite/commands/issue/start-execute.md
@@ -25,9 +25,12 @@ Execute the implementation phase for an Issue. This sub-skill is invoked from `s
 **MUST run before any execute logic** (Phase 5.0 stop-hook verification / Phase 5.1 implementation / Phase 5.2 lint / Phase 5.2.1 checklist / return-output emission)。**not optional**:
 
 ```bash
-# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
-# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。state-path-resolve.sh
-# + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill での
+# Pre-flight pattern (同 pattern は他 sub-skill / create-interview workflow でも使用される
+# 共有 pattern)。plugins/rite/hooks/tests/4-site-symmetry.test.sh は create-interview
+# workflow (create.md / create-interview.md) 専用で本 sub-skill は対象外。
+# state-path-resolve.sh + _resolve-flow-state-path.sh で per-session (schema_version=2) /
+# legacy 両形式に対応。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then
@@ -285,9 +288,9 @@ Execute the Module procedure: grep `- [ ]` pattern (Phase 5.2.1) → if `≥1` i
 Immediately before emitting the four-line return block, re-patch flow state (idempotent with Pre-flight write):
 
 ```bash
-# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
-# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。Pre-flight 後の
-# self-patch のため file 存在は保証済み。
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill での
+# Pre-flight pattern (共有 pattern)。Pre-flight 後の self-patch のため file 存在は保証済み。
+# 4-site-symmetry.test.sh は create-interview workflow 専用で本 sub-skill は対象外。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then

--- a/plugins/rite/commands/issue/start-publish.md
+++ b/plugins/rite/commands/issue/start-publish.md
@@ -26,9 +26,12 @@ Execute the publish phase for an Issue. This sub-skill is invoked from `start.md
 **MUST run before any publish logic** (Phase 5.3 PR creation / Phase 5.4 review-fix loop / return-output emission)。**not optional**:
 
 ```bash
-# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
-# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。state-path-resolve.sh
-# + _resolve-flow-state-path.sh で per-session (schema_version=2) / legacy 両形式に対応。
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill での
+# Pre-flight pattern (同 pattern は他 sub-skill / create-interview workflow でも使用される
+# 共有 pattern)。plugins/rite/hooks/tests/4-site-symmetry.test.sh は create-interview
+# workflow (create.md / create-interview.md) 専用で本 sub-skill は対象外。
+# state-path-resolve.sh + _resolve-flow-state-path.sh で per-session (schema_version=2) /
+# legacy 両形式に対応。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then
@@ -309,9 +312,9 @@ bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
 Immediately before emitting the four-line return block, re-patch flow state (idempotent with Pre-flight write):
 
 ```bash
-# 4 引数 symmetry (--phase / --active / --next / --preserve-error-count) は
-# plugins/rite/hooks/tests/4-site-symmetry.test.sh で test 担保。Pre-flight 後の
-# self-patch のため file 存在は保証済み。
+# 4 引数 (--phase / --active / --next / --preserve-error-count) は本 sub-skill での
+# Pre-flight pattern (共有 pattern)。Pre-flight 後の self-patch のため file 存在は保証済み。
+# 4-site-symmetry.test.sh は create-interview workflow 専用で本 sub-skill は対象外。
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/_resolve-flow-state-path.sh "$state_root" 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then


### PR DESCRIPTION
## 概要

`start-execute.md` / `start-publish.md` の Pre-flight + Return Output Format コメント計 4 箇所で「4-site-symmetry.test.sh で test 担保」という false claim を、PR #969 (start-finalize.md, Issue #965) で採用された scope 明示パターンに統一する。

test SCOPE は `create.md` / `create-interview.md` のみで、start-* 系 sub-skill は対象外。コメント側でその事実を明示し、reader が誤って test 担保を仮定するのを防ぐ。

## 関連 Issue

Closes #970

## 変更内容

- `plugins/rite/commands/issue/start-execute.md`
  - L28-33 (旧 L28-30): Pre-flight bash block 内コメントを scope 明示 5 行コメントに置換
  - L291-293 (旧 L288-290): Return Output Format 内 re-patch コメントを scope 明示 3 行コメントに置換
- `plugins/rite/commands/issue/start-publish.md`
  - L29-34 (旧 L29-31): Pre-flight bash block 内コメントを scope 明示 5 行コメントに置換
  - L315-317 (旧 L312-314): Return Output Format 内 re-patch コメントを scope 明示 3 行コメントに置換

test 本体 (`plugins/rite/hooks/tests/4-site-symmetry.test.sh`) は変更なし。

## 検証

- `grep -nE "4-site-symmetry.test.sh" plugins/rite/commands/issue/start-*.md` で全 5 箇所 (start-execute.md x 2 + start-finalize.md x 1 + start-publish.md x 2) が「create-interview workflow」「対象外」を含む scope-explicit パターンに統一されていることを確認
- `bash plugins/rite/hooks/tests/4-site-symmetry.test.sh` PASS (8/8) を維持

## 不採用案

**option (a)**: test SITES に start-* sub-skill を追加 — `4-site-symmetry.test.sh` header で「create-interview workflow 専用」と明示されており、start sub-skill 群への scope 拡張は別の drift contract と混合する設計違反になるため不採用。

## チェックリスト

- [x] start-execute.md (Pre-flight) のコメント修正
- [x] start-execute.md (Return Output Format) のコメント修正
- [x] start-publish.md (Pre-flight) のコメント修正
- [x] start-publish.md (Return Output Format) のコメント修正
- [x] 全 5 箇所の scope 明示確認
- [x] `4-site-symmetry.test.sh` PASS 確認

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
