### PR TITLE
refactor(hooks): rite-config.yml path を STATE_ROOT 起点に統一

### DIFF
--- a/plugins/rite/hooks/notification.sh
+++ b/plugins/rite/hooks/notification.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 # Notifications are best-effort; exit gracefully if jq is not available
 command -v jq >/dev/null 2>&1 || exit 0
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Read CWD from stdin JSON (consistent with other hooks).
 # CWD is provided by the Claude Code runtime and is already an absolute path;
 # realpath normalization is unnecessary and would add a portability concern.
@@ -17,7 +19,13 @@ if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
     exit 0
 fi
 
-CONFIG_FILE="$CWD/rite-config.yml"
+# Resolve project root (git root anchored). Matches session-start.sh /
+# _resolve-schema-version.sh / post-tool-wm-sync.sh convention; `$CWD` based
+# lookup would silently miss rite-config.yml when Claude Code is launched from
+# a subdirectory (Issue #976).
+STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
+
+CONFIG_FILE="$STATE_ROOT/rite-config.yml"
 if [ ! -f "$CONFIG_FILE" ]; then
     exit 0
 fi

--- a/plugins/rite/hooks/stop-create-interview-block.sh
+++ b/plugins/rite/hooks/stop-create-interview-block.sh
@@ -95,8 +95,13 @@ STATE_PR=$(jq -r '.pr_number // 0' "$STATE_FILE_PATH" 2>/dev/null) || STATE_PR="
 # exit 0 even when the gate condition matches. `|| true` keeps the chain compatible
 # with strict-mode contexts (no-match → empty result → default-on fallback).
 WORKFLOW_INCIDENT_ENABLED="true"
-if [ -f "$CWD/rite-config.yml" ]; then
-  workflow_incident_enabled=$(sed -n '/^workflow_incident:/,/^[a-zA-Z]/p' "$CWD/rite-config.yml" 2>/dev/null \
+# `$STATE_ROOT_PATH/rite-config.yml` is the canonical project-config path resolved
+# via state-path-resolve.sh (git root anchored). Matches session-start.sh /
+# _resolve-schema-version.sh / post-tool-wm-sync.sh convention; `$CWD` based
+# lookup would silently miss the opt-out when Claude Code is launched from a
+# subdirectory (Issue #976).
+if [ -f "$STATE_ROOT_PATH/rite-config.yml" ]; then
+  workflow_incident_enabled=$(sed -n '/^workflow_incident:/,/^[a-zA-Z]/p' "$STATE_ROOT_PATH/rite-config.yml" 2>/dev/null \
     | grep -E '^[[:space:]]+enabled:' | head -1 | sed 's/#.*//' \
     | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]' || true)
   value=$(printf '%s' "$workflow_incident_enabled" | tr -d '"'"'"'' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## 概要

`stop-create-interview-block.sh` の `rite-config.yml` path 解決を `$CWD` 起点から `$STATE_ROOT_PATH` 起点に変更し、同パターンを使用していた `notification.sh` も `$STATE_ROOT` 起点に統一する。subdirectory 起動時に `workflow_incident.enabled=false` opt-out が silent に無視される潜在問題を解消し、他 hook (session-start.sh / _resolve-schema-version.sh / post-tool-wm-sync.sh) と convention を一致させる。

## 関連 Issue

Closes #976

## 変更内容

- `plugins/rite/hooks/stop-create-interview-block.sh`: line 98-101 の `[ -f "$CWD/rite-config.yml" ]` および sed 引数の `"$CWD/rite-config.yml"` を `$STATE_ROOT_PATH/rite-config.yml` (line 65-71 で解決済) に置換。convention 一致理由を 4-line コメントで明示。
- `plugins/rite/hooks/notification.sh`: `SCRIPT_DIR` 解決行と `STATE_ROOT=$(state-path-resolve.sh "$CWD") || STATE_ROOT="$CWD"` フォールバック付きの呼び出しを追加し、`CONFIG_FILE` を `$STATE_ROOT/rite-config.yml` に変更。

## 検証

- `bash -n` で両ファイルの syntax 通過確認
- 既存テスト全件 pass:
  - `plugins/rite/hooks/tests/stop-create-interview-block.test.sh`: 24/24
  - `plugins/rite/hooks/tests/notification.test.sh`: 14/14 (+ 1 skipped)
- `grep -c 'CWD/rite-config'` で両ファイルが `0` であることを確認

## チェックリスト

- [x] プロジェクトの規約に準拠
- [x] 既存テストが pass
- [x] convention 一致 (session-start.sh / _resolve-schema-version.sh / post-tool-wm-sync.sh と同 pattern)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
