### PR TITLE
docs(test): stop-create-interview-block.test.sh の AC mapping header を Issue #920 体系へ整合化 (#977)

### DIFF
--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Tests for hooks/stop-create-interview-block.sh — Stop event hook (#920).
 #
-# Covers Issue #920 acceptance criteria:
-#   AC-1 — gate condition (phase=create_post_interview + active=true + pr_number=0)
-#          triggers exit 2 + ACTION message + manual_fallback_adopted sentinel
-#   AC-2 — ACTION message contains the idempotent Step 0 patch literal for resume
-#   AC-4 — manual_fallback_adopted workflow_incident sentinel is emitted via stderr
-#   AC-5 — exit 0 (allow Stop) for gate-mismatched states
+# Primary AC coverage:
+#   AC-4 (Issue #920) — implicit stop detection emits workflow_incident sentinel
+# Back-stop behavior tests (not direct Issue AC mapping):
+#   - gate-match → exit 2 + ACTION (TC-1, TC-9)
+#   - gate-mismatch / recursion guard / non-Stop → exit 0 (TC-2..TC-6, TC-8)
+#   - workflow_incident.enabled=false respected (TC-7)
+# Note: Issue AC-1/AC-2/AC-5 are orchestrator-side e2e concerns, out of hook test scope.
+# Note: AC-3 (structural invariants) covered by 4-site-symmetry.test.sh et al.
+# Note: AC-6 (charter violation grep) covered separately.
 #
 # Usage: bash plugins/rite/hooks/tests/stop-create-interview-block.test.sh
 set -euo pipefail


### PR DESCRIPTION
## Summary

PR #975 cycle 4 + cycle 6 で test reviewer が検出した LOW (スコープ外) を解消。

`plugins/rite/hooks/tests/stop-create-interview-block.test.sh` の header コメント (lines 4-9) が「Issue #920 acceptance criteria」を主張するが、Issue #920 の実 AC と test 内部の便宜的番号付けが不整合だった。また AC-3 / AC-6 が別 invariant test に委譲される旨も明記されていなかった。

header を以下の構造に再構成し traceability を改善:

- **Primary AC coverage**: AC-4 (Issue #920) — implicit stop detection emits workflow_incident sentinel
- **Back-stop behavior tests** (not direct Issue AC mapping):
  - gate-match → exit 2 + ACTION (TC-1, TC-9)
  - gate-mismatch / recursion guard / non-Stop → exit 0 (TC-2..TC-6, TC-8)
  - workflow_incident.enabled=false respected (TC-7)
- **Note**: AC-1/AC-2/AC-5 は orchestrator-side e2e concerns で hook test scope 外
- **Note**: AC-3 (structural invariants) は `4-site-symmetry.test.sh` 他に委譲
- **Note**: AC-6 (charter violation grep) は別 grep test に委譲

## 関連 Issue

Closes #977

## 変更内容

- `plugins/rite/hooks/tests/stop-create-interview-block.test.sh` (lines 4-9) — header コメントを 10 行の新ブロックに置換 (+9 / -6)

## 影響範囲

コメントのみの変更で TC ロジックは無変更。既存テストの正しさへの影響なし。

## 動作確認

- 既存テスト全実行: 9 TC / 24 assertion 全 pass を確認 (`bash plugins/rite/hooks/tests/stop-create-interview-block.test.sh`)
- bang-backtick check: 0 findings
- `/rite:lint`: success (変更ファイル外の既存 warning のみ)

## チェックリスト

- [x] header コメントを Issue #920 AC 体系と整合化
- [x] AC-3 / AC-6 の委譲先を明記
- [x] 既存テスト全 pass を確認
