### PR TITLE
docs(workflow): workflow-incident-detection.md に Strict-mode caller variant を併記 (#978)

### DIFF
--- a/plugins/rite/commands/issue/references/workflow-incident-detection.md
+++ b/plugins/rite/commands/issue/references/workflow-incident-detection.md
@@ -44,6 +44,29 @@ Retain `workflow_incident_enabled` in conversation context. Phase 5.4.4.1 reads 
 
 > **Note on non-blocking / dedupe behavior**: The implementation always behaves as non-blocking (registration failure does not halt the workflow) and deduplicates incidents per session (same type is only prompted once). Only `enabled` is a configurable key.
 
+### Strict-mode caller variant
+
+`set -euo pipefail` + ERR trap を有効化した caller (hook 等) は、上記 Canonical bash literal を **そのまま** copy-paste すると silent regression を再発する経路がある。`workflow_incident:` section が `rite-config.yml` に存在しない場合、`grep -E '^[[:space:]]+enabled:'` が no-match で exit 1 を返し、pipefail で pipeline 全体が exit 1 になる。`$(...)` substitution 経由で assignment 文の exit code が non-zero となり、ERR trap が発火して silent exit する経路を生む。
+
+PR #975 cycle 2 CRITICAL では `plugins/rite/hooks/stop-create-interview-block.sh` の `workflow_incident.enabled` parser がまさにこの経路で発火し、Stop hook が user-facing ACTION message を表示せず exit する regression を発生させた。canonical (上記) は default 想定で動作するが、`set -euo pipefail` + ERR trap caller では assignment 末尾 pipeline に `|| true` を追加した以下 variant を使用すること:
+
+```bash
+# Canonical との差分: `tr -d '[:space:]')` → `tr -d '[:space:]' || true)`
+# `|| true` を assignment subshell 内の pipeline 末尾に置くことで、
+# grep の no-match 時 pipefail 伝播を遮断する (ERR trap 起因の silent exit を防ぐ)。
+workflow_incident_enabled=$(sed -n '/^workflow_incident:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null \
+  | grep -E '^[[:space:]]+enabled:' | head -1 | sed 's/#.*//' \
+  | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]' || true)
+workflow_incident_enabled=$(echo "$workflow_incident_enabled" | tr '[:upper:]' '[:lower:]')
+case "$workflow_incident_enabled" in
+  true|yes|1)  workflow_incident_enabled="true" ;;
+  false|no|0)  workflow_incident_enabled="false" ;;
+  *) workflow_incident_enabled="true" ;;  # 不明値 / 空 → default-on
+esac
+```
+
+> **Drift detection contract**: `plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh` Section 1.1 は (a) 本 subsection heading の存在、(b) variant bash literal (`tr -d '[:space:]' || true`) の存在、(c) strict-mode caller (`stop-create-interview-block.sh`) が `|| true` guard を保持していること、の 3 点を assert する。将来の refactor で hook 側 `|| true` を誤って削除する drift を機械検出し、SoT (本 ref) ↔ implementation (hook) の 2 site 対称性を保証する (Issue #978)。
+
 ## Phase 5.4.4.1 — Workflow Incident Detection
 
 ### Sentinel `type` の意味

--- a/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
+++ b/plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh
@@ -95,6 +95,35 @@ assert_grep "detection: Default-on behavior invariant" \
   "$REF_DETECTION" \
   '^### Default-on behavior'
 
+# === 1.1 Strict-mode caller variant (Issue #978) ===
+# PR #975 cycle 2 CRITICAL で stop-create-interview-block.sh の workflow_incident.enabled parser が
+# strict-mode (set -euo pipefail + ERR trap) 下で grep no-match → pipefail → ERR trap → silent exit
+# 経路を踏んだため、hook 側で pipeline 末尾に `|| true` を追加して strict-mode 対応した。
+# Issue #978 で SoT 側 (workflow-incident-detection.md) にも同等の guidance を併記し、
+# 将来別の strict-mode caller が canonical をそのまま copy-paste して同じ罠を踏まないよう構造的に予防。
+# 本 section は (a) SoT 側 subsection の存在、(b) SoT 側 variant bash literal の存在、
+# (c) hook 側 `|| true` guard の保持、の 3 点を assert し SoT ↔ implementation の対称性を保証する。
+echo ""
+echo "--- 1.1 Strict-mode caller variant (Issue #978) ---"
+
+assert_grep "detection: Strict-mode caller variant subsection heading" \
+  "$REF_DETECTION" \
+  '^### Strict-mode caller variant'
+
+# variant bash literal は assignment 末尾の `tr -d '[:space:]' || true)` 形式
+# (canonical は `tr -d '[:space:]')` で `|| true` なし、その差分が strict-mode 対応の本体)
+assert_grep "detection: Strict-mode variant adds '|| true' to assignment pipeline" \
+  "$REF_DETECTION" \
+  "tr -d '\[:space:\]' \|\| true"
+
+# Hook-side drift detection: stop-create-interview-block.sh が `|| true` guard を保持していること
+# 将来 hook 側で `|| true` が削除される drift を機械検出する (Issue #978 対応案 2)
+HOOK_STOP_CREATE_INTERVIEW="$REPO_ROOT/plugins/rite/hooks/stop-create-interview-block.sh"
+
+assert_grep "detection: stop-create-interview-block.sh retains '|| true' guard (Issue #978 drift detection)" \
+  "$HOOK_STOP_CREATE_INTERVIEW" \
+  "tr -d '\[:space:\]' \|\| true"
+
 # === 2. workflow-incident-emit-pattern.md の必須コンテンツ ===
 echo ""
 echo "--- 2. workflow-incident-emit-pattern.md ---"


### PR DESCRIPTION
## 概要

PR #975 cycle 2 CRITICAL で `plugins/rite/hooks/stop-create-interview-block.sh` の `workflow_incident.enabled` parser が strict-mode (`set -euo pipefail` + ERR trap) 下で `grep` no-match → pipefail → ERR trap → silent exit 経路を踏んだ。hook 側で pipeline 末尾に `|| true` を追加して対応したが、SoT である `workflow-incident-detection.md` の Canonical bash literal にはこの guidance が欠落していたため、将来別の strict-mode caller が canonical をそのまま copy-paste すると同じ罠を踏む経路が残存していた (Issue #978)。

## 変更内容

### 1. SoT 側に Strict-mode caller variant subsection を追加

`plugins/rite/commands/issue/references/workflow-incident-detection.md` の `### Canonical bash literal` 直後に `### Strict-mode caller variant` subsection を新設。

- **背景説明**: `set -euo pipefail` + ERR trap caller が canonical をそのまま copy-paste すると silent regression する経路 (PR #975 cycle 2 CRITICAL 引用)
- **Variant bash literal**: Canonical との差分は `tr -d '[:space:]')` → `tr -d '[:space:]' || true)` のみ。`|| true` を assignment subshell 内 pipeline 末尾に置くことで grep の no-match 時 pipefail 伝播を遮断
- **Drift detection contract**: hook ↔ SoT の 2 site 対称性は `sentinel-visibility-rule.test.sh` Section 1.1 で機械保証することを明示

### 2. test 側に Section 1.1 (drift detection) を追加

`plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh` Section 1 末尾に `1.1 Strict-mode caller variant (Issue #978)` ブロックを追加し、3 assert を追加:

1. SoT 側 subsection heading `### Strict-mode caller variant` の存在
2. SoT 側 variant bash literal (`tr -d '[:space:]' || true`) の存在
3. Hook 側 (`stop-create-interview-block.sh`) が `|| true` guard を保持していること

assert (3) が drift detection の本体: 将来の refactor で hook 側 `|| true` を誤って削除した場合に機械検出する。SoT ↔ implementation の 2 site 対称性を test レイヤーで保証。

## 関連 Issue

Closes #978

## 関連 PR / 経験則

- 元の事案: PR #975 (Issue #920 — Stop event hook back-stop for create-interview implicit stop)
- 検出 cycle: 6 / 検出 reviewer: error-handling
- 重要度: MINOR (累積系列予防、defense-in-depth)
- Wiki 関連経験則: `Asymmetric Fix Transcription (対称位置への伝播漏れ)` — hook 側修正と SoT 側 guidance の 2 site 対称化を構造的に保証

## テスト

`bash plugins/rite/hooks/tests/sentinel-visibility-rule.test.sh`:
- 全 91 assert PASS (既存 88 + 新規 3)
- 新規 Section 1.1 の 3 assert がいずれも PASS
- 既存 assertion は変更なし

## チェックリスト

- [x] SoT (`workflow-incident-detection.md`) に Strict-mode caller variant を追加
- [x] variant bash literal に `|| true` を含む
- [x] test (`sentinel-visibility-rule.test.sh`) に drift detection assertion を追加
- [x] `sentinel-visibility-rule.test.sh` 実行で 0 FAIL を確認
- [x] Conventional Commits `docs(workflow):` で commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
