### PR TITLE
test(hooks): TC-7 を workflow_incident.enabled variant matrix にループ parameterize

### DIFF
--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -6,7 +6,7 @@
 # Back-stop behavior tests (not direct Issue AC mapping):
 #   - gate-match → exit 2 + ACTION (TC-1, TC-9)
 #   - gate-mismatch / recursion guard / non-Stop → exit 0 (TC-2..TC-6, TC-8)
-#   - workflow_incident.enabled=false respected (TC-7)
+#   - workflow_incident.enabled=false respected (TC-7 variant matrix)
 # Note: Issue AC-1/AC-2/AC-5 are orchestrator-side e2e concerns, out of hook test scope.
 # Note: AC-3 (structural invariants) covered by 4-site-symmetry.test.sh et al.
 # Note: AC-6 (charter violation grep) covered separately.
@@ -192,20 +192,39 @@ assert_eq "TC-6.1: exit code 0 (allow)" "0" "$rc"
 assert_eq "TC-6.2: no stderr output" "" "$STDERR"
 rm -rf "$SBX"; cleanup_dirs=("${cleanup_dirs[@]/$SBX}")
 
-# ---- TC-7: workflow_incident.enabled=false → block but skip sentinel emission ----
-echo "TC-7: workflow_incident.enabled=false → exit 2 but no sentinel emitted"
-SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
-write_flow_state "$SBX" "create_post_interview" "true" "0"
-cat > "$SBX/rite-config.yml" <<'YAML'
+# ---- TC-7: workflow_incident.enabled variant matrix → all opt-out forms block + skip sentinel ----
+# Canonical SoT (workflow-incident-detection.md) accepts 6+ syntactic variants of falsy values
+# (`false` / `no` / `0`, case-insensitive, with/without quotes, with trailing comment). The hook
+# parser (stop-create-interview-block.sh:103-111) implements quote stripping + case-folding +
+# case branch. This loop pins all variants so future parser refactors cannot silently degrade
+# any form to default-on (cycle 4 LOW finding — Issue #979).
+echo "TC-7: workflow_incident.enabled variant matrix (7 syntactic forms) → exit 2 + no sentinel"
+
+TC7_VARIANTS=(
+  "false"
+  "FALSE"
+  '"false"'
+  "'false'"
+  "no"
+  "0"
+  "false # trailing comment"
+)
+
+for variant in "${TC7_VARIANTS[@]}"; do
+  echo "  variant: enabled: $variant"
+  SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+  write_flow_state "$SBX" "create_post_interview" "true" "0"
+  cat > "$SBX/rite-config.yml" <<YAML
 workflow_incident:
-  enabled: false
+  enabled: $variant
 YAML
-payload=$(build_stop_payload "$SBX" false)
-run_hook "$SBX" "$payload"; rc=$HOOK_RC
-assert_eq "TC-7.1: exit code 2 (block respected)" "2" "$rc"
-assert_contains "TC-7.2: ACTION still shown" "Issue #920" "$STDERR"
-assert_not_contains "TC-7.3: workflow_incident sentinel NOT emitted (opt-out respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
-rm -rf "$SBX"; cleanup_dirs=("${cleanup_dirs[@]/$SBX}")
+  payload=$(build_stop_payload "$SBX" false)
+  run_hook "$SBX" "$payload"; rc=$HOOK_RC
+  assert_eq "TC-7.1 [enabled: $variant]: exit code 2 (block respected)" "2" "$rc"
+  assert_contains "TC-7.2 [enabled: $variant]: ACTION still shown" "Issue #920" "$STDERR"
+  assert_not_contains "TC-7.3 [enabled: $variant]: workflow_incident sentinel NOT emitted (opt-out respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
+  rm -rf "$SBX"; cleanup_dirs=("${cleanup_dirs[@]/$SBX}")
+done
 
 # ---- TC-8: non-Stop event → allow (other hooks are out of scope) ----
 echo "TC-8: hook_event_name=PreToolUse → exit 0 (scope check)"


### PR DESCRIPTION
## 概要

PR #975 cycle 4 で test reviewer が検出した LOW（スコープ外）への対応。
`plugins/rite/hooks/tests/stop-create-interview-block.test.sh` の TC-7
を 7 variant のループ parameterize に変更し、canonical SoT
(`workflow-incident-detection.md`) が受容する全 variant について
exit 2 + ACTION + sentinel NOT emitted を pin する。

## 背景

- 実装側 (`stop-create-interview-block.sh:103-111`) は sed → grep → sed →
  tr (quote 剥がし) → tr (case-folding) → case branch で全 variant を
  既に処理している
- 旧 TC-7 は単一 variant (`enabled: false` lowercase, unquoted) しか
  pin していなかった
- 将来の parser 改修で `FALSE` / quote 付き / `no` / `0` / trailing
  comment のいずれかが silent default-on に degrade した場合に regression
  を検出できないため、variant matrix で全 form を pin する

## 変更内容

`plugins/rite/hooks/tests/stop-create-interview-block.test.sh`:

1. ヘッダーコメント (line 8) の TC-7 説明を「variant matrix」表記に更新
2. TC-7 ブロック (旧 line 195-208) を 7 variant のループ parameterize に変換

variant 一覧 (Issue 仕様準拠):

- `enabled: false` (lowercase, unquoted) — 旧 TC-7 をそのまま継承
- `enabled: FALSE` — case-folding 経路
- `enabled: "false"` — double-quote 剥がし経路
- `enabled: 'false'` — single-quote 剥がし経路
- `enabled: no` — case branch (`no`)
- `enabled: 0` — case branch (`0`)
- `enabled: false # trailing comment` — sed comment 剥がし経路

各 variant で以下を assert:

- `TC-7.1`: exit code 2 (block respected)
- `TC-7.2`: stderr に `Issue #920` (ACTION shown)
- `TC-7.3`: stderr に `WORKFLOW_INCIDENT=1` **NOT** 含まれない (opt-out 尊重)

## 検証

- 全テスト合格: PASS 42 / FAIL 0 (旧 24 から拡張、増分 18 = 6 variant × 3 assertion)
- Plugin checks: 変更ファイルに新規 lint warning なし

## 関連 Issue

Closes #979

## 関連 PR

- 元の検出 PR: #975 (cycle 4 test reviewer LOW)
