### PR TITLE
refactor(hooks): wiki-query-inject.sh / wiki-ingest-trigger.sh の rite-config.yml path を STATE_ROOT 起点に統一

### DIFF
--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -44,6 +44,16 @@
 #   - The script does NOT do any LLM work — it is a pure file-writing utility.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve project root (git root anchored). Matches session-start.sh /
+# _resolve-schema-version.sh / notification.sh / stop-create-interview-block.sh
+# convention; `$PWD`-based rite-config.yml lookup would silently miss the
+# config file when this script is invoked from a subdirectory (Issue #976).
+# This script is a CLI tool (not a Claude Code hook), so $PWD is used in place
+# of the stdin-supplied CWD that hook scripts receive.
+STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$PWD" 2>/dev/null) || STATE_ROOT="$PWD"
+
 TYPE=""
 SOURCE_REF=""
 CONTENT_FILE=""
@@ -196,10 +206,11 @@ if [[ ! -s "$CONTENT_FILE" ]]; then
   exit 1
 fi
 
-# --- Wiki enable check (best-effort: only checks rite-config.yml in CWD) ---
-# This guard is intentionally lenient: when rite-config.yml is absent, we
-# proceed and let /rite:wiki:ingest handle the strict validation later. The
-# trigger only refuses when wiki.enabled is explicitly false.
+# --- Wiki enable check (best-effort: checks rite-config.yml at STATE_ROOT) ---
+# STATE_ROOT is resolved via state-path-resolve.sh at script entry (git-root
+# anchored). When rite-config.yml is absent, we proceed and let /rite:wiki:ingest
+# handle the strict validation later. The trigger only refuses when wiki.enabled
+# is explicitly false.
 #
 # F-01 fix: avoid `set -euo pipefail` × `grep no-match` silent abort.
 # When `wiki:` section or `enabled:` key is missing, grep returns exit 1, which
@@ -217,12 +228,12 @@ fi
 # lib/wiki-config.sh が canonical 定義。lib 化済みの script
 # (wiki-ingest-commit.sh / wiki-worktree-commit.sh / wiki-worktree-setup.sh) は source して
 # 同一実装を共有するため、上記 3 箇所を lib に統合する場合は別 Issue で追跡すること。
-if [[ -f "rite-config.yml" ]]; then
+if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   # cycle 9 MEDIUM fix: sed/awk の stderr を tempfile に捕捉 (silent swallow 禁止)。
   # 旧実装 `2>/dev/null || wiki_section=""` は grep no-match だけでなく sed/awk の構文エラー /
   # binary 破損 / IO エラーも silent に空扱いし、Wiki enable check が誤動作する経路を持っていた。
   _yaml_err=$(mktemp /tmp/rite-wiki-trigger-yaml-err-XXXXXX 2>/dev/null) || _yaml_err=""
-  if wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>"${_yaml_err:-/dev/null}"); then
+  if wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' "$STATE_ROOT/rite-config.yml" 2>"${_yaml_err:-/dev/null}"); then
     :  # success (sed no-match は exit 0 なので legitimate)
   else
     _sed_rc=$?

--- a/plugins/rite/hooks/wiki-query-inject.sh
+++ b/plugins/rite/hooks/wiki-query-inject.sh
@@ -44,6 +44,16 @@
 #     + summary, weighted by confidence (high=1.5, medium=1.0, low=0.5).
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve project root (git root anchored). Matches session-start.sh /
+# _resolve-schema-version.sh / notification.sh / stop-create-interview-block.sh
+# convention; `$PWD`-based rite-config.yml lookup would silently miss the
+# config file when this script is invoked from a subdirectory (Issue #976).
+# This script is a CLI tool (not a Claude Code hook), so $PWD is used in place
+# of the stdin-supplied CWD that hook scripts receive.
+STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$PWD" 2>/dev/null) || STATE_ROOT="$PWD"
+
 # Tempfile paths declared up front, trap set up before any mktemp, cleanup on
 # both normal exit and signal termination. Mirrors the repo convention used in
 # commands/pr/review.md Phase 2.2.1 and commands/pr/fix.md Phase 4.5.2 so that
@@ -154,13 +164,13 @@ esac
 # on grep no-match (exit 0), but surface legitimate IO errors as a WARNING
 # before falling through.
 wiki_section=""
-if [[ -f "rite-config.yml" ]]; then
+if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   if ! _yaml_err=$(mktemp /tmp/rite-wiki-query-yaml-err-XXXXXX); then
     echo "WARNING: mktemp failed for YAML stderr capture; falling back to /dev/null" >&2
     echo "  対処: /tmp の permission / read-only / inode 枯渇を確認してください" >&2
     _yaml_err=""
   fi
-  if wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>"${_yaml_err:-/dev/null}"); then
+  if wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' "$STATE_ROOT/rite-config.yml" 2>"${_yaml_err:-/dev/null}"); then
     :  # success (sed no-match still returns 0)
   else
     _sed_rc=$?


### PR DESCRIPTION
## 概要

`wiki-query-inject.sh:157` と `wiki-ingest-trigger.sh:220` が implicit CWD で `rite-config.yml` を参照しており、Issue #976 で修正した `stop-create-interview-block.sh` / `notification.sh` と同型の subdirectory invocation silent-miss 問題を抱えていた。PR #980 で採用された SCRIPT_DIR + `state-path-resolve.sh` canonical pattern を本 2 ファイルにも対称適用する。

## 関連 Issue

Closes #981

## 変更内容

- `plugins/rite/hooks/wiki-query-inject.sh`:
  - `set -uo pipefail` 直後に `SCRIPT_DIR` + `STATE_ROOT` 解決ブロックを追加
  - line 157 / 163 の 2 箇所 (実コード) を `$STATE_ROOT/rite-config.yml` に置換
- `plugins/rite/hooks/wiki-ingest-trigger.sh`:
  - `set -euo pipefail` 直後に `SCRIPT_DIR` + `STATE_ROOT` 解決ブロックを追加
  - line 220 / 225 の 2 箇所 (実コード) を `$STATE_ROOT/rite-config.yml` に置換
  - line 199 の「best-effort: only checks rite-config.yml in CWD」コメントを「checks rite-config.yml at STATE_ROOT」に更新

両 script は stdin JSON を読まない CLI tool のため、hook script で使用する stdin-supplied CWD ではなく shell builtin の `$PWD` を `state-path-resolve.sh` に渡す (notification.sh との唯一の差分)。

## 検証

- `bash -n` で両ファイルの syntax 通過
- `plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh`: 45/45 pass
- 残存する bare `rite-config.yml` 参照はコメント文字列 / エラーメッセージのみで実コードは全て `$STATE_ROOT` prefix 化

## チェックリスト

- [x] プロジェクトの規約に準拠
- [x] 既存テストが pass (wiki-ingest-trigger.test.sh: 45/45)
- [x] convention 一致 (session-start.sh / _resolve-schema-version.sh / post-tool-wm-sync.sh / notification.sh / stop-create-interview-block.sh と同 pattern)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
