### PR TITLE
test(hooks): subdirectory invocation 回帰テスト追加 (TC-10 / TC-016)

### DIFF
--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -298,19 +298,26 @@ echo ""
 echo "TC-016: Subdirectory CWD invocation → walkup resolves project-root rite-config.yml"
 dir016="$TEST_DIR/tc016"
 mkdir -p "$dir016/sub"
-(
+# Setup error は test failure と区別する (`|| true` で setup 失敗を呑むと、walkup 不能化と
+# 同じ「empty output / exit 0」症状になり F-02 で指摘された false-negative を再導入する)。
+# make_sandbox (stop-create-interview-block.test.sh) と同じ fail-fast 構造を採用。
+if ! (
   cd "$dir016"
   git init -q 2>/dev/null
   echo a > a && git add a 2>/dev/null
   git -c user.email=t@test.local -c user.name=test commit -q -m init 2>/dev/null
-) || true
-touch "$dir016/rite-config.yml"
-
-output=$(run_hook "$dir016/sub" "pr_created")
-if echo "$output" | grep -q "Notification for PR created"; then
-  pass "Subdirectory CWD → walkup found project-root rite-config.yml → echo emitted"
+); then
+  echo "ERROR: TC-016 sandbox git init failed in $dir016" >&2
+  skip "TC-016 (sandbox setup failed — setup error は test failure と区別)"
 else
-  fail "Expected 'Notification for PR created' from subdir CWD, got: '$output'"
+  touch "$dir016/rite-config.yml"
+
+  output=$(run_hook "$dir016/sub" "pr_created")
+  if echo "$output" | grep -q "Notification for PR created"; then
+    pass "Subdirectory CWD → walkup found project-root rite-config.yml → echo emitted"
+  else
+    fail "Expected 'Notification for PR created' from subdir CWD, got: '$output'"
+  fi
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -284,6 +284,37 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-016: Subdirectory invocation → git root walkup resolves rite-config.yml
+# --------------------------------------------------------------------------
+# Regression guard for Issue #976 (PR #980): notification.sh MUST use state-path-resolve.sh
+# (git rev-parse --show-toplevel) to walk up from CWD to the project root when looking up
+# rite-config.yml. A revert to `$CWD`-based lookup would cause the config to be silently
+# missing when Claude Code launches the hook from a subdirectory, breaking notifications.
+#
+# This test creates a git-init'd sandbox with rite-config.yml at the project root and a
+# nested `sub/` directory. The hook receives CWD=$SBX/sub via stdin JSON. The hook MUST
+# still emit "Notification for PR created" because walkup found the config; a regression
+# would yield empty output (exit 0 without echo).
+echo "TC-016: Subdirectory CWD invocation → walkup resolves project-root rite-config.yml"
+dir016="$TEST_DIR/tc016"
+mkdir -p "$dir016/sub"
+(
+  cd "$dir016"
+  git init -q 2>/dev/null
+  echo a > a && git add a 2>/dev/null
+  git -c user.email=t@test.local -c user.name=test commit -q -m init 2>/dev/null
+) || true
+touch "$dir016/rite-config.yml"
+
+output=$(run_hook "$dir016/sub" "pr_created")
+if echo "$output" | grep -q "Notification for PR created"; then
+  pass "Subdirectory CWD → walkup found project-root rite-config.yml → echo emitted"
+else
+  fail "Expected 'Notification for PR created' from subdir CWD, got: '$output'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="

--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -259,6 +259,40 @@ assert_contains "TC-9.2: ACTION shown" "Issue #920" "$STDERR"
 assert_contains "TC-9.3: workflow_incident sentinel emitted (default-on respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
 rm -rf "$SBX"; cleanup_dirs=("${cleanup_dirs[@]/$SBX}")
 
+# ---- TC-10: subdirectory invocation → git root walkup resolves rite-config.yml + flow-state ----
+# Regression guard for Issue #976 (PR #980): when Claude Code runs Stop hook with CWD set to a
+# subdirectory of the project root, the hook MUST walk up via state-path-resolve.sh
+# (git rev-parse --show-toplevel) to find rite-config.yml and .rite-flow-state at the project
+# root. A revert to `$CWD`-based lookup would cause both files to be missing → hook silently
+# exits 0 (no block) and the opt-out semantics break.
+#
+# This test pins TWO orthogonal walkup-dependent behaviors:
+#   1. flow-state walkup: $SBX/.rite-flow-state resolved from CWD=$SBX/sub → gate fires (exit 2)
+#   2. rite-config.yml walkup: $SBX/rite-config.yml resolved from CWD=$SBX/sub → opt-out
+#      respected (no WORKFLOW_INCIDENT=1 sentinel)
+#
+# Issue #982 attached the literal `if ! grep -q "WORKFLOW_INCIDENT=1"` as a proposal, but
+# without flow-state setup that single assertion silently passes when the hook exits 0 due
+# to flow-state walkup failure (Test pin protection theater anti-pattern). The 3-axis pin
+# below (exit 2 + ACTION + no sentinel) gives discriminating power across both regression
+# modes.
+echo "TC-10: subdirectory CWD invocation → walkup resolves project-root config + flow-state"
+SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+mkdir -p "$SBX/sub"
+write_flow_state "$SBX" "create_post_interview" "true" "0"
+cat > "$SBX/rite-config.yml" <<'YAML'
+workflow_incident:
+  enabled: false
+YAML
+# Build payload with CWD pointing at $SBX/sub (subdirectory of git root)
+payload=$(jq -n --arg cwd "$SBX/sub" \
+  '{hook_event_name: "Stop", cwd: $cwd, transcript_path: "/tmp/x.jsonl", session_id: "test", stop_hook_active: false}')
+run_hook "$SBX" "$payload"; rc=$HOOK_RC
+assert_eq "TC-10.1: exit code 2 (flow-state walkup OK → gate fires)" "2" "$rc"
+assert_contains "TC-10.2: ACTION still shown despite subdir CWD" "Issue #920" "$STDERR"
+assert_not_contains "TC-10.3: workflow_incident sentinel NOT emitted (rite-config.yml walkup OK → opt-out respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
+rm -rf "$SBX"; cleanup_dirs=("${cleanup_dirs[@]/$SBX}")
+
 echo ""
 echo "================================="
 echo "PASS: $PASS / FAIL: $FAIL"

--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -284,9 +284,8 @@ cat > "$SBX/rite-config.yml" <<'YAML'
 workflow_incident:
   enabled: false
 YAML
-# Build payload with CWD pointing at $SBX/sub (subdirectory of git root)
-payload=$(jq -n --arg cwd "$SBX/sub" \
-  '{hook_event_name: "Stop", cwd: $cwd, transcript_path: "/tmp/x.jsonl", session_id: "test", stop_hook_active: false}')
+# build_stop_payload で CWD=$SBX/sub を指定 (TC-1〜TC-7 と同じ helper 経由パターン)
+payload=$(build_stop_payload "$SBX/sub" false)
 run_hook "$SBX" "$payload"; rc=$HOOK_RC
 assert_eq "TC-10.1: exit code 2 (flow-state walkup OK → gate fires)" "2" "$rc"
 assert_contains "TC-10.2: ACTION still shown despite subdir CWD" "Issue #920" "$STDERR"


### PR DESCRIPTION
## Summary

PR #980 (Issue #976) で `stop-create-interview-block.sh` / `notification.sh` の rite-config.yml path を `$STATE_ROOT(_PATH)` 起点に統一したが、修正の核心 scenario (subdirectory 起動時に git root walkup で rite-config.yml を解決) の回帰テストが追加されていなかった。`state-path-resolve.sh` の `git rev-parse --show-toplevel` を誤って revert しても既存 TC は全 pass のままで silent regression する穴を、両 hook の test に subdirectory invocation pin を追加して塞ぐ。

## Closes

Closes #982

## 変更内容

### TC-10 (stop-create-interview-block.test.sh)

- `mkdir $SBX/sub` で subdirectory を作成、CWD=`$SBX/sub` で hook 起動
- flow-state を `$SBX/.rite-flow-state` (gate match: phase=create_post_interview/active=true/pr=0)、`rite-config.yml` を `$SBX/rite-config.yml` (`workflow_incident.enabled: false` で opt-out) に配置
- 3 軸 assert:
  - **TC-10.1**: `exit 2` (flow-state walkup OK → gate fires)
  - **TC-10.2**: ACTION 表示 (`Issue #920` literal pin)
  - **TC-10.3**: `WORKFLOW_INCIDENT=1` NOT emitted (rite-config.yml walkup OK → opt-out respected)

Issue #982 原文の対応案は flow-state setup を含まない single grep `! grep -q "WORKFLOW_INCIDENT=1"` のみで、hook が早期 exit 0 した場合に silent PASS する **Test pin protection theater** 化リスクがあった。本実装は 3 軸 pin に拡張して discriminating power を確保する。

### TC-016 (notification.test.sh)

- `mkdir $dir016/sub` + `git init` + rite-config.yml at `$dir016`
- `run_hook "$dir016/sub" "pr_created"` で event を渡す
- "Notification for PR created" literal pin (walkup 経由で config 発見の empirical 証拠)

## Mutation 検証 (empirical evidence)

`state-path-resolve.sh` の `git rev-parse --show-toplevel` 行を `root=""` に置換した状態で両 test を実行し、`TC-10.1` / `TC-10.2` / `TC-016` が確実に FAIL することを確認した。revert 後 resolver は canonical content と完全一致。Wiki 経験則 _Mutation testing で test の真正性 (dead code 検出 + identification power) を empirical 検証する_ の canonical gate 適用例。

## Test Plan

- [x] `bash plugins/rite/hooks/tests/stop-create-interview-block.test.sh` → 45/45 pass (TC-1〜TC-10、TC-7 variants 7 種含む)
- [x] `bash plugins/rite/hooks/tests/notification.test.sh` → 15/15 pass + 1 skip (jq 不在環境のみ skip)
- [x] Mutation 検証: `root=""` 化で `TC-10.1` / `TC-10.2` / `TC-016` 確実 FAIL、revert 後 canonical 一致
- [x] `/rite:lint` 全 Phase pass (pre-existing warnings は本 PR の変更外)

## Sibling Symmetry

両 hook (`stop-create-interview-block.sh` / `notification.sh`) は同形に `state-path-resolve.sh` の git root walkup に依存しており、本 PR は TC-10 / TC-016 を sibling test として同 PR で対称導入する。Wiki 経験則 _Asymmetric Fix Transcription (対称位置への伝播漏れ)_ の予防適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
