### PR TITLE
test(hooks): TC-11 truthy variant matrix を追加

### DIFF
--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -6,7 +6,7 @@
 # Back-stop behavior tests (not direct Issue AC mapping):
 #   - gate-match → exit 2 + ACTION (TC-1, TC-9)
 #   - gate-mismatch / recursion guard / non-Stop → exit 0 (TC-2..TC-6, TC-8)
-#   - workflow_incident.enabled=false respected (TC-7 variant matrix)
+#   - workflow_incident.enabled variant matrix (TC-7 falsy / TC-11 truthy)
 # Note: Issue AC-1/AC-2/AC-5 are orchestrator-side e2e concerns, out of hook test scope.
 # Note: AC-3 (structural invariants) covered by 4-site-symmetry.test.sh et al.
 # Note: AC-6 (charter violation grep) covered separately.
@@ -308,6 +308,40 @@ assert_eq "TC-10.1: exit code 2 (flow-state walkup OK → gate fires)" "2" "$rc"
 assert_contains "TC-10.2: ACTION still shown despite subdir CWD" "Issue #920" "$STDERR"
 assert_not_contains "TC-10.3: workflow_incident sentinel NOT emitted (rite-config.yml walkup OK → opt-out respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
 rm -rf "$SBX"; _remove_from_cleanup_dirs "$SBX"
+
+# ---- TC-11: workflow_incident.enabled truthy variant matrix → default-on 同等動作 ----
+# Canonical SoT (workflow-incident-detection.md) defines `true|yes|1)` branch alongside
+# `false|no|0)` / `*)` 3 branches. The hook parser (stop-create-interview-block.sh:108-110)
+# currently implements only `false|no|0)` branch — truthy variants fall through to the
+# default `WORKFLOW_INCIDENT_ENABLED="true"` (line 97), so behavior is default-on.
+# This loop pins all 5 truthy variants so a future refactor that adds an explicit
+# `true|yes|1)` branch cannot silently break any variant's default-on semantics
+# (Issue #987 — TC-10 番号は PR #989 で subdirectory walkup test に取得済のため TC-11 へ renumber)。
+echo "TC-11: workflow_incident.enabled truthy variant matrix (5 syntactic forms) → exit 2 + sentinel"
+
+TC11_TRUTHY_VARIANTS=(
+  "true"
+  "TRUE"
+  '"true"'
+  "yes"
+  "1"
+)
+
+for variant in "${TC11_TRUTHY_VARIANTS[@]}"; do
+  echo "  variant: enabled: $variant"
+  SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+  write_flow_state "$SBX" "create_post_interview" "true" "0"
+  cat > "$SBX/rite-config.yml" <<YAML
+workflow_incident:
+  enabled: $variant
+YAML
+  payload=$(build_stop_payload "$SBX" false)
+  run_hook "$SBX" "$payload"; rc=$HOOK_RC
+  assert_eq "TC-11.1 [enabled: $variant]: exit code 2 (block fires)" "2" "$rc"
+  assert_contains "TC-11.2 [enabled: $variant]: ACTION shown" "Issue #920" "$STDERR"
+  assert_contains "TC-11.3 [enabled: $variant]: workflow_incident sentinel emitted (default-on respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
+  rm -rf "$SBX"; _remove_from_cleanup_dirs "$SBX"
+done
 
 echo ""
 echo "================================="

--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -311,23 +311,26 @@ rm -rf "$SBX"; _remove_from_cleanup_dirs "$SBX"
 
 # ---- TC-11: workflow_incident.enabled truthy variant matrix → default-on 同等動作 ----
 # Canonical SoT (workflow-incident-detection.md) defines `true|yes|1)` branch alongside
-# `false|no|0)` / `*)` 3 branches. The hook parser (stop-create-interview-block.sh:108-110)
-# currently implements only `false|no|0)` branch — truthy variants fall through to the
-# default `WORKFLOW_INCIDENT_ENABLED="true"` (line 97), so behavior is default-on.
-# This loop pins all 5 truthy variants so a future refactor that adds an explicit
-# `true|yes|1)` branch cannot silently break any variant's default-on semantics
+# `false|no|0)` / `*)` 3 branches. The hook parser implements only the `false|no|0)`
+# case arm; truthy variants fall through to the default-on initialization (line where
+# `WORKFLOW_INCIDENT_ENABLED="true"` is assigned, immediately before the `if [ -f .../rite-config.yml ]`
+# block) and behavior matches default-on. This loop pins all 7 truthy variants in TC-7
+# symmetry so a future refactor that adds an explicit `true|yes|1)` case arm cannot
+# silently break any variant's default-on semantics
 # (Issue #987 — TC-10 番号は PR #989 で subdirectory walkup test に取得済のため TC-11 へ renumber)。
-echo "TC-11: workflow_incident.enabled truthy variant matrix (5 syntactic forms) → exit 2 + sentinel"
+echo "TC-11: workflow_incident.enabled truthy variant matrix (7 syntactic forms) → exit 2 + sentinel"
 
-TC11_TRUTHY_VARIANTS=(
+TC11_VARIANTS=(
   "true"
   "TRUE"
   '"true"'
+  "'true'"
   "yes"
   "1"
+  "true # trailing comment"
 )
 
-for variant in "${TC11_TRUTHY_VARIANTS[@]}"; do
+for variant in "${TC11_VARIANTS[@]}"; do
   echo "  variant: enabled: $variant"
   SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
   write_flow_state "$SBX" "create_post_interview" "true" "0"
@@ -339,7 +342,7 @@ YAML
   run_hook "$SBX" "$payload"; rc=$HOOK_RC
   assert_eq "TC-11.1 [enabled: $variant]: exit code 2 (block fires)" "2" "$rc"
   assert_contains "TC-11.2 [enabled: $variant]: ACTION shown" "Issue #920" "$STDERR"
-  assert_contains "TC-11.3 [enabled: $variant]: workflow_incident sentinel emitted (default-on respected)" "WORKFLOW_INCIDENT=1" "$STDERR"
+  assert_contains "TC-11.3 [enabled: $variant]: workflow_incident sentinel emitted (truthy variant → default-on)" "WORKFLOW_INCIDENT=1" "$STDERR"
   rm -rf "$SBX"; _remove_from_cleanup_dirs "$SBX"
 done
 


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/stop-create-interview-block.test.sh` に **TC-11** truthy variant matrix を追加し、`workflow_incident.enabled` の truthy 側 5 variants (`true`/`TRUE`/`"true"`/`yes`/`1`) で default-on 動作（exit 2 + ACTION + `WORKFLOW_INCIDENT=1` sentinel emit）が pin されるようにしました。

canonical SoT (`plugins/rite/commands/issue/references/workflow-incident-detection.md`) では `true|yes|1)` ブランチも定義されていますが、実装側 hook (`stop-create-interview-block.sh:108-110`) は `false|no|0)` ブランチのみで、truthy 値は default `WORKFLOW_INCIDENT_ENABLED="true"` (line 97) にフォールスルーします。将来 hook の case 文に truthy 分岐ロジックが追加された場合の variant gap 再発を本テストで構造的に予防します。

## 関連 Issue

Closes #987

## 変更内容

- `plugins/rite/hooks/tests/stop-create-interview-block.test.sh`:
  - 新規 TC-11 ブロック (`TC11_TRUTHY_VARIANTS` 配列 + for-loop + 3 軸 assert) を TC-10 直後に追加
  - ヘッダコメント (line 9) を `workflow_incident.enabled=false respected (TC-7 variant matrix)` から `workflow_incident.enabled variant matrix (TC-7 falsy / TC-11 truthy)` に対称性更新

## TC 番号衝突対応

- Issue #987 本文は「新規 TC-10」追加を求めていましたが、Issue 起票後 (2026-05-15) の PR #989 merge で TC-10 番号は subdirectory walkup test に取得済でした
- ユーザー承認のもと **TC-11 へ renumber**、Issue 本文の outdated reference は本 PR description で明示

## Test Plan

- [x] `bash plugins/rite/hooks/tests/stop-create-interview-block.test.sh` を実行し全 60 件 PASS を確認（TC-11: 5 variants × 3 assertions = 15 件追加）
- [x] 既存 TC-1〜TC-10 のロジック・命名規約は touch していないことを diff で確認
- [x] TC-7 (falsy) と TC-11 (truthy) の構造対称性を確認 (`TCN_VARIANTS=` + for-loop + 3 軸 assert)

## Checklist

- [x] Code follows project conventions (TC-7 / TC-9 と同形構造)
- [x] Tests pass (全 60 件 PASS)
- [x] Documentation updated (ヘッダコメントを TC-11 言及で対称更新)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
