### PR TITLE
refactor(hooks/tests): make_sandbox / make_plain_sandbox を _test-helpers.sh へ集約

### DIFF
--- a/plugins/rite/hooks/tests/_resolve-session-id-from-file.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-session-id-from-file.test.sh
@@ -27,6 +27,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HELPER="$HOOKS_DIR/_resolve-session-id-from-file.sh"
 
+# Issue #990: source common helpers for make_plain_sandbox.
+# This file's prior `make_sandbox` was a no-git variant with auto-cleanup-push;
+# we now build on make_plain_sandbox and rename the wrapper to
+# setup_session_id_sandbox, mirroring _validate-helpers.test.sh and avoiding a
+# collision with the helper's git-init `make_sandbox`.
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
 PASS=0
 FAIL=0
 cleanup_dirs=()
@@ -64,9 +72,11 @@ assert_match() {
   fi
 }
 
-make_sandbox() {
+# Issue #990: thin wrapper preserving the auto-cleanup-push convention used
+# throughout this file's tests; built on make_plain_sandbox from _test-helpers.sh.
+setup_session_id_sandbox() {
   local sbx
-  sbx=$(mktemp -d)
+  sbx=$(make_plain_sandbox)
   cleanup_dirs+=("$sbx")
   printf '%s' "$sbx"
 }
@@ -74,7 +84,7 @@ make_sandbox() {
 # ================================================================
 echo "TC-1: 正常 path + valid UUID file → exit 0 + UUID stdout (lowercase)"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 echo "550e8400-e29b-41d4-a716-446655440000" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-1.1: exit code is 0" "0" "$rc"
@@ -83,7 +93,7 @@ assert_eq "TC-1.2: stdout is the validated UUID" "550e8400-e29b-41d4-a716-446655
 # ================================================================
 echo "TC-2: 正常 path + .rite-session-id 不在 → exit 0 + empty stdout"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-2.1: exit code is 0" "0" "$rc"
 assert_eq "TC-2.2: stdout is empty (file absent → graceful)" "" "$out"
@@ -91,7 +101,7 @@ assert_eq "TC-2.2: stdout is empty (file absent → graceful)" "" "$out"
 # ================================================================
 echo "TC-3: 正常 path + invalid UUID content → exit 0 + empty stdout"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 echo "not-a-valid-uuid" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-3.1: exit code is 0 (graceful fallback)" "0" "$rc"
@@ -100,7 +110,7 @@ assert_eq "TC-3.2: stdout is empty (validation 失敗 → empty)" "" "$out"
 # ================================================================
 echo "TC-4: 正常 path + empty file → exit 0 + empty stdout"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 : > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-4.1: exit code is 0" "0" "$rc"
@@ -109,7 +119,7 @@ assert_eq "TC-4.2: stdout is empty" "" "$out"
 # ================================================================
 echo "TC-5: STATE_ROOT に path traversal (../foo) → exit 1 + ERROR"
 # ================================================================
-out=$(bash "$HELPER" "$(make_sandbox)/../foo" 2>&1) && rc=0 || rc=$?
+out=$(bash "$HELPER" "$(setup_session_id_sandbox)/../foo" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-5.1: exit code is 1" "1" "$rc"
 assert_match "TC-5.2: ERROR mentions 'unsafe traversal or shell metacharacter'" "unsafe traversal or shell metacharacter" "$out"
 
@@ -149,7 +159,7 @@ assert_match "TC-9.2: ERROR mentions usage" "usage" "$out"
 # ================================================================
 echo "TC-10: 正常 path + .rite-session-id が whitespace のみ → exit 0 + empty"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 printf '   \t\n   ' > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-10.1: exit code is 0 (whitespace strip → empty raw → fallback)" "0" "$rc"
@@ -161,7 +171,7 @@ echo "TC-11 (NEW API verification): UPPERCASE UUID input → lowercase normalize
 # _resolve-session-id.sh が cycle 44 F-10 で導入した case-insensitive accept + lowercase
 # normalize の transitive 動作を helper 経由で verify する (caller 経由の indirect カバレッジ
 # を補強する direct test)。
-sbx=$(make_sandbox)
+sbx=$(setup_session_id_sandbox)
 echo "550E8400-E29B-41D4-A716-446655440000" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-11.1: exit code is 0" "0" "$rc"

--- a/plugins/rite/hooks/tests/_resolve-session-id-from-file.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-session-id-from-file.test.sh
@@ -72,19 +72,19 @@ assert_match() {
   fi
 }
 
-# Issue #990: thin wrapper preserving the auto-cleanup-push convention used
-# throughout this file's tests; built on make_plain_sandbox from _test-helpers.sh.
+# Issue #990: thin wrapper built on make_plain_sandbox from _test-helpers.sh.
+# IMPORTANT: This wrapper does NOT push to cleanup_dirs — callers MUST push
+# from the parent shell (after capturing $(setup_session_id_sandbox)) because
+# any push performed inside $(...) is lost in the command-substitution subshell.
+# This matches the helper's documented caller convention (see _test-helpers.sh).
 setup_session_id_sandbox() {
-  local sbx
-  sbx=$(make_plain_sandbox)
-  cleanup_dirs+=("$sbx")
-  printf '%s' "$sbx"
+  make_plain_sandbox
 }
 
 # ================================================================
 echo "TC-1: 正常 path + valid UUID file → exit 0 + UUID stdout (lowercase)"
 # ================================================================
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 echo "550e8400-e29b-41d4-a716-446655440000" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-1.1: exit code is 0" "0" "$rc"
@@ -93,7 +93,7 @@ assert_eq "TC-1.2: stdout is the validated UUID" "550e8400-e29b-41d4-a716-446655
 # ================================================================
 echo "TC-2: 正常 path + .rite-session-id 不在 → exit 0 + empty stdout"
 # ================================================================
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-2.1: exit code is 0" "0" "$rc"
 assert_eq "TC-2.2: stdout is empty (file absent → graceful)" "" "$out"
@@ -101,7 +101,7 @@ assert_eq "TC-2.2: stdout is empty (file absent → graceful)" "" "$out"
 # ================================================================
 echo "TC-3: 正常 path + invalid UUID content → exit 0 + empty stdout"
 # ================================================================
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 echo "not-a-valid-uuid" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-3.1: exit code is 0 (graceful fallback)" "0" "$rc"
@@ -110,7 +110,7 @@ assert_eq "TC-3.2: stdout is empty (validation 失敗 → empty)" "" "$out"
 # ================================================================
 echo "TC-4: 正常 path + empty file → exit 0 + empty stdout"
 # ================================================================
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 : > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-4.1: exit code is 0" "0" "$rc"
@@ -119,7 +119,8 @@ assert_eq "TC-4.2: stdout is empty" "" "$out"
 # ================================================================
 echo "TC-5: STATE_ROOT に path traversal (../foo) → exit 1 + ERROR"
 # ================================================================
-out=$(bash "$HELPER" "$(setup_session_id_sandbox)/../foo" 2>&1) && rc=0 || rc=$?
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
+out=$(bash "$HELPER" "$sbx/../foo" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-5.1: exit code is 1" "1" "$rc"
 assert_match "TC-5.2: ERROR mentions 'unsafe traversal or shell metacharacter'" "unsafe traversal or shell metacharacter" "$out"
 
@@ -159,7 +160,7 @@ assert_match "TC-9.2: ERROR mentions usage" "usage" "$out"
 # ================================================================
 echo "TC-10: 正常 path + .rite-session-id が whitespace のみ → exit 0 + empty"
 # ================================================================
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 printf '   \t\n   ' > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-10.1: exit code is 0 (whitespace strip → empty raw → fallback)" "0" "$rc"
@@ -171,7 +172,7 @@ echo "TC-11 (NEW API verification): UPPERCASE UUID input → lowercase normalize
 # _resolve-session-id.sh が cycle 44 F-10 で導入した case-insensitive accept + lowercase
 # normalize の transitive 動作を helper 経由で verify する (caller 経由の indirect カバレッジ
 # を補強する direct test)。
-sbx=$(setup_session_id_sandbox)
+sbx=$(setup_session_id_sandbox); cleanup_dirs+=("$sbx")
 echo "550E8400-E29B-41D4-A716-446655440000" > "$sbx/.rite-session-id"
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-11.1: exit code is 0" "0" "$rc"

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -174,10 +174,20 @@ assert_not_grep() {
 #   stderr : ERROR line(s) on failure, plus up to 5 lines of git's own stderr
 #            to aid CI debugging when git config issues break sandbox setup.
 #
+# Exit code semantics:
+#   exit 1   — hard-fail (default): mktemp -d or git init/commit failure halts the run.
+#   return 1 — soft-fail (--soft):  same failures, but caller decides skip vs. test failure.
+#   return 2 — option parse error:  unknown option or --branch without a non-empty argument.
+#
 # Caller patterns (the helper does NOT push to cleanup_dirs — callers do):
 #   SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
 #   SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 #   if ! SBX=$(make_sandbox --soft); then skip "TC-N (sandbox setup failed)"; fi
+#
+# Note: $(make_sandbox) runs in a command substitution subshell — any cleanup_dirs
+# push performed inside a wrapper that is itself called via $(...) stays local to
+# that subshell and is lost in the parent. Callers MUST push to cleanup_dirs from
+# the parent shell (the assignment line, not inside the wrapper).
 make_sandbox() {
   local branch_arg=""
   local soft_fail=0
@@ -208,7 +218,10 @@ make_sandbox() {
     [ "$soft_fail" -eq 1 ] && return 1
     exit 1
   }
-  sandbox_err=$(mktemp /tmp/rite-sandbox-err-XXXXXX 2>/dev/null) || sandbox_err="/dev/null"
+  sandbox_err=$(mktemp /tmp/rite-sandbox-err-XXXXXX 2>/dev/null) || {
+    echo "WARNING: make_sandbox: mktemp /tmp/rite-sandbox-err-XXXXXX failed; diagnostic capture disabled (git stderr will not be surfaced on failure)" >&2
+    sandbox_err="/dev/null"
+  }
 
   if ! (
     cd "$d" || exit 1
@@ -216,8 +229,8 @@ make_sandbox() {
       # Pre-2.28 git lacks `-b`; fall back to plain init + checkout to ensure
       # the requested branch name is the active HEAD regardless of git version.
       if ! git init -q -b "$branch_arg" 2>"$sandbox_err"; then
-        git init -q 2>>"$sandbox_err"
-        git checkout -q -b "$branch_arg" 2>>"$sandbox_err" || true
+        git init -q 2>>"$sandbox_err" || exit 1
+        git checkout -q -b "$branch_arg" 2>>"$sandbox_err" || exit 1
       fi
     else
       git init -q 2>"$sandbox_err"
@@ -243,16 +256,42 @@ make_sandbox() {
 # The helper does NOT push to cleanup_dirs — callers do — to match the
 # `make_sandbox` convention (single uniform caller pattern across tests).
 #
+# Options:
+#   --soft  Return non-zero on mktemp failure (caller decides whether to `skip`
+#           or treat as test failure). Default behavior is hard-fail (echo ERROR
+#           + exit 1). Mirrors `make_sandbox` for API symmetry.
+#
 # Output:
 #   stdout : sandbox path (one line) on success.
 #   stderr : ERROR line on mktemp failure.
 #
+# Exit code semantics:
+#   exit 1   — hard-fail (default): mktemp -d failure halts the run.
+#   return 1 — soft-fail (--soft):  same failure, but caller decides skip vs. test failure.
+#   return 2 — option parse error:  unknown option.
+#
 # Caller pattern:
 #   sbx=$(make_plain_sandbox); cleanup_dirs+=("$sbx")
+#   if ! sbx=$(make_plain_sandbox --soft); then skip "TC-N (sandbox setup failed)"; fi
 make_plain_sandbox() {
+  local soft_fail=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --soft)
+        soft_fail=1
+        shift
+        ;;
+      *)
+        echo "ERROR: make_plain_sandbox: unknown option '$1'" >&2
+        return 2
+        ;;
+    esac
+  done
+
   local d
   d=$(mktemp -d) || {
     echo "ERROR: make_plain_sandbox: mktemp -d failed" >&2
+    [ "$soft_fail" -eq 1 ] && return 1
     exit 1
   }
   echo "$d"

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -68,7 +68,7 @@
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0
 #   make_sandbox       [--branch <name>] [--soft]   # git-init+commit sandbox, echoes path
-#   make_plain_sandbox                              # bare mktemp -d sandbox, echoes path
+#   make_plain_sandbox [--soft]                     # bare mktemp -d sandbox, echoes path
 
 # Resolve PLUGIN_ROOT from the test's SCRIPT_DIR (tests/ is 2 levels below).
 # plugins/rite/hooks/tests/<test>.sh -> plugins/rite (2 up)

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -67,6 +67,8 @@
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0
+#   make_sandbox       [--branch <name>] [--soft]   # git-init+commit sandbox, echoes path
+#   make_plain_sandbox                              # bare mktemp -d sandbox, echoes path
 
 # Resolve PLUGIN_ROOT from the test's SCRIPT_DIR (tests/ is 2 levels below).
 # plugins/rite/hooks/tests/<test>.sh -> plugins/rite (2 up)
@@ -149,6 +151,111 @@ assert_not_grep() {
   else
     pass "$label"
   fi
+}
+
+# make_sandbox — git-init + initial-commit sandbox (Issue #990).
+#
+# Consolidates the inline `make_sandbox()` definitions previously duplicated in
+# stop-create-interview-block.test.sh, state-read.test.sh, work-memory-update.test.sh
+# (with `--branch` for the `fix/issue-687-test` branch parsing test) and
+# notification.test.sh TC-016 (with `--soft` for the setup-failure-skip path).
+#
+# Options:
+#   --branch <name>  git init -b <name>; fall back to plain `git init` if -b is
+#                    unsupported (older git pre-2.28).
+#   --soft           Return non-zero on git-init/commit failure (caller decides
+#                    whether to `skip` or treat as test failure). Default behavior
+#                    is hard-fail (echo ERROR + exit 1) — used by tests where a
+#                    broken sandbox indicates an infrastructure problem that must
+#                    halt the run.
+#
+# Output:
+#   stdout : sandbox path (one line) on success.
+#   stderr : ERROR line(s) on failure, plus up to 5 lines of git's own stderr
+#            to aid CI debugging when git config issues break sandbox setup.
+#
+# Caller patterns (the helper does NOT push to cleanup_dirs — callers do):
+#   SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+#   SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
+#   if ! SBX=$(make_sandbox --soft); then skip "TC-N (sandbox setup failed)"; fi
+make_sandbox() {
+  local branch_arg=""
+  local soft_fail=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --branch)
+        if [ $# -lt 2 ] || [ -z "$2" ]; then
+          echo "ERROR: make_sandbox: --branch requires a non-empty argument" >&2
+          return 2
+        fi
+        branch_arg="$2"
+        shift 2
+        ;;
+      --soft)
+        soft_fail=1
+        shift
+        ;;
+      *)
+        echo "ERROR: make_sandbox: unknown option '$1'" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  local d sandbox_err
+  d=$(mktemp -d) || {
+    echo "ERROR: make_sandbox: mktemp -d failed" >&2
+    [ "$soft_fail" -eq 1 ] && return 1
+    exit 1
+  }
+  sandbox_err=$(mktemp /tmp/rite-sandbox-err-XXXXXX 2>/dev/null) || sandbox_err="/dev/null"
+
+  if ! (
+    cd "$d" || exit 1
+    if [ -n "$branch_arg" ]; then
+      # Pre-2.28 git lacks `-b`; fall back to plain init + checkout to ensure
+      # the requested branch name is the active HEAD regardless of git version.
+      if ! git init -q -b "$branch_arg" 2>"$sandbox_err"; then
+        git init -q 2>>"$sandbox_err"
+        git checkout -q -b "$branch_arg" 2>>"$sandbox_err" || true
+      fi
+    else
+      git init -q 2>"$sandbox_err"
+    fi
+    echo a > a && git add a 2>>"$sandbox_err"
+    git -c user.email=t@test.local -c user.name=test commit -q -m init 2>>"$sandbox_err"
+  ); then
+    echo "ERROR: make_sandbox: git init/commit failed in $d" >&2
+    [ "$sandbox_err" != "/dev/null" ] && [ -s "$sandbox_err" ] && head -5 "$sandbox_err" | sed 's/^/  /' >&2
+    rm -rf "$d"
+    [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
+    [ "$soft_fail" -eq 1 ] && return 1
+    exit 1
+  fi
+  [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
+  echo "$d"
+}
+
+# make_plain_sandbox — bare `mktemp -d` sandbox (no git init), echoes path.
+#
+# Consolidates the no-git sandbox helpers previously duplicated in
+# _validate-helpers.test.sh and _resolve-session-id-from-file.test.sh.
+# The helper does NOT push to cleanup_dirs — callers do — to match the
+# `make_sandbox` convention (single uniform caller pattern across tests).
+#
+# Output:
+#   stdout : sandbox path (one line) on success.
+#   stderr : ERROR line on mktemp failure.
+#
+# Caller pattern:
+#   sbx=$(make_plain_sandbox); cleanup_dirs+=("$sbx")
+make_plain_sandbox() {
+  local d
+  d=$(mktemp -d) || {
+    echo "ERROR: make_plain_sandbox: mktemp -d failed" >&2
+    exit 1
+  }
+  echo "$d"
 }
 
 # Print summary block and return non-zero when any assertion failed.

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -257,32 +257,73 @@ else
   outer_fail "TC-9.2: expected rc=1 (soft-fail on mktemp failure), got rc=$rc_soft_fail"
 fi
 
-# Cycle 2 F-05: TC-9.3 — failure path: git unreachable but mktemp reachable。
-# mktemp は本物を残し git のみ shim で無効化することで、helper の git init/commit 失敗 branch
-# (subshell 内 `git init -q 2>"$sandbox_err"` 失敗 → 外側 if ! で soft-fail return) を実際に exercise する。
-# Mutation で該当 branch の `return 1` を `exit 1` に書き換えると caller が `if !` で受けられず
-# subshell ごと exit するため、本テストは「git failure → soft-fail return contract」を直接 pin する。
-tc93_dir=$(mktemp -d)
-trap "rm -rf '$tc93_dir'" EXIT  # one-shot best-effort (再 trap)
-# real mktemp into shim PATH; only `git` is invalidated by creating a non-executable stub.
-ln -sf "$(command -v mktemp)" "$tc93_dir/mktemp"
-# git invalidator: an executable file that always exits non-zero so `git init` 失敗を再現する。
-# PATH に shim dir を置くことで本物の git ($(command -v git)) より優先される。
+# TC-9.3 — failure path: git unreachable but mktemp reachable。
+# git shim 経由で git init/commit を強制失敗させ、helper の soft-fail return branch
+# (subshell 内 `git init -q ...` 失敗 → 外側 if ! で `return 1`) を実際に exercise する。
+#
+# Cycle 3 F-03 (claim 縮小): 旧コメントは「mutation で return 1 → exit 1 に書き換えると test が
+# 失敗する」と主張していたが、production caller (TC-016 等) はすべて `$(make_sandbox --soft)` の
+# command substitution 経由で呼び出すため、`return 1` も `exit 1` も subshell rc=1 として観測され
+# 区別不能。本テストの契約は「git failure → 親に rc=1 が伝わり caller が `if !` で受けられる」
+# ことに縮小する (return/exit semantic 区別は本契約の本質ではない)。
+#
+# Cycle 3 F-05/F-07 (trap quartet): 既存の line 111 `trap 'rm -f "$tmpfile"' EXIT` を破壊せず、
+# tc93_dir cleanup を加算した結合 trap を signal quartet 全 (EXIT/INT/TERM/HUP) に設定する。
+# Cycle 3 F-08 (command -v guard): `command -v mktemp` empty で broken symlink を作る silent
+# failure 経路を fail-fast guard で塞ぐ。
+# Cycle 3 F-09 (stderr verify): git shim ERROR を tempfile に capture し shim 実行を assert する
+# (PATH ordering 退行で real git が解決される regression を構造的に検出可能化)。
+# Cycle 3 F-10 (rm -rf check): cleanup は trap 経由で確実に実行されるため、明示 rm -rf は不要。
+tc93_dir=$(mktemp -d) || { echo "FATAL: TC-9.3 mktemp -d failed" >&2; exit 1; }
+# 既存 line 111 trap (`trap 'rm -f "$tmpfile"' EXIT`) を破壊せず、tc93_dir cleanup を加算 + quartet 化。
+trap 'rm -rf "$tc93_dir"; rm -f "$tmpfile"' EXIT
+trap 'rm -rf "$tc93_dir"; rm -f "$tmpfile"; exit 130' INT
+trap 'rm -rf "$tc93_dir"; rm -f "$tmpfile"; exit 143' TERM
+trap 'rm -rf "$tc93_dir"; rm -f "$tmpfile"; exit 129' HUP
+
+# command -v mktemp guard (F-08): empty 結果 (mktemp 不在環境) で broken symlink を作る silent
+# failure を防ぐ。empty なら fail-fast。
+mktemp_path=$(command -v mktemp || true)
+if [ -z "$mktemp_path" ]; then
+  echo "FATAL: TC-9.3 requires mktemp on PATH but command -v mktemp returned empty" >&2
+  exit 1
+fi
+ln -sf "$mktemp_path" "$tc93_dir/mktemp"
+
+# git invalidator: PATH に置いた shim が本物の git より優先される。
 cat > "$tc93_dir/git" <<'GIT_SHIM_EOF'
 #!/bin/sh
 echo "ERROR: git shim invoked (TC-9.3 force-failure)" >&2
 exit 127
 GIT_SHIM_EOF
 chmod +x "$tc93_dir/git"
+
+# F-09: shim invocation を観測可能にするため stderr を tempfile に capture (2>/dev/null では
+# PATH ordering 退行を構造的に検出できない)。
+shim_stderr="$tc93_dir/shim-stderr.log"
 rc_git_fail=0
-bash -c "source '$HELPERS'; PATH='$tc93_dir':/usr/bin:/bin make_sandbox --soft 2>/dev/null" || rc_git_fail=$?
+bash -c "source '$HELPERS'; PATH='$tc93_dir':/usr/bin:/bin make_sandbox --soft" \
+  2>"$shim_stderr" || rc_git_fail=$?
+
 if [ "$rc_git_fail" = "1" ]; then
-  outer_pass "TC-9.3: make_sandbox --soft returns rc=1 on git failure (does NOT exit)"
+  outer_pass "TC-9.3: make_sandbox --soft returns rc=1 on git failure (soft-fail contract)"
 else
   outer_fail "TC-9.3: expected rc=1 (soft-fail on git failure), got rc=$rc_git_fail"
 fi
+
+# F-09: shim が実際に invoke されたことを assert (PATH ordering 退行検出)。
+if grep -q "git shim invoked" "$shim_stderr"; then
+  outer_pass "TC-9.3.shim: git shim was invoked (PATH ordering correct)"
+else
+  outer_fail "TC-9.3.shim: git shim was NOT invoked — PATH ordering may have changed (stderr: $(head -3 "$shim_stderr"))"
+fi
+
+# Restore trap to original (line 111) form for the remaining TCs.
+# tc93_dir は本 block 後に不要 (assertion 完了) のため EXIT までは trap chain で保持しても問題なし、
+# ただし後続 TC で tc93_dir 参照は発生しないため EXIT trap を simple form に戻して理解しやすくする。
 rm -rf "$tc93_dir"
-trap 'rm -f "$tmpfile"' EXIT  # 既存 trap (line 111) を restore
+trap 'rm -f "$tmpfile"' EXIT
+trap - INT TERM HUP
 
 # === TC-10: make_sandbox unknown option → return 2 ===
 echo
@@ -329,6 +370,19 @@ if [ "$rc_plain_bogus" = "2" ]; then
   outer_pass "TC-11.3: make_plain_sandbox --bogus returns rc=2 (option parse error)"
 else
   outer_fail "TC-11.3: expected rc=2 for unknown option, got rc=$rc_plain_bogus"
+fi
+
+# Cycle 3 F-04: TC-11.4 — make_plain_sandbox --soft failure path (TC-9.2 と対称)。
+# make_plain_sandbox の --soft contract は make_sandbox と同型 (mktemp 失敗時に exit ではなく
+# rc=1 で return)。Mutation で `[ "$soft_fail" -eq 1 ] && return 1` を `exit 1` に書き換えると
+# このテストが失敗する保証は (return/exit semantic の説明は TC-9.3 と同じ理由で subshell 経由
+# のため部分的) が、少なくとも mktemp failure → rc=1 contract を pin する。
+rc_plain_soft_fail=0
+bash -c "source '$HELPERS'; PATH=/dev/null make_plain_sandbox --soft 2>/dev/null" || rc_plain_soft_fail=$?
+if [ "$rc_plain_soft_fail" = "1" ]; then
+  outer_pass "TC-11.4: make_plain_sandbox --soft returns rc=1 on mktemp failure"
+else
+  outer_fail "TC-11.4: expected rc=1 (soft-fail on mktemp failure), got rc=$rc_plain_soft_fail"
 fi
 
 # === Summary ===

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -176,6 +176,74 @@ else
   outer_fail "TC-6.1: drift hint not found in: $summary_output"
 fi
 
+# === TC-7: make_sandbox basic (Issue #990) ===
+echo
+echo "TC-7: make_sandbox default invocation → git-init + commit"
+
+sbx_default=$(bash -c "source '$HELPERS'; make_sandbox")
+if [ -d "$sbx_default" ] && [ -d "$sbx_default/.git" ]; then
+  outer_pass "TC-7.1: make_sandbox returns an existing path with a .git directory"
+else
+  outer_fail "TC-7.1: make_sandbox path '$sbx_default' missing .git or directory"
+fi
+
+# Initial commit reachable via `git log` (any non-zero output proves commit landed).
+log_output=$(cd "$sbx_default" 2>/dev/null && git log --oneline 2>/dev/null || true)
+if [ -n "$log_output" ]; then
+  outer_pass "TC-7.2: make_sandbox produced an initial commit (git log non-empty)"
+else
+  outer_fail "TC-7.2: make_sandbox did not produce an initial commit (git log empty)"
+fi
+rm -rf "$sbx_default"
+
+# === TC-8: make_sandbox --branch ===
+echo
+echo "TC-8: make_sandbox --branch <name> → HEAD on requested branch"
+
+sbx_branch=$(bash -c "source '$HELPERS'; make_sandbox --branch fix/issue-687-test")
+head_branch=$(cd "$sbx_branch" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+if [ "$head_branch" = "fix/issue-687-test" ]; then
+  outer_pass "TC-8.1: HEAD is on the requested branch (fix/issue-687-test)"
+else
+  outer_fail "TC-8.1: expected HEAD on fix/issue-687-test, got '$head_branch'"
+fi
+rm -rf "$sbx_branch"
+
+# === TC-9: make_sandbox --soft (success path) ===
+echo
+echo "TC-9: make_sandbox --soft → still returns a sandbox on success path"
+
+# Success path: --soft must not change the success-side contract.
+sbx_soft=$(bash -c "source '$HELPERS'; make_sandbox --soft")
+if [ -d "$sbx_soft/.git" ]; then
+  outer_pass "TC-9.1: make_sandbox --soft returns a working sandbox on success path"
+else
+  outer_fail "TC-9.1: make_sandbox --soft missing .git (path: '$sbx_soft')"
+fi
+rm -rf "$sbx_soft"
+
+# === TC-10: make_sandbox unknown option → exit 2 ===
+echo
+echo "TC-10: make_sandbox unknown option rejected"
+
+if bash -c "source '$HELPERS'; make_sandbox --bogus 2>/dev/null"; then
+  outer_fail "TC-10.1: make_sandbox accepted --bogus (expected non-zero exit)"
+else
+  outer_pass "TC-10.1: make_sandbox rejects unknown options"
+fi
+
+# === TC-11: make_plain_sandbox ===
+echo
+echo "TC-11: make_plain_sandbox → bare mktemp -d (no .git)"
+
+sbx_plain=$(bash -c "source '$HELPERS'; make_plain_sandbox")
+if [ -d "$sbx_plain" ] && [ ! -e "$sbx_plain/.git" ]; then
+  outer_pass "TC-11.1: make_plain_sandbox returns a bare directory without .git"
+else
+  outer_fail "TC-11.1: make_plain_sandbox unexpected layout at '$sbx_plain'"
+fi
+rm -rf "$sbx_plain"
+
 # === Summary ===
 echo
 echo "─── $(basename "$0") summary ──────────────────────"

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -243,19 +243,46 @@ else
 fi
 rm -rf "$sbx_soft"
 
-# F-03: TC-9.2 — failure path: --soft の存在意義 (git 失敗時に exit ではなく return 1) を pin。
-# PATH=/dev/null で git unreachable 化し、make_sandbox --soft が rc=1 で返る (subshell が
-# exit せず caller が `if !` で受けられる) ことを assert する。
-# 注意: bash builtin (cd, mktemp は core utility) は PATH 不要だが、git は PATH 探索される。
-# `command -v git` が無効化されることで `git init` が "command not found" になる。
+# TC-9.2 — failure path: --soft の存在意義 (infrastructure 失敗時に exit ではなく return 1) を pin。
+# Cycle 2 F-05 修正: 旧コメントは「git 失敗時に return 1」と主張していたが、`mktemp` は GNU coreutils
+# の外部コマンド (bash builtin ではない) のため、`PATH=/dev/null` 下では `mktemp -d` (helper line 216
+# 相当) が先に失敗し soft-fail return が発火する。git init/commit 失敗の soft-fail branch (helper
+# line 245 相当) は untested のまま。TC-9.3 で git 失敗 path を別途 pin する。
 # `|| rc=$?` 形式: set -e の下で非ゼロ exit が abort を起こさないよう短絡。
 rc_soft_fail=0
 bash -c "source '$HELPERS'; PATH=/dev/null make_sandbox --soft 2>/dev/null" || rc_soft_fail=$?
 if [ "$rc_soft_fail" = "1" ]; then
-  outer_pass "TC-9.2: make_sandbox --soft returns rc=1 on git failure (does NOT exit)"
+  outer_pass "TC-9.2: make_sandbox --soft returns rc=1 on mktemp failure (does NOT exit)"
 else
-  outer_fail "TC-9.2: expected rc=1 (soft-fail), got rc=$rc_soft_fail"
+  outer_fail "TC-9.2: expected rc=1 (soft-fail on mktemp failure), got rc=$rc_soft_fail"
 fi
+
+# Cycle 2 F-05: TC-9.3 — failure path: git unreachable but mktemp reachable。
+# mktemp は本物を残し git のみ shim で無効化することで、helper の git init/commit 失敗 branch
+# (subshell 内 `git init -q 2>"$sandbox_err"` 失敗 → 外側 if ! で soft-fail return) を実際に exercise する。
+# Mutation で該当 branch の `return 1` を `exit 1` に書き換えると caller が `if !` で受けられず
+# subshell ごと exit するため、本テストは「git failure → soft-fail return contract」を直接 pin する。
+tc93_dir=$(mktemp -d)
+trap "rm -rf '$tc93_dir'" EXIT  # one-shot best-effort (再 trap)
+# real mktemp into shim PATH; only `git` is invalidated by creating a non-executable stub.
+ln -sf "$(command -v mktemp)" "$tc93_dir/mktemp"
+# git invalidator: an executable file that always exits non-zero so `git init` 失敗を再現する。
+# PATH に shim dir を置くことで本物の git ($(command -v git)) より優先される。
+cat > "$tc93_dir/git" <<'GIT_SHIM_EOF'
+#!/bin/sh
+echo "ERROR: git shim invoked (TC-9.3 force-failure)" >&2
+exit 127
+GIT_SHIM_EOF
+chmod +x "$tc93_dir/git"
+rc_git_fail=0
+bash -c "source '$HELPERS'; PATH='$tc93_dir':/usr/bin:/bin make_sandbox --soft 2>/dev/null" || rc_git_fail=$?
+if [ "$rc_git_fail" = "1" ]; then
+  outer_pass "TC-9.3: make_sandbox --soft returns rc=1 on git failure (does NOT exit)"
+else
+  outer_fail "TC-9.3: expected rc=1 (soft-fail on git failure), got rc=$rc_git_fail"
+fi
+rm -rf "$tc93_dir"
+trap 'rm -f "$tmpfile"' EXIT  # 既存 trap (line 111) を restore
 
 # === TC-10: make_sandbox unknown option → return 2 ===
 echo
@@ -284,6 +311,25 @@ else
   outer_fail "TC-11.1: make_plain_sandbox unexpected layout at '$sbx_plain'"
 fi
 rm -rf "$sbx_plain"
+
+# Cycle 2 F-03: TC-11.2 / TC-11.3 — API symmetry with make_sandbox.
+# `make_plain_sandbox` exposes the same --soft / option-parse contract; pin both contracts here
+# (parallels TC-9.2 / TC-10.1 for make_sandbox).
+sbx_plain_soft=$(bash -c "source '$HELPERS'; make_plain_sandbox --soft")
+if [ -d "$sbx_plain_soft" ] && [ ! -e "$sbx_plain_soft/.git" ]; then
+  outer_pass "TC-11.2: make_plain_sandbox --soft returns a working sandbox on success path"
+else
+  outer_fail "TC-11.2: make_plain_sandbox --soft unexpected layout at '$sbx_plain_soft'"
+fi
+rm -rf "$sbx_plain_soft"
+
+rc_plain_bogus=0
+bash -c "source '$HELPERS'; make_plain_sandbox --bogus 2>/dev/null" || rc_plain_bogus=$?
+if [ "$rc_plain_bogus" = "2" ]; then
+  outer_pass "TC-11.3: make_plain_sandbox --bogus returns rc=2 (option parse error)"
+else
+  outer_fail "TC-11.3: expected rc=2 for unknown option, got rc=$rc_plain_bogus"
+fi
 
 # === Summary ===
 echo

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -209,9 +209,30 @@ else
 fi
 rm -rf "$sbx_branch"
 
-# === TC-9: make_sandbox --soft (success path) ===
+# F-08: TC-8.2 / TC-8.3 — option-parse error variants (return 2).
+# Pins the explicit `if [ $# -lt 2 ] || [ -z "$2" ]` guard so a regression that
+# changes `shift 2` to `shift` (and silently accepts `--branch` with no value)
+# is caught.
+# `|| rc=$?` 形式: set -e の下で非ゼロ exit が abort を起こさないよう短絡。
+rc_empty=0
+bash -c "source '$HELPERS'; make_sandbox --branch '' 2>/dev/null" || rc_empty=$?
+if [ "$rc_empty" = "2" ]; then
+  outer_pass "TC-8.2: --branch \"\" returns rc=2 (option parse error)"
+else
+  outer_fail "TC-8.2: expected rc=2 for --branch \"\", got rc=$rc_empty"
+fi
+
+rc_missing=0
+bash -c "source '$HELPERS'; make_sandbox --branch 2>/dev/null" || rc_missing=$?
+if [ "$rc_missing" = "2" ]; then
+  outer_pass "TC-8.3: --branch with no argument returns rc=2 (option parse error)"
+else
+  outer_fail "TC-8.3: expected rc=2 for --branch with no argument, got rc=$rc_missing"
+fi
+
+# === TC-9: make_sandbox --soft ===
 echo
-echo "TC-9: make_sandbox --soft → still returns a sandbox on success path"
+echo "TC-9: make_sandbox --soft → success returns sandbox, failure returns rc=1 (no exit)"
 
 # Success path: --soft must not change the success-side contract.
 sbx_soft=$(bash -c "source '$HELPERS'; make_sandbox --soft")
@@ -222,14 +243,34 @@ else
 fi
 rm -rf "$sbx_soft"
 
-# === TC-10: make_sandbox unknown option → exit 2 ===
-echo
-echo "TC-10: make_sandbox unknown option rejected"
-
-if bash -c "source '$HELPERS'; make_sandbox --bogus 2>/dev/null"; then
-  outer_fail "TC-10.1: make_sandbox accepted --bogus (expected non-zero exit)"
+# F-03: TC-9.2 — failure path: --soft の存在意義 (git 失敗時に exit ではなく return 1) を pin。
+# PATH=/dev/null で git unreachable 化し、make_sandbox --soft が rc=1 で返る (subshell が
+# exit せず caller が `if !` で受けられる) ことを assert する。
+# 注意: bash builtin (cd, mktemp は core utility) は PATH 不要だが、git は PATH 探索される。
+# `command -v git` が無効化されることで `git init` が "command not found" になる。
+# `|| rc=$?` 形式: set -e の下で非ゼロ exit が abort を起こさないよう短絡。
+rc_soft_fail=0
+bash -c "source '$HELPERS'; PATH=/dev/null make_sandbox --soft 2>/dev/null" || rc_soft_fail=$?
+if [ "$rc_soft_fail" = "1" ]; then
+  outer_pass "TC-9.2: make_sandbox --soft returns rc=1 on git failure (does NOT exit)"
 else
-  outer_pass "TC-10.1: make_sandbox rejects unknown options"
+  outer_fail "TC-9.2: expected rc=1 (soft-fail), got rc=$rc_soft_fail"
+fi
+
+# === TC-10: make_sandbox unknown option → return 2 ===
+echo
+echo "TC-10: make_sandbox unknown option → return 2 (option parse error)"
+
+# F-06: rc=2 specific assertion. The previous test only verified non-zero exit,
+# which would not catch a regression that changes `return 2` to `return 1` (the
+# soft-fail code) or `exit 1` (hard-fail). Pin the specific contract.
+# `|| rc=$?` 形式: set -e の下で非ゼロ exit が abort を起こさないよう短絡。
+rc_bogus=0
+bash -c "source '$HELPERS'; make_sandbox --bogus 2>/dev/null" || rc_bogus=$?
+if [ "$rc_bogus" = "2" ]; then
+  outer_pass "TC-10.1: make_sandbox --bogus returns rc=2 (option parse error)"
+else
+  outer_fail "TC-10.1: expected rc=2 for unknown option, got rc=$rc_bogus"
 fi
 
 # === TC-11: make_plain_sandbox ===

--- a/plugins/rite/hooks/tests/_validate-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_validate-helpers.test.sh
@@ -28,6 +28,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HELPER="$HOOKS_DIR/_validate-helpers.sh"
 
+# Issue #990: source common helpers for make_plain_sandbox.
+# This file's prior `make_sandbox` was a no-git variant that also pushed to
+# cleanup_dirs and populated DEFAULT_HELPERS_LIST entries; we now build on
+# make_plain_sandbox and keep the helper-placement step in a renamed wrapper
+# (setup_validate_sandbox) to avoid clashing with the git-init `make_sandbox`
+# provided by _test-helpers.sh.
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
 PASS=0
 FAIL=0
 cleanup_dirs=()
@@ -86,9 +95,12 @@ if [ "${#DEFAULT_HELPERS_LIST[@]}" -eq 0 ]; then
   exit 1
 fi
 
-make_sandbox() {
+# Issue #990: build on make_plain_sandbox from _test-helpers.sh and keep the
+# helper-placement step here (this file's domain-specific setup).
+# Renamed to avoid shadowing the helper's git-init `make_sandbox`.
+setup_validate_sandbox() {
   local sbx
-  sbx=$(mktemp -d)
+  sbx=$(make_plain_sandbox)
   cleanup_dirs+=("$sbx")
   # 検査対象 helper 群を sandbox に配置 (executable)
   for h in "${DEFAULT_HELPERS_LIST[@]}"; do
@@ -108,7 +120,7 @@ assert_match "TC-1.2: ERROR mentions 'at least 1 argument'" "at least 1 argument
 # ================================================================
 echo "TC-2 (NEW API): 引数 1 個 (script_dir のみ) で DEFAULT_HELPERS を使用 — exit 0"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_validate_sandbox)
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-2.1: exit code is 0 (DEFAULT_HELPERS 使用、全 helper 存在)" "0" "$rc"
 assert_eq "TC-2.2: stdout/stderr is silent" "" "$out"
@@ -116,7 +128,7 @@ assert_eq "TC-2.2: stdout/stderr is silent" "" "$out"
 # ================================================================
 echo "TC-3 (legacy API, backward compat): 明示 list で全 helper 存在 → exit 0 silent"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_validate_sandbox)
 out=$(bash "$HELPER" "$sbx" \
   state-path-resolve.sh _resolve-session-id.sh _resolve-session-id-from-file.sh \
   _resolve-schema-version.sh _resolve-cross-session-guard.sh \
@@ -127,7 +139,7 @@ assert_eq "TC-3.2: stdout/stderr is silent" "" "$out"
 # ================================================================
 echo "TC-4 (legacy API): 1 helper missing (chmod -x) で exit 1 + ERROR"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_validate_sandbox)
 chmod -x "$sbx/_mktemp-stderr-guard.sh"
 out=$(bash "$HELPER" "$sbx" \
   state-path-resolve.sh _resolve-session-id.sh _resolve-session-id-from-file.sh \
@@ -147,7 +159,7 @@ assert_match "TC-5.2: ERROR mentions helper basename" "state-path-resolve.sh" "$
 # ================================================================
 echo "TC-6 (legacy API): 複数 helper missing で最初の missing で fail-fast (順序保証)"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_validate_sandbox)
 chmod -x "$sbx/_resolve-session-id.sh"
 chmod -x "$sbx/_emit-cross-session-incident.sh"
 out=$(bash "$HELPER" "$sbx" \
@@ -161,7 +173,7 @@ assert_match "TC-6.2: ERROR mentions FIRST missing helper (順序保証)" "_reso
 # ================================================================
 echo "TC-7 (NEW API): DEFAULT_HELPERS 経路で 1 helper missing → exit 1 + ERROR"
 # ================================================================
-sbx=$(make_sandbox)
+sbx=$(setup_validate_sandbox)
 chmod -x "$sbx/_resolve-cross-session-guard.sh"
 # 引数なし (script_dir のみ) で DEFAULT_HELPERS を使用
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
@@ -175,7 +187,7 @@ echo "TC-8 (NEW API): DEFAULT_HELPERS 配列の全 entry すべてが検査さ�
 # DEFAULT_HELPERS 配列の completeness を verify する (Issue #687 root cause と
 # 同型の片肺更新 drift を防ぐための structural invariant 検証)
 for missing_helper in "${DEFAULT_HELPERS_LIST[@]}"; do
-  sbx=$(make_sandbox)
+  sbx=$(setup_validate_sandbox)
   chmod -x "$sbx/$missing_helper"
   out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
   if [ "$rc" = "1" ] && [[ "$out" == *"$missing_helper"* ]]; then

--- a/plugins/rite/hooks/tests/_validate-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_validate-helpers.test.sh
@@ -98,10 +98,12 @@ fi
 # Issue #990: build on make_plain_sandbox from _test-helpers.sh and keep the
 # helper-placement step here (this file's domain-specific setup).
 # Renamed to avoid shadowing the helper's git-init `make_sandbox`.
+# IMPORTANT: This wrapper does NOT push to cleanup_dirs — callers MUST push
+# from the parent shell (after capturing $(setup_validate_sandbox)) because
+# any push performed inside $(...) is lost in the command-substitution subshell.
 setup_validate_sandbox() {
   local sbx
   sbx=$(make_plain_sandbox)
-  cleanup_dirs+=("$sbx")
   # 検査対象 helper 群を sandbox に配置 (executable)
   for h in "${DEFAULT_HELPERS_LIST[@]}"; do
     : > "$sbx/$h"
@@ -120,7 +122,7 @@ assert_match "TC-1.2: ERROR mentions 'at least 1 argument'" "at least 1 argument
 # ================================================================
 echo "TC-2 (NEW API): 引数 1 個 (script_dir のみ) で DEFAULT_HELPERS を使用 — exit 0"
 # ================================================================
-sbx=$(setup_validate_sandbox)
+sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
 assert_eq "TC-2.1: exit code is 0 (DEFAULT_HELPERS 使用、全 helper 存在)" "0" "$rc"
 assert_eq "TC-2.2: stdout/stderr is silent" "" "$out"
@@ -128,7 +130,7 @@ assert_eq "TC-2.2: stdout/stderr is silent" "" "$out"
 # ================================================================
 echo "TC-3 (legacy API, backward compat): 明示 list で全 helper 存在 → exit 0 silent"
 # ================================================================
-sbx=$(setup_validate_sandbox)
+sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
 out=$(bash "$HELPER" "$sbx" \
   state-path-resolve.sh _resolve-session-id.sh _resolve-session-id-from-file.sh \
   _resolve-schema-version.sh _resolve-cross-session-guard.sh \
@@ -139,7 +141,7 @@ assert_eq "TC-3.2: stdout/stderr is silent" "" "$out"
 # ================================================================
 echo "TC-4 (legacy API): 1 helper missing (chmod -x) で exit 1 + ERROR"
 # ================================================================
-sbx=$(setup_validate_sandbox)
+sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
 chmod -x "$sbx/_mktemp-stderr-guard.sh"
 out=$(bash "$HELPER" "$sbx" \
   state-path-resolve.sh _resolve-session-id.sh _resolve-session-id-from-file.sh \
@@ -159,7 +161,7 @@ assert_match "TC-5.2: ERROR mentions helper basename" "state-path-resolve.sh" "$
 # ================================================================
 echo "TC-6 (legacy API): 複数 helper missing で最初の missing で fail-fast (順序保証)"
 # ================================================================
-sbx=$(setup_validate_sandbox)
+sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
 chmod -x "$sbx/_resolve-session-id.sh"
 chmod -x "$sbx/_emit-cross-session-incident.sh"
 out=$(bash "$HELPER" "$sbx" \
@@ -173,7 +175,7 @@ assert_match "TC-6.2: ERROR mentions FIRST missing helper (順序保証)" "_reso
 # ================================================================
 echo "TC-7 (NEW API): DEFAULT_HELPERS 経路で 1 helper missing → exit 1 + ERROR"
 # ================================================================
-sbx=$(setup_validate_sandbox)
+sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
 chmod -x "$sbx/_resolve-cross-session-guard.sh"
 # 引数なし (script_dir のみ) で DEFAULT_HELPERS を使用
 out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
@@ -187,7 +189,7 @@ echo "TC-8 (NEW API): DEFAULT_HELPERS 配列の全 entry すべてが検査さ�
 # DEFAULT_HELPERS 配列の completeness を verify する (Issue #687 root cause と
 # 同型の片肺更新 drift を防ぐための structural invariant 検証)
 for missing_helper in "${DEFAULT_HELPERS_LIST[@]}"; do
-  sbx=$(setup_validate_sandbox)
+  sbx=$(setup_validate_sandbox); cleanup_dirs+=("$sbx")
   chmod -x "$sbx/$missing_helper"
   out=$(bash "$HELPER" "$sbx" 2>&1) && rc=0 || rc=$?
   if [ "$rc" = "1" ] && [[ "$out" == *"$missing_helper"* ]]; then

--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -23,6 +23,9 @@ source "$SCRIPT_DIR/_test-helpers.sh"
 
 cleanup() {
   rm -rf "$TEST_DIR"
+  # F-05: TC-016 が make_sandbox --soft で作る sandbox は TEST_DIR 配下に無いため、
+  # set -e で TC-016 が abort しても rm -rf が走らず leak する。常に cleanup する。
+  [ -n "${dir016:-}" ] && rm -rf "$dir016"
 }
 trap cleanup EXIT
 
@@ -311,6 +314,8 @@ echo "TC-016: Subdirectory CWD invocation → walkup resolves project-root rite-
 if ! dir016=$(make_sandbox --soft); then
   skip "TC-016 (sandbox setup failed — setup error は test failure と区別)"
 else
+  # F-05: dir016 は cleanup() trap が EXIT 時に cleanup する (TEST_DIR と同様)。
+  # set -e で abort しても trap が発火し /tmp の leak を防ぐ。明示的な rm -rf は不要。
   mkdir -p "$dir016/sub"
   touch "$dir016/rite-config.yml"
 
@@ -320,7 +325,6 @@ else
   else
     fail "Expected 'Notification for PR created' from subdir CWD, got: '$output'"
   fi
-  rm -rf "$dir016"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -316,14 +316,16 @@ echo ""
 echo "TC-016: Subdirectory CWD invocation → walkup resolves project-root rite-config.yml"
 # Issue #990: replaced inline sandbox setup with `make_sandbox --soft` from
 # _test-helpers.sh. Setup error は test failure と区別する (skip path) -- helper の
-# --soft return preserves that. The helper's mktemp -d is independent of
-# TEST_DIR; we clean it up explicitly on the success path since it is not
-# under TEST_DIR's trap-managed cleanup.
+# --soft return preserves that. The helper's mktemp -d puts dir016 under /tmp
+# (independent of TEST_DIR), but cleanup() (lines 24-30) now handles dir016
+# alongside TEST_DIR for every signal in the EXIT/INT/TERM/HUP quartet, so
+# no explicit rm -rf is needed on the test body's success/failure paths.
 if ! dir016=$(make_sandbox --soft); then
   skip "TC-016 (sandbox setup failed — setup error は test failure と区別)"
 else
-  # F-05: dir016 は cleanup() trap が EXIT 時に cleanup する (TEST_DIR と同様)。
-  # set -e で abort しても trap が発火し /tmp の leak を防ぐ。明示的な rm -rf は不要。
+  # Issue #990 cycle 2 F-05 + cycle 3 F-02: dir016 は cleanup() trap (lines 24-30) が
+  # EXIT/INT/TERM/HUP の全 signal で cleanup する。明示的な rm -rf は不要 (signal trap
+  # quartet で完全カバー、sister test 規約と一貫)。
   mkdir -p "$dir016/sub"
   touch "$dir016/rite-config.yml"
 

--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -11,6 +11,13 @@ PASS=0
 FAIL=0
 SKIP=0
 
+# Issue #990: source common helpers for make_sandbox.
+# pass/fail/skip below intentionally override the helper-provided versions
+# (this file uses `PASS:`/`FAIL:`/`SKIP:` prefixed labels and tracks SKIP,
+# neither of which the helper covers).
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
 # Note: notification.sh has best-effort exit handling (exits 0 if jq is missing)
 # so jq is not strictly required for the hook, but tests verify behavior with it
 
@@ -296,20 +303,15 @@ echo ""
 # still emit "Notification for PR created" because walkup found the config; a regression
 # would yield empty output (exit 0 without echo).
 echo "TC-016: Subdirectory CWD invocation → walkup resolves project-root rite-config.yml"
-dir016="$TEST_DIR/tc016"
-mkdir -p "$dir016/sub"
-# Setup error は test failure と区別する (`|| true` で setup 失敗を呑むと、walkup 不能化と
-# 同じ「empty output / exit 0」症状になり F-02 で指摘された false-negative を再導入する)。
-# make_sandbox (stop-create-interview-block.test.sh) と同じ fail-fast 構造を採用。
-if ! (
-  cd "$dir016"
-  git init -q 2>/dev/null
-  echo a > a && git add a 2>/dev/null
-  git -c user.email=t@test.local -c user.name=test commit -q -m init 2>/dev/null
-); then
-  echo "ERROR: TC-016 sandbox git init failed in $dir016" >&2
+# Issue #990: replaced inline sandbox setup with `make_sandbox --soft` from
+# _test-helpers.sh. Setup error は test failure と区別する (skip path) -- helper の
+# --soft return preserves that. The helper's mktemp -d is independent of
+# TEST_DIR; we clean it up explicitly on the success path since it is not
+# under TEST_DIR's trap-managed cleanup.
+if ! dir016=$(make_sandbox --soft); then
   skip "TC-016 (sandbox setup failed — setup error は test failure と区別)"
 else
+  mkdir -p "$dir016/sub"
   touch "$dir016/rite-config.yml"
 
   output=$(run_hook "$dir016/sub" "pr_created")
@@ -318,6 +320,7 @@ else
   else
     fail "Expected 'Notification for PR created' from subdir CWD, got: '$output'"
   fi
+  rm -rf "$dir016"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/notification.test.sh
+++ b/plugins/rite/hooks/tests/notification.test.sh
@@ -27,7 +27,15 @@ cleanup() {
   # set -e で TC-016 が abort しても rm -rf が走らず leak する。常に cleanup する。
   [ -n "${dir016:-}" ] && rm -rf "$dir016"
 }
+# Cycle 2 F-02: signal-specific trap quartet to match sister tests (state-read.test.sh /
+# stop-create-interview-block.test.sh / work-memory-update.test.sh / _resolve-cross-session-guard.test.sh /
+# resume-active-flag-restore.test.sh / _resolve-session-id-from-file.test.sh / _validate-helpers.test.sh).
+# Without INT/TERM/HUP, Ctrl-C during interactive debug leaks dir016 (which lives under /tmp via
+# mktemp -d, NOT under $TEST_DIR) as an orphan git repo.
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
 
 pass() {
   PASS=$((PASS + 1))

--- a/plugins/rite/hooks/tests/resume-active-flag-restore.test.sh
+++ b/plugins/rite/hooks/tests/resume-active-flag-restore.test.sh
@@ -32,6 +32,14 @@ PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HELPER="$PLUGIN_ROOT/hooks/resume-active-flag-restore.sh"
 FLOW_STATE_UPDATE="$PLUGIN_ROOT/hooks/flow-state-update.sh"
 
+# Issue #990 cycle 2 F-01: source make_sandbox from common helper.
+# This file's prior inline make_sandbox() (default no-option git-init+commit) was a
+# functionally-identical duplicate of the helper's `make_sandbox` default invocation.
+# assert_eq / assert_contains below are preserved inline because they have a custom
+# label/expected/actual signature distinct from the helper's `assert` 3-arg form.
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
 if [ ! -x "$HELPER" ]; then
   echo "ERROR: resume-active-flag-restore.sh missing or not executable: $HELPER" >&2
   exit 1
@@ -45,6 +53,8 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# Reset counters after `source` (helper initialises PASS=FAIL=0 / FAILED_NAMES=() on source;
+# this is a no-op duplicate kept here for clarity that this test owns its counters).
 PASS=0
 FAIL=0
 FAILED_NAMES=()
@@ -92,26 +102,6 @@ assert_contains() {
     FAIL=$((FAIL+1))
     FAILED_NAMES+=("$name")
   fi
-}
-
-make_sandbox() {
-  local d sandbox_err
-  d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
-  sandbox_err=$(mktemp /tmp/rite-resume-sandbox-err-XXXXXX) || sandbox_err="/dev/null"
-  if ! (
-    cd "$d"
-    git init -q 2>"$sandbox_err"
-    echo a > a && git add a 2>>"$sandbox_err"
-    git -c user.email=t@test.local -c user.name=test commit -q -m init 2>>"$sandbox_err"
-  ); then
-    echo "ERROR: make_sandbox: git init/commit failed in $d" >&2
-    [ "$sandbox_err" != "/dev/null" ] && [ -s "$sandbox_err" ] && head -5 "$sandbox_err" | sed 's/^/  /' >&2
-    rm -rf "$d"
-    [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-    exit 1
-  fi
-  [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-  echo "$d"
 }
 
 write_config_v2() {

--- a/plugins/rite/hooks/tests/state-read.test.sh
+++ b/plugins/rite/hooks/tests/state-read.test.sh
@@ -27,9 +27,11 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-PASS=0
-FAIL=0
-FAILED_NAMES=()
+# Issue #990: source common helpers for make_sandbox.
+# The helper resets PASS/FAIL/FAILED_NAMES on source, matching the prior
+# manual reset behavior below.
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
 
 # Signal trap (EXIT/INT/TERM/HUP) で sandbox / 個別 file の leak を防ぐ。
 # 実装は Form B (portability variant、return 0 必須) — 詳細は bash-trap-patterns.md "cleanup 関数の契約" 節 Form B 参照
@@ -65,28 +67,10 @@ assert_eq() {
   fi
 }
 
-# Each test uses its own sandbox so failures don't pollute siblings.
-# git failure は silent suppression せず fail-fast (CI で git config 由来の問題で sandbox が
-# 破損すると state-path-resolve.sh が cwd fallback して偶発的 silent regression を起こすため)。
-make_sandbox() {
-  local d sandbox_err
-  d=$(mktemp -d) || { echo "ERROR: make_sandbox: mktemp -d failed" >&2; exit 1; }
-  sandbox_err=$(mktemp /tmp/rite-sandbox-err-XXXXXX) || sandbox_err="/dev/null"
-  if ! (
-    cd "$d"
-    git init -q 2>"$sandbox_err"
-    echo a > a && git add a 2>>"$sandbox_err"
-    git -c user.email=t@test.local -c user.name=test commit -q -m init 2>>"$sandbox_err"
-  ); then
-    echo "ERROR: make_sandbox: git init/commit failed in $d" >&2
-    [ "$sandbox_err" != "/dev/null" ] && [ -s "$sandbox_err" ] && head -5 "$sandbox_err" | sed 's/^/  /' >&2
-    rm -rf "$d"
-    [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-    exit 1
-  fi
-  [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-  echo "$d"
-}
+# Issue #990: make_sandbox is now provided by _test-helpers.sh (sourced above).
+# Behavior preserved: hard-fail on git init/commit failure with up to 5 lines
+# of captured git stderr emitted to aid CI debugging (state-path-resolve.sh
+# silent-fallback would otherwise hide sandbox corruption symptoms).
 
 write_config_v2() {
   local d="$1"

--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -26,9 +26,12 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-PASS=0
-FAIL=0
-FAILED_NAMES=()
+# Issue #990: source common helpers for make_sandbox.
+# The helper resets PASS/FAIL/FAILED_NAMES on source, so any pre-existing
+# counter state is implicitly cleared here (which matches the prior
+# line-29-31 manual reset behavior).
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
 
 cleanup_dirs=()
 _stop_hook_test_cleanup() {
@@ -100,18 +103,6 @@ assert_not_contains() {
     echo "  ✅ $name"
     PASS=$((PASS+1))
   fi
-}
-
-make_sandbox() {
-  local d
-  d=$(mktemp -d) || { echo "ERROR: make_sandbox: mktemp -d failed" >&2; exit 1; }
-  (
-    cd "$d"
-    git init -q 2>/dev/null
-    echo a > a && git add a 2>/dev/null
-    git -c user.email=t@test.local -c user.name=test commit -q -m init 2>/dev/null
-  ) || { echo "ERROR: make_sandbox: git init failed in $d" >&2; rm -rf "$d"; exit 1; }
-  echo "$d"
 }
 
 write_flow_state() {

--- a/plugins/rite/hooks/tests/work-memory-update.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-update.test.sh
@@ -34,9 +34,9 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-PASS=0
-FAIL=0
-FAILED_NAMES=()
+# Issue #990: source common helpers for make_sandbox.
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
 
 cleanup_dirs=()
 _wm_update_test_cleanup() {
@@ -79,27 +79,11 @@ assert_contains() {
   fi
 }
 
-make_sandbox() {
-  local d sandbox_err
-  d=$(mktemp -d) || { echo "ERROR: make_sandbox: mktemp -d failed" >&2; exit 1; }
-  sandbox_err=$(mktemp /tmp/rite-wm-sandbox-err-XXXXXX) || sandbox_err="/dev/null"
-  if ! (
-    cd "$d"
-    git init -q -b "fix/issue-687-test" 2>"$sandbox_err" \
-      || git init -q 2>>"$sandbox_err"
-    git checkout -q -b "fix/issue-687-test" 2>>"$sandbox_err" || true
-    echo a > a && git add a 2>>"$sandbox_err"
-    git -c user.email=t@test.local -c user.name=test commit -q -m init 2>>"$sandbox_err"
-  ); then
-    echo "ERROR: make_sandbox: git init/commit failed in $d" >&2
-    [ "$sandbox_err" != "/dev/null" ] && [ -s "$sandbox_err" ] && head -5 "$sandbox_err" | sed 's/^/  /' >&2
-    rm -rf "$d"
-    [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-    exit 1
-  fi
-  [ "$sandbox_err" != "/dev/null" ] && rm -f "$sandbox_err"
-  echo "$d"
-}
+# Issue #990: make_sandbox is now provided by _test-helpers.sh; callers below
+# invoke `make_sandbox --branch fix/issue-687-test` to preserve the
+# branch-based issue-number extraction path validated by TC-1.
+# The fix/issue-687-test branch name is the SoT for EXPECTED_ISSUE_NUM=687
+# below (any branch rename would require both call sites to sync).
 
 write_config_v2() {
   cat > "$1/rite-config.yml" <<EOF
@@ -140,7 +124,7 @@ run_update() {
 # cycle 12 fix の core invariant: WM_REQUIRE_FLOW_STATE check が legacy file 直接 [ -f ] check ではなく
 # state-read.sh 経由になったので per-session のみで skip しない
 echo "TC-1: schema_v=2 + per-session present + legacy absent + WM_REQUIRE_FLOW_STATE=true → return 0 (cycle 12 false negative regression guard)"
-SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config_v2 "$SBX"
 SID="11111111-1111-1111-1111-111111111111"
 write_session_id "$SBX" "$SID"
@@ -175,7 +159,7 @@ assert_eq "TC-1.2: WM file created via branch parsing (issue-${EXPECTED_ISSUE_NU
 
 # --- TC-2: schema_version=2 + both files absent + WM_REQUIRE_FLOW_STATE=true ---
 echo "TC-2: schema_v=2 + per-session/legacy 両不在 + WM_REQUIRE_FLOW_STATE=true → return 1 (skip)"
-SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config_v2 "$SBX"
 write_session_id "$SBX" "22222222-2222-2222-2222-222222222222"
 # per-session は作成しない、legacy も作成しない
@@ -194,7 +178,7 @@ assert_eq "TC-2.2: WM file NOT created" "no" \
 
 # --- TC-3: WM_READ_FROM_FLOW_STATE=true + per-session has pr_number/loop_count ---
 echo "TC-3: schema_v=2 + per-session pr_number=100 loop_count=3 + WM_READ_FROM_FLOW_STATE=true → frontmatter 反映 (cycle 10 stale residue regression guard)"
-SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config_v2 "$SBX"
 SID="33333333-3333-3333-3333-333333333333"
 write_session_id "$SBX" "$SID"
@@ -224,7 +208,7 @@ fi
 
 # --- TC-4: schema_version=1 + legacy file present ---
 echo "TC-4: schema_v=1 + legacy file present + WM_REQUIRE_FLOW_STATE=true → return 0 (legacy 経路維持)"
-SBX=$(make_sandbox); cleanup_dirs+=("$SBX")
+SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config_v1 "$SBX"
 write_legacy "$SBX" '{"phase":"phase5_lint","next_action":"continue","pr_number":50,"loop_count":1,"active":true}'
 

--- a/plugins/rite/hooks/tests/work-memory-update.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-update.test.sh
@@ -138,13 +138,15 @@ write_per_session "$SBX" "$SID" '{"phase":"phase5_lint","next_action":"continue"
 # 旧実装は issue-687-test.md を期待する dead if 分岐を持ち、常に else 経路 (WM_ISSUE_NUMBER override)
 # が実行されていた。これを branch-based extraction の直接 assert に修正する。
 # branch-based extraction の直接検証 (cycle 12 false negative regression guard):
-# make_sandbox が `fix/issue-687-test` branch を作るため、branch parsing が `687` を抽出して
-# `.rite-work-memory/issue-687.md` を生成することを確認する。
+# `make_sandbox --branch fix/issue-687-test` が指定の branch を作るため、branch parsing が `687`
+# を抽出して `.rite-work-memory/issue-687.md` を生成することを確認する。
 #
-# PR #688 followup F-06 LOW (branch-name coupling 軽減): make_sandbox の git init branch
-# (fix/issue-687-test) と本 TC の assertion で参照する issue 番号 (687) を local var で 1 か所に集約。
-# make_sandbox の branch 名を変更した場合、本 var を同期更新するだけで TC-1.1 / TC-1.2 が追従する。
-EXPECTED_ISSUE_NUM=687  # make_sandbox 関数内の "fix/issue-687-test" branch 名から抽出される値 (branch 名を変更する場合は本 var を同期更新)
+# PR #688 followup F-06 LOW (branch-name coupling 軽減): make_sandbox 呼び出しで渡している
+# `--branch fix/issue-687-test` 引数と本 TC の assertion で参照する issue 番号 (687) を local var
+# で 1 か所に集約。Issue #990 cycle 3 F-01: make_sandbox は _test-helpers.sh の共通 helper に
+# 集約されたため、コメントの「関数内」は誤り — call site の `--branch` 引数が SoT。
+# branch 名を変更する場合は本 var と make_sandbox --branch 引数の両方を同期更新する。
+EXPECTED_ISSUE_NUM=687  # make_sandbox --branch 引数 "fix/issue-687-test" (下記 call site 参照) から抽出される値 (branch 名を変更する場合は本 var と --branch 引数の両方を同期更新)
 if run_update "$SBX" \
   WM_SOURCE="lint" WM_PHASE="phase5_lint" WM_PHASE_DETAIL="quality check" \
   WM_NEXT_ACTION="rite:lint" WM_BODY_TEXT="Test body." \


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/` 配下で 5+ ファイルに inline 複製されていた `make_sandbox` 相当の git-init sandbox 生成ロジックを、共通 helper モジュール `_test-helpers.sh` の `make_sandbox` / `make_plain_sandbox` に集約。各 caller の差異 (hard-fail / soft-skip / branch-specific) を `--branch <name>` / `--soft` オプションで吸収。

## 変更内容

### `_test-helpers.sh` — helper 追加

- **`make_sandbox`** (git-init + initial commit 版)
  - `--branch <name>`: 初期 branch 指定。pre-2.28 git で `-b` 非対応の場合は `git init` + `git checkout -b` に自動 fallback
  - `--soft`: 失敗時に非ゼロ return（hard-fail = `exit 1` のデフォルトと区別、`skip` 連携用）
  - 失敗時に最大 5 行の git stderr を `head -5 | sed 's/^/  /'` で出力（CI debugging 用）
- **`make_plain_sandbox`** (git なし bare mktemp -d 版)
  - cleanup_dirs push は caller 側で実行（既存 git-init 系と整合）

### 各 test の inline 削除 + helper 利用

| ファイル | 変更内容 |
|---|---|
| `stop-create-interview-block.test.sh` | inline `make_sandbox()` 削除 → `source _test-helpers.sh` |
| `state-read.test.sh` | 同上（grep で追加発見） |
| `work-memory-update.test.sh` | inline 削除 + `make_sandbox --branch fix/issue-687-test` に置換（4 箇所） |
| `notification.test.sh` | TC-016 inline sandbox を `make_sandbox --soft` に置換、setup 失敗時 `skip` 連携 |
| `_validate-helpers.test.sh` | git なし変種 → `setup_validate_sandbox` (make_plain_sandbox base) に rename |
| `_resolve-session-id-from-file.test.sh` | git なし変種 → `setup_session_id_sandbox` (make_plain_sandbox base) に rename |

### `_test-helpers.test.sh` — helper 単体テスト追加

- TC-7: `make_sandbox` default invocation → `.git` directory + initial commit 確認
- TC-8: `make_sandbox --branch` → HEAD が指定 branch
- TC-9: `make_sandbox --soft` success path（既存契約維持）
- TC-10: unknown option rejected（非ゼロ exit）
- TC-11: `make_plain_sandbox` → bare directory, no `.git`

## 設計の根拠

- **caller 規約の統一**: helper は path を echo するのみ、`cleanup_dirs+=("$SBX")` は caller 側で実行。 helper 内 push 規約だった `_validate-helpers` / `_resolve-session-id-from-file` も統一規約に migrate
- **同名衝突回避**: 上記 2 ファイルの git なし sandbox は thin wrapper (`setup_*_sandbox`) として残し、git-init 版 `make_sandbox` と区別
- **SoT 単一化**: `_test-helpers.sh` 単一に集約（Wiki 経験則「References 抽出 refactor では canonical contract の SoT を 1 reference に固定」に整合）

## テスト結果

`bash plugins/rite/hooks/tests/run-tests.sh` で **52/52 PASS, 0 FAIL**。modified test も個別実行で全 PASS:

- `_test-helpers.test.sh`: 18/0
- `stop-create-interview-block.test.sh`: 66/0
- `state-read.test.sh`: 50/0
- `work-memory-update.test.sh`: 9/0
- `notification.test.sh`: 15/0 (1 skip — TC-016 success path の skip ではなく既存 jq-missing skip)
- `_validate-helpers.test.sh`: 23/0
- `_resolve-session-id-from-file.test.sh`: 22/0

## 関連 Issue

Closes #990

## Test plan

- [x] `_test-helpers.test.sh` で helper 単体検証 (TC-7〜TC-11 追加)
- [x] `run-tests.sh` で全 52 テストの regression check
- [x] modified test 6 ファイル個別実行で PASS 確認
- [x] `plugins/rite/hooks/scripts/bang-backtick-check.sh --all` で 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
