### PR TITLE
docs(tests): TC-7 comment の '6+ syntactic variants' を '7 syntactic variants' に統一

### DIFF
--- a/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
+++ b/plugins/rite/hooks/tests/stop-create-interview-block.test.sh
@@ -201,7 +201,7 @@ assert_eq "TC-6.2: no stderr output" "" "$STDERR"
 rm -rf "$SBX"; _remove_from_cleanup_dirs "$SBX"
 
 # ---- TC-7: workflow_incident.enabled variant matrix → all opt-out forms block + skip sentinel ----
-# Canonical SoT (workflow-incident-detection.md) accepts 6+ syntactic variants of falsy values
+# Canonical SoT (workflow-incident-detection.md) accepts 7 syntactic variants of falsy values
 # (`false` / `no` / `0`, case-insensitive, with/without quotes, with trailing comment). The hook
 # parser (stop-create-interview-block.sh:103-111) implements quote stripping + case-folding +
 # case branch. This loop pins all variants so future parser refactors cannot silently degrade


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/stop-create-interview-block.test.sh:204` の TC-7 コメントに残った `accepts 6+ syntactic variants of falsy values` を `accepts 7 syntactic variants of falsy values` に書き換え、TC-7 / TC-11 の 4 site 対称性を完成させる 1 行修正。

## 関連 Issue

Closes #993

## 背景

PR #992 (Issue #987) で TC-11 (truthy variant matrix) を追加した際、TC-11 は最初から「7 syntactic forms」で一貫した表記を採用したが、TC-7 (falsy variant matrix) のコメント部分が旧 `6+` 表記のまま残った。

4 site 対称性の状況:

| Site | 表記 (修正前) | 表記 (修正後) |
|------|--------------|--------------|
| TC-7 comment (line 204) | `6+ syntactic variants` ❌ | `7 syntactic variants` ✅ |
| TC-7 echo (line 209) | `7 syntactic forms` ✅ | (変更なし) ✅ |
| TC-11 comment (line 308) | `7 truthy variants` ✅ | (変更なし) ✅ |
| TC-11 echo (line 312) | `7 syntactic forms` ✅ | (変更なし) ✅ |

本 fix で TC-7 comment のみ非同期だった状態を解消する。

## 変更内容

- `plugins/rite/hooks/tests/stop-create-interview-block.test.sh:204` の 1 行コメントを変更

## 検証

- `bash plugins/rite/hooks/tests/stop-create-interview-block.test.sh` → PASS 66 / FAIL 0
- `git grep "6+ syntactic" plugins/rite/hooks/tests/` → 0 件 (PR #838 canonical「明示宣言した literal の git grep 残存 0 verify」を遵守)
- 4 site 対称性: `grep -E "(7 syntactic (variants|forms)|7 truthy variants)"` で 4 件マッチを確認

## Wiki 経験則との関係

- **Asymmetric Fix Transcription** (anti-patterns / high confidence、累積 32 回目)
- 対称位置への伝播漏れの典型パターン follow-up。本 PR は元 PR #992 の symmetric narrative completion であり review-fix loop ではなく一回 commit で収束する想定。
- PR #992 で確立した「self-application 経路で review-fix loop が独立検証として機能する」サイクルの follow-up にも該当。

## チェックリスト

- [x] 4 site 対称性の確保
- [x] テスト全件 PASS (66/66)
- [x] git grep で旧表記 (`6+`) の残存件数 0 確認
