### PR TITLE
fix(hooks): pre-tool-bash-guard Pattern 4 subagent detection に 3-tier fallback 追加 (#998)

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -67,8 +67,8 @@ fi
 # upgrade to an allow-list check (e.g. `*-reviewer` glob) here. Tier 3 env vars
 # share the same risk — see BLOCKED_ALTERNATIVE recovery text for `unset` guidance.
 #
-# Both jq lookups read $INPUT in a single invocation to halve subprocess fork
-# overhead on the PreToolUse hot path.
+# All three field extractions share a single jq invocation; the original
+# three-jq layout would triple subprocess fork overhead on the PreToolUse hot path.
 JQ_OUT=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>/dev/null) || JQ_OUT=$'\t\t'
 TRANSCRIPT_PATH=$(printf '%s' "$JQ_OUT" | cut -f1)
 INPUT_SUBAGENT_TYPE=$(printf '%s' "$JQ_OUT" | cut -f2)

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -305,8 +305,9 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #
   # 設計判断 (documentation-only): Layer 2 の責務はあくまで「静的 token として `git` を含む
   # コマンド」をスコープとし、alias / function indirection は二次防御 (agent prompt 規約) と
-  # 三次防御 (Layer 3 post-condition state-verify gate) に委ねる。本 limitation は
-  # security-reviewer cycle 2 (PR #997) で documented limitation として ack 済み。
+  # 三次防御 (Layer 3 post-condition state-verify gate) に委ねる。三層防御の構造を維持する
+  # 設計判断であり、Layer 2 を fail-closed にしようとすると overhead と false positive の
+  # コストが正味の defense gain を上回ると判定した。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED// command git/ git}"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -40,17 +40,46 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Reviewer subagent detection (Issue #442).
+# Reviewer subagent detection (Issue #442, extended in Issue #998).
 # Claude Code routes subagent sessions to jsonl files under a "subagents/"
 # directory inside the project transcript root; the main session does not.
 # When the PreToolUse hook runs inside a subagent, transcript_path therefore
 # contains the "/subagents/" path component. Pattern 4 below uses this as a
 # heuristic to scope state-mutating git denylist checks to reviewer contexts.
+#
+# Three-tier detection (Issue #998 — future-proofing against SDK convention drift):
+#   Tier 1 (primary):  transcript_path glob `*/subagents/*` — current Claude Code
+#                      convention (Issue #442). Most reliable signal today.
+#   Tier 2 (fallback): hook input JSON `subagent_type` / `agent_type` field —
+#                      reserved for future SDK schemas that surface subagent
+#                      identity in the hook envelope rather than the path.
+#                      Any non-empty value triggers IS_SUBAGENT=1 (presence-only
+#                      check; specific values like `code-reviewer` are not
+#                      enumerated because the SDK has not finalized the schema).
+#   Tier 3 (fallback): environment variables CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE —
+#                      catch-all if a future SDK exposes subagent context via
+#                      env vars before updating the hook input schema. Presence-only.
+#
+# If a future SDK release changes transcript_path conventions, Tiers 2 & 3 keep
+# Pattern 4 functional rather than silently disabling enforcement (false negative).
+# Tier 3 inherits the parent process environment, which is the standard contract
+# for hook subprocesses.
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null) || TRANSCRIPT_PATH=""
 IS_SUBAGENT=0
 case "$TRANSCRIPT_PATH" in
   */subagents/*) IS_SUBAGENT=1 ;;
 esac
+if [ "$IS_SUBAGENT" = "0" ]; then
+  SUBAGENT_TYPE=$(echo "$INPUT" | jq -r '.subagent_type // .agent_type // empty' 2>/dev/null) || SUBAGENT_TYPE=""
+  if [ -n "$SUBAGENT_TYPE" ]; then
+    IS_SUBAGENT=1
+  fi
+fi
+if [ "$IS_SUBAGENT" = "0" ]; then
+  if [ -n "${CLAUDE_SUBAGENT_TYPE:-}" ] || [ -n "${CLAUDE_AGENT_TYPE:-}" ]; then
+    IS_SUBAGENT=1
+  fi
+fi
 
 # --- Fail-open for pattern matching stage ---
 # If heredoc extraction or pattern matching crashes (e.g., edge-case failures with
@@ -267,8 +296,17 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #   - `/usr/bin/git` / `/opt/homebrew/bin/git` 等の絶対パス → ` git`
   #   - `command git` / `exec git` / `builtin git` (builtin は構文 invalid だが safety) → ` git`
   #   - `\git` (backslash-escaped) → ` git`
-  # 注意: alias / function 経由 (`alias gg='git'` 後に `gg checkout`) は本 hook では検出不能。
-  # 一次防御は agent prompt + Layer 3 post-condition gate に委ねる。
+  # Acknowledged residual gap: alias / shell function indirection.
+  #   `alias gg='git'; gg checkout -b evil` や `my_git() { command git "$@"; }; my_git checkout`
+  #   は parent shell の alias / function 解決後に `gg` / `my_git` という独立トークンとして
+  #   渡るため、本 hook の静的 glob では `git` を識別不能。bash の `type` 解決を hook 内で
+  #   再現する選択肢は overhead が大きく、誤判定（user-defined function が `git` を呼ばないケース）
+  #   も避けられない。
+  #
+  # 設計判断 (documentation-only): Layer 2 の責務はあくまで「静的 token として `git` を含む
+  # コマンド」をスコープとし、alias / function indirection は二次防御 (agent prompt 規約) と
+  # 三次防御 (Layer 3 post-condition state-verify gate) に委ねる。本 limitation は
+  # security-reviewer cycle 2 (PR #997) で documented limitation として ack 済み。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED// command git/ git}"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -47,31 +47,38 @@ fi
 # contains the "/subagents/" path component. Pattern 4 below uses this as a
 # heuristic to scope state-mutating git denylist checks to reviewer contexts.
 #
-# Three-tier detection (Issue #998 — future-proofing against SDK convention drift):
+# Three-tier detection (future-proofing against SDK convention drift):
 #   Tier 1 (primary):  transcript_path glob `*/subagents/*` — current Claude Code
-#                      convention (Issue #442). Most reliable signal today.
+#                      convention. Most reliable signal today.
 #   Tier 2 (fallback): hook input JSON `subagent_type` / `agent_type` field —
 #                      reserved for future SDK schemas that surface subagent
 #                      identity in the hook envelope rather than the path.
-#                      Any non-empty value triggers IS_SUBAGENT=1 (presence-only
-#                      check; specific values like `code-reviewer` are not
-#                      enumerated because the SDK has not finalized the schema).
+#                      Presence-only check on STRING values; numeric/array/object
+#                      values are rejected via `| strings` filter to avoid jq's
+#                      `//` operator treating only null/false as falsy.
 #   Tier 3 (fallback): environment variables CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE —
 #                      catch-all if a future SDK exposes subagent context via
 #                      env vars before updating the hook input schema. Presence-only.
 #
-# If a future SDK release changes transcript_path conventions, Tiers 2 & 3 keep
-# Pattern 4 functional rather than silently disabling enforcement (false negative).
-# Tier 3 inherits the parent process environment, which is the standard contract
-# for hook subprocesses.
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null) || TRANSCRIPT_PATH=""
+# Forward-compatibility caveat: presence-only check fires on any non-empty string.
+# If a future SDK starts emitting `subagent_type: "main"` / `"none"` / `"null"`
+# sentinel values on main-session hooks, every main-session git command in this
+# block would be blocked (false positive). When such a convention appears,
+# upgrade to an allow-list check (e.g. `*-reviewer` glob) here. Tier 3 env vars
+# share the same risk — see BLOCKED_ALTERNATIVE recovery text for `unset` guidance.
+#
+# Both jq lookups read $INPUT in a single invocation to halve subprocess fork
+# overhead on the PreToolUse hot path.
+JQ_OUT=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>/dev/null) || JQ_OUT=$'\t\t'
+TRANSCRIPT_PATH=$(printf '%s' "$JQ_OUT" | cut -f1)
+INPUT_SUBAGENT_TYPE=$(printf '%s' "$JQ_OUT" | cut -f2)
+INPUT_AGENT_TYPE=$(printf '%s' "$JQ_OUT" | cut -f3)
 IS_SUBAGENT=0
 case "$TRANSCRIPT_PATH" in
   */subagents/*) IS_SUBAGENT=1 ;;
 esac
 if [ "$IS_SUBAGENT" = "0" ]; then
-  SUBAGENT_TYPE=$(echo "$INPUT" | jq -r '.subagent_type // .agent_type // empty' 2>/dev/null) || SUBAGENT_TYPE=""
-  if [ -n "$SUBAGENT_TYPE" ]; then
+  if [ -n "$INPUT_SUBAGENT_TYPE" ] || [ -n "$INPUT_AGENT_TYPE" ]; then
     IS_SUBAGENT=1
   fi
 fi
@@ -296,18 +303,10 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #   - `/usr/bin/git` / `/opt/homebrew/bin/git` 等の絶対パス → ` git`
   #   - `command git` / `exec git` / `builtin git` (builtin は構文 invalid だが safety) → ` git`
   #   - `\git` (backslash-escaped) → ` git`
-  # Acknowledged residual gap: alias / shell function indirection.
-  #   `alias gg='git'; gg checkout -b evil` や `my_git() { command git "$@"; }; my_git checkout`
-  #   は parent shell の alias / function 解決後に `gg` / `my_git` という独立トークンとして
-  #   渡るため、本 hook の静的 glob では `git` を識別不能。bash の `type` 解決を hook 内で
-  #   再現する選択肢は overhead が大きく、誤判定（user-defined function が `git` を呼ばないケース）
-  #   も避けられない。
-  #
-  # 設計判断 (documentation-only): Layer 2 の責務はあくまで「静的 token として `git` を含む
-  # コマンド」をスコープとし、alias / function indirection は二次防御 (agent prompt 規約) と
-  # 三次防御 (Layer 3 post-condition state-verify gate) に委ねる。三層防御の構造を維持する
-  # 設計判断であり、Layer 2 を fail-closed にしようとすると overhead と false positive の
-  # コストが正味の defense gain を上回ると判定した。
+  # Residual gap: alias / function indirection (`alias gg='git'`, `my_git() { ... }`)
+  # は parent shell 解決後の独立トークンとして渡るため、本 hook の静的 glob では検出不能。
+  # Layer 2 の責務は「静的 token として `git` を含むコマンド」に限定し、一次防御は agent prompt、
+  # 三次防御は Layer 3 post-condition state-verify gate に委ねる三層構造を維持する。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED// command git/ git}"
@@ -581,7 +580,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
 
   if [ -n "$BLOCKED_PATTERN" ]; then
     BLOCKED_REASON="Reviewer subagents must not mutate the working tree, index, or refs. State-changing git commands (checkout/reset/add/stash push/restore/commit/push/merge/rebase/cherry-pick/revert/tag -a -d -f/clean/gc/branch -D --delete/update-ref/symbolic-ref/am/apply/mv/notes/config/remote/bisect/filter-branch/replace/reflog expire/worktree remove/fetch --prune/--force/etc.) are forbidden inside reviewer contexts."
-    BLOCKED_ALTERNATIVE="Use read-only alternatives: 'git show <ref>:<file>' to read a blob, 'git diff <ref> -- <file>' to compare, 'git worktree add <path> <ref>' to inspect a different ref in an isolated directory, 'git tag -l' / 'git stash list' / 'git reflog' / 'git branch --list' for display-only queries, or bare 'git fetch' (without --prune/--force) for ref sync. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the full list."
+    BLOCKED_ALTERNATIVE="Use read-only alternatives: 'git show <ref>:<file>' to read a blob, 'git diff <ref> -- <file>' to compare, 'git worktree add <path> <ref>' to inspect a different ref in an isolated directory, 'git tag -l' / 'git stash list' / 'git reflog' / 'git branch --list' for display-only queries, or bare 'git fetch' (without --prune/--force) for ref sync. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the full list. If this block fires on a main session (not a reviewer subagent), check whether CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE env vars are accidentally set; recover with: unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE"
   fi
 fi
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1345,6 +1345,81 @@ fi
 rm -rf "$tmpdir"
 
 # --------------------------------------------------------------------------
+# Issue #998: subagent detection fallback (input JSON field + environment variable)
+#
+# Tier 2 (input JSON subagent_type / agent_type field) と Tier 3 (CLAUDE_SUBAGENT_TYPE /
+# CLAUDE_AGENT_TYPE 環境変数) が transcript_path 不在/規約変更時の future-proofing として
+# 機能することを確認する。既存 transcript_path 経路 (Tier 1) との独立性も担保する。
+# --------------------------------------------------------------------------
+
+# Helper: run hook with a raw JSON envelope (allows specifying subagent_type field).
+run_guard_with_json() {
+  local raw_input="$1"
+  local rc=0
+  local output
+  output=$(echo "$raw_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  echo "$output"
+  return $rc
+}
+
+# --------------------------------------------------------------------------
+# TC-113: subagent_type field set → IS_SUBAGENT=1, state-mutating git denied
+#
+# transcript_path に "/subagents/" を含まないが、input JSON に subagent_type field が
+# 存在する場合に Tier 2 fallback で deny されることを確認。
+# --------------------------------------------------------------------------
+echo "TC-113: input JSON subagent_type field → reviewer-state-mutating-git deny"
+rc=0
+tc113_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl", subagent_type: "code-reviewer"}')
+output=$(run_guard_with_json "$tc113_input") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-113 subagent_type field triggers Tier 2 fallback (git checkout blocked)"
+else
+  fail "TC-113 expected deny, got decision=$decision reason=$reason"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-114: CLAUDE_SUBAGENT_TYPE env var set → IS_SUBAGENT=1
+#
+# transcript_path と subagent_type field 両方とも不在/main 経路でも、環境変数のみで
+# Tier 3 fallback が発火することを確認。
+# --------------------------------------------------------------------------
+echo "TC-114: CLAUDE_SUBAGENT_TYPE env var → Tier 3 fallback deny"
+rc=0
+tc114_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl"}')
+output=$(CLAUDE_SUBAGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114_input" "$HOOK" "$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-114 CLAUDE_SUBAGENT_TYPE env var triggers Tier 3 fallback"
+else
+  fail "TC-114 expected deny via env var, got decision=$decision reason=$reason"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-115: All three tiers unset → main session, git checkout allowed (regression guard)
+#
+# transcript_path = main, subagent_type field 不在, CLAUDE_*_TYPE 環境変数 unset の場合に
+# git checkout が allow されることを確認。Tier 2/3 追加で main 経路への false positive が
+# 発生していない (Issue #442 regression guard) ことを保証する。
+# --------------------------------------------------------------------------
+echo "TC-115: main session, all three tiers unset → git checkout allowed (regression guard)"
+rc=0
+tc115_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl"}')
+# unset env vars explicitly within subshell to avoid host env leakage
+output=$(env -u CLAUDE_SUBAGENT_TYPE -u CLAUDE_AGENT_TYPE bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc115_input" "$HOOK" "$STDERR_FILE") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-115 main session git checkout allowed (Tier 2/3 do not introduce false positives)"
+else
+  fail "TC-115 expected allow, got rc=$rc output=$output"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -3,6 +3,12 @@
 # Usage: bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
 set -euo pipefail
 
+# Issue #998: Tier 3 (env var) subagent detection を導入したため、host 環境に
+# CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE が export されていると既存の
+# main-session allow テスト (TC-022 stderr branch / TC-023 / TC-028 / TC-062 等) が
+# Tier 3 経路で誤って deny 判定され flake する。全テストで一律遮断する。
+unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../pre-tool-bash-guard.sh"
 PASS=0
@@ -1353,17 +1359,26 @@ rm -rf "$tmpdir"
 #
 # テストでは host 環境からの env var leakage を遮断するため `env -u CLAUDE_SUBAGENT_TYPE
 # -u CLAUDE_AGENT_TYPE` で囲み、Tier 2 単独 / Tier 3 単独動作を独立に検証する。
-# helper は既存の `run_guard_raw` を再利用する (重複定義回避)。
+# Tier 3 env var leakage 遮断のため、`run_guard_raw` とは env scope が異なる別 helper
+# として `run_guard_clean_env` を定義する (TC-114 / TC-114b の env var SET 経路も引数で
+# 表現可能にしている)。
 # --------------------------------------------------------------------------
 
-MAIN_TRANSCRIPT_TC113="/home/user/.claude/projects/proj/session-id/main.jsonl"
+# alias of MAIN_TRANSCRIPT (L397) — Tier 2/3 セクションを self-contained に保つため局所定義
+MAIN_TRANSCRIPT_TC113="$MAIN_TRANSCRIPT"
 
 # Helper: run hook with raw JSON input + clean env (Tier 3 env vars unset)
+#   Optional 引数: $2 / $3 に `NAME=value` 形式を渡すと、env -u で unset した後に SET する
+#   (TC-114 / TC-114b の Tier 3 env var 経路を helper 経由で表現可能にする)。
 run_guard_clean_env() {
   local raw_input="$1"
+  local set1="${2:-}"
+  local set2="${3:-}"
   local rc=0
   local output
-  output=$(env -u CLAUDE_SUBAGENT_TYPE -u CLAUDE_AGENT_TYPE bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$raw_input" "$HOOK" "$STDERR_FILE") || rc=$?
+  # env(1) は引数順序で処理する: `-u X` で X を unset した直後の `X=val` は最終的に
+  # X=val として export される。${var:+...} expansion により空引数を env に渡さない。
+  output=$(env -u CLAUDE_SUBAGENT_TYPE -u CLAUDE_AGENT_TYPE ${set1:+"$set1"} ${set2:+"$set2"} bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$raw_input" "$HOOK" "$STDERR_FILE") || rc=$?
   echo "$output"
   return $rc
 }
@@ -1400,10 +1415,16 @@ tc113b_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool
 output=$(run_guard_clean_env "$tc113b_input") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+stderr_log=$(cat "$STDERR_FILE")
 if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
   pass "TC-113b agent_type field triggers Tier 2 fallback (OR with subagent_type)"
 else
   fail "TC-113b expected deny, got decision=$decision reason=$reason"
+fi
+if [[ "$stderr_log" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-113b stderr block log recorded"
+else
+  fail "TC-113b expected stderr block log, got: $stderr_log"
 fi
 echo ""
 
@@ -1423,11 +1444,11 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-113d-input-numeric: subagent_type: 123 (non-string numeric) → Tier 2 fires NOT
+# TC-113d: subagent_type=123 (non-string numeric) → Tier 2 fires NOT
 #   `(.subagent_type | strings // "")` filter が numeric 値を空文字に正規化することを検証。
 #   `| strings` filter を `// empty` 等に縮退する mutation を kill する coverage。
 # --------------------------------------------------------------------------
-echo "TC-113d-input-numeric: subagent_type=123 → Tier 2 does not fire (numeric rejected by | strings)"
+echo "TC-113d: subagent_type=123 → Tier 2 does not fire (numeric rejected by | strings)"
 rc=0
 tc113d_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: 123}')
 output=$(run_guard_clean_env "$tc113d_input") || rc=$?
@@ -1439,10 +1460,10 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-113e-input-array: subagent_type: [...] (non-string array) → Tier 2 fires NOT
+# TC-113e: subagent_type=[...] (non-string array) → Tier 2 fires NOT
 #   `(.subagent_type | strings // "")` filter が array 値を空文字に正規化することを検証。
 # --------------------------------------------------------------------------
-echo "TC-113e-input-array: subagent_type=[...] → Tier 2 does not fire (array rejected by | strings)"
+echo "TC-113e: subagent_type=[...] → Tier 2 does not fire (array rejected by | strings)"
 rc=0
 tc113e_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: ["code-reviewer", "security"]}')
 output=$(run_guard_clean_env "$tc113e_input") || rc=$?
@@ -1454,10 +1475,10 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-113f-input-object: subagent_type: {...} (non-string object) → Tier 2 fires NOT
+# TC-113f: subagent_type={...} (non-string object) → Tier 2 fires NOT
 #   `(.subagent_type | strings // "")` filter が object 値を空文字に正規化することを検証。
 # --------------------------------------------------------------------------
-echo "TC-113f-input-object: subagent_type={...} → Tier 2 does not fire (object rejected by | strings)"
+echo "TC-113f: subagent_type={...} → Tier 2 does not fire (object rejected by | strings)"
 rc=0
 tc113f_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: {name: "code-reviewer", level: 1}}')
 output=$(run_guard_clean_env "$tc113f_input") || rc=$?
@@ -1470,12 +1491,12 @@ echo ""
 
 # --------------------------------------------------------------------------
 # TC-114: CLAUDE_SUBAGENT_TYPE env var set → Tier 3 deny
-#   CLAUDE_AGENT_TYPE を host から明示 unset し SUBAGENT 単独経路を検証
+#   run_guard_clean_env の第 2 引数で SUBAGENT 単独経路を検証 (helper 経由 = DRY)
 # --------------------------------------------------------------------------
 echo "TC-114: CLAUDE_SUBAGENT_TYPE env var → Tier 3 deny"
 rc=0
 tc114_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: $tp}')
-output=$(env -u CLAUDE_AGENT_TYPE CLAUDE_SUBAGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114_input" "$HOOK" "$STDERR_FILE") || rc=$?
+output=$(run_guard_clean_env "$tc114_input" "CLAUDE_SUBAGENT_TYPE=code-reviewer") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
 stderr_log=$(cat "$STDERR_FILE")
@@ -1498,13 +1519,19 @@ echo ""
 echo "TC-114b: CLAUDE_AGENT_TYPE env var → Tier 3 deny"
 rc=0
 tc114b_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: $tp}')
-output=$(env -u CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114b_input" "$HOOK" "$STDERR_FILE") || rc=$?
+output=$(run_guard_clean_env "$tc114b_input" "CLAUDE_AGENT_TYPE=code-reviewer") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+stderr_log=$(cat "$STDERR_FILE")
 if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
   pass "TC-114b CLAUDE_AGENT_TYPE triggers Tier 3 fallback (OR with CLAUDE_SUBAGENT_TYPE)"
 else
   fail "TC-114b expected deny via env var, got decision=$decision reason=$reason"
+fi
+if [[ "$stderr_log" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-114b stderr block log recorded"
+else
+  fail "TC-114b expected stderr block log, got: $stderr_log"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1423,6 +1423,52 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-113d-input-numeric: subagent_type: 123 (non-string numeric) → Tier 2 fires NOT
+#   `(.subagent_type | strings // "")` filter が numeric 値を空文字に正規化することを検証。
+#   `| strings` filter を `// empty` 等に縮退する mutation を kill する coverage。
+# --------------------------------------------------------------------------
+echo "TC-113d-input-numeric: subagent_type=123 → Tier 2 does not fire (numeric rejected by | strings)"
+rc=0
+tc113d_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: 123}')
+output=$(run_guard_clean_env "$tc113d_input") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-113d numeric subagent_type does not trigger Tier 2 (| strings filter rejects non-string)"
+else
+  fail "TC-113d expected allow, got rc=$rc output=$output"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-113e-input-array: subagent_type: [...] (non-string array) → Tier 2 fires NOT
+#   `(.subagent_type | strings // "")` filter が array 値を空文字に正規化することを検証。
+# --------------------------------------------------------------------------
+echo "TC-113e-input-array: subagent_type=[...] → Tier 2 does not fire (array rejected by | strings)"
+rc=0
+tc113e_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: ["code-reviewer", "security"]}')
+output=$(run_guard_clean_env "$tc113e_input") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-113e array subagent_type does not trigger Tier 2 (| strings filter rejects non-string)"
+else
+  fail "TC-113e expected allow, got rc=$rc output=$output"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-113f-input-object: subagent_type: {...} (non-string object) → Tier 2 fires NOT
+#   `(.subagent_type | strings // "")` filter が object 値を空文字に正規化することを検証。
+# --------------------------------------------------------------------------
+echo "TC-113f-input-object: subagent_type={...} → Tier 2 does not fire (object rejected by | strings)"
+rc=0
+tc113f_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: {name: "code-reviewer", level: 1}}')
+output=$(run_guard_clean_env "$tc113f_input") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-113f object subagent_type does not trigger Tier 2 (| strings filter rejects non-string)"
+else
+  fail "TC-113f expected allow, got rc=$rc output=$output"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # TC-114: CLAUDE_SUBAGENT_TYPE env var set → Tier 3 deny
 #   CLAUDE_AGENT_TYPE を host から明示 unset し SUBAGENT 単独経路を検証
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1345,75 +1345,132 @@ fi
 rm -rf "$tmpdir"
 
 # --------------------------------------------------------------------------
-# Issue #998: subagent detection fallback (input JSON field + environment variable)
+# subagent detection fallback (input JSON field + environment variable)
 #
 # Tier 2 (input JSON subagent_type / agent_type field) と Tier 3 (CLAUDE_SUBAGENT_TYPE /
 # CLAUDE_AGENT_TYPE 環境変数) が transcript_path 不在/規約変更時の future-proofing として
 # 機能することを確認する。既存 transcript_path 経路 (Tier 1) との独立性も担保する。
+#
+# テストでは host 環境からの env var leakage を遮断するため `env -u CLAUDE_SUBAGENT_TYPE
+# -u CLAUDE_AGENT_TYPE` で囲み、Tier 2 単独 / Tier 3 単独動作を独立に検証する。
+# helper は既存の `run_guard_raw` を再利用する (重複定義回避)。
 # --------------------------------------------------------------------------
 
-# Helper: run hook with a raw JSON envelope (allows specifying subagent_type field).
-run_guard_with_json() {
+MAIN_TRANSCRIPT_TC113="/home/user/.claude/projects/proj/session-id/main.jsonl"
+
+# Helper: run hook with raw JSON input + clean env (Tier 3 env vars unset)
+run_guard_clean_env() {
   local raw_input="$1"
   local rc=0
   local output
-  output=$(echo "$raw_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  output=$(env -u CLAUDE_SUBAGENT_TYPE -u CLAUDE_AGENT_TYPE bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$raw_input" "$HOOK" "$STDERR_FILE") || rc=$?
   echo "$output"
   return $rc
 }
 
 # --------------------------------------------------------------------------
-# TC-113: subagent_type field set → IS_SUBAGENT=1, state-mutating git denied
-#
-# transcript_path に "/subagents/" を含まないが、input JSON に subagent_type field が
-# 存在する場合に Tier 2 fallback で deny されることを確認。
+# TC-113: subagent_type field set → Tier 2 deny (git checkout blocked)
 # --------------------------------------------------------------------------
-echo "TC-113: input JSON subagent_type field → reviewer-state-mutating-git deny"
+echo "TC-113: input JSON subagent_type field → Tier 2 deny"
 rc=0
-tc113_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl", subagent_type: "code-reviewer"}')
-output=$(run_guard_with_json "$tc113_input") || rc=$?
+tc113_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: "code-reviewer"}')
+output=$(run_guard_clean_env "$tc113_input") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+stderr_log=$(cat "$STDERR_FILE")
 if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
-  pass "TC-113 subagent_type field triggers Tier 2 fallback (git checkout blocked)"
+  pass "TC-113 subagent_type field triggers Tier 2 fallback"
 else
   fail "TC-113 expected deny, got decision=$decision reason=$reason"
+fi
+if [[ "$stderr_log" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-113 stderr block log recorded"
+else
+  fail "TC-113 expected stderr block log, got: $stderr_log"
 fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-114: CLAUDE_SUBAGENT_TYPE env var set → IS_SUBAGENT=1
-#
-# transcript_path と subagent_type field 両方とも不在/main 経路でも、環境変数のみで
-# Tier 3 fallback が発火することを確認。
+# TC-113b: agent_type field set (subagent_type 不在) → Tier 2 deny
+#   実装が `.subagent_type // .agent_type` の OR 経路を持つことを検証 (silent breakage 防止)
 # --------------------------------------------------------------------------
-echo "TC-114: CLAUDE_SUBAGENT_TYPE env var → Tier 3 fallback deny"
+echo "TC-113b: agent_type field set → Tier 2 deny"
 rc=0
-tc114_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl"}')
-output=$(CLAUDE_SUBAGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114_input" "$HOOK" "$STDERR_FILE") || rc=$?
+tc113b_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, agent_type: "code-reviewer"}')
+output=$(run_guard_clean_env "$tc113b_input") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
 if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
-  pass "TC-114 CLAUDE_SUBAGENT_TYPE env var triggers Tier 3 fallback"
+  pass "TC-113b agent_type field triggers Tier 2 fallback (OR with subagent_type)"
+else
+  fail "TC-113b expected deny, got decision=$decision reason=$reason"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-113c: subagent_type: "" (空文字列) → Tier 2 fires NOT (main session 扱い)
+#   `| strings` filter + `[ -n "" ]` false により presence-only check が空文字を弾く挙動を検証
+# --------------------------------------------------------------------------
+echo "TC-113c: subagent_type=\"\" → Tier 2 does not fire (main session)"
+rc=0
+tc113c_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp, subagent_type: ""}')
+output=$(run_guard_clean_env "$tc113c_input") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-113c empty subagent_type does not trigger Tier 2 (main session preserved)"
+else
+  fail "TC-113c expected allow, got rc=$rc output=$output"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-114: CLAUDE_SUBAGENT_TYPE env var set → Tier 3 deny
+#   CLAUDE_AGENT_TYPE を host から明示 unset し SUBAGENT 単独経路を検証
+# --------------------------------------------------------------------------
+echo "TC-114: CLAUDE_SUBAGENT_TYPE env var → Tier 3 deny"
+rc=0
+tc114_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: $tp}')
+output=$(env -u CLAUDE_AGENT_TYPE CLAUDE_SUBAGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114_input" "$HOOK" "$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+stderr_log=$(cat "$STDERR_FILE")
+if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-114 CLAUDE_SUBAGENT_TYPE triggers Tier 3 fallback"
 else
   fail "TC-114 expected deny via env var, got decision=$decision reason=$reason"
+fi
+if [[ "$stderr_log" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-114 stderr block log recorded"
+else
+  fail "TC-114 expected stderr block log, got: $stderr_log"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-114b: CLAUDE_AGENT_TYPE env var single (SUBAGENT unset) → Tier 3 deny
+#   実装 `[ -n "${CLAUDE_SUBAGENT_TYPE:-}" ] || [ -n "${CLAUDE_AGENT_TYPE:-}" ]` の OR 経路検証
+# --------------------------------------------------------------------------
+echo "TC-114b: CLAUDE_AGENT_TYPE env var → Tier 3 deny"
+rc=0
+tc114b_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git reset --hard HEAD"}, cwd: "/tmp", transcript_path: $tp}')
+output=$(env -u CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE=code-reviewer bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc114b_input" "$HOOK" "$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-114b CLAUDE_AGENT_TYPE triggers Tier 3 fallback (OR with CLAUDE_SUBAGENT_TYPE)"
+else
+  fail "TC-114b expected deny via env var, got decision=$decision reason=$reason"
 fi
 echo ""
 
 # --------------------------------------------------------------------------
 # TC-115: All three tiers unset → main session, git checkout allowed (regression guard)
-#
-# transcript_path = main, subagent_type field 不在, CLAUDE_*_TYPE 環境変数 unset の場合に
-# git checkout が allow されることを確認。Tier 2/3 追加で main 経路への false positive が
-# 発生していない (Issue #442 regression guard) ことを保証する。
 # --------------------------------------------------------------------------
-echo "TC-115: main session, all three tiers unset → git checkout allowed (regression guard)"
+echo "TC-115: 3 tiers unset → main session allowed (regression guard)"
 rc=0
-tc115_input=$(jq -n '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: "/home/user/.claude/projects/proj/session-id/main.jsonl"}')
-# unset env vars explicitly within subshell to avoid host env leakage
-output=$(env -u CLAUDE_SUBAGENT_TYPE -u CLAUDE_AGENT_TYPE bash -c 'echo "$1" | bash "$2" 2>"$3"' _ "$tc115_input" "$HOOK" "$STDERR_FILE") || rc=$?
+tc115_input=$(jq -n --arg tp "$MAIN_TRANSCRIPT_TC113" '{tool_name: "Bash", tool_input: {command: "git checkout develop"}, cwd: "/tmp", transcript_path: $tp}')
+output=$(run_guard_clean_env "$tc115_input") || rc=$?
 if [ "$rc" = "0" ] && [ -z "$output" ]; then
-  pass "TC-115 main session git checkout allowed (Tier 2/3 do not introduce false positives)"
+  pass "TC-115 main session git checkout allowed (Tier 2/3 no false positives)"
 else
   fail "TC-115 expected allow, got rc=$rc output=$output"
 fi


### PR DESCRIPTION
## Summary

PR #997 (Issue #995) cycle 2 で security-reviewer + コード本体のコメントに明示された **Pattern 4 の 2 つの pre-existing limitation** を解消する。

- **対象 1** (shell function/alias bypass): documentation-only として確定。コメントを強化し三層防御 (agent prompt + Layer 2 hook + Layer 3 post-condition) の責任分担を明確化
- **対象 2** (transcript_path subagent detection): 環境変数 + input JSON field の fallback を追加し SDK 仕様変更耐性を獲得

Closes #998

## 変更内容

### `plugins/rite/hooks/pre-tool-bash-guard.sh`

**3-tier subagent detection** (L43-72):

| Tier | 検出ソース | 役割 |
|------|-----------|------|
| 1 (primary) | `transcript_path` glob `*/subagents/*` | 既存 (Issue #442) — 現在の Claude Code 規約 |
| 2 (fallback) | hook input JSON `subagent_type` / `agent_type` field | 将来 SDK で hook envelope 内に subagent 識別 field が surface された場合に対応 |
| 3 (fallback) | 環境変数 `CLAUDE_SUBAGENT_TYPE` / `CLAUDE_AGENT_TYPE` | 環境変数経由で subagent context が露出する場合の catch-all |

判定は presence-only (具体値 `code-reviewer` 等の enumeration はせず、SDK schema 未確定のため非 empty 値全てを subagent とみなす)。

**alias/function indirection limitation の documentation 強化** (L266-281):
- `alias gg='git'` / `my_git() { command git "$@"; }` 経路を Layer 2 で検出する設計の overhead と false positive コストを明文化
- 一次防御を agent prompt + Layer 3 post-condition state-verify gate に委ねる三層構造を明示

### `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`

3 件追加 (現在 163 テスト pass):

- **TC-113**: input JSON `subagent_type: "code-reviewer"` set で git checkout block (Tier 2)
- **TC-114**: 環境変数 `CLAUDE_SUBAGENT_TYPE=code-reviewer` で git reset block (Tier 3)
- **TC-115**: 3 tier 全 unset で main session git checkout allow (regression guard)

## SDK 仕様調査記録 (Issue #998 受入条件 対象 2)

現在判明している事実 (Claude Code 2026-05 時点、Issue #442 / PR #531):

1. **`transcript_path` 規約**: Claude Code は subagent session の jsonl ファイルを project transcript root 配下の `subagents/` ディレクトリにルーティング。main session はこのディレクトリを通らないため `*/subagents/*` glob が現状の最も信頼できる識別シグナル
2. **`subagent_type` field**: 現状の Claude Code PreToolUse hook input JSON schema には `subagent_type` field は含まれていない。Tier 2 は future-proofing として presence-only 検出を追加
3. **環境変数**: 現状の Claude Code は `CLAUDE_SUBAGENT_TYPE` / `CLAUDE_AGENT_TYPE` 等の subagent 識別環境変数を設定していない。Tier 3 も future-proofing として presence-only 検出を追加

**リスク評価**: 将来 SDK が transcript_path 規約を変更した場合、Tier 1 のみだと silent disable (false negative) になる。Tier 2/3 のいずれかが先行して新 SDK で実装されれば Pattern 4 enforcement が継続する。Tier 2/3 全部空でも main 経路は影響なし (TC-115 で保証)。

## Test plan

- [x] TC-113/114/115 が pass する (163 件全 pass)
- [x] 既存 transcript_path 経路の regression なし (TC-022 〜 TC-058 + 派生)
- [x] main session で git checkout が引き続き allow される (TC-023, TC-028, TC-115)
- [x] Tier 2/3 が独立に動作する (TC-113 は transcript_path=main + subagent_type set, TC-114 は transcript_path=main + env var set)