### PR TITLE
fix(quality): PR #997 cycle 2 LOW follow-up — review.md / pre-tool-bash-guard / state-verify

### DIFF
--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -1885,8 +1885,10 @@ Phase 4.0.A で記録した `ORIG_BR` / `ORIG_SC` / `ORIG_BLH` をリテラル s
 # {orig_br} / {orig_sc} / {orig_blh} は Phase 4.0.A の出力値をリテラル substitute する。
 # Placeholder 残留 fail-fast gate (Phase 6.1.b と同 pattern): {orig_br} が `{orig_br}` のまま残ったまま
 # 渡されると verifier が non-empty 文字列として branch 比較し silent false-positive cascade を起こすため、
-# 形状検査で {...} 残留を絶対早期 reject する。Phase 4.0.A 起動時に detached HEAD で ORIG_BR=""
-# だった legitimate 経路 (orchestrator が worktree --detach で起動した場合) は空文字列のまま通過する。
+# 形状検査で {...} 残留を絶対早期 reject する。Phase 4.0.A 起動時に detached HEAD だった
+# legitimate 経路 (orchestrator が worktree --detach で起動した場合) は Phase 4.0.A の line
+# 1401-1404 で `DETACHED:<short-hash>` sentinel に変換済みのため、本 case 文には常に非空文字列
+# として到達する (verify script 側で `DETACHED:*` は branch drift check を skip する経路)。
 case "{orig_br}" in
   "{"*"}")
     echo "ERROR: Phase 5.0.A の {orig_br} placeholder が literal substitute されていません (値: '{orig_br}'). Phase 4.0.A 未実行 / Bash tool 間変数の引き継ぎ失敗の可能性。" >&2

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -307,6 +307,17 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # は parent shell 解決後の独立トークンとして渡るため、本 hook の静的 glob では検出不能。
   # Layer 2 の責務は「静的 token として `git` を含むコマンド」に限定し、一次防御は agent prompt、
   # 三次防御は Layer 3 post-condition state-verify gate に委ねる三層構造を維持する。
+  #
+  # `/git` substring 全置換の boundary 設計 (Issue #999 LOW follow-up):
+  # 本 line は `/git` を ` git` に置換するため `/home/user/.config/git/config` のような
+  # path 構成要素も置換対象になる (例: `grep -r foo /home/user/.config/git/config` →
+  # `grep -r foo /home/user/.config git/config`)。現状の (A)〜(G) deny case-glob は
+  # `*" git <verb> "*` 形式で **後続スペース必須** のため、path 由来で生成される `git/config`
+  # のように `/` が続くトークンは match せず false positive は発生しない。
+  # 将来、Always-deny verb の新規追加で末尾境界条件を緩める (e.g., `*" git <verb>"*` で
+  # trailing space を省略する) 設計変更を行う場合は、本正規化を `/git ` (後続スペース必須:
+  # `${CMD_NORMALIZED//\/git / git }`) に変更して token boundary を保ち、false positive 混入を
+  # 構造的に塞ぐこと。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED// command git/ git}"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -311,17 +311,19 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # `/git` substring 全置換の boundary 設計 (Issue #999 LOW follow-up):
   # 本 line は `/git` を ` git` に置換するため `/home/user/.config/git/config` のような
   # path 構成要素も置換対象になる (例: `grep -r foo /home/user/.config/git/config` →
-  # `grep -r foo /home/user/.config git/config`)。実装上、現状 false positive は発生しないが、
-  # その根拠はサブブロックごとに異なる:
-  #   - (A) Always-deny verbs (line 381 以降) の case-glob は `*" git <verb> "*` 形式で
-  #     trailing space 必須 のため、path 由来 `git/<X>` トークンは match しない
-  #   - (B) stash sub-action / (C) tag / (D) reflog / (E) worktree / (G) branch --delete 等の
-  #     後続 sub-block は `*" git <verb>"*` 形式 (trailing space 省略) を採用しているが、
-  #     path 由来トークンは `/` が verb 境界を崩して `git/<X>` 形となり、deny glob が要求する
-  #     連続 token `git <verb>` のシーケンスに到達しないため別経路で safe
-  # 将来 (A) Always-deny に新規 verb を追加し末尾境界条件を緩める (e.g., trailing space を省略
-  # する) 設計変更を行う場合は、本正規化を `/git ` (後続スペース必須:
-  # `${CMD_NORMALIZED//\/git / git }`) に変更して token boundary を保つこと。(B)-(G) を変更
+  # `grep -r foo /home/user/.config git/config`)。実装上、現状 false positive は発生しない。
+  # 主要因 (全サブブロック共通): path 由来トークンは置換後 ` git/<X>` 形 (前 boundary に leading
+  # space、`/` で verb 境界が崩れる) となり、(A)〜(G) すべての deny glob (trailing space 必須形 /
+  # 省略形いずれも) が要求する連続 token `git <verb>` シーケンスに到達しないため別経路で safe。
+  # 補強要因 (サブブロック別の trailing space): (A) Always-deny verbs の case-glob は
+  # `*" git <verb> "*` 形式で trailing space 必須 (verb 末尾の token boundary も二重に保護)。
+  # (B) stash / (C) tag / (D) reflog の case-glob、および (E) worktree の case-glob (remove/move/
+  # prune 等) は `*" git <verb>"*` 形式で trailing space 省略。(E) worktree の token-loop
+  # precondition (`add` 等) は ` git worktree add ` で trailing space 必須。(G) branch は混在で、
+  # 短形式 (`-D` / `-d` / `-f` / `-m` / `-M` / `-c` / `-C` 等) は trailing space あり、long-form
+  # (`--delete` / `--force` / `--move` / `--copy` 等) は trailing space 省略。
+  # 将来、本正規化を `/git ` (後続スペース必須: `${CMD_NORMALIZED//\/git / git }`) に変更すべき
+  # ケース: (A) Always-deny に新規 verb を追加し末尾境界条件を緩める設計変更時。(B)-(G) を変更
   # する場合も path 由来トークンとの衝突を再検証する必要がある。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -311,13 +311,18 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # `/git` substring 全置換の boundary 設計 (Issue #999 LOW follow-up):
   # 本 line は `/git` を ` git` に置換するため `/home/user/.config/git/config` のような
   # path 構成要素も置換対象になる (例: `grep -r foo /home/user/.config/git/config` →
-  # `grep -r foo /home/user/.config git/config`)。現状の (A)〜(G) deny case-glob は
-  # `*" git <verb> "*` 形式で **後続スペース必須** のため、path 由来で生成される `git/config`
-  # のように `/` が続くトークンは match せず false positive は発生しない。
-  # 将来、Always-deny verb の新規追加で末尾境界条件を緩める (e.g., `*" git <verb>"*` で
-  # trailing space を省略する) 設計変更を行う場合は、本正規化を `/git ` (後続スペース必須:
-  # `${CMD_NORMALIZED//\/git / git }`) に変更して token boundary を保ち、false positive 混入を
-  # 構造的に塞ぐこと。
+  # `grep -r foo /home/user/.config git/config`)。実装上、現状 false positive は発生しないが、
+  # その根拠はサブブロックごとに異なる:
+  #   - (A) Always-deny verbs (line 381 以降) の case-glob は `*" git <verb> "*` 形式で
+  #     trailing space 必須 のため、path 由来 `git/<X>` トークンは match しない
+  #   - (B) stash sub-action / (C) tag / (D) reflog / (E) worktree / (G) branch --delete 等の
+  #     後続 sub-block は `*" git <verb>"*` 形式 (trailing space 省略) を採用しているが、
+  #     path 由来トークンは `/` が verb 境界を崩して `git/<X>` 形となり、deny glob が要求する
+  #     連続 token `git <verb>` のシーケンスに到達しないため別経路で safe
+  # 将来 (A) Always-deny に新規 verb を追加し末尾境界条件を緩める (e.g., trailing space を省略
+  # する) 設計変更を行う場合は、本正規化を `/git ` (後続スペース必須:
+  # `${CMD_NORMALIZED//\/git / git }`) に変更して token boundary を保つこと。(B)-(G) を変更
+  # する場合も path 由来トークンとの衝突を再検証する必要がある。
   CMD_NORMALIZED="${CMD_NORMALIZED//\/git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED//\\git/ git}"
   CMD_NORMALIZED="${CMD_NORMALIZED// command git/ git}"

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -212,8 +212,11 @@ if [ -n "$incident_script" ]; then
 fi
 
 # --- JSON summary ---
-printf '{"drift":true,"type":"%s","detail":"%s","recovered":%s}\n' \
-  "$drift_type" "$drift_detail" "$recovered"
+# `drift_detail` / `drift_type` は他 hook script 由来の長文メッセージを内包する可能性があるため、
+# printf で JSON value に直接埋め込むのではなく jq で escape する (Issue #999 LOW follow-up)。
+# `recovered` は "true"/"false" 文字列を JSON boolean に変換する。
+jq -nc --arg t "$drift_type" --arg d "$drift_detail" --arg r "$recovered" \
+  '{drift: true, type: $t, detail: $d, recovered: ($r == "true")}'
 
 # Exit code: recovered=true → 0、recovered=false → 1 (manual intervention required)
 if [ "$recovered" = "true" ] || [ "$drift_type" = "stash" ] || [ "$drift_type" = "branch_list" ]; then


### PR DESCRIPTION
## 概要

PR #997 cycle 2 code-quality-reviewer の LOW 推奨事項 3 件を一括対応。いずれも future-risk / 軽微な整合性問題で、scope を最小化するため `/git` 正規化はコード変更ではなく comment 追加のみで対応した。

## 変更内容

### 対象 1: `commands/pr/review.md` (line 1888-1890)
Phase 5.0.A の placeholder 残留 reject 部のコメントを Phase 4.0.A 現状動作 (`DETACHED:<short-hash>` sentinel に変換) と整合させる。旧コメントは「detached HEAD で `ORIG_BR=""` だった経路は空文字列のまま通過する」と書かれていたが、Phase 4.0.A line 1401-1404 で空文字列を `DETACHED:<short-hash>` に変換するため、本 case 文には常に非空文字列として到達する。

### 対象 2: `hooks/pre-tool-bash-guard.sh` (line 310 周辺)
`/git` substring 全置換の boundary 設計を comment で明示。現状の deny case-glob (`*" git <verb> "*`) が後続スペース必須のため `/etc/git/foo` のような path 由来トークンは false positive にならないが、将来 Always-deny verb の追加で末尾境界条件を緩める場合に備え、本正規化を `/git ` (後続スペース必須) に変更すべき旨を inline 文書化した。コード自体は変更していない。

### 対象 3: `hooks/scripts/post-review-state-verify.sh` (line 215-219)
drift=true path の `printf` JSON 出力を `jq -nc` 経由に変更し、`drift_detail` 内のダブルクォート / バックスラッシュ / 制御文字に対する JSON safety を保証。`recovered` は `($r == "true")` で boolean に変換。drift=false path (line 155) は static 出力なので `printf` のまま維持 (scope 限定)。

## Known Issues

なし

## チェックリスト

- [x] 対象 1: review.md コメント整合性
- [x] 対象 2: `/git` 正規化の boundary 明示 (comment 追加)
- [x] 対象 3: JSON escape を jq 経由に移行
- [x] 既存テスト sanity (bash -n 構文チェック / jq edge case 検証で double-quote / backslash 含む文字列が valid JSON として escape されることを確認)

## 関連 Issue

Closes #999

元 PR: #997 (Issue #995 — cycle 2 code-quality-reviewer LOW 推奨事項を follow-up)
