### PR TITLE
refactor(fix): mktemp failure 経路の WARNING / retained flag emit format を統一

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -795,7 +795,7 @@ if [ -z "$review_source" ]; then
     # mktemp 失敗時も WARNING を emit (format 概形は cleanup.md Phase 2.5 と共有、rc capture は
     # reason=`mktemp_failure_norm_tmp` の SoT block (Phase 1.2.0 schema 1.1.0 normalization 内の
     # `if norm_tmp=$(mktemp ...); then ... else mktemp_norm_rc=$?; fi` 構造) と semantic 同期)。
-    # 構造: bash の `!` 否定 pipeline では then 節内 $? が常に 0 になるため、SoT と同じ
+    # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、SoT と同じ
     # `if cmd; then :; else rc=$?; fi` 形式を採用する。mktemp の native stderr は SoT (norm_tmp) と
     # 揃えて `2>/dev/null` で抑制する (本ファイル内の他 mktemp capture site と同じ pattern)。
     if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX 2>/dev/null); then

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -793,10 +793,12 @@ if [ -z "$review_source" ]; then
     :
   else
     # mktemp 失敗時も WARNING を emit (format 概形は cleanup.md Phase 2.5 と共有、rc capture は
-    # L1147-L1150 (mktemp_failure_norm_tmp) と semantic 同期)。
-    # 構造: bash の `!` 否定 pipeline では then 節内 $? が常に 0 になるため、SoT (L1147 系) と同じ
-    # `if cmd; then :; else rc=$?; fi` 形式を採用する。
-    if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
+    # reason=`mktemp_failure_norm_tmp` の SoT block (Phase 1.2.0 schema 1.1.0 normalization 内の
+    # `if norm_tmp=$(mktemp ...); then ... else mktemp_norm_rc=$?; fi` 構造) と semantic 同期)。
+    # 構造: bash の `!` 否定 pipeline では then 節内 $? が常に 0 になるため、SoT と同じ
+    # `if cmd; then :; else rc=$?; fi` 形式を採用する。mktemp の native stderr は SoT (norm_tmp) と
+    # 揃えて `2>/dev/null` で抑制する (fix.md 内 24/25 site と pattern 一致)。
+    if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX 2>/dev/null); then
       : # mktemp 成功 — find_err は valid path
     else
       mktemp_find_err_rc=$?

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -797,7 +797,7 @@ if [ -z "$review_source" ]; then
     # `if norm_tmp=$(mktemp ...); then ... else mktemp_norm_rc=$?; fi` 構造) と semantic 同期)。
     # 構造: bash の `!` 否定 pipeline では then 節内 $? が常に 0 になるため、SoT と同じ
     # `if cmd; then :; else rc=$?; fi` 形式を採用する。mktemp の native stderr は SoT (norm_tmp) と
-    # 揃えて `2>/dev/null` で抑制する (fix.md 内 24/25 site と pattern 一致)。
+    # 揃えて `2>/dev/null` で抑制する (本ファイル内の他 mktemp capture site と同じ pattern)。
     if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX 2>/dev/null); then
       : # mktemp 成功 — find_err は valid path
     else

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -792,9 +792,13 @@ if [ -z "$review_source" ]; then
     # dir 不在 = 正常経路。Priority 3 へ silent fall-through。
     :
   else
-    # mktemp 失敗時も WARNING を emit (cleanup.md Phase 2.5 / Phase 6.1.a と対称化)。
-    # 旧実装は `|| find_err=""` で silent fallback し、find の IO エラー詳細を失う経路があった。
-    if ! find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
+    # mktemp 失敗時も WARNING を emit (format 概形は cleanup.md Phase 2.5 と共有、rc capture は
+    # L1147-L1150 (mktemp_failure_norm_tmp) と semantic 同期)。
+    # 構造: bash の `!` 否定 pipeline では then 節内 $? が常に 0 になるため、SoT (L1147 系) と同じ
+    # `if cmd; then :; else rc=$?; fi` 形式を採用する。
+    if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
+      : # mktemp 成功 — find_err は valid path
+    else
       mktemp_find_err_rc=$?
       echo "WARNING: find stderr 退避用 tempfile の mktemp に失敗しました (rc=$mktemp_find_err_rc)。find の IO エラー詳細は失われます" >&2
       echo "  対処: /tmp の inode 枯渇 / read-only filesystem / permission 拒否のいずれかを確認してください" >&2
@@ -1739,7 +1743,7 @@ exit 1
 | `pr_comment_commit_sha_mismatch` | Priority 3 の PR コメント Raw JSON の `commit_sha` が現 HEAD と不一致 (stale detection、WARNING のみで continue) |
 | `jq_error_on_commit_sha` | Priority 0/2/3 の `.commit_sha` 抽出 jq が IO/binary エラーで失敗 (I-4 対応。stale detection 無効化を silent にしない。`priority=0|2|3` として retained flag に付記される) |
 | `local_file_find_io_error` | Priority 2 の `find .rite/review-results/` が IO エラーで failed (L-3 対応) |
-| `mktemp_failure_find_err` | Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称)。silent skip 防止のため WARNING + retained flag を必ず emit する (rc 付き、Issue #1025 対応) |
+| `mktemp_failure_find_err` | Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称)。silent skip 防止のため WARNING + retained flag を必ず emit する (Issue #1025 対応) |
 | `latest_file_stat_failure` | Priority 2 で find が見つけた `latest_file` が `-f` check で脱落 (M-4 対応、permission denied / symlink 破壊) |
 | `state_file_read_io_error` | Phase 1.2.0 Priority 1 の retry state file `cat` が IO エラーで失敗 (I-1 対応、hard gate を safe side に倒すため `retry_current=999`) |
 | `happy_path_rm_failure` | Phase 1.2.0 happy path の retry state file 削除が失敗 (I-2 対応、cleanup.md Phase 2.5 と対称) |

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -795,9 +795,10 @@ if [ -z "$review_source" ]; then
     # mktemp 失敗時も WARNING を emit (cleanup.md Phase 2.5 / Phase 6.1.a と対称化)。
     # 旧実装は `|| find_err=""` で silent fallback し、find の IO エラー詳細を失う経路があった。
     if ! find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
-      echo "WARNING: find stderr 退避用 tempfile の mktemp に失敗しました。find の IO エラー詳細は失われます" >&2
+      mktemp_find_err_rc=$?
+      echo "WARNING: find stderr 退避用 tempfile の mktemp に失敗しました (rc=$mktemp_find_err_rc)。find の IO エラー詳細は失われます" >&2
       echo "  対処: /tmp の inode 枯渇 / read-only filesystem / permission 拒否のいずれかを確認してください" >&2
-      echo "[CONTEXT] REVIEW_SOURCE_FIND_FAILED=1; reason=mktemp_failure_find_err" >&2
+      echo "[CONTEXT] REVIEW_SOURCE_FIND_FAILED=1; reason=mktemp_failure_find_err; rc=$mktemp_find_err_rc" >&2
       find_err=""
     fi
 
@@ -1738,7 +1739,7 @@ exit 1
 | `pr_comment_commit_sha_mismatch` | Priority 3 の PR コメント Raw JSON の `commit_sha` が現 HEAD と不一致 (stale detection、WARNING のみで continue) |
 | `jq_error_on_commit_sha` | Priority 0/2/3 の `.commit_sha` 抽出 jq が IO/binary エラーで失敗 (I-4 対応。stale detection 無効化を silent にしない。`priority=0|2|3` として retained flag に付記される) |
 | `local_file_find_io_error` | Priority 2 の `find .rite/review-results/` が IO エラーで failed (L-3 対応) |
-| `mktemp_failure_find_err` | Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称) |
+| `mktemp_failure_find_err` | Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称)。silent skip 防止のため WARNING + retained flag を必ず emit する (rc 付き、Issue #1025 対応) |
 | `latest_file_stat_failure` | Priority 2 で find が見つけた `latest_file` が `-f` check で脱落 (M-4 対応、permission denied / symlink 破壊) |
 | `state_file_read_io_error` | Phase 1.2.0 Priority 1 の retry state file `cat` が IO エラーで失敗 (I-1 対応、hard gate を safe side に倒すため `retry_current=999`) |
 | `happy_path_rm_failure` | Phase 1.2.0 happy path の retry state file 削除が失敗 (I-2 対応、cleanup.md Phase 2.5 と対称) |


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/fix.md` L797-L802 の `mktemp_failure_find_err` 経路を、PR #1023 で導入された新 SoT (L1147-L1150 = `mktemp_failure_norm_tmp`) と format 同期する refactor。

PR #1023 cycle 2 で prompt-engineer / code-quality reviewer が指摘した非対称 (rc capture / WARNING wording) を解消する。

## 変更内容

### 実装変更 (`plugins/rite/commands/pr/fix.md` L797-L802)

旧:
```bash
if ! find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
  echo "WARNING: find stderr 退避用 tempfile の mktemp に失敗しました。find の IO エラー詳細は失われます" >&2
  echo "  対処: ..." >&2
  echo "[CONTEXT] REVIEW_SOURCE_FIND_FAILED=1; reason=mktemp_failure_find_err" >&2
  find_err=""
fi
```

新 (L1147-L1150 SoT に揃える):
```bash
if ! find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX); then
  mktemp_find_err_rc=$?
  echo "WARNING: find stderr 退避用 tempfile の mktemp に失敗しました (rc=$mktemp_find_err_rc)。find の IO エラー詳細は失われます" >&2
  echo "  対処: ..." >&2
  echo "[CONTEXT] REVIEW_SOURCE_FIND_FAILED=1; reason=mktemp_failure_find_err; rc=$mktemp_find_err_rc" >&2
  find_err=""
fi
```

### Reason 表エントリ format 同期 (L1742)

旧: `Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称)`

新: 上記 + 「silent skip 防止のため WARNING + retained flag を必ず emit する (rc 付き、Issue #1025 対応)」を追記し L1755 (`mktemp_failure_norm_tmp` 表エントリ) と format 同期。

## 4-site 対称性検証

| Site | 役割 | 状態 |
|------|------|------|
| L797-L802 block | 実装 SoT | ✅ rc capture + WARNING rc + CONTEXT rc 揃え |
| L1147-L1150 block | 参考実装 (PR #1023 で導入) | — 既存 SoT |
| L1742 reason 表エントリ | 人間可読 spec | ✅ format 同期 |
| L1755 sibling 表エントリ | 参考 spec | — 既存 SoT |
| L1758 enumeration (Pattern-5 drift check) | machine-readable enum | — 既に `mktemp_failure_find_err` 含む |

## Out of Scope (Follow-up)

- **L4900 `commit_err` (wiki-ingest-commit)**: 同種 WARNING-emit パターンだが Issue 本文に明示なし。別 Issue #1031 として follow-up。
- **L512/591/664/853/868 等の silent fallback パターン** (`mktemp ... 2>/dev/null || var=""`): WARNING を emit しない設計のため scope 外 (~25 サイト)。

## 関連 Issue

Closes #1025

### 検出された問題 (別 Issue として追跡)
- #1031: refactor(fix): L4900 commit_err mktemp failure 経路を L797/L1147 と対称化

## チェックリスト

- [x] L797-L802 改修
- [x] L1742 reason 表エントリ format 同期
- [x] 4-site 対称性 grep 検証
- [x] /rite:lint 実行 (skipped command, plugin checks: pre-existing warnings only)
- [x] follow-up Issue #1031 作成

## 経験則適用

- Wiki: Asymmetric Fix Transcription (累積 33 回目, PR #1028) — anchor (`mktemp_failure_find_err`) と context (人間可読 description) を分離
- Wiki: 新規 exit 1 経路 / sentinel type 追加時の N-site canonical sync — L797 block / L1742 表 / L1755 表 / L1758 enumeration の 4-site 同期
