### PR TITLE
refactor(fix): hand-off tempfile orphan を trap registry で解消 (#1026)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -488,8 +488,15 @@ find_err=""
 jq_val_err_p0=""
 jq_val_err_p2=""
 norm_tmp=""
+# Issue #1026: norm_tmp hand-off 後の path を保持する registry variable。
+# hand-off 完了時 `norm_tmp=""` で trap 対象から外す既存 semantic を維持しつつ、
+# downstream (severity_map build 等) が `review_source_path` 経由で参照を終えた後の
+# block 終了タイミング (EXIT/INT/TERM/HUP) で本変数経由で必ず削除されるようにし、
+# `/tmp/rite-fix-normalized-XXXXXX` orphan を解消する。
+handed_off_norm_tmp=""
 _rite_fix_p120_cleanup() {
-  rm -f "${find_err:-}" "${jq_val_err_p0:-}" "${jq_val_err_p2:-}" "${norm_tmp:-}"
+  rm -f "${find_err:-}" "${jq_val_err_p0:-}" "${jq_val_err_p2:-}" "${norm_tmp:-}" \
+        "${handed_off_norm_tmp:-}"
 }
 trap 'rc=$?; _rite_fix_p120_cleanup; exit $rc' EXIT
 trap '_rite_fix_p120_cleanup; exit 130' INT
@@ -1142,7 +1149,11 @@ if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]
         fi
         review_source_path="$norm_tmp"
         # hand-off 完了: 下流の severity_map 構築が review_source_path 経由で参照するため、
-        # trap cleanup 対象から外す (二重 rm 回避 + downstream 参照保護)
+        # trap cleanup 対象から外す (二重 rm 回避 + downstream 参照保護)。
+        # Issue #1026: hand-off pattern 統一 — block 終了時 (EXIT/INT/TERM/HUP) に trap で
+        # `/tmp/rite-fix-normalized-XXXXXX` を必ず削除するため、`handed_off_norm_tmp` に path を保持する
+        # (severity_map build 完了後、bash block 終了の trap EXIT で削除される)。
+        handed_off_norm_tmp="$norm_tmp"
         norm_tmp=""
       else
         rm -f "$norm_tmp"


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/fix.md` の Phase 1.2.0 schema 1.1.0 normalization で hand-off された tempfile (`norm_tmp` → `review_source_path`) が enclosing bash block の trap 管理外に出るため、block 終了時に `/tmp/rite-fix-normalized-XXXXXX` が orphan として残存していた問題を解消する。

## 変更内容

`_rite_fix_p120_cleanup` cleanup function に `handed_off_norm_tmp` registry variable を追加し、`review_source_path="$norm_tmp"; norm_tmp=""` の hand-off 時に path を `handed_off_norm_tmp` へ保存する。これにより:

- 同一 bash block 内で downstream (severity_map build 等) が `review_source_path` 経由で参照可能
- block 終了時 (EXIT / INT=130 / TERM=143 / HUP=129) に signal-specific trap が `handed_off_norm_tmp` を rm し、orphan を解消
- 既存の `norm_tmp=""` クリア semantic (二重 rm 回避 + downstream 参照保護) は維持
- `latest_file` (Priority 2) は永続ファイル参照 (`.rite/review-results/{pr_number}-*.json`) のため tempfile cleanup の対象外

## 関連 Issue

Closes #1026

## 変更ファイル

- `plugins/rite/commands/pr/fix.md` - 変更（+13 / -2）

## 設計判断

- **既存 trap 機構を再利用**: 新規 cleanup block を追加するのではなく、`_rite_fix_p120_cleanup` cleanup function に変数を 1 つ追加する最小拡張。Wiki 経験則「trap 登録 → mktemp 順序」「signal-specific exit code 明示渡し」を維持
- **対象は `norm_tmp` のみ**: 同一ファイル内の他の mktemp (`*_err` 系) は「stderr capture → 即時消費 → rm」の標準パターンで hand-off せず、cleanup されるため変更不要 (asymmetric fix transcription 観点で確認済み)
- **PR-specific wildcard cleanup は採用しない**: tempfile 命名規約変更 (`/tmp/rite-fix-normalized-${pr_number}-*` 化) は大規模変更を伴うため scope 外。本 PR は trap 機構内での最小修正に留める

## 動作確認

- 既存の `/rite:lint` plugin-specific checks 全 pass（本 PR 由来の新規 warning 0 件）
- 修正後 fix.md の `_rite_fix_p120_cleanup` に `handed_off_norm_tmp` が含まれることを Grep で検証
- 後続 `/rite:pr:fix` 実行時に `/tmp/rite-fix-normalized-*` が残存しないことは実運用で間接確認

## チェックリスト

- [x] 既存テストへの影響なし（テストファイル未変更）
- [x] CLAUDE.md / 設計原則に従う
- [x] Wiki 経験則を参照し計画に反映済み
- [x] Conventional Commits 形式のコミットメッセージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
