### PR TITLE
refactor(fix): commit_err mktemp failure 経路を SoT 形式 (find_err / mktemp_norm_rc) と対称化

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -513,11 +513,19 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # wiki-ingest-commit.sh stderr. See pr/review.md Phase 6.5.W.2 for the
 # detailed rationale; this block is kept symmetric across review / fix /
 # close to preserve the single-source principle for the wiki commit path.
-if ! commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture — script stderr will be suppressed" >&2
+#
+# 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
+# fix.md L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
+# else 先頭で capture する (Issue #1031: 3-site 対称化)。
+if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
+  : # mktemp 成功 — commit_err は valid path
+else
+  mktemp_commit_err_rc=$?
+  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{issue_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -519,8 +519,10 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は SoT (fix.md L814, L1168) と同じ `details=...; rc=$<var>_rc` の
-# semicolon-separated 独立 field 形式に揃える。
+# sentinel format は peer fallback_sentinel (fix.md L4968/4992/5013、本ファイル
+# L568/592/613 等) と同じ canonical WORKFLOW_INCIDENT schema (3 semicolon invariant)
+# に従い、rc は details= 値内に space-separated で embed する (canonical schema は
+# workflow-incident-emit.sh L112-116 で定義、TC-009 sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -528,7 +530,7 @@ else
   echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{issue_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2 rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -515,14 +515,15 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # close to preserve the single-source principle for the wiki commit path.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# fix.md L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
-# fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
+# fix.md 内 SoT block (mktemp_failure_find_err / mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は peer fallback_sentinel (fix.md L4968/4992/5013、本ファイル
-# L568/592/613 等) と同じ canonical WORKFLOW_INCIDENT schema (3 semicolon invariant)
-# に従い、rc は details= 値内に space-separated で embed する (canonical schema は
-# workflow-incident-emit.sh L112-116 で定義、TC-009 sep_count=3 で enforce)。
+# sentinel format は peer fallback_sentinel (本ファイルおよび fix.md 内の
+# wiki_ingest_skipped / wiki_ingest_push_failed / wiki_ingest_failed 各 fallback) と
+# 同じ canonical WORKFLOW_INCIDENT schema (3 semicolon invariant) に従い、rc は
+# details= 値内に space-separated で embed する (canonical schema は
+# workflow-incident-emit.sh で定義、workflow-incident-emit.test.sh TC-009
+# sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -515,9 +515,12 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # close to preserve the single-source principle for the wiki commit path.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# fix.md L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# fix.md L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
+# fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
+# sentinel format は SoT (fix.md L814, L1168) と同じ `details=...; rc=$<var>_rc` の
+# semicolon-separated 独立 field 形式に揃える。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -525,7 +528,7 @@ else
   echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{issue_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in issue/close.md Phase 4.4.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4917,14 +4917,14 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # principle for the wiki commit path.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
-# L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
+# 同ファイル内 SoT block (mktemp_failure_find_err / mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は peer fallback_sentinel (L4968/4992/5013) と同じ canonical
-# WORKFLOW_INCIDENT schema (3 semicolon invariant) に従い、rc は details= 値内に
-# space-separated で embed する (canonical schema は workflow-incident-emit.sh
-# L112-116 で定義、TC-009 sep_count=3 で enforce)。
+# sentinel format は同ファイル内 peer fallback_sentinel (wiki_ingest_skipped /
+# wiki_ingest_push_failed / wiki_ingest_failed) と同じ canonical WORKFLOW_INCIDENT
+# schema (3 semicolon invariant) に従い、rc は details= 値内に space-separated で
+# embed する (canonical schema は workflow-incident-emit.sh で定義、
+# workflow-incident-emit.test.sh TC-009 sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4917,9 +4917,12 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # principle for the wiki commit path.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
+# L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
+# sentinel format は SoT (L814, L1168) と同じ `details=...; rc=$<var>_rc` の
+# semicolon-separated 独立 field 形式に揃える。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -4927,7 +4930,7 @@ else
   echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4915,11 +4915,19 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # See pr/review.md Phase 6.5.W.2 for the detailed rationale; this block is
 # kept symmetric across review / fix / close to preserve the single-source
 # principle for the wiki commit path.
-if ! commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture — script stderr will be suppressed" >&2
+#
+# 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
+# L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
+# else 先頭で capture する (Issue #1031: 3-site 対称化)。
+if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
+  : # mktemp 成功 — commit_err は valid path
+else
+  mktemp_commit_err_rc=$?
+  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -4921,8 +4921,10 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は SoT (L814, L1168) と同じ `details=...; rc=$<var>_rc` の
-# semicolon-separated 独立 field 形式に揃える。
+# sentinel format は peer fallback_sentinel (L4968/4992/5013) と同じ canonical
+# WORKFLOW_INCIDENT schema (3 semicolon invariant) に従い、rc は details= 値内に
+# space-separated で embed する (canonical schema は workflow-incident-emit.sh
+# L112-116 で定義、TC-009 sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -4930,7 +4932,7 @@ else
   echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/fix.md Phase 4.6.W.2 rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4123,13 +4123,21 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # Emit an explicit
 # sentinel via workflow-incident-emit.sh so Phase 5.4.4.1 treats mktemp
 # failure itself as a workflow incident.
-if ! commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
-  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture — script stderr will be suppressed" >&2
+#
+# 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
+# fix.md L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
+# else 先頭で capture する (Issue #1031: 3-site 対称化)。
+if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
+  : # mktemp 成功 — commit_err は valid path
+else
+  mktemp_commit_err_rc=$?
+  echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
   echo "  hint: check /tmp permission / disk space / inode exhaustion" >&2
   # Emit a hook_abnormal_exit sentinel directly (workflow-incident-emit.sh
   # may itself be unable to create tempfiles, so fall back to inline).
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4125,9 +4125,12 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # failure itself as a workflow incident.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# fix.md L808 (find_err) / L1163 (mktemp_norm_rc) と同じ
+# fix.md L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
+# fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
+# sentinel format は SoT (fix.md L814, L1168) と同じ `details=...; rc=$<var>_rc` の
+# semicolon-separated 独立 field 形式に揃える。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -4137,7 +4140,7 @@ else
   # Emit a hook_abnormal_exit sentinel directly (workflow-incident-emit.sh
   # may itself be unable to create tempfiles, so fall back to inline).
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2 (rc=$mktemp_commit_err_rc); iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4125,14 +4125,15 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # failure itself as a workflow incident.
 #
 # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# fix.md L811 (mktemp_find_err_rc capture, reason=mktemp_failure_find_err) /
-# fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
+# fix.md 内 SoT block (mktemp_failure_find_err / mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は peer fallback_sentinel (fix.md L4968/4992/5013、本ファイル
-# L4182/4215/4236 等) と同じ canonical WORKFLOW_INCIDENT schema (3 semicolon
-# invariant) に従い、rc は details= 値内に space-separated で embed する (canonical
-# schema は workflow-incident-emit.sh L112-116 で定義、TC-009 sep_count=3 で enforce)。
+# sentinel format は peer fallback_sentinel (本ファイルおよび fix.md 内の
+# wiki_ingest_skipped / wiki_ingest_push_failed / wiki_ingest_failed 各 fallback) と
+# 同じ canonical WORKFLOW_INCIDENT schema (3 semicolon invariant) に従い、rc は
+# details= 値内に space-separated で embed する (canonical schema は
+# workflow-incident-emit.sh で定義、workflow-incident-emit.test.sh TC-009
+# sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4129,8 +4129,10 @@ trap 'rm -f "${commit_err:-}" "${emit_err:-}"' EXIT INT TERM HUP
 # fix.md L1165 (mktemp_norm_rc capture, reason=mktemp_failure_norm_tmp) と同じ
 # `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
 # else 先頭で capture する (Issue #1031: 3-site 対称化)。
-# sentinel format は SoT (fix.md L814, L1168) と同じ `details=...; rc=$<var>_rc` の
-# semicolon-separated 独立 field 形式に揃える。
+# sentinel format は peer fallback_sentinel (fix.md L4968/4992/5013、本ファイル
+# L4182/4215/4236 等) と同じ canonical WORKFLOW_INCIDENT schema (3 semicolon
+# invariant) に従い、rc は details= 値内に space-separated で embed する (canonical
+# schema は workflow-incident-emit.sh L112-116 で定義、TC-009 sep_count=3 で enforce)。
 if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
   : # mktemp 成功 — commit_err は valid path
 else
@@ -4140,7 +4142,7 @@ else
   # Emit a hook_abnormal_exit sentinel directly (workflow-incident-emit.sh
   # may itself be unable to create tempfiles, so fall back to inline).
   fallback_iter="{pr_number}-$(date +%s)"
-  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2; rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
+  fallback_sentinel="[CONTEXT] WORKFLOW_INCIDENT=1; type=hook_abnormal_exit; details=mktemp failed for commit_err in pr/review.md Phase 6.5.W.2 rc=$mktemp_commit_err_rc; iteration_id=$fallback_iter"
   echo "$fallback_sentinel"
   echo "$fallback_sentinel" >&2
   commit_err="/dev/null"


### PR DESCRIPTION
## Summary

`commit_err=$(mktemp ...)` のmktemp failure 経路を pr/fix.md / pr/review.md / issue/close.md の 3 ファイルで symmetrize し、L797 (find_err) / L1147 (mktemp_norm_rc) の新 SoT pattern `if cmd; then :; else rc=$?; fi` 形式に揃えました。

旧実装 `if ! cmd; then ...; fi` は bash の `!` 否定により then 内 `$?` が常に 0 になる構造的問題があり (fix.md L805-807 SoT comment で明示)、`mktemp_<var>_rc=$?` capture を追加しても false signal (`rc=0`) しか得られませんでした。

## 変更内容

各サイト共通:

1. **構造変換**: `if ! commit_err=$(mktemp ...); then ... fi` → `if commit_err=$(mktemp ...); then : ; else mktemp_commit_err_rc=$? ... fi`
2. **rc capture**: `else` ブロック先頭で `mktemp_commit_err_rc=$?` を実施
3. **WARNING wording**: `(rc=$mktemp_commit_err_rc)` を主文中に組込
4. **fallback_sentinel**: `details=` 値内に `rc=$mktemp_commit_err_rc` を追加

差分は意図通り:
- `pr/fix.md`: Phase 4.6.W.2, `{pr_number}` 使用
- `pr/review.md`: Phase 6.5.W.2, `{pr_number}` 使用
- `issue/close.md`: Phase 4.4.W.2, `{issue_number}` 使用 (PR 番号 scope 外のため)

## スコープ拡大の理由

Issue #1031 本文は fix.md L4900 のみ言及していたが、同一 pattern が 3 ファイルに存在し、fix.md L4914-4917 のコメントで「kept symmetric across review / fix / close to preserve the single-source principle」と明示されていた。fix.md のみ修正すると intra-3-site (L797/L1147/L4900) の SoT 対称化と引き換えに cross-file 3-site (fix/review/close) 対称性が壊れる矛盾が発生するため、ユーザー確認の上 3 ファイル同時修正に scope 拡大しました。

## Closes

Closes #1031

## 関連

- 元 Issue: #1025 (L797 mktemp_failure_find_err SoT 確立)
- 経験則: Wiki Asymmetric Fix Transcription (累積 34 回目)

## Test Plan

- [x] 3 ファイル間 diff 検証: 意図通りの差分 (phase 識別子 + `{pr_number}` vs `{issue_number}`) のみ
- [x] `grep` で `mktemp_commit_err_rc=$?` と `(rc=$mktemp_commit_err_rc)` の存在確認
- [x] L797/L1147 SoT 構造 (`if cmd; then :; else rc=$?; fi`) との semantic 一致確認
- [x] `/rite:lint` 全 plugin-specific checks 実行 (3 warning は全て pre-existing、本 PR 変更行非該当)

## Known Issues

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
