### PR TITLE
refactor(fix): block continuity note を 7 項目 bullet 化で scannability 向上

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1085,7 +1085,13 @@ esac
 set +o pipefail
 ```
 
-**`review_source` state transitions within pr_comment path**: `review_source="pr_comment"` に設定された後、Priority 3 処理 (下記 awk block) で (a) Raw JSON 抽出に成功した場合は `review_source` は `pr_comment` のまま維持、(b) Raw JSON が無い / schema_unknown で legacy Markdown parser に fallthrough した場合も `pr_comment` のまま。つまり Priority 3 内部での format (new / legacy) 切り替えは `review_source` では表現せず、後続 Phase は両 format を同じ code path で処理する。`review_source_path=""` は Priority 3 が PR コメント (in-memory data) を参照することを示すマーカーで、`"$review_source_path"` を読もうとする後続 code は Priority 3 で実行されない (下記 Phase 1.2.0 の `=== severity_map build (local_file/explicit_file only ...) ===` grep anchor でマーキングされた bash block の `if` 条件で local_file / explicit_file のみに限定済み。grep anchor 参照は行番号変動への耐性を確保するため)。
+**`review_source` state transitions within pr_comment path**: `review_source="pr_comment"` に設定された後、Priority 3 処理 (下記 awk block) における state 遷移と意味論は以下の通り:
+
+> 1. **Raw JSON 抽出成功**: `review_source` は `pr_comment` のまま維持
+> 2. **Raw JSON なし / schema_unknown で legacy Markdown parser に fallthrough**: 同じく `pr_comment` のまま維持
+> 3. **format 切り替えの表現方法**: Priority 3 内部での format (new / legacy) 切り替えは `review_source` では表現しない。つまり後続 Phase は両 format を同じ code path で処理する
+> 4. **`review_source_path=""` の意味**: Priority 3 が PR コメント (in-memory data) を参照することを示すマーカー
+> 5. **後続 code が Priority 3 で実行されない仕組み**: `"$review_source_path"` を読もうとする後続 code は Priority 3 で実行されない (下記 Phase 1.2.0 の `=== severity_map build (local_file/explicit_file only ...) ===` grep anchor でマーキングされた bash block の `if` 条件で local_file / explicit_file のみに限定済み。grep anchor 参照は行番号変動への耐性を確保するため)
 
 **On Priority 0 failure** (explicit file missing/invalid/schema_unknown): `review_source="fallback"` triggers Phase 1.2.0.1 interactive fallback. Do NOT fall through to Priority 1-3 silently when `--review-file` was explicitly requested but unusable — the user's intent was to use that specific file.
 
@@ -1093,7 +1099,7 @@ set +o pipefail
 
 > **block continuity note**: 本 block は Phase 1.2.0 Selection logic block と **同一 Bash tool invocation 内で連続実行する前提**で設計されている。詳細:
 >
-> 1. **anchor**: Selection logic block は上記 `pipefail scope note` blockquote 直下の bash block で、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking。Claude は本 block を独立した Bash 呼び出しとして発行せず、Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること (fenced 区切りは Claude が論理的に併合する)
+> 1. **anchor & 連結指示**: Selection logic block は上記 `pipefail scope note` blockquote 直下の bash block で、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking。Claude は本 block を独立した Bash 呼び出しとして発行せず、Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること (fenced 区切りは Claude が論理的に併合する)。**bullet ラベルが「anchor」のみだと behavior-critical な連結指示が情報メタデータに紛れて Claude が読み飛ばすリスクがあるため、ラベルを `anchor & 連結指示` に拡張して MUST-DO 命令の存在を可視化している。**
 > 2. **継承変数**: `$review_source` / `$review_source_path` 等のシェル変数は Selection logic block で設定された値を継承する
 > 3. **silent-skip 経路**: 別 invocation で実行すると `$review_source=""` となり下記 `if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]` 条件を満たさず、normalization step (schema 1.0 後方互換 + invariant #5 auto-correct) が silent skip する経路が成立する
 > 4. **observability marker**: Selection logic block 末尾近くの `[CONTEXT] REVIEW_SOURCE=...` stderr emit は本 invocation 統合運用時の **observability marker** として機能する

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1099,7 +1099,7 @@ set +o pipefail
 
 > **block continuity note**: 本 block は Phase 1.2.0 Selection logic block と **同一 Bash tool invocation 内で連続実行する前提**で設計されている。詳細:
 >
-> 1. **anchor & 連結指示**: Selection logic block は上記 `pipefail scope note` blockquote 直下の bash block で、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking。Claude は本 block を独立した Bash 呼び出しとして発行せず、Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること (fenced 区切りは Claude が論理的に併合する)。**bullet ラベルが「anchor」のみだと behavior-critical な連結指示が情報メタデータに紛れて Claude が読み飛ばすリスクがあるため、ラベルを `anchor & 連結指示` に拡張して MUST-DO 命令の存在を可視化している。**
+> 1. **anchor & 連結指示**: Selection logic block は上記 `pipefail scope note` blockquote 直下の bash block で、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking。Claude は本 block を独立した Bash 呼び出しとして発行せず、**Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること** (fenced 区切りは Claude が論理的に併合する)
 > 2. **継承変数**: `$review_source` / `$review_source_path` 等のシェル変数は Selection logic block で設定された値を継承する
 > 3. **silent-skip 経路**: 別 invocation で実行すると `$review_source=""` となり下記 `if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]` 条件を満たさず、normalization step (schema 1.0 後方互換 + invariant #5 auto-correct) が silent skip する経路が成立する
 > 4. **observability marker**: Selection logic block 末尾近くの `[CONTEXT] REVIEW_SOURCE=...` stderr emit は本 invocation 統合運用時の **observability marker** として機能する

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -1091,7 +1091,15 @@ set +o pipefail
 
 **On Priority 2 success**: Skip the existing "Target Comment Fast Path" and "Broad Comment Retrieval" sub-sections below. Parse the JSON file per [review-result-schema.md](../../references/review-result-schema.md#json-schema) and construct `severity_map` directly from `findings[]`:
 
-> **block continuity note**: 本 block は Phase 1.2.0 Selection logic block (上記 `pipefail scope note` blockquote 直下の bash block、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking) と **同一 Bash tool invocation 内で連続実行する前提**で設計されている。Claude は本 block を独立した Bash 呼び出しとして発行せず、Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること (fenced 区切りは Claude が論理的に併合する)。`$review_source` / `$review_source_path` 等のシェル変数は Selection logic block で設定された値を継承するため、別 invocation で実行すると `$review_source=""` となり下記 `if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]` 条件を満たさず、normalization step (schema 1.0 後方互換 + invariant #5 auto-correct) が silent skip する経路が成立する。なお Selection logic block 末尾近くの `[CONTEXT] REVIEW_SOURCE=...` stderr emit は本 invocation 統合運用時の **observability marker** として機能する (将来 merge/split リファクタで別 invocation 化する場合は、同 emit を hand-off marker として再 purpose し、本 block 冒頭に literal 代入文 `review_source="<会話コンテキストの値>"` を追加する必要がある)。上記 `pipefail scope note` は Selection logic block の単一 invocation 完結性 (shell-process bounded scope、Bash 自然挙動) を述べるのに対し、本注記はそれを本 block まで延長する追加の **multi-block 運用契約** を述べる。将来の merge/split リファクタでも本前提を維持すること。
+> **block continuity note**: 本 block は Phase 1.2.0 Selection logic block と **同一 Bash tool invocation 内で連続実行する前提**で設計されている。詳細:
+>
+> 1. **anchor**: Selection logic block は上記 `pipefail scope note` blockquote 直下の bash block で、末尾は `# === Phase 1.2.0 Selection logic block end ===` grep anchor で marking。Claude は本 block を独立した Bash 呼び出しとして発行せず、Selection logic block の末尾に本 block の bash 内容を連結して単一の Bash tool invocation として実行すること (fenced 区切りは Claude が論理的に併合する)
+> 2. **継承変数**: `$review_source` / `$review_source_path` 等のシェル変数は Selection logic block で設定された値を継承する
+> 3. **silent-skip 経路**: 別 invocation で実行すると `$review_source=""` となり下記 `if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]` 条件を満たさず、normalization step (schema 1.0 後方互換 + invariant #5 auto-correct) が silent skip する経路が成立する
+> 4. **observability marker**: Selection logic block 末尾近くの `[CONTEXT] REVIEW_SOURCE=...` stderr emit は本 invocation 統合運用時の **observability marker** として機能する
+> 5. **merge/split 時の hand-off**: 将来 merge/split リファクタで別 invocation 化する場合は、同 emit を hand-off marker として再 purpose し、本 block 冒頭に literal 代入文 `review_source="<会話コンテキストの値>"` を追加する必要がある
+> 6. **pipefail scope note との関係**: 上記 `pipefail scope note` は Selection logic block の単一 invocation 完結性 (shell-process bounded scope、Bash 自然挙動) を述べるのに対し、本注記はそれを本 block まで延長する追加の **multi-block 運用契約** を述べる
+> 7. **将来維持**: 将来の merge/split リファクタでも本前提を維持すること
 
 ```bash
 # Build severity_map from JSON findings array (schema_version 検証は Selection logic 内で既に完了済み)


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/fix.md` L1094 の `block continuity note` (約 700 chars の単一段落) を 7 項目の番号付き bullet リストに書き換える。scannability を改善し、merge/split リファクタ時の参照性を向上させる。

## 関連 Issue

Closes #1029

## 変更内容

- L1094 の continuity note blockquote を 7 項目 (anchor / 継承変数 / silent-skip 経路 / observability marker / merge/split 時の hand-off / pipefail scope note との関係 / 将来維持) に分解
- 原文の情報量を保持: Claude 行動指示 (本 block を独立した Bash 呼び出しとして発行しない / fenced 区切りは Claude が論理的に併合する) / grep anchor 位置詳細 (`pipefail scope note` blockquote 直下の bash block) / invariant #5 言及 (normalization step の括弧書き) はそれぞれ該当 bullet 内に保持
- 段落 lead-in (「同一 Bash tool invocation 内で連続実行する前提」) は短縮した上で「詳細:」で 7 項目に展開

## 背景

PR #1028 (Issue #1024) cycle 3 review で prompt-engineer reviewer が `scope:out-of-this-pr` 推奨事項として指摘:
- 単一段落 ~700 chars は scannability が低い
- 既存 `pipefail scope note` (L425 周辺) は ~250 chars と短く比較対象になる
- 7 項目を bullet で分解すれば検索性・参照性が向上

本 PR (#1028) のスコープは「Block 2 冒頭に prose 注記を追加して merge/split リファクタ耐性を上げる」であり、注記内の構造 refinement は scope 外と判定 → 別 Issue として切り出し (#1029)。

## チェックリスト

- [x] 7 項目すべて (anchor / 継承変数 / silent-skip 経路 / observability marker / merge/split 時の hand-off / pipefail scope note との関係 / 将来維持) が網羅されている
- [x] 原文情報 (Claude 行動指示・grep anchor 詳細・invariant #5 言及) が損なわれていない
- [x] 周辺コンテキスト (前後の blockquote / bash block) を破壊していない
- [x] `/rite:lint` で新規 finding ゼロを確認 (drift / comment_journal / comment_line_ref の既存警告のみ、本 PR 対象外)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
