### PR TITLE
refactor(tests): T-1〜T-4 を _test-helpers.sh パターンに揃える

### DIFF
--- a/plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh
@@ -9,50 +9,48 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 BASE_FILE="$REPO_ROOT/plugins/rite/agents/_reviewer-base.md"
 SEVERITY_FILE="$REPO_ROOT/plugins/rite/references/severity-levels.md"
-
-fail_count=0
-fail_messages=()
 
 # Note: BASE_FILE (_reviewer-base.md) と SEVERITY_FILE (severity-levels.md) は意図的に異なる
 # heading 名を持つ (前者は "nit-noted 禁止"、後者は "scope 制約")。これは責務の差を反映: BASE_FILE は
 # 「nit-noted を禁止する」という制約を、SEVERITY_FILE は「scope 軸の許容/禁止 matrix」を主題とする。
 # テストは両方の正確な heading を独立に literal match で検証する。
 
+# section-scoped check のための tempfile を準備
+base_section_file=$(mktemp)
+severity_section_file=$(mktemp)
+trap 'rm -f "$base_section_file" "$severity_section_file"' EXIT
+
 # 1. _reviewer-base.md の Hypothetical Exception 4 reviewer nit-noted 禁止節 (literal heading 固定)
-if ! grep -qE '^### Hypothetical Exception カテゴリの nit-noted 禁止$' "$BASE_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md missing '### Hypothetical Exception カテゴリの nit-noted 禁止' literal heading")
-fi
+assert_grep "_reviewer-base.md: '### Hypothetical Exception カテゴリの nit-noted 禁止' heading" \
+  "$BASE_FILE" \
+  '^### Hypothetical Exception カテゴリの nit-noted 禁止$'
 
 # 2. 4 reviewer 名がすべて _reviewer-base.md の該当節に登場
+awk '/^### Hypothetical Exception カテゴリの nit-noted 禁止$/,/^##[^#]/' "$BASE_FILE" > "$base_section_file"
 for r in security database devops dependencies; do
-  if ! awk '/^### Hypothetical Exception カテゴリの nit-noted 禁止$/,/^##[^#]/' "$BASE_FILE" | grep -q "${r}\.md\|${r}-reviewer\|\`${r}\`"; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: _reviewer-base.md Hypothetical Exception section missing $r reviewer reference")
-  fi
+  assert_grep "_reviewer-base.md Hypothetical Exception section: $r reviewer reference" \
+    "$base_section_file" \
+    "${r}\\.md|${r}-reviewer|\`${r}\`"
 done
 
 # 3. severity-levels.md の Hypothetical Exception scope 制約節 (literal heading 固定)
-if ! grep -qE '^### Hypothetical Exception カテゴリの scope 制約$' "$SEVERITY_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: severity-levels.md missing '### Hypothetical Exception カテゴリの scope 制約' literal heading")
-fi
+assert_grep "severity-levels.md: '### Hypothetical Exception カテゴリの scope 制約' heading" \
+  "$SEVERITY_FILE" \
+  '^### Hypothetical Exception カテゴリの scope 制約$'
 
 # 4. 4 reviewer 名と nit-noted 禁止記述が severity-levels.md に列挙
+awk '/^### Hypothetical Exception カテゴリの scope 制約$/,/^##[^#]/' "$SEVERITY_FILE" > "$severity_section_file"
 for r in security database devops dependencies; do
-  if ! awk '/^### Hypothetical Exception カテゴリの scope 制約$/,/^##[^#]/' "$SEVERITY_FILE" | grep -q "${r}\.md\|${r}-reviewer\|\`${r}\`"; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: severity-levels.md scope 制約 section missing $r reviewer reference")
-  fi
+  assert_grep "severity-levels.md scope 制約 section: $r reviewer reference" \
+    "$severity_section_file" \
+    "${r}\\.md|${r}-reviewer|\`${r}\`"
 done
 
-if [ "$fail_count" -gt 0 ]; then
-  printf '%s\n' "${fail_messages[@]}" >&2
-  echo "FAILED: $fail_count assertion(s) failed" >&2
+if ! print_summary "$(basename "$0")"; then
   exit 1
 fi
-
-echo "PASS: reviewer-hypothetical-nit-noted-ban (4 reviewer nit-noted 禁止 documented in both files)"

--- a/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
@@ -9,27 +9,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 AGENTS_DIR="$REPO_ROOT/plugins/rite/agents"
 
-fail_count=0
-fail_messages=()
-
-# 1. _reviewer-base.md に 5 列ヘッダーが存在することを確認
+# 1. _reviewer-base.md に 5 列ヘッダーが存在する
 base_file="$AGENTS_DIR/_reviewer-base.md"
-if [ ! -f "$base_file" ]; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: $base_file not found")
-elif ! grep -q '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' "$base_file"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md does not contain 5-column header (重要度|スコープ|ファイル:行|内容|推奨対応)")
-fi
+assert_grep "_reviewer-base.md: 5-column header (重要度|スコープ|ファイル:行|内容|推奨対応)" \
+  "$base_file" \
+  '\| 重要度 \| スコープ \| ファイル:行 \| 内容 \| 推奨対応 \|'
 
-# 2. _reviewer-base.md の旧 4 列ヘッダーがどこかに残存していないか
-if grep -qE '\| 重要度 \| ファイル:行 \| 内容 \| 推奨対応 \|' "$base_file"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md still contains 4-column header (drift)")
-fi
+# 2. _reviewer-base.md の旧 4 列ヘッダーがどこかに残存していないこと
+assert_not_grep "_reviewer-base.md: 4-column header drift (must not exist)" \
+  "$base_file" \
+  '\| 重要度 \| ファイル:行 \| 内容 \| 推奨対応 \|'
 
 # 3. 13 reviewer agent の example 表が 5 列か
 reviewers=(
@@ -50,25 +44,14 @@ reviewers=(
 
 for r in "${reviewers[@]}"; do
   f="$AGENTS_DIR/$r.md"
-  if [ ! -f "$f" ]; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: $r.md not found")
-    continue
-  fi
-  if ! grep -q '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' "$f"; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: $r.md missing 5-column header")
-  fi
-  if grep -qE '\| 重要度 \| ファイル:行 \| 内容 \| 推奨対応 \|' "$f"; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: $r.md still has 4-column header (drift)")
-  fi
+  assert_grep "$r.md: 5-column header present" \
+    "$f" \
+    '\| 重要度 \| スコープ \| ファイル:行 \| 内容 \| 推奨対応 \|'
+  assert_not_grep "$r.md: 4-column header drift (must not exist)" \
+    "$f" \
+    '\| 重要度 \| ファイル:行 \| 内容 \| 推奨対応 \|'
 done
 
-if [ "$fail_count" -gt 0 ]; then
-  printf '%s\n' "${fail_messages[@]}" >&2
-  echo "FAILED: $fail_count assertion(s) failed" >&2
+if ! print_summary "$(basename "$0")"; then
   exit 1
 fi
-
-echo "PASS: reviewer-scope-column-symmetry (13 reviewers + base have 5-column scope header)"

--- a/plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh
+++ b/plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh
@@ -10,42 +10,36 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 BASE_FILE="$REPO_ROOT/plugins/rite/agents/_reviewer-base.md"
 
-fail_count=0
-fail_messages=()
+# section-scoped check のための tempfile
+guardrail_section_file=$(mktemp)
+trap 'rm -f "$guardrail_section_file"' EXIT
 
 # 1. Finding Quality Guardrail に Scope self-degradation chain Category が存在
-if ! grep -q "Scope self-degradation chain\|scope 自己降格" "$BASE_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md missing 'Scope self-degradation chain' Guardrail category")
-fi
+assert_grep "_reviewer-base.md: 'Scope self-degradation chain' or 'scope 自己降格' Guardrail category" \
+  "$BASE_FILE" \
+  'Scope self-degradation chain|scope 自己降格'
 
 # 2. 二重 degrade パターン (severity 降格 + scope 降格 の連鎖) の記述
-if ! grep -qE "二重 degrade|severity.*scope.*degrade|severity.*降格.*scope.*降格|CRITICAL.*MEDIUM.*nit-noted" "$BASE_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md missing double-degrade (severity + scope) chain example")
-fi
+assert_grep "_reviewer-base.md: double-degrade (severity + scope) chain example" \
+  "$BASE_FILE" \
+  '二重 degrade|severity.*scope.*degrade|severity.*降格.*scope.*降格|CRITICAL.*MEDIUM.*nit-noted'
 
-# 3. Finding Quality Guardrail Filter categories テーブルに Category #5 (Scope self-degradation) が
-#    存在する (テーブル内で 5 行目以降に scope 関連 entry がある)
-guardrail_section=$(awk '/## Finding Quality Guardrail/,/^## [^F]/' "$BASE_FILE")
-if ! printf '%s\n' "$guardrail_section" | grep -qE '\| 5 \|.*[Ss]cope|\| 5 \|.*scope 自己降格'; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: Finding Quality Guardrail filter table missing Category #5 (Scope self-degradation chain)")
-fi
+# 3. Finding Quality Guardrail Filter categories テーブルに Category #5 (Scope self-degradation) が存在
+awk '/## Finding Quality Guardrail/,/^## [^F]/' "$BASE_FILE" > "$guardrail_section_file"
+assert_grep "Finding Quality Guardrail filter table: Category #5 (Scope self-degradation chain)" \
+  "$guardrail_section_file" \
+  '\| 5 \|.*[Ss]cope|\| 5 \|.*scope 自己降格'
 
 # 4. original_severity フィールド (schema 1.1.0) への参照があるか (修正方針の根拠)
-if ! grep -q 'original_severity' "$BASE_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: _reviewer-base.md missing reference to original_severity field (schema 1.1.0 trace)")
-fi
+assert_grep "_reviewer-base.md: original_severity field reference (schema 1.1.0 trace)" \
+  "$BASE_FILE" \
+  'original_severity'
 
-if [ "$fail_count" -gt 0 ]; then
-  printf '%s\n' "${fail_messages[@]}" >&2
-  echo "FAILED: $fail_count assertion(s) failed" >&2
+if ! print_summary "$(basename "$0")"; then
   exit 1
 fi
-
-echo "PASS: scope-self-degradation-guardrail (Finding Quality Guardrail extended for scope self-degradation chain)"

--- a/plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh
+++ b/plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh
@@ -12,76 +12,68 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 SEVERITY_FILE="$REPO_ROOT/plugins/rite/references/severity-levels.md"
 SCHEMA_FILE="$REPO_ROOT/plugins/rite/references/review-result-schema.md"
 
-fail_count=0
-fail_messages=()
+# section-scoped check のための tempfile
+matrix_section_file=$(mktemp)
+cross_field_section_file=$(mktemp)
+trap 'rm -f "$matrix_section_file" "$cross_field_section_file"' EXIT
 
 # 1. severity-levels.md に Severity × Scope Matrix 節が存在
-if ! grep -q "^## Severity × Scope Matrix\|Severity × Scope Matrix" "$SEVERITY_FILE"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: severity-levels.md missing Severity × Scope Matrix section heading")
-fi
+assert_grep "severity-levels.md: Severity × Scope Matrix section heading" \
+  "$SEVERITY_FILE" \
+  '^## Severity × Scope Matrix|Severity × Scope Matrix'
 
 # 2. matrix 節内に 5 severity 等級が列挙
-matrix_section=$(awk '/Severity × Scope Matrix/,/^## [^S]/' "$SEVERITY_FILE")
+awk '/Severity × Scope Matrix/,/^## [^S]/' "$SEVERITY_FILE" > "$matrix_section_file"
 for sev in "CRITICAL" "HIGH" "MEDIUM" "LOW-MEDIUM" "LOW"; do
-  if ! printf '%s\n' "$matrix_section" | grep -qE "\*\*${sev}\*\*"; then
-    fail_count=$((fail_count + 1))
-    fail_messages+=("FAIL: matrix section missing severity '$sev'")
-  fi
+  assert_grep "matrix section: severity '$sev' listed" \
+    "$matrix_section_file" \
+    "\\*\\*${sev}\\*\\*"
 done
 
 # 3. 禁止セル CRITICAL × follow-up / nit-noted が記述
-if ! printf '%s\n' "$matrix_section" | grep -qE "CRITICAL.*\`follow-up\`.*\`nit-noted\`|follow-up.*nit-noted.*CRITICAL"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: matrix section missing CRITICAL × follow-up/nit-noted 禁止 cell")
-fi
+assert_grep "matrix section: CRITICAL × follow-up/nit-noted 禁止 cell" \
+  "$matrix_section_file" \
+  'CRITICAL.*`follow-up`.*`nit-noted`|follow-up.*nit-noted.*CRITICAL'
 
 # 4. 禁止セル HIGH × nit-noted が記述
-if ! printf '%s\n' "$matrix_section" | grep -qE "HIGH.*\`nit-noted\`"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: matrix section missing HIGH × nit-noted 禁止 cell")
-fi
+assert_grep "matrix section: HIGH × nit-noted 禁止 cell" \
+  "$matrix_section_file" \
+  'HIGH.*`nit-noted`'
 
 # 5. 禁止セル LOW × follow-up が記述
-if ! printf '%s\n' "$matrix_section" | grep -qE "LOW.*\`follow-up\`|\`follow-up\`.*LOW"; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: matrix section missing LOW × follow-up 禁止 cell")
-fi
+assert_grep "matrix section: LOW × follow-up 禁止 cell" \
+  "$matrix_section_file" \
+  'LOW.*`follow-up`|`follow-up`.*LOW'
 
 # 6. schema 1.1.0 Cross-field invariant #4 (CRITICAL/HIGH × nit-noted FAIL) の本体定義を確認
 #    Cross-field invariants セクション内に絞った section-scoped grep で、
 #    L127 等の forward-pointer 記述による false-pass を排除する。
 #    番号付き定義 "4. **`severity ∈ {CRITICAL, HIGH}` ∧ `scope == \"nit-noted\"` 禁止**" を anchor とする。
-cross_field_section=$(awk '/^### Cross-field invariants/,/^## /' "$SCHEMA_FILE")
-if ! printf '%s\n' "$cross_field_section" | grep -qE '^4\.\s+\*\*.*severity.*CRITICAL.*HIGH.*scope.*nit-noted.*禁止'; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: schema 1.1.0 Cross-field invariants section missing item #4 body definition (CRITICAL/HIGH × nit-noted FAIL invariant)")
-fi
+awk '/^### Cross-field invariants/,/^## /' "$SCHEMA_FILE" > "$cross_field_section_file"
+assert_grep "schema 1.1.0 Cross-field invariants: item #4 body definition (CRITICAL/HIGH × nit-noted FAIL)" \
+  "$cross_field_section_file" \
+  '^4\.[[:space:]]+\*\*.*severity.*CRITICAL.*HIGH.*scope.*nit-noted.*禁止'
 
 # 7. jq invariant 実行: 禁止セル CRITICAL × nit-noted を含む JSON が FAIL する
 jq_test_json='{"findings":[{"severity":"CRITICAL","scope":"nit-noted","file_line":"src/x.ts:1"},{"severity":"MEDIUM","scope":"current-pr","file_line":"src/y.ts:2"}]}'
 jq_result=$(printf '%s' "$jq_test_json" | jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length == 0')
-if [ "$jq_result" != "false" ]; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: jq invariant did not detect CRITICAL × nit-noted forbidden cell (result=$jq_result, expected false)")
-fi
+assert "jq invariant: CRITICAL × nit-noted forbidden cell detected (expected false)" \
+  "false" \
+  "$jq_result"
 
 # 8. jq invariant: 許容セル (MEDIUM × follow-up / LOW-MEDIUM × nit-noted) は PASS
 jq_test_json2='{"findings":[{"severity":"MEDIUM","scope":"follow-up","file_line":"src/x.ts:1"},{"severity":"LOW-MEDIUM","scope":"nit-noted","file_line":"src/y.ts:2"}]}'
 jq_result2=$(printf '%s' "$jq_test_json2" | jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length == 0')
-if [ "$jq_result2" != "true" ]; then
-  fail_count=$((fail_count + 1))
-  fail_messages+=("FAIL: jq invariant rejected valid combinations (MEDIUM × follow-up, LOW-MEDIUM × nit-noted, result=$jq_result2, expected true)")
-fi
+assert "jq invariant: valid combinations accepted (MEDIUM × follow-up, LOW-MEDIUM × nit-noted, expected true)" \
+  "true" \
+  "$jq_result2"
 
-if [ "$fail_count" -gt 0 ]; then
-  printf '%s\n' "${fail_messages[@]}" >&2
-  echo "FAILED: $fail_count assertion(s) failed" >&2
+if ! print_summary "$(basename "$0")"; then
   exit 1
 fi
-
-echo "PASS: severity-scope-matrix-invariants (matrix 禁止セル integrate with schema invariant #4 and jq blocks forbidden combinations)"


### PR DESCRIPTION
## 概要

Issue #1017 で追加した 4 つの test (T-1〜T-4) を、`_test-helpers.sh` を `source` する 18 ファイルと同じ pattern (`assert_grep` / `assert_not_grep` / `assert` + `print_summary`) に揃える refactor。PR #1036 で code-quality reviewer が指摘した F-09 (MEDIUM) への対応。

Closes #1038

## 背景

- 4 test (T-1〜T-4) は独自の inline `fail_count=0` / `fail_messages=()` パターンで実装されており、`_test-helpers.sh` を共有する他 18 ファイルから外れていた
- 結果として Core Principle 1 (Pattern consistency) 違反、`_test-helpers.sh` の将来的な共通化拡張 (output convention 改定、報告フォーマット標準化 等) の coverage 外、合計 ~60 行の重複 boilerplate
- 最も近い canonical reference は `4-site-symmetry.test.sh`

## 主な変更

| ファイル | 変更内容 |
|---------|---------|
| `plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh` (T-1) | inline `fail_count`/`fail_messages` を削除、先頭で `_test-helpers.sh` を source、`assert_grep` / `assert_not_grep` + `print_summary` パターンへ置換 |
| `plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh` (T-2) | 同上。`awk '/.../, /.../' \| grep` の section-scoped 検査 (4 件 × 2) は `mktemp` + `trap 'rm' EXIT` で tempfile に section を書き出し、`assert_grep` で検証する形に変更 |
| `plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh` (T-3) | 同上。`guardrail_section` 変数 (1 件) を tempfile に置換 |
| `plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh` (T-4) | 同上。`matrix_section` (5 件) + `cross_field_section` (1 件) を tempfile に置換。`jq` 結果文字列比較 (2 件) は `assert "label" "expected" "$actual"` に置換 |

## 効果

- **Pattern consistency**: `_test-helpers.sh` を source する 18 ファイル全体での Core Principle 1 違反を解消
- **共通化拡張への coverage**: 将来 `_test-helpers.sh` の output convention 改定 (stdout/stderr 規約変更 等) や報告フォーマット標準化が一元適用可能に
- **stderr → stdout 移行**: FAIL 出力先が `>&2` 直書きから `_test-helpers.sh` の output convention (stdout) に揃う
- **行数**: 270 → 237 (-33 行)。section tempfile boilerplate のため pure な boilerplate 削減効果は控えめだが、pattern consistency が主目的

## 検証

- 4 test それぞれ独立実行: 全 `exit 0` で summary に `PASS: N, FAIL: 0` 出力
  - reviewer-scope-column-symmetry.test.sh: PASS=28 / FAIL=0
  - reviewer-hypothetical-nit-noted-ban.test.sh: PASS=10 / FAIL=0
  - scope-self-degradation-guardrail.test.sh: PASS=4 / FAIL=0
  - severity-scope-matrix-invariants.test.sh: PASS=12 / FAIL=0
- `run-tests.sh` 全 test suite: **59/59 passed, 0 failed** (regression なし)

## 関連

- Issue #1015 (M1+M2+M5 Epic)
- Issue #1017 (T-1〜T-4 を追加した Sub-2)
- PR #1036 (本 PR 起点の code-quality 指摘 F-09)

## チェックリスト

- [x] 4 test ファイル全てを `_test-helpers.sh` パターンに refactor
- [x] section-scoped grep は tempfile + `assert_grep` で置換
- [x] T-4 の jq 結果比較を `assert` に置換
- [x] 4 test 個別実行で全 pass を確認
- [x] `run-tests.sh` 全 59 test の regression を確認
