### PR TITLE
feat(tests): _test-helpers.sh に section-scoped grep helper を追加

### DIFF
--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -66,6 +66,8 @@
 #   assert <label> <expected> <actual>           # writes to stdout (via pass/fail)
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
+#   assert_grep_in_section <label> <file> <start_pattern> <end_pattern> <grep_pattern>
+#                                                # extract awk-range section + ERE grep with self-cleanup
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0
 #   make_sandbox       [--branch <name>] [--soft]   # git-init+commit sandbox, echoes path
 #   make_plain_sandbox [--soft]                     # bare mktemp -d sandbox, echoes path
@@ -151,6 +153,59 @@ assert_not_grep() {
   else
     pass "$label"
   fi
+}
+
+# Section-scoped pattern presence assertion (Issue #1047).
+# Extracts an awk address-range section ([start_pattern, end_pattern]) from `file`
+# into a private tempfile, runs `grep -qE grep_pattern` against it, then self-cleans.
+#
+# Consolidates the boilerplate previously duplicated in T-2/T-3/T-4:
+#   section_file=$(mktemp)
+#   trap 'rm -f "$section_file"' EXIT
+#   awk '/start/, /end/' "$file" > "$section_file"
+#   assert_grep "label" "$section_file" "pattern"
+#
+# What is consolidated: section tempfile lifecycle (mktemp + cleanup) and the
+# awk range extraction. What is NOT consolidated: callers managing their own
+# tempfiles for non-section uses still need their own mktemp + trap.
+#
+# Patterns are passed to awk via `-v` variables (not interpolated into the awk
+# program text) so caller-supplied strings cannot inject awk syntax.
+#
+# Failure modes (each falls through to fail() with diagnostic context):
+#   - file not found          → "file not found: <file>"
+#   - mktemp -d failure       → "mktemp failed" (infrastructure error to stderr)
+#   - empty section           → reported as pattern-not-found with section bounds
+#   - pattern not in section  → "pattern not found in section [<start>..<end>] of <file>: <pattern>"
+#
+# Caller pattern:
+#   assert_grep_in_section "T-2 reviewer ref" "$BASE_FILE" \
+#     '^### Hypothetical Exception カテゴリの nit-noted 禁止$' \
+#     '^##[^#]' \
+#     "security\\.md|security-reviewer"
+assert_grep_in_section() {
+  local label="$1"
+  local file="$2"
+  local start_pattern="$3"
+  local end_pattern="$4"
+  local grep_pattern="$5"
+  if [ ! -f "$file" ]; then
+    fail "$label (file not found: $file)"
+    return
+  fi
+  local section_file
+  if ! section_file=$(mktemp); then
+    echo "ERROR: assert_grep_in_section: mktemp failed" >&2
+    fail "$label (mktemp failed)"
+    return
+  fi
+  awk -v start="$start_pattern" -v end="$end_pattern" '$0 ~ start, $0 ~ end' "$file" > "$section_file"
+  if grep -qE "$grep_pattern" "$section_file"; then
+    pass "$label"
+  else
+    fail "$label (pattern not found in section [$start_pattern..$end_pattern] of $file: $grep_pattern)"
+  fi
+  rm -f "$section_file"
 }
 
 # make_sandbox — git-init + initial-commit sandbox (Issue #990).

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -174,8 +174,10 @@ assert_not_grep() {
 #
 # Failure modes (each falls through to fail() with diagnostic context):
 #   - file not found          → "file not found: <file>"
-#   - mktemp -d failure       → "mktemp failed" (infrastructure error to stderr)
-#   - empty section           → reported as pattern-not-found with section bounds
+#   - mktemp failure          → "mktemp failed" (infrastructure error to stderr)
+#   - awk extraction failure  → "awk extraction failed" (rc, syntax / IO error to stderr)
+#   - empty section           → "empty section: start_pattern matched no line"
+#                               (distinguishable from "pattern not found in section")
 #   - pattern not in section  → "pattern not found in section [<start>..<end>] of <file>: <pattern>"
 #
 # Caller pattern:
@@ -199,7 +201,21 @@ assert_grep_in_section() {
     fail "$label (mktemp failed)"
     return
   fi
-  awk -v start="$start_pattern" -v end="$end_pattern" '$0 ~ start, $0 ~ end' "$file" > "$section_file"
+  local awk_err
+  if ! awk -v start="$start_pattern" -v end="$end_pattern" \
+       '$0 ~ start, $0 ~ end' "$file" > "$section_file" 2>"$section_file.err"; then
+    awk_err=$(head -3 "$section_file.err" 2>/dev/null)
+    echo "ERROR: assert_grep_in_section: awk extraction failed (file=$file start=$start_pattern end=$end_pattern): $awk_err" >&2
+    fail "$label (awk extraction failed)"
+    rm -f "$section_file" "$section_file.err"
+    return
+  fi
+  rm -f "$section_file.err"
+  if [ ! -s "$section_file" ]; then
+    fail "$label (empty section: start_pattern [$start_pattern] matched no line in $file — section heading drift?)"
+    rm -f "$section_file"
+    return
+  fi
   if grep -qE "$grep_pattern" "$section_file"; then
     pass "$label"
   else

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -385,6 +385,83 @@ else
   outer_fail "TC-11.4: expected rc=1 (soft-fail on mktemp failure), got rc=$rc_plain_soft_fail"
 fi
 
+# === TC-12: assert_grep_in_section (Issue #1047) ===
+echo
+echo "TC-12: assert_grep_in_section"
+
+# TC-12 fixture: 3 sections (h3 start anchor + h2 end anchor mirrors T-2/T-3/T-4 usage pattern)
+tc12_fixture=$(mktemp)
+trap 'rm -f "$tc12_fixture" "$tmpfile"' EXIT
+cat > "$tc12_fixture" <<'FIXTURE_EOF'
+## Top heading
+
+### Subsection Alpha
+alpha-keyword
+alpha-only
+
+### Subsection Beta
+beta-keyword
+beta-only
+
+## Next top heading
+gamma-keyword
+FIXTURE_EOF
+
+# TC-12.1: matching pattern within bounded section → PASS
+# start: h3 heading (Alpha), end: h2 heading boundary (won't match the start line itself)
+grep_in_section_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep_in_section 'match-in-alpha' '$tc12_fixture' '^### Subsection Alpha\$' '^## [^#]' 'alpha-keyword' >/dev/null
+  echo \"PASS=\$PASS FAIL=\$FAIL\"
+")
+gp=$(echo "$grep_in_section_state" | grep -oE 'PASS=[0-9]+' | cut -d= -f2)
+gf=$(echo "$grep_in_section_state" | grep -oE 'FAIL=[0-9]+' | cut -d= -f2)
+if [ "$gp" = "1" ] && [ "$gf" = "0" ]; then
+  outer_pass "TC-12.1: assert_grep_in_section matches pattern within bounded section"
+else
+  outer_fail "TC-12.1: expected PASS=1 FAIL=0 got PASS=$gp FAIL=$gf"
+fi
+
+# TC-12.2: pattern outside section (in Beta) when scoped to Alpha → FAIL with section bounds diagnostic
+# Note: the awk range terminates at the next h3 (Beta) line by also matching `^### ` boundary
+out_of_scope_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep_in_section 'beta-from-alpha' '$tc12_fixture' '^### Subsection Alpha\$' '^### Subsection B' 'beta-only' 2>&1
+  echo \"FAIL=\$FAIL\"
+")
+oof=$(echo "$out_of_scope_state" | grep -oE 'FAIL=[0-9]+' | tail -1 | cut -d= -f2)
+if [ "$oof" = "1" ] && echo "$out_of_scope_state" | grep -q 'pattern not found in section'; then
+  outer_pass "TC-12.2: pattern outside section fails with section-bound diagnostic"
+else
+  outer_fail "TC-12.2: expected FAIL=1 + 'pattern not found in section' diagnostic, got '$out_of_scope_state'"
+fi
+
+# TC-12.3: file not found → FAIL with file diagnostic
+missing_file_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep_in_section 'missing-section' '/nonexistent/xyz' '## Anything' '^## ' 'pattern' 2>&1
+  echo \"FAIL=\$FAIL\"
+")
+mff=$(echo "$missing_file_state" | grep -oE 'FAIL=[0-9]+' | tail -1 | cut -d= -f2)
+if [ "$mff" = "1" ] && echo "$missing_file_state" | grep -q 'file not found'; then
+  outer_pass "TC-12.3: file-not-found path emits diagnostic and increments FAIL"
+else
+  outer_fail "TC-12.3: expected FAIL=1 + 'file not found' got '$missing_file_state'"
+fi
+
+# TC-12.4: empty section (start_pattern matches no line) → FAIL with empty-section diagnostic
+empty_section_state=$(bash -c "
+  source '$HELPERS'
+  assert_grep_in_section 'never-matches' '$tc12_fixture' '^### Never Appears In Fixture$' '^## ' 'anything' 2>&1
+  echo \"FAIL=\$FAIL\"
+")
+ess=$(echo "$empty_section_state" | grep -oE 'FAIL=[0-9]+' | tail -1 | cut -d= -f2)
+if [ "$ess" = "1" ] && echo "$empty_section_state" | grep -q 'empty section'; then
+  outer_pass "TC-12.4: empty section distinguished from pattern-not-found with explicit diagnostic"
+else
+  outer_fail "TC-12.4: expected FAIL=1 + 'empty section' diagnostic, got '$empty_section_state'"
+fi
+
 # === Summary ===
 echo
 echo "─── $(basename "$0") summary ──────────────────────"

--- a/plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh
@@ -20,21 +20,17 @@ SEVERITY_FILE="$REPO_ROOT/plugins/rite/references/severity-levels.md"
 # 「nit-noted を禁止する」という制約を、SEVERITY_FILE は「scope 軸の許容/禁止 matrix」を主題とする。
 # テストは両方の正確な heading を独立に literal match で検証する。
 
-# section-scoped check のための tempfile を準備
-base_section_file=$(mktemp)
-severity_section_file=$(mktemp)
-trap 'rm -f "$base_section_file" "$severity_section_file"' EXIT
-
 # 1. _reviewer-base.md の Hypothetical Exception 4 reviewer nit-noted 禁止節 (literal heading 固定)
 assert_grep "_reviewer-base.md: '### Hypothetical Exception カテゴリの nit-noted 禁止' heading" \
   "$BASE_FILE" \
   '^### Hypothetical Exception カテゴリの nit-noted 禁止$'
 
 # 2. 4 reviewer 名がすべて _reviewer-base.md の該当節に登場
-awk '/^### Hypothetical Exception カテゴリの nit-noted 禁止$/,/^##[^#]/' "$BASE_FILE" > "$base_section_file"
 for r in security database devops dependencies; do
-  assert_grep "_reviewer-base.md Hypothetical Exception section: $r reviewer reference" \
-    "$base_section_file" \
+  assert_grep_in_section "_reviewer-base.md Hypothetical Exception section: $r reviewer reference" \
+    "$BASE_FILE" \
+    '^### Hypothetical Exception カテゴリの nit-noted 禁止$' \
+    '^##[^#]' \
     "${r}\\.md|${r}-reviewer|\`${r}\`"
 done
 
@@ -44,10 +40,11 @@ assert_grep "severity-levels.md: '### Hypothetical Exception カテゴリの sco
   '^### Hypothetical Exception カテゴリの scope 制約$'
 
 # 4. 4 reviewer 名と nit-noted 禁止記述が severity-levels.md に列挙
-awk '/^### Hypothetical Exception カテゴリの scope 制約$/,/^##[^#]/' "$SEVERITY_FILE" > "$severity_section_file"
 for r in security database devops dependencies; do
-  assert_grep "severity-levels.md scope 制約 section: $r reviewer reference" \
-    "$severity_section_file" \
+  assert_grep_in_section "severity-levels.md scope 制約 section: $r reviewer reference" \
+    "$SEVERITY_FILE" \
+    '^### Hypothetical Exception カテゴリの scope 制約$' \
+    '^##[^#]' \
     "${r}\\.md|${r}-reviewer|\`${r}\`"
 done
 

--- a/plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh
+++ b/plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh
@@ -15,10 +15,6 @@ source "$SCRIPT_DIR/_test-helpers.sh"
 REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 BASE_FILE="$REPO_ROOT/plugins/rite/agents/_reviewer-base.md"
 
-# section-scoped check のための tempfile
-guardrail_section_file=$(mktemp)
-trap 'rm -f "$guardrail_section_file"' EXIT
-
 # 1. Finding Quality Guardrail に Scope self-degradation chain Category が存在
 assert_grep "_reviewer-base.md: 'Scope self-degradation chain' or 'scope 自己降格' Guardrail category" \
   "$BASE_FILE" \
@@ -30,9 +26,10 @@ assert_grep "_reviewer-base.md: double-degrade (severity + scope) chain example"
   '二重 degrade|severity.*scope.*degrade|severity.*降格.*scope.*降格|CRITICAL.*MEDIUM.*nit-noted'
 
 # 3. Finding Quality Guardrail Filter categories テーブルに Category #5 (Scope self-degradation) が存在
-awk '/## Finding Quality Guardrail/,/^## [^F]/' "$BASE_FILE" > "$guardrail_section_file"
-assert_grep "Finding Quality Guardrail filter table: Category #5 (Scope self-degradation chain)" \
-  "$guardrail_section_file" \
+assert_grep_in_section "Finding Quality Guardrail filter table: Category #5 (Scope self-degradation chain)" \
+  "$BASE_FILE" \
+  '## Finding Quality Guardrail' \
+  '^## [^F]' \
   '\| 5 \|.*[Ss]cope|\| 5 \|.*scope 自己降格'
 
 # 4. original_severity フィールド (schema 1.1.0) への参照があるか (修正方針の根拠)

--- a/plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh
+++ b/plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh
@@ -18,46 +18,49 @@ REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 SEVERITY_FILE="$REPO_ROOT/plugins/rite/references/severity-levels.md"
 SCHEMA_FILE="$REPO_ROOT/plugins/rite/references/review-result-schema.md"
 
-# section-scoped check のための tempfile
-matrix_section_file=$(mktemp)
-cross_field_section_file=$(mktemp)
-trap 'rm -f "$matrix_section_file" "$cross_field_section_file"' EXIT
-
 # 1. severity-levels.md に Severity × Scope Matrix 節が存在
 assert_grep "severity-levels.md: Severity × Scope Matrix section heading" \
   "$SEVERITY_FILE" \
   '^## Severity × Scope Matrix|Severity × Scope Matrix'
 
 # 2. matrix 節内に 5 severity 等級が列挙
-awk '/Severity × Scope Matrix/,/^## [^S]/' "$SEVERITY_FILE" > "$matrix_section_file"
 for sev in "CRITICAL" "HIGH" "MEDIUM" "LOW-MEDIUM" "LOW"; do
-  assert_grep "matrix section: severity '$sev' listed" \
-    "$matrix_section_file" \
+  assert_grep_in_section "matrix section: severity '$sev' listed" \
+    "$SEVERITY_FILE" \
+    'Severity × Scope Matrix' \
+    '^## [^S]' \
     "\\*\\*${sev}\\*\\*"
 done
 
 # 3. 禁止セル CRITICAL × follow-up / nit-noted が記述
-assert_grep "matrix section: CRITICAL × follow-up/nit-noted 禁止 cell" \
-  "$matrix_section_file" \
+assert_grep_in_section "matrix section: CRITICAL × follow-up/nit-noted 禁止 cell" \
+  "$SEVERITY_FILE" \
+  'Severity × Scope Matrix' \
+  '^## [^S]' \
   'CRITICAL.*`follow-up`.*`nit-noted`|follow-up.*nit-noted.*CRITICAL'
 
 # 4. 禁止セル HIGH × nit-noted が記述
-assert_grep "matrix section: HIGH × nit-noted 禁止 cell" \
-  "$matrix_section_file" \
+assert_grep_in_section "matrix section: HIGH × nit-noted 禁止 cell" \
+  "$SEVERITY_FILE" \
+  'Severity × Scope Matrix' \
+  '^## [^S]' \
   'HIGH.*`nit-noted`'
 
 # 5. 禁止セル LOW × follow-up が記述
-assert_grep "matrix section: LOW × follow-up 禁止 cell" \
-  "$matrix_section_file" \
+assert_grep_in_section "matrix section: LOW × follow-up 禁止 cell" \
+  "$SEVERITY_FILE" \
+  'Severity × Scope Matrix' \
+  '^## [^S]' \
   'LOW.*`follow-up`|`follow-up`.*LOW'
 
 # 6. schema 1.1.0 Cross-field invariant #4 (CRITICAL/HIGH × nit-noted FAIL) の本体定義を確認
 #    Cross-field invariants セクション内に絞った section-scoped grep で、
 #    L127 等の forward-pointer 記述による false-pass を排除する。
 #    番号付き定義 "4. **`severity ∈ {CRITICAL, HIGH}` ∧ `scope == \"nit-noted\"` 禁止**" を anchor とする。
-awk '/^### Cross-field invariants/,/^## /' "$SCHEMA_FILE" > "$cross_field_section_file"
-assert_grep "schema 1.1.0 Cross-field invariants: item #4 body definition (CRITICAL/HIGH × nit-noted FAIL)" \
-  "$cross_field_section_file" \
+assert_grep_in_section "schema 1.1.0 Cross-field invariants: item #4 body definition (CRITICAL/HIGH × nit-noted FAIL)" \
+  "$SCHEMA_FILE" \
+  '^### Cross-field invariants' \
+  '^## ' \
   '^4\.[[:space:]]+\*\*.*severity.*CRITICAL.*HIGH.*scope.*nit-noted.*禁止'
 
 # 7. jq invariant 実行: 禁止セル CRITICAL × nit-noted を含む JSON が FAIL する


### PR DESCRIPTION
## 概要

`_test-helpers.sh` に section-scoped grep API `assert_grep_in_section` を追加し、T-2/T-3/T-4 の 5 箇所の `mktemp` + `trap 'rm -f' EXIT` + `awk '/start/, /end/' file > tempfile` boilerplate を解消した。helper 内で section tempfile の lifecycle (作成→検証→cleanup) を自動管理する。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `plugins/rite/hooks/tests/_test-helpers.sh` | `assert_grep_in_section <label> <file> <start_pattern> <end_pattern> <grep_pattern>` を追加。awk pattern は `-v` variable 経由で渡し shell injection を防止。docstring に「集約される機能 (section tempfile lifecycle)」と「依然 caller-managed の機能 (非 section の tempfile)」を明示 |
| `plugins/rite/hooks/tests/reviewer-hypothetical-nit-noted-ban.test.sh` (T-2) | 2 section × 4 reviewer = 8 assertion を新 API に置換 |
| `plugins/rite/hooks/tests/scope-self-degradation-guardrail.test.sh` (T-3) | 1 section × 1 assertion を新 API に置換 |
| `plugins/rite/hooks/tests/severity-scope-matrix-invariants.test.sh` (T-4) | 2 section × 9 assertion (matrix 8 + cross-field 1) を新 API に置換 |

## 効果

**達成**:
- 5 箇所の `mktemp + trap + awk` boilerplate を削除 (caller が tempfile lifecycle 管理から解放)
- 将来の section-scoped 検証で `assert_grep_in_section` を再利用可能
- API は既存 `assert_grep` / `assert_not_grep` と一貫した signature・出力規約に準拠

**測定**:
- 3 test ファイル合計 line delta = `+32 / -35` (net -3 行)
- helper ファイル: +55 行 (新 API + docstring)
- Issue 本文の見積り (~10 行削減) には届かず — `assert_grep_in_section` 呼出 1 回あたり 2 追加引数行 (start_pattern + end_pattern) が必要で、boilerplate 削減と相殺された。本質的価値は **行数削減ではなく boilerplate elimination + DRY API の一貫性** にある

## テスト

- T-2 (10 assertion) / T-3 (4 assertion) / T-4 (12 assertion) すべて PASS
- migrate 後の grep 残存ゼロ確認: `grep -lE "_section_file=\$\(mktemp\)" plugins/rite/hooks/tests/*.test.sh` → 0 件

## 関連

- Closes #1047
- 起点: PR #1046 (Issue #1038) test reviewer recommendation #1
- 親 Epic: Issue #1015 (M1+M2+M5)

## Test plan

- [x] T-2/T-3/T-4 全 26 assertion が PASS
- [x] mktemp/trap/awk boilerplate 残存ゼロ (3 ファイル grep 確認)
- [x] Asymmetric Fix Transcription 予防: 3 ファイル symmetric 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
