### PR TITLE
fix(tests): T-1 で reviewer ファイル不在時の fail メッセージ膨張を解消

### DIFF
--- a/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
@@ -44,6 +44,14 @@ reviewers=(
 
 for r in "${reviewers[@]}"; do
   f="$AGENTS_DIR/$r.md"
+  # File-existence guard (Issue #1048): assert_grep / assert_not_grep はそれぞれ独立に
+  # ファイル不在チェックを行うため、不在時には 1 reviewer = 2 fail message に膨張する。
+  # 原本 (PR #1046 refactor 前) の「1 reviewer = 1 fail」挙動を回復するため、loop の
+  # 先頭で存在確認し、不在なら 1 件 fail して後続 assertion を skip する。
+  if [ ! -f "$f" ]; then
+    fail "$r.md (file not found: $f)"
+    continue
+  fi
   assert_grep "$r.md: 5-column header present" \
     "$f" \
     '\| 重要度 \| スコープ \| ファイル:行 \| 内容 \| 推奨対応 \|'


### PR DESCRIPTION
## 概要

PR #1046 (Issue #1038) の refactor で T-1 (`reviewer-scope-column-symmetry.test.sh`) の挙動が原本から変化し、reviewer.md ファイル不在時に `assert_grep` + `assert_not_grep` が独立にファイル存在チェックを行うため、 1 reviewer = 2 fail message に inflate していた。本 PR で per-reviewer loop の先頭に missing-file ガードを追加し、原本の「1 reviewer = 1 fail message」挙動を回復する。

## 関連 Issue

Closes #1048

Refs: #1046, #1038

## 変更内容

- `plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh`: 13 reviewer の per-reviewer loop の先頭に `if [ ! -f "$f" ]; then fail "$r.md (file not found: $f)"; continue; fi` を追加

## 採用方針

Issue 本文の対処方針案 3 つから案 2 (T-1 局所修正) を採用:

- **採用**: T-1 のループ内に missing-file ガードを明示 → 他テストへの影響なし、原本挙動と一致
- 不採用: `_test-helpers.sh` API 拡張 (`--require-file` モード) → 18 ファイルへの波及あり
- 不採用: 許容 (記録のみ) → 将来 reviewer.md 削除を伴う PR で fail message が膨張し読み取り混乱

## 検証

- `bash plugins/rite/hooks/tests/run-tests.sh` で全件 PASS (59/59) を確認 — 回帰なし
- `api-reviewer.md` を一時 rename した状態で T-1 を実行し、 fail message が 1 行/missing-reviewer に収まることを確認 (検証後 revert 済)

## チェックリスト

- [x] テストが pass する (59/59)
- [x] missing-file 時の fail 出力が「1 reviewer = 1 fail」になることを検証
- [x] 既存 reviewer 13 件すべての PASS を維持

## Known Issues

- lint 未実行 (lint コマンドが検出されませんでした)
- plugin-specific drift / comment-journal / comment-line-ref 検出は本 PR 由来でない既存検出 (非 blocking)
