### PR TITLE
feat(tests): _test-helpers.sh に assert_file_exists_or_fail ヘルパーを追加 (#1051)

### DIFF
--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -66,6 +66,7 @@
 #   assert <label> <expected> <actual>           # writes to stdout (via pass/fail)
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
+#   assert_file_exists_or_fail <label> <file>    # 1-fail file-existence guard for assertion-pair loops
 #   assert_grep_in_section <label> <file> <start_pattern> <end_pattern> <grep_pattern>
 #                                                # extract awk-range section + ERE grep with self-cleanup
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0
@@ -153,6 +154,36 @@ assert_not_grep() {
   else
     pass "$label"
   fi
+}
+
+# File-existence pre-condition guard for assertion-pair loops (Issue #1051).
+#
+# Consolidates the inline `[ ! -f "$f" ] && fail ... && continue` boilerplate
+# previously inlined in callers that run multiple assertions against the same
+# file inside a loop. Without this guard the standalone assert_grep / assert_not_grep
+# file-existence checks each emit their own fail() when the file is absent,
+# inflating one missing file into N fails (one per assertion pair).
+#
+# Caller pattern (the helper writes the failure marker via fail() and returns
+# non-zero so the caller can `|| continue` to skip the subsequent assertions):
+#   for r in "${reviewers[@]}"; do
+#     f="$AGENTS_DIR/$r.md"
+#     assert_file_exists_or_fail "$r.md" "$f" || continue
+#     assert_grep     "..." "$f" 'pattern1'
+#     assert_not_grep "..." "$f" 'pattern2'
+#   done
+#
+# Return code semantics (consumed by caller `|| continue`):
+#   0 — file exists, caller proceeds with the subsequent assertions
+#   1 — file is missing, fail() was already invoked, caller should skip
+assert_file_exists_or_fail() {
+  local label="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    fail "$label (file not found: $file)"
+    return 1
+  fi
+  return 0
 }
 
 # Section-scoped pattern presence assertion (Issue #1047).

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -462,6 +462,56 @@ else
   outer_fail "TC-12.4: expected FAIL=1 + 'empty section' diagnostic, got '$empty_section_state'"
 fi
 
+# === TC-13: assert_file_exists_or_fail (Issue #1051) ===
+echo
+echo "TC-13: assert_file_exists_or_fail"
+
+# TC-13.1: file present → PASS=0 FAIL=0 RC=0 (silent guard — NOT an assertion).
+# The helper is a pre-condition guard, not a positive assertion: on success it
+# must remain silent so it does not inflate the PASS count of the assertions
+# it protects (the real assertions invoked after `|| continue` own the PASS
+# accounting). The caller's `|| continue` only depends on RC=0.
+tc13_existing=$(mktemp)
+trap 'rm -f "$tc13_existing" "$tc12_fixture" "$tmpfile"' EXIT
+printf 'present\n' > "$tc13_existing"
+
+present_state=$(bash -c "
+  source '$HELPERS'
+  if assert_file_exists_or_fail 'present-file' '$tc13_existing' >/dev/null; then
+    rc=0
+  else
+    rc=\$?
+  fi
+  echo \"PASS=\$PASS FAIL=\$FAIL RC=\$rc\"
+")
+pp=$(echo "$present_state" | grep -oE 'PASS=[0-9]+' | cut -d= -f2)
+pf=$(echo "$present_state" | grep -oE 'FAIL=[0-9]+' | cut -d= -f2)
+prc=$(echo "$present_state" | grep -oE 'RC=[0-9]+' | cut -d= -f2)
+if [ "$pp" = "0" ] && [ "$pf" = "0" ] && [ "$prc" = "0" ]; then
+  outer_pass "TC-13.1: existing file → PASS=0 FAIL=0 RC=0 (silent guard, caller proceeds)"
+else
+  outer_fail "TC-13.1: expected PASS=0 FAIL=0 RC=0 got PASS=$pp FAIL=$pf RC=$prc"
+fi
+
+# TC-13.2: file missing → FAIL=1, helper returns 1, "file not found" diagnostic emitted
+missing_state=$(bash -c "
+  source '$HELPERS'
+  if assert_file_exists_or_fail 'missing-file' '/nonexistent/path/xyz' 2>&1; then
+    rc=0
+  else
+    rc=\$?
+  fi
+  echo \"PASS=\$PASS FAIL=\$FAIL RC=\$rc\"
+")
+mp=$(echo "$missing_state" | grep -oE 'PASS=[0-9]+' | tail -1 | cut -d= -f2)
+mf=$(echo "$missing_state" | grep -oE 'FAIL=[0-9]+' | tail -1 | cut -d= -f2)
+mrc=$(echo "$missing_state" | grep -oE 'RC=[0-9]+' | tail -1 | cut -d= -f2)
+if [ "$mp" = "0" ] && [ "$mf" = "1" ] && [ "$mrc" = "1" ] && echo "$missing_state" | grep -q 'file not found'; then
+  outer_pass "TC-13.2: missing file → FAIL=1 RC=1 + 'file not found' diagnostic (caller skips via || continue)"
+else
+  outer_fail "TC-13.2: expected PASS=0 FAIL=1 RC=1 + diagnostic, got PASS=$mp FAIL=$mf RC=$mrc state='$missing_state'"
+fi
+
 # === Summary ===
 echo
 echo "─── $(basename "$0") summary ──────────────────────"

--- a/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
@@ -44,14 +44,12 @@ reviewers=(
 
 for r in "${reviewers[@]}"; do
   f="$AGENTS_DIR/$r.md"
-  # File-existence guard (Issue #1048): assert_grep / assert_not_grep はそれぞれ独立に
-  # ファイル不在チェックを行うため、不在時には 1 reviewer = 2 fail message に膨張する。
-  # 原本 (PR #1046 refactor 前) の「1 reviewer = 1 fail」挙動を回復するため、loop の
-  # 先頭で存在確認し、不在なら 1 件 fail して後続 assertion を skip する。
-  if [ ! -f "$f" ]; then
-    fail "$r.md (file not found: $f)"
-    continue
-  fi
+  # File-existence guard (Issue #1048 → Issue #1051): assert_grep / assert_not_grep は
+  # それぞれ独立にファイル不在チェックを行うため、不在時には 1 reviewer = 2 fail message
+  # に膨張する。assert_file_exists_or_fail で 1 件 fail + caller の `|| continue` で
+  # 後続 assertion を skip し、原本の「1 reviewer = 1 fail」挙動を維持する
+  # (Issue #1051 で _test-helpers.sh 側に共通化済)。
+  assert_file_exists_or_fail "$r.md" "$f" || continue
   assert_grep "$r.md: 5-column header present" \
     "$f" \
     '\| 重要度 \| スコープ \| ファイル:行 \| 内容 \| 推奨対応 \|'


### PR DESCRIPTION
## 概要

T-1 (`reviewer-scope-column-symmetry.test.sh`) の loop 内 inline `[ ! -f "$f" ] && fail && continue` ボイラープレートを **`assert_file_exists_or_fail <label> <file>`** helper に共通化し、`_test-helpers.sh` に集約する。

将来 T-2/T-3/T-4 や他テストで同パターン (loop で同一ファイルへ複数 assertion を独立に呼び不在時 fail メッセージが膨張) が発生した際の予防策として helper を用意する。本 PR では T-1 のみに適用し、現状 inflation 構造を持たない T-2/T-3/T-4 は据え置く (Issue 本文の優先度「低」記述と Lean 順序方針に整合)。

## 関連 Issue

Closes #1051

関連:
- 元の局所修正 PR: #1050 (Issue #1048)
- _test-helpers.sh 進化系譜: #1046 (refactor) / #1049 (section-scoped helper)

## 変更内容

### `plugins/rite/hooks/tests/_test-helpers.sh`
- `assert_file_exists_or_fail <label> <file>` 関数を新規追加 (`assert_not_grep` の直後に配置)
- ヘッダーコメントの `Provided functions:` 一覧に追記
- Return code semantics: ファイル存在時 0 (silent guard、caller 続行) / 不在時 1 (`fail()` で 1 件 fail + diagnostic 出力)

### `plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh`
- inline `if [ ! -f "$f" ]; then fail ...; continue; fi` (T-1 line 47-54) を `assert_file_exists_or_fail "$r.md" "$f" || continue` に置換
- Issue #1048 の経緯コメントは保持し、`(Issue #1048 → Issue #1051)` 表記で履歴連続性を確保

### `plugins/rite/hooks/tests/_test-helpers.test.sh`
- TC-13.1: ファイル存在時 → `PASS=0 FAIL=0 RC=0` (silent guard contract)
- TC-13.2: ファイル不在時 → `FAIL=1 RC=1` + `file not found` diagnostic

## 検証

`bash plugins/rite/hooks/tests/run-tests.sh` で **全 59 テスト PASS** (exit 0)。

特に:
- `_test-helpers.test.sh` PASS=32 FAIL=0 (TC-13 含む)
- `reviewer-scope-column-symmetry.test.sh` PASS=28 FAIL=0 (新ヘルパー経由の existing-file パスを確認)

## Issue 受入条件

- [x] `_test-helpers.sh` に新規ヘルパー (Option A) を追加
- [x] `reviewer-scope-column-symmetry.test.sh` (T-1) の既存 guard を新ヘルパーに置換
- [x] 他テスト (T-2/T-3/T-4 / sentinel-visibility-rule.test.sh 等) で同様 inflation が起きうるパターンがあれば、それも新ヘルパーに統一 — 調査の結果、T-2/T-3/T-4 は単一固定ファイル (`_reviewer-base.md` / `severity-levels.md`) への assertion で loop iteration を持たないため inflation 構造に該当しない。Issue 本文の「現状 T-2/T-3/T-4 は構造的に inflation を起こさない」記述と整合し、本 PR では追加対応なし。
- [x] `_test-helpers.test.sh` に新ヘルパーのテストを追加 (TC-13)
- [x] 全件 PASS を維持 (run-tests.sh exit 0、59/59 passed)

## 設計判断

`assert_file_exists_or_fail` は **assertion ではなく pre-condition guard**: 成功時に `pass()` を呼ばずに silent return することで、保護対象の `assert_grep` / `assert_not_grep` の PASS カウントを不要に膨張させない。これは caller の `|| continue` で後続 assertion を skip させる usage と整合する。
