### PR TITLE
docs(tests): assert_file_exists_or_fail のヘッダー表記を意図が伝わる形に修正 (#1053)

### DIFF
--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -66,7 +66,7 @@
 #   assert <label> <expected> <actual>           # writes to stdout (via pass/fail)
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
-#   assert_file_exists_or_fail <label> <file>    # 1-fail file-existence guard for assertion-pair loops
+#   assert_file_exists_or_fail <label> <file>    # pre-condition guard (1 fail per missing file, caller skips via || continue)
 #   assert_grep_in_section <label> <file> <start_pattern> <end_pattern> <grep_pattern>
 #                                                # extract awk-range section + ERE grep with self-cleanup
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -66,7 +66,8 @@
 #   assert <label> <expected> <actual>           # writes to stdout (via pass/fail)
 #   assert_grep     <label> <file> <pattern>     # ERE, exits via fail() if not found
 #   assert_not_grep <label> <file> <pattern>     # ERE, exits via fail() if found
-#   assert_file_exists_or_fail <label> <file>    # pre-condition guard (1 fail per missing file, caller skips via || continue)
+#   assert_file_exists_or_fail <label> <file>    # pre-condition guard for assertion-pair loops
+#                                                # (1 fail per missing file; caller pattern: || continue)
 #   assert_grep_in_section <label> <file> <start_pattern> <end_pattern> <grep_pattern>
 #                                                # extract awk-range section + ERE grep with self-cleanup
 #   print_summary [test_name] [drift_hint_text]  # writes to stdout, returns 1 if FAIL > 0


### PR DESCRIPTION
## Summary

- `_test-helpers.sh` line 69 のヘッダーコメント「1-fail file-existence guard for assertion-pair loops」を `pre-condition guard (1 fail per missing file, caller skips via || continue)` に変更
- 「1-fail」が文脈なしでは意図が読み取れないという PR #1052 レビュー (code-quality-reviewer) の follow-up 推奨事項に対応
- caller pattern / return code の詳細は line 159-178 の関数 docstring 側で保持し、ヘッダー側は要約に専念という分担を維持

## Test plan

- [x] `bash plugins/rite/hooks/tests/run-tests.sh` で全テスト PASS を確認 (59/59 passed)
- [x] 関数定義 (line 179-187) や caller (`continue` を伴う assertion-pair loop) には変更なし

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)