### PR TITLE
test(reviewer): scope-column-symmetry test を skills/reviewers/* にも拡張

### DIFF
--- a/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# T-1 (Issue #1017): 13 reviewer agent すべて _reviewer-base.md を継承し scope 列を Output Format に持つ
+# T-1 (Issue #1017, extended in #1040): reviewer SoT 群すべてが 5 列形式の Output Format を持つ
 #
 # Verification:
-#   - _reviewer-base.md の Output Format テーブルが 5 列 (重要度|スコープ|ファイル:行|内容|推奨対応)
+#   - agents/_reviewer-base.md (Japanese 列名: 重要度|スコープ|ファイル:行|内容|推奨対応)
 #   - 13 reviewer agent (api/code-quality/database/dependencies/devops/error-handling/frontend/
-#     performance/prompt-engineer/security/tech-writer/test/type-design) すべての example 表が 5 列
+#     performance/prompt-engineer/security/tech-writer/test/type-design) すべての example 表
+#     (Japanese 列名)
+#   - skills/reviewers/{SKILL.md, references/output-format.md, references/finding-examples.md}
+#     (English 列名: Severity|Scope|File:Line|Issue|Recommendation) — Issue #1040 で拡張
 
 set -euo pipefail
 
@@ -56,6 +59,30 @@ for r in "${reviewers[@]}"; do
   assert_not_grep "$r.md: 4-column header drift (must not exist)" \
     "$f" \
     '\| 重要度 \| ファイル:行 \| 内容 \| 推奨対応 \|'
+done
+
+# 4. skills/reviewers/* の SoT ファイル群 (英語列名) が 5 列形式 を持つ
+#    Issue #1040: agent 側 (日本語列名) と同じ symmetric pair (5-column present /
+#    4-column drift NOT present) を skills 側 (英語列名) にも適用する。
+#    Asymmetric Fix Transcription (対称位置への伝播漏れ) を防ぐため、Issue #1037 で
+#    skills/reviewers/* を 4 列 → 5 列に同期した変更が将来 regression で 4 列に
+#    戻された場合に静かに通過しないよう保護する。
+SKILLS_DIR="$REPO_ROOT/plugins/rite/skills/reviewers"
+skills_files=(
+  "SKILL.md"
+  "references/output-format.md"
+  "references/finding-examples.md"
+)
+
+for sf in "${skills_files[@]}"; do
+  f="$SKILLS_DIR/$sf"
+  assert_file_exists_or_fail "skills/reviewers/$sf" "$f" || continue
+  assert_grep "skills/reviewers/$sf: 5-column header present (English)" \
+    "$f" \
+    '\| Severity \| Scope \| File:Line \| Issue \| Recommendation \|'
+  assert_not_grep "skills/reviewers/$sf: 4-column header drift (must not exist, English)" \
+    "$f" \
+    '\| Severity \| File:Line \| Issue \| Recommendation \|'
 done
 
 if ! print_summary "$(basename "$0")"; then


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh` のカバレッジを `plugins/rite/skills/reviewers/` 配下にも拡張し、Output Format schema 1.1.0 (5 列形式) の drift を構造的に予防する。

## 変更内容

既存の 13 reviewer agent loop (日本語列名) に加え、`skills/reviewers/` 配下 3 ファイル (英語列名) への symmetric assertion pair を追加:

- `plugins/rite/skills/reviewers/SKILL.md`
- `plugins/rite/skills/reviewers/references/output-format.md`
- `plugins/rite/skills/reviewers/references/finding-examples.md`

各ファイルに対し:
- 5 列ヘッダー (`| Severity | Scope | File:Line | Issue | Recommendation |`) が **含まれる**
- 旧 4 列ヘッダー (`| Severity | File:Line | Issue | Recommendation |`) が **含まれない**

## 背景

Issue #1037 / PR #1039 で `skills/reviewers/` 配下の 4 列 → 5 列同期 (計 8 箇所) を実施。しかし既存テストは `agents/*-reviewer.md` のみを対象としており、`skills/reviewers/*` への regression は検出されなかった。

prompt-engineer reviewer (PR #1039 推奨事項 #2) を起点として、Wiki 経験則 **Asymmetric Fix Transcription (対称位置への伝播漏れ)** に基づき symmetric な 2 assertion (present + NOT drift) を skills 側にも適用する。

## 検証

`bash plugins/rite/hooks/tests/reviewer-scope-column-symmetry.test.sh` 実行で 34/34 pass を確認 (既存 28 + 新規 6)。

## 関連 Issue

Closes #1040

関連: #1037, #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)
