### PR TITLE
feat(artifacts): schema 1.1.0 migration script + version-drift hook + scope-enum test

### DIFF
--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -111,7 +111,16 @@ if [ "${#TARGETS[@]}" -eq 0 ]; then
 fi
 
 DRIFT_COUNT_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
-trap 'rm -f "$DRIFT_COUNT_FILE"' EXIT
+# Pattern 6 (Issue #1021) で使用する stderr capture tempfile を script-level で宣言し、
+# 統合 trap で signal interrupt 時の orphan を防ぐ (F-08)。
+PATTERN6_STDERR=""
+_drift_check_cleanup() {
+  rm -f "${DRIFT_COUNT_FILE:-}" "${PATTERN6_STDERR:-}"
+}
+trap 'rc=$?; _drift_check_cleanup; exit $rc' EXIT
+trap '_drift_check_cleanup; exit 130' INT
+trap '_drift_check_cleanup; exit 143' TERM
+trap '_drift_check_cleanup; exit 129' HUP
 echo 0 > "$DRIFT_COUNT_FILE"
 report() {
   # report PATTERN FILE LINE MESSAGE
@@ -308,20 +317,23 @@ done
 # against the accept list ("1.0.0" / "1.0" / "1.1.0"). Runs once per invocation
 # (independent of the TARGETS loop above, since the JSON files are scanned by
 # the delegate). Captures stderr to surface drift details via report().
+#
+# Issue #1021 F-03/F-08 fix: delegate を 1 回のみ invoke し (旧実装は --quiet + verbose
+# の 2 回 invoke で I/O 2 倍化)、`|| true` で exit code を握りつぶす代わりに rc を明示
+# capture して unexpected exit code を log に残す。`PATTERN6_STDERR` は script-level
+# 変数で trap (上記) が EXIT/INT/TERM/HUP 全てで cleanup する。
 check_pattern_6() {
   local checker_script="$REPO_ROOT/plugins/rite/hooks/scripts/review-schema-version-check.sh"
   if [ ! -x "$checker_script" ]; then
     log "Pattern 6 skipped: review-schema-version-check.sh not found / not executable"
     return 0
   fi
-  local stderr_capture
-  stderr_capture=$(mktemp) || { log "Pattern 6 skipped: mktemp failed"; return 0; }
+  PATTERN6_STDERR=$(mktemp) || { log "Pattern 6 skipped: mktemp failed"; return 0; }
   local rc=0
-  bash "$checker_script" --all --repo-root "$REPO_ROOT" --quiet 2>"$stderr_capture" || rc=$?
+  # 1 回のみ invoke: --quiet なしで stderr に drift 行を出力させ、後段で parse する。
+  bash "$checker_script" --all --repo-root "$REPO_ROOT" 2>"$PATTERN6_STDERR" || rc=$?
   if [ "$rc" -eq 1 ]; then
-    # Re-run without --quiet to surface drift details in our own report stream.
-    # The delegate emits one `[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=...; schema_version=...` line per drift.
-    bash "$checker_script" --all --repo-root "$REPO_ROOT" 2>>"$stderr_capture" || true
+    # rc=1: drift detected. stderr の `[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1` 行を parse。
     while IFS= read -r drift_line; do
       [ -z "$drift_line" ] && continue
       # Extract file path from `file=...; schema_version=...` for cleaner reporting
@@ -330,11 +342,17 @@ check_pattern_6() {
       if [ -n "$drift_file" ]; then
         report 6 "$drift_file" 0 "schema_version='$drift_ver' outside accept list (1.0.0 / 1.0 / 1.1.0)"
       fi
-    done < <(grep -E '^\[CONTEXT\] REVIEW_SCHEMA_VERSION_DRIFT=1' "$stderr_capture" 2>/dev/null)
+    done < <(grep -E '^\[CONTEXT\] REVIEW_SCHEMA_VERSION_DRIFT=1' "$PATTERN6_STDERR")
   elif [ "$rc" -ne 0 ]; then
-    log "Pattern 6 delegate exited with unexpected code $rc; skipping"
+    # rc != 0/1 (delegate invocation error / jq missing 等): silent に握りつぶさず log + stderr 内容を表示
+    log "Pattern 6 delegate exited with unexpected code $rc; check delegate diagnostics:"
+    if [ -s "$PATTERN6_STDERR" ]; then
+      head -5 "$PATTERN6_STDERR" | sed 's/^/    /' >&2
+    fi
   fi
-  rm -f "$stderr_capture"
+  # trap が cleanup を保証するが、明示 reset で次回 invocation 時の stale 参照を防ぐ
+  rm -f "$PATTERN6_STDERR"
+  PATTERN6_STDERR=""
 }
 
 run_pattern 6 && check_pattern_6

--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -13,6 +13,9 @@
 #   3. if-wrap drift            — `cat <<'EOF' > "$tmpfile"` not wrapped by `if !`
 #   4. anchor drift             — markdown `[text](path#anchor)` resolving to non-existent heading
 #   5. eval-table list drift    — evaluation-order table parenthesized list vs emit
+#   6. review-result schema_version drift — `.rite/review-results/*.json` whose
+#      `.schema_version` is outside the accept list (delegates to
+#       `review-schema-version-check.sh`; Issue #1021)
 #
 # Usage:
 #   distributed-fix-drift-check.sh [--all] [--target FILE]... [--pattern N]
@@ -42,7 +45,7 @@ Usage: distributed-fix-drift-check.sh [options]
 Options:
   --all              Check the default target set (fix.md, review.md, tech-writer.md)
   --target FILE      Check FILE (repeatable). Path relative to repo root.
-  --pattern N        Only run pattern N (1-5). Default: all patterns.
+  --pattern N        Only run pattern N (1-6). Default: all patterns.
   --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
   --quiet            Suppress per-finding output (still exit non-zero on drift)
   -h, --help         Show this help
@@ -98,9 +101,13 @@ if [ "${#TARGETS[@]}" -gt 0 ]; then
 fi
 
 if [ "${#TARGETS[@]}" -eq 0 ]; then
-  echo "ERROR: no targets specified (use --all or --target FILE)" >&2
-  usage >&2
-  exit 2
+  # Pattern 6 (review-result JSON drift) scans .rite/review-results/ on its own
+  # and does not consume the TARGETS list. Allow `--pattern 6` without targets.
+  if [ "$PATTERN_FILTER" != "6" ]; then
+    echo "ERROR: no targets specified (use --all or --target FILE)" >&2
+    usage >&2
+    exit 2
+  fi
 fi
 
 DRIFT_COUNT_FILE="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
@@ -295,6 +302,42 @@ for file in "${TARGETS[@]}"; do
   run_pattern 4 && check_pattern_4 "$file"
   run_pattern 5 && check_pattern_5 "$file"
 done
+
+# ----- Pattern 6: review-result schema_version drift (Issue #1021) -----------
+# Delegates to review-schema-version-check.sh, which checks .rite/review-results/*.json
+# against the accept list ("1.0.0" / "1.0" / "1.1.0"). Runs once per invocation
+# (independent of the TARGETS loop above, since the JSON files are scanned by
+# the delegate). Captures stderr to surface drift details via report().
+check_pattern_6() {
+  local checker_script="$REPO_ROOT/plugins/rite/hooks/scripts/review-schema-version-check.sh"
+  if [ ! -x "$checker_script" ]; then
+    log "Pattern 6 skipped: review-schema-version-check.sh not found / not executable"
+    return 0
+  fi
+  local stderr_capture
+  stderr_capture=$(mktemp) || { log "Pattern 6 skipped: mktemp failed"; return 0; }
+  local rc=0
+  bash "$checker_script" --all --repo-root "$REPO_ROOT" --quiet 2>"$stderr_capture" || rc=$?
+  if [ "$rc" -eq 1 ]; then
+    # Re-run without --quiet to surface drift details in our own report stream.
+    # The delegate emits one `[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=...; schema_version=...` line per drift.
+    bash "$checker_script" --all --repo-root "$REPO_ROOT" 2>>"$stderr_capture" || true
+    while IFS= read -r drift_line; do
+      [ -z "$drift_line" ] && continue
+      # Extract file path from `file=...; schema_version=...` for cleaner reporting
+      drift_file=$(printf '%s' "$drift_line" | sed -nE 's/.*file=([^;]+); schema_version=.*/\1/p')
+      drift_ver=$(printf '%s'  "$drift_line" | sed -nE 's/.*schema_version=(.+)$/\1/p')
+      if [ -n "$drift_file" ]; then
+        report 6 "$drift_file" 0 "schema_version='$drift_ver' outside accept list (1.0.0 / 1.0 / 1.1.0)"
+      fi
+    done < <(grep -E '^\[CONTEXT\] REVIEW_SCHEMA_VERSION_DRIFT=1' "$stderr_capture" 2>/dev/null)
+  elif [ "$rc" -ne 0 ]; then
+    log "Pattern 6 delegate exited with unexpected code $rc; skipping"
+  fi
+  rm -f "$stderr_capture"
+}
+
+run_pattern 6 && check_pattern_6
 
 DRIFT_COUNT=$(<"$DRIFT_COUNT_FILE")
 if [ "$DRIFT_COUNT" -gt 0 ]; then

--- a/plugins/rite/hooks/scripts/review-schema-version-check.sh
+++ b/plugins/rite/hooks/scripts/review-schema-version-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# review-schema-version-check.sh
+#
+# Detect schema_version drift in review-result JSON files. Issue #1021 (Epic #1015).
+#
+# Accept list (canonical SoT: review-result-schema.md §Schema Version):
+#   "1.0.0" — canonical 1.0
+#   "1.0"   — legacy semver MAJOR.MINOR alias (accepted until v2.0)
+#   "1.1.0" — canonical 1.1
+#
+# Any other value (including missing schema_version) is reported as drift via:
+#   [CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=<path>; schema_version=<value>
+#
+# Invoked from `distributed-fix-drift-check.sh` Pattern 6, and can be run
+# standalone for ad-hoc inspection.
+#
+# Usage:
+#   review-schema-version-check.sh --target FILE [--target FILE]...
+#   review-schema-version-check.sh --all              # scan .rite/review-results/*.json
+#   REPO_ROOT="/path/to/repo" review-schema-version-check.sh --all
+#
+# Exit codes:
+#   0 — all targets within accept list (or no targets)
+#   1 — drift detected on at least one target
+#   2 — invocation error (bad args / jq missing)
+
+set -uo pipefail
+
+ACCEPT_LIST=("1.0.0" "1.0" "1.1.0")
+
+usage() {
+  cat <<'EOF'
+Usage: review-schema-version-check.sh [options]
+
+Options:
+  --all              Scan .rite/review-results/*.json in REPO_ROOT
+  --target FILE      Check FILE (repeatable). Path may be absolute or relative.
+  --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
+  --quiet            Suppress per-file drift output (exit code still reflects state)
+  -h, --help         Show this help
+
+Exit: 0 = clean, 1 = drift detected, 2 = invocation error.
+EOF
+}
+
+REPO_ROOT=""
+QUIET=0
+declare -a TARGETS=()
+USE_ALL=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --all) USE_ALL=1; shift ;;
+    --target)
+      if [ -z "${2:-}" ]; then
+        echo "ERROR: --target requires a value" >&2
+        exit 2
+      fi
+      TARGETS+=("$2"); shift 2 ;;
+    --repo-root)
+      if [ -z "${2:-}" ]; then
+        echo "ERROR: --repo-root requires a value" >&2
+        exit 2
+      fi
+      REPO_ROOT="$2"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[rite] ERROR: jq is required for review-schema-version-check.sh but was not found in PATH" >&2
+  exit 2
+fi
+
+if [ "$USE_ALL" -eq 0 ] && [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "ERROR: no targets specified (use --all or --target FILE)" >&2
+  usage >&2
+  exit 2
+fi
+
+# Resolve REPO_ROOT only when --all is used (per-target paths are resolved as-is)
+if [ "$USE_ALL" -eq 1 ]; then
+  REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+  if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
+    echo "ERROR: REPO_ROOT could not be resolved (not in a git repo and --repo-root unset)" >&2
+    exit 2
+  fi
+  REVIEW_DIR="$REPO_ROOT/.rite/review-results"
+  if [ ! -d "$REVIEW_DIR" ]; then
+    # No review results yet — clean.
+    exit 0
+  fi
+  while IFS= read -r -d '' f; do
+    TARGETS+=("$f")
+  done < <(find "$REVIEW_DIR" -maxdepth 1 -type f -name '*.json' -print0 2>/dev/null)
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  # Nothing to check — clean.
+  exit 0
+fi
+
+DRIFT_COUNT=0
+
+is_in_accept_list() {
+  local v="$1"
+  local accepted
+  for accepted in "${ACCEPT_LIST[@]}"; do
+    if [ "$v" = "$accepted" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+for file in "${TARGETS[@]}"; do
+  if [ ! -f "$file" ]; then
+    [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=__missing_file__" >&2
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    continue
+  fi
+
+  if ! jq empty "$file" 2>/dev/null; then
+    [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=__invalid_json__" >&2
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    continue
+  fi
+
+  version=$(jq -r '.schema_version // "__missing__"' "$file" 2>/dev/null) || version="__missing__"
+
+  if is_in_accept_list "$version"; then
+    continue
+  fi
+
+  [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=$version" >&2
+  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+done
+
+if [ "$DRIFT_COUNT" -gt 0 ]; then
+  [ "$QUIET" -eq 0 ] && echo "[rite] review-schema-version-check: $DRIFT_COUNT drift(s) detected (accept list: ${ACCEPT_LIST[*]})" >&2
+  exit 1
+fi
+
+exit 0

--- a/plugins/rite/hooks/scripts/review-schema-version-check.sh
+++ b/plugins/rite/hooks/scripts/review-schema-version-check.sh
@@ -119,16 +119,24 @@ is_in_accept_list() {
   return 1
 }
 
+# Emit drift marker (DRY helper — Issue #1021 F-11):
+# 3 drift reason (missing file / invalid JSON / version mismatch) で同形式の
+# `[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=...; schema_version=...` を emit する。
+emit_drift() {
+  local f="$1"
+  local v="$2"
+  [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$f; schema_version=$v" >&2
+  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+}
+
 for file in "${TARGETS[@]}"; do
   if [ ! -f "$file" ]; then
-    [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=__missing_file__" >&2
-    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    emit_drift "$file" "__missing_file__"
     continue
   fi
 
   if ! jq empty "$file" 2>/dev/null; then
-    [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=__invalid_json__" >&2
-    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    emit_drift "$file" "__invalid_json__"
     continue
   fi
 
@@ -138,8 +146,7 @@ for file in "${TARGETS[@]}"; do
     continue
   fi
 
-  [ "$QUIET" -eq 0 ] && echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=$file; schema_version=$version" >&2
-  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+  emit_drift "$file" "$version"
 done
 
 if [ "$DRIFT_COUNT" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/scope-enum-check.test.sh
+++ b/plugins/rite/hooks/tests/scope-enum-check.test.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Tests for review-result schema 1.1.0 scope enum / cross-field invariants
+# Issue #1021 (Epic #1015 — schema 1.0 → 1.1.0 evolution).
+#
+# Test cases (AC-4):
+#   T-1: basic — scope ∈ {current-pr, follow-up, nit-noted} valid
+#   T-2: CRITICAL × nit-noted FAIL invariant (review-result-schema invariant #4)
+#   T-3: LOW × current-pr → migration default mapping demotes to nit-noted
+#        (migrate-review-state-to-1.1.sh fills scope from severity when scope absent;
+#         LOW severity yields nit-noted per default-mapping table)
+#   T-4: pre_existing=false × nit-noted auto-correct (invariant #5)
+#
+# Usage: bash plugins/rite/hooks/tests/scope-enum-check.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+MIGRATE_SCRIPT="$REPO_ROOT/plugins/rite/scripts/migrate-review-state-to-1.1.sh"
+
+# Sanity: required tooling
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for scope-enum-check.test.sh" >&2
+  exit 2
+fi
+if [ ! -x "$MIGRATE_SCRIPT" ]; then
+  echo "ERROR: migrate-review-state-to-1.1.sh not found / not executable at $MIGRATE_SCRIPT" >&2
+  exit 2
+fi
+
+# Per-test sandbox
+sandbox=$(mktemp -d) || { echo "ERROR: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$sandbox"' EXIT
+
+mkdir -p "$sandbox/.rite/review-results"
+mkdir -p "$sandbox/.rite/state"
+
+# ------------------------------------------------------------------
+# T-1: basic scope enum check (current-pr / follow-up / nit-noted)
+# ------------------------------------------------------------------
+echo "=== T-1: basic scope enum ==="
+T1_FILE="$sandbox/T1.json"
+cat > "$T1_FILE" <<'EOF'
+{
+  "schema_version": "1.1.0",
+  "pr_number": 1,
+  "timestamp": "2026-01-01T00:00:00+09:00",
+  "commit_sha": "abc",
+  "overall_assessment": "fix-needed",
+  "findings": [
+    { "id": "F-01", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "HIGH",   "scope": "current-pr", "pre_existing": false, "file": "a.ts", "line": 1, "description": "d", "suggestion": "s", "status": "open" },
+    { "id": "F-02", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "MEDIUM", "scope": "follow-up",  "pre_existing": false, "file": "b.ts", "line": 2, "description": "d", "suggestion": "s", "status": "deferred" },
+    { "id": "F-03", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "LOW",    "scope": "nit-noted",  "pre_existing": true,  "nit_reason": "stylistic", "file": "c.ts", "line": 3, "description": "d", "suggestion": "s", "status": "acknowledged" }
+  ]
+}
+EOF
+
+T1_INVALID_SCOPE_COUNT=$(jq '[.findings[] | select(.scope != "current-pr" and .scope != "follow-up" and .scope != "nit-noted")] | length' "$T1_FILE")
+assert "T-1 all scope values are valid enum members" "0" "$T1_INVALID_SCOPE_COUNT"
+
+# ------------------------------------------------------------------
+# T-2: CRITICAL/HIGH × nit-noted FAIL invariant (#4)
+# ------------------------------------------------------------------
+echo "=== T-2: CRITICAL × nit-noted FAIL invariant ==="
+T2_FILE="$sandbox/T2.json"
+cat > "$T2_FILE" <<'EOF'
+{
+  "schema_version": "1.1.0",
+  "pr_number": 2,
+  "timestamp": "2026-01-01T00:00:00+09:00",
+  "commit_sha": "abc",
+  "overall_assessment": "fix-needed",
+  "findings": [
+    { "id": "F-01", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "CRITICAL", "scope": "nit-noted", "pre_existing": false, "file": "a.ts", "line": 1, "description": "d", "suggestion": "s", "status": "open" }
+  ]
+}
+EOF
+
+# Canonical jq from schema doc invariant #4:
+T2_VIOLATIONS=$(jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length' "$T2_FILE")
+# Expect at least 1 violation detected for FAIL invariant
+if [ "$T2_VIOLATIONS" -ge 1 ]; then
+  pass "T-2 invariant #4 detects CRITICAL × nit-noted (violations=$T2_VIOLATIONS)"
+else
+  fail "T-2 invariant #4 missed CRITICAL × nit-noted (violations=$T2_VIOLATIONS, expected ≥ 1)"
+fi
+
+# Negative confirm: same JSON with severity HIGH should also trigger
+T2B_FILE="$sandbox/T2b.json"
+jq '.findings[0].severity = "HIGH"' "$T2_FILE" > "$T2B_FILE"
+T2B_VIOLATIONS=$(jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length' "$T2B_FILE")
+if [ "$T2B_VIOLATIONS" -ge 1 ]; then
+  pass "T-2 invariant #4 detects HIGH × nit-noted (violations=$T2B_VIOLATIONS)"
+else
+  fail "T-2 invariant #4 missed HIGH × nit-noted (violations=$T2B_VIOLATIONS, expected ≥ 1)"
+fi
+
+# ------------------------------------------------------------------
+# T-3: LOW × current-pr → migration default mapping demotes to nit-noted
+#      (input is 1.0 JSON without scope field; migration fills scope from
+#       severity; LOW → nit-noted per schema default-mapping table)
+# ------------------------------------------------------------------
+echo "=== T-3: LOW default mapping → nit-noted ==="
+T3_DIR=$(mktemp -d) || { fail "T-3 mktemp failed"; }
+mkdir -p "$T3_DIR/.rite/review-results"
+
+# 1.0 JSON (no scope, no pre_existing) with LOW finding
+cat > "$T3_DIR/.rite/review-results/300-20260101000000.json" <<'EOF'
+{
+  "schema_version": "1.0.0",
+  "pr_number": 300,
+  "timestamp": "2026-01-01T00:00:00+09:00",
+  "commit_sha": "abc",
+  "overall_assessment": "fix-needed",
+  "findings": [
+    { "id": "F-01", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "LOW", "file": "a.ts", "line": 1, "description": "stylistic nit", "suggestion": "ignore", "status": "open" }
+  ]
+}
+EOF
+
+REPO_ROOT="$T3_DIR" bash "$MIGRATE_SCRIPT" >/dev/null 2>&1
+T3_RC=$?
+if [ "$T3_RC" -ne 0 ]; then
+  fail "T-3 migration script exit code (expected 0, got $T3_RC)"
+fi
+
+T3_SCOPE=$(jq -r '.findings[0].scope' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_SCOPE="<error>"
+assert "T-3 LOW finding scope after migration" "nit-noted" "$T3_SCOPE"
+
+T3_VER=$(jq -r '.schema_version' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_VER="<error>"
+assert "T-3 schema_version bumped to 1.1.0" "1.1.0" "$T3_VER"
+
+T3_PE=$(jq -r '.findings[0].pre_existing' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_PE="<error>"
+assert "T-3 pre_existing initialized to false" "false" "$T3_PE"
+
+rm -rf "$T3_DIR"
+
+# ------------------------------------------------------------------
+# T-4: pre_existing=false × nit-noted auto-correct (invariant #5)
+# ------------------------------------------------------------------
+echo "=== T-4: pre_existing=false × nit-noted auto-correct ==="
+T4_FILE="$sandbox/T4.json"
+cat > "$T4_FILE" <<'EOF'
+{
+  "schema_version": "1.1.0",
+  "pr_number": 4,
+  "timestamp": "2026-01-01T00:00:00+09:00",
+  "commit_sha": "abc",
+  "overall_assessment": "fix-needed",
+  "findings": [
+    { "id": "F-01", "reviewer": "code-quality-reviewer", "category": "code_quality", "severity": "MEDIUM", "scope": "nit-noted", "pre_existing": false, "nit_reason": "should-be-current-pr", "file": "a.ts", "line": 1, "description": "d", "suggestion": "s", "status": "open" }
+  ]
+}
+EOF
+
+# Canonical jq mutation from schema doc invariant #5:
+T4_CORRECTED=$(jq '(.findings[] | select(.pre_existing == false and .scope == "nit-noted") | .scope) |= "current-pr"' "$T4_FILE")
+T4_NEW_SCOPE=$(echo "$T4_CORRECTED" | jq -r '.findings[0].scope')
+assert "T-4 auto-correct rewrites scope to current-pr" "current-pr" "$T4_NEW_SCOPE"
+
+# Verify invariant #5 detector: count violations BEFORE correction
+T4_PRE_VIOLATIONS=$(jq '[.findings[] | select(.pre_existing == false and .scope == "nit-noted")] | length' "$T4_FILE")
+if [ "$T4_PRE_VIOLATIONS" -ge 1 ]; then
+  pass "T-4 invariant #5 detects pre_existing=false × nit-noted before auto-correct (violations=$T4_PRE_VIOLATIONS)"
+else
+  fail "T-4 invariant #5 missed pre_existing=false × nit-noted (violations=$T4_PRE_VIOLATIONS, expected ≥ 1)"
+fi
+
+# Verify invariant #5 NOT triggered when pre_existing=true (legitimate nit)
+T4B_FILE="$sandbox/T4b.json"
+jq '.findings[0].pre_existing = true' "$T4_FILE" > "$T4B_FILE"
+T4B_VIOLATIONS=$(jq '[.findings[] | select(.pre_existing == false and .scope == "nit-noted")] | length' "$T4B_FILE")
+assert "T-4 invariant #5 does NOT fire when pre_existing=true" "0" "$T4B_VIOLATIONS"
+
+# ------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------
+if ! print_summary "$(basename "$0")" "Hint: scope enum / invariants are defined in plugins/rite/references/review-result-schema.md"; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/scope-enum-check.test.sh
+++ b/plugins/rite/hooks/tests/scope-enum-check.test.sh
@@ -3,19 +3,23 @@
 # Issue #1021 (Epic #1015 — schema 1.0 → 1.1.0 evolution).
 #
 # Test cases (AC-4):
-#   T-1: basic — scope ∈ {current-pr, follow-up, nit-noted} valid
-#   T-2: CRITICAL × nit-noted FAIL invariant (review-result-schema invariant #4)
+#   T-1: basic — scope ∈ {current-pr, follow-up, nit-noted} valid (+MEDIUM × nit-noted negative)
+#   T-2: CRITICAL × nit-noted / HIGH × nit-noted FAIL invariant (review-result-schema invariant #4)
+#        + MEDIUM × nit-noted negative case (selector が CRITICAL/HIGH 限定であることを fix)
 #   T-3: LOW × current-pr → migration default mapping demotes to nit-noted
 #        (migrate-review-state-to-1.1.sh fills scope from severity when scope absent;
 #         LOW severity yields nit-noted per default-mapping table)
 #   T-4: pre_existing=false × nit-noted auto-correct (invariant #5)
+#        — schema-level contract test (canonical jq mutation の動作のみを assert する。
+#         fix.md Phase 1.2.0 の read-side integration は本 test で検証しない。
+#         read-side との bit-exact 一致は別 E2E test の責務 [follow-up scope])
 #
 # Usage: bash plugins/rite/hooks/tests/scope-enum-check.test.sh
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/_test-helpers.sh"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 MIGRATE_SCRIPT="$REPO_ROOT/plugins/rite/scripts/migrate-review-state-to-1.1.sh"
 
 # Sanity: required tooling
@@ -28,9 +32,22 @@ if [ ! -x "$MIGRATE_SCRIPT" ]; then
   exit 2
 fi
 
-# Per-test sandbox
+# Sandbox + cleanup_dirs array for proper trap-based cleanup (Issue #1021 F-06)
+# Use specific path tracking instead of relying on $sandbox single rm -rf.
+declare -a cleanup_dirs=()
+_test_cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+}
+trap '_test_cleanup' EXIT
+trap '_test_cleanup; exit 130' INT
+trap '_test_cleanup; exit 143' TERM
+trap '_test_cleanup; exit 129' HUP
+
 sandbox=$(mktemp -d) || { echo "ERROR: mktemp failed" >&2; exit 2; }
-trap 'rm -rf "$sandbox"' EXIT
+cleanup_dirs+=("$sandbox")
 
 mkdir -p "$sandbox/.rite/review-results"
 mkdir -p "$sandbox/.rite/state"
@@ -60,6 +77,7 @@ assert "T-1 all scope values are valid enum members" "0" "$T1_INVALID_SCOPE_COUN
 
 # ------------------------------------------------------------------
 # T-2: CRITICAL/HIGH × nit-noted FAIL invariant (#4)
+#      + MEDIUM × nit-noted negative case (Issue #1021 F-04 — symmetry with T-4)
 # ------------------------------------------------------------------
 echo "=== T-2: CRITICAL × nit-noted FAIL invariant ==="
 T2_FILE="$sandbox/T2.json"
@@ -78,7 +96,6 @@ EOF
 
 # Canonical jq from schema doc invariant #4:
 T2_VIOLATIONS=$(jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length' "$T2_FILE")
-# Expect at least 1 violation detected for FAIL invariant
 if [ "$T2_VIOLATIONS" -ge 1 ]; then
   pass "T-2 invariant #4 detects CRITICAL × nit-noted (violations=$T2_VIOLATIONS)"
 else
@@ -95,13 +112,22 @@ else
   fail "T-2 invariant #4 missed HIGH × nit-noted (violations=$T2B_VIOLATIONS, expected ≥ 1)"
 fi
 
+# Negative case: MEDIUM × nit-noted should NOT trigger (Issue #1021 F-04)
+# selector が CRITICAL/HIGH 限定であることを verify。selector が将来 MEDIUM を含むよう
+# 誤って変更されても検出できるようにする (T-4 の pre_existing=true negative pair と対称)。
+T2C_FILE="$sandbox/T2c.json"
+jq '.findings[0].severity = "MEDIUM"' "$T2_FILE" > "$T2C_FILE"
+T2C_VIOLATIONS=$(jq '[.findings[] | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length' "$T2C_FILE")
+assert "T-2 invariant #4 does NOT fire on MEDIUM × nit-noted" "0" "$T2C_VIOLATIONS"
+
 # ------------------------------------------------------------------
 # T-3: LOW × current-pr → migration default mapping demotes to nit-noted
-#      (input is 1.0 JSON without scope field; migration fills scope from
-#       severity; LOW → nit-noted per schema default-mapping table)
+#      Input is 1.0 JSON without scope field; migration fills scope from severity;
+#      LOW → nit-noted per schema default-mapping table.
 # ------------------------------------------------------------------
 echo "=== T-3: LOW default mapping → nit-noted ==="
-T3_DIR=$(mktemp -d) || { fail "T-3 mktemp failed"; }
+T3_DIR=$(mktemp -d) || { echo "ERROR: T-3 mktemp -d failed" >&2; exit 2; }
+cleanup_dirs+=("$T3_DIR")
 mkdir -p "$T3_DIR/.rite/review-results"
 
 # 1.0 JSON (no scope, no pre_existing) with LOW finding
@@ -118,27 +144,57 @@ cat > "$T3_DIR/.rite/review-results/300-20260101000000.json" <<'EOF'
 }
 EOF
 
-REPO_ROOT="$T3_DIR" bash "$MIGRATE_SCRIPT" >/dev/null 2>&1
-T3_RC=$?
-if [ "$T3_RC" -ne 0 ]; then
-  fail "T-3 migration script exit code (expected 0, got $T3_RC)"
+# Capture stderr for diagnostic purposes (Issue #1021 F-14)
+T3_STDERR=$(mktemp /tmp/rite-scope-enum-t3-stderr-XXXXXX) || { fail "T-3 stderr tmpfile mktemp failed"; T3_STDERR=""; }
+T3_RC=0
+if [ -n "$T3_STDERR" ]; then
+  REPO_ROOT="$T3_DIR" bash "$MIGRATE_SCRIPT" >/dev/null 2>"$T3_STDERR"
+  T3_RC=$?
+else
+  REPO_ROOT="$T3_DIR" bash "$MIGRATE_SCRIPT" >/dev/null 2>&1
+  T3_RC=$?
 fi
 
-T3_SCOPE=$(jq -r '.findings[0].scope' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_SCOPE="<error>"
-assert "T-3 LOW finding scope after migration" "nit-noted" "$T3_SCOPE"
+# Issue #1021 F-05: migration failure 時は後続 assert を short-circuit する
+if [ "$T3_RC" -ne 0 ]; then
+  if [ -n "$T3_STDERR" ] && [ -s "$T3_STDERR" ]; then
+    fail "T-3 migration script exit code (expected 0, got $T3_RC). stderr: $(head -5 "$T3_STDERR" | tr '\n' ' ')"
+  else
+    fail "T-3 migration script exit code (expected 0, got $T3_RC)"
+  fi
+else
+  T3_SCOPE=$(jq -r '.findings[0].scope' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_SCOPE="<error>"
+  assert "T-3 LOW finding scope after migration" "nit-noted" "$T3_SCOPE"
 
-T3_VER=$(jq -r '.schema_version' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_VER="<error>"
-assert "T-3 schema_version bumped to 1.1.0" "1.1.0" "$T3_VER"
+  T3_VER=$(jq -r '.schema_version' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_VER="<error>"
+  assert "T-3 schema_version bumped to 1.1.0" "1.1.0" "$T3_VER"
 
-T3_PE=$(jq -r '.findings[0].pre_existing' "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_PE="<error>"
-assert "T-3 pre_existing initialized to false" "false" "$T3_PE"
+  # Issue #1021 F-01: migration script は pre_existing=false 初期化を行わない (schema doc canonical)。
+  # field 不在 (`null`) を期待する。jq の `// "<absent>"` で field 不在を sentinel 化して assert。
+  T3_PE=$(jq -r '.findings[0] | if has("pre_existing") then (.pre_existing | tostring) else "<absent>" end' \
+    "$T3_DIR/.rite/review-results/300-20260101000000.json" 2>/dev/null) || T3_PE="<error>"
+  assert "T-3 pre_existing field NOT added (schema doc canonical default mapping = 適用しない)" "<absent>" "$T3_PE"
 
-rm -rf "$T3_DIR"
+  # accepted-fingerprints state file 初期化も verify (Issue #1021 F-06 related — migration の完全性)
+  T3_STATE_FILE="$T3_DIR/.rite/state/accepted-fingerprints-300.txt"
+  if [ -f "$T3_STATE_FILE" ]; then
+    pass "T-3 accepted-fingerprints state file initialized for PR #300"
+  else
+    fail "T-3 accepted-fingerprints state file NOT created: $T3_STATE_FILE"
+  fi
+fi
+[ -n "$T3_STDERR" ] && rm -f "$T3_STDERR"
 
 # ------------------------------------------------------------------
 # T-4: pre_existing=false × nit-noted auto-correct (invariant #5)
+#      — schema-level contract test for canonical jq mutation
 # ------------------------------------------------------------------
-echo "=== T-4: pre_existing=false × nit-noted auto-correct ==="
+echo "=== T-4: pre_existing=false × nit-noted auto-correct (schema-level contract test) ==="
+# Schema-level contract test: This test verifies the canonical jq expression from
+# review-result-schema.md invariant #5 in isolation. It does NOT verify the actual
+# read-side integration in fix.md Phase 1.2.0. If fix.md ever drifts from this
+# canonical jq expression, T-4 alone would not catch it — that bit-exact alignment
+# is the responsibility of a separate E2E test (follow-up scope, Issue #1021 F-12).
 T4_FILE="$sandbox/T4.json"
 cat > "$T4_FILE" <<'EOF'
 {

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# migrate-review-state-to-1.1.sh
+#
+# Migrate review-result JSON files in `.rite/review-results/` from schema
+# 1.0 / 1.0.0 / missing to canonical 1.1.0. Issue #1021 (Epic #1015).
+#
+# Migration adds the two fields introduced in 1.1.0 (Issue #1016):
+#   - findings[].scope        — default mapping from severity
+#                                 (CRITICAL/HIGH/MEDIUM → current-pr,
+#                                  LOW-MEDIUM/LOW       → nit-noted)
+#   - findings[].pre_existing — initialized to false (revert-test result
+#                                 unknown for migrated findings; reviewer
+#                                 must update manually if applicable)
+#
+# Additionally initializes per-PR accepted-fingerprints state files
+# (`.rite/state/accepted-fingerprints-{pr}.txt`) as empty files when missing.
+#
+# Idempotency: jq `has(...)` guards ensure repeated runs are no-ops once a
+# file is already 1.1.0. Files with schema_version already 1.1.0 are skipped.
+#
+# Usage:
+#   migrate-review-state-to-1.1.sh                     # apply (default REPO_ROOT)
+#   migrate-review-state-to-1.1.sh --dry-run           # detect only
+#   REPO_ROOT="/path/to/repo" migrate-review-state-to-1.1.sh
+#
+# Exit codes:
+#   0 — migration completed (including no-op / dry-run / empty target set)
+#   1 — migration failed (atomic write or jq parse error on a file)
+
+set -uo pipefail
+
+# --- Argument parsing ---
+DRY_RUN=false
+case "${1:-}" in
+  --dry-run) DRY_RUN=true ;;
+  '') ;;
+  *) echo "ERROR: unknown argument: $1 (expected: --dry-run)" >&2; exit 1 ;;
+esac
+
+# --- REPO_ROOT resolution ---
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
+  echo "ERROR: REPO_ROOT could not be resolved (not in a git repo and REPO_ROOT env unset)" >&2
+  exit 1
+fi
+
+REVIEW_DIR="$REPO_ROOT/.rite/review-results"
+STATE_DIR="$REPO_ROOT/.rite/state"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[rite] ERROR: jq is required for migrate-review-state-to-1.1.sh but was not found in PATH" >&2
+  exit 1
+fi
+
+# --- Helper: severity → default scope mapping (1.1.0 schema doc Table) ---
+# CRITICAL / HIGH / MEDIUM → current-pr
+# LOW-MEDIUM / LOW         → nit-noted
+# unknown severity         → current-pr (conservative — surface in fix loop)
+DEFAULT_SCOPE_FILTER='
+  if .severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM" then "current-pr"
+  elif .severity == "LOW-MEDIUM" or .severity == "LOW" then "nit-noted"
+  else "current-pr"
+  end
+'
+
+# --- Migration filter: only fills missing fields (idempotent) ---
+# Outer guard: if schema_version already "1.1.0", emit unchanged.
+# Otherwise: bump schema_version to "1.1.0", and per-finding fill scope /
+# pre_existing only when absent (has(...) guard preserves explicit values).
+MIGRATE_FILTER='
+  if (.schema_version // "") == "1.1.0" then .
+  else
+    .schema_version = "1.1.0"
+    | .findings |= map(
+        (if has("scope") then . else .scope = ('"$DEFAULT_SCOPE_FILTER"') end)
+        | (if has("pre_existing") then . else .pre_existing = false end)
+      )
+  end
+'
+
+MIGRATED_COUNT=0
+SKIPPED_COUNT=0
+FAILED_COUNT=0
+FAILED_FILES=()
+
+migrate_file() {
+  local file="$1"
+  local tmp parsed_ver
+
+  if ! jq empty "$file" 2>/dev/null; then
+    echo "[rite] ERROR: $file is not valid JSON — skipping" >&2
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    FAILED_FILES+=("$file")
+    return
+  fi
+
+  parsed_ver=$(jq -r '.schema_version // "missing"' "$file" 2>/dev/null) || parsed_ver="missing"
+
+  case "$parsed_ver" in
+    "1.1.0")
+      # Already canonical — no-op (idempotency)
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      return
+      ;;
+    "1.0.0"|"1.0"|"missing")
+      : # proceed
+      ;;
+    *)
+      echo "[rite] WARNING: $file has unknown schema_version='$parsed_ver' — skipping (manual review required)" >&2
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      return
+      ;;
+  esac
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[rite] dry-run: would migrate $file (schema_version='$parsed_ver' → 1.1.0)"
+    MIGRATED_COUNT=$((MIGRATED_COUNT + 1))
+    return
+  fi
+
+  # Atomic write: jq → tempfile → mv
+  tmp=$(mktemp "${file}.XXXXXX") || {
+    echo "[rite] ERROR: mktemp failed for $file" >&2
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    FAILED_FILES+=("$file")
+    return
+  }
+
+  if ! jq "$MIGRATE_FILTER" "$file" > "$tmp" 2>/dev/null; then
+    echo "[rite] ERROR: jq migration filter failed for $file" >&2
+    rm -f "$tmp"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    FAILED_FILES+=("$file")
+    return
+  fi
+
+  if [ ! -s "$tmp" ]; then
+    echo "[rite] ERROR: migrated output empty for $file (jq produced no output)" >&2
+    rm -f "$tmp"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    FAILED_FILES+=("$file")
+    return
+  fi
+
+  if ! mv "$tmp" "$file"; then
+    echo "[rite] ERROR: atomic mv failed for $file (tmp=$tmp left behind for inspection)" >&2
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    FAILED_FILES+=("$file")
+    return
+  fi
+
+  echo "[rite] migrated: $file ($parsed_ver → 1.1.0)" >&2
+  MIGRATED_COUNT=$((MIGRATED_COUNT + 1))
+}
+
+# --- Step 1: Migrate review-result JSON files ---
+if [ -d "$REVIEW_DIR" ]; then
+  while IFS= read -r -d '' f; do
+    migrate_file "$f"
+  done < <(find "$REVIEW_DIR" -maxdepth 1 -type f -name '*.json' -print0 2>/dev/null)
+else
+  echo "[rite] info: review-results directory not present ($REVIEW_DIR) — skipping JSON migration" >&2
+fi
+
+# --- Step 2: Initialize per-PR accepted-fingerprints state files ---
+# Enumerate PR numbers from `.rite/review-results/{pr}-*.json` and ensure
+# `.rite/state/accepted-fingerprints-{pr}.txt` exists (empty if newly created).
+INIT_COUNT=0
+if [ -d "$REVIEW_DIR" ]; then
+  pr_numbers=$(find "$REVIEW_DIR" -maxdepth 1 -type f -name '*.json' 2>/dev/null \
+    | sed 's|.*/||; s|-.*||' \
+    | grep -E '^[0-9]+$' \
+    | sort -u)
+
+  if [ -n "$pr_numbers" ]; then
+    if [ "$DRY_RUN" != "true" ] && [ ! -d "$STATE_DIR" ]; then
+      mkdir -p "$STATE_DIR" 2>/dev/null || {
+        echo "[rite] WARNING: failed to create state directory $STATE_DIR — accepted-fingerprints init skipped" >&2
+        pr_numbers=""
+      }
+    fi
+
+    while IFS= read -r pr; do
+      [ -z "$pr" ] && continue
+      state_file="$STATE_DIR/accepted-fingerprints-${pr}.txt"
+      if [ ! -f "$state_file" ]; then
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "[rite] dry-run: would initialize empty $state_file"
+        else
+          : > "$state_file" || {
+            echo "[rite] WARNING: failed to initialize $state_file" >&2
+            continue
+          }
+          echo "[rite] initialized: $state_file (empty)" >&2
+        fi
+        INIT_COUNT=$((INIT_COUNT + 1))
+      fi
+    done <<< "$pr_numbers"
+  fi
+fi
+
+# --- Summary ---
+if [ "$DRY_RUN" = "true" ]; then
+  echo "[rite] dry-run summary: would migrate=$MIGRATED_COUNT, skip=$SKIPPED_COUNT, fail=$FAILED_COUNT, init-fingerprint-files=$INIT_COUNT" >&2
+else
+  echo "[rite] migration summary: migrated=$MIGRATED_COUNT, skipped=$SKIPPED_COUNT, failed=$FAILED_COUNT, init-fingerprint-files=$INIT_COUNT" >&2
+fi
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  echo "[rite] failed files:" >&2
+  for f in "${FAILED_FILES[@]}"; do
+    echo "  - $f" >&2
+  done
+  exit 1
+fi
+
+exit 0

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -27,7 +27,25 @@
 #   0 — migration completed (including no-op / dry-run / empty target set)
 #   1 — migration failed (atomic write or jq parse error on a file)
 
+# `-e` を意図的に省略する: 個別ファイルの jq parse 失敗で全体停止させず、
+# FAILED_FILES 配列に集約してから末尾で exit 1 する設計 (post-review-state-verify.sh:40
+# と同パターン)。pipefail は維持して pipeline 失敗を捕捉する。
 set -uo pipefail
+
+# --- Signal-specific trap setup ---
+# canonical pattern: references/bash-trap-patterns.md#signal-specific-trap-template
+# SIGINT/SIGTERM/SIGHUP で中断時に per-file mktemp tempfile (`${file}.XXXXXX`) を残さない。
+# 配列で trap action を管理し、migrate_file 内で `_orphan_tmps+=("$tmp")` を追加する。
+declare -a _orphan_tmps=()
+_migrate_cleanup() {
+  for t in "${_orphan_tmps[@]:-}"; do
+    [ -n "$t" ] && [ -e "$t" ] && rm -f "$t"
+  done
+}
+trap 'rc=$?; _migrate_cleanup; exit $rc' EXIT
+trap '_migrate_cleanup; exit 130' INT
+trap '_migrate_cleanup; exit 143' TERM
+trap '_migrate_cleanup; exit 129' HUP
 
 # --- Argument parsing ---
 DRY_RUN=false
@@ -65,15 +83,24 @@ DEFAULT_SCOPE_FILTER='
 
 # --- Migration filter: only fills missing fields (idempotent) ---
 # Outer guard: if schema_version already "1.1.0", emit unchanged.
-# Otherwise: bump schema_version to "1.1.0", and per-finding fill scope /
-# pre_existing only when absent (has(...) guard preserves explicit values).
+# Otherwise: bump schema_version to "1.1.0", and per-finding fill scope only
+# when absent (has(...) guard preserves explicit values).
+#
+# pre_existing は default mapping を **適用しない** (フィールドを欠落させたまま保持)。
+# review-result-schema.md §後方互換性 (line 197-203) が canonical SoT:
+#   - revert test (reviewer による mental revert) なしに severity 等から推論不可
+#   - 欠落のままで Cross-field invariant #5 (pre_existing=false × scope=nit-noted) が
+#     発火しない (`null != false`)
+#   - 1.0/1.0.0 JSON の finding は invariant #5 auto-correct 対象外となり後方互換が保たれる
+# 旧実装は `.pre_existing = false` を初期化していたが、これは migrated LOW finding を
+# scope=nit-noted + pre_existing=false の組合せにし、read 側 invariant #5 で scope を
+# current-pr に書き換えてしまう後方互換破壊だった (Issue #1021 review F-01)。
 MIGRATE_FILTER='
   if (.schema_version // "") == "1.1.0" then .
   else
     .schema_version = "1.1.0"
     | .findings |= map(
         (if has("scope") then . else .scope = ('"$DEFAULT_SCOPE_FILTER"') end)
-        | (if has("pre_existing") then . else .pre_existing = false end)
       )
   end
 '
@@ -113,7 +140,7 @@ migrate_file() {
   esac
 
   if [ "$DRY_RUN" = "true" ]; then
-    echo "[rite] dry-run: would migrate $file (schema_version='$parsed_ver' → 1.1.0)"
+    echo "[rite] dry-run: would migrate $file (schema_version='$parsed_ver' → 1.1.0)" >&2
     MIGRATED_COUNT=$((MIGRATED_COUNT + 1))
     return
   fi
@@ -125,6 +152,9 @@ migrate_file() {
     FAILED_FILES+=("$file")
     return
   }
+  # Signal-aware orphan tracking (Issue #1021 F-07): SIGINT/SIGTERM/SIGHUP で
+  # 中断時に `${file}.XXXXXX` が `.rite/review-results/` 直下に残らないよう trap 配列に登録。
+  _orphan_tmps+=("$tmp")
 
   if ! jq "$MIGRATE_FILTER" "$file" > "$tmp" 2>/dev/null; then
     echo "[rite] ERROR: jq migration filter failed for $file" >&2
@@ -145,9 +175,17 @@ migrate_file() {
   if ! mv "$tmp" "$file"; then
     echo "[rite] ERROR: atomic mv failed for $file (tmp=$tmp left behind for inspection)" >&2
     FAILED_COUNT=$((FAILED_COUNT + 1))
-    FAILED_FILES+=("$file")
+    FAILED_FILES+=("$file (tmp=$tmp)")
     return
   fi
+  # mv 成功後: orphan 配列から該当 tmp を除外 (二重 rm 回避 / failure 時の inspection 用に preserve)
+  # 配列から要素を削除する portable な方法: tmp が一致する要素のみ skip して新配列を作る
+  declare -a _new_orphans=()
+  for t in "${_orphan_tmps[@]:-}"; do
+    [ "$t" = "$tmp" ] || _new_orphans+=("$t")
+  done
+  _orphan_tmps=("${_new_orphans[@]:-}")
+  unset _new_orphans
 
   echo "[rite] migrated: $file ($parsed_ver → 1.1.0)" >&2
   MIGRATED_COUNT=$((MIGRATED_COUNT + 1))
@@ -185,7 +223,7 @@ if [ -d "$REVIEW_DIR" ]; then
       state_file="$STATE_DIR/accepted-fingerprints-${pr}.txt"
       if [ ! -f "$state_file" ]; then
         if [ "$DRY_RUN" = "true" ]; then
-          echo "[rite] dry-run: would initialize empty $state_file"
+          echo "[rite] dry-run: would initialize empty $state_file" >&2
         else
           : > "$state_file" || {
             echo "[rite] WARNING: failed to initialize $state_file" >&2


### PR DESCRIPTION
## 概要

Issue #1021 (Epic #1015) — review-result schema 1.0 → 1.1.0 evolution に必要な 3 つの新規 artifacts + 既存 drift-check への統合を実装。

## 関連 Issue

Closes #1021

## 変更内容

### 新規ファイル

1. **`plugins/rite/scripts/migrate-review-state-to-1.1.sh`** (217 lines)
   - `.rite/review-results/*.json` の `schema_version` を 1.0 / 1.0.0 / 無記述 → 1.1.0 に migrate
   - `findings[].scope` を severity から default mapping で付与
     - `CRITICAL` / `HIGH` / `MEDIUM` → `current-pr`
     - `LOW-MEDIUM` / `LOW` → `nit-noted`
   - `findings[].pre_existing` を `false` で初期化 (revert test 不明として保守的に)
   - `.rite/state/accepted-fingerprints-{pr}.txt` を空ファイルとして init
   - 冪等性: 既に 1.1.0 の JSON は no-op、`jq has(...)` ガードで既存値を上書きしない
   - `--dry-run` オプション、atomic write (mktemp + mv)

2. **`plugins/rite/hooks/scripts/review-schema-version-check.sh`** (150 lines)
   - accept list (`1.0.0` / `1.0` / `1.1.0`) check
   - drift 時に `[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=...; schema_version=...` を stderr emit
   - `--all` / `--target` / `--quiet` / `--repo-root` オプション

3. **`plugins/rite/hooks/tests/scope-enum-check.test.sh`** (181 lines, `.test.sh` 形式)
   - 4 ケース全カバー (AC-4):
     - **T-1**: 基本 scope enum (`current-pr` / `follow-up` / `nit-noted`)
     - **T-2**: CRITICAL × nit-noted / HIGH × nit-noted FAIL invariant (#4)
     - **T-3**: LOW × default mapping → nit-noted (migration 動作検証)
     - **T-4**: pre_existing=false × nit-noted auto-correct (invariant #5)
   - 9 assertion 全 pass

### 既存ファイル修正

4. **`plugins/rite/hooks/scripts/distributed-fix-drift-check.sh`**
   - Pattern 6 として `review-schema-version-check.sh` 委譲を追加
   - `--pattern 6` 単独実行を許容 (markdown target 不要)
   - help / header comment / usage を更新

## Test Format に関する設計判断

Issue 本文 + AC-4 は `.bats` 形式を指定していましたが、本プロジェクトに既存 `.bats` ファイルが無く bats も未インストールのため、ユーザー確認の上で `.test.sh` 形式 (既存 60 テストと同一規約) を採用しました。

- Issue 本文の `.bats` 拡張子は plan ([rite-issue-start-issue-wobbly-frog.md](https://github.com/B16B1RD/cc-rite-workflow/blob/develop/.gitignore)) からの copy-paste で project convention と乖離したもの
- AC-4 の 4 ケースは `.test.sh` 形式で完全カバー (Tテスト → 9 assertion 全 pass)
- AC-5 「既存 `bats hooks/tests/` 全テスト pass」は「既存 `.test.sh` テスト全 60 件 pass」として解釈し検証

## Acceptance Criteria 検証結果

| AC | 内容 | 検証コマンド | 結果 |
|----|------|-------------|------|
| AC-1 | migration が 1.0 → 1.1 変換 + scope 推論 | `REPO_ROOT=$fixture bash plugins/rite/scripts/migrate-review-state-to-1.1.sh` で `scope=current-pr (HIGH)`、`pre_existing=false` | ✅ |
| AC-2 | 冪等性 (2 回実行で変更なし) | `md5sum` 比較で hash 不変 | ✅ |
| AC-3 | accept list (`1.0` 系 / `1.1.0`) check + drift 検出 | 3 値で exit 0、`9.9.9` で exit 1 + `REVIEW_SCHEMA_VERSION_DRIFT=1` emit | ✅ |
| AC-4 | scope-enum-check で 4 ケース pass | T-1〜T-4 全 9 assertion pass | ✅ |
| AC-5 | 既存 hook テスト regression なし | `run-tests.sh` で 60/60 passed | ✅ |

## チェックリスト

- [x] プロジェクト規約に従っている (`.test.sh` 形式 + `_test-helpers.sh` source pattern)
- [x] テスト pass (`run-tests.sh` 60/60、新規 `scope-enum-check.test.sh` 9/9)
- [x] ドキュメント不要 (Issue body と PR description が SoT)
- [x] AC 検証完了 (上記 5 件全 pass)

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
