### PR TITLE
refactor(post-compact): pr_root_cause / pr_root_cause_hint の 3-site 命名対称化

### DIFF
--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -194,14 +194,14 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       # caller Phase 5.4.4.1 で偽 Issue を auto-register する経路を防ぐため別 hint で emit する。
       # regex は `pull\s*request` で空白あり/なし両対応 (CamelCase 連結も classic 表現も catch)。
       if printf '%s' "$pr_err_oneline" | grep -qiE 'could not resolve.*pull\s*request|no.*pull\s*request found'; then
-        pr_root_cause="pr_deleted_or_inaccessible"
+        pr_root_cause_hint="pr_deleted_or_inaccessible"
       else
-        pr_root_cause="post_compact_gh_pr_view_failed"
+        pr_root_cause_hint="post_compact_gh_pr_view_failed"
       fi
       bash "$PLUGIN_ROOT_PC/hooks/workflow-incident-emit.sh" \
         --type projects_status_in_review_missing \
         --details "Issue #$ISSUE post-compact: gh pr view failed (rc=$pr_rc, stderr=$pr_err_oneline)" \
-        --root-cause-hint "$pr_root_cause" \
+        --root-cause-hint "$pr_root_cause_hint" \
         --pr-number "$PR" >&2 || true
       PR_IS_DRAFT=""
     fi


### PR DESCRIPTION
## 概要

PR #1066 cycle 1 review (prompt-engineer) で検出された変数名 drift を解消する純粋な命名 refactor。`post-compact.sh` の `pr_root_cause` を、PR #1066 で `start.md` / `start-finalize.md` に追加された分岐ブロックの canonical 命名 `pr_root_cause_hint` に統一する。

## 変更点

`plugins/rite/hooks/post-compact.sh` の以下 3 箇所のみ:

- `pr_root_cause="pr_deleted_or_inaccessible"` → `pr_root_cause_hint="pr_deleted_or_inaccessible"`
- `pr_root_cause="post_compact_gh_pr_view_failed"` → `pr_root_cause_hint="post_compact_gh_pr_view_failed"`
- `--root-cause-hint "$pr_root_cause"` → `--root-cause-hint "$pr_root_cause_hint"`

`start.md` / `start-finalize.md` 側は既に `pr_root_cause_hint` を使用しているため変更不要。

## 検証

`pr_root_cause` (suffix `_hint` なし) を 3 site (`post-compact.sh` / `start.md` / `start-finalize.md`) で grep し、残存ゼロを確認:

```bash
grep -nE 'pr_root_cause([^_]|$)' plugins/rite/hooks/post-compact.sh plugins/rite/commands/issue/start.md plugins/rite/commands/issue/start-finalize.md
# (no matches)
```

## 機能的影響

なし。変数は subshell 内 local — caller との変数共有はないため runtime 挙動は完全に同一。bash semantics 不変、emit する `--root-cause-hint` 値は両 branch とも変更前と同じ (`pr_deleted_or_inaccessible` / `post_compact_gh_pr_view_failed`)。

## 関連 Issue

Closes #1067

## チェックリスト

- [x] 3 site で `pr_root_cause_hint` 統一済
- [x] `pr_root_cause` (suffix なし) の残存 0 件を grep で検証
- [x] 機能的影響なし (subshell 内 local、bash semantics 不変)
- [x] Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」対策として 3-site 一括 rename

## Wiki 経験則の参照

Wiki query injection (Phase 3.0.W) で「Asymmetric Fix Transcription」を最関連経験則として確認し、3-site 一括 rename を採用。S4 (3-site grep 検証ステップ) を計画段階で組み込み、partial migration 再発を予防。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
