### PR TITLE
fix(tests): T-04e regex を case-arm anchor 化し ready.md 対称 coverage を追加 (#1009)

### DIFF
--- a/plugins/rite/hooks/tests/projects-status-incident-emit.test.sh
+++ b/plugins/rite/hooks/tests/projects-status-incident-emit.test.sh
@@ -130,17 +130,32 @@ else
 fi
 
 echo ""
-echo "[T-04e] start-finalize.md Phase 5.5.1 case logical completeness (cycle 10 F-01 / F-07)"
+echo "[T-04e] start-finalize.md & ready.md case logical completeness (cycle 10 F-01 / F-07 / Issue #1009)"
 # Regression guard for cycle 9 CRITICAL bug: start-finalize.md case "$status_result" was missing
 # `updated)` arm, causing success path (status_result=updated) to fall-through to failed|*) catchall
 # and emit false-positive projects_status_update_failed sentinel.
-# Verify all 3 arms (updated / skipped_not_in_project / failed|*) are present in the case block.
-assert_file_contains "$FINALIZE_MD" 'updated\)' \
-  "start-finalize.md Phase 5.5.1 case has updated) arm (cycle 10 F-01 regression guard)"
-assert_file_contains "$FINALIZE_MD" 'skipped_not_in_project\)' \
-  "start-finalize.md Phase 5.5.1 case has skipped_not_in_project) arm"
-assert_file_contains "$FINALIZE_MD" 'failed\|\*\)' \
-  "start-finalize.md Phase 5.5.1 case has failed|*) catchall"
+#
+# Issue #1009: previous patterns 'updated\)' / 'skipped_not_in_project\)' / 'failed\|\*\)' matched
+# docstring occurrences (e.g., `(status_result=updated)`) as false-positives — pattern hit 4 sites in
+# start-finalize.md (3 docstring + 1 actual case arm), so deleting the actual case arm would still
+# leave the test passing via docstring matches. Anchor patterns at blockquote-prefix + whitespace
+# (`^>[[:space:]]+`) to pin **case arms only** (case arms live inside `> ` blockquote bash blocks
+# in both files). Cross-file coverage: assert symmetric 3-arm structure in **both** start-finalize.md
+# (Phase 5.5.1) and ready.md (Phase 4.2 minimal skeleton) per Wiki cross-file-cross-site-coverage
+# canonical (PR #1066). Mutation-verified: deleting any case arm now fails the corresponding assert
+# (was silent-pass before this fix).
+assert_file_contains "$FINALIZE_MD" '^>[[:space:]]+updated\)' \
+  "start-finalize.md Phase 5.5.1 case arm: updated) (anchored, cycle 10 F-01 / Issue #1009 regression guard)"
+assert_file_contains "$FINALIZE_MD" '^>[[:space:]]+skipped_not_in_project\)' \
+  "start-finalize.md Phase 5.5.1 case arm: skipped_not_in_project) (anchored)"
+assert_file_contains "$FINALIZE_MD" '^>[[:space:]]+failed\|\*\)' \
+  "start-finalize.md Phase 5.5.1 case arm: failed|*) catchall (anchored)"
+assert_file_contains "$READY_MD" '^>[[:space:]]+updated\)' \
+  "ready.md Phase 4.2 case arm: updated) (anchored, Issue #1009 cross-file symmetric coverage)"
+assert_file_contains "$READY_MD" '^>[[:space:]]+skipped_not_in_project\)' \
+  "ready.md Phase 4.2 case arm: skipped_not_in_project) (anchored)"
+assert_file_contains "$READY_MD" '^>[[:space:]]+failed\|\*\)' \
+  "ready.md Phase 4.2 case arm: failed|*) catchall (anchored)"
 
 echo ""
 echo "==============================="


### PR DESCRIPTION
## 概要

T-04e の `assert_file_contains` パターンが docstring 内の literal にも false-positive match していた構造的欠陥を修正。`grep -cE 'updated\)' start-finalize.md` で 4 hit (3 docstring + 1 case arm) する事実があり、actual case arm を削除しても docstring match で test pass し続けるため、cycle 8 C7-F19 と同形の CRITICAL regression が再導入されても検知不能だった。

## 変更内容

`plugins/rite/hooks/tests/projects-status-incident-emit.test.sh` の T-04e ブロック:

- **Anchor 化**: pattern を `^>[[:space:]]+<arm>\)` に変更 (blockquote prefix + whitespace 量で case arm のみに pin)
- **Cross-file 対称 coverage**: ready.md Phase 4.2 minimal skeleton の 3-arm 構造に対する対称 assert を追加 (Wiki `cross-file-cross-site-coverage` canonical / PR #1066 準拠)
- **ヘッダコメント更新**: 「docstring false-positive 回避 + cross-file 対称」の意図を明文化、後続改修者の誤理解を防止

## 検証

- 既存 + 新規 assertion すべて pass: **20 passed, 0 failed**
- **Mutation test (3 軸)**:
  - start-finalize.md の `>   updated)` 一時削除 → 対応する assert が FAIL → 復元後 PASS ✅
  - ready.md の `>   updated)` 一時削除 → 対応する assert が FAIL → 復元後 PASS ✅
  - start-finalize.md の docstring に `(status_result=updated)` 擬似挿入 → test PASS 維持 (false-positive 不発火) ✅
- Lint pre-existing warnings (drift 52 / journal 179 / line-ref 22) は本変更で増加なし (`.test.sh` のみ変更)

## 設計判断

Issue #1009 は 4 つの解決提案を「または」で列挙していた:

1. anchor 化 (採用)
2. parse-based test (不採用: overkill)
3. ready.md 追加 (採用)
4. docstring 表記変更 (不採用: 提案 1 で不要化)

提案 1 + 3 の組合せが minimal-diff かつ Wiki 経験則と整合性が高いため採用。POSIX ERE portable のため `\s` ではなく `[[:space:]]+` を使用。

## scope 外項目

T-04c (L83-105) の同型 false-positive 可能性は本 PR の scope 外。Issue #1009 は T-04e のみを対象としているため別 Issue 化候補として記録。

## 関連 Issue

Closes #1009

## 関連 PR

- cycle 8 C7-F19: 元 bug (`failed|*)` catchall 追加時の `updated)` arm コピー漏れ)
- cycle 9 F-01: bug 検出
- cycle 10 F-01: bug 修正 (T-04e 導入)
- cycle 11 F-02: T-04e 構造的欠陥検出 (本 PR で対応)
- PR #1066: cross-file-cross-site-coverage Wiki 経験則
