### PR TITLE
fix(workflow): parent-routing Phase 1.5.5 auto-close 後の Projects Status を Done に更新 (#1070)

### DIFF
--- a/plugins/rite/commands/issue/parent-routing.md
+++ b/plugins/rite/commands/issue/parent-routing.md
@@ -350,21 +350,12 @@ if [ "$close_status" -eq 0 ]; then
           --root-cause-hint "issue_not_registered_in_project_at_parent_auto_close" \
           --pr-number 0 >&2 || true
         ;;
-      failed)
+      failed|*)
         [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  warning: /' >&2
-        echo "⚠️ Projects Status の Done 更新に失敗しました。手動で更新してください。" >&2
+        echo "⚠️ Projects Status の Done 更新に失敗しました ($status_result)。手動で更新してください。" >&2
         bash {plugin_root}/hooks/workflow-incident-emit.sh \
           --type projects_status_update_failed \
-          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed" \
-          --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
-          --pr-number 0 >&2 || true
-        ;;
-      *)
-        [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  warning: /' >&2
-        echo "⚠️ Projects Status の Done 更新で未知の結果を受信しました ($status_result)。手動で確認してください。" >&2
-        bash {plugin_root}/hooks/workflow-incident-emit.sh \
-          --type projects_status_update_failed \
-          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned unknown value: $status_result" \
+          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed or unrecognized result ($status_result)" \
           --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
           --pr-number 0 >&2 || true
         ;;

--- a/plugins/rite/commands/issue/parent-routing.md
+++ b/plugins/rite/commands/issue/parent-routing.md
@@ -347,14 +347,25 @@ if [ "$close_status" -eq 0 ]; then
         bash {plugin_root}/hooks/workflow-incident-emit.sh \
           --type projects_status_update_failed \
           --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned skipped_not_in_project" \
+          --root-cause-hint "issue_not_registered_in_project_at_parent_auto_close" \
           --pr-number 0 >&2 || true
         ;;
-      failed|*)
+      failed)
         [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  warning: /' >&2
         echo "⚠️ Projects Status の Done 更新に失敗しました。手動で更新してください。" >&2
         bash {plugin_root}/hooks/workflow-incident-emit.sh \
           --type projects_status_update_failed \
-          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned $status_result" \
+          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed" \
+          --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
+          --pr-number 0 >&2 || true
+        ;;
+      *)
+        [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  warning: /' >&2
+        echo "⚠️ Projects Status の Done 更新で未知の結果を受信しました ($status_result)。手動で確認してください。" >&2
+        bash {plugin_root}/hooks/workflow-incident-emit.sh \
+          --type projects_status_update_failed \
+          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned unknown value: $status_result" \
+          --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
           --pr-number 0 >&2 || true
         ;;
     esac

--- a/plugins/rite/commands/issue/parent-routing.md
+++ b/plugins/rite/commands/issue/parent-routing.md
@@ -316,8 +316,50 @@ Issue #{number} のすべての子 Issue が完了しています。
 
 **When "Close parent Issue" is selected:**
 
+> **Module**: [Projects Status Update Callsites](./references/projects-status-update-callsites.md#callsite-4--phase-155-parent-auto-close--done) — Callsite 4 (Phase 1.5.5) の bash literal SoT を参照。`gh issue close` 成功後に `projects-status-update.sh` を `status_name="Done"` / `auto_add=true` / `non_blocking=true` で呼び出す。Common contract Item 5 (Issue #1003 AC-4 silent skip 禁止) に従い `.result` が `skipped_not_in_project` / `failed` の場合は `workflow-incident-emit.sh --type projects_status_update_failed` で sentinel を emit する。
+
 ```bash
 gh issue close {issue_number} --comment "すべての子 Issue が完了したため、自動クローズします。"
+close_status=$?
+
+# Projects Status → Done (non-blocking).
+# Skip if gh issue close failed (parent still OPEN — Done would be inconsistent).
+if [ "$close_status" -eq 0 ]; then
+  projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
+  if [ "$projects_enabled" = "true" ]; then
+    status_json=$(bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+      --argjson issue {issue_number} \
+      --arg owner "{owner}" \
+      --arg repo "{repo}" \
+      --argjson project_number {project_number} \
+      --arg status "Done" \
+      --argjson auto_add true \
+      --argjson non_blocking true \
+      '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')") || status_json=""
+    status_result=$(printf '%s' "$status_json" | jq -r '.result // "failed"' 2>/dev/null)
+    status_warning_lines=$(printf '%s' "$status_json" | jq -r '.warnings[]?' 2>/dev/null)
+    case "$status_result" in
+      updated)
+        echo "Projects Status を \"Done\" に更新しました"
+        ;;
+      skipped_not_in_project)
+        echo "⚠️ Issue #{issue_number} は Project に登録されていません。手動で Projects ボード上で Status を Done に更新してください。" >&2
+        bash {plugin_root}/hooks/workflow-incident-emit.sh \
+          --type projects_status_update_failed \
+          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned skipped_not_in_project" \
+          --pr-number 0 >&2 || true
+        ;;
+      failed|*)
+        [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  warning: /' >&2
+        echo "⚠️ Projects Status の Done 更新に失敗しました。手動で更新してください。" >&2
+        bash {plugin_root}/hooks/workflow-incident-emit.sh \
+          --type projects_status_update_failed \
+          --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned $status_result" \
+          --pr-number 0 >&2 || true
+        ;;
+    esac
+  fi
+fi
 ```
 
 ---

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -175,7 +175,7 @@ Inspect the script's stdout JSON:
 - `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking). Emit `workflow_incident` sentinel.
 - `.result == "failed"` → display `.warnings[]` and continue (non-blocking). Emit `workflow_incident` sentinel.
 
-**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する。`failed` arm は `failed|*)` combined (sibling callsite 群 — `close.md` Phase 1.3.2 / Phase 4.6.3 minimal skeleton、`start-finalize.md` Phase 5.5.1、`ready.md` Phase 4.2、`archive-procedures.md` 2 site と統一) で unknown schema 値も `details` 列に `$status_result` として embed する:
+**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する。`failed` arm は `failed|*)` combined (sibling callsite 群 — `close.md` Phase 1.3.2 / Phase 4.2 minimal skeleton、`start-finalize.md` Phase 5.5.1、`ready.md` Phase 4.2、`archive-procedures.md` 2 site と統一。Phase 4.6.3 は full state machine で `failed)`/`*)` 分離だが minimal skeleton ではないため列挙から除外) で unknown schema 値も `details` 列に `$status_result` として embed する:
 
 ```bash
 # skipped_not_in_project arm

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -175,7 +175,7 @@ Inspect the script's stdout JSON:
 - `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking). Emit `workflow_incident` sentinel.
 - `.result == "failed"` → display `.warnings[]` and continue (non-blocking). Emit `workflow_incident` sentinel.
 
-**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する。`failed` arm は `failed|*)` combined (sibling 5 callsite と統一) で unknown schema 値も `details` 列に embed する:
+**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する。`failed` arm は `failed|*)` combined (sibling callsite 群 — `close.md` Phase 1.3.2 / Phase 4.6.3 minimal skeleton、`start-finalize.md` Phase 5.5.1、`ready.md` Phase 4.2、`archive-procedures.md` 2 site と統一) で unknown schema 値も `details` 列に `$status_result` として embed する:
 
 ```bash
 # skipped_not_in_project arm
@@ -185,10 +185,10 @@ bash {plugin_root}/hooks/workflow-incident-emit.sh \
   --root-cause-hint "issue_not_registered_in_project_at_parent_auto_close" \
   --pr-number 0 >&2 || true
 
-# failed|*) combined arm (unknown schema 値は details に embed)
+# failed|*) combined arm (unknown schema 値は details に $status_result を embed)
 bash {plugin_root}/hooks/workflow-incident-emit.sh \
   --type projects_status_update_failed \
-  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed or unrecognized result (\$status_result)" \
+  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed or unrecognized result ($status_result)" \
   --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
   --pr-number 0 >&2 || true
 ```

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -1,8 +1,8 @@
 # Projects Status Update — 3 Callsite Delegation SoT
 
-> **Source of Truth**: 本ファイルは `/rite:issue:start` 内で `plugins/rite/scripts/projects-status-update.sh` を invoke する **3 callsite (Phase 2.4 / 5.5.1 / 5.7.2) の bash literal SoT** である。`start.md` 本体の各 callsite は本ファイルへ semantic 参照する anchor stub のみ保持する。
+> **Source of Truth**: 本ファイルは `/rite:issue:start` 内で `plugins/rite/scripts/projects-status-update.sh` を invoke する **4 callsite (Phase 2.4 / 5.5.1 / 5.7.2 / 1.5.5) の bash literal SoT** である。`start.md` 本体および sub-skill (`parent-routing.md`) の各 callsite は本ファイルへ semantic 参照する anchor stub のみ保持する。
 >
-> **抽出経緯**: 3 callsite はすべて同一の `bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n ...)"` 構造を持つが、`status_name` (In Progress / In Review / Done) と `auto_add` フラグ (true / false) のみ異なる。bash literal を 1 reference に集約することで drift を防止し、本体の認知負荷を下げる。Issue #901 (PR E — #896 親 Issue) で抽出。
+> **抽出経緯**: 4 callsite はすべて同一の `bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n ...)"` 構造を持つが、`status_name` (In Progress / In Review / Done) と `auto_add` フラグ (true / false) のみ異なる。bash literal を 1 reference に集約することで drift を防止し、本体の認知負荷を下げる。Issue #901 (PR E — #896 親 Issue) で 3 callsite を抽出。Issue #1070 で Callsite 4 (Phase 1.5.5 Parent Auto-Close → Done) を追加。
 >
 > **API レベル仕様 SoT との役割分担**: `references/projects-integration.md` §2.4 は GraphQL projectItems / item-add / field-list / item-edit の **API 動作仕様** SoT。本ファイルは **caller bash literal** の SoT。両 reference は補完関係 (semantically orthogonal、重複契約なし)。
 >
@@ -26,6 +26,7 @@
 > - **Callsite 1 (Phase 2.4 In Progress)**: 本 SoT の bash literal には emit 例なし。`start.md` Phase 2.4 caller 側で `.result` が `failed` の場合に emit を inline 記述する責務がある。通常 `auto_add: true` で `skipped_not_in_project` は発火しにくいため failed 経路が主対象。
 > - **Callsite 2 (Phase 5.5.1 In Review)**: `start-finalize.md` Phase 5.5.1 (defense-in-depth) と `pr/ready.md` Phase 4.2 (primary) の両 caller で emit を実装済み。`auto_add: false` のため `skipped_not_in_project` が発生しやすく、本契約の主対象。
 > - **Callsite 3 (Phase 5.7.2 Done)**: 本 SoT の bash literal には emit 例なし。`start-finalize.md` Phase 5.7.2 caller および `close.md` Phase 4.6.3 (`status update` 経由) の caller 側で emit を inline 記述する責務がある。`auto_add: false` のため `skipped_not_in_project` が発生しやすい。
+> - **Callsite 4 (Phase 1.5.5 Parent Auto-Close → Done)**: `parent-routing.md` Phase 1.5.5 caller 側で emit を実装済み (Issue #1070 で追加)。`auto_add: true` のため通常 `skipped_not_in_project` は発火しにくいが、Projects API 失敗 (5xx / 認証エラー等) で `failed` 経路が発火する場合に sentinel を emit する。
 > - **最終 fallback**: emit 漏れがあった場合の最終 fallback は `start-finalize.md` Workflow Termination Step 0 (Issue #1003 AC-8) の状態 query 経路で surface される。
 
 ## Callsite 1 — Phase 2.4 (Issue Status → In Progress)
@@ -133,13 +134,70 @@ Inspect the script's stdout JSON:
 
 **Step 2** (Phase 5.7.2 specific): Close the parent Issue via `/rite:issue:close` Skill invocation — see `start.md` Phase 5.7.2 本体の Step 2 invocation block。本 reference は Step 1 (Status update) の bash literal SoT のみ提供する。
 
-## 差分 summary (3 callsite 比較)
+## Callsite 4 — Phase 1.5.5 (Parent Auto-Close → Done)
+
+**Owner**: `/rite:issue:start` (via `parent-routing.md` Phase 1.5.5 sub-skill — auto-close path when all child Issues are CLOSED).
+
+**Note**: `parent-routing.md` Phase 1.5.5 で「親 Issue をクローズする」が選択され `gh issue close` が成功した場合に呼ばれる。`auto_add: true` のため Projects 未登録の親 Epic でも自動追加 + Done 設定が行われる (`pr/cleanup.md` の通常 PR merge 経路 — Issue #658 で対応済 — とは異なる auto-close 経路を埋める)。
+
+**Step 1** — Verify `gh issue close` succeeded; skip Status update if it failed (parent still OPEN — Done would be inconsistent):
+
+```bash
+gh issue close {issue_number} --comment "すべての子 Issue が完了したため、自動クローズします。"
+close_status=$?
+```
+
+**Step 2** — Skip the Status update block if `projects.enabled: false`:
+
+```bash
+projects_enabled=$(awk '/^github:/{h=1;next} h && /^  projects:/{p=1;next} p && /^    enabled:/{print $2; exit}' rite-config.yml 2>/dev/null)
+```
+
+**Step 3** — Invoke the shared script to transition the Issue Status to **Done** (only when `close_status -eq 0` and `projects_enabled = true`):
+
+```bash
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue_number} \
+  --arg owner "{owner}" \
+  --arg repo "{repo}" \
+  --argjson project_number {project_number} \
+  --arg status "Done" \
+  --argjson auto_add true \
+  --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+```
+
+`auto_add: true` because the parent Epic may not always be registered in the Project (defensive against unregistered parents). The script internally executes the GraphQL `projectItems` query → auto-add if missing → `field-list` → Status `item-edit`.
+
+Inspect the script's stdout JSON:
+
+- `.result == "updated"` → success.
+- `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking). Emit `workflow_incident` sentinel.
+- `.result == "failed"` → display `.warnings[]` and continue (non-blocking). Emit `workflow_incident` sentinel.
+
+**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4):
+
+```bash
+bash {plugin_root}/hooks/workflow-incident-emit.sh \
+  --type projects_status_update_failed \
+  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned <result>" \
+  --pr-number 0 >&2 || true
+```
+
+`--pr-number 0` because Phase 1.5.5 runs before any PR is created in the workflow.
+
+**Constraint** — Projects update failure MUST NOT roll back the `gh issue close` itself. The parent Issue remains CLOSED even when Status update fails (non-blocking design).
+
+See [projects-integration.md §2.4](../../../references/projects-integration.md#24-github-projects-status-update) for the underlying API calls.
+
+## 差分 summary (4 callsite 比較)
 
 | Callsite | `status` | `auto_add` | `--argjson issue` 引数 | 補足 |
 |----------|----------|------------|------------------------|------|
 | Phase 2.4 | `In Progress` | `true` | `{issue_number}` | 当該 Issue 自身。未登録なら auto-add (true) |
 | Phase 5.5.1 | `In Review` | `false` | `{issue_number}` | 既に Phase 2.4 で auto-add 済みのため `false` |
 | Phase 5.7.2 | `Done` | `false` | `{parent_issue_number}` | 親 Issue 対象。auto-add 不要 |
+| Phase 1.5.5 | `Done` | `true` | `{issue_number}` | 親 Epic auto-close 経路。未登録に備え auto-add (true) |
 
 ## 関連
 

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -1,4 +1,4 @@
-# Projects Status Update — 3 Callsite Delegation SoT
+# Projects Status Update — 4 Callsite Delegation SoT
 
 > **Source of Truth**: 本ファイルは `/rite:issue:start` 内で `plugins/rite/scripts/projects-status-update.sh` を invoke する **4 callsite (Phase 2.4 / 5.5.1 / 5.7.2 / 1.5.5) の bash literal SoT** である。`start.md` 本体および sub-skill (`parent-routing.md`) の各 callsite は本ファイルへ semantic 参照する anchor stub のみ保持する。
 >
@@ -6,7 +6,7 @@
 >
 > **API レベル仕様 SoT との役割分担**: `references/projects-integration.md` §2.4 は GraphQL projectItems / item-add / field-list / item-edit の **API 動作仕様** SoT。本ファイルは **caller bash literal** の SoT。両 reference は補完関係 (semantically orthogonal、重複契約なし)。
 >
-> **caller**: `start.md` の 3 sites (Phase 2.4 / 5.5.1 / 5.7.2) すべてが本 reference の対応セクションへ delegate する。
+> **caller**: `start.md` の 3 sites (Phase 2.4 / 5.5.1 / 5.7.2) と sub-skill `parent-routing.md` の 1 site (Phase 1.5.5) すべてが本 reference の対応セクションへ delegate する。
 
 ## Common contract
 
@@ -175,16 +175,27 @@ Inspect the script's stdout JSON:
 - `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking). Emit `workflow_incident` sentinel.
 - `.result == "failed"` → display `.warnings[]` and continue (non-blocking). Emit `workflow_incident` sentinel.
 
-**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4):
+**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する:
 
 ```bash
+# skipped_not_in_project arm
 bash {plugin_root}/hooks/workflow-incident-emit.sh \
   --type projects_status_update_failed \
-  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned <result>" \
+  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned skipped_not_in_project" \
+  --root-cause-hint "issue_not_registered_in_project_at_parent_auto_close" \
+  --pr-number 0 >&2 || true
+
+# failed arm
+bash {plugin_root}/hooks/workflow-incident-emit.sh \
+  --type projects_status_update_failed \
+  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed" \
+  --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
   --pr-number 0 >&2 || true
 ```
 
 `--pr-number 0` because Phase 1.5.5 runs before any PR is created in the workflow.
+
+> **Observability reach note (Issue #1070 review F-05)**: Phase 1.5.5 は **PR 作成前** に実行されるため、本 emit した sentinel は `start.md` Phase 5.4.4.1 grep 検出経路 (PR review-fix loop 内で動作) には **乗らない**。emit は observability log として stderr / conversation context に残り後追い debug に使えるが、auto-Issue-register 経路には乗らない (workflow 終了経路)。sibling Callsite 2/3 とは observability reach のレベルが異なる点に留意。
 
 **Constraint** — Projects update failure MUST NOT roll back the `gh issue close` itself. The parent Issue remains CLOSED even when Status update fails (non-blocking design).
 
@@ -202,5 +213,5 @@ See [projects-integration.md §2.4](../../../references/projects-integration.md#
 ## 関連
 
 - [`../../../references/projects-integration.md`](../../../references/projects-integration.md#24-github-projects-status-update) — API レベル動作仕様 SoT (GraphQL queries / item-add / field-list / item-edit)
-- `plugins/rite/scripts/projects-status-update.sh` — Single source of truth (delegated by all 3 callsites)
+- `plugins/rite/scripts/projects-status-update.sh` — Single source of truth (delegated by all 4 callsites)
 - `plugins/rite/hooks/tests/parent-child-sync-static.test.sh` Group 4 — `Issue #513 regression guard` literal pin (本 reference の Callsite 1 Step 3 が grep 対象)

--- a/plugins/rite/commands/issue/references/projects-status-update-callsites.md
+++ b/plugins/rite/commands/issue/references/projects-status-update-callsites.md
@@ -175,7 +175,7 @@ Inspect the script's stdout JSON:
 - `.result == "skipped_not_in_project"` → display `警告: Issue #{issue_number} は Project に登録されていません` and continue (non-blocking). Emit `workflow_incident` sentinel.
 - `.result == "failed"` → display `.warnings[]` and continue (non-blocking). Emit `workflow_incident` sentinel.
 
-**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する:
+**Step 4** — Emit `workflow_incident` sentinel on `skipped_not_in_project` / `failed` (Common contract Item 5 / Issue #1003 AC-4). sibling Callsite 2/3 (`pr/ready.md` Phase 4.2 / `start-finalize.md` Phase 5.5.1 / 5.7.2) と observability 対称性を保つため `--root-cause-hint` を必ず付与する。`failed` arm は `failed|*)` combined (sibling 5 callsite と統一) で unknown schema 値も `details` 列に embed する:
 
 ```bash
 # skipped_not_in_project arm
@@ -185,10 +185,10 @@ bash {plugin_root}/hooks/workflow-incident-emit.sh \
   --root-cause-hint "issue_not_registered_in_project_at_parent_auto_close" \
   --pr-number 0 >&2 || true
 
-# failed arm
+# failed|*) combined arm (unknown schema 値は details に embed)
 bash {plugin_root}/hooks/workflow-incident-emit.sh \
   --type projects_status_update_failed \
-  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed" \
+  --details "Issue #{issue_number} parent auto-close (Phase 1.5.5): projects-status-update.sh returned failed or unrecognized result (\$status_result)" \
   --root-cause-hint "gh_api_or_graphql_failure_at_parent_auto_close" \
   --pr-number 0 >&2 || true
 ```


### PR DESCRIPTION
## 概要

`parent-routing.md` Phase 1.5.5 (Auto-Close 経路) で親 Epic Issue を `gh issue close` した直後に Projects Status を "Done" に更新するロジックを追加し、Projects ボード上で Status が "Todo"/"In Progress" のまま停留する不具合を解消する。

## 関連 Issue

Closes #1070

## 変更内容

- `plugins/rite/commands/issue/parent-routing.md` — 変更
  - Phase 1.5.5 の `gh issue close` 直後に `projects-status-update.sh` を `status_name="Done"` / `auto_add=true` / `non_blocking=true` で呼ぶブロックを追加
  - `projects.enabled: false` skip guard、`gh issue close` 成功条件 (`$? -eq 0`)、`.result` 別 warning、Common contract Item 5 (Issue #1003 AC-4) に従う `workflow-incident-emit.sh --type projects_status_update_failed` sentinel emit を含む
- `plugins/rite/commands/issue/references/projects-status-update-callsites.md` — 変更
  - 新 Callsite「Callsite 4 — Phase 1.5.5 (Parent Auto-Close → Done)」を追記 (既存 Callsite 1/2/3 と同形式)
  - SoT 宣言を 3 callsite → 4 callsite へ更新
  - 差分 summary 表に Phase 1.5.5 行を追加 (`auto_add=true`, `status=Done`)
  - Issue #1003 AC-4 適用範囲 blockquote に Callsite 4 のエントリ追加

## Acceptance Criteria

- [x] AC-1: 子 Issue 全 CLOSED で auto-close 時に Projects Status が Done に更新される (実装: status_name="Done")
- [x] AC-2: Projects 未設定環境では Status 更新ブロックが skip される (実装: `if [ "$projects_enabled" = "true" ]` guard)
- [x] AC-3: Projects API 失敗時も Issue close は完了する (実装: non_blocking=true + `|| status_json=""` + `|| true`)
- [x] AC-4: Callsite reference が更新されている (callsites.md に Callsite 4 セクション追記済み)

## テスト

- T-04 non-regression: `parent-child-sync-static.test.sh` 55/55 PASS (Issue #513 regression guard literal 2 occurrences 保持)
- T-05 docs: `grep "Callsite 4"` / `grep "Parent Auto-Close"` 両方 hit、差分 summary 表 4 行確認済み
- T-01/T-02/T-03 静的検証: ブロック実装が AC-1/AC-2/AC-3 を満たすことを実装内容で確認

## Checklist

- [x] Code follows project conventions (Conventional Commits / 既存 Callsite 1-3 と同 short-form)
- [x] Tests pass (parent-child-sync-static.test.sh 55/55 PASS)
- [x] Documentation updated (callsites.md SoT を 4 callsite 構成へ拡張)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
