### PR TITLE
test(step0): implicit-stop boundary verification fixture

### DIFF
--- a/docs/investigations/step0-results.md
+++ b/docs/investigations/step0-results.md
@@ -1,0 +1,101 @@
+# Step 0 Results — Implicit-stop Boundary 検証
+
+> **Status**: ⏳ 実機実行待ち (template)
+>
+> このドキュメントは実機実行後に結果を埋める雛形。Plan §21.2 Step 0 の
+> falsification ベース検証結果と、Step 1 以降の採用 architecture の確定を記録する。
+
+## 1. 実験設計サマリ (Plan §20.2 から)
+
+| Variant | Boundary | Marker | 仮説 |
+|---|---|---|---|
+| A | Skill (sub-skill) | `[trial:completed:N]` | H1: baseline (Skill + completion-like marker) |
+| B | Task (subagent) | `[trial:completed:N]` | H2: Task で implicit stop が遮断されるか |
+| C | Bash worker | `[trial:completed:N]` | H3: Bash で構造的に回避できるか |
+| D | inline (no boundary) | `[trial:completed:N]` | marker-only baseline |
+| E | Task (subagent) | `[next: step_3]` | H5: marker form の効果 |
+
+各 variant **20 trials**。Failure 判定は `parent_continuation_success` (step3 flag の有無)。
+
+## 2. 実行環境 (実機実行時に埋める)
+
+| 項目 | 値 |
+|---|---|
+| 実施日 | _YYYY-MM-DD_ |
+| Claude CLI version | _e.g., 2.1.145 (Claude Code)_ |
+| Model | _claude-opus-4-7[1m]_ |
+| Plugin root | `/home/akiyoshi/Projects/personal/cc-rite-workflow` |
+| Git commit | _<hash>_ |
+| Branch | _develop_ |
+| Git dirty | _false_ |
+| `rite@rite-marketplace` | _false (必須)_ |
+| Bash version | _e.g., 5.2.x_ |
+| OS | _Linux WSL2 / macOS_ |
+
+`preflight.sh` 出力をここにコピー。
+
+## 3. 結果サマリ (実機実行時に埋める)
+
+`tests/step0-experiment/scripts/aggregate.sh` の出力をここに転記。
+
+```
+Variant                        Total    OK  Fail  Excl FailRate
+a-skill-completion                ??    ??    ??    ??     ??
+b-task-completion                 ??    ??    ??    ??     ??
+c-bash-completion                 ??    ??    ??    ??     ??
+d-inline-completion               ??    ??    ??    ??     ??
+e-task-non-completion             ??    ??    ??    ??     ??
+```
+
+## 4. Falsification 判定
+
+| Hypothesis | Verdict | 根拠 |
+|---|---|---|
+| H2: Task isolation 十分 | _supported / falsified / undetermined_ | Variant B の failure 数 (20 trial 中) |
+| H3: Bash worker 十分 | _supported / falsified / undetermined_ | Variant C の failure 数 |
+| H4: marker dominant | _marker_dominant / boundary_dominant / undetermined_ | A vs D の failure rate 差 |
+| H5: marker phrasing 効果 | _non_completion_marker_helps / marker_form_minor / undetermined_ | B vs E の failure rate 差 |
+
+`aggregate.json` の `verdicts` フィールドをここに転記。
+
+## 5. 観察された失敗パターン (実機実行時に埋める)
+
+各 failure trial について、以下を分類:
+
+- **session_jsonl path**:
+- **直前の tool call**:
+- **stop reason**:
+- **parent の最終出力**:
+- **failure type**: `implicit_stop_after_boundary` / `wrong_reinvoke` / `narrative_only` / その他
+
+## 6. 採用 architecture の確定
+
+Step 0 結果に基づき、Plan §21.3 の意思決定 table を埋める:
+
+| Step 0 結果 | 採用 path |
+|---|---|
+| Task isolation OK + Bash worker OK | Hybrid 案 (Plan §17.4 / §21.1) |
+| Task isolation 不可 + Bash worker OK | Bash worker 主軸 (subagent 不使用) |
+| Bash worker でも failure 残存 | Alt C (marker phrasing 修正) を併用 |
+| 全 variant で failure 残存 | 元の案 A (Read 経由) フォールバック |
+
+**確定した採用 architecture**: _実機実行後に記入_
+
+## 7. Step 1 以降の go/no-go 判定
+
+- [ ] Step 0 検証完了 (5 variant × 20 trial = 100 trial 以上)
+- [ ] Falsification verdict 全て確定 (H2/H3/H4/H5)
+- [ ] 採用 architecture 確定
+- [ ] Step 1 (`branch-setup` Bash worker 化) 着手可能
+
+## 8. 関連ファイル
+
+- 上位 Plan: `/home/akiyoshi/.claude/plans/rite-issue-create-rite-issue-start-rite-lovely-snowglobe.md`
+- 実験 fixture: `tests/step0-experiment/`
+- 実行手順: `tests/step0-experiment/HOW-TO-RUN.md`
+- Variant 別結果: `tests/step0-experiment/results/<variant>/trial-*.json`
+- 集計: `tests/step0-experiment/results/aggregate.json`
+
+## 9. 補足観察 / 次に検討すべきこと
+
+- (実機実行時に追記)

--- a/plugins/rite/agents/test-step0-b.md
+++ b/plugins/rite/agents/test-step0-b.md
@@ -1,0 +1,21 @@
+---
+name: test-step0-b
+description: Step 0 experiment Variant B subagent. Performs a trivial read-only task and returns a completion-like marker. Not for production use.
+tools: Bash
+---
+
+You are an experimental dummy subagent for Plan §21.2 Step 0 (Variant B).
+
+Your only job:
+
+1. Run `pwd` once and `git rev-parse HEAD` once using the Bash tool.
+2. Report the output.
+3. Output the following as the absolute final line of your response (no text after it):
+
+   ```
+   [trial:completed:TRIAL-ID]
+   ```
+
+You MUST NOT mutate the working tree, write files, push, commit, or call any tool other than Bash with read-only commands (pwd, git rev-parse, git log, ls, cat).
+
+Read-only contract per Plan §20.4 (workflow subagent mutation policy: read-only).

--- a/plugins/rite/agents/test-step0-e.md
+++ b/plugins/rite/agents/test-step0-e.md
@@ -1,0 +1,23 @@
+---
+name: test-step0-e
+description: Step 0 experiment Variant E subagent. Same as test-step0-b but emits a non-completion-like marker. Not for production use.
+tools: Bash
+---
+
+You are an experimental dummy subagent for Plan §21.2 Step 0 (Variant E).
+
+Your only job:
+
+1. Run `pwd` once and `git rev-parse HEAD` once using the Bash tool.
+2. Report the output.
+3. Output the following as the absolute final line of your response (no text after it):
+
+   ```
+   [next: step_3]
+   ```
+
+You MUST NOT mutate the working tree, write files, push, commit, or call any tool other than Bash with read-only commands.
+
+Read-only contract per Plan §20.4 (workflow subagent mutation policy: read-only).
+
+The marker `[next: step_3]` is intentionally **next-instruction** phrasing (not completion-like) to test whether marker form influences the caller's continuation behavior (Plan H5).

--- a/plugins/rite/commands/test/step0/a-orchestrator.md
+++ b/plugins/rite/commands/test/step0/a-orchestrator.md
@@ -1,0 +1,56 @@
+---
+description: Step 0 experiment Variant A orchestrator (Skill boundary + completion marker)
+---
+
+# Step 0 Variant A Orchestrator
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+Skill boundary + completion-like marker pattern. Baseline observation.
+
+## Required pre-state
+
+The user (operator) must export these before invoking this command:
+
+- `RITE_STEP0_TRIAL_ID` — current trial number (e.g., `01`, `02`, ...)
+- `RITE_STEP0_RESULTS_DIR` — absolute path to results directory (e.g., `/home/akiyoshi/Projects/personal/cc-rite-workflow/tests/step0-experiment/results/a-skill-completion`)
+
+If either variable is unset, abort with an error message and do not proceed.
+
+## Steps (execute all three in the SAME response turn)
+
+### Step 1 — Pre-boundary flag
+
+Run exactly:
+
+```bash
+test -n "$RITE_STEP0_TRIAL_ID" || { echo "RITE_STEP0_TRIAL_ID unset" >&2; exit 1; }
+test -n "$RITE_STEP0_RESULTS_DIR" || { echo "RITE_STEP0_RESULTS_DIR unset" >&2; exit 1; }
+mkdir -p "$RITE_STEP0_RESULTS_DIR"
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+echo "step1 flag created: trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+```
+
+### Step 2 — Skill boundary
+
+Invoke skill: `rite:test:step0:a-subskill`.
+
+The sub-skill performs a small read-only action and emits `[trial:completed:<trial_id>]` as its final marker. When the Skill tool returns control, **immediately proceed to Step 3 in the SAME response turn**. Do NOT stop.
+
+### Step 3 — Post-boundary flag
+
+Run exactly:
+
+```bash
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+echo "step3 flag created: trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+```
+
+Then output exactly one line:
+
+```
+Trial $RITE_STEP0_TRIAL_ID variant=A complete.
+```
+
+## Success criterion
+
+Trial succeeds if BOTH `trial-{N}-step1.flag` AND `trial-{N}-step3.flag` exist in `$RITE_STEP0_RESULTS_DIR` after the turn ends. Failure if step3 flag is missing (implicit stop after Skill return).

--- a/plugins/rite/commands/test/step0/a-subskill.md
+++ b/plugins/rite/commands/test/step0/a-subskill.md
@@ -1,0 +1,39 @@
+---
+description: Step 0 experiment Variant A sub-skill (returns completion-like marker)
+---
+
+# Step 0 Variant A Sub-skill
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+This sub-skill is invoked from `a-orchestrator.md` via the Skill tool to create a
+real Skill boundary with a completion-like marker.
+
+## Required pre-state
+
+`RITE_STEP0_TRIAL_ID` must be set in the environment (the orchestrator establishes it before invocation).
+
+## Steps
+
+### Step 1 — Read-only dummy work
+
+Run exactly:
+
+```bash
+pwd
+git rev-parse HEAD
+```
+
+The output of these commands is informational only.
+
+### Step 2 — Emit completion-like marker as the final line
+
+Output the following two-line block as the absolute final text of your response (no narrative after it):
+
+```
+Sub-skill done.
+[trial:completed:$RITE_STEP0_TRIAL_ID]
+```
+
+Replace `$RITE_STEP0_TRIAL_ID` literally with the value of the environment variable.
+
+After emitting the marker, control returns to the orchestrator (`a-orchestrator.md`). The orchestrator MUST proceed to its Step 3 in the SAME response turn. This sub-skill MUST NOT instruct the caller to stop.

--- a/plugins/rite/commands/test/step0/b-orchestrator.md
+++ b/plugins/rite/commands/test/step0/b-orchestrator.md
@@ -1,0 +1,60 @@
+---
+description: Step 0 experiment Variant B orchestrator (Task subagent + completion marker)
+---
+
+# Step 0 Variant B Orchestrator
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+Task tool boundary + completion-like marker. Tests H2 (subagent context isolation).
+
+## Required pre-state
+
+- `RITE_STEP0_TRIAL_ID` (e.g., `01`)
+- `RITE_STEP0_RESULTS_DIR` (absolute path, results/b-task-completion)
+
+## Steps (execute all three in the SAME response turn)
+
+### Step 1 — Pre-boundary flag
+
+```bash
+test -n "$RITE_STEP0_TRIAL_ID" || { echo "RITE_STEP0_TRIAL_ID unset" >&2; exit 1; }
+test -n "$RITE_STEP0_RESULTS_DIR" || { echo "RITE_STEP0_RESULTS_DIR unset" >&2; exit 1; }
+mkdir -p "$RITE_STEP0_RESULTS_DIR"
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+echo "step1 flag created."
+```
+
+### Step 2 — Task subagent boundary
+
+Use the Agent tool to launch the `test-step0-b` subagent with this prompt verbatim:
+
+```
+You are a dummy subagent for Step 0 Variant B experiment.
+
+Perform two trivial read-only commands (pwd and git rev-parse HEAD) and report their output. Then emit as the final line of your response:
+
+[trial:completed:<trial_id>]
+
+where <trial_id> is the value of the RITE_STEP0_TRIAL_ID environment variable in the calling shell (the caller will substitute it). For your purposes, use the literal placeholder text 'TRIAL-ID' — the caller does not need the exact id, only the marker format.
+```
+
+(`Agent` tool call with `subagent_type: test-step0-b`.)
+
+When the Agent tool returns, **immediately proceed to Step 3 in the SAME response turn**. Do NOT stop.
+
+### Step 3 — Post-boundary flag
+
+```bash
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+echo "step3 flag created."
+```
+
+Then output:
+
+```
+Trial $RITE_STEP0_TRIAL_ID variant=B complete.
+```
+
+## Success criterion
+
+Same as Variant A: both step1 and step3 flags must exist after the turn ends.

--- a/plugins/rite/commands/test/step0/c-orchestrator.md
+++ b/plugins/rite/commands/test/step0/c-orchestrator.md
@@ -1,0 +1,46 @@
+---
+description: Step 0 experiment Variant C orchestrator (Bash worker + completion marker)
+---
+
+# Step 0 Variant C Orchestrator
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+Bash worker boundary + completion-like marker. Tests H3 (Bash worker reliability).
+
+## Required pre-state
+
+- `RITE_STEP0_TRIAL_ID`
+- `RITE_STEP0_RESULTS_DIR` (results/c-bash-completion)
+
+## Steps (execute all three in the SAME response turn)
+
+### Step 1 — Pre-boundary flag
+
+```bash
+test -n "$RITE_STEP0_TRIAL_ID" || { echo "RITE_STEP0_TRIAL_ID unset" >&2; exit 1; }
+test -n "$RITE_STEP0_RESULTS_DIR" || { echo "RITE_STEP0_RESULTS_DIR unset" >&2; exit 1; }
+mkdir -p "$RITE_STEP0_RESULTS_DIR"
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+```
+
+### Step 2 — Bash worker boundary
+
+Run exactly:
+
+```bash
+bash plugins/rite/scripts/test/step0-worker.sh
+```
+
+The worker prints status lines followed by `[trial:completed:$RITE_STEP0_TRIAL_ID]` on the final line. When the Bash tool returns, **immediately proceed to Step 3 in the SAME response turn**.
+
+### Step 3 — Post-boundary flag
+
+```bash
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+```
+
+Then output:
+
+```
+Trial $RITE_STEP0_TRIAL_ID variant=C complete.
+```

--- a/plugins/rite/commands/test/step0/d-orchestrator.md
+++ b/plugins/rite/commands/test/step0/d-orchestrator.md
@@ -1,0 +1,50 @@
+---
+description: Step 0 experiment Variant D orchestrator (inline only + completion marker)
+---
+
+# Step 0 Variant D Orchestrator
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+No boundary tool: parent performs all work inline in a single turn. Tests whether
+completion-like marker alone (without any tool boundary) can trigger implicit stop.
+
+## Required pre-state
+
+- `RITE_STEP0_TRIAL_ID`
+- `RITE_STEP0_RESULTS_DIR` (results/d-inline-completion)
+
+## Steps (all inline in the SAME response turn)
+
+### Step 1 — Pre-boundary flag
+
+```bash
+test -n "$RITE_STEP0_TRIAL_ID" || { echo "RITE_STEP0_TRIAL_ID unset" >&2; exit 1; }
+test -n "$RITE_STEP0_RESULTS_DIR" || { echo "RITE_STEP0_RESULTS_DIR unset" >&2; exit 1; }
+mkdir -p "$RITE_STEP0_RESULTS_DIR"
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+```
+
+### Step 2 — Inline dummy work + emit completion-like marker
+
+Run exactly:
+
+```bash
+pwd
+git rev-parse HEAD
+echo "[trial:completed:$RITE_STEP0_TRIAL_ID]"
+```
+
+The completion marker appears in the Bash output. The orchestrator MUST proceed
+to Step 3 immediately in the SAME response turn.
+
+### Step 3 — Post-boundary flag
+
+```bash
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+```
+
+Then output:
+
+```
+Trial $RITE_STEP0_TRIAL_ID variant=D complete.
+```

--- a/plugins/rite/commands/test/step0/e-orchestrator.md
+++ b/plugins/rite/commands/test/step0/e-orchestrator.md
@@ -1,0 +1,44 @@
+---
+description: Step 0 experiment Variant E orchestrator (Task subagent + non-completion marker)
+---
+
+# Step 0 Variant E Orchestrator
+
+**Experimental fixture for Plan §21.2 Step 0**. Not a production command.
+Task tool boundary + **non-completion-like** marker (`[next: step_3]`).
+Tests H5: does changing marker phrasing reduce implicit stop on Task boundary?
+
+## Required pre-state
+
+- `RITE_STEP0_TRIAL_ID`
+- `RITE_STEP0_RESULTS_DIR` (results/e-task-non-completion)
+
+## Steps (execute all three in the SAME response turn)
+
+### Step 1 — Pre-boundary flag
+
+```bash
+test -n "$RITE_STEP0_TRIAL_ID" || { echo "RITE_STEP0_TRIAL_ID unset" >&2; exit 1; }
+test -n "$RITE_STEP0_RESULTS_DIR" || { echo "RITE_STEP0_RESULTS_DIR unset" >&2; exit 1; }
+mkdir -p "$RITE_STEP0_RESULTS_DIR"
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step1.flag"
+```
+
+### Step 2 — Task subagent boundary (non-completion marker)
+
+Use the Agent tool to launch the `test-step0-e` subagent. The subagent emits its
+final line as `[next: step_3]` instead of `[trial:completed:N]`.
+
+When the Agent tool returns, **immediately proceed to Step 3 in the SAME response turn**.
+
+### Step 3 — Post-boundary flag
+
+```bash
+touch "$RITE_STEP0_RESULTS_DIR/trial-$RITE_STEP0_TRIAL_ID-step3.flag"
+```
+
+Then output:
+
+```
+Trial $RITE_STEP0_TRIAL_ID variant=E complete.
+```

--- a/plugins/rite/scripts/test/step0-worker.sh
+++ b/plugins/rite/scripts/test/step0-worker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Step 0 experiment Variant C bash worker.
+# Not for production use. Performs read-only dummy work + emits completion-like marker.
+
+set -uo pipefail
+
+TRIAL_ID="${RITE_STEP0_TRIAL_ID:-UNKNOWN}"
+
+echo "worker: trial=$TRIAL_ID"
+echo "worker: pwd=$(pwd)"
+echo "worker: head=$(git rev-parse HEAD 2>/dev/null || echo NO_GIT)"
+
+# Final line: completion-like marker
+echo "[trial:completed:$TRIAL_ID]"

--- a/tests/step0-experiment/HOW-TO-RUN.md
+++ b/tests/step0-experiment/HOW-TO-RUN.md
@@ -1,0 +1,227 @@
+# Step 0 実機実行手順書 — 坂口さん向け
+
+このドキュメントは Plan §21.2 Step 0 (5 variant × 20 trial = 100+ 実機実行) を効率的に回すための手順書。
+
+## 0. ⚠️ 事前に必須の修正
+
+`preflight.sh` の検出結果 (2026-05-21 時点):
+
+```
+FAIL: rite@rite-marketplace=true in settings.json.
+Per CLAUDE.md this shadows local changes. Set to false.
+```
+
+CLAUDE.md の警告:
+
+> **`rite@rite-marketplace: false` を維持すること**: `~/.claude/settings.json` の `enabledPlugins` で `rite@rite-marketplace` が `true` になっていると、キャッシュされた古いマーケットプレイス版が優先ロードされ、ローカルの修正が一切反映されない
+
+**Step 0 着手前に必ず修正**:
+
+```bash
+# 確認
+jq '.enabledPlugins["rite@rite-marketplace"]' ~/.claude/settings.json
+# → true なら NG
+
+# 修正 (バックアップ取得後)
+cp ~/.claude/settings.json ~/.claude/settings.json.bak
+jq '.enabledPlugins["rite@rite-marketplace"] = false' ~/.claude/settings.json.bak > ~/.claude/settings.json
+```
+
+修正後 `bash tests/step0-experiment/scripts/preflight.sh` で再確認し、`preflight_ok=true` が出力されることを確認すること。
+
+## 1. 事前準備 (1 回だけ実行)
+
+```bash
+cd /home/akiyoshi/Projects/personal/cc-rite-workflow
+
+# 1. preflight 全項目を pass にする
+bash tests/step0-experiment/scripts/preflight.sh
+# → 最後の行が `preflight_ok=true` ならOK
+
+# 2. 全 fixture が plugin に展開されていることを確認
+ls plugins/rite/commands/test/step0/
+# a-orchestrator.md a-subskill.md b-orchestrator.md c-orchestrator.md d-orchestrator.md e-orchestrator.md
+
+ls plugins/rite/agents/ | grep test-step0
+# test-step0-b.md
+# test-step0-e.md
+
+ls plugins/rite/scripts/test/
+# step0-worker.sh
+
+# 3. Claude Code を再起動 (新しい command / agent を認識させる)
+# → ターミナルで `/exit` してから `claude` 再起動
+
+# 4. 結果ディレクトリ準備
+mkdir -p tests/step0-experiment/results/{a-skill-completion,b-task-completion,c-bash-completion,d-inline-completion,e-task-non-completion}
+```
+
+## 2. 1 trial の手順
+
+各 trial は **新しい Claude Code セッション**で実行する (前 trial の context が漏れないように)。
+
+### Step A — 環境変数を export してセッション開始
+
+ターミナル A (記録用) で：
+
+```bash
+# variant と trial ID を決定
+export RITE_STEP0_VARIANT=a-skill-completion    # a/b/c/d/e に応じて変える
+export RITE_STEP0_TRIAL_ID=01                   # 01, 02, ..., 20
+export RITE_STEP0_RESULTS_DIR=/home/akiyoshi/Projects/personal/cc-rite-workflow/tests/step0-experiment/results/$RITE_STEP0_VARIANT
+
+# 同じシェルで Claude Code セッションを開始 (env が継承される)
+claude code
+```
+
+### Step B — orchestrator を呼ぶ
+
+Claude セッション内で variant に応じた slash command を実行:
+
+| Variant | Slash command |
+|---|---|
+| a-skill-completion | `/rite:test:step0:a-orchestrator` |
+| b-task-completion | `/rite:test:step0:b-orchestrator` |
+| c-bash-completion | `/rite:test:step0:c-orchestrator` |
+| d-inline-completion | `/rite:test:step0:d-orchestrator` |
+| e-task-non-completion | `/rite:test:step0:e-orchestrator` |
+
+orchestrator が 3 step を実行する (Step 1: flag → Step 2: boundary → Step 3: flag)。`Trial $RITE_STEP0_TRIAL_ID variant=X complete.` の 1 行で終わるのが成功。途中で stop してユーザー入力を求められたら **continue を入力せずそのまま 1 トライアル失敗**として記録。
+
+### Step C — Claude セッションを終了して結果を記録
+
+ターミナル A に戻り:
+
+```bash
+# /exit でセッション終了 (または Ctrl-D)
+
+# 結果を記録
+bash tests/step0-experiment/scripts/record-trial.sh \
+  $RITE_STEP0_VARIANT $RITE_STEP0_TRIAL_ID
+
+# 出力: results/<variant>/trial-<N>.json
+```
+
+### Step D — 次の trial へ
+
+`RITE_STEP0_TRIAL_ID` をインクリメント (01 → 02 → ... → 20) して Step A-C を繰り返す。
+20 trial が終わったら次の variant へ (a → b → c → d → e)。
+
+## 3. 効率化のヒント
+
+### 3.1 バッチ的に回すパターン
+
+各 trial 間に手動操作 (セッション再起動 + slash command 入力) があるため完全自動化は難しい。最低限の効率化:
+
+```bash
+# シェル関数で 1 trial 分の env 設定を一発化
+step0_trial() {
+  local variant=$1 trial=$2
+  export RITE_STEP0_VARIANT=$variant
+  export RITE_STEP0_TRIAL_ID=$(printf '%02d' $trial)
+  export RITE_STEP0_RESULTS_DIR=/home/akiyoshi/Projects/personal/cc-rite-workflow/tests/step0-experiment/results/$variant
+  echo "READY: variant=$variant trial=$RITE_STEP0_TRIAL_ID"
+  echo "slash command: /rite:test:step0:${variant%%-*}-orchestrator"
+}
+# 使い方: step0_trial a-skill-completion 1
+#         claude code
+#         (slash command 実行)
+#         /exit
+#         bash tests/step0-experiment/scripts/record-trial.sh $RITE_STEP0_VARIANT $RITE_STEP0_TRIAL_ID
+```
+
+### 3.2 1 セッションで複数 trial を回す変則実装
+
+**非推奨** (context 汚染が起きる) だが、急ぐ場合:
+
+- 1 セッション内で `RITE_STEP0_TRIAL_ID` を変えながら同 orchestrator を何度も呼ぶ
+- ただし前 trial の出力が次の trial の判断に影響する可能性があり、結果の信頼度が下がる
+- やむを得ず使う場合、各 trial 間で `/clear` を入れる
+
+### 3.3 タイムアウト
+
+各 trial は通常 30 秒〜2 分で終わる。5 分以上待っても完了しない場合は異常 trial として `excluded` 扱いにする。
+
+## 4. 異常 trial の判断基準
+
+`outcome` フィールドの種類:
+
+| outcome | 意味 | 集計 |
+|---|---|---|
+| `success` | step1 と step3 の両 flag 存在 | failure rate の分母+分子 (success として) |
+| `failure_implicit_stop` | step1 のみ存在、step3 なし | failure rate の分母+分子 (failure として) |
+| `excluded_no_start` | step1 すら無い (orchestrator が起動失敗) | 除外 (re-trial) |
+
+`excluded_no_start` は環境設定ミス (env var 未 export 等) なので、原因を解消して同じ trial ID で再実行。
+
+それ以外の異常 (例: Claude が Step 1 で異常終了した、Bash error が出た等) は手動で結果ファイルに `"outcome": "excluded_anomaly"` と書き換えて備考を記入。
+
+## 5. 全 trial 完了後
+
+```bash
+bash tests/step0-experiment/scripts/aggregate.sh
+```
+
+出力例:
+
+```
+========================================
+Step 0 Aggregate Results
+========================================
+Variant                        Total    OK  Fail  Excl FailRate
+a-skill-completion                20    18     2     0   .1000
+b-task-completion                 20    20     0     0   .0000
+c-bash-completion                 20    20     0     0   .0000
+d-inline-completion               20    20     0     0   .0000
+e-task-non-completion             20    20     0     0   .0000
+
+Falsification verdicts:
+  H2 (Task isolation):     supported
+  H3 (Bash worker):        supported
+  ...
+```
+
+この結果を `docs/investigations/step0-results.md` の各セクションに転記。
+
+## 6. 採用 architecture 決定
+
+`step0-results.md` §6 の table に沿って Step 1 以降の方針を確定。Plan §21.3 を参照:
+
+| Step 0 結果 | 採用 path |
+|---|---|
+| Task isolation OK + Bash worker OK | **Hybrid 案** (推奨、Plan §17.4 / §21.1) |
+| Task isolation 不可 + Bash worker OK | Bash worker 主軸 (subagent 不使用) |
+| Bash worker でも failure 残存 | Alt C (marker phrasing 修正) を併用 |
+| 全 variant で failure 残存 | 元の案 A (Read 経由) フォールバック |
+
+## 7. トラブルシューティング
+
+### 7.1 slash command が見つからない
+
+```
+/rite:test:step0:a-orchestrator → "command not found"
+```
+
+→ Claude Code を再起動して plugin 再ロード。再起動後も見つからなければ `~/.claude/settings.json` の `enabledPlugins` に "rite" が `true` で入っているか確認。
+
+### 7.2 Task agent が見つからない
+
+```
+Agent tool error: subagent_type "test-step0-b" not registered
+```
+
+→ Claude Code 再起動。`plugins/rite/agents/test-step0-b.md` の YAML frontmatter `name: test-step0-b` を確認。
+
+### 7.3 step1 flag が作られない
+
+→ env var が未 export。`echo $RITE_STEP0_TRIAL_ID $RITE_STEP0_RESULTS_DIR` で確認してから Claude セッションを開始。
+
+### 7.4 marketplace cache が残っている
+
+`preflight.sh` を再実行して `marketplace=ok (rite@rite-marketplace=false)` を確認。trial 結果 JSON の `marketplace_rite` フィールドが `"false"` であることも `record-trial.sh` 実行後に確認する。
+
+## 8. 関連 doc
+
+- 上位 Plan: `/home/akiyoshi/.claude/plans/rite-issue-create-rite-issue-start-rite-lovely-snowglobe.md` §21 (最終確定 Plan)
+- 実験設計: `tests/step0-experiment/README.md`
+- 結果レポート: `docs/investigations/step0-results.md`

--- a/tests/step0-experiment/README.md
+++ b/tests/step0-experiment/README.md
@@ -1,0 +1,111 @@
+# Step 0: Implicit-stop Boundary 検証実験
+
+このディレクトリは、Plan `/home/akiyoshi/.claude/plans/rite-issue-create-rite-issue-start-rite-lovely-snowglobe.md` §21.2 Step 0 の **「Sub-skill return 後の implicit stop は本当に Skill ツール仕様外用法が原因か」** という leading hypothesis を falsification ベースで検証する実験 fixture と観測ツール群。
+
+## 実験の目的
+
+5 つの異なる「parent ↔ child boundary tool」を比較し、以下を確定させる:
+
+- **H1**: Skill boundary が implicit stop を発火させやすいか
+- **H2**: Task subagent boundary は parent context を遮断し implicit stop を起こさないか
+- **H3**: Bash worker boundary は implicit stop を構造的に回避するか
+- **H4**: Completion-like marker (`[X:completed]`) 自体が独立した stop trigger になっているか
+- **H5**: Non-completion marker (`[next: phase_X]`) に変えると Task boundary でも parent が継続するか
+
+Step 0 が **Plan 全体の go/no-go ゲート**。ここで採用アーキテクチャが確定し、Step 1 以降の作業方針が決まる。
+
+## Variants 一覧
+
+各 variant は同一の「3 step orchestrator」を持ち、Step 2 の boundary tool だけを差し替える。
+
+| Variant | Boundary Tool | Marker | 検証する仮説 |
+|---|---|---|---|
+| A (baseline) | `Skill: test:step0-variant-a-subskill` | `[trial:completed:N]` (completion-like) | H1: Skill 経由は止まりやすいか |
+| B | `Task` (subagent) | `[trial:completed:N]` | H2: Task で隔離されるか |
+| C | `Bash` (worker) | `[trial:completed:N]` | H3: Bash で構造的に回避できるか |
+| D | (no boundary, inline) | `[trial:completed:N]` | Inline + marker のベースライン |
+| E | `Task` (subagent) | `[next: step_3]` (next-instruction) | H5: marker 形式の効果 |
+
+D vs A の差で「Skill boundary 自体の効果」、E vs B の差で「marker 形式の効果」、C vs A の差で「Bash の効果」を分離できる。
+
+## Primary metric: `parent_continuation_success`
+
+各 trial の orchestrator は以下の 3 step を実行する:
+
+1. **Step 1**: `tests/step0-experiment/results/{variant}/trial-{N}-step1.flag` ファイルを `touch` で作る (parent が orchestrator を起動した証拠)
+2. **Step 2**: boundary tool を呼び出し、completion marker (variant E は next-instruction marker) を含むテキストを return させる
+3. **Step 3**: boundary 結果を受けて、`trial-{N}-step3.flag` を `touch` で作る (parent が boundary 後に next action を取った証拠)
+
+**判定**:
+- step1 と step3 の両方の flag が存在 → `parent_continuation_success = true`
+- step1 のみ (step3 なし) + session が `stop_reason: end_turn` で終了 → `parent_continuation_success = false` (= implicit stop)
+- step1 すらない → 異常 trial (除外)
+
+## Falsification thresholds
+
+| Hypothesis | Falsification condition |
+|---|---|
+| H2 (Task isolation) | Variant B で 20 trial 中 **2 回以上**失敗 → Task isolation 不十分 |
+| H3 (Bash worker) | Variant C で 20 trial 中 **2 回以上**失敗 → Bash worker でも防げない |
+| H4 (Marker dominance) | A vs D の failure rate 差が **小さい** (< 5 percentage points) → boundary tool より marker phrasing が dominant |
+| H5 (Non-completion marker) | E vs B の failure rate 差が **大きい** (> 30 percentage points) → marker phrasing の効果が大きい |
+
+## Controls (全 variant 共通)
+
+各 trial で以下を fixed control として固定する。`scripts/preflight.sh` で検証:
+
+- 同 Claude Code version (CLI version を `claude --version` で取得)
+- 同 model (Opus 4.7、`~/.claude/settings.json` 確認)
+- 同 plugin root (`/home/akiyoshi/Projects/personal/cc-rite-workflow`、marketplace cache 無効化)
+- 同 git commit hash
+- 同 `rite-config.yml`
+- `rite@rite-marketplace: false` 設定済み
+
+## ディレクトリ構造
+
+実 Skill ツール / Task agent の発火に slash command/agent 登録が必要なため、fixture は plugin 配下に置く。本ディレクトリは補助スクリプトと結果置き場のみ。
+
+```
+plugins/rite/
+├── commands/test/step0/
+│   ├── a-orchestrator.md    # /rite:test:step0:a-orchestrator
+│   ├── a-subskill.md        # /rite:test:step0:a-subskill (Variant A の child skill)
+│   ├── b-orchestrator.md    # /rite:test:step0:b-orchestrator
+│   ├── c-orchestrator.md
+│   ├── d-orchestrator.md
+│   └── e-orchestrator.md
+├── agents/
+│   ├── test-step0-b.md      # Variant B/E の subagent (Task tool spawn)
+│   └── test-step0-e.md      # Variant E の subagent (non-completion marker emit)
+└── scripts/test/
+    └── step0-worker.sh      # Variant C の bash worker
+
+tests/step0-experiment/
+├── README.md (本ファイル)
+├── HOW-TO-RUN.md            # 坂口さん向け実機実行手順書
+├── variants/
+│   ├── a-skill-completion/README.md      # variant 詳細説明
+│   ├── b-task-completion/README.md
+│   ├── c-bash-completion/README.md
+│   ├── d-inline-completion/README.md
+│   └── e-task-non-completion/README.md
+├── scripts/
+│   ├── preflight.sh         # marketplace cache 検出 + 環境ロック
+│   ├── observe.sh           # JSONL parser, parent_continuation_success 判定
+│   ├── record-trial.sh      # 1 trial 完了時に呼ぶ記録ヘルパー
+│   └── aggregate.sh         # 全 variant の集計と falsification 判定
+└── results/                 # gitignore (.gitkeep のみ commit)
+    └── {variant}/trial-{N}.json
+```
+
+## 関連 doc
+
+- 上位 plan: `/home/akiyoshi/.claude/plans/rite-issue-create-rite-issue-start-rite-lovely-snowglobe.md`
+- 結果レポート (実機実行後に埋める): `docs/investigations/step0-results.md`
+- 操作手順書: `tests/step0-experiment/HOW-TO-RUN.md`
+
+## 注意事項
+
+- 本ディレクトリの fixture は **実験専用**。プロダクションコード (`plugins/rite/`) には影響しない設計
+- variants の `.md` ファイルは Claude Code セッション内で `Read` で読み込んで実行する想定。Slash command 化は不要
+- 各 trial は独立した Claude Code セッションで実行する (前 trial の context が漏れないように `/clear` 必須)

--- a/tests/step0-experiment/scripts/aggregate.sh
+++ b/tests/step0-experiment/scripts/aggregate.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Aggregate all Step 0 trial records and emit a falsification verdict.
+#
+# Usage:
+#   aggregate.sh
+#
+# Reads:  tests/step0-experiment/results/<variant>/trial-*.json
+# Writes: tests/step0-experiment/results/aggregate.json + human summary to stdout
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(pwd)}"
+RESULTS_ROOT="$REPO_ROOT/tests/step0-experiment/results"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for aggregation" >&2
+  exit 1
+fi
+
+VARIANTS=(a-skill-completion b-task-completion c-bash-completion d-inline-completion e-task-non-completion)
+
+# Build per-variant stats
+tmp_agg=$(mktemp)
+trap 'rm -f "$tmp_agg"' EXIT
+echo '{}' > "$tmp_agg"
+
+for v in "${VARIANTS[@]}"; do
+  dir="$RESULTS_ROOT/$v"
+  if [ ! -d "$dir" ]; then
+    jq --arg v "$v" '. + {($v): {total: 0, success: 0, failure: 0, excluded: 0, failure_rate: null}}' "$tmp_agg" > "$tmp_agg.next" && mv "$tmp_agg.next" "$tmp_agg"
+    continue
+  fi
+  total=0; success=0; failure=0; excluded=0
+  for trial in "$dir"/trial-*.json; do
+    [ -f "$trial" ] || continue
+    total=$((total + 1))
+    outcome=$(jq -r '.outcome // "unknown"' "$trial" 2>/dev/null)
+    case "$outcome" in
+      success) success=$((success + 1)) ;;
+      failure_implicit_stop) failure=$((failure + 1)) ;;
+      excluded_no_start) excluded=$((excluded + 1)) ;;
+    esac
+  done
+  countable=$((success + failure))
+  failure_rate="null"
+  if [ "$countable" -gt 0 ]; then
+    failure_rate=$(echo "scale=4; $failure / $countable" | bc 2>/dev/null || echo "null")
+  fi
+  jq --arg v "$v" \
+     --argjson t "$total" \
+     --argjson s "$success" \
+     --argjson f "$failure" \
+     --argjson x "$excluded" \
+     --arg fr "$failure_rate" \
+     '. + {($v): {total: $t, success: $s, failure: $f, excluded: $x, failure_rate: (if $fr == "null" then null else ($fr | tonumber) end)}}' \
+     "$tmp_agg" > "$tmp_agg.next" && mv "$tmp_agg.next" "$tmp_agg"
+done
+
+# Falsification verdicts (Plan §20.2)
+A_FAIL=$(jq -r '."a-skill-completion".failure' "$tmp_agg")
+B_FAIL=$(jq -r '."b-task-completion".failure' "$tmp_agg")
+C_FAIL=$(jq -r '."c-bash-completion".failure' "$tmp_agg")
+D_FAIL=$(jq -r '."d-inline-completion".failure' "$tmp_agg")
+E_FAIL=$(jq -r '."e-task-non-completion".failure' "$tmp_agg")
+
+A_RATE=$(jq -r '."a-skill-completion".failure_rate' "$tmp_agg")
+B_RATE=$(jq -r '."b-task-completion".failure_rate' "$tmp_agg")
+C_RATE=$(jq -r '."c-bash-completion".failure_rate' "$tmp_agg")
+D_RATE=$(jq -r '."d-inline-completion".failure_rate' "$tmp_agg")
+E_RATE=$(jq -r '."e-task-non-completion".failure_rate' "$tmp_agg")
+
+verdict_H2="undetermined"; [ "$B_FAIL" != "null" ] && [ "$B_FAIL" -ge 2 ] && verdict_H2="falsified_task_isolation_insufficient"
+[ "$B_FAIL" != "null" ] && [ "$B_FAIL" -lt 2 ] && [ "$(jq '."b-task-completion".total' "$tmp_agg")" -ge 20 ] && verdict_H2="supported"
+
+verdict_H3="undetermined"; [ "$C_FAIL" != "null" ] && [ "$C_FAIL" -ge 2 ] && verdict_H3="falsified_bash_worker_insufficient"
+[ "$C_FAIL" != "null" ] && [ "$C_FAIL" -lt 2 ] && [ "$(jq '."c-bash-completion".total' "$tmp_agg")" -ge 20 ] && verdict_H3="supported"
+
+# H4: marker dominance — compare A vs D failure rate. If |A_rate - D_rate| < 0.05, marker dominates (boundary doesn't matter)
+verdict_H4="undetermined"
+if [ "$A_RATE" != "null" ] && [ "$D_RATE" != "null" ]; then
+  diff=$(echo "scale=4; if ($A_RATE > $D_RATE) $A_RATE - $D_RATE else $D_RATE - $A_RATE" | bc 2>/dev/null || echo "0")
+  small=$(echo "$diff < 0.05" | bc 2>/dev/null || echo 0)
+  if [ "$small" = "1" ]; then
+    verdict_H4="marker_dominant"
+  else
+    verdict_H4="boundary_dominant"
+  fi
+fi
+
+# H5: marker phrasing — compare B vs E. If E_rate - B_rate < -0.3 (E much better), phrasing matters
+verdict_H5="undetermined"
+if [ "$B_RATE" != "null" ] && [ "$E_RATE" != "null" ]; then
+  diff_be=$(echo "scale=4; $B_RATE - $E_RATE" | bc 2>/dev/null || echo "0")
+  big=$(echo "$diff_be > 0.3" | bc 2>/dev/null || echo 0)
+  if [ "$big" = "1" ]; then
+    verdict_H5="non_completion_marker_helps"
+  else
+    verdict_H5="marker_form_minor"
+  fi
+fi
+
+jq \
+  --arg h2 "$verdict_H2" \
+  --arg h3 "$verdict_H3" \
+  --arg h4 "$verdict_H4" \
+  --arg h5 "$verdict_H5" \
+  '. + {verdicts: {H2: $h2, H3: $h3, H4: $h4, H5: $h5}}' \
+  "$tmp_agg" > "$RESULTS_ROOT/aggregate.json"
+
+# Human summary
+echo "========================================"
+echo "Step 0 Aggregate Results"
+echo "========================================"
+printf "%-30s %5s %5s %5s %5s %s\n" "Variant" "Total" "OK" "Fail" "Excl" "FailRate"
+for v in "${VARIANTS[@]}"; do
+  t=$(jq -r --arg v "$v" '.[$v].total' "$tmp_agg")
+  s=$(jq -r --arg v "$v" '.[$v].success' "$tmp_agg")
+  f=$(jq -r --arg v "$v" '.[$v].failure' "$tmp_agg")
+  x=$(jq -r --arg v "$v" '.[$v].excluded' "$tmp_agg")
+  r=$(jq -r --arg v "$v" '.[$v].failure_rate' "$tmp_agg")
+  printf "%-30s %5s %5s %5s %5s %s\n" "$v" "$t" "$s" "$f" "$x" "$r"
+done
+echo ""
+echo "Falsification verdicts:"
+echo "  H2 (Task isolation):     $verdict_H2"
+echo "  H3 (Bash worker):        $verdict_H3"
+echo "  H4 (Marker vs Boundary): $verdict_H4"
+echo "  H5 (Marker phrasing):    $verdict_H5"
+echo ""
+echo "Full JSON: $RESULTS_ROOT/aggregate.json"

--- a/tests/step0-experiment/scripts/observe.sh
+++ b/tests/step0-experiment/scripts/observe.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Step 0 observation script.
+# Determines parent_continuation_success for a single trial by examining the
+# result flag files and (optionally) the session JSONL log.
+#
+# Usage:
+#   observe.sh <variant> <trial_id> [session_jsonl_path]
+#
+# Variant names: a-skill-completion, b-task-completion, c-bash-completion,
+#                d-inline-completion, e-task-non-completion
+#
+# Output: JSON to stdout summarizing the trial.
+
+set -uo pipefail
+
+VARIANT="${1:-}"
+TRIAL_ID="${2:-}"
+SESSION_JSONL="${3:-}"
+
+if [ -z "$VARIANT" ] || [ -z "$TRIAL_ID" ]; then
+  echo "usage: $0 <variant> <trial_id> [session_jsonl_path]" >&2
+  exit 1
+fi
+
+REPO_ROOT="${REPO_ROOT:-$(pwd)}"
+RESULTS_DIR="$REPO_ROOT/tests/step0-experiment/results/$VARIANT"
+
+STEP1_FLAG="$RESULTS_DIR/trial-$TRIAL_ID-step1.flag"
+STEP3_FLAG="$RESULTS_DIR/trial-$TRIAL_ID-step3.flag"
+
+step1_present=false
+step3_present=false
+[ -f "$STEP1_FLAG" ] && step1_present=true
+[ -f "$STEP3_FLAG" ] && step3_present=true
+
+# Determine outcome
+if [ "$step1_present" = false ]; then
+  outcome="excluded_no_start"
+  parent_continuation_success="null"
+elif [ "$step3_present" = true ]; then
+  outcome="success"
+  parent_continuation_success="true"
+else
+  outcome="failure_implicit_stop"
+  parent_continuation_success="false"
+fi
+
+# Session log analysis (optional)
+session_summary='""'
+if [ -n "$SESSION_JSONL" ] && [ -f "$SESSION_JSONL" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    skill_calls=$(grep -c '"name":"Skill"' "$SESSION_JSONL" 2>/dev/null || true)
+    task_calls=$(grep -c '"name":"Task"' "$SESSION_JSONL" 2>/dev/null || true)
+    bash_calls=$(grep -c '"name":"Bash"' "$SESSION_JSONL" 2>/dev/null || true)
+    end_turn_count=$(grep -c '"stop_reason":"end_turn"' "$SESSION_JSONL" 2>/dev/null || true)
+    : "${skill_calls:=0}"; : "${task_calls:=0}"; : "${bash_calls:=0}"; : "${end_turn_count:=0}"
+    session_summary=$(jq -n \
+      --argjson sc "$skill_calls" \
+      --argjson tc "$task_calls" \
+      --argjson bc "$bash_calls" \
+      --argjson et "$end_turn_count" \
+      '{skill_calls: $sc, task_calls: $tc, bash_calls: $bc, end_turn_count: $et}')
+  fi
+fi
+
+# Emit JSON
+if command -v jq >/dev/null 2>&1; then
+  jq -n \
+    --arg variant "$VARIANT" \
+    --arg trial_id "$TRIAL_ID" \
+    --arg outcome "$outcome" \
+    --argjson step1 "$step1_present" \
+    --argjson step3 "$step3_present" \
+    --argjson pcs "$parent_continuation_success" \
+    --argjson session "$session_summary" \
+    '{
+      variant: $variant,
+      trial_id: $trial_id,
+      outcome: $outcome,
+      step1_flag_present: $step1,
+      step3_flag_present: $step3,
+      parent_continuation_success: $pcs,
+      session_summary: $session
+    }'
+else
+  cat <<EOF
+{
+  "variant": "$VARIANT",
+  "trial_id": "$TRIAL_ID",
+  "outcome": "$outcome",
+  "step1_flag_present": $step1_present,
+  "step3_flag_present": $step3_present,
+  "parent_continuation_success": $parent_continuation_success
+}
+EOF
+fi

--- a/tests/step0-experiment/scripts/preflight.sh
+++ b/tests/step0-experiment/scripts/preflight.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Step 0 experiment preflight check.
+# Verifies the controlled environment before any trial runs (Plan §20.12).
+#
+# Exit codes:
+#   0  — environment is locked; trials may proceed
+#   1  — usage error
+#   2  — environment mismatch (marketplace cache override, wrong plugin root, dirty git)
+#
+# Output: structured key=value lines on stdout. Human-readable diagnostics on stderr.
+
+set -uo pipefail
+
+EXPECTED_PLUGIN_ROOT="${EXPECTED_PLUGIN_ROOT:-/home/akiyoshi/Projects/personal/cc-rite-workflow}"
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "preflight_ok=false"
+  exit 2
+}
+
+warn() {
+  echo "WARN: $1" >&2
+}
+
+# 1. Settings.json marketplace check
+SETTINGS_FILE="$HOME/.claude/settings.json"
+if [ ! -f "$SETTINGS_FILE" ]; then
+  warn "settings.json not found at $SETTINGS_FILE — cannot verify marketplace state"
+  marketplace_status="unknown"
+else
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not installed — falling back to grep"
+    if grep -q '"rite@rite-marketplace":[[:space:]]*true' "$SETTINGS_FILE"; then
+      fail "rite@rite-marketplace is TRUE in settings.json. This causes stale marketplace plugin to shadow local changes. Set it to false."
+    fi
+    marketplace_status="grep_check_passed"
+  else
+    # NOTE: cannot use `// "absent"` because jq treats `false` as falsy and
+    # falls through to the alternative, masking the explicit `false` value.
+    rite_mp=$(jq -r 'if (.enabledPlugins | has("rite@rite-marketplace")) then (.enabledPlugins["rite@rite-marketplace"] | tostring) else "absent" end' "$SETTINGS_FILE" 2>/dev/null)
+    if [ "$rite_mp" = "true" ]; then
+      fail "rite@rite-marketplace=true in settings.json. Per CLAUDE.md this shadows local changes. Set to false."
+    fi
+    marketplace_status="ok (rite@rite-marketplace=$rite_mp)"
+  fi
+fi
+echo "marketplace=$marketplace_status"
+
+# 2. CWD == expected plugin root
+ACTUAL_CWD="$(pwd)"
+if [ "$ACTUAL_CWD" != "$EXPECTED_PLUGIN_ROOT" ]; then
+  fail "CWD=$ACTUAL_CWD does not match EXPECTED_PLUGIN_ROOT=$EXPECTED_PLUGIN_ROOT. Run preflight from the plugin root."
+fi
+echo "plugin_root=$EXPECTED_PLUGIN_ROOT"
+
+# 3. Git presence + state
+if ! command -v git >/dev/null 2>&1; then
+  fail "git not installed"
+fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  fail "not a git repository: $(pwd)"
+fi
+GIT_HEAD=$(git rev-parse HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "git_head=$GIT_HEAD"
+echo "git_branch=$GIT_BRANCH"
+
+# Warn (not fail) on uncommitted changes — operator may have intentional edits
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  warn "uncommitted changes detected. Trials may not reflect the recorded git_head."
+  echo "git_dirty=true"
+else
+  echo "git_dirty=false"
+fi
+
+# 4. Required CLI versions
+if command -v claude >/dev/null 2>&1; then
+  CC_VERSION=$(claude --version 2>/dev/null | head -1)
+  echo "claude_cli=$CC_VERSION"
+else
+  warn "claude CLI not on PATH — version cannot be recorded"
+  echo "claude_cli=unknown"
+fi
+
+# 5. Bash version (Plan §20.3 requires 4.2+)
+BASH_VER="$BASH_VERSION"
+BASH_MAJOR="${BASH_VER%%.*}"
+if [ "$BASH_MAJOR" -lt 4 ]; then
+  fail "Bash $BASH_VER detected; Plan §20.3 requires 4.2+. On macOS, brew install bash."
+fi
+echo "bash_version=$BASH_VER"
+
+# 6. Plugin fixture files present
+REQUIRED=(
+  "plugins/rite/commands/test/step0/a-orchestrator.md"
+  "plugins/rite/commands/test/step0/a-subskill.md"
+  "plugins/rite/commands/test/step0/b-orchestrator.md"
+  "plugins/rite/commands/test/step0/c-orchestrator.md"
+  "plugins/rite/commands/test/step0/d-orchestrator.md"
+  "plugins/rite/commands/test/step0/e-orchestrator.md"
+  "plugins/rite/agents/test-step0-b.md"
+  "plugins/rite/agents/test-step0-e.md"
+  "plugins/rite/scripts/test/step0-worker.sh"
+)
+missing=0
+for f in "${REQUIRED[@]}"; do
+  if [ ! -f "$f" ]; then
+    warn "missing fixture: $f"
+    missing=1
+  fi
+done
+[ "$missing" = 0 ] || fail "step 0 fixtures incomplete; aborting"
+echo "fixtures=ok"
+
+echo "preflight_ok=true"

--- a/tests/step0-experiment/scripts/record-trial.sh
+++ b/tests/step0-experiment/scripts/record-trial.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Record a single Step 0 trial.
+# Captures environment, runs observe.sh, and persists result JSON.
+#
+# Usage:
+#   record-trial.sh <variant> <trial_id> [session_jsonl_path]
+#
+# Side effects: writes
+#   tests/step0-experiment/results/<variant>/trial-<trial_id>.json
+#
+# Exit codes:
+#   0 — recorded
+#   1 — usage / invalid input
+#   2 — observe.sh failed
+
+set -uo pipefail
+
+VARIANT="${1:-}"
+TRIAL_ID="${2:-}"
+SESSION_JSONL="${3:-}"
+
+if [ -z "$VARIANT" ] || [ -z "$TRIAL_ID" ]; then
+  echo "usage: $0 <variant> <trial_id> [session_jsonl_path]" >&2
+  exit 1
+fi
+
+REPO_ROOT="${REPO_ROOT:-$(pwd)}"
+SCRIPT_DIR="$REPO_ROOT/tests/step0-experiment/scripts"
+RESULTS_DIR="$REPO_ROOT/tests/step0-experiment/results/$VARIANT"
+mkdir -p "$RESULTS_DIR"
+OUT="$RESULTS_DIR/trial-$TRIAL_ID.json"
+
+# Capture environment context (matches preflight.sh categories)
+SETTINGS_FILE="$HOME/.claude/settings.json"
+marketplace="unknown"
+if [ -f "$SETTINGS_FILE" ] && command -v jq >/dev/null 2>&1; then
+  marketplace=$(jq -r '.enabledPlugins["rite@rite-marketplace"] // "absent"' "$SETTINGS_FILE" 2>/dev/null)
+fi
+
+git_head=$(git rev-parse HEAD 2>/dev/null || echo "")
+git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+git_dirty="false"
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  git_dirty="true"
+fi
+cc_version=""
+if command -v claude >/dev/null 2>&1; then
+  cc_version=$(claude --version 2>/dev/null | head -1)
+fi
+
+# Auto-detect session JSONL if not provided
+if [ -z "$SESSION_JSONL" ]; then
+  proj_dir="$HOME/.claude/projects/-home-akiyoshi-Projects-personal-cc-rite-workflow"
+  if [ -d "$proj_dir" ]; then
+    SESSION_JSONL=$(ls -t "$proj_dir"/*.jsonl 2>/dev/null | head -1)
+  fi
+fi
+
+# Run observation
+OBSERVE_OUT=$(bash "$SCRIPT_DIR/observe.sh" "$VARIANT" "$TRIAL_ID" "$SESSION_JSONL" 2>/dev/null)
+observe_rc=$?
+if [ "$observe_rc" -ne 0 ]; then
+  echo "observe.sh failed (rc=$observe_rc)" >&2
+  exit 2
+fi
+
+# Compose final record (merge env context with observation)
+if command -v jq >/dev/null 2>&1; then
+  echo "$OBSERVE_OUT" | jq \
+    --arg ts "$(date -Iseconds)" \
+    --arg head "$git_head" \
+    --arg branch "$git_branch" \
+    --arg dirty "$git_dirty" \
+    --arg ccv "$cc_version" \
+    --arg mp "$marketplace" \
+    --arg sjl "$SESSION_JSONL" \
+    '. + {
+      recorded_at: $ts,
+      git_head: $head,
+      git_branch: $branch,
+      git_dirty: ($dirty == "true"),
+      claude_cli: $ccv,
+      marketplace_rite: $mp,
+      session_jsonl: $sjl
+    }' > "$OUT"
+else
+  printf '%s\n' "$OBSERVE_OUT" > "$OUT"
+fi
+
+echo "recorded: $OUT"

--- a/tests/step0-experiment/variants/a-skill-completion/README.md
+++ b/tests/step0-experiment/variants/a-skill-completion/README.md
@@ -1,0 +1,24 @@
+# Variant A: Skill boundary + completion marker (baseline)
+
+## Setup
+
+- Orchestrator: `/rite:test:step0:a-orchestrator`
+- Sub-skill: `/rite:test:step0:a-subskill`
+- Marker: `[trial:completed:N]` (completion-like)
+
+## Boundary tool
+
+`Skill` tool. The orchestrator invokes `rite:test:step0:a-subskill` and the
+sub-skill emits the completion-like marker before returning control.
+
+## Hypothesis tested
+
+**H1**: Skill tool boundary increases the probability of `stop_reason: end_turn`
+after the sub-skill returns the completion-like marker.
+
+This variant is the **baseline** — its failure rate is the reference point that
+B/C/D/E variants are compared against.
+
+## Results location
+
+`tests/step0-experiment/results/a-skill-completion/trial-{N}-{step1,step3}.flag`

--- a/tests/step0-experiment/variants/b-task-completion/README.md
+++ b/tests/step0-experiment/variants/b-task-completion/README.md
@@ -1,0 +1,28 @@
+# Variant B: Task subagent + completion marker
+
+## Setup
+
+- Orchestrator: `/rite:test:step0:b-orchestrator`
+- Subagent: `test-step0-b` (agents/test-step0-b.md)
+- Marker: `[trial:completed:N]` (completion-like, same as Variant A)
+
+## Boundary tool
+
+`Agent` (Task) tool. Subagent runs in an isolated context and returns a textual
+report ending with the completion-like marker.
+
+## Hypothesis tested
+
+**H2**: Task subagent boundary isolates `stop_reason: end_turn` to the
+subagent's own context, so the parent continues normally after Task return.
+
+## Comparison
+
+vs Variant A (Skill boundary, same marker): differential measures Task vs Skill
+boundary effect.
+vs Variant E (Task boundary, non-completion marker): differential measures the
+effect of marker form on Task boundary.
+
+## Results location
+
+`tests/step0-experiment/results/b-task-completion/trial-{N}-{step1,step3}.flag`

--- a/tests/step0-experiment/variants/c-bash-completion/README.md
+++ b/tests/step0-experiment/variants/c-bash-completion/README.md
@@ -1,0 +1,28 @@
+# Variant C: Bash worker + completion marker
+
+## Setup
+
+- Orchestrator: `/rite:test:step0:c-orchestrator`
+- Worker: `plugins/rite/scripts/test/step0-worker.sh`
+- Marker: `[trial:completed:N]` (completion-like)
+
+## Boundary tool
+
+`Bash` tool. Worker script executes in a sub-process and returns stdout to the
+caller. The final stdout line is the completion-like marker.
+
+## Hypothesis tested
+
+**H3**: Bash worker boundary structurally avoids implicit stop because the
+parent treats Bash output as data rather than a skill/agent handoff.
+
+## Comparison
+
+vs Variant A (Skill boundary, same marker): differential measures Bash vs Skill
+boundary effect.
+vs Variant D (no boundary, same marker): differential isolates the effect of
+Bash boundary specifically vs pure inline execution.
+
+## Results location
+
+`tests/step0-experiment/results/c-bash-completion/trial-{N}-{step1,step3}.flag`

--- a/tests/step0-experiment/variants/d-inline-completion/README.md
+++ b/tests/step0-experiment/variants/d-inline-completion/README.md
@@ -1,0 +1,30 @@
+# Variant D: Inline (no boundary) + completion marker
+
+## Setup
+
+- Orchestrator: `/rite:test:step0:d-orchestrator`
+- Marker: `[trial:completed:N]` (completion-like, embedded in inline Bash echo)
+
+## Boundary tool
+
+**None**. Parent performs all dummy work in a single inline Bash call. The
+completion marker appears in Bash stdout but no separate skill/agent/worker
+return event occurs.
+
+## Hypothesis tested
+
+This variant is a **control** to isolate marker effect from boundary effect:
+
+- If A (Skill + marker) fails more than D (inline + marker), boundary tool
+  matters
+- If D fails as often as A, marker phrasing alone may be sufficient to trigger
+  implicit stop
+
+## Comparison
+
+vs Variant A: isolates Skill boundary effect.
+vs Variant C: isolates Bash boundary effect (vs no boundary at all).
+
+## Results location
+
+`tests/step0-experiment/results/d-inline-completion/trial-{N}-{step1,step3}.flag`

--- a/tests/step0-experiment/variants/e-task-non-completion/README.md
+++ b/tests/step0-experiment/variants/e-task-non-completion/README.md
@@ -1,0 +1,29 @@
+# Variant E: Task subagent + non-completion marker
+
+## Setup
+
+- Orchestrator: `/rite:test:step0:e-orchestrator`
+- Subagent: `test-step0-e` (agents/test-step0-e.md)
+- Marker: `[next: step_3]` (next-instruction, not completion-like)
+
+## Boundary tool
+
+`Agent` (Task) tool, same as Variant B. Only the marker form differs.
+
+## Hypothesis tested
+
+**H5**: Non-completion marker (next-instruction phrasing) reduces implicit stop
+even on the same Task boundary as Variant B.
+
+## Comparison
+
+vs Variant B (same boundary, completion marker): direct measurement of marker
+form effect with all else held constant.
+
+If E succeeds dramatically more than B, marker phrasing is a major factor
+independent of boundary tool. This would suggest **marker redesign alone**
+might be a viable patch (cf. Plan §20.13 Alternative C).
+
+## Results location
+
+`tests/step0-experiment/results/e-task-non-completion/trial-{N}-{step1,step3}.flag`


### PR DESCRIPTION
## Summary

- Sub-skill 連鎖中の implicit stop 問題の根本原因検証のために、5 variants の対照実験 fixture と補助スクリプトを追加
- Variant A (Skill + completion marker) / B (Task + completion marker) / C (Bash worker + completion marker) / D (inline + completion marker) / E (Task + non-completion marker) を `branch-setup` 規模の最小単位で再現
- 補助スクリプト 4 個 (preflight / observe / record-trial / aggregate) と実行手順書 (HOW-TO-RUN.md) で 20 trials × 5 variants の対照実験を回せる状態にした

## Background

実装フェーズではなく、検証フェーズの PR。本 fixture は Plan で確定した「Skill ツールを内部手順分割に使うのは公式仕様外用法」という仮説 (H1〜H5) を falsification ベースで検証するために用意した。Step 0 の結果が後続の Step 1〜7 の採用 architecture (Hybrid / Bash-only / Alt C / 元案 A) を確定させる **go/no-go ゲート**。

## What's included

| 種別 | パス | 内容 |
|---|---|---|
| Orchestrator | `plugins/rite/commands/test/step0/{a,b,c,d,e}-orchestrator.md` | 5 variants の parent skill |
| Sub-skill | `plugins/rite/commands/test/step0/a-subskill.md` | Variant A の child skill |
| Subagent | `plugins/rite/agents/test-step0-{b,e}.md` | Variant B/E (read-only contract) |
| Bash worker | `plugins/rite/scripts/test/step0-worker.sh` | Variant C |
| Scripts | `tests/step0-experiment/scripts/{preflight,observe,record-trial,aggregate}.sh` | 環境ロック / 観測 / 記録 / 集計 |
| Docs | `tests/step0-experiment/{README,HOW-TO-RUN}.md` + `variants/*/README.md` | 実験設計と運用手順 |
| Report template | `docs/investigations/step0-results.md` | 結果記録雛形 |

## Preliminary observation (n=1, 非公式)

PR 著者の動作確認セッション内で Variant A baseline の implicit stop が再現:

- `[trial:completed:01]` marker emit 直後に `stop_reason: end_turn`
- parent orchestrator の Step 3 (post-boundary flag touch) は未実行
- ユーザー手動 continue で初めて Step 3 進行
- (Variant 仮説 H1: Skill + completion marker baseline で implicit stop が発生する) を支持する 1 データ点

n=1 + 開発セッション context のため正式集計対象外。**正式な 20 trials × 5 variants 対照実験は別途実施予定** (`tests/step0-experiment/HOW-TO-RUN.md` 参照)。

## Test plan

- [ ] `bash tests/step0-experiment/scripts/preflight.sh` で `preflight_ok=true` を確認
- [ ] Claude Code を再起動 (新規 slash command と subagent の認識)
  - 起動: `claude --plugin-dir ./plugins/rite` (現状のドッグフーディング方式)
- [ ] `/rite:test:step0:a-orchestrator` が認識されること
- [ ] Variant A〜E 各 20 trials を `HOW-TO-RUN.md` の手順で実行
- [ ] `bash tests/step0-experiment/scripts/aggregate.sh` で集計
- [ ] 結果を `docs/investigations/step0-results.md` に転記
- [ ] Falsification verdict (H2/H3/H4/H5) を確定させ、後続 Step の採用 architecture を決定

## Non-goals

- 本 PR は **検証 fixture の追加のみ**。production code (`plugins/rite/commands/issue/`, `pr/`, `wiki/`) は変更しない
- Step 0 結果に基づく architecture 改修 (Step 1〜7) は別 PR

## Notes

- `preflight.sh` の jq `// "absent"` バグ (false が falsy として alternative に流れる) は修正済み
- subagent は read-only contract (`tools: Bash` のみ、mutation 不可)
- 5 variants 比較設計は Codex review (approve-with-revisions) の指摘を反映 (20 trials / variant + falsification thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)