### PR TITLE
fix(workflow): Issue checklist 進捗反映の visibility 向上と大量残存検出時の警告経路を導入 (#1077)

### DIFF
--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -29,11 +29,12 @@ When incomplete checklist items are detected, evaluate each item's fulfillment s
 
 ### Evaluation procedure
 
-**Step 0: Mass-residual warning (≥5 incomplete items)** — Before evaluation, count incomplete items (excluding parent-child Tasklist `- [ ] #XX` entries) and surface a Root Cause investigation prompt when the count meets the mass-residual threshold. Threshold = **5** (symmetric with `cleanup.md` Phase 1.6.5.2 mass-detection `workflow_incident` emit; Issue #1077 §4.4 MUST AC-2):
+**Step 0: Mass-residual warning (≥5 incomplete items)** — Before evaluation, count incomplete items (excluding parent-child Tasklist `- [ ] #XX` entries) and surface a Root Cause investigation prompt when the count meets the mass-residual threshold (5 件以上):
 
 ```bash
 issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-incomplete_count=$(printf '%s' "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)
+[ -z "$issue_body" ] && echo "WARNING: Step 0 Issue body 取得失敗 — mass-residual 検出を skip" >&2 && incomplete_count=0
+incomplete_count=${incomplete_count:-$(echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)}
 echo "incomplete_count=$incomplete_count"
 if [ "${incomplete_count:-0}" -ge 5 ]; then
   echo "⚠️ Phase 5.2.1: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています (${incomplete_count} 件)。"
@@ -41,10 +42,11 @@ if [ "${incomplete_count:-0}" -ge 5 ]; then
   echo "   - Phase 5.1.1.1 (implement.md) の per-task checklist 更新が trigger されていない"
   echo "   - 実装が Definition of Done を完全充足していない"
   echo "   - チェックリスト項目テキストと実装内容の対応付けが Auto-Check で unreliable と判定された"
+  echo "   ACTION REQUIRED: 下記 AskUserQuestion で Root Cause を選択してから Step 1 に進むこと"
 fi
 ```
 
-When `incomplete_count >= 5`, present `AskUserQuestion` for Root Cause investigation:
+**MUST**: `incomplete_count >= 5` の場合、Step 1 (Collect evidence) に進む前に **必ず以下の `AskUserQuestion` を発火させる**。bash 出力 + warning だけで Step 1 へ直行することは禁止 (silent fall-through 防止)。`{incomplete_count}` placeholder は上記 bash block の `incomplete_count` 出力値を substitute する:
 
 ```
 警告: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています ({incomplete_count} 件)

--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -37,7 +37,7 @@ issue_body=$(gh issue view {issue_number} --json body --jq '.body')
 incomplete_count=${incomplete_count:-$(echo "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)}
 echo "incomplete_count=$incomplete_count"
 if [ "${incomplete_count:-0}" -ge 5 ]; then
-  echo "⚠️ Phase 5.2.1: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています (${incomplete_count} 件)。"
+  echo "⚠️ Phase 5.2.1.1 Step 0: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています (${incomplete_count} 件)。"
   echo "   Root Cause として以下が考えられます:"
   echo "   - Phase 5.1.1.1 (implement.md) の per-task checklist 更新が trigger されていない"
   echo "   - 実装が Definition of Done を完全充足していない"

--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -29,6 +29,37 @@ When incomplete checklist items are detected, evaluate each item's fulfillment s
 
 ### Evaluation procedure
 
+**Step 0: Mass-residual warning (≥5 incomplete items)** — Before evaluation, count incomplete items (excluding parent-child Tasklist `- [ ] #XX` entries) and surface a Root Cause investigation prompt when the count meets the mass-residual threshold. Threshold = **5** (symmetric with `cleanup.md` Phase 1.6.5.2 mass-detection `workflow_incident` emit; Issue #1077 §4.4 MUST AC-2):
+
+```bash
+issue_body=$(gh issue view {issue_number} --json body --jq '.body')
+incomplete_count=$(printf '%s' "$issue_body" | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)
+echo "incomplete_count=$incomplete_count"
+if [ "${incomplete_count:-0}" -ge 5 ]; then
+  echo "⚠️ Phase 5.2.1: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています (${incomplete_count} 件)。"
+  echo "   Root Cause として以下が考えられます:"
+  echo "   - Phase 5.1.1.1 (implement.md) の per-task checklist 更新が trigger されていない"
+  echo "   - 実装が Definition of Done を完全充足していない"
+  echo "   - チェックリスト項目テキストと実装内容の対応付けが Auto-Check で unreliable と判定された"
+fi
+```
+
+When `incomplete_count >= 5`, present `AskUserQuestion` for Root Cause investigation:
+
+```
+警告: Issue 本文に 5 件以上の未完了チェックリスト項目が残存しています ({incomplete_count} 件)
+
+このまま Auto-Check Evaluation を続行すると一括判定で誤検知のリスクがあります。
+Root Cause を調査しますか?
+
+オプション:
+- Root Cause を調査してから Auto-Check (推奨): Phase 5.1 に戻り per-task 更新漏れの根本原因を特定してから再評価
+- このまま Auto-Check Evaluation を続行: 既存パスで一括評価 (実装が確実に完了している場合)
+- 手動でチェックリスト確認: workflow を中断しユーザーが Issue body を手動更新
+```
+
+「Root Cause 調査」→ Phase 5.1 に戻る (`implement.md` Phase 5.1.1.1 を per-task で再実行)。「そのまま Auto-Check」→ Step 1 へ続行。「手動確認」→ workflow 中断、ユーザー手動更新後 `/rite:issue:start {N}` で再開を案内。`incomplete_count < 5` の場合は本 Step を skip し Step 1 へ直接遷移する。
+
 1. **Collect evidence**: Use `git diff origin/{base_branch}...HEAD --name-only` and `git log --oneline origin/{base_branch}...HEAD` to understand what was implemented.
 
 2. **Evaluate each incomplete item**: For each `- [ ]` item, assess whether the item is satisfied based on the implementation evidence:

--- a/plugins/rite/commands/issue/start-execute.md
+++ b/plugins/rite/commands/issue/start-execute.md
@@ -141,6 +141,8 @@ Run [Preflight Protocol](./start.md#preflight-protocol) before starting implemen
 
 > **Module**: [Implementation Guidance](./implement.md) - Follow Phase 3 plan. Handles: Read/Edit/Bash, parallel (5.1.0), commit message (5.1.1), checklist update (5.1.1.1), parent progress (5.1.2), flow state updates, mandatory `rite:lint` invocation.
 
+> **Issue body checklist — per-task update obligation**: `implement.md` Phase 5.1.1.1 is the SoT for Issue body checklist updates. The orchestrator MUST surface this obligation: as each Definition-of-Done / acceptance-criteria item is satisfied during implementation, the corresponding `- [ ]` line in the Issue body MUST be updated to `- [x]` via the `issue-body-safe-update.sh` 3-step pattern (NOT only at the final commit). Skipping per-task updates causes mass-residual `- [ ]` detection in cleanup Phase 1.6.5 / start-execute Phase 5.2.1, which is now surfaced as a warning when the threshold (5) is exceeded. Parent-child Tasklist entries (`- [ ] #XX`) remain excluded from this obligation.
+
 Skipping lint risks merging code that violates project quality standards, creating technical debt that compounds across subsequent Issues.
 **Critical**: After 5.1.1, **immediately** invoke `rite:lint`. Do NOT stop.
 

--- a/plugins/rite/commands/issue/start-execute.md
+++ b/plugins/rite/commands/issue/start-execute.md
@@ -141,7 +141,7 @@ Run [Preflight Protocol](./start.md#preflight-protocol) before starting implemen
 
 > **Module**: [Implementation Guidance](./implement.md) - Follow Phase 3 plan. Handles: Read/Edit/Bash, parallel (5.1.0), commit message (5.1.1), checklist update (5.1.1.1), parent progress (5.1.2), flow state updates, mandatory `rite:lint` invocation.
 
-> **Issue body checklist — per-task update obligation**: `implement.md` Phase 5.1.1.1 is the SoT for Issue body checklist updates. The orchestrator MUST surface this obligation: as each Definition-of-Done / acceptance-criteria item is satisfied during implementation, the corresponding `- [ ]` line in the Issue body MUST be updated to `- [x]` via the `issue-body-safe-update.sh` 3-step pattern (NOT only at the final commit). Skipping per-task updates causes mass-residual `- [ ]` detection in cleanup Phase 1.6.5 / start-execute Phase 5.2.1, which is now surfaced as a warning when the threshold (5) is exceeded. Parent-child Tasklist entries (`- [ ] #XX`) remain excluded from this obligation.
+> **Issue body checklist update**: `implement.md` Phase 5.1.1.1 が per-task update を強制 (SoT)。大量残存は `checklist-auto-check.md` Phase 5.2.1 Step 0 / `cleanup.md` Phase 1.6.5.2 で警告される。
 
 Skipping lint risks merging code that violates project quality standards, creating technical debt that compounds across subsequent Issues.
 **Critical**: After 5.1.1, **immediately** invoke `rite:lint`. Do NOT stop.

--- a/plugins/rite/commands/issue/start-execute.md
+++ b/plugins/rite/commands/issue/start-execute.md
@@ -141,7 +141,7 @@ Run [Preflight Protocol](./start.md#preflight-protocol) before starting implemen
 
 > **Module**: [Implementation Guidance](./implement.md) - Follow Phase 3 plan. Handles: Read/Edit/Bash, parallel (5.1.0), commit message (5.1.1), checklist update (5.1.1.1), parent progress (5.1.2), flow state updates, mandatory `rite:lint` invocation.
 
-> **Issue body checklist update**: `implement.md` Phase 5.1.1.1 が per-task update を強制 (SoT)。大量残存は `checklist-auto-check.md` Phase 5.2.1 Step 0 / `cleanup.md` Phase 1.6.5.2 で警告される。
+> **Issue body checklist update**: `implement.md` Phase 5.1.1.1 が per-task update を強制 (SoT)。大量残存は `checklist-auto-check.md` Phase 5.2.1.1 Step 0 / `cleanup.md` Phase 1.6.5.2 で警告される。
 
 Skipping lint risks merging code that violates project quality standards, creating technical debt that compounds across subsequent Issues.
 **Critical**: After 5.1.1, **immediately** invoke `rite:lint`. Do NOT stop.

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -292,7 +292,7 @@ If incomplete tasks are found, prompt with `AskUserQuestion`:
 
 In addition to checking the work memory, also check the checklist in the Issue body.
 
-> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` Phase 5.1.1.1 (`implement.md` per-task checklist 更新) および Phase 5.2.1 (Auto-Check Evaluation) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出時は primary path の機能不全を示唆するため Phase 1.6.5.2 で `workflow_incident` sentinel を emit し observability を確保する。
+> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` Phase 5.1.1.1 (`implement.md` per-task checklist 更新) および Phase 5.2.1.1 (Auto-Check Evaluation) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出時は primary path の機能不全を示唆するため Phase 1.6.5.2 で `workflow_incident` sentinel を emit し observability を確保する。
 
 **1.6.5.1 Extract Checklist**
 
@@ -314,7 +314,7 @@ incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \
 if [ "${incomplete_count:-0}" -ge 5 ]; then
   bash {plugin_root}/hooks/workflow-incident-emit.sh \
     --type manual_fallback_adopted \
-    --details "Issue #{issue_number} cleanup Phase 1.6.5.2 mass-residual detection: ${incomplete_count} incomplete checklist items at cleanup time (threshold: 5). Primary update path (implement.md Phase 5.1.1.1 per-task / start-execute.md Phase 5.2.1 Auto-Check) appears to have malfunctioned." \
+    --details "Issue #{issue_number} cleanup Phase 1.6.5.2 mass-residual detection: ${incomplete_count} incomplete checklist items at cleanup time (threshold: 5). Primary update path (implement.md Phase 5.1.1.1 per-task / checklist-auto-check.md Phase 5.2.1.1 Auto-Check) appears to have malfunctioned." \
     --root-cause-hint "checklist_mass_remaining_at_cleanup" \
     --pr-number {pr_number} >&2 || true
 fi

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -292,6 +292,8 @@ If incomplete tasks are found, prompt with `AskUserQuestion`:
 
 In addition to checking the work memory, also check the checklist in the Issue body.
 
+> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` Phase 5.1.1.1 (`implement.md` per-task checklist 更新) および Phase 5.2.1 (Auto-Check Evaluation) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出 (≥5 件) は primary path の機能不全を示唆するため Phase 1.6.5.2 で `workflow_incident` sentinel を emit し observability を確保する (Issue #1077 §4.4 MUST AC-3、3 site (start-execute.md / checklist-auto-check.md / cleanup.md) threshold=5 対称化)。
+
 **1.6.5.1 Extract Checklist**
 
 Phase 1.5 で取得済みの Issue body からチェックリストを抽出する (再取得不要):
@@ -304,7 +306,21 @@ gh issue view {issue_number} --json body --jq '.body'
 
 **1.6.5.2 Detect Incomplete Checklist Items**
 
-抽出されたチェックリストから `- [ ]` 項目を検出。未完了項目が存在する場合 `AskUserQuestion`:
+抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** (Issue #1077 §4.4 MUST AC-3 threshold、3 site 対称) の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は observability log として記録され、後続の Phase 5.4.4.1 grep 検出経路で Issue auto-register 候補に surface する:
+
+```bash
+incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \
+  | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)
+if [ "${incomplete_count:-0}" -ge 5 ]; then
+  bash {plugin_root}/hooks/workflow-incident-emit.sh \
+    --type manual_fallback_adopted \
+    --details "Issue #{issue_number} cleanup Phase 1.6.5.2 mass-residual detection: ${incomplete_count} incomplete checklist items at cleanup time (threshold: 5). Primary update path (implement.md Phase 5.1.1.1 per-task / start-execute.md Phase 5.2.1 Auto-Check) appears to have malfunctioned." \
+    --root-cause-hint "checklist_mass_remaining_at_cleanup" \
+    --pr-number {pr_number} >&2 || true
+fi
+```
+
+未完了項目が存在する場合 `AskUserQuestion`:
 
 ```
 警告: Issue 本文に未完了のチェック項目があります

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -292,7 +292,7 @@ If incomplete tasks are found, prompt with `AskUserQuestion`:
 
 In addition to checking the work memory, also check the checklist in the Issue body.
 
-> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` Phase 5.1.1.1 (`implement.md` per-task checklist 更新) および Phase 5.2.1 (Auto-Check Evaluation) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出 (≥5 件) は primary path の機能不全を示唆するため Phase 1.6.5.2 で `workflow_incident` sentinel を emit し observability を確保する (Issue #1077 §4.4 MUST AC-3、3 site (start-execute.md / checklist-auto-check.md / cleanup.md) threshold=5 対称化)。
+> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` Phase 5.1.1.1 (`implement.md` per-task checklist 更新) および Phase 5.2.1 (Auto-Check Evaluation) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出時は primary path の機能不全を示唆するため Phase 1.6.5.2 で `workflow_incident` sentinel を emit し observability を確保する。
 
 **1.6.5.1 Extract Checklist**
 
@@ -306,7 +306,7 @@ gh issue view {issue_number} --json body --jq '.body'
 
 **1.6.5.2 Detect Incomplete Checklist Items**
 
-抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** (Issue #1077 §4.4 MUST AC-3 threshold、3 site 対称) の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は observability log として記録され、後続の Phase 5.4.4.1 grep 検出経路で Issue auto-register 候補に surface する:
+抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は cleanup session の stderr に observability log として記録される。`/rite:pr:cleanup` workflow には Phase 5.4.4.1 detector が存在しないため (workflow-incident-detection.md caller 表は lint/pr:create/pr:review/pr:fix/pr:ready/issue:start 系のみ)、本 sentinel は cleanup 内で自動 Issue 化されない。手動 triage が必要な場合は stderr ログを確認すること:
 
 ```bash
 incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -306,7 +306,7 @@ gh issue view {issue_number} --json body --jq '.body'
 
 **1.6.5.2 Detect Incomplete Checklist Items**
 
-抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は cleanup session の stderr に observability log として記録される。`/rite:pr:cleanup` workflow には Phase 5.4.4.1 detector が存在しないため (workflow-incident-detection.md caller 表は lint/pr:create/pr:review/pr:fix/pr:ready の 5 caller のみ)、本 sentinel は cleanup 内で自動 Issue 化されない。手動 triage が必要な場合は stderr ログを確認すること:
+抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1.1 Auto-Check) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は cleanup session の stderr に observability log として記録される。`/rite:pr:cleanup` workflow には Phase 5.4.4.1 detector が存在しないため (workflow-incident-detection.md caller 表は lint/pr:create/pr:review/pr:fix/pr:ready の 5 caller のみ)、本 sentinel は cleanup 内で自動 Issue 化されない。手動 triage が必要な場合は stderr ログを確認すること:
 
 ```bash
 incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -306,7 +306,7 @@ gh issue view {issue_number} --json body --jq '.body'
 
 **1.6.5.2 Detect Incomplete Checklist Items**
 
-抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は cleanup session の stderr に observability log として記録される。`/rite:pr:cleanup` workflow には Phase 5.4.4.1 detector が存在しないため (workflow-incident-detection.md caller 表は lint/pr:create/pr:review/pr:fix/pr:ready/issue:start 系のみ)、本 sentinel は cleanup 内で自動 Issue 化されない。手動 triage が必要な場合は stderr ログを確認すること:
+抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) の機能不全を示唆するため `workflow_incident` sentinel (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する。emit は cleanup session の stderr に observability log として記録される。`/rite:pr:cleanup` workflow には Phase 5.4.4.1 detector が存在しないため (workflow-incident-detection.md caller 表は lint/pr:create/pr:review/pr:fix/pr:ready の 5 caller のみ)、本 sentinel は cleanup 内で自動 Issue 化されない。手動 triage が必要な場合は stderr ログを確認すること:
 
 ```bash
 incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \


### PR DESCRIPTION
## 概要

`/rite:issue:start` ワークフローにおいて、Issue body の checklist (Definition of Done 等) が実装中に `- [x]` 化されず cleanup Phase 1.6.5 で大量未完了として検出される UX 問題に対応する。3 site (`start-execute.md` / `checklist-auto-check.md` / `cleanup.md`) に threshold=5 の対称的な警告・observability 経路を追加し、Issue body checklist の per-task 更新責務を明示化した。

## 関連 Issue

Closes #1077

## 変更内容

### `plugins/rite/commands/issue/start-execute.md` (Phase 5.1)

`implement.md` Phase 5.1.1.1 を SoT とする Issue body checklist の per-task 更新義務を明示する reminder note を追加。orchestrator level で更新責務を surface し、`- [ ] #XX` 親子 Tasklist の除外を維持。

### `plugins/rite/commands/issue/references/checklist-auto-check.md` (Phase 5.2.1.1)

Evaluation procedure の **Step 0** として「5 件以上残存検出時の Root Cause 警告経路」を追加:

- 残存数 ≥ 5 で `⚠️` 警告 + 3 つの Root Cause 候補 (Phase 5.1.1.1 未 trigger / 実装の DoD 不充足 / Auto-Check unreliable 判定) を表示
- `AskUserQuestion` で 3 オプション提示 (Root Cause 調査 / そのまま Auto-Check 続行 / 手動確認)
- `incomplete_count < 5` の場合は本 Step を skip し既存の Step 1-4 に直接遷移

### `plugins/rite/commands/pr/cleanup.md` (Phase 1.6.5)

- **Phase 1.6.5 冒頭**: 「safety net (例外残存項目の救済)」責務を明示する prose を追加。primary update path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1) との関係性を文書化
- **Phase 1.6.5.2**: 5 件以上検出時に `workflow_incident-emit.sh` (`type=manual_fallback_adopted`, `--root-cause-hint=checklist_mass_remaining_at_cleanup`) を non-blocking で emit する step を追加。Phase 5.4.4.1 grep 検出経路で auto-register 候補に surface

### 3 site 対称性

| Site | threshold | 除外パターン | non-blocking |
|------|-----------|--------------|--------------|
| `start-execute.md` Phase 5.1 (reminder note) | 5 (言及) | `- [ ] #XX` (言及) | N/A (prose only) |
| `checklist-auto-check.md` Phase 5.2.1.1 Step 0 | 5 (`-ge 5`) | `grep -v -E '^- \[[ xX]\] #[0-9]+'` | `|| true` |
| `cleanup.md` Phase 1.6.5.2 | 5 (`-ge 5`) | `grep -v -E '^- \[[ xX]\] #[0-9]+'` | `\|\| true` |

Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」の dominant failure mode を予防するため、3 site すべてで同一の threshold / 除外パターン / non-blocking 規約を統一。

## チェックリスト

- [x] Issue #1077 §4.4 MUST 全 3 件 (Phase 5.1 per-task update / Phase 5.2.1 警告 / cleanup workflow_incident emit) を実装
- [x] AC-1〜AC-5 を実装で覆い、テストは PR review で fact-check
- [x] SHOULD: 既存 Checkbox Update pattern (`issue-body-safe-update.sh`) を reuse、独自 sed 実装なし
- [x] MUST NOT: work memory ロジック (`post-tool-wm-sync.sh`) 不変、`- [x]` → `- [ ]` 逆変換なし
- [x] 3 site 対称性確認 (threshold=5 / `- [ ] #XX` 除外 / non-blocking)

## Known Issues

なし
