### PR TITLE
fix(workflow): start.md ステップ 2.3 の gh issue develop フラグを --branch から --name に修正

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -194,7 +194,7 @@ fi
 Issue にブランチを関連付け (失敗しても workflow は続行するが、stderr に WARNING + `workflow_incident` sentinel を emit):
 
 ```bash
-if ! develop_err=$(gh issue develop {issue_number} --branch "{branch_name}" 2>&1); then
+if ! develop_err=$(gh issue develop {issue_number} --name "{branch_name}" 2>&1); then
   # Strip control characters before truncation. gh error messages occasionally
   # contain binary bytes; allowing them through could break JSON details
   # serialization or trigger unintended terminal escape sequences downstream.


### PR DESCRIPTION
## 概要

`commands/issue/start.md` ステップ 2.3 で実行される `gh issue develop {issue_number} --branch "{branch_name}"` を `--name "{branch_name}"` に修正。`gh` CLI v2 の仕様では `--branch` フラグが存在せず unknown flag エラーとなり、Issue↔branch の関連付け (GitHub UI Development パネル) が空のままになっていた。

## 関連 Issue

Closes #1086

## 変更内容

- `plugins/rite/commands/issue/start.md:197` の 1 行のみ修正:
  - 旧: `gh issue develop {issue_number} --branch "{branch_name}"`
  - 新: `gh issue develop {issue_number} --name "{branch_name}"`

## 検証

- `gh issue develop --help` で `-n, --name string` が正規フラグであることを確認
- リポジトリ全体を `grep -rn "gh issue develop"` で走査し、修正対象は本 1 箇所のみであることを確認
- `workflow_incident` emit 経路 (gh failure 時の sentinel) は構造を変更していないため挙動不変

## 影響範囲

- non-blocking warning だった `issue_branch_link_failed` workflow incident が今後発生しなくなる
- 既存の lint warning (drift / comment-journal / comment-line-ref) は本 PR 起因ではない既存問題

## チェックリスト

- [x] 修正対象が 1 箇所のみであることを grep で確認
- [x] `gh issue develop` の正しいフラグを `gh` 公式 help で確認
- [x] /rite:lint 実行 (warning なし、新規 finding なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
