### PR TITLE
refactor(workflow): PR 2a documentation drift cleanup (HIGH 4 件 + start.md sibling)

### DIFF
--- a/plugins/rite/commands/issue/references/flow-state-scaffolding.md
+++ b/plugins/rite/commands/issue/references/flow-state-scaffolding.md
@@ -32,9 +32,9 @@ bash {plugin_root}/hooks/flow-state.sh set \
 1. **`/rite:resume` の復帰経路保証**: コンテキスト消失 / セッション中断時、書き込まれた `phase` / `issue` / `branch` / `pr` / `next` フィールドを `/rite:resume` が読み取り、`commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) で対応する step に復帰する。
 2. **next フィールドによる継続指示**: `next` 文字列は「中断時の次行動」を natural language で記述し、LLM が `/rite:resume` 経由で復帰した際の routing hint として機能する。
 
-## patch mode の例外 (Workflow Termination の 1 site)
+## Terminal state write の例外 (Workflow Termination の 1 site)
 
-`start.md` のステップ 8 終端 1 site のみ `flow-state.sh set` を使う。terminal state (`completed` + `active false`) を書き込み、workflow 終了をマークする:
+flat workflow では全ステップが同一の `flow-state.sh set` を呼ぶ (v3 では mode 区別はなく、merge semantics により未指定フィールドは既存値を保持する)。`start.md` のステップ 8 終端 1 site のみ、上記 5 引数の標準形ではなく terminal 専用の引数セットで `set` を呼び、terminal state (`completed` + `active false`) を書き込んで workflow 終了をマークする:
 
 ```bash
 bash {plugin_root}/hooks/flow-state.sh set \
@@ -42,7 +42,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
  --if-exists --preserve-error-count
 ```
 
-`create` mode は新規 phase marker 専用で、`previous_phase` をシフトする。terminal state は phase progression ではないため preserving operation の `patch` を使う。`--if-exists` で state file 不在時の no-op、`--preserve-error-count` で過去 review-fix loop の error count を保持する。
+この呼び出しは phase progression ではなく terminal marker なので、`--issue` / `--branch` / `--pr` を指定せず merge semantics で既存値を保持する。`--active false` で workflow 終了をマーク、`--if-exists` で state file 不在時は no-op (idempotent)、`--preserve-error-count` で過去 review-fix loop の `error_count` を保持する (`--preserve-error-count` を付けない通常の `set` は `error_count` を 0 にリセットする)。
 
 ## 適用箇所 (start.md flat workflow)
 
@@ -56,21 +56,21 @@ bash {plugin_root}/hooks/flow-state.sh set \
 | 6 | `pr` | ステップ 6.3 |
 | 7.1 | `review` | ステップ 7.4 |
 | 7.2 | `fix` | ステップ 7.4 |
-| 8 | `completed` (patch) | ステップ 8.6 |
+| 8 | `completed` (terminal) | ステップ 8.6 |
 
 (step 名 / phase 名は `commands/issue/start.md` を参照。`commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) が phase → step の正規 mapping)
 
-> **位置のセマンティクス**: 表の write 位置は「当該 phase 名を `create` mode で書き込む sub-step」を指し、その実行時点ではすでに当該 phase の作業（lint 実行 / PR 作成 / review 実行など）が完了している。`/rite:resume` から復帰する際、書き込まれた phase は **その次のステップ**（`resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) の Resume action 行）への routing キーとして使われる。
+> **位置のセマンティクス**: 表の write 位置は「当該 phase 名を `flow-state.sh set` で書き込む sub-step」を指し、その実行時点ではすでに当該 phase の作業（lint 実行 / PR 作成 / review 実行など）が完了している。`/rite:resume` から復帰する際、書き込まれた phase は **その次のステップ**（`resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) の Resume action 行）への routing キーとして使われる。
 
 ## アンチパターン
 
 1. **5 引数のうちどれかを省略する**: 例えばステップ 2 前で `--branch ""` を省略すると state file の `branch` フィールドが未定義になり、`/rite:resume` の routing が失敗する
-2. **terminal state を `create` で書く**: `create` は `previous_phase` シフトを伴うので、`completed` を `create` で書くと過去 phase 履歴が消える。必ず `patch` を使う
+2. **terminal state を 5 引数標準形で書く**: ステップ 8 の `completed` を per-step と同じ 5 引数形 (`--issue` / `--branch` / `--pr` を明示) で書くと、`--preserve-error-count` が付かず過去 review-fix loop の `error_count` がリセットされる。terminal write は `--active false --if-exists --preserve-error-count` を使う
 
 ## 関連
 
 - [`pre-condition-gate.md`](./pre-condition-gate.md) — pre-condition の `flow-state.sh` fail-fast pattern
-- `plugins/rite/hooks/flow-state.sh` — `create` / `patch` / `increment` modes の実装
+- `plugins/rite/hooks/flow-state.sh` — `set` / `get` / `deactivate` / `migrate` subcommand の実装 (`set` の merge semantics + `--if-exists` / `--preserve-error-count` flag を含む)
 - `plugins/rite/hooks/phase-transition-whitelist.sh` — 遷移許可定義 (flat phase 群を反映)
 - `plugins/rite/hooks/flow-state.sh` — per-session flow-state 読み出し
 - `plugins/rite/commands/resume.md` Phase 5.3 — Phase enum → Step mapping (SoT)

--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -68,9 +68,9 @@ fi
 | `1` + `phase=ready` | ステップ 8.3 から再開 (Ready は完了済 — Projects Status In Review → 親判定 → 完了レポート) |
 | `1` + `phase=ready_error` | ステップ 8 (Ready & 完結) から再開。PR は既に存在するため `/rite:pr:create` は呼ばない |
 | `1` + `phase=completed` | Issue は既に完結。AskUserQuestion で「新規作業として再開 / 中止」を提示 |
-| `1` + `phase=<legacy>` (`phase5_*` 等) | Phase 2 の自動 migration で v3 enum に変換された後、`commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) の対応行に従う |
+| `1` + `phase=<legacy>` (`phase5_*` 等) | `phase5_*` は v3 enum (13 個) に該当せず `_phase_migrate` でも変換されない legacy 値 (pre-v3 state file の残存)。start.md 自体は migration を行わないため、`/rite:resume {issue_number}` での再開を案内する (resume.md の Phase 2 migration + Phase 3.5 cross-check が v3 phase へ解決し、`commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) の対応行に routing する) |
 
-`active=false` または `issue_number` が引数と異なる場合は、別 Issue の state が残っているだけなので新規セッション扱い (ステップ 1 から開始)。state file は新 phase 書き込み時に `previous_phase` がシフトされるため、誤った overwrite は発生しない。
+`active=false` または `issue_number` が引数と異なる場合は、別 Issue の state が残っているだけなので新規セッション扱い (ステップ 1 から開始)。ステップ 1.5 が新しい issue 番号で `--phase init` を書き込んで当該 session の state を更新するため、古い state が誤って参照され続けることはない。
 
 ---
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -5491,7 +5491,7 @@ ACTION: Return to Phase 4.6.W and execute the Wiki Ingest Trigger before outputt
 
 ### 8.1 Output Pattern (Return Control to Caller)
 
-The `phase5_post_fix` flow-state write below keeps in-flight state files consistent with what older versions expected, so a `/rite:resume` started against a partially-migrated state still classifies correctly:
+The `fix` flow-state write below records the v3 phase so a `/rite:resume` started after a fix iteration classifies the resume point correctly (`commands/resume.md` Phase 5.3 で `fix` → ステップ 7.2 へ routing):
 
 ```bash
 bash {plugin_root}/hooks/flow-state.sh set \
@@ -5520,7 +5520,7 @@ if [ -n "$hook_err" ]; then
   # 旧 `if ! cmd; then hook_wm_update_rc=$?` パターンは bash 仕様上 `$?` が常に 0 を返す。
   # `if cmd; then :; else rc=$?; fi` の else 節形式に切り替えて hook 自身の exit code を正しく取得する。
   if WM_SOURCE="fix" \
-      WM_PHASE="phase5_post_fix" \
+      WM_PHASE="fix" \
       WM_PHASE_DETAIL="レビュー修正後処理" \
       WM_NEXT_ACTION="re-review or completion" \
       WM_BODY_TEXT="Post-fix sync." \
@@ -5551,7 +5551,7 @@ else
   # head -5 で上位 5 行のみ保持する簡易 fallback に変更する。
   echo "WARNING: hook_err mktemp 失敗により local-wm-update.sh の stderr 詳細が取得できません" >&2
   if hook_combined=$(WM_SOURCE="fix" \
-        WM_PHASE="phase5_post_fix" \
+        WM_PHASE="fix" \
         WM_PHASE_DETAIL="レビュー修正後処理" \
         WM_NEXT_ACTION="re-review or completion" \
         WM_BODY_TEXT="Post-fix sync." \

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4719,8 +4719,8 @@ Before outputting any result pattern (`[review:mergeable]`, `[review:fix-needed:
 
 | Result | Phase | Next Action |
 |--------|-------|-------------|
-| `[review:mergeable]` | `phase5_post_review` | `rite:pr:review completed. Result: [review:mergeable]. Proceed to Phase 5.5 (Ready for Review). Do NOT stop.` |
-| `[review:fix-needed:{n}]` | `phase5_post_review` | `rite:pr:review completed. Result: [review:fix-needed:{n}]. Proceed to Phase 5.4.4 (fix). Do NOT stop.` |
+| `[review:mergeable]` | `review` | `rite:pr:review completed. Result: [review:mergeable]. Proceed to Phase 5.5 (Ready for Review). Do NOT stop.` |
+| `[review:fix-needed:{n}]` | `review` | `rite:pr:review completed. Result: [review:fix-needed:{n}]. Proceed to Phase 5.4.4 (fix). Do NOT stop.` |
 
 ```bash
 bash {plugin_root}/hooks/flow-state.sh set \

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -22,10 +22,25 @@ description: 中断した作業を再開
 
 ## Placeholder Legend
 
+> 後続 Phase は別々の Bash tool 呼び出しとなりシェル変数を引き継げないため、Phase 3.1 / 3.5 / 4.2 が stdout に emit する `[CONTEXT] STATE_* / RESOLVED_PHASE / FINAL_PHASE` marker を source とし、LLM が会話コンテキストから読んで placeholder を実値置換する (詳細は Phase 5.2 の注記参照)。
+
 | Placeholder | Source |
 |-------------|--------|
-| `{issue_number}` | 引数 or ブランチ名抽出 |
-| `{branch}` | `git branch --show-current` |
+| `{issue_number}` / `{issue_arg}` / `{number}` | Phase 1.1: 引数 or ブランチ名 `{type}/issue-{number}-{slug}` 抽出 (`[CONTEXT] RESUME_ISSUE` marker) |
+| `{title}` | Phase 1.2: `gh issue view` の title |
+| `{branch}` / `{git_branch}` | Phase 3.2: `git branch --show-current` |
+| `{base_branch}` | Phase 3.2: `rite-config.yml` の `branch.base` (default `develop`) |
+| `{git_commit_count}` | Phase 3.2: `git rev-list --count origin/{base_branch}..HEAD` |
+| `{git_has_uncommitted}` | Phase 3.2: `git status --porcelain` の非空判定 (サマリでは「あり」/「なし」整形) |
+| `{state_next}` | Phase 3.1: `[CONTEXT] STATE_NEXT` marker (flow-state `next_action`) |
+| `{state_parent}` | Phase 3.1: `[CONTEXT] STATE_PARENT` marker (flow-state `parent_issue_number`) |
+| `{state_parent_display}` | Phase 3.1: `[CONTEXT] STATE_PARENT_DISPLAY` marker (`0`/空 → 「なし」、それ以外 → `#NN` 整形) |
+| `{pr_number}` | Phase 3.3: `gh pr view` の `.number` (Phase 3.1 `[CONTEXT] STATE_PR` も参照可) |
+| `{pr_state}` | Phase 3.3: `gh pr view` の `.state` (NONE/OPEN/MERGED/CLOSED) |
+| `{pr_is_draft}` | Phase 3.3: `gh pr view` の `.isDraft` |
+| `{wm_next}` | Phase 3.4: work memory (`.rite-work-memory/issue-{n}.md`) の `next_action:` |
+| `{resolved_phase}` | Phase 3.5: cross-check 確定 phase (`[CONTEXT] RESOLVED_PHASE` marker)。Phase 4.2 で user が phase 変更を選んだ場合は `[CONTEXT] FINAL_PHASE` marker を優先 |
+| `{type}` / `{slug}` | ブランチ名 `{type}/issue-{number}-{slug}` の構成要素 |
 | `{plugin_root}` | [Plugin Path Resolution](../references/plugin-path-resolution.md#resolution-script-full-version) |
 
 ---
@@ -296,4 +311,6 @@ init / branch / plan / implement / lint / pr / review / fix / ready /
 ready_error / cleanup / ingest / completed
 ```
 
-旧 v1/v2 schema の phase 値 (`cleanup_pre_ingest`, `ingest_pre_lint`, `create_*`, `phase5_*` 等) は Phase 2 の自動 migration で v3 に変換される。Migration の reduction matrix は `plugins/rite/hooks/flow-state.sh` の `_phase_migrate` 関数を参照。
+旧 v1/v2 schema の phase 値 (`cleanup_pre_ingest`, `ingest_pre_lint`, `create_*`, `implementing` 等) は Phase 2 の自動 migration で v3 に変換される。Migration の reduction matrix は `plugins/rite/hooks/flow-state.sh` の `_phase_migrate` 関数を参照。
+
+なお `phase5_*` 系の legacy 名 (pre-v3 の sub-skill chain アーキテクチャが書き込んだ古い state file に残存しうる) は `_phase_migrate` の reduction matrix に **含まれず pass-through される**。これらは PHASE_ENUM_V3 (13 個) に該当しないため Phase 2 migration では変換されず、Phase 3.5 の cross-check (state_phase が v3 enum でない → wm_phase / git commit / PR 状態からの fallback 推定) で再開 phase が解決される。

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -313,4 +313,4 @@ ready_error / cleanup / ingest / completed
 
 旧 v1/v2 schema の phase 値 (`cleanup_pre_ingest`, `ingest_pre_lint`, `create_*`, `implementing` 等) は Phase 2 の自動 migration で v3 に変換される。Migration の reduction matrix は `plugins/rite/hooks/flow-state.sh` の `_phase_migrate` 関数を参照。
 
-なお `phase5_*` 系の legacy 名 (pre-v3 の sub-skill chain アーキテクチャが書き込んだ古い state file に残存しうる) は `_phase_migrate` の reduction matrix に **含まれず pass-through される**。これらは PHASE_ENUM_V3 (13 個) に該当しないため Phase 2 migration では変換されず、Phase 3.5 の cross-check (state_phase が v3 enum でない → wm_phase / git commit / PR 状態からの fallback 推定) で再開 phase が解決される。
+なお `phase5_*` 系の legacy 名 (pre-v3 の sub-skill chain アーキテクチャが書き込んだ古い state file に残存しうる) は `_phase_migrate` の reduction matrix に **含まれず pass-through される**。これらは PHASE_ENUM_V3 (13 個) に該当しないため Phase 2 migration では変換されず、Phase 3.5 の整合性判定 (cross-check) で再開 phase が確定される (cross-check は rule 1 で v3 enum 値のみを直接採用するため、非 v3 enum の legacy 値はそのまま採用されず、cross-check の判定を経て v3 phase へ解決される)。


### PR DESCRIPTION
## 概要

PR 2a (#1089) のセルフレビューで検出された HIGH 残 4 件の documentation drift を解消する。すべて実動作に silent failure を起こさない pure documentation drift で、変更は markdown のみ・code 変更なし。

着手時調査で Issue 記載の行番号は PR 2a/2b マージ後に shift していたため、現ファイルの実位置で対応した。`_phase_migrate` は `cleanup_*`/`ingest_*`/`create_*`/`implementing` のみ変換し `phase5_*` は pass-through するため、HIGH-4 は **主張削除** を選択。

## 関連 Issue

Closes #1090

## 変更内容

| AC | ファイル | 内容 |
|----|---------|------|
| AC-1 | `commands/resume.md` | migration リストから `phase5_*` を除外し、Phase 3.5 cross-check で解決される旨を明記（`_phase_migrate` は pass-through する事実に一致） |
| AC-2 | `commands/resume.md` | Placeholder Legend に本文使用の全 placeholder を Phase 3.1 STATE marker / Phase 3.2-3.5 を source として列挙 |
| AC-3 | `commands/pr/review.md` | Phase 8.0 "State update by result" 表の `phase5_post_review` → `review`（直下 bash `--phase "review"` と一致） |
| AC-3 | `commands/pr/fix.md` | Phase 8.1 prose + WM_PHASE 2 箇所の `phase5_post_fix` → `fix`（`WM_PHASE="fix"` は post-tool-wm-sync.sh の case にも合致） |
| AC-4 | `commands/issue/references/flow-state-scaffolding.md` | 削除済 API（`create`/`patch`/`increment` mode・`previous_phase` schema field）を新 `flow-state.sh set` の merge semantics + `--if-exists` / `--preserve-error-count` 説明に書換 |
| AC-1 sibling | `commands/issue/start.md` | Resume Dispatch の `phase=<legacy>` 行が HIGH-4 と同一の `phase5_*` migration 誤主張 → `/rite:resume` 経由解決に修正。あわせて直後の段落の `previous_phase`（削除済 field）言及を merge semantics 記述に置換（レビューで承認済の追加スコープ） |

## Acceptance Criteria（本 PR で対応済）

- [x] AC-1: `resume.md` の `phase5_*` 言及を実装と一致（主張削除を選択）
- [x] AC-2: `resume.md` Placeholder Legend に全 placeholder を列挙し source を明示
- [x] AC-3: `pr/review.md` / `pr/fix.md` の `phase5_post_*` prose / WM_PHASE を v3 enum に同期
- [x] AC-4: `flow-state-scaffolding.md` を新 `set` API に書き換え、retired API 言及を撤去
- [x] AC-5: 全 hook tests PASS（44/44 — 47 は PR 2b でのテスト撤去前の数）

## 検出された問題（別 Issue として追跡）

作業中に検出したスコープ外 findings を issue_accountability 原則に従い別 Issue 化:

- #1092: `gh issue develop` が `--base` 未指定で remote ブランチを main から作成し push 衝突（workflow bug、本 PR で実際に発生 / High）
- #1093: `review.md` ⇔ `fix.md` の error_count 記述の矛盾 + retired "patch mode" 用語（doc drift / Medium）
- #1094: `phase-mapping.md` の resume.md Phase 3.2 legacy alias 表への broken reference（broken ref / Medium）

## 検証

- hook test suite: 44/44 PASS
- `/rite:lint` plugin-specific drift checks: 私の変更による新規 finding 0 件（既存 warning は全て編集箇所外）
- 各ファイル単位で `git revert` 可能

## チェックリスト

- [x] markdown のみの変更（code 変更なし）
- [x] retired API 言及（`phase5_*` migration / `create`/`patch`/`increment` mode / `previous_phase`）を撤去
- [x] hook tests PASS
- [ ] レビュー反映
