### PR TITLE
fix(workflow): gh issue develop に --base を追加し push 衝突を解消

### DIFF
--- a/plugins/rite/commands/issue/start.md
+++ b/plugins/rite/commands/issue/start.md
@@ -194,7 +194,13 @@ fi
 Issue にブランチを関連付け (失敗しても workflow は続行するが、stderr に WARNING を出力):
 
 ```bash
-if ! develop_err=$(gh issue develop {issue_number} --name "{branch_name}" 2>&1); then
+# --base "{base_branch}" is REQUIRED: without it, `gh issue develop` creates the
+# remote branch from the repository's default branch (e.g. main). In a git-flow
+# layout where branch.base (develop) ≠ default branch (main), the remote branch
+# would diverge from the local develop-based branch and the first `git push`
+# fails with non-fast-forward. Passing --base anchors the remote branch to
+# {base_branch}, matching the local branch created in 2.3. (Issue #1092)
+if ! develop_err=$(gh issue develop {issue_number} --name "{branch_name}" --base "{base_branch}" 2>&1); then
   # Strip control characters before truncation. gh error messages occasionally
   # contain binary bytes; allowing them through could break JSON details
   # serialization or trigger unintended terminal escape sequences downstream.


### PR DESCRIPTION
## 概要

`commands/issue/start.md` ステップ 2.3 の `gh issue develop` 呼び出しに `--base "{base_branch}"` を追加し、git-flow 構成 (base=develop ≠ default=main) で remote ブランチがデフォルトブランチ (main) 起点で作成され、初回 `git push` が non-fast-forward で失敗する問題を解消する。

## 変更内容

- `gh issue develop {issue_number} --name "{branch_name}"` に `--base "{base_branch}"` を追加
- `--base` が必要な理由（remote ブランチを base_branch に固定し push 衝突を防ぐ）を drift 防止コメントとして併記

## 背景

`gh issue develop` は `--base` 未指定時にリポジトリのデフォルトブランチから remote ブランチを作成する。ローカルは `branch.base` (develop) から派生するため両者が乖離し push が衝突していた。`--base` の副次効果で `gh pr create` の base も base_branch に設定されるが、`pr:create` は自前で `--base "{base_branch}"` を指定済みのため無害。

採用方針: link 専用化（remote ブランチ作成を `git push -u` 側に一本化）案は、`gh issue develop --name` が必ず remote ブランチを作る仕様上、別 API への置換が必要で複雑化するため不採用。最小変更の `--base` 明示案を採用。

## 検証

- 変更ファイル (`start.md`) 起因の plugin-specific lint finding なし（既存 warning はスコープ外）

Closes #1092
