### PR TITLE
docs(workflow): error_count note を実装準拠に統一し patch mode 用語を撤去

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -876,7 +876,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 
 Replace `{phase_value}` and `{next_action_value}` with the values from the table above based on the lint result.
 
-**Note on `error_count`**: `flow-state.sh` patch mode resets `error_count` to 0 on every phase transition (since #294). This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
 
 **Also sync to local work memory** (`.rite-work-memory/issue-{n}.md`) when flow state file exists:
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -5501,7 +5501,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --if-exists
 ```
 
-**Note on `error_count`**: `flow-state.sh` patch mode resets `error_count` to 0 on every phase transition (since #294). This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
 
 **Also update local work memory** (`.rite-work-memory/issue-{n}.md`) with phase transition:
 

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -485,7 +485,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --if-exists
 ```
 
-**Note on `error_count`**: `flow-state.sh` patch mode resets `error_count` to 0 on every phase transition (since #294). This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
 
 **Also sync to local work memory** (`.rite-work-memory/issue-{n}.md`) when flow state file exists:
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4732,7 +4732,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 
 Replace `{next_action_value}` with the value from the table above based on the review result. Also replace `{n}` in the next_action string with the actual finding count from the review result (e.g., if the result is `[review:fix-needed:3]`, then `{n}` = `3`).
 
-**Note on `error_count`**: `flow-state.sh` patch mode preserves all existing fields not explicitly set — only `phase`, `updated_at`, and `next_action` are changed (consistent with `lint.md` Phase 4.0 and `fix.md` Phase 8.1). The count is effectively reset when `/rite:issue:start` writes a new complete object via `jq -n` at the next phase transition.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
 
 ### 8.0.1 W Phase Completion Gate (Defense-in-Depth, #535)
 


### PR DESCRIPTION
## 概要

`commands/` 配下の「Note on `error_count`」blockquote を実装挙動に合わせて統一し、retired な "patch mode" 用語を撤去する。

Closes #1093

## 背景

- `review.md` の note は「`error_count` は preserve され、`/rite:issue:start` の `jq -n` でのみ reset される」と記述していたが、これは実装と不一致。
- `fix.md` / `lint.md` / `ready.md` の note は「patch mode が毎回 0 reset する」と記述しており挙動は正確だが、"patch mode" は v3 で廃止された概念。
- 実装 (`flow-state.sh` の `cmd_set`) は、`set` が default で `error_count` を 0 にリセットし、`--preserve-error-count` 指定時のみ既存値を保持する。

## 変更内容

同一の note を持つ 4 ファイルを共通文面へ統一（`error_count` 用語撤去を中途半端に残さないため、Issue 記載の 2 ファイルから lint.md / ready.md へ範囲を拡張。範囲拡張はユーザー確認済み）。

統一後の文面:

> **Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.

| ファイル | 変更 |
|---|---|
| `commands/pr/review.md` | 不正確な記述を実装準拠に修正 + patch mode 撤去 |
| `commands/pr/fix.md` | patch mode 撤去 |
| `commands/lint.md` | patch mode 撤去 |
| `commands/pr/ready.md` | patch mode 撤去 |

検証: `commands/` 配下に "patch mode" 残存 0 件、4 ファイルの note が完全一致（grep でユニーク 1 行）を確認済み。

## スコープ外メモ（透明性のための開示）

調査中に以下を確認したが、本 Issue のスコープ外として未対応:

- `docs/migration-guides/v2-to-v3.md` / `docs/designs/multi-session-state.md` の "patch mode" は v2→v3 移行を説明する**歴史的言及**のため、撤去対象に含めていない。
- `docs/SPEC.md` および `docs/designs/multi-session-state.md` に `flow-state-update.sh`（現行は `flow-state.sh`）という旧スクリプト名への参照があり、別系統の drift の可能性。本 PR では扱わず、必要なら別 Issue で追跡。

## チェックリスト

- [x] 4 ファイルの note を実装準拠に統一
- [x] "patch mode" 用語を commands/ 配下から撤去
- [x] note の完全一致を grep で検証
- [ ] レビュー
