### PR TITLE
docs(workflow): phase-mapping.md の Phase 3.2 broken reference を Phase 3.5/5.3 参照に修正

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/phase-mapping.md
+++ b/plugins/rite/skills/rite-workflow/references/phase-mapping.md
@@ -14,7 +14,7 @@ Mapping information for phase details. Used in work memory session information.
 
 ### `/rite:issue:start` (flat workflow)
 
-`start.md` のステップ番号と 1:1 対応する 11 phase。`/rite:resume` の routing は `commands/resume.md` Phase 3.2 表を SoT とする。
+`start.md` のステップ番号と 1:1 対応する 11 phase。`/rite:resume` の routing は `commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) を SoT とする。
 
 | Phase | Phase Detail | Step in start.md |
 |-------|-------------|------------------|
@@ -32,11 +32,11 @@ Mapping information for phase details. Used in work memory session information.
 
 ### Legacy phase 名
 
-旧 sub-skill chain アーキテクチャで使われていた `phase5_*` / `phase1_*` / `phase2_*` / `phase3_*` 系 phase 名は `flow-state-update.sh` の write path からは消滅した。古い state file が残っている環境では `/rite:resume` が `commands/resume.md` Phase 3.2 の legacy alias 行で routing する。
+旧 sub-skill chain アーキテクチャで使われていた `phase5_*` / `phase1_*` / `phase2_*` / `phase3_*` 系 phase 名は `flow-state-update.sh` の write path からは消滅した。古い state file が残っている環境では `/rite:resume` の `commands/resume.md` Phase 3.5 整合性判定 (cross-check) が legacy phase 値を v3 enum に解決して routing する。
 
 旧 phase 名は `phase-transition-whitelist.sh` 内の `_RITE_PHASE_TRANSITIONS` から削除済。`rite_phase_transition_allowed` の forward-compat 経路で未知 prev phase は accept される (terminal phase 以外への遷移は許可、terminal phase への遷移のみ canonical predecessor set による厳密 check)。caller 側 (production hook は predicate のみ使用) の WARNING / ERROR は、predicate の戻り値ではなく caller の判定で生じる。
 
-> **詳細 routing は `commands/resume.md` Phase 3.2 "For rite:issue:start" Legacy phase 名 compatibility 表が SoT**。legacy `phase5_implementation` → ステップ 4 等、具体的なマッピングは resume.md を参照する。
+> **legacy phase の解決は `commands/resume.md` Phase 3.5 整合性判定 (cross-check) が担当**: cross-check の rule 1 は v3 enum (13 個) の値のみを直接採用するため、`phase5_*` 等の非 v3 enum legacy 値はそのまま採用されず、cross-check の判定を経て v3 phase へ解決される。解決後の v3 phase → start.md ステップの routing は同 `commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) を参照する。
 
 ## Usage Example
 


### PR DESCRIPTION
## 概要

`skills/rite-workflow/references/phase-mapping.md` が `commands/resume.md` の存在しない「Phase 3.2 legacy alias 表」を SoT として参照していた broken reference を修正する。現行 resume.md の Phase 3.2 は「git 状態取得」であり、legacy phase の解決は Phase 3.5 整合性判定 (cross-check)、解決後の v3 phase → step routing は Phase 5.3 (Phase enum → Step mapping (SoT)) が担当する。

## 関連 Issue

Closes #1094

## 変更内容

- `plugins/rite/skills/rite-workflow/references/phase-mapping.md` - 変更
  - L17: `/rite:resume` の routing SoT 参照を Phase 3.2 表 → **Phase 5.3 (Phase enum → Step mapping (SoT))** に修正
  - L35: legacy state file の routing 説明を Phase 3.2 legacy alias 行 → **Phase 3.5 整合性判定 (cross-check) が legacy phase 値を v3 enum に解決して routing** に修正
  - L39: 詳細 routing SoT を Phase 3.2 compatibility 表 → **Phase 3.5 cross-check (legacy 解決) + Phase 5.3 (step mapping)** に修正し、start.md の legacy routing 注記と表現を統一

## スコープ補足

Issue body の対象は L35-39 だが、同一ファイル L17 にも同種の「Phase 3.2 を routing SoT とする」broken reference が存在したため、ユーザー合意のうえ scope を拡張して同時修正した。参照先 (resume.md Phase 3.5 / Phase 5.3) はいずれも実在を確認済み。

## チェックリスト

- [x] phase-mapping.md 内に `Phase 3.2` 参照が残っていないことを確認
- [x] 参照先 (resume.md Phase 3.5 / Phase 5.3) の実在を確認
- [x] hardcoded-line-number drift check が clean (構造的参照を使用、行番号ハードコードなし)
