### PR TITLE
docs(workflow): 残存 phase5_* doc 参照の完全掃除 (ready.md 帰属 + review.md Phase 6.2)

### DIFF
--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -198,7 +198,7 @@ End processing.
 
 ### 2.1 Confirm with User (Standalone Path)
 
-> **Skip this confirmation when invoked from the main end-to-end flow path**: the orchestrator (`start.md` ステップ 8) has already confirmed the Ready transition with the user, so a second confirmation is duplicate (per [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) — fourth of the five self-questions: "Is this re-confirming an already-approved decision? → eliminate duplicates"). This sub-skill reads the flow state `.phase` and `.active`, and skips the confirmation when `.phase` matches one of the post-review / post-fix transition phases — either the legacy `phase5_post_review` / `phase5_post_fix` (written by `pr/review.md` / `pr/fix.md`) or the flat `review` / `fix` (written by `start.md` ステップ 7.1 / 7.2 before invoking the sub-skill) — AND `.active` is `true` (the AND condition closes the same-session interruption gap — see the next paragraph for details).
+> **Skip this confirmation when invoked from the main end-to-end flow path**: the orchestrator (`start.md` ステップ 8) has already confirmed the Ready transition with the user, so a second confirmation is duplicate (per [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md) — fourth of the five self-questions: "Is this re-confirming an already-approved decision? → eliminate duplicates"). This sub-skill reads the flow state `.phase` and `.active`, and skips the confirmation when `.phase` matches one of the post-review / post-fix transition phases — either the legacy `phase5_post_review` / `phase5_post_fix` (no current writer — these values only persist as residue in pre-v3 state files; the whitelist still accepts them for resume-from-old-state compatibility) or the flat `review` / `fix` (current writers: `start.md` ステップ 7.1 / 7.2 before invoking the sub-skill, plus the sub-skills themselves — `pr/review.md` Phase 8.0 / `pr/fix.md` Phase 8.1) — AND `.active` is `true` (the AND condition closes the same-session interruption gap — see the next paragraph for details).
 >
 > **Side paths fall back fail-safe to the standalone path (legacy behavior)**: when this sub-skill is reached via any non-main path (e.g., via `/rite:resume`, a standalone re-invocation after an in-session e2e interruption, or an unexpected `.phase` value), or when the flow state is not active (`active=false`), the `else` branch sets `in_e2e_flow=false` and the confirmation is shown. Erring on the side of "silent confirm" rather than "silent skip" preserves UX safety. Same-session interruption + standalone re-invocation is also covered by the bash AND condition (`active = "true"`): `flow-state.sh` cross-session guard classifies the legacy file as `same` (`legacy.session_id == current_sid`), so the helper returns the legacy file's stored value rather than the default. The bash test `[ "$active" = "true" ]` then rejects the legacy file because its `active` field is `false` once the e2e flow stopped.
 >
@@ -235,9 +235,12 @@ fi
 # AND condition closes the same-session interruption + standalone re-invocation gap
 # left open by the cross-session guard alone (legacy file's `active=false` after
 # e2e stop is the rejecting condition).
-# Both legacy `phase5_*` names (written by sub-skills) and flat `review` / `fix`
-# (written by the orchestrator before sub-skill invocation) must be accepted —
-# the two coexist until sub-skill writes are migrated.
+# Both legacy `phase5_post_review` / `phase5_post_fix` (no current writer — only
+# residual in pre-v3 state files; accepted for resume-from-old-state compat) and
+# flat `review` / `fix` (written by the orchestrator `start.md` ステップ 7.1 / 7.2
+# before sub-skill invocation, and by the sub-skills `pr/review.md` Phase 8.0 /
+# `pr/fix.md` Phase 8.1) must be accepted — the legacy names are retained in the
+# whitelist solely for backward-compatible resume from pre-v3 state files.
 if { [ "$phase" = "phase5_post_review" ] || [ "$phase" = "phase5_post_fix" ] || [ "$phase" = "review" ] || [ "$phase" = "fix" ]; } && [ "$active" = "true" ]; then
   in_e2e_flow=true
 else

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3929,7 +3929,7 @@ fi
 
 ### 6.2 Update Work Memory Phase
 
-> **Reference**: Update work memory per `work-memory-format.md` (at `{plugin_root}/skills/rite-workflow/references/work-memory-format.md`). Update phase to `phase5_review`, detail to `レビュー中`.
+> **Reference**: Update work memory per `work-memory-format.md` (at `{plugin_root}/skills/rite-workflow/references/work-memory-format.md`). Update phase to `review`, detail to `レビュー中`.
 
 **Step 1: Update local work memory (SoT)**
 
@@ -3943,7 +3943,7 @@ Use the self-resolving wrapper. See [Work Memory Format - Usage in Commands](../
 hook_err=$(mktemp /tmp/rite-review-p62-hook-err-XXXXXX) || hook_err=""
 if [ -n "$hook_err" ]; then
  if WM_SOURCE="review" \
- WM_PHASE="phase5_review" \
+ WM_PHASE="review" \
  WM_PHASE_DETAIL="レビュー中" \
  WM_NEXT_ACTION="レビュー結果に基づき次のアクションを決定" \
  WM_BODY_TEXT="Review cycle completed." \
@@ -3969,7 +3969,7 @@ else
  # mktemp 失敗時は stderr を 2>&1 経由で stdout 統合し、失敗時に上位 5 行を表示する簡易 fallback
  echo "WARNING: hook_err mktemp 失敗により local-wm-update.sh の stderr 詳細が取得できません" >&2
  if hook_combined=$(WM_SOURCE="review" \
- WM_PHASE="phase5_review" \
+ WM_PHASE="review" \
  WM_PHASE_DETAIL="レビュー中" \
  WM_NEXT_ACTION="レビュー結果に基づき次のアクションを決定" \
  WM_BODY_TEXT="Review cycle completed." \
@@ -3995,7 +3995,7 @@ if [ -n "$sync_err" ]; then
  if bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
  --issue {issue_number} \
  --transform update-phase \
- --phase "phase5_review" --phase-detail "レビュー中" \
+ --phase "review" --phase-detail "レビュー中" \
  2>"$sync_err"; then
  :
  else
@@ -4016,7 +4016,7 @@ else
  if sync_combined=$(bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
  --issue {issue_number} \
  --transform update-phase \
- --phase "phase5_review" --phase-detail "レビュー中" \
+ --phase "review" --phase-detail "レビュー中" \
  2>&1); then
  : # success
  else
@@ -4114,7 +4114,7 @@ _rite_review_p64_run_sync "p64 update-phase" \
  bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
  --issue {issue_number} \
  --transform update-phase \
- --phase "phase5_review" --phase-detail "レビュー中"
+ --phase "review" --phase-detail "レビュー中"
 
 # Step 2: レビュー対応履歴追記
 review_tmp=$(mktemp) || {


### PR DESCRIPTION
## 概要

残存していた `phase5_*` documentation drift 2 箇所を実態に合わせて掃除する。いずれも flat workflow / v3 phase enum 化以降に stale 化した pure documentation の修正で、code 変更・挙動変更はない。

## 変更内容

### AC-1: `commands/pr/ready.md` 生成元帰属の事実修正
- 旧 prose は legacy `phase5_post_review` / `phase5_post_fix` を「`pr/review.md` / `pr/fix.md` が生成」と帰属していたが、リポジトリ内に当該値の **writer は存在しない**（grep 確認済。pre-v3 state file の残存値のみ）
- legacy 値 = 「現行 writer なし・pre-v3 state file 残存値（whitelist は resume-from-old-state compat のため受理）」、flat `review` / `fix` = 「現行生成元: `start.md` ステップ 7.1/7.2 + `pr/review.md` Phase 8.0 / `pr/fix.md` Phase 8.1」と区別するよう prose と直後の bash コメント（双子）を同期
- whitelist 判定（`phase5_post_*` を受理する条件分岐）は reader compat として **維持**

### AC-2: `commands/pr/review.md` Phase 6.2/6.4 の work-memory phase 同期
- Phase 6.2/6.4 の work-memory 更新（`WM_PHASE` / `issue-comment-wm-sync` の `--phase`）が legacy `phase5_review` のまま残存していたのを `review` に統一（6 箇所）
- 全コマンドの WM_PHASE/`--phase` 慣習（`create.md`=pr / `start.md`=branch,plan,implement / `fix.md`=fix / `ready.md`=ready / `implement.md`=lint）、および review.md 自身の Phase 8.0 flow-state write（`--phase review`）と整合
- line 8 の reader 側 compat（`phase: phase5_review` 受理）は input contract として意図的に保持

### AC-3: 検証
- `phase5_review` 残存は review.md line 8（reader compat）のみ
- 変更後の phase 値はすべて v3 enum（`PHASE_ENUM_V3` に `review` 含む）準拠

## 前提訂正（要確認）

Issue の Where 表 / AC-3 の前提「`--phase "phase5_review"` が `flow-state.sh:_phase_is_valid` の `WARNING: unknown phase` を emit する」は **事実誤認**。Phase 6.2/6.4 の `WM_PHASE` / `--phase` は work-memory 系呼び出し（`local-wm-update.sh` は phase 無検証 / `issue-comment-wm-sync.sh`→`issue-comment-wm-update.py` も flow-state 非経由）であり、flow-state.sh の検証経路を通らない。よって当該 WARNING は元々発生していない。実際の flow-state.sh 呼び出しは review.md Phase 8.0（`--phase review`）のみで、これは PR 2c で既に v3 enum 化済み。

ただし修正方向（`phase5_review` → `review` の命名統一）自体は上記の全コマンド慣習・Phase 8.0 との整合の観点で正しいため、本 PR では実施した。

## フォローアップ候補（本 PR スコープ外）

- `skills/rite-workflow/references/work-memory-format.md` の例（`phase5_implementation` / `phase5_lint`）も同系統の命名 drift の可能性。ただし work-memory の phase 語彙が `phase-mapping.md` 由来で別系統の可能性もあり、未確定のため別途切り出し推奨
- `commands/pr/review.md` の `phase5_3_8_loop_count`（CONTEXT marker 名）は phase 値ではないため対象外

## テスト

- `commands.lint: null`（markdown/shell プラグイン）のため主 lint は対象外
- プラグイン固有チェック実行: bang-backtick / doc-heavy-patterns-drift / hardcoded-line-number / wiki-growth / gitignore-health / backlink-format / direct-gh-issue-create すべて exit 0
- distributed-fix-drift / comment-journal / comment-line-ref の warning は全て pre-existing かつ変更行外（本 PR 起因の新規 finding ゼロ）

## 関連 Issue

Closes #1096
