### PR TITLE
docs(workflow): error_count note の rationale を reader 不在の実装に整合

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -876,7 +876,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 
 Replace `{phase_value}` and `{next_action_value}` with the values from the table above based on the lint result.
 
-**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.
 
 **Also sync to local work memory** (`.rite-work-memory/issue-{n}.md`) when flow state file exists:
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -5501,7 +5501,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --if-exists
 ```
 
-**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.
 
 **Also update local work memory** (`.rite-work-memory/issue-{n}.md`) with phase transition:
 

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -488,7 +488,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --if-exists
 ```
 
-**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.
 
 **Also sync to local work memory** (`.rite-work-memory/issue-{n}.md`) when flow state file exists:
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -4732,7 +4732,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 
 Replace `{next_action_value}` with the value from the table above based on the review result. Also replace `{n}` in the next_action string with the actual finding count from the review result (e.g., if the result is `[review:fix-needed:3]`, then `{n}` = `3`).
 
-**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.
+**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.
 
 ### 8.0.1 W Phase Completion Gate (Defense-in-Depth, #535)
 


### PR DESCRIPTION
## 概要

`commands/` 配下 4 ファイルの「Note on `error_count`」blockquote の rationale 最終文を、`error_count` を読む production reader が存在しない実装の現状に整合させた。

## 変更内容

以下 4 ファイルの rationale 最終文を統一:

- `plugins/rite/commands/lint.md`
- `plugins/rite/commands/pr/fix.md`
- `plugins/rite/commands/pr/ready.md`
- `plugins/rite/commands/pr/review.md`

**変更前:**
> This prevents stale circuit breaker counts from one phase from poisoning subsequent phases.

**変更後:**
> `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.

「circuit breaker counts ... poisoning」という表現は `error_count` を circuit-breaker 信号として消費する reader の存在を含意していたが、実装には判定・分岐に使う production reader が存在しない。sibling docs（`commands/issue/start.md` / `commands/issue/create.md` / `commands/pr/cleanup.md` / `commands/wiki/ingest.md`）の「reserved/legacy schema slot で production reader 不在」という記述と趣旨を統一する。

実装挙動（default で 0 リセット、`--preserve-error-count` 時のみ保持）の記述自体は元から正確であり、本 PR は rationale 文言のみを対象とする。

## 関連 Issue

Closes #1101
