### PR TITLE
docs(workflow): phase5_* 例示を v3 enum (implement/lint) に統一

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/session-detection.md
+++ b/plugins/rite/skills/rite-workflow/references/session-detection.md
@@ -53,7 +53,7 @@ Display when ALL of the following conditions are met:
 Issue: #288 - checkpoint.json を廃止し Issue 作業メモリに統合
 ブランチ: refactor/issue-288-checkpoint-removal
 コマンド: rite:issue:start
-フェーズ: phase5_implementation
+フェーズ: implement
 フェーズ詳細: 実装作業中
 最終更新: 2026-01-29T12:00:00+09:00
 

--- a/plugins/rite/skills/rite-workflow/references/work-memory-format.md
+++ b/plugins/rite/skills/rite-workflow/references/work-memory-format.md
@@ -58,7 +58,7 @@ _ボトルネック検出はありません_
 | `{timestamp}` | ISO 8601 `YYYY-MM-DDTHH:MM:SS+HH:MM` | `2026-01-29T14:30:00+09:00` |
 | `{branch_name}` | `{type}/issue-{number}-{slug}` | `feat/issue-13-new-feature` |
 | `{command_name}` | Command path | `/rite:issue:start`, `/rite:pr:create` |
-| `{phase}` | Phase ID (see [phase-mapping.md](./phase-mapping.md)) | `phase5_implementation` |
+| `{phase}` | Phase ID (see [phase-mapping.md](./phase-mapping.md)) | `implement` |
 | `{phase_detail}` | Detail state | `実装作業中`, `PR 作成完了` |
 | `{next_command}` | Next command | `/rite:pr:create`, `/rite:pr:review #42` |
 | `{next_status}` | `待機中` / `実行中` / `完了` | `待機中` |
@@ -297,7 +297,7 @@ sync_revision: 3
 sync_status: synced
 source: pre_compact
 last_modified_at: "2026-02-21T06:30:00Z"
-phase: "phase5_implementation"
+phase: "implement"
 phase_detail: "ファイル編集"
 next_action: "テスト実行"
 branch: "feat/issue-721"
@@ -322,7 +322,7 @@ loop_count: 0
 | `sync_status` | string | No | `synced` / `pending` / `conflict` |
 | `source` | string | No | Provenance tracking (e.g., `pre_compact`, `resume`, `init`) |
 | `last_modified_at` | string | No | UTC ISO 8601 timestamp (`Z` suffix) |
-| `phase` | string | No | Current phase ID (e.g., `phase5_implementation`; see [phase-mapping.md](./phase-mapping.md)) |
+| `phase` | string | No | Current phase ID (e.g., `implement`; see [phase-mapping.md](./phase-mapping.md)) |
 | `phase_detail` | string | No | Phase detail |
 | `next_action` | string | No | Next action description |
 | `branch` | string | No | Branch name |
@@ -388,7 +388,7 @@ Issue-level locking prevents concurrent access to local work memory files from i
 
 ```bash
 WM_SOURCE="implement" \
-  WM_PHASE="phase5_lint" \
+  WM_PHASE="lint" \
   WM_PHASE_DETAIL="品質チェック準備" \
   WM_NEXT_ACTION="rite:lint を実行" \
   WM_BODY_TEXT="Post-implementation." \


### PR DESCRIPTION
## 概要

`work-memory-format.md` と `session-detection.md` に残っていた旧 sub-skill chain 時代の phase 例示値 `phase5_implementation` / `phase5_lint` を、phase-mapping.md の v3 enum (`implement` / `lint`) に統一する。例示値であり機能には影響しないが、読者が古い phase 名を canonical と誤認するのを防ぐ。

## 変更内容

- `skills/rite-workflow/references/work-memory-format.md`: 4 箇所 (`{phase}` 例 / frontmatter 例 / フィールド説明 / `WM_PHASE` 例)
  - `phase5_implementation` → `implement` (3 箇所)
  - `phase5_lint` → `lint` (1 箇所)
- `skills/rite-workflow/references/session-detection.md`: 1 箇所 (Display Example の `フェーズ:`)
  - `phase5_implementation` → `implement`

legacy migration を意図的に扱う箇所 (`resume.md` / `start.md` / `pr/*.md` の phase5_* 参照、hooks/tests のフィクスチャ) は対象外とした。

## 関連 Issue

Closes #1104

## チェックリスト

- [x] 対象 2 ファイルから `phase5_` が消えたことを grep で確認
- [x] 置換先 `implement` / `lint` が phase-mapping.md の v3 enum に存在することを確認
- [x] plugin-specific drift checks: 変更分に finding なし
