### PR TITLE
docs(workflow): metrics gate marker の phase5_* 注記を legacy drift 区別へ強化

### DIFF
--- a/plugins/rite/commands/issue/references/metrics-recording.md
+++ b/plugins/rite/commands/issue/references/metrics-recording.md
@@ -12,8 +12,18 @@
 > captured. A future reintroduction (post-PR metrics dashboard, retro logs,
 > etc.) should pick up from this file rather than re-deriving the criteria.
 >
-> Section headings still use the historical `Phase 5.5.2 / phase5_post_metrics`
-> labels for traceability with the original design discussion.
+> **The `phase5_*`-form identifiers in this file are intentional — not legacy
+> drift.** The markers used below (`phase5_post_metrics`,
+> `phase5_post_status_in_review`, `phase5_5_2_metrics`) are **metrics-gate
+> internal markers, NOT work-memory phase vocabulary**. They are distinct from
+> the work-memory `phase5_*` examples that Issue #1104 / #1109 unified to the v3
+> enum (`implement` / `lint` / …): those were work-memory phase labels, whereas
+> these name points in the (now-orphan) metrics recording flow. The `phase5_*`
+> form here is **historically fixed and deliberately NOT renamed**, to preserve
+> traceability with the original design discussion. Because this file has no live
+> writer/reader (see the orphan banner above), these markers never appear in a
+> real flow-state `.phase` value — a `phase5_*` drift-cleanup grep that lands here
+> can treat them as documentation-only and skip them.
 
 ## Skip Steps note (Phase 5.6 pre-condition)
 


### PR DESCRIPTION
## 概要

flow-state 内部の metrics gate marker (`phase5_post_metrics` / `phase5_post_status_in_review` / `phase5_5_2_metrics`) の命名が legacy の `phase5_*` (旧 sub-skill chain phase 名) と同形式のため、`phase5_*` drift 掃除の調査で誤検出されやすい問題に対応する。

採用案は **(A) 注記補強**。調査の結果これら 3 marker は live writer/reader を一切持たない documentation-only であり、(B) rename はこのファイルの設計議論 traceability を破壊し live sibling marker との命名不整合も生むため不採用とした。

## 変更内容

`plugins/rite/commands/issue/references/metrics-recording.md` 冒頭バナーの note を強化注記へ置換:

- 3 marker が work-memory phase 語彙 (v3 enum) ではなく metrics gate の internal marker である旨を明示
- Issue #1104 / #1109 が v3 enum へ統一した work-memory `phase5_*` 例示とは別語彙であることを区別
- `phase5_*` 形式は historical に固定で意図的に rename しないことを明示
- orphan で live writer/reader を持たず real な flow-state `.phase` には現れないため、`phase5_*` drift-cleanup grep は documentation-only として skip 可能と明記

## 関連 Issue

Closes #1110

## チェックリスト

- [x] AC-1: (A) 注記補強 / (B) rename のトレードオフ評価と採用案確定
- [x] AC-2: 採用案 (A) を実装
- [x] AC-3: `phase5_*` grep で metrics gate marker が legacy drift でないと判別可能
- [x] lint (plugin-specific checks) 実行済 — 変更ファイル (`metrics-recording.md`) に findings なし
