### PR TITLE
refactor(pr): PR 系コマンド slim 化 part 1 — cleanup.md (-63%) + close.md (-42%) (#1112)

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -20,7 +20,7 @@ Check the completion status of an Issue and guide necessary actions.
 
 ## Shared: Projects Status → Done (delegate pattern)
 
-Phase 1.3.2 / 4.2 / 4.6.3 はいずれも Projects Status を **Done** に更新する。直接の `gh api graphql` + `field-list` + `item-edit` インライン呼び出しは substep 間で LLM attention が失われ silent skip を生む（Issue #658）ため、共通スクリプト `projects-status-update.sh` に委譲する（`start.md` Phase 2.4 / 5.5.1 / 5.7.2 と同一）。スクリプトは冪等で、API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
+Phase 1.3.2 / 4.2 / 4.6.3 はいずれも Projects Status を **Done** に更新する。直接の `gh api graphql` + `field-list` + `item-edit` インライン呼び出しは substep 間で LLM attention が失われ silent skip を生む（Issue #658）ため、共通スクリプト `projects-status-update.sh` に委譲する（`start.md` Phase 2.4 / 8.3 と同一）。スクリプトは冪等で、API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
 
 **委譲呼び出し**（`{issue}` は対象 Issue 番号、`auto_add false`・`non_blocking true`）:
 

--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -4,11 +4,11 @@ description: Issue の完了状態を確認
 
 # /rite:issue:close
 
-Check the completion status of an Issue and guide necessary actions
+Check the completion status of an Issue and guide necessary actions.
+
+> **Charter**: This command is subject to the [Simplification Charter](../../skills/rite-workflow/references/simplification-charter.md). Runtime に効かない経緯記述・cycle 番号引用・重複 confirmation は書かない。
 
 ---
-
-When this command is executed, run the following phases in order.
 
 ## Arguments
 
@@ -18,11 +18,33 @@ When this command is executed, run the following phases in order.
 
 ---
 
+## Shared: Projects Status → Done (delegate pattern)
+
+Phase 1.3.2 / 4.2 / 4.6.3 はいずれも Projects Status を **Done** に更新する。直接の `gh api graphql` + `field-list` + `item-edit` インライン呼び出しは substep 間で LLM attention が失われ silent skip を生む（Issue #658）ため、共通スクリプト `projects-status-update.sh` に委譲する（`start.md` Phase 2.4 / 5.5.1 / 5.7.2 と同一）。スクリプトは冪等で、API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
+
+**委譲呼び出し**（`{issue}` は対象 Issue 番号、`auto_add false`・`non_blocking true`）:
+
+```bash
+bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+  --argjson issue {issue} --arg owner "{owner}" --arg repo "{repo}" \
+  --argjson project_number {project_number} --arg status "Done" \
+  --argjson auto_add false --argjson non_blocking true \
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+```
+
+**`.result` による分岐**（全分岐 non-blocking — Status 更新失敗は close フローを止めない）:
+
+| `.result` | 表示 |
+|-----------|------|
+| `"updated"` | `Projects Status を "Done" に更新しました`（冪等のため既 Done も updated になる） |
+| `"skipped_not_in_project"` | `警告: Issue #{issue} は Project に登録されていません` |
+| `"failed"` | `.warnings[]` を stderr に出し、`警告: Projects Status の "Done" 更新に失敗。手動: GitHub Projects 画面で Status を Done に変更、または gh project item-edit ...` |
+
+---
+
 ## Phase 1: Check Issue Status
 
 ### 1.1 Retrieve Issue Information
-
-Retrieve detailed information for the specified Issue:
 
 ```bash
 gh issue view {issue_number} --json number,title,body,state,labels,closedAt
@@ -30,9 +52,7 @@ gh issue view {issue_number} --json number,title,body,state,labels,closedAt
 
 ### 1.2 Determine Issue State
 
-Branch based on the Issue state:
-
-**If the Issue is already closed:**
+**Issue が既にクローズ済みの場合:**
 
 ```
 {i18n:issue_close_already_closed} (variables: number={number})
@@ -43,80 +63,21 @@ Branch based on the Issue state:
 {i18n:issue_close_no_action_needed}
 ```
 
-Proceed to Phase 1.3 (Projects Status Sync for Already-Closed Issues).
-
-**If the Issue is open:**
-
-Proceed to Phase 2.
+→ Phase 1.3 へ。**Open の場合**は Phase 2 へ。
 
 ---
 
 ## Phase 1.3: Projects Status Sync for Already-Closed Issues
 
-When an Issue is already closed but its Projects Status may not be "Done" (e.g., closed outside the rite workflow), check and update the status.
+Issue が既にクローズ済みでも Projects Status が "Done" でない場合（rite 外でクローズされた等）に同期する。
 
 ### 1.3.1 Projects Enabled Check
 
-Read `rite-config.yml` with the Read tool and check `github.projects.enabled`.
+Read tool で `rite-config.yml` の `github.projects.enabled` を確認。`false`（または未設定）なら本 Phase をスキップして Phase 5 へ。
 
-If `projects.enabled: false` (or not configured): skip this phase and proceed to Phase 5.
+### 1.3.2 Update Status
 
-### 1.3.2 Update Status via Shared Script
-
-> **Source of truth**: This phase delegates to `plugins/rite/scripts/projects-status-update.sh` — the same shared script used by `commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2 (Issue #496 / PR #531). Direct inline `gh api graphql` + `gh project field-list` + `gh project item-edit` calls have been removed because the multi-stage inline pipeline produced silent skips when LLM attention was lost between substeps, leaving Issue Status stuck at the previous value (Issue #658). The script is idempotent: invoking it when the Status is already "Done" returns `.result == "updated"` with no observable side-effect, so the explicit "already Done" check is no longer required.
-
-Invoke the shared script to transition the Issue Status to **Done**:
-
-```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
- --argjson issue {issue_number} \
- --arg owner "{owner}" \
- --arg repo "{repo}" \
- --argjson project_number {project_number} \
- --arg status "Done" \
- --argjson auto_add false \
- --argjson non_blocking true \
- '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
-```
-
-`auto_add: false` because the Issue is already CLOSED at this point — auto-adding a closed Issue is unexpected and would mask a configuration drift. The script internally executes the GraphQL `projectItems` query → `gh project field-list` → `gh project item-edit` triple in a single fail-fast pipeline.
-
-#### 1.3.2.1 Result Handling
-
-Inspect the script's stdout JSON and route by `.result`:
-
-| `.result` | User-visible action |
-|-----------|--------------------|
-| `"updated"` | Display `Projects Status を "Done" に更新しました` and proceed to Phase 5. Note: the script always PATCHes regardless of pre-state, so `already Done` and `newly Done` both surface as `.result == "updated"` (idempotent at API level, but indistinguishable from the caller's perspective) |
-| `"skipped_not_in_project"` | Display `警告: Issue #{issue_number} は Project に登録されていません` and proceed to Phase 5 |
-| `"failed"` | Display each `.warnings[]` entry to stderr, then display `警告: Projects Status の "Done" への更新に失敗しました。手動で更新する場合: GitHub Projects 画面で Issue #{issue_number} の Status を "Done" に変更するか、または gh project item-edit --project-id <project_id> --id <item_id> --field-id <status_field_id> --single-select-option-id <done_option_id> を実行してください。` and proceed to Phase 5 |
-
-**All result branches are non-blocking** — the Issue is already closed; a Projects Status update issue MUST NOT halt the close flow.
-
-> **Bash 実装 minimal skeleton (delegate-only 経路の標準形)**:
->
-> ```bash
-> status_json=$(bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args") || status_json=""
-> status_result=$(printf '%s' "$status_json" | jq -r '.result // "failed"' 2>/dev/null)
-> status_warning_lines=$(printf '%s' "$status_json" | jq -r '.warnings[]?' 2>/dev/null)
-> case "$status_result" in
-> updated)
-> echo "Projects Status を \"Done\" に更新しました" ;;
-> skipped_not_in_project)
-> echo "警告: Issue #{issue_number} は Project に登録されていません" >&2 ;;
-> failed|*)
-> [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/ warning: /' >&2
-> echo "警告: Projects Status の \"Done\" への更新に失敗しました。手動回復: gh project item-edit ..." >&2 ;;
-> esac
-> ```
->
-> 上記が delegate-only 経路 (close + summary 不要) の標準パターン。`.warnings[]` の stderr surface を必ず含めること (省略すると AC-2 silent skip risk)。
->
-> **完全形 (state machine + signal-specific trap + tempfile + Step 3 inconsistency summary)** が必要な場合は `commands/issue/close.md` Phase 4.6.3 を参照。
-
-> **Underlying API documentation**: See [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) for the API-level details (GraphQL query, field-list, item-edit) that the script encapsulates.
-
-Proceed to Phase 5.
+[Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern) の委譲パターンを実行する（`{issue}` = `{issue_number}`、`auto_add false` の理由: 既に CLOSED の Issue を auto-add するのは config drift を masking するため）。結果分岐は共通テーブルに従い、いずれの場合も Phase 5 へ進む（non-blocking — Issue は既にクローズ済み）。
 
 ---
 
@@ -124,37 +85,25 @@ Proceed to Phase 5.
 
 ### 2.1 Search for Related PRs
 
-Search for PRs linked to the Issue:
-
 ```bash
 gh pr list --state all --search "linked:issue:{issue_number}" --json number,title,state,mergedAt,url
 ```
 
-Or search for PRs that reference the Issue number:
+見つからなければ PR body の close キーワードを検索する:
 
 ```bash
 gh pr list --state all --json number,title,state,body,mergedAt,url
 ```
 
-Check whether the body of the found PRs contains the following patterns:
-- `Closes #{issue_number}`
-- `closes #{issue_number}`
-- `Fixes #{issue_number}`
-- `fixes #{issue_number}`
-- `Resolves #{issue_number}`
-- `resolves #{issue_number}`
+body が `Closes/Fixes/Resolves #{issue_number}`（大文字小文字とも）を含むか確認する。
 
 ### 2.2 Search PRs by Branch Name
-
-Also search for PRs from branches containing the Issue number:
 
 ```bash
 gh pr list --state all --head "*issue-{issue_number}*" --json number,title,state,mergedAt,url
 ```
 
 ### 2.3 Aggregate Search Results
-
-List all related PRs found:
 
 | # | タイトル | 状態 | マージ日時 |
 |---|---------|------|----------|
@@ -166,16 +115,13 @@ List all related PRs found:
 
 ### 3.1 Auto-Close Conditions
 
-Conditions under which an Issue is automatically closed:
-
-1. The PR body contains `Closes #XXX`, `Fixes #XXX`, or `Resolves #XXX`
-2. That PR has been merged
+Issue が自動クローズされる条件: (1) リンク PR の body に `Closes/Fixes/Resolves #XXX` が含まれ、(2) その PR がマージ済み。
 
 ### 3.2 Determination Results by Scenario
 
 #### Pattern A: Already Auto-Closed (or Scheduled)
 
-If a linked PR is merged and contains a close keyword:
+リンク PR がマージ済みかつ close キーワードを含む場合:
 
 ```
 {i18n:issue_close_auto_close_will_happen} (variables: number={number})
@@ -189,7 +135,7 @@ If a linked PR is merged and contains a close keyword:
 
 #### Pattern B: PR Exists but No Auto-Close
 
-If a linked PR exists but does not contain a close keyword:
+リンク PR はあるが close キーワードが無い場合:
 
 ```
 {i18n:issue_close_no_auto_close} (variables: number={number})
@@ -204,14 +150,14 @@ If a linked PR exists but does not contain a close keyword:
 
 #### Pattern C: PR Awaiting Merge
 
-If a linked PR is in open state:
+リンク PR が open の場合:
 
 ```
 {i18n:issue_close_pr_pending} (variables: number={number})
 
 {i18n:issue_close_linked_prs}:
 - #{pr_number}: {pr_title} (Open)
- URL: {pr_url}
+  URL: {pr_url}
 
 {i18n:issue_close_recommended_action}:
 1. PR をレビュー・マージ
@@ -220,25 +166,20 @@ If a linked PR is in open state:
 
 #### Pattern D: No PR Found
 
-If no related PR is found:
+関連 PR が無い場合:
 
 ```
 {i18n:issue_close_no_prs_found} (variables: number={number})
-
-オプション:
-- PR を作成してから Issue をクローズ: /rite:pr:create
-- 手動で Issue をクローズ: gh issue close {number}
-- Issue を開いたままにする
 ```
 
-Use `AskUserQuestion` to confirm the next action:
+`AskUserQuestion` で次のアクションを確認する:
 
 ```
 {i18n:issue_close_ask_action}
 
 オプション:
-- {i18n:issue_close_option_create_pr}
-- {i18n:issue_close_option_close_manual}
+- {i18n:issue_close_option_create_pr}（/rite:pr:create）
+- {i18n:issue_close_option_close_manual}（gh issue close {number}）
 - {i18n:issue_close_option_do_nothing}
 ```
 
@@ -248,84 +189,31 @@ Use `AskUserQuestion` to confirm the next action:
 
 ### 4.1 Execute Manual Close
 
-If the user selected manual close:
+ユーザーが手動クローズを選択した場合:
 
 ```bash
 gh issue close {issue_number}
 ```
 
-### 4.2 Update Projects Status via Shared Script
+### 4.2 Update Projects Status
 
-> **Source of truth**: This phase delegates to `plugins/rite/scripts/projects-status-update.sh` — the same shared script used by `commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2 (Issue #496 / PR #531). Direct inline `gh api graphql` + `gh project field-list` + `gh project item-edit` calls have been removed because the multi-stage inline pipeline produced silent skips when LLM attention was lost between substeps, leaving Issue Status stuck at the previous value (Issue #658).
-
-Skip Phase 4.2 if `github.projects.enabled: false` in `rite-config.yml` and proceed to Phase 4.3. Otherwise, invoke the shared script to transition the Issue Status to **Done**:
-
-```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
- --argjson issue {issue_number} \
- --arg owner "{owner}" \
- --arg repo "{repo}" \
- --argjson project_number {project_number} \
- --arg status "Done" \
- --argjson auto_add false \
- --argjson non_blocking true \
- '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
-```
-
-`auto_add: false` because by close time the Issue is already registered in the Project (start.md Phase 2.4 auto-added it if missing). The script internally executes the GraphQL `projectItems` query → `gh project field-list` → `gh project item-edit` triple in a single fail-fast pipeline.
-
-#### 4.2.1 Result Handling
-
-Inspect the script's stdout JSON and route by `.result`:
-
-| `.result` | User-visible action |
-|-----------|--------------------|
-| `"updated"` | Display `Projects Status を "Done" に更新しました` and proceed to Phase 4.3 |
-| `"skipped_not_in_project"` | Display `警告: Issue #{issue_number} は Project に登録されていません。Status 更新をスキップします` and proceed to Phase 4.3 |
-| `"failed"` | Display each `.warnings[]` entry to stderr, then display `警告: Projects Status の "Done" への更新に失敗しました。手動で更新する場合: GitHub Projects 画面で Issue #{issue_number} の Status を "Done" に変更するか、または gh project item-edit --project-id <project_id> --id <item_id> --field-id <status_field_id> --single-select-option-id <done_option_id> を実行してください。` and proceed to Phase 4.3 |
-
-**All result branches are non-blocking** — the close has already executed (`gh issue close` in Phase 4.1); a Projects Status update issue MUST NOT halt the close flow.
-
-> **Bash 実装 minimal skeleton (delegate-only 経路の標準形)**:
->
-> ```bash
-> status_json=$(bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args") || status_json=""
-> status_result=$(printf '%s' "$status_json" | jq -r '.result // "failed"' 2>/dev/null)
-> status_warning_lines=$(printf '%s' "$status_json" | jq -r '.warnings[]?' 2>/dev/null)
-> case "$status_result" in
-> updated)
-> echo "Projects Status を \"Done\" に更新しました" ;;
-> skipped_not_in_project)
-> echo "警告: Issue #{issue_number} は Project に登録されていません" >&2 ;;
-> failed|*)
-> [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/ warning: /' >&2
-> echo "警告: Projects Status の \"Done\" への更新に失敗しました。手動回復: gh project item-edit ..." >&2 ;;
-> esac
-> ```
->
-> 上記が delegate-only 経路 (close + summary 不要) の標準パターン。`.warnings[]` の stderr surface を必ず含めること (省略すると AC-2 silent skip risk)。
->
-> **完全形 (state machine + signal-specific trap + tempfile + Step 3 inconsistency summary)** が必要な場合は `commands/issue/close.md` Phase 4.6.3 を参照。
-
-> **Underlying API documentation**: See [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) for the API-level details (GraphQL query, field-list, item-edit) that the script encapsulates.
+`github.projects.enabled: false` ならスキップして Phase 4.3 へ。そうでなければ [Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern) の委譲パターンを実行する（`{issue}` = `{issue_number}`、`auto_add false` の理由: close 時点で start.md Phase 2.4 が登録済み）。結果分岐は共通テーブルに従い、いずれの場合も Phase 4.3 へ（non-blocking — close は Phase 4.1 で実行済み）。
 
 ### 4.3 Update Local Work Memory
 
-Before deletion in Phase 5, record the completion state in local work memory:
+Phase 5 の削除前に完了状態をローカル作業メモリに記録する:
 
 ```bash
 WM_SOURCE="close" \
- WM_PHASE="completed" \
- WM_PHASE_DETAIL="Issue クローズ完了" \
- WM_NEXT_ACTION="なし" \
- WM_BODY_TEXT="Issue closed." \
- WM_ISSUE_NUMBER="{issue_number}" \
- bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+  WM_PHASE="completed" \
+  WM_PHASE_DETAIL="Issue クローズ完了" \
+  WM_NEXT_ACTION="なし" \
+  WM_BODY_TEXT="Issue closed." \
+  WM_ISSUE_NUMBER="{issue_number}" \
+  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
-**On lock failure**: Log a warning and continue — local work memory update is best-effort. The file will be deleted in Phase 5 regardless.
-
-**Step 2: Sync to Issue comment (backup)** — Skipped. Phase 5 deletes the local work memory file, and the Issue comment serves as the final archival record (updated by `rite:pr:cleanup` Phase 4.5). No separate backup sync is needed here.
+lock 失敗時は WARNING を出して続行（best-effort — Phase 5 でどのみち削除される）。Issue コメントへの backup sync は不要（最終的な archival record は `rite:pr:cleanup` Phase 4.5 が更新する）。
 
 ### 4.4 Completion Report
 
@@ -338,66 +226,44 @@ Status: Done
 関連 PR: #{pr_number} (Merged)
 ```
 
-Proceed to Phase 4.4.W.
+→ Phase 4.4.W へ。
 
 ### 4.4.W Wiki Ingest Trigger (Conditional)
 
-> **Reference**: [Wiki Ingest](../wiki/ingest.md) — `wiki-ingest-trigger.sh` API
+> **Reference**: [Wiki Ingest](../wiki/ingest.md) — `wiki-ingest-trigger.sh` API。本 Phase は raw source の **蓄積** を担う（page 統合は後続の `/rite:wiki:ingest` が冪等に行う）。raw 蓄積と page 統合を分離することで、page 統合が skip / 失敗しても raw source は失われない。
 
-After completing the Issue close actions, trigger Wiki Ingest to capture retrospective knowledge from this Issue.
+> **⚠️ E2E Mandatory**: 本 Phase は出力最小化ルールで skip しない。`/rite:issue:start` ステップ 8.4（親 close）経由でも実行する。唯一の正当な skip は Step 1 の config ベース skip（`WIKI_INGEST_SKIPPED=1` sentinel + WARNING を必ず emit）。
 
-> **⚠️ E2E Mandatory**: Phase 4.4.W and 4.4.W.2 are **NEVER** skipped under any output-minimization rule. Even when called from `/rite:issue:start` ステップ 8.4 (parent close) or downstream automation, this section MUST execute (subject only to the configuration-based skip in Step 1 below). Wiki Ingest を silent skip させると Issue 完結ごとに experiential knowledge が失われる。
-
-**Condition**: Execute only when `wiki.enabled: true` AND `wiki.auto_ingest: true` in `rite-config.yml`. Configuration-based skip is the **only** legitimate skip path — it MUST emit a `WIKI_INGEST_SKIPPED=1` status line and `wiki_ingest_skipped` sentinel so the caller can detect and report (see Phase 4.4.W.3 below).
-
-**Step 1**: Check Wiki configuration:
+**Step 1**: Wiki 設定を確認する（`wiki.enabled` opt-out default true / `wiki.auto_ingest` default false）:
 
 ```bash
 wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || wiki_section=""
-wiki_enabled=""
-if [[ -n "$wiki_section" ]]; then
- wiki_enabled=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+enabled:/ { print; exit }' \
- | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
-fi
-auto_ingest=""
-if [[ -n "$wiki_section" ]]; then
- auto_ingest=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+auto_ingest:/ { print; exit }' \
- | sed 's/[[:space:]]#.*//' | sed 's/.*auto_ingest:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
-fi
-case "$wiki_enabled" in false|no|0) wiki_enabled="false" ;; true|yes|1) wiki_enabled="true" ;; *) wiki_enabled="true" ;; esac # #483: opt-out default
+parse_wiki_key() {
+  printf '%s\n' "$wiki_section" | awk -v k="$1" '$0 ~ "^[[:space:]]+" k ":" { print; exit }' \
+    | sed 's/[[:space:]]#.*//' | sed "s/.*$1:[[:space:]]*//" | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]'
+}
+wiki_enabled=$(parse_wiki_key enabled)
+auto_ingest=$(parse_wiki_key auto_ingest)
+case "$wiki_enabled" in false|no|0) wiki_enabled="false" ;; *) wiki_enabled="true" ;; esac
 case "$auto_ingest" in true|yes|1) auto_ingest="true" ;; *) auto_ingest="false" ;; esac
-echo "wiki_enabled=$wiki_enabled auto_ingest=$auto_ingest"
-```
 
-If `wiki_enabled=false` or `auto_ingest=false`, **emit a skip status line + sentinel and proceed to Phase 4.5** (do not silently skip — the caller relies on this signal for Phase 5.6 reporting):
-
-```bash
-if [ "$wiki_enabled" = "false" ]; then
- reason="disabled"
-elif [ "$auto_ingest" = "false" ]; then
- reason="auto_ingest_off"
-else
- reason=""
-fi
+reason=""
+[ "$wiki_enabled" = "false" ] && reason="disabled"
+[ -z "$reason" ] && [ "$auto_ingest" = "false" ] && reason="auto_ingest_off"
 if [ -n "$reason" ]; then
- echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=$reason"
- echo "WARNING: close Phase 4.4.W Wiki ingest skipped: $reason" >&2
+  echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=$reason"
+  echo "WARNING: close Phase 4.4.W Wiki ingest skipped: $reason" >&2
 fi
+echo "wiki_enabled=$wiki_enabled auto_ingest=$auto_ingest reason=${reason:-<run>}"
 ```
 
-If `reason` is non-empty, skip Steps 2 and Phase 4.4.W.2 and proceed directly to Phase 4.5. Otherwise continue to Step 2.
+`reason` が非空なら Step 2 / Phase 4.4.W.2 をスキップして Phase 4.5 へ。
 
-**Step 2**: Generate a retrospective Raw Source from the Issue context:
-
-The retrospective content includes: Issue title, key decisions made during implementation, unexpected difficulties encountered, and effective approaches used.
+**Step 2**: Issue コンテキストから retrospective Raw Source を生成する。`wiki-ingest-trigger.sh` は `--content-file` に `$PWD` 配下または `/tmp/rite-*` prefix のみを受容する（Issue #518 — mktemp デフォルトの `/tmp/tmp.*` では silent fail する）:
 
 ```bash
-# {plugin_root} はリテラル値で埋め込む
-# ⚠️ wiki-ingest-trigger.sh は --content-file に $PWD 配下 または /tmp/rite-* prefix のみを受容する
-# (Issue #518 根本原因)。mktemp デフォルトの /tmp/tmp.* では trigger が exit 1 で silent fail する
 tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
-# rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
 trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
 
 cat <<'RETRO_EOF' > "$tmpfile"
@@ -412,487 +278,252 @@ cat <<'RETRO_EOF' > "$tmpfile"
 RETRO_EOF
 
 bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
- --type retrospectives \
- --source-ref "issue-{issue_number}" \
- --content-file "$tmpfile" \
- --issue-number {issue_number} \
- --title "Issue #{issue_number} close retrospective" \
- 2>"$trigger_stderr"
+  --type retrospectives --source-ref "issue-{issue_number}" \
+  --content-file "$tmpfile" --issue-number {issue_number} \
+  --title "Issue #{issue_number} close retrospective" \
+  2>"$trigger_stderr"
 trigger_exit=$?
 echo "trigger_exit=$trigger_exit"
-if [ "$trigger_exit" -ne 0 ] && [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
- # UTF-8 multi-byte 境界を safe にする (head -c 500 で切れた invalid sequence を drop)
- # (F-09 対応) iconv 不在環境 (Alpine 等) では LC_ALL=C tr で ASCII-only fallback
- if command -v iconv >/dev/null 2>&1; then
- _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | iconv -c -f UTF-8 -t UTF-8 2>/dev/null)
- else
- _wiki_err_snippet=$(tr '\n' ' ' < "$trigger_stderr" | head -c 500 | LC_ALL=C tr -cd '\11\12\15\40-\176')
- fi
- echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
-fi
-```
-
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips Phase 4.4.W.2 when it is non-zero. Ingest failure does not block the close workflow.
-
-**Step 3 — Failure surfacing (Issue #524)**: When `trigger_exit != 0` AND `trigger_exit != 2` (exit 2 = Wiki disabled/uninitialized = legitimate skip already covered by Step 1), surface the failure as a plain WARNING so the operator can triage it from stderr:
-
-```bash
+# trigger 失敗 (exit != 0 かつ != 2; exit 2 = Wiki disabled/uninitialized = legitimate skip) を surface
 if [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
- echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
- echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during issue/close.md Phase 4.4.W" >&2
+  echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
+  echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during close Phase 4.4.W" >&2
+  if [ "$trigger_stderr" != "/dev/null" ] && [ -s "$trigger_stderr" ]; then
+    head -3 "$trigger_stderr" | sed 's/^/  /' >&2
+  fi
 fi
 ```
 
-### 4.4.W.2 Wiki Raw Commit (Shell — deterministic path)
+**Non-blocking**: trigger 失敗は workflow を止めない。LLM は `trigger_exit` を読み、非 0 なら Phase 4.4.W.2 をスキップする。
 
-> **Design rationale (supersedes the previous Skill-based design)**: Earlier revisions of this phase invoked `/rite:wiki:ingest` via the Skill tool, which in turn required Claude to correctly chain `ingest.md` Phase 5.1 Block A → LLM Write/Edit phase → Block B across multiple Bash tool boundaries and a sub-skill auto-continuation step. That contract was structurally fragile under E2E output minimization and auto-continuation failures (Issue #525), producing the observed regression where the `wiki` branch never grew in practice despite multiple rounds of silent-skip defence layers (Issues #515, #518, #524). This phase now delegates the raw-source commit to a **single shell script**, `wiki-ingest-commit.sh`, which completes the stash→checkout→add→commit→push→checkout-back→stash-pop cycle in one process with no dependency on Claude multi-step orchestration.
+### 4.4.W.2 Wiki Raw Commit
 
-**Responsibility scope**: this block commits **raw sources only**. LLM-driven Wiki **page** integration is deferred to `/rite:wiki:ingest`, which is idempotent over accumulated raw sources and can be invoked later. The split guarantees raw sources are never lost even when page integration is skipped or fails.
+> raw source の commit を単一スクリプト `wiki-ingest-commit.sh`（stash→checkout→add→commit→push→checkout-back→stash-pop を 1 プロセスで完結）に委譲する。LLM の multi-step orchestration に依存した旧 Skill 設計が E2E で fragile だった（Issue #525）ため。**本 block は raw source のみ commit**（page 統合は `/rite:wiki:ingest`）。
 
-**Condition**: Execute only when **all** of the following are true (read from prior Phase 4.4.W stdout):
-
-- `wiki_enabled=true`
-- `auto_ingest=true`
-- `trigger_exit=0` (the trigger ran successfully — non-zero means Wiki disabled/uninitialized, so there is nothing to commit)
-
-When the condition is not satisfied, skip this block and proceed to Phase 4.5.
+**Condition**: `wiki_enabled=true` AND `auto_ingest=true` AND `trigger_exit=0` の場合のみ実行。満たさなければスキップして Phase 4.5 へ。
 
 ```bash
-# {plugin_root} はリテラル値で埋め込む
-#
-# commit_err の signal trap 登録を block 冒頭で行う。
-commit_err=""
+commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null) || commit_err=/dev/null
 trap 'rm -f "${commit_err:-}"' EXIT INT TERM HUP
-
-# mktemp failure must NOT silently swallow wiki-ingest-commit.sh stderr.
-# See pr/review.md Phase 6.5.W.2 for the detailed rationale; this block is kept
-# symmetric across review / fix / close to preserve the single-source principle
-# for the wiki commit path.
-#
-# 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、
-# `if cmd; then :; else rc=$?; fi` 形式を採用し、`mktemp_commit_err_rc=$?` を
-# else 先頭で capture する。
-if commit_err=$(mktemp /tmp/rite-wiki-commit-err-XXXXXX 2>/dev/null); then
- : # mktemp 成功 — commit_err は valid path
-else
- mktemp_commit_err_rc=$?
- echo "WARNING: mktemp failed for wiki-ingest-commit stderr capture (rc=$mktemp_commit_err_rc) — script stderr will be suppressed" >&2
- echo " hint: check /tmp permission / disk space / inode exhaustion" >&2
- commit_err="/dev/null"
-fi
 commit_rc=0
 if commit_out=$(bash {plugin_root}/hooks/scripts/wiki-ingest-commit.sh 2>"${commit_err}"); then
- echo "$commit_out"
- echo "[CONTEXT] WIKI_INGEST_DONE=1; issue={issue_number}; type=retrospectives"
+  echo "$commit_out"
+  echo "[CONTEXT] WIKI_INGEST_DONE=1; issue={issue_number}; type=retrospectives"
 else
- commit_rc=$?
- if [ "$commit_err" != "/dev/null" ] && [ -s "$commit_err" ]; then
- head -5 "$commit_err" | sed 's/^/ /' >&2
- fi
- # exit 2 は legitimate skip (wiki disabled / wiki branch missing).
- # exit 4 = commit landed locally but origin push failed; surface the
- # WIKI_INGEST_PUSH_FAILED marker + WARNING so the push failure stays observable.
- case "$commit_rc" in
- 2)
- echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=commit_branch_missing; exit_code=$commit_rc"
- echo "WARNING: wiki-ingest-commit.sh exited 2 (wiki branch missing / disabled) during issue/close.md Phase 4.4.W.2" >&2
- ;;
- 4)
- echo "[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4; exit_code=$commit_rc"
- if [ -n "${commit_out:-}" ]; then
- echo "$commit_out"
- fi
- echo "WARNING: wiki-ingest-commit.sh exited 4 (commit landed locally, push failed) during issue/close.md Phase 4.4.W.2" >&2
- ;;
- *)
- echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=commit_rc_$commit_rc; exit_code=$commit_rc"
- echo "WARNING: wiki-ingest-commit.sh exited $commit_rc during issue/close.md Phase 4.4.W.2" >&2
- ;;
- esac
+  commit_rc=$?
+  [ "$commit_err" != "/dev/null" ] && [ -s "$commit_err" ] && head -5 "$commit_err" | sed 's/^/  /' >&2
+  # exit 2 = legitimate skip (wiki branch missing/disabled); exit 4 = commit landed, push failed
+  case "$commit_rc" in
+    2) echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=commit_branch_missing; exit_code=$commit_rc"
+       echo "WARNING: wiki-ingest-commit.sh exited 2 (wiki branch missing/disabled) during close Phase 4.4.W.2" >&2 ;;
+    4) echo "[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4; exit_code=$commit_rc"
+       [ -n "${commit_out:-}" ] && echo "$commit_out"
+       echo "WARNING: wiki-ingest-commit.sh exited 4 (commit landed locally, push failed) during close Phase 4.4.W.2" >&2 ;;
+    *) echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=commit_rc_$commit_rc; exit_code=$commit_rc"
+       echo "WARNING: wiki-ingest-commit.sh exited $commit_rc during close Phase 4.4.W.2" >&2 ;;
+  esac
 fi
 [ "$commit_err" != "/dev/null" ] && rm -f "$commit_err"
-commit_err=""
 trap - EXIT INT TERM HUP
 ```
 
-**Non-blocking**: failures do not halt the close workflow. `wiki-ingest-commit.sh` restores raw source files on failure via its cleanup trap, so the next invocation can retry them.
-
-**Responsibility boundary**: `wiki-ingest-trigger.sh` writes a raw source file into the dev branch working tree; `wiki-ingest-commit.sh` moves that file onto the `wiki` branch and commits it. LLM-driven page integration is the exclusive responsibility of `/rite:wiki:ingest` at a later time.
-
-Proceed to Phase 4.5.
+**Non-blocking**: 失敗は close を止めない。`wiki-ingest-commit.sh` は失敗時に cleanup trap で raw source を復元するので次回再試行できる。→ Phase 4.5 へ。
 
 ---
 
 ## Phase 4.5: Parent Issue Body Update
 
-When a child Issue is closed, automatically update the parent Issue's body to reflect the child's completion status.
+子 Issue がクローズされたら、親 Issue の body に完了状態を反映する。
 
 ### 4.5.1 Detect Parent Issue
 
-Detect the parent Issue via **three methods tried in order (OR combination)**. This mirrors the 3-method detection in [`projects-integration.md` 2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) — the two sites MUST stay consistent to prevent silent-skip regressions (see Issue #513 / past incidents #115, #381, #15).
+親 Issue を **3 method の OR 検出**で特定する。この 3-method 構造は [`projects-integration.md` §2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) と一致させる（method 順序・OR 意味・total-failure 時の `[DEBUG] parent not detected` emission を揃える。乖離すると Issue #115/#381/#15 の silent-skip 回帰が再発する）。
 
-**Method 1: `## 親 Issue` body meta (PRIMARY)**
-
-Read the closing Issue body and search for the `## 親 Issue` section written by `/rite:issue:create` (Decompose Path、flat workflow).
-
-```
-## 親 Issue
-
-#{parent_number} - {parent_title}
-```
+**Method 1: `## 親 Issue` body meta（PRIMARY）** — `/rite:issue:create`（Decompose Path）が書く section:
 
 ```bash
 issue_body=$(gh issue view {issue_number} --json body --jq '.body')
-# SIGPIPE 防止 (#398): here-string で subprocess を排除
 parent_number=$(grep -A2 '^## 親 Issue' <<< "$issue_body" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 echo "method1_parent=${parent_number:-none}"
 ```
 
-If `parent_number` is non-empty, proceed to 4.5.2.
+非空なら 4.5.2 へ。
 
-**Method 2: Sub-Issues API (secondary)**
-
-If Method 1 returned empty, query GitHub's native Sub-Issues feature:
+**Method 2: Sub-Issues API（secondary）** — Method 1 が空の場合:
 
 ```bash
 parent_number=$(gh api graphql -H "GraphQL-Features: sub_issues" -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
- repository(owner: $owner, name: $repo) {
- issue(number: $number) {
- parent { number }
- }
- }
+  repository(owner: $owner, name: $repo) { issue(number: $number) { parent { number } } }
 }' -f owner="{owner}" -f repo="{repo}" -F number={issue_number} \
- --jq '.data.repository.issue.parent.number // empty')
+  --jq '.data.repository.issue.parent.number // empty')
 echo "method2_parent=${parent_number:-none}"
 ```
 
-If non-empty, proceed to 4.5.2.
+非空なら 4.5.2 へ。
 
-**Method 3: Tasklist search (last resort)**
-
-If both methods failed:
+**Method 3: Tasklist search（last resort）** — 両 method が失敗した場合。GitHub code search の `[`/`]` は不安定なので最後の手段。`--state all`（closing Issue の親が既に closed の可能性）:
 
 ```bash
 parent_number=$(gh issue list --state all --search "in:body \"- [ ] #{issue_number}\" OR \"- [x] #{issue_number}\"" --json number --limit 1 --jq '.[0].number // empty')
 echo "method3_parent=${parent_number:-none}"
 ```
 
-GitHub code search with `[`/`]` is unreliable, which is why this is the last resort. `--state all` (not `--state open`) because the closing Issue's parent may already be closed if someone closed it manually.
-
-**When all three methods failed (`parent_number` empty)**:
+**3 method すべて失敗（`parent_number` 空）の場合**は standalone として処理する（AC-4 — 正常動作。silent-skip 回帰検出のため debug log は残す）:
 
 ```bash
-echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"
+echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods: body_meta, sub_issues_api, tasklist_search)"
 ```
 
-Display:
-
-```
-親 Issue の参照が見つかりませんでした。親 Issue 更新をスキップします。
-```
-
-Skip the rest of Phase 4.5 and Phase 4.6 and proceed to Phase 5. This is normal behavior (AC-4), not an error — but the debug log above makes the skip visible so silent-skip regressions are detectable.
+`親 Issue の参照が見つかりませんでした。親 Issue 更新をスキップします。` を表示し、Phase 4.5 残り + Phase 4.6 をスキップして Phase 5 へ。
 
 ### 4.5.2 Update Parent Issue Body
 
-Update the parent Issue's Sub-Issues checkbox and 実装フェーズ status using the 3-step safe update pattern via `issue-body-safe-update.sh`.
+`issue-body-safe-update.sh` の 3-step safe update pattern（fetch/edit/apply + body shrinkage detection + diff-check 冪等性。`implement.md` / `archive-procedures.md` と同パターン）で親の Sub-Issues checkbox と実装フェーズ status を更新する。
 
-> **Reference**: Uses the same safe update pattern as `implement.md` and `archive-procedures.md` — fetch/edit/apply with body shrinkage detection and diff-check idempotency.
-
-**Step 1: Fetch parent Issue body**
-
-Execute the fetch script directly. The LLM reads `tmpfile_read`, `tmpfile_write`, and `original_length` from the Bash tool output:
+**Step 1: Fetch**:
 
 ```bash
 bash {plugin_root}/hooks/issue-body-safe-update.sh fetch --issue {parent_number} --parent
 ```
 
-If the output contains `tmpfile_read=`, `tmpfile_write=`, and `original_length=`, proceed to Step 2. If the script outputs only a WARNING or fails, display a warning and proceed to Phase 5 (non-blocking, AC-4).
+出力に `tmpfile_read=` / `tmpfile_write=` / `original_length=` があれば Step 2 へ。WARNING のみ / 失敗なら警告して Phase 5 へ（non-blocking, AC-4）。
 
-**Step 2: Apply updates via Read tool + Write tool** (Sub-Issues checkbox + 実装フェーズ status in a single pass)
+**Step 2: Read tool + Write tool で更新** — Read tool で `$tmpfile_read` を読み、以下 2 置換を適用して Write tool で `$tmpfile_write` に書く:
+1. **Sub-Issues checkbox**: `- [ ] #{issue_number}` 行の `- [ ]` を `- [x]` に（該当 Issue 番号行のみ）
+2. **実装フェーズ table**: `内容` 列に `#{issue_number}` を含む行の `[ ] 未着手` を `[x] 完了` に
 
-Read `$tmpfile_read` (the path from Step 1 output) using the Read tool. Then apply the following two replacements to the body text:
+`#{issue_number}` を含む行のみ変更（他 section は不変）。
 
-1. **Sub-Issues checkbox**: Find the line matching `- [ ] #{issue_number}` and replace `- [ ]` with `- [x]` (only the specific Issue number line)
-2. **実装フェーズ table**: Find rows whose `内容` column contains `#{issue_number}` and replace `[ ] 未着手` with `[x] 完了` in those rows
-
-Write the updated body to `$tmpfile_write` (the path from Step 1 output) using the Write tool.
-
-**Note**: Only lines containing `#{issue_number}` are modified. Other sections remain untouched (R7).
-
-**Step 3: Apply the update**
+**Step 3: Apply**:
 
 ```bash
 bash {plugin_root}/hooks/issue-body-safe-update.sh apply \
- --issue {parent_number} \
- --tmpfile-read "$tmpfile_read" \
- --tmpfile-write "$tmpfile_write" \
- --original-length "$original_length" \
- --parent --diff-check
+  --issue {parent_number} --tmpfile-read "$tmpfile_read" --tmpfile-write "$tmpfile_write" \
+  --original-length "$original_length" --parent --diff-check
 ```
 
-If the script exits with 0, the update succeeded (or was skipped by `--diff-check` if no changes were needed). If non-zero, display a warning and proceed to Phase 5.
-
-**On failure**: Display warning and proceed to Phase 4.6 (non-blocking, AC-4). The `--parent` flag is passed for future differentiation but currently all errors are treated as warnings by the script. The `--diff-check` flag skips the apply if no actual changes were made (idempotency). The Issue close itself (Phase 4.1) has already succeeded at this point.
-
-Proceed to Phase 4.6.
+exit 0 で成功（`--diff-check` で変更不要時は skip）。非 0 なら警告して Phase 4.6 へ（non-blocking, AC-4。close 自体は Phase 4.1 で成功済み）。→ Phase 4.6 へ。
 
 ---
 
 ## Phase 4.6: Parent Auto-Close (All Children Completed)
 
-> **Issue #513 AC-2**: When all child Issues of the detected parent are now closed (including the just-closed one), offer to auto-close the parent. This closes the "child close → parent stays Open" silent-skip hole.
+検出した親のすべての子 Issue が closed になったら、親の auto-close を提案する（"child close → parent stays Open" の silent-skip hole を塞ぐ、Issue #513 AC-2）。
 
-**Execution condition**: Only execute when `{parent_number}` was detected in Phase 4.5.1 (any of the three methods succeeded). If no parent was detected, skip Phase 4.6 entirely and proceed to Phase 5.
+**実行条件**: Phase 4.5.1 で `{parent_number}` が検出された場合のみ。未検出なら Phase 4.6 全体をスキップして Phase 5 へ。**直接の親のみ処理**し、祖父母には再帰しない（three-level nesting は out of scope）。
 
-**Three-level nesting guard (AC / MUST NOT)**: This phase processes only the direct parent. It does NOT recurse into the parent's parent (grandparent). Three-level nesting is explicitly out of scope (see Issue #513 Section 2 Out of Scope).
+### 4.6.0 + 4.6.1 Idempotency Check & Child Enumeration
 
-### 4.6.0 Idempotency Check (parent-already-closed no-op)
-
-Before enumerating children, check whether the parent Issue is already closed. If so, this is a no-op invocation (the parent was previously closed — manually, by a prior auto-close run, or externally) and we must not re-prompt the user.
-
-> **Note on AC-6**: Issue #513's AC-6 as written addresses the **start** side ("parent already In Progress → no-op"). This Phase 4.6.0 applies the **same idempotency principle** to the close side (parent already CLOSED → no-op). AC-6 is not literally covering the close-side case, so we avoid citing AC-6 directly and instead describe this as "close-side idempotency, extending the AC-6 principle to the symmetric close path."
-
-Design principle (Issue #517 cycle 2 review fix): this bash block follows the same silent-failure avoidance pattern as Phase 4.6.1 — stderr is captured to a tempfile and surfaced on failure, explicit sentinels (`[CONTEXT] P460_DECISION=...`) drive LLM routing, and the retrieval-failure branch is implemented in bash (not prose only).
+冪等性チェック（親が既 closed なら no-op）→ 子 Issue 列挙 → `all_closed` 判定を **単一 Bash block** で行う（block 間の shell state 喪失を回避）。stderr は tempfile に退避して surface する（`2>/dev/null` の silent-skip anti-pattern を避ける）。`set -uo pipefail`（`-e` は明示 `|| fallback` のため省略）。
 
 ```bash
-# ============================================================================
-# Phase 4.6.0: Idempotency check (parent already closed → no-op)
-# ============================================================================
-set -uo pipefail # strict mode (fail on undefined vars + preserve pipeline failure code)
-
-parent_number="{parent_number}"
-
-# --- Placeholder substitution sanity guard ---
-# Phase 4.6 is only reachable when Phase 4.5.1 detected a parent. If the LLM
-# routed into Phase 4.6 without substituting `{parent_number}` (e.g., skip-logic
-# bug or placeholder left literal), subsequent `gh issue view "{parent_number}"`
-# would fail with an "invalid issue number" error on stderr, and the Phase 4.6.0
-# else branch would classify it as "retrieval failed" — which is technically
-# correct but masks the true root cause (routing bug, not API failure).
-# This case statement surfaces the routing bug explicitly instead of silently
-# degrading into the retrieval-failure path.
-case "$parent_number" in
- ''|'{parent_number}')
- echo "[DEBUG] p460: parent_number is empty or unsubstituted literal ('$parent_number') — Phase 4.6 should not have been entered. Aborting Phase 4.6 (caller routing bug)." >&2
- echo "[CONTEXT] P460_DECISION=skip_routing_bug"
- exit 0
- ;;
- *[!0-9]*)
- echo "[DEBUG] p460: parent_number is not numeric ('$parent_number') — Phase 4.6 should not have been entered. Aborting Phase 4.6." >&2
- echo "[CONTEXT] P460_DECISION=skip_routing_bug"
- exit 0
- ;;
-esac
-
-parent_state=""
-p460_err=""
-_rite_close_p460_cleanup() {
- rm -f "${p460_err:-}"
-}
-trap 'rc=$?; _rite_close_p460_cleanup; exit $rc' EXIT
-trap '_rite_close_p460_cleanup; exit 130' INT
-trap '_rite_close_p460_cleanup; exit 143' TERM
-trap '_rite_close_p460_cleanup; exit 129' HUP
-
-# Capture stderr to tempfile (not /dev/null) so auth / network failures surface.
-# `mktemp` with no arguments respects $TMPDIR (honoring macOS /var/folders, CI overrides, etc.)
-if ! p460_err=$(mktemp 2>/dev/null); then
- echo "[DEBUG] p460: mktemp failed — stderr from gh issue view will not be captured" >&2
- p460_err=""
-fi
-
-if parent_state=$(gh issue view "$parent_number" --json state --jq '.state' 2>"${p460_err:-/dev/null}"); then
- echo "parent_state=$parent_state"
-else
- p460_rc=$?
- parent_state=""
- echo "[DEBUG] p460: gh issue view failed (rc=$p460_rc)" >&2
- if [ -n "$p460_err" ] && [ -s "$p460_err" ]; then
- head -3 "$p460_err" | sed 's/^/ p460 stderr: /' >&2
- fi
-fi
-
-if [ -n "$p460_err" ]; then
- rm -f "$p460_err"
- p460_err=""
-fi
-
-# Emit branch decision sentinel (machine-readable) for LLM routing.
-if [ -z "$parent_state" ]; then
- echo "警告: 親 Issue #${parent_number} の state 取得に失敗しました。親の自動クローズ判定をスキップします。" >&2
- echo "[CONTEXT] P460_DECISION=skip_retrieval_failed"
-elif [ "$parent_state" = "CLOSED" ]; then
- echo "[DEBUG] parent #${parent_number} already closed — skipping Phase 4.6 (close-side idempotency, extends AC-6 principle)"
- echo "[CONTEXT] P460_DECISION=skip_already_closed"
-else
- echo "[CONTEXT] P460_DECISION=proceed_to_enumeration"
-fi
-```
-
-**LLM routing rule** (Claude reads the `[CONTEXT] P460_DECISION=` sentinel from the bash block's stdout):
-
-| `P460_DECISION` value | Next action |
-|----------------------|-------------|
-| `skip_routing_bug` | Sanity guard fired: `parent_number` is empty, literal, or non-numeric — Phase 4.6 was entered via a routing bug. Warning emitted to stderr. Skip the rest of Phase 4.6 and proceed to Phase 5. |
-| `skip_retrieval_failed` | Warning already emitted to stderr. Skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5 (non-blocking). |
-| `skip_already_closed` | Parent is already closed — skip the rest of Phase 4.6 (4.6.1–4.6.3) and proceed to Phase 5. This is the close-side idempotency no-op. |
-| `proceed_to_enumeration` | Parent is open → proceed to 4.6.1. |
-
-### 4.6.1 Enumerate Parent's Child Issues and Determine all_closed
-
-Retrieve the parent's child Issues via **two methods (OR combination, Method A → Method B fallback)**, then determine whether every child is closed. All of this is done in a **single Bash tool invocation** to avoid shell state loss between calls.
-
-**Design notes** (Issue #517 review fixes — cycles 1 + 2):
-
-- **Method A uses the `trackedIssues` field (Tasklists API), NOT the Sub-Issues API**: `trackedIssues` resolves the parent→children relationship via GitHub's Tasklists feature (which parses the body `- [ ] #N` section) — this is intentional because the repo uses `/rite:issue:create` (Decompose Path、flat workflow) to write body tasklists. The newer GitHub Sub-Issues API uses a separate `subIssues` field and requires the `GraphQL-Features: sub_issues` header. This block does not call `subIssues` — the header is omitted to avoid misleading the reader. See `epic-detection.md` for the `trackedIssues` vs `subIssues` distinction.
-- **Method A stderr is captured, not suppressed**: Previous `2>/dev/null` silently downgraded auth / network / permission errors to "empty result", which is the silent-skip anti-pattern Issue #513 aims to eliminate. Instead, stderr is captured to a tempfile and surfaced in debug logs on failure.
-- **Method A → Method B fallback is an explicit bash conditional**: branches on `jq length` of Method A's result rather than relying on prose.
-- **Method B uses a per-child loop, not an LLM-generated alias query**: deterministic, fully auditable, O(N) API calls for small N.
-- **`set -uo pipefail` is enabled at the block top**: strict mode (fail on undefined vars + propagate pipeline failures) adds a defense layer against silent failures introduced by future edits. `-e` is omitted to allow explicit `|| fallback` paths without unintended aborts.
-- **`mktemp` respects `$TMPDIR`**: using bare `mktemp` (no hardcoded `/tmp` path) honors macOS `/var/folders`, CI `$TMPDIR` overrides, and read-only-/tmp environments.
-
-```bash
-# ============================================================================
-# Phase 4.6.1: Enumerate children + determine all_closed (single bash block)
-# ============================================================================
 set -uo pipefail
-
 parent_number="{parent_number}"
 owner="{owner}"
 repo="{repo}"
 
-children_json=""
-method_a_err=""
-_rite_close_p461_cleanup() {
- rm -f "${method_a_err:-}"
-}
-trap 'rc=$?; _rite_close_p461_cleanup; exit $rc' EXIT
-trap '_rite_close_p461_cleanup; exit 130' INT
-trap '_rite_close_p461_cleanup; exit 143' TERM
-trap '_rite_close_p461_cleanup; exit 129' HUP
+# --- Placeholder sanity guard: Phase 4.6 は親検出時のみ到達。未置換/非数値は routing bug ---
+case "$parent_number" in
+  ''|'{parent_number}'|*[!0-9]*)
+    echo "[DEBUG] p460: parent_number invalid ('$parent_number') — Phase 4.6 should not have been entered (routing bug)." >&2
+    echo "[CONTEXT] P460_DECISION=skip_routing_bug"
+    exit 0 ;;
+esac
 
-# --- Method A: Tasklists (trackedIssues) — parent→children via body tasklist ---
-# stderr is captured to tempfile (NOT suppressed) so auth / network / GraphQL errors surface.
-# Note: trackedIssues is the Tasklists feature (the body `- [ ] #N` parser); the `GraphQL-Features: sub_issues`
-# header is NOT used here because it targets the separate `subIssues` field. See epic-detection.md.
-if ! method_a_err=$(mktemp 2>/dev/null); then
- echo "[DEBUG] p461: mktemp failed for method_a_err — method_a stderr will not be captured" >&2
- method_a_err=""
-fi
+p46_err=""
+trap 'rm -f "${p46_err:-}"' EXIT INT TERM HUP
+p46_err=$(mktemp 2>/dev/null) || p46_err=""
 
-method_a_rc=0
-if method_a_raw=$(gh api graphql -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
- repository(owner: $owner, name: $repo) {
- issue(number: $number) {
- trackedIssues(first: 100) {
- nodes { number state }
- }
- }
- }
-}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" \
- --jq '[.data.repository.issue.trackedIssues.nodes[]? | {number: .number, state: .state}]' \
- 2>"${method_a_err:-/dev/null}"); then
- children_json="$method_a_raw"
- method_a_count=$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)
- echo "[DEBUG] method_a succeeded: ${method_a_count} children via trackedIssues (Tasklists API)"
+# --- 4.6.0: Idempotency — 親が既に CLOSED なら no-op (close-side idempotency, extends AC-6 principle) ---
+parent_state=""
+if parent_state=$(gh issue view "$parent_number" --json state --jq '.state' 2>"${p46_err:-/dev/null}"); then
+  echo "parent_state=$parent_state"
 else
- method_a_rc=$?
- echo "[DEBUG] method_a failed (rc=$method_a_rc) — Tasklists API unavailable, will try Method B"
- if [ -n "$method_a_err" ] && [ -s "$method_a_err" ]; then
- head -3 "$method_a_err" | sed 's/^/ method_a stderr: /' >&2
- fi
- children_json=""
-fi
-if [ -n "$method_a_err" ]; then
- rm -f "$method_a_err"
- method_a_err=""
+  echo "[DEBUG] p460: gh issue view failed (rc=$?)" >&2
+  [ -n "$p46_err" ] && [ -s "$p46_err" ] && head -3 "$p46_err" | sed 's/^/  p460 stderr: /' >&2
+  parent_state=""
 fi
 
-# --- Method B: Parent body `## Sub-Issues` section parse (fallback) ---
-# Note: "Sub-Issues" here is the literal heading text that /rite:issue:create (Decompose Path,
-# flat workflow) writes into parent bodies. It is not the GitHub Sub-Issues feature.
-# Method B only parses body markdown.
-method_a_length=$(printf '%s' "${children_json:-[]}" | jq 'length' 2>/dev/null || echo 0)
-if [ -z "$children_json" ] || [ "$method_a_length" -eq 0 ]; then
- echo "[DEBUG] falling back to Method B (parent body '## Sub-Issues' section parse)"
- parent_body=$(gh issue view "$parent_number" --json body --jq '.body' 2>/dev/null || echo "")
- if [ -z "$parent_body" ]; then
- echo "[DEBUG] method_b: failed to fetch parent body"
- children_json="[]"
- else
- # Extract child numbers from `- [ ] #N` / `- [x] #N` lines under a `## Sub-Issues` (exact) heading.
- # The `/^## Sub-Issues$/` anchor prevents false matches against headings like `## Sub-Issues-Extended`.
- child_numbers=$(awk '/^## Sub-Issues$/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
- echo "[DEBUG] method_b child_numbers=${child_numbers:-none}"
+if [ -z "$parent_state" ]; then
+  echo "警告: 親 Issue #${parent_number} の state 取得に失敗しました。自動クローズ判定をスキップします。" >&2
+  echo "[CONTEXT] P460_DECISION=skip_retrieval_failed"
+  exit 0
+elif [ "$parent_state" = "CLOSED" ]; then
+  echo "[DEBUG] parent #${parent_number} already closed — skipping Phase 4.6 (close-side idempotency)"
+  echo "[CONTEXT] P460_DECISION=skip_already_closed"
+  exit 0
+fi
+echo "[CONTEXT] P460_DECISION=proceed_to_enumeration"
 
- if [ -z "$child_numbers" ]; then
- children_json="[]"
- else
- # Deterministic per-child loop (O(N) API calls, N typically small).
- # Build JSON array by iterating and appending state per child.
- children_json="["
- first=1
- for n in $child_numbers; do
- child_state=$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "")
- if [ -z "$child_state" ]; then
- echo "[DEBUG] method_b: failed to fetch state for #$n (treating as OPEN to block auto-close — fail-closed)" >&2
- child_state="OPEN"
- fi
- if [ "$first" -eq 1 ]; then
- first=0
- else
- children_json+=","
- fi
- children_json+="{\"number\":$n,\"state\":\"$child_state\"}"
- done
- children_json+="]"
- fi
- fi
+# --- 4.6.1: Enumerate children (Method A: trackedIssues / Tasklists API → Method B: body parse) ---
+# trackedIssues は Tasklists 機能 (body `- [ ] #N` parser)。GitHub Sub-Issues API (subIssues) とは別物。
+children_json=""
+if children_json=$(gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) { trackedIssues(first: 100) { nodes { number state } } }
+  }
+}' -f owner="$owner" -f repo="$repo" -F number="$parent_number" \
+  --jq '[.data.repository.issue.trackedIssues.nodes[]? | {number, state}]' 2>"${p46_err:-/dev/null}"); then
+  echo "[DEBUG] method_a: $(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0) children via trackedIssues"
+else
+  echo "[DEBUG] method_a failed (rc=$?) — trying Method B" >&2
+  [ -n "$p46_err" ] && [ -s "$p46_err" ] && head -3 "$p46_err" | sed 's/^/  method_a stderr: /' >&2
+  children_json=""
 fi
 
-# --- all_closed determination ---
-# Empty array is treated as "cannot auto-close" (safe default — no children detected).
+# Method B: 親 body の `## Sub-Issues` section parse (literal heading text — GitHub 機能ではない)
+if [ -z "$children_json" ] || [ "$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)" -eq 0 ]; then
+  echo "[DEBUG] fallback to Method B (parent body '## Sub-Issues' parse)"
+  parent_body=$(gh issue view "$parent_number" --json body --jq '.body' 2>/dev/null || echo "")
+  child_numbers=$(awk '/^## Sub-Issues$/{flag=1;next} /^## /{flag=0} flag && /^- \[[ xX]\] #[0-9]+/{print}' <<< "$parent_body" | grep -oE '#[0-9]+' | tr -d '#')
+  if [ -z "$child_numbers" ]; then
+    children_json="[]"
+  else
+    children_json="["; first=1
+    for n in $child_numbers; do
+      # state 取得失敗は fail-closed (OPEN 扱い) で auto-close を抑止する
+      child_state=$(gh issue view "$n" --json state --jq '.state' 2>/dev/null || echo "OPEN")
+      [ -z "$child_state" ] && child_state="OPEN"
+      [ "$first" -eq 1 ] && first=0 || children_json+=","
+      children_json+="{\"number\":$n,\"state\":\"$child_state\"}"
+    done
+    children_json+="]"
+  fi
+fi
+
+# --- all_closed 判定 (空配列は「判定不能」= auto-close 不可の safe default) ---
 final_length=$(printf '%s' "$children_json" | jq 'length' 2>/dev/null || echo 0)
 if [ "$final_length" -eq 0 ]; then
- all_closed="false"
- open_count="0"
- echo "[DEBUG] children_json is empty after both methods — cannot determine all_closed (skipping auto-close)"
+  echo "all_closed=false open_count=0 children_total=0"
+  echo "[CONTEXT] P461_DECISION=skip_empty_children"
 else
- if ! all_closed=$(printf '%s' "$children_json" | jq -r 'all(.[]; .state == "CLOSED") | tostring' 2>/dev/null); then
- echo "[DEBUG] jq all_closed evaluation failed — treating as false (fail-closed)" >&2
- all_closed="false"
- fi
- if ! open_count=$(printf '%s' "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length' 2>/dev/null); then
- echo "[DEBUG] jq open_count evaluation failed — defaulting to 0" >&2
- open_count="0"
- fi
-fi
-echo "all_closed=$all_closed open_count=$open_count children_total=$final_length"
-
-# --- Branch decision sentinel for LLM routing ---
-if [ "$final_length" -eq 0 ]; then
- echo "[CONTEXT] P461_DECISION=skip_empty_children"
-elif [ "$all_closed" = "true" ]; then
- echo "[CONTEXT] P461_DECISION=proceed_to_confirmation"
-else
- echo "[CONTEXT] P461_DECISION=skip_open_children; open_count=$open_count"
+  all_closed=$(printf '%s' "$children_json" | jq -r 'all(.[]; .state == "CLOSED") | tostring' 2>/dev/null || echo "false")
+  open_count=$(printf '%s' "$children_json" | jq -r '[.[] | select(.state != "CLOSED")] | length' 2>/dev/null || echo 0)
+  echo "all_closed=$all_closed open_count=$open_count children_total=$final_length"
+  if [ "$all_closed" = "true" ]; then
+    echo "[CONTEXT] P461_DECISION=proceed_to_confirmation"
+  else
+    echo "[CONTEXT] P461_DECISION=skip_open_children; open_count=$open_count"
+  fi
 fi
 ```
 
-**LLM routing rule** (Claude reads the `[CONTEXT] P461_DECISION=` sentinel from the bash block's stdout). Match by **prefix** (`skip_open_children` is emitted as `skip_open_children; open_count=N` — the `N` value is extracted from the payload and used to fill the `{open_count}` placeholder in the displayed message):
+**LLM routing**（stdout の `[CONTEXT] P460_DECISION=` / `P461_DECISION=` を prefix match で読む）:
 
-| `P461_DECISION` prefix | Payload | Next action |
-|----------------------|---------|-------------|
-| `skip_empty_children` | (none) | Display warning `親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。親の自動クローズをスキップします。` and proceed to Phase 5 (non-blocking, AC-5 spirit) |
-| `skip_open_children` | `; open_count=N` | Display `親 Issue #{parent_number} にはまだ {open_count} 件の未完了子 Issue があります。親の自動クローズはスキップします。` (substitute `N` for `{open_count}`) and proceed to Phase 5 |
-| `proceed_to_confirmation` | (none) | Proceed to 4.6.2 (User Confirmation) |
+| 値 | Next action |
+|----|-------------|
+| `P460_DECISION=skip_routing_bug` | routing bug（empty/literal/非数値）。Phase 4.6 を抜けて Phase 5 へ |
+| `P460_DECISION=skip_retrieval_failed` | 親 state 取得失敗。Phase 4.6 を抜けて Phase 5 へ（non-blocking） |
+| `P460_DECISION=skip_already_closed` | 親が既 closed の no-op。Phase 4.6 を抜けて Phase 5 へ |
+| `P461_DECISION=skip_empty_children` | 子一覧取得不可。`親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。自動クローズをスキップします。` を表示し Phase 5 へ |
+| `P461_DECISION=skip_open_children; open_count=N` | `親 Issue #{parent_number} にはまだ N 件の未完了子 Issue があります。自動クローズはスキップします。` を表示し Phase 5 へ |
+| `P461_DECISION=proceed_to_confirmation` | 4.6.2 へ |
 
 ### 4.6.2 User Confirmation
 
-Confirm via `AskUserQuestion`:
+`AskUserQuestion`:
 
 ```
 親 Issue #{parent_number} のすべての子 Issue が完了しました。親 Issue もクローズしますか？
@@ -902,261 +533,132 @@ Confirm via `AskUserQuestion`:
 - 親 Issue を開いたまま終了
 ```
 
-| Selection | Action |
-|-----------|--------|
-| クローズする | Proceed to 4.6.3 |
-| 開いたまま終了 | `echo "[DEBUG] user declined parent auto-close for #{parent_number}"`. Proceed to Phase 5 |
+「クローズする」→ 4.6.3。「開いたまま終了」→ `echo "[DEBUG] user declined parent auto-close for #{parent_number}"` し Phase 5 へ。
 
-### 4.6.3 Update Parent Projects Status to "Done" and Close
+### 4.6.3 Update Parent Status to Done & Close
 
-Skip the Status update if `github.projects.enabled: false` in `rite-config.yml`; still execute the Issue close in Step 2.
-
-The Status update delegates to `plugins/rite/scripts/projects-status-update.sh` (the same shared script used by `commands/issue/start.md` Phase 2.4 / 5.5.1 / 5.7.2 — Issue #496 / PR #531). Inline `gh api graphql` + `gh project field-list` + `gh project item-edit` calls have been removed because the multi-stage inline pipeline produced silent skips (Issue #658). Step 1 (Status update) and Step 2 (Issue close) run sequentially, and Step 3 (state-inconsistency summary) MUST always emit — running this whole substep in a single bash block preserves intermediate variable state.
-
-**Design notes** (Issue #517 invariants preserved):
-
-- **Step 3 state-inconsistency summary always emits** to make silent data corruption (one of `gh issue close` / Status update succeeded while the other silently failed) impossible.
-- **Step 2 (`gh issue close`) captures stderr to a tempfile (not `2>/dev/null`)** so failures surface the first 5 stderr lines via `head -5 | sed` for auth / network / permission / rate-limit diagnostics.
-- **Status update failures already surface `.warnings[]` from the script's stdout JSON** — the script handles its own stderr capture internally. The orchestrator reads `.result` and `.warnings[]` from the JSON.
-- **5-class → 4-class consolidation**: Inline-only failure modes `field_lookup_failed` (option-ID resolution failed mid-pipeline) and `update_failed` (item-edit call failed) merge into the script's single `.result == "failed"` (with the specific cause in `.warnings[]`). The user-visible "two entities, one inconsistent" guarantee is unchanged.
-- **`set -uo pipefail`** enables strict mode against undefined variables and pipeline failure propagation. `-e` is omitted so explicit `|| fallback` handling remains intentional.
-- **`mktemp` respects `$TMPDIR`** (no `/tmp` hardcode).
-- **Placeholder source assumption**: `{projects_enabled}`, `{project_number}`, `{owner}`, `{repo}` are substituted by the LLM from `rite-config.yml` before executing this block. `{parent_number}` and `{issue_number}` are substituted from Phase 4.5.1 and Phase 0 respectively. `{plugin_root}` is substituted per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version). If any placeholder is missing, the LLM must read `rite-config.yml` before substituting.
+親の Projects Status → Done（[共通委譲パターン](#shared-projects-status--done-delegate-pattern)、`github.projects.enabled: false` ならスキップ）と `gh issue close` を **単一 block** で実行する。Step 3 の state-inconsistency summary を**必ず** emit し、片方成功/片方失敗の silent data corruption を可視化する。`{projects_enabled}` / `{project_number}` / `{owner}` / `{repo}` は `rite-config.yml` から、`{parent_number}` / `{issue_number}` は前 Phase から置換する。
 
 ```bash
-# ============================================================================
-# Phase 4.6.3: Parent Projects Status → Done + Issue close (unified block)
-# ============================================================================
 set -uo pipefail
-
 parent_number="{parent_number}"
 owner="{owner}"
 repo="{repo}"
-projects_enabled="{projects_enabled}" # "true" or "false" from rite-config.yml
-project_number="{project_number}" # integer from rite-config.yml
-issue_number="{issue_number}" # the child Issue that triggered this close
+projects_enabled="{projects_enabled}"
+project_number="{project_number}"
+issue_number="{issue_number}"
 
-status_update_result="projects_disabled" # success | not_registered | update_failed | projects_disabled
- # 初期値は "projects_disabled" (= 「処理未到達 = projects_disabled として扱う」safe-side 既定値)。
- # 後段の `if [ "$projects_enabled" = "true" ]` 分岐で必ず別値に上書きされるが、将来 early-exit
- # 経路が混入した場合でも Step 3 case の `success:projects_disabled` が整合性 OK 判定を出す経路に倒す
- # (旧初期値 "skipped" は case 文に該当ラベルが無く silent fall-through の risk があった)。
-status_warning_lines="" # captured .warnings[] from the script for Step 3 surface
-issue_close_result="pending" # success | failed | pending
+status_update_result="projects_disabled"   # success | not_registered | update_failed | projects_disabled
+status_warning_lines=""
+issue_close_result="pending"                # success | failed | pending
+script_item_id=""; script_project_id=""; script_status_field_id=""; script_option_id=""
 
-# --- stderr capture tempfiles ---
-# p463_err_close: gh issue close stderr 退避
-# p463_err_status: projects-status-update.sh script invocation stderr 退避
-# (Issue #659 F-03: 旧実装は `2>/dev/null` で script 起動側 stderr を完全廃棄していた。
-# script 内部の gh stderr は `.warnings[]` で surface されるが、script 外部エラー
-# (jq 不在 / bash syntax / mktemp 失敗 / `{plugin_root}` 置換漏れ) は stderr 直書きのため
-# `2>/dev/null` で完全消失していた)
-p463_err_close=""
-p463_err_status=""
-_rite_close_p463_cleanup() {
- rm -f "${p463_err_close:-}" "${p463_err_status:-}"
-}
-trap 'rc=$?; _rite_close_p463_cleanup; exit $rc' EXIT
-trap '_rite_close_p463_cleanup; exit 130' INT
-trap '_rite_close_p463_cleanup; exit 143' TERM
-trap '_rite_close_p463_cleanup; exit 129' HUP
+p463_err_close=""; p463_err_status=""
+trap 'rm -f "${p463_err_close:-}" "${p463_err_status:-}"' EXIT INT TERM HUP
+_mktemp_or_warn() { mktemp 2>/dev/null || { echo "[DEBUG] p463 $1: mktemp failed — gh stderr not captured" >&2; printf ''; }; }
 
-_mktemp_or_warn() {
- local label="$1"
- local tmp
- if tmp=$(mktemp 2>/dev/null); then
- printf '%s' "$tmp"
- else
- echo "[DEBUG] p463 ${label}: mktemp failed — stderr from gh call will not be captured" >&2
- printf ''
- fi
-}
-
-# --- Step 1: Update parent's Projects Status via shared script ---
+# --- Step 1: Parent Projects Status → Done (delegate) ---
 if [ "$projects_enabled" = "true" ]; then
- status_json_args=$(jq -n \
- --argjson issue "$parent_number" \
- --arg owner "$owner" \
- --arg repo "$repo" \
- --argjson project_number "$project_number" \
- --arg status "Done" \
- --argjson auto_add false \
- --argjson non_blocking true \
- '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
- # script の stderr を tempfile に退避し、JSON 出力前死亡時 (jq 不在 / mktemp 失敗 / `{plugin_root}`
- # 置換漏れ等) の原因を Step 3 inconsistency summary に surface できるようにする (Issue #659 F-03)
- p463_err_status=$(_mktemp_or_warn "Step 1 invocation")
- status_json=$(bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args" 2>"${p463_err_status:-/dev/null}") || status_json=""
- status_result=$(printf '%s' "$status_json" | jq -r '.result // "failed"' 2>/dev/null || echo "failed")
- status_warning_lines=$(printf '%s' "$status_json" | jq -r '.warnings[]?' 2>/dev/null)
- # 失敗時の recovery one-liner で実値埋め込みするため、script JSON から 4 ID を抽出する。
- # projects-status-update.sh は失敗時にも .item_id / .project_id / .status_field_id / .option_id を
- # 含めて emit する (output_result() 仕様、scripts/projects-status-update.sh §27-35)。
- # 部分パイプライン失敗時 (例: gh project item-edit のみ失敗) では 4 ID 全て populated されるため
- # copy-paste-ready な recovery command を Step 3 で構築できる。空値時は placeholder template に fallback。
- script_item_id=$(printf '%s' "$status_json" | jq -r '.item_id // empty' 2>/dev/null)
- script_project_id=$(printf '%s' "$status_json" | jq -r '.project_id // empty' 2>/dev/null)
- script_status_field_id=$(printf '%s' "$status_json" | jq -r '.status_field_id // empty' 2>/dev/null)
- script_option_id=$(printf '%s' "$status_json" | jq -r '.option_id // empty' 2>/dev/null)
-
- # script が JSON を吐く前に死んだ場合 (status_json="") は status_warning_lines も空のため、
- # 退避した stderr を warning_lines に注入して Step 3 で surface する
- if [ -z "$status_json" ] && [ -n "$p463_err_status" ] && [ -s "$p463_err_status" ]; then
- status_warning_lines=$(printf 'script invocation died before JSON emit: %s' "$(head -5 "$p463_err_status")")
- fi
-
- case "$status_result" in
- updated)
- status_update_result="success"
- echo "親 Issue #${parent_number} の Status を 'Done' に更新しました"
- ;;
- skipped_not_in_project)
- status_update_result="not_registered"
- echo "警告: 親 Issue #${parent_number} は Project #${project_number} に登録されていません。Status 更新をスキップします。" >&2
- ;;
- failed)
- status_update_result="update_failed"
- echo "警告: 親 Issue #${parent_number} の Status 更新に失敗しました。後続の gh issue close は続行します。" >&2
- if [ -n "$status_warning_lines" ]; then
- printf '%s\n' "$status_warning_lines" | sed 's/^/ p463 Step 1 warning: /' >&2
- fi
- ;;
- *)
- # 未知の .result 値 (script の schema 拡張で `not_eligible` / `rate_limited` 等が将来追加された場合)
- # silent miscategorization を防ぐため [DEBUG] 内部 trace を出してから update_failed 扱いにする
- # codebase convention: [DEBUG] = 内部 trace / observability、警告: = user-actionable warning
- status_update_result="update_failed"
- echo "[DEBUG] projects-status-update.sh から未知の .result='$status_result' を受信しました。update_failed として扱います" >&2
- echo "警告: 親 Issue #${parent_number} の Status 更新に失敗しました。後続の gh issue close は続行します。" >&2
- if [ -n "$status_warning_lines" ]; then
- printf '%s\n' "$status_warning_lines" | sed 's/^/ p463 Step 1 warning: /' >&2
- fi
- ;;
- esac
-else
- status_update_result="projects_disabled"
+  status_json_args=$(jq -n \
+    --argjson issue "$parent_number" --arg owner "$owner" --arg repo "$repo" \
+    --argjson project_number "$project_number" --arg status "Done" \
+    --argjson auto_add false --argjson non_blocking true \
+    '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
+  p463_err_status=$(_mktemp_or_warn "Step 1")
+  status_json=$(bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args" 2>"${p463_err_status:-/dev/null}") || status_json=""
+  status_result=$(printf '%s' "$status_json" | jq -r '.result // "failed"' 2>/dev/null || echo "failed")
+  status_warning_lines=$(printf '%s' "$status_json" | jq -r '.warnings[]?' 2>/dev/null)
+  # 失敗時 recovery one-liner 用に script JSON から 4 ID 抽出 (script は失敗時も emit する)
+  script_item_id=$(printf '%s' "$status_json" | jq -r '.item_id // empty' 2>/dev/null)
+  script_project_id=$(printf '%s' "$status_json" | jq -r '.project_id // empty' 2>/dev/null)
+  script_status_field_id=$(printf '%s' "$status_json" | jq -r '.status_field_id // empty' 2>/dev/null)
+  script_option_id=$(printf '%s' "$status_json" | jq -r '.option_id // empty' 2>/dev/null)
+  if [ -z "$status_json" ] && [ -n "$p463_err_status" ] && [ -s "$p463_err_status" ]; then
+    status_warning_lines=$(printf 'script invocation died before JSON emit: %s' "$(head -5 "$p463_err_status")")
+  fi
+  case "$status_result" in
+    updated) status_update_result="success"; echo "親 Issue #${parent_number} の Status を 'Done' に更新しました" ;;
+    skipped_not_in_project) status_update_result="not_registered"; echo "警告: 親 Issue #${parent_number} は Project #${project_number} に未登録。Status 更新をスキップします。" >&2 ;;
+    *) status_update_result="update_failed"
+       [ "$status_result" != "failed" ] && echo "[DEBUG] 未知の .result='$status_result' — update_failed 扱い" >&2
+       echo "警告: 親 Issue #${parent_number} の Status 更新に失敗。後続の gh issue close は続行します。" >&2
+       [ -n "$status_warning_lines" ] && printf '%s\n' "$status_warning_lines" | sed 's/^/  p463 Step 1 warning: /' >&2 ;;
+  esac
 fi
 
 # --- Step 2: Close the parent Issue ---
 p463_err_close=$(_mktemp_or_warn "Step 2")
-if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため、自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>"${p463_err_close:-/dev/null}"; then
- issue_close_result="success"
- echo "親 Issue #${parent_number} を自動クローズしました"
+if gh issue close "$parent_number" --comment "子 Issue がすべて完了したため自動クローズします。(/rite:issue:close 経由、Issue #${issue_number} の close をトリガー)" >/dev/null 2>"${p463_err_close:-/dev/null}"; then
+  issue_close_result="success"; echo "親 Issue #${parent_number} を自動クローズしました"
 else
- p463_close_rc=$?
- issue_close_result="failed"
- echo "警告: 親 Issue #${parent_number} のクローズに失敗しました (rc=$p463_close_rc)。手動でクローズしてください: gh issue close ${parent_number}" >&2
- if [ -n "$p463_err_close" ] && [ -s "$p463_err_close" ]; then
- head -5 "$p463_err_close" | sed 's/^/ p463 Step 2 stderr: /' >&2
- fi
+  issue_close_result="failed"
+  echo "警告: 親 Issue #${parent_number} のクローズに失敗 (rc=$?)。手動: gh issue close ${parent_number}" >&2
+  [ -n "$p463_err_close" ] && [ -s "$p463_err_close" ] && head -5 "$p463_err_close" | sed 's/^/  p463 Step 2 stderr: /' >&2
 fi
 
-# --- Step 3: State inconsistency summary (MUST always emit — silent data corruption prevention) ---
-# Parent Issue と Projects Status は別エンティティのため、片方成功 / 片方失敗の不整合を
-# 必ずユーザーに可視化する。script delegate 化に伴い 5-class → 4-class に整理 (.result の
-# updated / skipped_not_in_project / failed への合流に揃えた)。
+# --- Step 3: State inconsistency summary (MUST always emit) ---
 echo ""
 echo "=== 親 Issue #${parent_number} 処理結果 ==="
-echo " Issue close: $issue_close_result"
-echo " Status update: $status_update_result"
-
+echo "  Issue close: $issue_close_result"
+echo "  Status update: $status_update_result"
 case "${issue_close_result}:${status_update_result}" in
- "success:success"|"success:projects_disabled"|"success:not_registered")
- echo " 状態: 整合性 OK"
- ;;
- "success:update_failed")
- echo ""
- echo "⚠️ state 不整合: 親 Issue は CLOSED ですが Projects Status が Done に更新されていません。"
- # case `*)` 経路で update_failed に倒した場合、scrollback に頼らず由来情報を summary 内に残す
- # (status_result は Step 1 内で capture 済みで preserved。"failed" 値は legitimate な script.result なので除外)
- if [ -n "${status_result:-}" ] && [ "$status_result" != "failed" ] && [ "$status_result" != "updated" ] && [ "$status_result" != "skipped_not_in_project" ]; then
- echo " (Note: 未知の .result='$status_result' を受信したため update_failed として処理 — script schema 拡張可能性)"
- fi
- # Step 1 で抽出した 4 ID が全て populated されていれば copy-paste-ready な recovery command を出す
- # (script は失敗時にも .item_id / .project_id / .status_field_id / .option_id を emit するため、
- # 例えば gh project item-edit のみ失敗の経路では 4 ID 全て揃って実用的な復旧コマンドが生成できる)。
- # いずれかが欠落している場合 (script が ID 解決前に死んだ等) は placeholder + 診断コマンドに fallback。
- if [ -n "${script_item_id:-}" ] && [ -n "${script_project_id:-}" ] \
- && [ -n "${script_status_field_id:-}" ] && [ -n "${script_option_id:-}" ]; then
- echo " 復旧コマンド: gh project item-edit --project-id ${script_project_id} --id ${script_item_id} --field-id ${script_status_field_id} --single-select-option-id ${script_option_id}"
- else
- echo " 手動更新の例: gh project item-edit --project-id <project_id> --id <item_id> --field-id <status_field_id> --single-select-option-id <done_option_id>"
- echo " 診断コマンド: gh project field-list ${project_number} --owner ${owner} --format json (Status field の id と 'Done' option の id を確認)"
- fi
- echo " またはブラウザで https://github.com/${owner}/${repo}/issues/${parent_number} の Projects サイドバーから手動更新" >&2
- ;;
- "failed:success")
- echo ""
- echo "⚠️ state 不整合: Projects Status は Done ですが親 Issue が OPEN のままです。"
- echo " 復旧コマンド: gh issue close ${parent_number}" >&2
- ;;
- "failed:projects_disabled")
- echo ""
- echo "⚠️ 親 Issue のクローズに失敗しました (Projects 機能は config で無効化されているため Status 更新は対象外)。手動でクローズしてください: gh issue close ${parent_number}" >&2
- ;;
- "failed:not_registered")
- echo ""
- echo "⚠️ 親 Issue のクローズに失敗しました (親 Issue は Project に未登録、config は enabled)。手動でクローズしてください: gh issue close ${parent_number}" >&2
- echo " Project に追加すべきか確認: gh project item-add ${project_number} --owner ${owner} --url https://github.com/${owner}/${repo}/issues/${parent_number}" >&2
- ;;
- "failed:"*)
- echo ""
- echo "⚠️ 親 Issue の処理が両方失敗しました (Issue close / Status update)。手動対応が必要です: gh issue close ${parent_number}" >&2
- ;;
+  "success:success"|"success:projects_disabled"|"success:not_registered") echo "  状態: 整合性 OK" ;;
+  "success:update_failed")
+    echo ""; echo "⚠️ state 不整合: 親 Issue は CLOSED ですが Projects Status が Done に更新されていません。"
+    if [ -n "${script_item_id:-}" ] && [ -n "${script_project_id:-}" ] && [ -n "${script_status_field_id:-}" ] && [ -n "${script_option_id:-}" ]; then
+      echo "  復旧コマンド: gh project item-edit --project-id ${script_project_id} --id ${script_item_id} --field-id ${script_status_field_id} --single-select-option-id ${script_option_id}"
+    else
+      echo "  手動更新例: gh project item-edit --project-id <project_id> --id <item_id> --field-id <status_field_id> --single-select-option-id <done_option_id>"
+      echo "  診断: gh project field-list ${project_number} --owner ${owner} --format json (Status field と 'Done' option の id を確認)"
+    fi ;;
+  "failed:success") echo ""; echo "⚠️ state 不整合: Projects Status は Done ですが親 Issue が OPEN のままです。"; echo "  復旧コマンド: gh issue close ${parent_number}" >&2 ;;
+  "failed:projects_disabled") echo ""; echo "⚠️ 親 Issue のクローズに失敗 (Projects は config で無効)。手動: gh issue close ${parent_number}" >&2 ;;
+  "failed:not_registered") echo ""; echo "⚠️ 親 Issue のクローズに失敗 (Project 未登録)。手動: gh issue close ${parent_number}" >&2 ;;
+  "failed:"*) echo ""; echo "⚠️ 親 Issue の処理が両方失敗 (close / status)。手動対応: gh issue close ${parent_number}" >&2 ;;
 esac
+trap - EXIT INT TERM HUP
 ```
 
-Proceed to Phase 5 regardless of the outcome (non-blocking — the Step 3 inconsistency summary above makes silent failure impossible per Issue #517 invariants).
+いずれの結果でも Phase 5 へ（non-blocking — Step 3 summary が silent failure を不可能にする、Issue #517 invariant）。
 
 ---
 
 ## Phase 5: Delete Local Work Memory Files
 
-**Execution condition**: Always executed as the final phase, regardless of whether the Issue was already closed (Phase 1.2) or just closed (Phase 4). Only requires `{issue_number}` to be available.
+**実行条件**: 既クローズ（Phase 1.2）/ 新規クローズ（Phase 4）を問わず最終 Phase として常に実行。`{issue_number}` のみ必要。
 
-Delete the local work memory file and its lock directory for the specified Issue using the cleanup-work-memory script with `--issue` flag (close mode: deletes only the specified Issue's files, does NOT reset flow state or sweep stale files).
-
-Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) if not already resolved.
+指定 Issue のローカル作業メモリファイルと lockdir を削除する（close mode: 指定 Issue のファイルのみ削除。flow state reset や stale sweep はしない）。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) で解決:
 
 ```bash
 bash {plugin_root}/hooks/cleanup-work-memory.sh --issue {issue_number}
 ```
 
-**Note**: The `--issue` flag passes the Issue number directly to the script, bypassing LLM placeholder substitution for file paths. The script constructs the exact file path internally. Unlike the full cleanup mode in `cleanup.md`, `{issue_number}` here is the user-provided argument to `/rite:issue:close`, not derived from state files.
+`--issue` フラグは Issue 番号を直接渡し、スクリプトが内部でパスを構築する（LLM placeholder 置換をバイパス）。`.rite-work-memory/` ディレクトリ自体は削除しない（スクリプトが保持）。
 
-**Do NOT delete** the `.rite-work-memory/` directory itself — the script preserves it.
-
-**Error handling:**
+**エラーハンドリング**（すべて non-blocking — 失敗時は警告して終了）:
 
 | Error Case | Response |
 |-----------|----------|
-| Files do not exist | No error (script handles gracefully) |
-| Permission error | Script displays WARNING to stderr; display warning and end processing (non-blocking) |
-| Script itself fails | Display warning and end processing (non-blocking) |
+| ファイル不在 | エラーなし（スクリプトが gracefully 処理） |
+| Permission / スクリプト失敗 | WARNING を表示して終了 |
 
-**Warning message on failure:**
+失敗時の警告:
 
 ```
 警告: ローカル作業メモリの削除に失敗しました
-手動で削除する場合: rm -f ".rite-work-memory/issue-{issue_number}.md" && rm -rf ".rite-work-memory/issue-{issue_number}.md.lockdir"
+手動削除: rm -f ".rite-work-memory/issue-{issue_number}.md" && rm -rf ".rite-work-memory/issue-{issue_number}.md.lockdir"
 ```
 
-**Note**: Failure to delete local work memory files does not block the process. Display a warning and end processing.
-
 ### 5.1 Deletion Result Display
-
-After executing the deletion commands, display the result:
 
 ```
 ローカル作業メモリ: {削除済み / 削除失敗（警告参照） / 該当なし}
 ```
 
-**Script output to display value mapping:**
-
 | Script Output | Display Value |
 |--------------|---------------|
-| `削除: 1` or more | `削除済み` |
-| `失敗: 1` or more | `削除失敗（警告参照）` |
+| `削除: 1` 以上 | `削除済み` |
+| `失敗: 1` 以上 | `削除失敗（警告参照）` |
 | `削除: 0, 失敗: 0` | `該当なし` |
 
 End processing.
@@ -1169,6 +671,6 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 
 | Error | Recovery |
 |-------|----------|
-| If the Issue Is Not Found | See [common patterns](../../references/common-error-handling.md) |
-| If a Permission Error Occurs | See [common patterns](../../references/common-error-handling.md) |
-| If a Network Error Occurs | See [common patterns](../../references/common-error-handling.md) |
+| Issue Not Found | See [common patterns](../../references/common-error-handling.md) |
+| Permission Error | See [common patterns](../../references/common-error-handling.md) |
+| Network Error | See [common patterns](../../references/common-error-handling.md) |

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -8,50 +8,23 @@ description: PR マージ後のクリーンアップを実行
 
 ## Contract
 **Input**: Merged PR (auto-detected from current branch or specified)
-**Output**: Cleanup result summary table (branch deletion, Status update, Issue close results)
+**Output**: Cleanup result summary (branch deletion, Status update, Issue close results)
 
-Automate post-PR-merge cleanup tasks (branch deletion, switch to main, Status update)
+PR マージ後のクリーンアップ（ブランチ削除・デフォルトブランチ切替・Projects Status 更新・関連 Issue クローズ）を自動化する。
 
----
-
-When this command is executed, run the following phases in order.
+途中で止まったら flow-state に `phase=cleanup, active=true` が残るので `/rite:resume` で再開する。Stop hook・自動継続機構・retrospective incident detector は無い（単層 + ユーザー操作の設計）。
 
 ## Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `[branch_name]` | Branch name to clean up (defaults to the current branch if omitted) |
-
----
-
-## Sub-skill Return Protocol
-
-> **Reference**: Canonical Sub-skill Return contract は [`skills/rite-workflow/SKILL.md`](../../skills/rite-workflow/SKILL.md) "Sub-skill Return — Flat Workflow" セクションを参照。**Mandatory After Wiki Ingest は本 cleanup.md ファイル固有の contract** (start.md / create.md の flat workflow が削除した「sub-skill chain return」rule とは独立)。Same rules apply: DO NOT end your response after `rite:wiki:ingest` returns, DO NOT re-invoke the completed skill, and IMMEDIATELY proceed to Mandatory After Wiki Ingest in the **same response turn**.
-
-### Routing dispatcher (MUST execute step-by-step)
-
-After any sub-skill return, output two HTML-comment evidence lines (bare bracket form is forbidden — it would conflict with the `[cleanup:completed]` sentinel rule). Neither evidence line may be the response's final line; the final line is reserved for Phase 5.2's last list item with inline `<!-- [cleanup:completed] -->`.
-
-1. `ingest` marker check — grep -F the previous response for any of `[ingest:completed]`, `[ingest:completed:`, `[CONTEXT] WIKI_INGEST_DONE=`, `[CONTEXT] INGEST_DONE=`. Emit `<!-- [routing-check] ingest=matched -->` or `<!-- [routing-check] ingest=unmatched -->`.
-2. `cleanup` marker check — grep -F the previous response for `[cleanup:completed]`. Emit `<!-- [routing-check] cleanup=matched -->` or `<!-- [routing-check] cleanup=unmatched -->`.
-3. Routing (priority: `ingest=matched` wins over `cleanup=matched` in mixed sessions because the most recent sub-skill return is the true continuation trigger):
-   - `ingest=matched` → continuation trigger: immediately run Mandatory After Wiki Ingest (re-patch `phase=cleanup` → Phase 5 Completion Report) in the same turn.
-   - `cleanup=matched` (and `ingest=unmatched`) → terminal reached.
-   - Both unmatched → workflow in progress, continue normally.
-
-### Correct continuation pattern
-
-The **correct-pattern**: in the same response turn, immediately (1) run Mandatory After Wiki Ingest Pre-write (post-ingest re-patch — v3 enum では引き続き `phase=cleanup`); (2) output Phase 5.1 Cleanup Result Summary; (3) output Phase 5.2 Guidance for Next Steps with **inline `<!-- [cleanup:completed] -->` HTML sentinel at the trailing position of the final list item** (not on an independent line); (4) Phase 5.3 Step 1 deactivates flow state (`phase=cleanup`, `active: false` — v3 enum の terminal state) and the turn closes — DO NOT stop earlier. Ending the turn after `rite:wiki:ingest` returns abandons the cleanup workflow mid-flight, leaves Phase 5 unexecuted, and leaves the flow state non-terminal.
-
-**Completion marker**: `[cleanup:completed]` is emitted as an HTML comment (`<!-- [cleanup:completed] -->`) inline at the trailing position of Phase 5.2's final list item — keeps the marker grep-matchable (`grep -F '[cleanup:completed]'`) while making `クリーンアップが完了しました` the user-visible final content. Protocol violations (premature `end_turn` during any step where `phase=cleanup` is active — v3 enum では Pre-write / re-patch / terminal の logical sub-step は phase 値ではなく step 名で区別される) からの復帰は `/rite:resume` による。Stop hook も retrospective incident detector も存在しない単層設計のため、`phase=cleanup` の `active=true` が flow-state に残っていれば `/rite:resume` が in-progress と判定して該当 step から再開する。
+| `[branch_name]` | クリーンアップ対象ブランチ（省略時は現在のブランチ） |
 
 ---
 
 ## Phase 1.0: Activate Flow State
 
-> **Plugin Path**: Resolve `{plugin_root}` using the inline one-liner in **Step 0** below before executing bash hook commands in this file. Do NOT improvise a different resolution script.
-
-**Step 0: Resolve plugin root** (execute once, reuse throughout):
+**Step 0: Resolve plugin root**（一度だけ実行し、以降の `{plugin_root}` で再利用）:
 
 ```bash
 plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
@@ -62,36 +35,20 @@ fi
 echo "plugin_root=$plugin_root"
 ```
 
-Retain the `plugin_root` value output above and use it for all subsequent `{plugin_root}` references in this command.
-
-Activate flow state to record that a cleanup workflow is in flight. The `.active=true, phase=cleanup` pair is the persistent signal read by `session-end.sh`'s lifecycle helpers on the next session to surface a stale-cleanup WARNING — without it, an interrupted cleanup leaves no trace.
-
-> **Fail-safe**: `flow-state.sh` 呼び出しは `if ! ... ; then echo "WARNING..." >&2; fi` で包み、失敗時もユーザー可視 WARNING のみで続行する。状態書込みが失敗しても cleanup ロジック自体は走るので、recovery は "continue" 入力で可能。
+cleanup が in-flight であることを記録する。`phase=cleanup, active=true` は次 session の `session-end.sh` が中断 cleanup を検出する唯一のシグナル。失敗しても WARNING のみで cleanup ロジックは続行する（recovery は `/rite:resume`）。
 
 ```bash
-# helper が空文字列を返した場合は後続の `[ -f "" ]` が false 評価され create 分岐に進む。
-# state file 不在と同等に扱う safe-default fallback。
-state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 state_file=$(bash {plugin_root}/hooks/flow-state.sh path 2>/dev/null) || state_file=""
 if [ -n "$state_file" ] && [ -f "$state_file" ]; then
-  # 前 session 終了時に {phase: cleanup, active: false} で残存している (v3 enum terminal state)
-  # ケースで `--active true` を省略すると patch モードは .active を更新しないため、
-  # lifecycle observability (session-end が `cleanup_*` の in-progress を検出する経路) が
-  # silent に無効化される。明示再活性化で防ぐ。
-  if ! bash {plugin_root}/hooks/flow-state.sh set \
-      --phase "cleanup" --active true --next "Execute cleanup phases. Do NOT stop."; then
-    echo "WARNING: flow-state.sh set (cleanup activate) failed — cleanup observability degraded (session-end will not see cleanup-in-progress on next session). 'continue' で再開可能." >&2
-  fi
+  bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --active true \
+    --next "Execute cleanup phases. Do NOT stop." \
+    || echo "WARNING: flow-state activate failed — cleanup observability degraded. '/rite:resume' で復帰可能." >&2
 else
-  if ! bash {plugin_root}/hooks/flow-state.sh set \
-      --phase "cleanup" --issue 0 --branch "" --pr 0 \
-      --next "Execute cleanup phases. Do NOT stop."; then
-    echo "WARNING: flow-state.sh set (cleanup activate) failed — flow state was not created. cleanup の進行記録が残らない (中断時に /rite:resume での復帰が効かなくなる可能性)." >&2
-  fi
+  bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --issue 0 --branch "" --pr 0 \
+    --next "Execute cleanup phases. Do NOT stop." \
+    || echo "WARNING: flow-state create failed — cleanup の進行記録が残らない." >&2
 fi
 ```
-
-**Purpose**: After PR merge, flow state is `active: false, phase: completed`。re-activation せずに cleanup を走らせると、session-end の lifecycle 検出が cleanup-in-progress を観測できないため interrupted cleanup の retrospective WARNING 経路が dead になる。
 
 ---
 
@@ -103,78 +60,31 @@ fi
 git branch --show-current
 ```
 
-**Retrieving the base branch**: Read tool で `rite-config.yml` を読み `branch.base` を取得 (set されていればその値を `{base_branch}` として採用)。未設定 / ファイル不在の場合、リポジトリのデフォルトブランチを検出する:
+**Base branch の取得**: Read tool で `rite-config.yml` の `branch.base` を読む。未設定ならデフォルトブランチを検出:
 
 ```bash
 git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
 ```
 
-`origin/HEAD` 未設定で `git symbolic-ref` が失敗する場合、誤ったブランチへの切り替え (data loss リスク) を防ぐため処理を中断してエラー表示する (推測 fallback 禁止):
+検出失敗時は誤ブランチ切替（data loss リスク）を防ぐため中断する（推測 fallback 禁止）。`rite-config.yml` の `branch.base` 設定、または `git remote set-head origin --auto` を案内する。
 
-```
-エラー: デフォルトブランチを自動検出できませんでした。
-
-rite-config.yml で明示的に設定してください:
-  branch:
-    base: "your-default-branch"
-
-または origin/HEAD を設定してください:
-  git remote set-head origin --auto
-```
-
-**When on the base branch** (引数省略時): merged branches を `git branch --merged {base_branch}` で表示し `AskUserQuestion` で選択させる:
-
-```
-現在 {branch} ブランチにいます
-
-クリーンアップするブランチを指定してください:
-/rite:pr:cleanup <branch_name>
-
-または最近マージされたブランチを確認:
-```
+**現在 base branch にいる場合**（引数省略時）: `git branch --merged {base_branch}` で候補を表示し、`/rite:pr:cleanup <branch_name>` での指定を案内する。
 
 ### 1.2 Search for Related PR
-
-Search for a PR associated with the current branch (or the specified branch):
 
 ```bash
 gh pr list --head {branch_name} --state all --json number,title,state,mergedAt,url
 ```
 
-**If no PR is found:**
-
-```
-警告: ブランチ {branch_name} に関連する PR が見つかりません
-
-オプション:
-- ブランチを削除してクリーンアップ続行
-- キャンセル
-```
+PR が見つからない場合は `AskUserQuestion` で「ブランチを削除して続行 / キャンセル」を確認する。
 
 ### 1.3 Verify PR State
 
-**If the PR has not been merged:**
-
-```
-警告: PR #{number} はまだマージされていません
-
-状態: {state}
-タイトル: {title}
-
-マージされていない PR のブランチを削除すると、作業内容が失われる可能性があります。
-
-オプション:
-- キャンセル（推奨）
-- 強制的にクリーンアップ
-```
-
-**If the PR has been merged:**
-
-Proceed to the next phase.
+PR が未マージの場合は警告し「キャンセル（推奨）/ 強制クリーンアップ」を確認する（未マージ PR のブランチ削除は作業内容を失う可能性がある）。マージ済みなら次へ。
 
 ### 1.4 Retrieve Repository Information
 
-後続 GitHub API 呼び出し用に owner / repo を取得し conversation context に保持する:
+後続の GitHub API 呼び出し用に owner / repo を取得し context に保持する:
 
 ```bash
 gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'
@@ -182,441 +92,120 @@ gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'
 
 ### 1.5 Identify Related Issue
 
-PR body の `Closes #XX` / `Fixes #XX` / `Resolves #XX` パターン、またはブランチ名の `issue-XX` パターンから関連 Issue を識別する:
+PR body の `Closes/Fixes/Resolves #XX`、またはブランチ名の `issue-XX` から関連 Issue を識別する:
 
 ```bash
 gh pr view {pr_number} --json body,headRefName
 ```
 
-**If an Issue number is identified, retrieve detailed Issue information** (Phase 1.7.3.1 で使用、OPEN/CLOSED どちらでも動作):
+Issue 番号が識別できたら詳細を取得する（`{original_issue_number}` / `{original_issue_title}` を Phase 1.7 の Issue 作成参照に、`{original_issue_body}` を `{task_details}` 推論に使用）:
 
 ```bash
-gh issue view {issue_number} --json number,title,state,body --jq '{number, title, state, body}'
+gh issue view {issue_number} --json number,title,state,body
 ```
-
-`{original_issue_number}` / `{original_issue_title}` は Phase 1.7.3 の Issue 作成参照に、`{original_issue_body}` は Phase 1.7.3.1 の `{task_details}` 推論時に LLM が実装要件・背景を抽出するために使用する。
 
 ### 1.5.1 Detect Parent Issue
 
-Check whether the related Issue is a child Issue (included in another Issue's Tasklist). Used by Phase 3.6.4 (parent Tasklist checkbox update) and Phase 3.7 (parent auto-close).
-
-#### 1.5.1.1 Detection via GitHub Sub-Issues API (preferred)
+関連 Issue が子 Issue か（他 Issue の Tasklist に含まれるか）を判定する。Phase 3 の親 Tasklist 更新・親 auto-close で使用。Sub-Issues API を優先し、無ければ Tasklist fallback:
 
 ```bash
 gh api graphql -H "GraphQL-Features: sub_issues" -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    issue(number: $number) {
-      parent {
-        number
-        title
-        state
-      }
-    }
-  }
+  repository(owner: $owner, name: $repo) { issue(number: $number) { parent { number title state } } }
 }' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
 ```
-
-**Note**: The `GraphQL-Features: sub_issues` header is required (the Sub-Issues API is in beta).
-
-#### 1.5.1.2 Tasklist Fallback
-
-If the Sub-Issues API does not find a parent, search repository Issues to check if the Issue is included in a Tasklist:
 
 ```bash
 gh issue list --search "in:body \"- [ ] #{issue_number}\" OR \"- [x] #{issue_number}\"" --json number,title,state --jq '.[0]'
 ```
 
-#### 1.5.1.3 Handling Detection Results
+親 Issue が見つかれば `{parent_issue_number}` / `{parent_issue_title}` / `{parent_issue_state}` を保持。見つからない / API エラー時は Phase 3 の親処理をスキップ（non-blocking — cleanup は続行）。
 
-| Detection Result | Action |
-|-----------------|--------|
-| Parent Issue found | Retain `{parent_issue_number}`, `{parent_issue_title}`, `{parent_issue_state}` in the conversation context |
-| Parent Issue not found | Skip Phase 3.6.4 and Phase 3.7 |
-| API error | Display a warning and skip Phase 3.6.4 and Phase 3.7 (non-blocking — cleanup continues) |
+### 1.6 Check Incomplete Tasks
 
-### 1.6 Check Incomplete Tasks in Work Memory
+関連 Issue が識別されていれば未完了タスクをチェックする（識別できなければ Phase 2 へ）。
 
-関連 Issue が識別されていれば、作業メモリコメントの未完了タスクをチェックする。識別されていなければ Phase 1.6 / 1.7 をスキップして Phase 2 に進む。
-
-#### 1.6.1 Retrieve Work Memory
-
-**Local work memory (SoT)**: Read `.rite-work-memory/issue-{issue_number}.md` with the Read tool. If the file exists, use its content for incomplete task detection.
-
-**Fallback (local file missing/corrupt)**: Fall back to the Issue comment API. Use `last` to pick the most recent matching comment (defends against multiple matches), and `// empty` to coerce null to empty string:
+**作業メモリ (SoT)**: Read tool で `.rite-work-memory/issue-{issue_number}.md` を読む。無ければ Issue コメント API に fallback（最新の一致コメントを `last` で選択）:
 
 ```bash
-comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last')
-comment_id=$(echo "$comment_data" | jq -r '.id // empty')
-comment_body=$(echo "$comment_data" | jq -r '.body // empty')
+comment_body=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
+  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | .body // empty')
 ```
 
-`{comment_id}` is reused when updating work memory in Phase 1.7.4 / Phase 3.5; `{comment_body}` feeds incomplete task detection. Bash variables do not persist across Bash tool invocations — the LLM retains `comment_id` in conversation context and embeds it directly in later updates (or re-runs this block to re-fetch).
-
-If no comment is found (both local file and Issue comment), skip this check and proceed to Phase 2.
-
-#### 1.6.2 Detect Incomplete Tasks
-
-Detect unchecked checkboxes (`- [ ]`) in the "Progress" section. The here-string form (`<<<`) avoids SIGPIPE when `head -10` exits early on large `comment_body` (>64KB pipe buffer). `head -10` caps display volume; the `sed` range extraction tolerates progress section at EOF (no trailing `### `):
+進捗セクションと Issue 本文の未完了チェックボックス（`- [ ]`。ただし `- [ ] #XX` の親子 Tasklist エントリは除外）を検出する:
 
 ```bash
-progress_section=$(sed -n '/### 進捗/,/### /p' <<< "$comment_body")
-incomplete_tasks=$(grep -E '^\s*- \[ \]' <<< "$progress_section" | head -10)
+incomplete=$(printf '%s\n' "$comment_body" | sed -n '/### 進捗/,/### /p' \
+  | grep -E '^\s*- \[ \]' | grep -v -E '^\s*- \[ \] #[0-9]+' | head -10)
 ```
 
-#### 1.6.3 Warning When Incomplete Tasks Exist
-
-If incomplete tasks are found, prompt with `AskUserQuestion`:
+未完了タスクが無ければ Phase 2 へ。あれば `AskUserQuestion`:
 
 ```
-警告: 作業メモリに未完了のタスクがあります
+警告: 作業メモリ / Issue 本文に未完了のタスクがあります
 
-未完了タスク:
-{incomplete_tasks}
+{incomplete}
 
 オプション:
-- 未完了タスクを先に完了する（推奨）
-- 未完了タスクを自動判定して処理する
+- 未完了タスクを Issue 化（推奨）
 - 無視してクリーンアップを続行
 - キャンセル
 ```
 
-「未完了タスクを先に完了 (推奨)」→ クリーンアップを中断し、未完了タスク対応後 `/rite:pr:cleanup` 再実行を案内。「自動判定」→ Phase 1.7。「無視して続行」→ Phase 2。「キャンセル」→ terminate。
+「Issue 化」→ Phase 1.7。「無視して続行」→ Phase 2。「キャンセル」→ terminate。
 
-#### 1.6.4 When No Incomplete Tasks Exist
-
-未完了タスクがなければ Phase 1.6.5 へ進む。
-
-#### 1.6.5 Check Issue Body Checklist
-
-In addition to checking the work memory, also check the checklist in the Issue body.
-
-> **責務 — safety net (例外残存項目の救済)**: 本 Phase は Issue 実装中の `/rite:issue:start` ステップ 4 (`implement.md` Phase 5.1 per-task checklist 更新) を **passthrough した例外残存項目** を merge 後に拾う **safety net** として位置付ける。primary update path は実装中の per-task update であり、本 Phase は最終 fallback。大量検出時は primary path の機能不全を示唆するため Phase 1.6.5.2 で `WARNING` を stderr に出力し observability を確保する。
-
-**1.6.5.1 Extract Checklist**
-
-Phase 1.5 で取得済みの Issue body からチェックリストを抽出する (再取得不要):
-
-```bash
-gh issue view {issue_number} --json body --jq '.body'
-```
-
-抽出パターン: `/^- \[[ xX]\] (.+)$/gm`、除外パターン: `/^- \[[ xX]\] #\d+/gm` (parent-child Issue 管理用 Tasklist エントリは除外)。
-
-**1.6.5.2 Detect Incomplete Checklist Items**
-
-抽出されたチェックリストから `- [ ]` 項目を検出 (除外パターン: `- [ ] #XX` 親子 Tasklist)。検出件数が **5 件以上** の場合は primary path (`implement.md` Phase 5.1.1.1 per-task / `checklist-auto-check.md` Phase 5.2.1.1 Auto-Check) の機能不全を示唆するため `WARNING` を non-blocking で stderr に出力する。observability log として cleanup session の stderr に記録される。手動 triage が必要な場合は stderr ログを確認すること:
-
-```bash
-incomplete_count=$(gh issue view {issue_number} --json body --jq '.body' \
-  | grep -E '^- \[[ xX]\] ' | grep -v -E '^- \[[ xX]\] #[0-9]+' | grep -c '^- \[ \] ' || true)
-if [ "${incomplete_count:-0}" -ge 5 ]; then
-  echo "WARNING: Issue #{issue_number} cleanup Phase 1.6.5.2 mass-residual detection: ${incomplete_count} incomplete checklist items at cleanup time (threshold: 5). Primary update path (implement.md Phase 5.1.1.1 per-task / checklist-auto-check.md Phase 5.2.1.1 Auto-Check) appears to have malfunctioned." >&2
-fi
-```
-
-未完了項目が存在する場合 `AskUserQuestion`:
-
-```
-警告: Issue 本文に未完了のチェック項目があります
-
-未完了項目:
-- [ ] {item_1}
-- [ ] {item_2}
-
-オプション:
-- Issue 本文のチェックリストを自動更新（推奨）: PR の変更内容を基に完了状態を判定し更新
-- チェックリストを手動で確認: クリーンアップを中断し手動確認
-- 無視してクリーンアップを続行: 未完了のまま続行
-- キャンセル
-```
-
-「自動更新」→ Phase 1.6.5.3、「手動で確認」→ 案内表示後 terminate、「無視して続行」→ Phase 2、「キャンセル」→ terminate。
-
-**1.6.5.3 Automatic Checklist Update**
-
-Based on PR changes, determine the completion status of incomplete checklist items and update the Issue body.
-
-**Assessment logic**: 各チェックリスト項目を PR 変更との関連性 ((1) 項目テキスト、(2) `gh pr diff {pr_number} --name-only` 出力、(3) `gh pr diff {pr_number}` 詳細) で判定する:
-
-```
-チェック項目: 「現在の CLAUDE.md の内容を評価」
-PR 変更ファイル: CLAUDE.md
-判定: ✅ CLAUDE.md を変更しているため、完了と判断
-
-チェック項目: 「テストを追加」
-PR 変更ファイル: src/utils.ts
-判定: ⬜ テストファイルへの変更がないため、未完了と判断
-```
-
-**Updating the Issue body**: Follow the "Checkbox Update" pattern in [gh-cli-patterns.md](../../references/gh-cli-patterns.md) — 3 steps (Bash → Read+Write → Bash):
-
-**Step 1 (Bash)**: 一時ファイル取得 + Issue body 読み込み + 検証 (`tmpfile_read=$(mktemp)` / `tmpfile_write=$(mktemp)` / `gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"` / 空 body は ERROR で abort / `echo` でパス出力 — 後続 Bash tool call からシェル変数は参照不可のため):
-
-```bash
-tmpfile_read=$(mktemp)
-tmpfile_write=$(mktemp)
-trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
-gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"
-[ ! -s "$tmpfile_read" ] && { echo "ERROR: Issue body の取得に失敗" >&2; exit 1; }
-echo "tmpfile_read=$tmpfile_read"
-echo "tmpfile_write=$tmpfile_write"
-```
-
-**Step 2 (Read + Write tool)**: Read tool で `$tmpfile_read` を読み、`[ ]` → `[x]` 置換した本文を Write tool で `$tmpfile_write` に書き出す。
-
-**Step 3 (Bash)**: 検証 + 適用 (Step 1 で出力されたパスを literal で記述、シェル変数は引き継がれない):
-
-```bash
-tmpfile_read="/tmp/tmp.XXXXXXXXXX"   # ← Step 1 の出力値
-tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Step 1 の出力値
-[ ! -s "$tmpfile_write" ] && { echo "ERROR: 更新内容が空" >&2; exit 1; }
-gh issue edit {issue_number} --body-file "$tmpfile_write"
-rm -f "$tmpfile_read" "$tmpfile_write"
-```
-
-**Displaying the update results:**
-
-```
-Issue 本文のチェックリストを更新しました:
-
-完了に更新:
-- [x] {item_1}（CLAUDE.md の変更により判定）
-- [x] {item_2}（src/utils.ts の変更により判定）
-
-未完了のまま:
-- [ ] {item_3}（関連する変更が見つかりませんでした）
-```
-
-**When remaining incomplete items exist:**
-
-```
-警告: 以下のチェック項目が未完了のままです:
-
-- [ ] {item_3}
-
-オプション:
-- 未完了のまま続行: 後続の作業で対応予定として続行
-- 別 Issue として登録: 未完了項目を新しい Issue として作成
-- キャンセル
-```
-
-| Option | Subsequent Processing |
-|--------|----------------------|
-| **未完了のまま続行** | Proceed to Phase 2 |
-| **別 Issue として登録** | Create an Issue by reusing the Phase 1.7.3 Issue creation flow -> Proceed to Phase 2 |
-| **キャンセル** | Terminate processing |
-
-**1.6.5.4 When No Checklist Exists**: Issue body にチェックリストがなければ本セクションをスキップして Phase 2 に進む。
+> マージ済みブランチへのコミットは base branch に反映されず、cleanup 中の変更はブランチ削除で失われる。残作業は Issue 化することで追跡可能性を保つ。
 
 ---
 
-## Phase 1.7: Automatic Assessment and Processing of Incomplete Tasks
+## Phase 1.7: Convert Incomplete Tasks to Issues
 
-**Prerequisite**: Phase 1.6.3 で「未完了タスクを自動判定して処理する」が選択された場合のみ実行。
+**Prerequisite**: Phase 1.6 で「Issue 化」が選択された場合のみ実行。各未完了タスクを PR マージ後の残作業として Issue 化する。
 
-### 1.7.0 Retrieve PR Diff
+### 1.7.1 Generate Issue Content
 
-Retrieve the PR diff for task analysis (used to assess "completed but unchecked" tasks and to generate `{task_details}` in Issue body):
-
-```bash
-gh pr diff {pr_number}
-```
-
-### 1.7.1 Analyze Tasks
-
-#### 1.7.1.1 Task Assessment
-
-LLM (Claude) は各未完了タスクを以下のカテゴリで分類する:
-
-| Assessment Category | Description | Examples |
-|--------------------|-------------|----------|
-| **Create Issue** | 残作業として追跡すべきタスク | "Add tests", "Update documentation", "Remove debug logs", TODO 対応 |
-| **Completed (unchecked)** | 実際は完了済みだがチェック漏れ | 作業メモリのチェック忘れ |
-| **Difficult to assess** | LLM が確信を持って分類できない | 「コード整理」「改善」等の曖昧な記述 |
-
-**Targets for Issue creation** (typical remaining work after PR merge):
-
-- Adding/expanding tests (unit, E2E, etc.)
-- Updating documentation (README, API docs, etc.)
-- Removing debug code (`console.log`, `print` statements added during development)
-- Addressing `// TODO:` comments left in code
-- Minor refactoring (XS/S complexity)
-
-Incomplete tasks default to Issue creation (unless the user selects "ignore") because commits to a merged PR branch are not reflected in the base branch and changes made during cleanup are lost when the branch is deleted — Issue conversion preserves traceability.
-
-#### 1.7.1.2 Assessment Algorithm
-
-タスクごとに以下のフローで評価する:
-
-1. **タスク名解析**: 作業内容を特定 (例「テスト追加」「コメント削除」)。
-2. **PR diff との照合** (1.7.0 で取得済み diff を使用): キーワードマッチ + 意味的マッチで関連変更を検索。
-   - 関連変更あり + 実質完了 → **完了済み（チェック漏れ）**
-   - 関連変更あり + 部分的/未完了 → **Issue 化**
-   - 関連変更なし → **Issue 化** (未着手)
-3. **判定困難条件**: タスク名が曖昧 (例「コード整理」「改善」「確認」) / 差分との関連性が不明確 / 複数解釈可能 のいずれか → **判定困難**。
-
-**Assessment confidence levels** (内部分類用): High = diff で完了が明確 → "completed"、Medium = タスク内容明確かつ diff 変更なし → "create Issue"、Low = それ以外 → "difficult to assess"。
-
-**Analysis perspectives**: (1) タスク内容の明確性、(2) PR diff による完了状況確認 (チェック漏れ判定)、(3) 複雑度 (下記基準)、(4) 優先度 (緊急対応 vs 後回し可)。
-
-**Complexity criteria:**
-
-| Complexity | Description | Guidelines |
-|-----------|-------------|------------|
-| **XS** | 1-line to a few-line changes, simple deletions/additions | Comment removal, log removal, typo fixes |
-| **S** | Localized changes within a single file | Function addition, validation addition, simple tests |
-| **M** | Changes spanning multiple files | Feature addition, refactoring |
-| **L** | Changes involving design modifications | Architecture changes, large-scale refactoring |
-
-**Displaying analysis results:**
-
-```
-未完了タスクを分析しました:
-
-Issue 化:
-- [ ] テスト追加 → 別途 Issue として管理（複雑度: S）
-- [ ] ドキュメント更新 → 別途 Issue として管理（複雑度: XS）
-- [ ] デバッグログ削除 → 別途 Issue として管理（複雑度: XS）
-
-完了済み（チェック漏れ）:
-- [ ] バリデーション追加 → PR #{pr_number} で実装済み。チェックを付けます
-
-判定困難（確認が必要）:
-- [ ] コード整理 → 内容を確認してください
-```
-
-**When assessed as "completed (unchecked)"**: 該当タスクを `- [x]` にマークし Issue 作成をスキップ。更新は Phase 1.7.4 で一括適用 (analysis phase 1.7.1 では結果記録のみ、ユーザーが confirmation 1.7.2 で修正できる余地を残す)。
-
-### 1.7.2 User Confirmation
-
-Display the analysis results and prompt with `AskUserQuestion`:
-
-```
-上記の分析結果で処理を進めますか？
-
-オプション:
-- この分類で Issue 作成（推奨）
-- 個別に確認する
-- すべて無視してクリーンアップを続行
-- キャンセル
-```
-
-**Subsequent processing for each option:**
-
-| Option | Subsequent Processing | Description |
-|--------|----------------------|-------------|
-| **この分類で Issue 作成（推奨）** | If there are difficult-to-assess tasks: 1.7.2.1 -> 1.7.3, otherwise: 1.7.3 | Create Issues based on the analysis results |
-| **個別に確認する** | Individual confirmation flow -> 1.7.3 | Confirm each task individually |
-| **すべて無視してクリーンアップを続行** | Skip to Phase 2 | Ignore incomplete tasks |
-| **キャンセル** | Terminate processing | Interrupt the entire cleanup process and maintain the current state |
-
-**"Create Issues with this classification" flow**: 判定困難タスクがあれば 1.7.2.1 で解決してから 1.7.3 に進む。なければ 1.7.3 へ直接遷移。
-
-#### 1.7.2.1 Resolving Difficult-to-Assess Tasks
-
-判定困難タスクごとに `AskUserQuestion` で確認 (1.7.3 進入前):
-
-```
-「{task_name}」の処理を選択してください:
-
-オプション:
-- Issue 化する（推奨）
-- 無視する
-- キャンセル（後で対応）
-```
-
-「Issue 化」 → 次タスクへ。「無視」 → 次タスクへ。「キャンセル」 → 未完了タスク処理を中断し Phase 2 へ進む (後日 `/rite:pr:cleanup` 再実行案内)。全タスクが「Issue 化」or「無視」に分類されるまで繰り返す。
-
-**「個別に確認する」flow**: タスクごとに `AskUserQuestion` で逐次確認する。"Completed (unchecked)" タスクは自動チェック済みで個別確認対象外 ("create Issue" / "difficult to assess" のみ surfacing。Phase 1.7.4 後に手動 uncheck か別 Issue 作成で override 可能、Issue closed 状態でも work memory 編集は動作する):
-
-```
-タスク: {task_name}
-分析結果: {category}（複雑度: {complexity}）
-
-このタスクの処理を選択してください:
-
-オプション:
-- Issue 化する（推奨）
-- 無視する
-```
-
-全タスクの分類確定後 1.7.3 へ進む。
-
-### 1.7.3 Convert Tasks to Issues
-
-Create Issues for tasks assessed (or confirmed) as "create Issue". Tasks classified as "ignore" are skipped (no Issue created). The checkbox in work memory remains `- [ ]` so a future `/rite:pr:cleanup` run will surface the task again — this preserves the option to revisit the decision.
-
-#### 1.7.3.1 Generate Issue Content
-
-Generate an Issue per task in the format below. The LLM infers `{task_details}` from the PR diff (Phase 1.7.0), the original Issue body (Phase 1.5), and the task name extracted from work memory.
-
-**Placeholder descriptions:**
-- `{task_summary}`: One-line summary of the incomplete task (synonymous with `{task_name}` — same value, used in overview vs title).
-- `{task_details}`: Specific steps and explanations for the incomplete work. Must include at minimum: target file path, target location (function/class/line), and concrete work content. Example:
-  ```markdown
-  - `src/utils.ts` の `calculateTotal` 関数にユニットテストを追加する
-  - テストケース: 正常系（複数アイテム）、境界値（空配列）、異常系（null 入力）
-  - テストファイル: `src/utils.test.ts` に追加
-  ```
-- `{pr_number}` / `{original_issue_number}` / `{original_issue_title}`: From Phase 1.2 / 1.5.
-- `{complexity}`: Determined in Phase 1.7.1 (XS, S, etc.)
+LLM は PR diff（`gh pr diff {pr_number}`）・元 Issue 本文（Phase 1.5）・タスク名から `{task_details}`（対象ファイルパス・対象箇所・具体的作業内容）を推論する。
 
 **Issue body template:**
 
 ```markdown
 ## 概要
-
 {task_summary}（PR #{pr_number} のマージに伴う残作業）
 
 ## 背景・目的
-
 Issue #{original_issue_number} の実装時に完了できなかったタスクです。
 
-## 関連 Issue
-
+## 関連
 - 元 Issue: #{original_issue_number} - {original_issue_title}
 - 関連 PR: #{pr_number}
 
 ## 変更内容
-
 {task_details}
 
-## 複雑度
-
-{complexity}
-
 ## チェックリスト
-
 - [ ] 実装完了
 - [ ] テスト追加/更新（必要な場合）
 ```
 
-#### 1.7.3.2 Create the Issue
+### 1.7.2 Create the Issue
 
-> **Reference**: [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md)
+> **Reference**: [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md)（Default Priority: Medium）
 
-Issue creation during cleanup uses the common script directly rather than the interactive `/rite:issue:create`. This skips the interview phase and creates the Issue quickly.
-
-**Note**: The block below is a template. Replace `{generated_body}` with the actual Issue body before execution. The single-quoted HEREDOC (`cat <<'BODY_EOF'`) prevents bash variable expansion — Claude must substitute placeholders as an LLM, not via shell. The `残作業` label flags Issues auto-created from incomplete tasks; create it once before first use:
+cleanup 中の Issue 作成は interactive な `/rite:issue:create` ではなく共通スクリプトを直接使う（interview をスキップ）。`残作業` label は初回のみ作成する:
 
 ```bash
 gh label create 残作業 --description "PR マージ後の残作業" --color "fbca04" 2>/dev/null || true
 ```
 
+以下はテンプレート。`cat <<'BODY_EOF'`（single-quoted HEREDOC）は bash 変数展開を抑止するので、`{generated_body}` / 各プレースホルダーは LLM が実値に置換してから実行する:
+
 ```bash
 tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT
-
 cat <<'BODY_EOF' > "$tmpfile"
 {generated_body}
 BODY_EOF
-
-if [ ! -s "$tmpfile" ]; then
-  echo "ERROR: Issue 本文の生成に失敗" >&2
-  exit 1
-fi
+[ -s "$tmpfile" ] || { echo "ERROR: Issue 本文の生成に失敗" >&2; exit 1; }
 
 result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
   --arg title "{task_name}（#{original_issue_number} 残作業）" \
@@ -626,162 +215,31 @@ result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
   --argjson project_number {project_number} \
   --arg owner "{owner}" \
   --arg priority "Medium" \
-  --arg complexity "{complexity}" \
   --arg iter_mode "none" \
-  '{
-    issue: { title: $title, body_file: $body_file, labels: $labels },
-    projects: {
-      enabled: $projects_enabled,
-      project_number: $project_number,
-      owner: $owner,
-      status: "Todo",
-      priority: $priority,
-      complexity: $complexity,
-      iteration: { mode: $iter_mode }
-    },
-    options: { source: "cleanup", non_blocking_projects: true }
-  }'
-)")
-
-if [ -z "$result" ]; then
-  echo "ERROR: create-issue-with-projects.sh returned empty result" >&2
-  exit 1
-fi
-issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
-issue_number=$(printf '%s' "$result" | jq -r '.issue_number')
-project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
-printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+  '{ issue: { title: $title, body_file: $body_file, labels: $labels },
+     projects: { enabled: $projects_enabled, project_number: $project_number, owner: $owner, status: "Todo", priority: $priority, iteration: { mode: $iter_mode } },
+     options: { source: "cleanup", non_blocking_projects: true } }')")
+[ -n "$result" ] || { echo "ERROR: create-issue-with-projects.sh returned empty result" >&2; exit 1; }
+printf '%s' "$result" | jq -r '"作成: #\(.issue_number) \(.issue_url)"'
+printf '%s' "$result" | jq -r '.warnings[]?' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
 ```
 
-**Placeholder descriptions:**
-- `{task_name}` / `{generated_body}`: Task name (work memory) / body generated in 1.7.3.1
-- `{original_issue_number}` / `{complexity}`: Phase 1.5 / Phase 1.7.1 values
-
-If Issue creation or field configuration fails, warnings surface from the script result; Projects registration is non-blocking so the Issue is still created. When `github.projects.enabled` is `false` or unset in `rite-config.yml`, skip 1.7.3.2.1 entirely and display:
+`github.projects.enabled` が false / 未設定なら Projects 登録はスキップされる（Issue 作成自体は継続）。全タスク作成後、結果を集計して Phase 2 へ:
 
 ```
-警告: GitHub Projects が設定されていません
-Projects への追加をスキップします
-```
-
-#### 1.7.3.3 Record Creation Results
-
-Record the information of the created Issue:
-
-```
-Issue を作成しました:
+未完了タスクを Issue 化しました:
 - #{new_issue_number} - {task_name}
-```
-
-### 1.7.4 Update Work Memory
-
-After all task processing is complete, update the work memory:
-
-```bash
-# Step 1: チェックボックス更新（完了済みだがチェック漏れのタスク）
-bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
-  --issue {issue_number} \
-  --transform update-checkboxes \
-  --tasks "{completed_unchecked_task_names_comma_separated}" \
-  2>/dev/null || true
-
-# Step 2: 未完了タスク処理結果を追記
-task_result_tmp=$(mktemp)
-trap 'rm -f "$task_result_tmp"' EXIT
-cat > "$task_result_tmp" << 'RESULT_EOF'
-{1.7.4 の内容を実際の値で置換して記述}
-RESULT_EOF
-
-bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
-  --issue {issue_number} \
-  --transform append-section \
-  --section "未完了タスクの処理結果" --content-file "$task_result_tmp" \
-  2>/dev/null || true
-
-rm -f "$task_result_tmp"
-```
-
-**Note for Claude**: `{completed_unchecked_task_names_comma_separated}` を完了済みタスク名のカンマ区切りで置換 (例: `"タスクA,タスクB"`)。`{1.7.4 の内容を実際の値で置換して記述}` は下記「Update content」テンプレートから生成した追記内容で置換する。
-
-**Update content** (preserve existing work memory and append):
-
-1. **Progress section**: 既存チェックリストを保持し末尾に `- [x] 未完了タスク処理済み` を追加
-2. **Fix unchecked items**: "completed (unchecked)" タスクの `- [ ]` を `- [x]` に置換 (タスク名 + 行内容の exact match で識別。同名タスク重複時は登場順 top-to-bottom で識別、例: `- [ ] テスト追加` と `- [ ] テスト追加（API）` は別タスク扱い)
-3. **New section**: 末尾に `### 未完了タスクの処理結果` を追加
-
-```markdown
-### 進捗
-- [x] 実装完了
-- [x] PR マージ済み
-- [x] バリデーション追加    ← チェック漏れ修正
-- [x] 未完了タスク処理済み  ← 新規追加
-
-### 未完了タスクの処理結果
-| タスク | 処理 | 結果 |
-|-------|------|------|
-| テスト追加 | Issue 化 | → #101 |
-| デバッグログ削除 | Issue 化 | → #102 |
-| バリデーション追加 | チェック完了 | 差分で確認済み |
-```
-
-**Result 列のフォーマット**: Issue 化 → `→ #{new_issue_number}`、チェック完了 → `差分で確認済み`、無視 → `スキップ`。既存進捗セクションの他チェックリスト項目は保持される (削除されない)。
-
-### 1.7.5 Transition to Phase 2
-
-Phase 1.7.3 処理完了時点で集計し、ユーザーに transition 確認を表示してから Phase 2 (cleanup execution) に進む:
-
-- `{issue_count}`: Issue 化件数
-- `{ignored_count}`: 無視件数
-- `{checked_count}`: 完了済み (チェック漏れ) 件数
-
-```
-未完了タスクの処理が完了しました:
-- Issue 化: {issue_count} 件
-- チェック完了: {checked_count} 件
-- 無視: {ignored_count} 件
-
-クリーンアップを続行します。
 ```
 
 ---
 
 ## Phase 2: Cleanup Execution
 
-**Sub-phases** (execute ALL in order — do NOT skip any):
-
-```
-2.1 Switch to Default Branch
-2.2 Pull Latest Default Branch
-2.3 Delete Local Branch
-2.4 Check and Delete Remote Branch
-2.5 Delete Review Result Local Files and Fix State Files (#443, #450)
-2.6 Wiki Worktree Lifecycle (no-op — kept persistent)
-2.7 PR Review-Fix Cycle Branch Cleanup
-```
+サブフェーズを順に全て実行する（スキップ禁止）。
 
 ### 2.1 Switch to Default Branch
 
-If currently on a branch other than the default branch:
-
-```bash
-git checkout {base_branch}
-```
-
-**If there are uncommitted changes:**
-
-```
-警告: 未コミットの変更があります
-
-オプション:
-- 変更をスタッシュしてクリーンアップ続行
-- キャンセル
-```
-
-If stash is selected:
-
-```bash
-git stash push -m "rite-cleanup: auto-stash before cleanup"
-```
+base branch 以外にいる場合 `git checkout {base_branch}`。未コミット変更があれば「stash して続行 / キャンセル」を確認する（stash 選択時 `git stash push -m "rite-cleanup: auto-stash before cleanup"`）。
 
 ### 2.2 Pull Latest Default Branch
 
@@ -789,18 +247,7 @@ git stash push -m "rite-cleanup: auto-stash before cleanup"
 git pull origin {base_branch}
 ```
 
-**If a conflict occurs:**
-
-```
-エラー: デフォルトブランチの更新中にコンフリクトが発生しました
-
-対処:
-1. `git status` で状態を確認
-2. コンフリクトを解決
-3. 再度クリーンアップを実行
-```
-
-Terminate processing.
+コンフリクト時は `git status` で確認・解決後の再実行を案内し terminate。
 
 ### 2.3 Delete Local Branch
 
@@ -808,284 +255,88 @@ Terminate processing.
 git branch -d {branch_name}
 ```
 
-**If deletion fails (unmerged changes exist):**
-
-```
-警告: ブランチ {branch_name} には未マージの変更があります
-
-オプション:
-- 強制削除（-D オプション）
-- スキップ
-```
-
-If force delete is selected:
-
-```bash
-git branch -D {branch_name}
-```
+未マージ変更で失敗したら「強制削除（`-D`）/ スキップ」を確認する。
 
 ### 2.4 Check and Delete Remote Branch
-
-Check if the remote branch exists:
 
 ```bash
 git ls-remote --heads origin {branch_name}
 ```
 
-**If the remote branch exists:**
+存在すれば `git push origin --delete {branch_name}`（GitHub auto-delete で既に削除済みの場合のエラーは無視して次へ）。
+
+### 2.5 Delete PR-Specific Local State Files <!-- AC-7 -->
+
+> **Acceptance Criteria anchor (AC-7)**: マージ済み PR に紐づく PR-specific local artifact を削除する。削除対象と failure reason の単一の真実の源（[review-result-schema.md](../../references/review-result-schema.md#クリーンアップ) と双方向リンク）。**他 PR のファイルを誤削除しないため、glob は `{pr_number}-` prefix 固定、state file は specific path 完全一致**。
+
+削除対象（評価順）:
+1. レビュー結果: `.rite/review-results/{pr_number}-*.json`
+2. 破損レビュー結果: `.rite/review-results/{pr_number}-*.json.corrupt-*`（fix.md Priority 2 が rename した orphan の回収）
+3. fix retry state: `.rite/state/fix-fallback-retry-{pr_number}.count`
+4. fix-cycle state: `.rite/fix-cycle-state/{pr_number}.json`
+5. legacy fix-cycle state: `.rite/fix-cycle-state.json`（workspace 直下の単一ファイル形式の残骸）
+6. accepted fingerprints: `.rite/state/accepted-fingerprints-{pr_number}.txt`
+
+ファイル不在は silent continue（idempotent）。`rm` 失敗は WARNING + `[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1`（Phase 5.1 が表示に使用）。
 
 ```bash
-git push origin --delete {branch_name}
-```
-
-**Note**: GitHub の auto-delete 設定で既に削除済みの場合、削除エラーは無視して Phase 2.5 へ進む。
-
-### 2.5 Delete Review Result Local Files and Fix State Files <!-- AC-7 -->
-
-> **Acceptance Criteria anchor (AC-7)**: PR マージ時に 6 カテゴリの PR-specific local artifacts を削除する: (1) `.rite/review-results/{pr_number}-*.json` wildcard 固定 prefix、(2) `.rite/review-results/{pr_number}-*.json.corrupt-*` corrupt rename ファイル、(3) `.rite/state/fix-fallback-retry-{pr_number}.count` specific path、(4) `.rite/fix-cycle-state/{pr_number}.json` specific path、(5) `.rite/fix-cycle-state.json` legacy 単一ファイル specific path、(6) `.rite/state/accepted-fingerprints-{pr_number}.txt` specific path (Issue #1019 M5 で導入された accept 永続化ファイル、`{pr_number}` suffix で PR ごとに分離)。他 PR ファイルを誤削除しない。
-
-Delete six categories of PR-specific local artifacts associated with the merged PR:
-
-1. **Review result files**: `.rite/review-results/{pr_number}-*.json` — see [review-result-schema.md](../../references/review-result-schema.md#クリーンアップ) for the contract
-2. **Corrupted review result files**: `.rite/review-results/{pr_number}-*.json.corrupt-*` — `.gitignore` 対象 orphan を防ぐため fix.md Phase 1.2.0 Priority 2 の corrupt rename を回収
-3. **Fix retry state file**: `.rite/state/fix-fallback-retry-{pr_number}.count`
-4. **Fix-cycle state file**: `.rite/fix-cycle-state/{pr_number}.json` — specific path 完全一致 (wildcard 禁止、収束エンジンが fix サイクルごとに記録する状態ファイル)
-5. **Legacy fix-cycle state file**: `.rite/fix-cycle-state.json` — workspace 直下に生成された単一ファイル形式の残骸。specific path 完全一致 (wildcard 禁止)、`.gitignore` エントリと併置で defense-in-depth
-6. **Accepted fingerprints state file**: `.rite/state/accepted-fingerprints-{pr_number}.txt` — fix.md Phase 2.1.A (Issue #1019 M5) で `accept (認知のみ)` 選択時に fingerprint を永続化したファイル。`{pr_number}` suffix で PR ごとに完全分離されているため specific path 完全一致 (wildcard 禁止) で削除する。PR merge 後は再 surface 不要 (revocability も PR-scope)
-
-**Safety constraints**:
-
-- **PR 番号 prefix 固定**: wildcard は `{pr_number}-` で始まるパターンのみ。`*.json` 単独や `.rite/review-results/*`、`.rite/state/*` など他 PR のファイルを巻き込む形式は禁止。state file は specific path 完全一致で削除する
-- **Non-blocking**: ファイル不在は silent continue。`rm` 失敗 (permission denied / IO error) は WARNING + `[CONTEXT]` で可視化する (silent 抑制しない)。canonical 定義: [common-error-handling.md](../../references/common-error-handling.md#non-blocking-contract-canonical-定義)
-- **Idempotent**: 削除済み / 不在は WARNING / ERROR なしで続行 (`ℹ️  削除対象のレビュー結果ファイルはありません` info は dir 存在 + マッチ 0 件経路で出力)
-
-> **scope note**: 本 bash block は単一 Bash tool invocation 内で閉じる前提で trap は block 外に伝播しない。block 末尾の trap restore は不要。
-
-```bash
-# 5 ブロック (matched_files / state_file / cycle_state / legacy_cycle_state / accepted_fingerprints)
-# ごとに独立した stderr 退避 tempfile を持たせ、非対称再利用による詳細ログ喪失を防ぐ。
-matched_files_rm_err=""
-state_file_rm_err=""
-cycle_state_rm_err=""
-legacy_cycle_state_rm_err=""
-accepted_fingerprints_rm_err=""
-_rite_cleanup_p25_cleanup() {
-  rm -f "${matched_files_rm_err:-}" "${state_file_rm_err:-}" "${cycle_state_rm_err:-}" "${legacy_cycle_state_rm_err:-}" "${accepted_fingerprints_rm_err:-}"
-}
-trap 'rc=$?; _rite_cleanup_p25_cleanup; exit $rc' EXIT
-trap '_rite_cleanup_p25_cleanup; exit 130' INT
-trap '_rite_cleanup_p25_cleanup; exit 143' TERM
-trap '_rite_cleanup_p25_cleanup; exit 129' HUP
-
 pr_number="{pr_number}"
-
-# 空 or 非数値の pr_number は glob path が変性して他 PR を誤削除しうる経路があるため
-# 早期検証して non-blocking で exit する (silent misclassification 防止)。
+# 空 / 非数値は glob が変性し他 PR を誤削除しうるため早期に non-blocking exit する。
 case "$pr_number" in
   ''|*[!0-9]*)
-    echo "ERROR: Phase 2.5 invoked with invalid pr_number: '$pr_number' (expected: numeric only, non-empty)" >&2
-    echo "  対処: 呼び出し元 (cleanup.md Phase 1 で抽出される pr_number) を確認してください" >&2
+    echo "ERROR: Phase 2.5 invalid pr_number: '$pr_number' (numeric only, non-empty)" >&2
     echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=invalid_pr_number" >&2
-    exit 0  # non-blocking (cleanup 全体を失敗させない)
-    ;;
+    exit 0 ;;
 esac
 
-review_results_dir=".rite/review-results"
-if [ -d "$review_results_dir" ]; then
-  # bash glob は no-match でリテラル文字列を返すため明示的 nullglob 相当の処理。
-  # 通常 `*.json` + fix.md Priority 2 が rename した `*.json.corrupt-*` を pr_number prefix
-  # に限定して削除対象に含める。broken symlink も対象 ([ -e ] + [ -L ] 併用)。
-  # Known limitation: glob → rm 間に TOCTOU window があるが pr_number prefix 固定 +
-  # single-session 運用のため実害リスクは極小 (件数メッセージ不正確化のみ)。
-  matched_files=()
-  for f in "$review_results_dir"/"${pr_number}"-*.json; do
-    { [ -e "$f" ] || [ -L "$f" ]; } && matched_files+=("$f")
-  done
-  for f in "$review_results_dir"/"${pr_number}"-*.json.corrupt-*; do
-    { [ -e "$f" ] || [ -L "$f" ]; } && matched_files+=("$f")
-  done
-  if [ ${#matched_files[@]} -gt 0 ]; then
-    # rm の stderr を独立 tempfile に退避し失敗時に可視化する (silent failure 禁止)。
-    # mktemp 構文は Phase 2.5 内 5 ブロック (matched_files / state_file / cycle_state /
-    # legacy_cycle_state / accepted_fingerprints) で `mktemp ... 2>/dev/null) || { ... }` 形式に統一。
-    matched_files_rm_err=$(mktemp /tmp/rite-cleanup-matched-rm-err-XXXXXX 2>/dev/null) || {
-      echo "WARNING: matched_files rm stderr 退避用 tempfile の mktemp に失敗しました。rm の stderr 詳細は失われます" >&2
-      echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=mktemp_failure_rm_err; pr=${pr_number}" >&2
-      echo "  対処: /tmp の inode 枯渇 / read-only filesystem / permission 拒否のいずれかを確認してください" >&2
-      matched_files_rm_err=""
-    }
-    if rm -f "${matched_files[@]}" 2>"${matched_files_rm_err:-/dev/null}"; then
-      echo "✅ レビュー結果ファイルを削除しました: ${#matched_files[@]} 件 (PR #${pr_number})" >&2
+# glob 無マッチ時は bash がリテラル文字列を返すため、ループ内の存在チェックで弾く（nullglob 不要）。
+# broken symlink も対象に含める（-e || -L）。
+rite_rm() {
+  local label="$1"; shift
+  local f
+  for f in "$@"; do
+    { [ -e "$f" ] || [ -L "$f" ]; } || continue
+    if rm -f "$f"; then
+      echo "✅ ${label} を削除: $f" >&2
     else
-      rm_rc=$?
-      echo "WARNING: 一部のレビュー結果ファイル削除に失敗 (PR #${pr_number}, rc=$rm_rc)" >&2
-      if [ -n "$matched_files_rm_err" ] && [ -s "$matched_files_rm_err" ]; then
-        head -5 "$matched_files_rm_err" | sed 's/^/  /' >&2
-      fi
-      echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=rm_failure; pr=${pr_number}" >&2
-      echo "  対処: permission denied / read-only filesystem / disk I/O エラーのいずれかを確認してください" >&2
+      echo "WARNING: ${label} 削除失敗 (PR #${pr_number}): $f" >&2
+      echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=${label}_rm_failure; pr=${pr_number}" >&2
+      echo "  対処: permission denied / read-only filesystem / disk I/O のいずれかを確認してください" >&2
     fi
-  else
-    echo "ℹ️  削除対象のレビュー結果ファイルはありません (PR #${pr_number})" >&2
-  fi
-else
-  # Directory absent → nothing to clean up; silent no-op
-  :
-fi
-
-# fix retry state file 削除。specific path 完全一致 (wildcard 禁止)。
-# fix.md Phase 1.2.0.1 Interactive Fallback の retry hard gate state file は PR merge 後不要。
-# 独立 stderr 退避 tempfile で matched_files 側と変数分離 (二重障害時の混線防止)。
-state_file=".rite/state/fix-fallback-retry-${pr_number}.count"
-state_file_rm_err=$(mktemp /tmp/rite-cleanup-state-rm-err-XXXXXX 2>/dev/null) || {
-  echo "WARNING: state file rm stderr 退避用 tempfile の mktemp に失敗しました。rm の stderr 詳細は失われます" >&2
-  echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=mktemp_failure_rm_err_state_file; pr=${pr_number}" >&2
-  echo "  対処: /tmp の inode 枯渇 / read-only filesystem / permission 拒否のいずれかを確認してください" >&2
-  state_file_rm_err=""
+  done
 }
-# state file の存在を事前チェックし、実削除と no-op でメッセージを分岐する
-state_file_existed=0
-[ -f "$state_file" ] && state_file_existed=1
-if rm -f "$state_file" 2>"${state_file_rm_err:-/dev/null}"; then
-  if [ "$state_file_existed" = "1" ]; then
-    echo "✅ fix retry state file を削除しました: $state_file" >&2
-  fi
-else
-  rm_state_rc=$?
-  echo "WARNING: fix retry state file の削除に失敗 (PR #${pr_number}, rc=$rm_state_rc): $state_file" >&2
-  if [ -n "$state_file_rm_err" ] && [ -s "$state_file_rm_err" ]; then
-    head -5 "$state_file_rm_err" | sed 's/^/  /' >&2
-  fi
-  echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=state_file_rm_failure; pr=${pr_number}" >&2
-  echo "  対処: permission denied / read-only filesystem / disk I/O エラーのいずれかを確認してください" >&2
-fi
 
-# fix-cycle state file 削除。specific path 完全一致 (wildcard 禁止)。
-# 既存の state_file 削除パターン (stderr tempfile + 詳細ログ) に対称化した error handling。
-cycle_state_file=".rite/fix-cycle-state/${pr_number}.json"
-cycle_state_rm_err=""
-if [ -f "$cycle_state_file" ]; then
-  cycle_state_rm_err=$(mktemp /tmp/rite-cleanup-cycle-state-rm-err-XXXXXX 2>/dev/null) || {
-    echo "WARNING: cycle state file rm stderr 退避用 tempfile の mktemp に失敗しました。rm の stderr 詳細は失われます" >&2
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=mktemp_failure_rm_err_cycle_state; pr=${pr_number}" >&2
-    cycle_state_rm_err=""
-  }
-  if rm -f "$cycle_state_file" 2>"${cycle_state_rm_err:-/dev/null}"; then
-    echo "✅ fix-cycle state file を削除しました: $cycle_state_file" >&2
-  else
-    rm_cycle_rc=$?
-    echo "WARNING: fix-cycle state file の削除に失敗 (PR #${pr_number}, rc=$rm_cycle_rc): $cycle_state_file" >&2
-    if [ -n "$cycle_state_rm_err" ] && [ -s "$cycle_state_rm_err" ]; then
-      head -5 "$cycle_state_rm_err" | sed 's/^/  /' >&2
-    fi
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=cycle_state_file_rm_failure; pr=${pr_number}" >&2
-    echo "  対処: permission denied / read-only filesystem / disk I/O エラーのいずれかを確認してください" >&2
-  fi
-  [ -n "$cycle_state_rm_err" ] && rm -f "$cycle_state_rm_err"
-fi
-
-# legacy fix-cycle state file 削除。specific path 完全一致 (PR 番号非依存・wildcard 禁止)。
-# workspace 直下に生成された単一ファイル形式の残骸を除去する。ファイル不在時は silent no-op、
-# 既存 cycle_state_file 削除パターンと対称化した error handling (mktemp + stderr 退避 + non-blocking)。
-legacy_cycle_state_file=".rite/fix-cycle-state.json"
-if [ -f "$legacy_cycle_state_file" ]; then
-  # incident response 用に mtime を捕捉してログ出力 (生成元トレース手段)。
-  # GNU stat (Linux) / BSD stat (macOS) 両対応、失敗時は "unknown" を non-blocking で出力。
-  legacy_cycle_mtime=$(stat -c '%y' "$legacy_cycle_state_file" 2>/dev/null \
-    || stat -f '%Sm' "$legacy_cycle_state_file" 2>/dev/null \
-    || echo "unknown")
-  echo "ℹ️  legacy fix-cycle state file の mtime: $legacy_cycle_mtime ($legacy_cycle_state_file)" >&2
-  echo "[CONTEXT] LEGACY_CYCLE_STATE_MTIME=$legacy_cycle_mtime; pr=${pr_number}" >&2
-  legacy_cycle_state_rm_err=$(mktemp /tmp/rite-cleanup-legacy-cycle-rm-err-XXXXXX 2>/dev/null) || {
-    echo "WARNING: legacy cycle state file rm stderr 退避用 tempfile の mktemp に失敗しました。rm の stderr 詳細は失われます" >&2
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=mktemp_failure_rm_err_legacy_cycle; pr=${pr_number}" >&2
-    legacy_cycle_state_rm_err=""
-  }
-  if rm -f "$legacy_cycle_state_file" 2>"${legacy_cycle_state_rm_err:-/dev/null}"; then
-    echo "✅ legacy fix-cycle state file を削除しました: $legacy_cycle_state_file" >&2
-  else
-    rm_legacy_rc=$?
-    echo "WARNING: legacy fix-cycle state file の削除に失敗 (PR #${pr_number}, rc=$rm_legacy_rc): $legacy_cycle_state_file" >&2
-    if [ -n "$legacy_cycle_state_rm_err" ] && [ -s "$legacy_cycle_state_rm_err" ]; then
-      head -5 "$legacy_cycle_state_rm_err" | sed 's/^/  /' >&2
-    fi
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=legacy_cycle_state_file_rm_failure; pr=${pr_number}" >&2
-    echo "  対処: permission denied / read-only filesystem / disk I/O エラーのいずれかを確認してください" >&2
-  fi
-  [ -n "$legacy_cycle_state_rm_err" ] && rm -f "$legacy_cycle_state_rm_err"
-fi
-
-# accepted-fingerprints state file 削除。specific path 完全一致 (wildcard 禁止)。
-# fix.md Phase 2.1.A (Issue #1019 M5) で `accept (認知のみ)` 選択時に fingerprint を永続化したファイル。
-# `{pr_number}` suffix で PR ごとに完全分離されているため specific path で削除する。
-# 既存 matched_files / state_file 削除パターン (stderr tempfile + 詳細ログ、block 末尾の inline rm 省略を含む)
-# と対称化した error handling。stderr tempfile の cleanup は centralized `_rite_cleanup_p25_cleanup`
-# 関数が EXIT trap 経由で回収する。
-accepted_fingerprints_file=".rite/state/accepted-fingerprints-${pr_number}.txt"
-if [ -f "$accepted_fingerprints_file" ]; then
-  accepted_fingerprints_rm_err=$(mktemp /tmp/rite-cleanup-accepted-fp-rm-err-XXXXXX 2>/dev/null) || {
-    echo "WARNING: accepted-fingerprints rm stderr 退避用 tempfile の mktemp に失敗しました。rm の stderr 詳細は失われます" >&2
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=mktemp_failure_rm_err_accepted_fingerprints; pr=${pr_number}" >&2
-    echo "  対処: /tmp の inode 枯渇 / read-only filesystem / permission 拒否のいずれかを確認してください" >&2
-    accepted_fingerprints_rm_err=""
-  }
-  if rm -f "$accepted_fingerprints_file" 2>"${accepted_fingerprints_rm_err:-/dev/null}"; then
-    echo "✅ accepted-fingerprints state file を削除しました: $accepted_fingerprints_file" >&2
-  else
-    rm_accepted_rc=$?
-    echo "WARNING: accepted-fingerprints state file の削除に失敗 (PR #${pr_number}, rc=$rm_accepted_rc): $accepted_fingerprints_file" >&2
-    if [ -n "$accepted_fingerprints_rm_err" ] && [ -s "$accepted_fingerprints_rm_err" ]; then
-      head -5 "$accepted_fingerprints_rm_err" | sed 's/^/  /' >&2
-    fi
-    echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=accepted_fingerprints_rm_failure; pr=${pr_number}" >&2
-    echo "  対処: permission denied / read-only filesystem / disk I/O エラーのいずれかを確認してください" >&2
-  fi
-fi
-
-# cleanup 関数が EXIT で stderr tempfile 5 種を削除する。block 末尾で cleanup を先に実行し
-# その後 trap reset することで block 外への伝播を遮断する (順序: 解除→cleanup だと解除〜
-# cleanup 間のシグナルで未実行になる、defense-in-depth)。
-_rite_cleanup_p25_cleanup
-trap - EXIT INT TERM HUP
+rite_rm review_results \
+  .rite/review-results/${pr_number}-*.json \
+  .rite/review-results/${pr_number}-*.json.corrupt-*
+rite_rm fix_retry_state ".rite/state/fix-fallback-retry-${pr_number}.count"
+rite_rm fix_cycle_state ".rite/fix-cycle-state/${pr_number}.json"
+rite_rm legacy_fix_cycle_state ".rite/fix-cycle-state.json"
+rite_rm accepted_fingerprints ".rite/state/accepted-fingerprints-${pr_number}.txt"
 ```
 
-**Placeholder**: `{pr_number}` はマージされた PR の番号 (Phase 1.2 で取得済み)。
+### 2.6 Wiki Worktree Lifecycle (削除しない)
 
-### 2.6 Wiki Worktree Lifecycle (設計原則 — 削除しない)
-
-`.rite/wiki-worktree/` は **永続化された worktree** であり、`/rite:pr:cleanup` では削除しません。理由:
-
-- `wiki-worktree-setup.sh` は冪等で既存 worktree は no-op になるが再作成コスト (clone 相当の I/O) が高い
-- 各 PR cycle で `wiki-ingest-trigger.sh` → `wiki-ingest-commit.sh` (review/fix/close Phase X.X.W.2) および `wiki-worktree-commit.sh` (ingest.md Phase 5.1 page 統合 / init.md Phase 3.5.1 .gitkeep migration / lint.md Phase 8.3 log.md 追記) がここを経由して wiki branch に raw source / page を landing させるため cycle を跨いで保持される必要がある
-- `git branch -d` は worktree が checkout している branch を削除できないため、wiki branch 自体への副作用もない
-
-**手動削除が必要な場合** (リポジトリ移動 / 構造変更 / debug):
+`.rite/wiki-worktree/` は永続 worktree であり cleanup では削除しない（再作成コストが高く、各 PR cycle の wiki ingest がここを経由して wiki branch に landing するため cycle を跨いで保持する必要がある）。手動削除が必要な場合（リポジトリ移動 / debug）:
 
 ```bash
-# 1. worktree を解除（git の internal 管理から外す）
-git worktree remove .rite/wiki-worktree
-# 2. dangling な worktree metadata を整理
+git worktree remove .rite/wiki-worktree   # modified/untracked files があれば --force
 git worktree prune
 ```
 
-`git worktree remove` が `worktree contains modified or untracked files` で失敗する場合、`--force` を付けるか、worktree 内で先に commit / push を完了させてから再試行してください。
-
 ### 2.7 PR Review-Fix Cycle Branch Cleanup
 
-Reviewer subagents create transient inspection worktrees via `git worktree add` (allowed under READ-ONLY enforcement). When the worktree path or `-b <name>` argument produces a `pr-{N}-cycle{X}` named branch and the worktree is removed without `git branch -D`, the branch leaks. Reviewers cannot self-clean (`git worktree remove` / `git branch -D` are prohibited per `agents/_reviewer-base.md`). Final PR cleanup is the last chance to drop these residuals before the next workflow starts.
-
-Cleanup uses a strict regex `^pr-[0-9]+-cycle[0-9]+$` and explicitly skips `.rite/wiki-worktree`. It is non-blocking — failure must not halt the cleanup workflow.
+Reviewer subagent が作る `pr-{N}-cycle{X}` 命名の transient ブランチ残骸を回収する（reviewer は READ-ONLY 制約で自己クリーン不可）。strict regex `^pr-[0-9]+-cycle[0-9]+$` で照合し `.rite/wiki-worktree` は除外、non-blocking:
 
 ```bash
-# {plugin_root} はリテラル値で埋め込む (詳細は ../../references/plugin-path-resolution.md)
 bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
 ```
 
 ---
 
-## Phase 3: Projects Status Update
+## Phase 3: Projects Status Update / Issue Close / State Reset
 
-> See [references/archive-procedures.md](./references/archive-procedures.md) for the full archive procedures: Projects Status Update (3.1-3.2), Work Memory final update (3.5), Issue close (3.6), Parent Issue handling (3.6.4, 3.7), and State reset (Phase 4). Status update delegates to `projects-status-update.sh`.
+> See [references/archive-procedures.md](./references/archive-procedures.md) for the full procedures: Projects Status Update (3.1-3.2), Work Memory final update (3.5), Issue close (3.6), Parent Issue handling (3.6.4, 3.7), and State reset (Phase 4). Status update delegates to `projects-status-update.sh`. The LLM retains `projects_status_updated` in context for Phase 5.1 display.
 
 ---
 
@@ -1093,219 +344,96 @@ bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
 
 > **Reference**: [Wiki Ingest](../wiki/ingest.md) — `/rite:wiki:ingest` Skill API.
 >
-> This phase is the **page integration** counterpart: it invokes `/rite:wiki:ingest` (LLM-driven page integration) to process pending raw sources accumulated on the wiki branch during the PR lifecycle. Raw source **accumulation** is handled by `wiki-ingest-trigger.sh` + `wiki-ingest-commit.sh` in `review.md` Phase 6.5.W.2 / `fix.md` Phase 4.6.W.2 / `close.md` Phase 4.4.W.2.
+> PR lifecycle 中に wiki branch へ蓄積された pending raw source を page へ統合する。Raw source の **蓄積** は review/fix/close の Phase X.X.W が担当し、本 Phase は **統合 (ingest)** を担う唯一の自動経路。
 >
-> **Loss-safe guarantee**: Ingest failure does NOT fail cleanup. Raw sources remain on the wiki branch and can be processed by a subsequent `/rite:wiki:ingest` invocation.
+> **Loss-safe**: ingest 失敗は cleanup を失敗させない。raw source は wiki branch に残り、後続の `/rite:wiki:ingest` で処理できる。`/rite:wiki:ingest` invoke 後に turn が止まっても flow-state は `phase=cleanup, active=true` のままなので `/rite:resume` で復帰する。
 
 ### 4.W.1 Pre-condition Check
 
-**Step 1**: Check Wiki configuration:
+`wiki.enabled`（opt-out, default true）/ `wiki.auto_ingest`（default false）と pending raw source を確認する。skip 時は sentinel を emit する（completion report がこのシグナルに依存するため silent skip しない）:
 
 ```bash
 wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || wiki_section=""
-wiki_enabled=""
-if [[ -n "$wiki_section" ]]; then
-  wiki_enabled=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+enabled:/ { print; exit }' \
-    | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
-fi
-auto_ingest=""
-if [[ -n "$wiki_section" ]]; then
-  auto_ingest=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+auto_ingest:/ { print; exit }' \
-    | sed 's/[[:space:]]#.*//' | sed 's/.*auto_ingest:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
-fi
-case "$wiki_enabled" in false|no|0) wiki_enabled="false" ;; true|yes|1) wiki_enabled="true" ;; *) wiki_enabled="true" ;; esac  # opt-out default
+parse_wiki_key() {
+  printf '%s\n' "$wiki_section" | awk -v k="$1" '$0 ~ "^[[:space:]]+" k ":" { print; exit }' \
+    | sed 's/[[:space:]]#.*//' | sed "s/.*$1:[[:space:]]*//" | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]'
+}
+wiki_enabled=$(parse_wiki_key enabled)
+auto_ingest=$(parse_wiki_key auto_ingest)
+case "$wiki_enabled" in false|no|0) wiki_enabled="false" ;; *) wiki_enabled="true" ;; esac
 case "$auto_ingest" in true|yes|1) auto_ingest="true" ;; *) auto_ingest="false" ;; esac
-echo "wiki_enabled=$wiki_enabled auto_ingest=$auto_ingest"
-```
 
-If `wiki_enabled=false` or `auto_ingest=false`, **emit a skip status line + sentinel and skip to Phase 5** (do not silently skip — the completion report relies on this signal):
+reason=""
+[ "$wiki_enabled" = "false" ] && reason="disabled"
+[ -z "$reason" ] && [ "$auto_ingest" = "false" ] && reason="auto_ingest_off"
 
-```bash
-if [ "$wiki_enabled" = "false" ]; then
-  reason="disabled"
-elif [ "$auto_ingest" = "false" ]; then
-  reason="auto_ingest_off"
-else
-  reason=""
+pending_count=0
+wiki_branch=$(parse_wiki_key branch_name); [ -z "$wiki_branch" ] && wiki_branch="wiki"
+if [ -z "$reason" ]; then
+  ref=""
+  git rev-parse --verify "$wiki_branch" >/dev/null 2>&1 && ref="$wiki_branch"
+  [ -z "$ref" ] && git rev-parse --verify "origin/$wiki_branch" >/dev/null 2>&1 && ref="origin/$wiki_branch"
+  if [ -n "$ref" ]; then
+    pending_count=$(git ls-tree -r --name-only "$ref" .rite/wiki/raw/ 2>/dev/null \
+      | while read -r f; do git show "$ref":"$f" 2>/dev/null | grep -q 'ingested: false' && echo "$f"; done | wc -l)
+  fi
+  [ "$pending_count" -eq 0 ] && reason="no_pending"
 fi
+
 if [ -n "$reason" ]; then
   echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=$reason"
-  echo "WARNING: cleanup Phase 4.W Wiki ingest skipped: $reason" >&2
+  echo "ℹ️ Wiki ingest をスキップします (reason: $reason)。Phase 5 へ進みます。"
 fi
+echo "wiki_ingest_reason=${reason:-<run>} pending_count=$pending_count wiki_branch=$wiki_branch"
 ```
 
-If `reason` is non-empty, skip Steps 2-3 and Phase 4.W.2-4.W.3 and proceed to Phase 5. Otherwise continue to Step 2.
-
-**Step 2**: Check for pending raw sources on the wiki branch:
-
-```bash
-wiki_branch=$(awk '/^wiki:/{h=1;next} h && /^[[:space:]]+branch_name:/{print;exit}' rite-config.yml 2>/dev/null \
-  | sed 's/[[:space:]]#.*//' | sed 's/.*branch_name:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
-[ -z "$wiki_branch" ] && wiki_branch="wiki"
-
-# Check if wiki branch exists (local or remote)
-# Use git ls-tree -r for flat file listing (avoids git show directory header/subdirectory issues)
-pending_count=0
-ref=""
-if git rev-parse --verify "$wiki_branch" >/dev/null 2>&1; then
-  ref="$wiki_branch"
-elif git rev-parse --verify "origin/$wiki_branch" >/dev/null 2>&1; then
-  ref="origin/$wiki_branch"
-fi
-
-if [ -n "$ref" ]; then
-  # git ls-tree -r --name-only lists all files recursively under .rite/wiki/raw/
-  # (e.g., .rite/wiki/raw/reviews/20260416T075144Z-pr-542.md)
-  pending_count=$(git ls-tree -r --name-only "$ref" .rite/wiki/raw/ 2>/dev/null \
-    | while read -r filepath; do
-        content=$(git show "$ref":"$filepath" 2>/dev/null)
-        if echo "$content" | grep -q 'ingested: false'; then
-          echo "$filepath"
-        fi
-      done | wc -l)
-fi
-echo "pending_count=$pending_count wiki_branch=$wiki_branch ref=$ref"
-```
-
-If `pending_count == 0`, **emit a skip sentinel and display message**, then proceed to Phase 5:
-
-```bash
-if [ "$pending_count" -eq 0 ]; then
-  echo "[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=no_pending"
-  echo "ℹ️ pending raw source はありません。Wiki ingest をスキップします。"
-fi
-```
-
-If `pending_count == 0`, skip Phase 4.W.2-4.W.3 and proceed to Phase 5. Otherwise continue to Phase 4.W.2.
+`reason` が非空なら 4.W.2 / 4.W.3 をスキップして Phase 5 へ。空（`<run>`）なら 4.W.2 へ。
 
 ### 4.W.2 Invoke Wiki Ingest
 
-**MUST**: `/rite:wiki:ingest` invoke は本 step の必須処理。**時間的制約・context 残量・セッション経過を理由にした skip は禁止** (LLM の自己判断省略は identity 違反)。skip が許される唯一の条件は Phase 4.W.1 で判定済みの機械的 Skip condition (`wiki.enabled=false` / `auto_ingest=false` / `pending_count == 0`)。
-
-> **Correct pattern**: Phase 4.W.1 で `pending_count >= 1` が確定したら例外なく下記 Skill invocation を実行する。継続困難な場合は `/clear` + `/rite:resume` をユーザーに案内する。
->
-> **Identity reference**: [workflow-identity.md](../../skills/rite-workflow/references/workflow-identity.md) の `no_step_omission` / `no_context_introspection` / `clear_resume_is_canonical` / `quality_over_expediency` principle を参照。
-
-**Pre-write** (before invoking `rite:wiki:ingest`): Re-affirm the flow state as `phase=cleanup, active=true` so the sub-skill return is tagged with the cleanup phase (v3 enum では `cleanup_pre_ingest` のような sub-phase 区別は phase 値では持たず、step 名で識別する)。The `if ! cmd; then` rc capture is mandatory — silent patch failure leaves the sub-skill flow untagged, so `/rite:resume` cannot correlate against the cleanup phase.
-
-```bash
-# --active true を明示する理由: Phase 1.0 patch が fail-safe path を経由した場合 active=false
-# 残存状態のまま到達する可能性があるため、各 patch で active=true を明示的に pin する。
-if ! bash {plugin_root}/hooks/flow-state.sh set \
-    --phase "cleanup" --active true \
-    --next "After rite:wiki:ingest returns: run 🚨 Mandatory After Wiki Ingest (re-patch phase=cleanup) → Phase 5 Completion Report (terminal: phase=cleanup, active=false + <!-- [cleanup:completed] --> as inline HTML sentinel at the trailing position of the final list item of Phase 5.2) in the SAME response turn. Do NOT stop." \
-    --if-exists; then
-  echo "WARNING: flow-state.sh set (Phase 4.W.2 Pre-write, phase=cleanup) failed — sub-skill will run unphased, so /rite:resume での phase=cleanup 復帰が効かなくなる可能性." >&2
-fi
-```
-
-Invoke the `/rite:wiki:ingest` Skill to process pending raw sources into Wiki pages:
+pending raw source があれば `/rite:wiki:ingest` を invoke する（機械的 Skip condition 以外での自己判断省略は禁止）:
 
 ```
 Skill: rite:wiki:ingest
 ```
 
-> **⚠️ Loss-safe continuation**: `/rite:wiki:ingest` は同セッション内で Skill ツール経由で invoke される。ingest.md の結果パターン（成功/失敗）を確認し、Phase 4.W.3 に進むこと。ingest 成否に関わらず cleanup は続行する。
-
-> **🚨 Immediate after rite:wiki:ingest returns**: When the sub-skill outputs `<!-- [ingest:completed] -->` and returns control, do **NOT** end the turn. The sub-skill return is a CONTINUATION TRIGGER (see [Correct continuation pattern](#correct-continuation-pattern) above). **Immediately** proceed to Phase 4.W.3 result handling, then to 🚨 Mandatory After Wiki Ingest below, in the **same response turn**.
+return 後は 4.W.3 へ進み、続いて 🚨 Mandatory After Wiki Ingest（Step 0 を VERY FIRST tool call として実行）を経て Phase 5 へ進む。ingest の成否に関わらず cleanup は続行する。
 
 ### 4.W.3 Result Handling
 
-**On success** (ingest completed):
+ingest Skill の出力を確認し、以下の sentinel を emit する（Phase 5.1 が表示判定に使用）:
 
-```
-✅ Wiki ingest 完了: {pages_created} ページ生成、{raw_processed} raw source 統合済み
-[CONTEXT] WIKI_INGEST_DONE=1; pr={pr_number}; type=cleanup_ingest
-```
+- **成功**: `[CONTEXT] WIKI_INGEST_DONE=1; pr={pr_number}` + `✅ Wiki ingest 完了: {pages_created} ページ生成、{raw_processed} raw source 統合済み`
+- **push 失敗併存**（ingest 出力に `push=failed` = `wiki-worktree-commit.sh` rc=4。commit は local wiki branch に landed、origin push のみ失敗）: 上記に加え `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; source=cleanup_4W`（loss-safe に継続）
+- **失敗**: `[CONTEXT] WIKI_INGEST_FAILED=1; reason=ingest_error` + `⚠️ Wiki ingest が失敗しました。raw source は wiki branch に保持されています。`
 
-**Push failure detection**: After the `rite:wiki:ingest` Skill returns, inspect its stdout for the marker `push=failed` (written by `wiki-worktree-commit.sh` when it returns rc=4 — the commit landed on local wiki branch but origin push failed). On detection, emit an observable sentinel so cleanup continues (loss-safe) and the incident layer registers the divergence.
+いずれの場合も次の 🚨 Mandatory After Wiki Ingest を経由して Phase 5 へ進む。
 
-**LLM detection and substitution rule**: Claude inspects the ingest Skill's output in the conversation context for a line matching `push=failed`. Typical positive match: `[wiki-worktree-commit] committed=1; branch=wiki; head=<sha>; push=failed`. Typical negatives: `push=ok`, `reason=no-pending`, or no `[wiki-worktree-commit]` status line (ingest skipped). Substitute `{wiki_push_failed}` with `"true"` (detected) or `"false"` (not detected) — Claude Code's Bash tool does not persist state across tool calls so shell env vars are not viable.
+### 🚨 Mandatory After Wiki Ingest
 
-```bash
-# Claude substitutes {wiki_push_failed} with "true" or "false" based on ingest output inspection.
-# {pr_number} is substituted with the PR number from Phase 1. {plugin_root} is substituted per
-# plugin-path-resolution.md.
-wiki_push_failed="{wiki_push_failed}"
-
-# Resolve wiki_branch from rite-config.yml (this bash block is a separate invocation from
-# Phase 4.W.1 Step 2, so the shell variable from that step is out of scope). Same parser as
-# Phase 4.W.1 Step 2.
-wiki_branch=$(awk '/^wiki:/{h=1;next} h && /^[[:space:]]+branch_name:/{print;exit}' rite-config.yml 2>/dev/null \
-  | sed 's/[[:space:]]#.*//' | sed 's/.*branch_name:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
-[ -z "$wiki_branch" ] && wiki_branch="wiki"
-
-if [ "$wiki_push_failed" = "true" ]; then
-  # cleanup 固有情報は source= key で併記。
-  echo "[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; reason=commit_rc_4; source=cleanup_4W"
-  echo "WARNING: wiki-worktree-commit.sh exited 4 (commit landed, push failed) during cleanup Phase 4.W" >&2
-  # ユーザー可視の push 失敗警告は Phase 5.1 Completion Report display rules に一元化済み。
-fi
-```
-
-**Non-blocking guarantee**: push failure does NOT fail cleanup; the commit is preserved on the local wiki branch. The next cleanup / manual push retry can recover the origin state.
-
-**On failure** (ingest error or partial failure):
-
-Emit failure sentinel and continue to Phase 5 (loss-safe continuation):
-
-```bash
-echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=ingest_error; phase=cleanup_4W"
-echo "WARNING: rite:wiki:ingest failed during cleanup Phase 4.W" >&2
-```
-
-```
-⚠️ Wiki ingest が失敗しました。raw source は wiki branch に保持されています。
-手動で `/rite:wiki:ingest` を実行してページ統合を再試行できます。
-```
-
-**Non-blocking guarantee**: Regardless of success or failure, proceed to Phase 5 (Completion Report).
-
-### 🚨 Mandatory After Wiki Ingest (Defense-in-Depth)
-
-> **⚠️ MUST execute in the SAME response turn**: `rite:wiki:ingest` の return 直後、応答を終了せずに Step 0 → Step 1 → Step 2 を即座に実行する。Phase 5 (Completion Report) は本セクション経由でのみ実行される唯一の経路。
+> **⚠️ MUST execute in the SAME response turn**: `rite:wiki:ingest` の return 直後、応答を終了せず Step 0 → Step 1 を実行し Phase 5 へ進む。Phase 5 はこの section 経由でのみ到達する唯一の経路。Stop hook も retrospective incident detector も無いため、implicit stop からの復帰は `/rite:resume`（flow-state に `phase=cleanup, active=true` が残る）。
 >
-> **Defense layers in effect**: (1) the prompt contract in this file telling the LLM not to stop; (2) caller HTML continuation hint emitted by `wiki/ingest.md` Phase 9.1. There is no Stop hook intercepting `end_turn`, no PostToolUse mechanical enforcement, and no retrospective incident detector; recovery from an implicit stop is by `/rite:resume`.
+> **⚠️ ring removal note**: この防御層は cleanup→`rite:wiki:ingest` sub-skill 境界の implicit-stop 回帰（Issue #910/#917）を防ぐ。`wiki/ingest.md` の continuation marker と対になっており、両者の廃止は ingest.md slim 化（PR 4）で一括して行う。
 
-**Self-check and branching**:
-
-1. **Has `<!-- [cleanup:completed] -->` been output (as inline HTML sentinel at the trailing position of Phase 5.2's final list item)?** Use `grep -F '[cleanup:completed]'` for terminal detection.
-   - **Yes** — terminal reached. flow state は既に terminal state (`phase=cleanup, active=false` — v3 enum) に到達。Step 0 / Step 1 below MUST be skipped (`flow-state.sh set --if-exists` は active=false でも patch するため、実行すると `--active true` で terminal state を上書きし flow state の terminal 性を破壊する)。
-   - **No** — Phase 5 has NOT been output yet。Steps 0-2 below are critical — execute immediately to force the workflow into the terminal state.
-
-**Step 0: Immediate Bash Action**: **MUST execute** this bash block as your **VERY FIRST tool call** after `rite:wiki:ingest` returns (Self-check No branch), **BEFORE any text output, narrative, or response generation**. text output を先に出すと LLM の turn-boundary heuristic が誤発火し implicit stop の経路が開く (Issue #910 で実証)。This replaces the natural turn-boundary point ("the sub-skill finished") with a concrete next tool call. The block re-affirms the flow-state phase (idempotent with Step 1) and, on failure only, emits `[CONTEXT] STEP_0_PATCH_FAILED=1` to stderr.
+**Step 0 (Immediate Bash Action)**: `rite:wiki:ingest` return 後の **VERY FIRST tool call** として、**BEFORE any text output**（narrative より先に）実行する。text を先に出すと LLM の turn-boundary heuristic が誤発火し implicit stop の経路が開く（Issue #910）。flow-state を `phase=cleanup` に書き戻す（ingest.md が一時的に `phase=ingest` へ上書きした ring を閉じる）:
 
 ```bash
-# --preserve-error-count: patch モードはデフォルトで .error_count = 0 にリセット
-#   する。現状 `.error_count` を読む production reader は存在せず half-legacy
-#   schema slot だが、Step 0/Step 1 の idempotent re-patch ペアで future reader
-#   再導入時の累積カウントを失わないよう preserve しておく。
-# --if-exists: flow state file 不在時は silent skip (defense-in-depth)。
-if ! bash {plugin_root}/hooks/flow-state.sh set \
-    --phase "cleanup" --active true \
-    --next "Step 0 Immediate Bash Action fired; proceeding to Phase 5 Completion Report. Do NOT stop." \
-    --if-exists \
-    --preserve-error-count; then
-  echo "[CONTEXT] STEP_0_PATCH_FAILED=1" >&2
-  # Step 1 が idempotent patch として再試行する non-blocking failure。
-fi
+bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --active true \
+  --next "Step 0 fired; proceeding to Phase 5 Completion Report. Do NOT stop." \
+  --if-exists --preserve-error-count \
+  || echo "[CONTEXT] STEP_0_PATCH_FAILED=1" >&2
 ```
 
-> **Rationale**: caller が implicit stop し `continue` 介入が必要となる症状の根本原因は、LLM が sub-skill return tag (`<!-- [ingest:completed] -->`) を turn 境界として誤認する turn-boundary heuristic の発火。Step 0 は **具体的な bash tool 呼び出し** を sub-skill return 直後の必須アクションとして挿入することで turn 境界シグナルを消去する。Step 0 / Step 1 は idempotent — この冗長性が防御機構である (片方が transient 失敗しても他方が正しい phase に書き込む)。
-
-**Step 1**: Update flow state to post-ingest re-patch (idempotent — v3 enum では引き続き `phase=cleanup` を維持し、Step 0 が既に書いた timestamp / `next_action` を refresh する)。2 重 patch design は transient failure 下でも Step 0 / Step 1 のいずれかが成功することを保証し、同時失敗時のみ `[CONTEXT] STEP_1_PATCH_FAILED=1` を retained flag として残す。`--preserve-error-count` は Step 0 と対称に付与 (`.error_count` は現状 half-legacy schema slot で production reader 不在だが、future reader 再導入時の累積カウントを失わないよう保持する):
+**Step 1 (idempotent re-patch)**: Step 0 が transient 失敗した場合の冗長 patch。Step 0 / Step 1 の二重化が防御機構（片方が失敗しても他方が正しい phase に書き込む）。同時失敗時のみ `[CONTEXT] STEP_1_PATCH_FAILED=1` を残す:
 
 ```bash
-if ! bash {plugin_root}/hooks/flow-state.sh set \
-    --phase "cleanup" --active true \
-    --next "rite:wiki:ingest completed/skipped/failed. Proceed to Phase 5 (Completion Report) and emit <!-- [cleanup:completed] --> as inline HTML sentinel at the trailing position of the final list item of Phase 5.2 in the SAME response turn. Do NOT stop." \
-    --if-exists \
-    --preserve-error-count; then
-  echo "[CONTEXT] STEP_1_PATCH_FAILED=1" >&2
-fi
+bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --active true \
+  --next "rite:wiki:ingest done. Emit Phase 5 (Completion Report) + <!-- [cleanup:completed] --> in the SAME response turn. Do NOT stop." \
+  --if-exists --preserve-error-count \
+  || echo "[CONTEXT] STEP_1_PATCH_FAILED=1" >&2
 ```
 
-**Step 2**: **→ Proceed to Phase 5 now**. Phase 5 outputs the user-visible completion message, the `<!-- [cleanup:completed] -->` HTML comment sentinel (inline at the trailing position of Phase 5.2's final list item), and the final flow-state deactivate (terminal state: `phase=cleanup`, `active: false` — v3 enum) in a single contiguous block. Recap lines like "※ wiki ingest 完了" are acceptable as **leading** content only — the final user-visible content MUST be the Phase 5.2 ordered list whose final item carries the inline HTML-commented sentinel (a recap as last line creates a turn-boundary heuristic trigger).
+**Step 2**: → Phase 5 へ進む。
 
 ---
 
@@ -1313,7 +441,7 @@ fi
 
 ### 5.1 Cleanup Result Summary
 
-> **出力形式 note**: 以下の fenced code block は **テンプレート記法**。LLM は実 output 時に fence なしでテキスト本文のみを展開し、プレースホルダー (`{pr_number}` / `{issue_number}` 等) は実値に置換する。fence そのものを rendered view に出力してはならない (Phase 5.2 と同趣旨の fence 禁止)。
+> 以下はテンプレート。実出力では fence なしで本文のみを展開し、プレースホルダー（`{pr_number}` 等）は実値に置換する。
 
 ```
 クリーンアップが完了しました
@@ -1327,168 +455,95 @@ Status: {projects_status_result}
 - [x] 最新のデフォルトブランチを pull
 - [x] ローカルブランチ {branch_name} を削除
 - [x] リモートブランチを削除
-- [{review_cleanup_check}] レビュー結果ファイル・fix state ファイルを削除
+- [{review_cleanup_check}] PR-specific state ファイルを削除
 - [x] flow state をリセット
 - [{projects_check}] Projects Status を Done に更新
 - [{wiki_ingest_check}] Wiki ingest（pending raw source のページ統合）
 - [x] 作業メモリを最終更新
 - [x] 関連 Issue をクローズ
-- [x] 親 Issue の Tasklist チェックボックスを更新（該当する場合）
-- [x] 親 Issue の自動クローズ（該当する場合）
-- [x] ローカル作業メモリを削除（該当する場合）
+- [x] 親 Issue の Tasklist 更新・自動クローズ（該当する場合）
 ```
 
-**Review cleanup result display rules:**
+**State ファイル削除の表示**:
 
 | `REVIEW_CLEANUP_PARTIAL_FAILURE` | `{review_cleanup_check}` |
-|----------------------------------|--------------------------|
-| not set (正常) | `x` |
-| `1` (部分失敗) | ` ` (space) + 下記の警告を表示 |
-
-When `REVIEW_CLEANUP_PARTIAL_FAILURE` is `1`, append the following after the checklist:
+|---|---|
+| 未設定（正常） | `x` |
+| `1`（部分失敗） | ` ` + 下記警告を付記 |
 
 ```
-⚠️ レビュー結果ファイルの削除が完了しませんでした (reason: {reason})。
-手動で確認してください: ls -la .rite/review-results/{pr_number}-* .rite/state/fix-fallback-retry-{pr_number}.count .rite/fix-cycle-state/{pr_number}.json .rite/fix-cycle-state.json .rite/state/accepted-fingerprints-{pr_number}.txt
+⚠️ 一部の PR-specific state ファイル削除が完了しませんでした (reason: {reason})。
+手動確認: ls -la .rite/review-results/{pr_number}-* .rite/state/fix-fallback-retry-{pr_number}.count .rite/fix-cycle-state/{pr_number}.json .rite/fix-cycle-state.json .rite/state/accepted-fingerprints-{pr_number}.txt
 ```
 
-**Projects Status update result display rules:**
+**Projects Status の表示**:
 
 | `projects_status_updated` | `{projects_status_result}` | `{projects_check}` |
-|---------------------------|---------------------------|---------------------|
+|---|---|---|
 | `true` | `Done` | `x` |
-| `false` | `⚠️ 更新失敗（手動確認が必要）` | ` ` (space) |
+| `false` | `⚠️ 更新失敗（手動確認が必要）` | ` ` |
 
-When `projects_status_updated` is `false`, append the following after the checklist:
+`false` の場合は「GitHub Projects 画面で Issue #{issue_number} の Status を Done に変更」を付記する。
 
-```
-⚠️ Projects Status の更新に失敗しました。手動で更新してください:
-GitHub Projects 画面で Issue #{issue_number} の Status を "Done" に変更
-```
+**Wiki ingest の表示**（上から順に評価し最初の一致を採用 — push 失敗は ingest 成功と併存しうるため優先）:
 
-**Wiki ingest result display rules:**
-
-| Sentinel | `{wiki_ingest_check}` | 表示内容 |
-|----------|----------------------|----------|
-| `WIKI_INGEST_DONE=1` 単独 | `x` | (追加表示なし) |
-| `WIKI_INGEST_DONE=1` + `WIKI_INGEST_PUSH_FAILED=1` 併存 | ` ` (space) | **PUSH_FAILED 優先**: 下記の push 失敗警告を表示 (commit は local wiki branch に保持、origin 側のみ divergence) |
-| `WIKI_INGEST_PUSH_FAILED=1` 単独 (DONE なし) | ` ` (space) | 下記の push 失敗警告を表示 |
+| Sentinel | `{wiki_ingest_check}` | 表示 |
+|---|---|---|
+| `WIKI_INGEST_DONE=1` + `WIKI_INGEST_PUSH_FAILED=1` | ` ` | push 失敗警告 |
+| `WIKI_INGEST_PUSH_FAILED=1` 単独 | ` ` | push 失敗警告 |
+| `WIKI_INGEST_DONE=1` 単独 | `x` | （追加なし） |
 | `WIKI_INGEST_SKIPPED=1; reason=disabled` | `x` | `ℹ️ Wiki ingest スキップ (wiki.enabled=false)` |
 | `WIKI_INGEST_SKIPPED=1; reason=auto_ingest_off` | `x` | `ℹ️ Wiki ingest スキップ (wiki.auto_ingest=false)` |
 | `WIKI_INGEST_SKIPPED=1; reason=no_pending` | `x` | `ℹ️ Wiki ingest スキップ (pending raw source なし)` |
-| `WIKI_INGEST_FAILED=1` | ` ` (space) | 下記の ingest 失敗警告を表示 |
-| sentinel なし (Phase 4.W 未実行) | ` ` (space) | `⚠️ Wiki ingest Phase が実行されませんでした` |
+| `WIKI_INGEST_FAILED=1` | ` ` | ingest 失敗警告 |
+| sentinel なし | ` ` | `⚠️ Wiki ingest Phase が実行されませんでした` |
 
-**Sentinel 評価優先順位**: 上記テーブルは上から順に評価し最初にマッチした行を採用する (push failure は ingest 成功 `WIKI_INGEST_DONE=1` と併存可能なため `WIKI_INGEST_PUSH_FAILED=1` 行を優先する)。`{wiki_branch}` は Phase 4.W.1 Step 2 と同じ parser で `rite-config.yml` の `wiki.branch_name` を解決する (未設定時 `wiki`)。
-
-`WIKI_INGEST_PUSH_FAILED` が検出された場合 (`WIKI_INGEST_DONE` との併存有無を問わず)、チェックリストの後に以下を付記する:
-
+push 失敗警告（`{wiki_branch}` は Phase 4.W.1 と同じ parser で解決）:
 ```
 ⚠️ Wiki ingest: commit は local wiki branch に landed しましたが origin への push に失敗しました。
   手動回復: git -C .rite/wiki-worktree push origin {wiki_branch}
 ```
-
-`WIKI_INGEST_FAILED` が検出された場合、チェックリストの後に以下を付記する:
-
+ingest 失敗警告:
 ```
-⚠️ Wiki ingest が失敗しました。raw source は wiki branch に保持されています。
-手動で `/rite:wiki:ingest` を実行してページ統合を再試行できます。
+⚠️ Wiki ingest が失敗しました。raw source は wiki branch に保持されています。手動で `/rite:wiki:ingest` を再実行できます。
 ```
 
-**Parent Issue close result (displayed only when Phase 3.7 was executed):**
-
+**親 Issue 処理結果**（Phase 3.7 が実行された場合のみ）:
 ```
 親 Issue 処理:
 - 親 Issue: #{parent_issue_number} - {parent_issue_title}
 - 結果: {parent_close_result}
 ```
+`{parent_close_result}`: `✅ 自動クローズ完了（全子 Issue 完了）` / `⏳ 残り {remaining_count} 件の子 Issue が未完了` / `✅ 既にクローズ済み` / `⚠️ クローズ失敗（手動対応が必要）`。
 
-**Values for `{parent_close_result}`:**
-
-| State | Display Value |
-|-------|--------------|
-| Auto-close succeeded | `✅ 自動クローズ完了（全子 Issue 完了）` |
-| Remaining child Issues | `⏳ 残り {remaining_count} 件の子 Issue が未完了` |
-| Already closed | `✅ 既にクローズ済み` |
-| Error occurred | `⚠️ クローズ失敗（手動対応が必要）` |
-
-**Incomplete task processing results (displayed only when Phase 1.7 was executed):**
-
+**Issue 化結果**（Phase 1.7 が実行された場合のみ）:
 ```
-未完了タスク処理:
-- Issue 化: {issue_count} 件
-- チェック完了: {checked_count} 件
-- 無視: {ignored_count} 件
-
-作成した Issue:
+未完了タスク処理 — 作成した Issue:
 | Issue | タイトル |
 |-------|----------|
 | #{new_issue_number} | {task_name}（#{original_issue_number} 残作業） |
 ```
 
-**Placeholder relationships:**
-- `{new_issue_number}`: The number of the new Issue created in Phase 1.7.3.2
-- `{task_name}`: The name of the incomplete task extracted from the work memory (base for the Issue title)
-- `{original_issue_number}`: The original Issue number (identified in Phase 1.5)
-
-**If there are stashed changes:**
-
-```
-スタッシュした変更を復元しますか？
-
-オプション:
-- 復元する（git stash pop）
-- 後で手動で復元する
-```
-
-If restore is selected:
-
-```bash
-git stash pop
-```
+stash した変更があれば「復元する（`git stash pop`）/ 後で手動で復元」を確認する。
 
 ### 5.2 Guidance for Next Steps
 
-> **⚠️ 出力形式**: 以下は **通常 ordered list** として出力する (fenced code block で囲まない)。末尾の HTML コメント sentinel `<!-- [cleanup:completed] -->` は **最終 list item 末尾に半角スペース区切りで inline 付加** する (独立行禁止 — 理由は Phase 5.3 参照)。
+通常 ordered list として出力する（**fenced code block 禁止** — fence 内では inline HTML が literal 文字列として可視化される）。`<!-- [cleanup:completed] -->` sentinel は **最終 list item 末尾に半角スペース区切りで inline 付加** する（独立行禁止 — 独立行だと CommonMark HTML block 化し rendered view に余計な空行が出る）:
 
 次のステップ:
 1. `/rite:issue:list` で次の Issue を確認
 2. `/rite:issue:start <issue_number>` で新しい作業を開始 <!-- [cleanup:completed] -->
 
-> **⚠️ MUST NOT**:
-> - 「次のステップ:」ブロック最終項目直後に余計な空行を出力してはならない (非退行)。
-> - Phase 5.2 を fenced code block (` ``` ` で囲む形式) にしてはならない。通常 ordered list として出力する。理由: fenced code block 内では inline HTML が literal 文字列として可視表示され、`[cleanup:completed]` bare bracket 形式の UI 可視化につながる。
-> - HTML コメント sentinel を独立行として出力してはならない。独立行だと CommonMark HTML block (type 2) として解釈され、renderer が前後に空行を要求し、`Ran 1 shell command` (下記 Phase 5.3 Step 1 bash UI) と後続 recap の間に余計な空行が rendered view で可視化する。最終 list item `2. /rite:issue:start ...` の末尾に **半角スペース区切りで inline 付加** することで inline HTML として処理され、前後空行要求を回避する。
-> - 末尾空行は LLM turn-boundary heuristic を誤発火させうる fragile 要因。本ファイルは `wiki/lint.md` Phase 9.2 三点セット規約 (3 独立ブロック構造) から意図的に divergence し、2 ブロック構造 (完了メッセージ + 次のステップ-with-inline-sentinel) を採用する (rendered view の空行抑制が 3 ブロック規約整合より優先)。
-
 ### 5.3 Terminal Completion
 
-> **⚠️ MUST NOT**: 「ユーザー可視最終行 = `[cleanup:completed]` の bare bracket 形式」で turn を終わらせてはならない。bare sentinel は LLM の turn-boundary heuristic を誤発火させ、recap 出力後の implicit stop を再発させる既知リスク。**HTML コメント形式 (`<!-- [cleanup:completed] -->`) のみ許容**、かつ **Phase 5.2 最終 list item 末尾に inline 配置** (独立行禁止)。
->
-> **Output ordering** (絶対遵守 — 各ブロック間に余計な空行を挿入しない、HTML sentinel は LLM の独立行として出力しない):
-> 1. Phase 5.1 Cleanup Result Summary — 前段で出力済み (ユーザー可視メッセージ + チェックリスト + 警告群)
-> 2. Phase 5.2 Guidance for Next Steps — 前段で出力済み (ユーザー可視 ordered list、最終項目末尾に inline HTML sentinel `<!-- [cleanup:completed] -->` を付加)
-> 3. Phase 5.3 Step 1: flow-state deactivate (下記 Step 1) — Phase 5.2 最終項目直後に連続実行 (中間に空行を挟まない)。bash 出力はユーザー可視だが、`(Bash completed with no output)` のため最終行にならない
-
-**Step 1**: Deactivate flow state to terminal state (`phase=cleanup, active=false` — v3 enum; idempotent — safe to re-execute). The `if ! cmd; then` rc capture is mandatory — silent failure here leaves `.active = true`、which causes the next session-end's lifecycle helpers to surface a stale "cleanup in progress" WARN_MSG even though cleanup actually finished:
+Phase 5.2 出力直後に flow state を terminal state（`phase=cleanup, active=false`）に落とす（idempotent）。silent failure を防ぐため rc を捕捉する:
 
 ```bash
-if ! bash {plugin_root}/hooks/flow-state.sh set \
-    --phase "cleanup" \
-    --next "none" --active false \
-    --if-exists; then
-  echo "WARNING: flow-state.sh set (cleanup terminal: active=false) failed — flow state may still report active=true. Subsequent self-verification will fail because '.phase = cleanup AND .active = false' won't hold. Manually run: bash {plugin_root}/hooks/flow-state.sh set --phase cleanup --next none --active false --if-exists" >&2
-fi
+bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --next "none" --active false --if-exists \
+  || echo "WARNING: flow-state deactivate failed — .active=true が残る可能性。手動: bash {plugin_root}/hooks/flow-state.sh set --phase cleanup --next none --active false --if-exists" >&2
 ```
 
-上記 Step 1 bash 実行はこの Phase 5.3 で LLM が取る最後の action。直後にさらに text output / tool call を追加してはならない (terminal 条件)。bash tool stdout は markdown text channel と分離されているため sentinel の最終行性質は保たれる。
-
-**Self-verification** (turn 終了直前の必須チェック — 全 3 項目 YES で turn を閉じてよい):
-- `grep -F '[cleanup:completed]'` against the response output finds the HTML-commented sentinel in Phase 5.2 final list item? → MUST be YES
-- User-visible `クリーンアップが完了しました` checklist + `次のステップ:` ordered list displayed? → MUST be YES
-- flow state の `.phase = cleanup` and `.active = false`? → MUST be YES (v3 enum: terminal state は `cleanup_completed` ではなく `phase=cleanup AND active=false` の組で表現される)
-
-If all three are YES, stop is allowed. If any is NO, return to the missing step and re-output before ending the turn.
+この bash 実行が Phase 5.3 で取る最後の action。直後に text output / tool call を追加しない（terminal 条件）。
 
 ---
 
@@ -1502,5 +557,5 @@ See [Common Error Handling](../../references/common-error-handling.md) for share
 | Branch Deletion Failure | `git branch` でブランチ一覧を確認; デフォルトブランチに切り替えてから再実行 |
 | Network Error | See [common patterns](../../references/common-error-handling.md) |
 | Issue Not Found | See [common patterns](../../references/common-error-handling.md) |
-| Issue Close Failure | `gh issue view {issue_number}` で Issue の状態を確認; 手動で `gh issue close {issue_number}` を実行 |
-| Incomplete Task Issue Creation Failure | クリーンアップは続行します; 以下のタスクを手動で Issue 化してください: |
+| Issue Close Failure | `gh issue view {issue_number}` で状態確認; 手動で `gh issue close {issue_number}` |
+| Incomplete Task Issue Creation Failure | クリーンアップは続行; タスクを手動で Issue 化 |

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -164,7 +164,7 @@ Each caller determines Priority using its own logic before passing it to the scr
 |---------|----------------|--------|
 | Unresolved issues detected during PR creation | Medium | Default for detected problems |
 
-### cleanup.md (Phase 1.7.3): Default Medium
+### cleanup.md (Phase 1.7): Default Medium
 
 | Context | Issue Priority | Reason |
 |---------|----------------|--------|

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -12,7 +12,7 @@ Referenced from:
 - `commands/pr/fix.md` Phase 4.3.4 Step 2
 - `commands/pr/review.md` Phase 7.4.2
 - `commands/pr/create.md` Phase 2.5.5
-- `commands/pr/cleanup.md` Phase 1.7.3.2
+- `commands/pr/cleanup.md` Phase 1.7.2
 - `commands/issue/create.md` ステップ 4.3 (Single Issue creation)
 - `commands/issue/create.md` ステップ 5.3 (parent Issue creation in XL decomposition)
 - `commands/issue/create.md` ステップ 5.4 (Sub-Issue bulk creation in XL decomposition)


### PR DESCRIPTION
## 概要

rite workflow 全体リファクタリング（シンプルイズベスト再設計 v2）の **PR 3 / Step D — PR 系コマンド slim 化** の **part 1（cleanup + close）**。

PR 1（hook 撤去 + sub-skill inline 化）・PR 2（phase enum v3 + flow-state.sh + resume 書き換え）は develop マージ済み。本 PR は Issue #1112 のうち `cleanup.md` と `close.md` を slim 化する。

> **Issue #1112 は close しない**: 残る `fix.md` / `review.md` は `distributed-fix-drift-check.sh`（Pattern-2/5）と密結合した core fix ループであり、drift-check を反復で回す focused セッション（PR 3b）に分離した。本 PR は part 1。

## 変更内容

| ファイル | 行数 | 削減 |
|---|---:|---:|
| `commands/pr/cleanup.md` | 1,506 → 561 | -63% |
| `commands/issue/close.md` | 1,174 → 676 | -42% |
| `references/issue-create-with-projects.md` | cross-ref 1 行更新 | — |

### cleanup.md
- 多層防御スキャフォルディング除去（Sub-skill Return Protocol / routing dispatcher / Phase 5 turn-boundary heuristic prose）
- Phase 1.6/1.7: 3 カテゴリ assessment 機構を「未完了タスクを Issue 化 / 無視」の **2 択化**
- Phase 2.5: 5 個別 stderr-tempfile 削除ブロックを `rite_rm` 共通関数 + 配列ループに集約
- Phase 4.W wiki ingest は**既存キー（wiki.enabled + wiki.auto_ingest）維持・振る舞い変えず**、prose のみ削減
- cleanup→wiki:ingest sub-skill 境界の implicit-stop 防御（Mandatory After Wiki Ingest）は ingest.md・CI test と対の ring 構造のため **slim 復元のみ**（ring 全体の廃止は ingest.md slim 時 = PR 4 に延期）

### close.md
- 3 箇所重複の projects-status-update 委譲を「Shared: Projects Status → Done」パターンに集約
- Phase 4.6 親 auto-close: 4.6.0（idempotency）+ 4.6.1（child 列挙）を単一 bash block に統合、design-notes prose（Issue #517/#513/#659 経緯）除去
- Phase 4.4.W wiki ingest: 設計経緯 prose 除去、trigger+commit の機能 bash に圧縮

## 死守した不変条件（テスト/参照で検証）
- `parent-child-sync-static.test.sh`: close.md の 3-method 検出（`## 親 Issue` / `trackedIssues` / `in:body`）+ `P460_DECISION`/`skip_already_closed`/`Phase 4.6` skeleton
- `projects-integration.md`: 4.5.1 の 3-method OR 構造
- `step0-imperative-phrasing-cleanup-ingest.test.sh`: cleanup.md の implicit-stop 防御 imperative
- `{i18n:}` マーカー 23 個（PR 3 では build-time 展開せず維持 — PR 4）
- `[cleanup:completed]` sentinel、Step 3 state-inconsistency summary、fail-closed child state、wiki-ingest-trigger の `/tmp/rite-*` content-file prefix

## 検証
- 全 44 hook test PASS
- cleanup.md 24 bash block / close.md 19 bash block すべて `bash -n` 構文 OK
- cleanup.md / close.md は `distributed-fix-drift-check.sh` の対象外（影響なし）

## マージ後の dogfooding gate
プラン規定通り、develop マージ後に `/rite:pr:cleanup` / `/rite:issue:close` が止まらず走ることを確認してから PR 3b（fix/review）に着手する。

Part of #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
