### PR TITLE
refactor(pr): PR 系コマンド slim 化 part 2 — fix.md retry-counter 廃止 + review.md Charter cleanup (#1112)

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -272,7 +272,7 @@ git ls-remote --heads origin {branch_name}
 削除対象（評価順）:
 1. レビュー結果: `.rite/review-results/{pr_number}-*.json`
 2. 破損レビュー結果: `.rite/review-results/{pr_number}-*.json.corrupt-*`（fix.md Priority 2 が rename した orphan の回収）
-3. fix retry state: `.rite/state/fix-fallback-retry-{pr_number}.count`
+3. fix retry state（legacy）: `.rite/state/fix-fallback-retry-{pr_number}.count` — 旧 retry-counter 機構の orphan 回収（fix.md は #1115 以降生成しない）
 4. fix-cycle state: `.rite/fix-cycle-state/{pr_number}.json`
 5. legacy fix-cycle state: `.rite/fix-cycle-state.json`（workspace 直下の単一ファイル形式の残骸）
 6. accepted fingerprints: `.rite/state/accepted-fingerprints-{pr_number}.txt`

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -5295,7 +5295,7 @@ Then, based on the Phase 4.6 completion report content **and the WM_UPDATE_FAILE
 
 | 評価順 | Condition | Output Pattern |
 |--------|-----------|---------------|
-| 1 (最優先) | Phase 1.0.1 / 1.2.0 / 1.2.0.1 で `[CONTEXT] FIX_FALLBACK_FAILED=1` を context に set した (`reason` の値は Phase 1.0.1 / 1.2.0 / 1.2.0.1 failure reasons table を **唯一の真実の源** として参照する。本セルでの固定列挙は drift 防止のため行わない) | `[fix:error]` (Phase 1.0.1 / 1.2.0 / 1.2.0.1 のレビューソース解決失敗。fallback 経路が尽きたか、ユーザーが Interactive Fallback で中止を選んだか、ファイルパス指定が 3 回連続で失敗した状態のため caller は手動介入を促す) |
+| 1 (最優先) | Phase 1.0.1 / 1.2.0 / 1.2.0.1 で `[CONTEXT] FIX_FALLBACK_FAILED=1` を context に set した (`reason` の値は Phase 1.0.1 / 1.2.0 / 1.2.0.1 failure reasons table を **唯一の真実の源** として参照する。本セルでの固定列挙は drift 防止のため行わない) | `[fix:error]` (Phase 1.0.1 / 1.2.0 / 1.2.0.1 のレビューソース解決失敗。fallback 経路が尽きたか、ユーザーが Interactive Fallback で中止を選んだか、ファイルパス指定の再実行でも有効なレビュー結果を取得できなかった状態のため caller は手動介入を促す) |
 | 2 | Phase 2.4 / 4.2 / 4.3.4 で `[CONTEXT] REPLY_POST_FAILED=1` / `[CONTEXT] REPORT_POST_FAILED=1` / `[CONTEXT] ISSUE_CREATE_FAILED=1` のいずれかを context に set した | `[fix:error]` (reply post / report post / Issue 化のいずれかが失敗。push 済みの可能性はあるが、レビュアー通知 / 完了報告 / 別 Issue 追跡の責務を果たせていないため caller は次の iteration ではなく手動介入を促す) |
 | 3 | Phase 4.5 (4.5.1 または 4.5.2) で `[CONTEXT] WM_UPDATE_FAILED=1` を context に set した (`reason` の値は下記 reason 表のいずれか — 固定列挙は行わず、reason 表を唯一の真実の源とする) | `[fix:pushed-wm-stale]` (Phase 4.5 で work memory 更新が silent skip された旨を caller に明示伝達。caller は work memory が stale であることを認識して fix loop を再実行するか手動介入する) |
 | 4 | Push completed (`プッシュ: 完了`) かつ work memory 更新成功 | `[fix:pushed]` |

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -643,145 +643,64 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
 fi
 
 # Priority 1: Conversation context (Claude が判断)
-# ⚠️ Claude への指示: Priority 0 が未発火 (review_source="") の状態で、
-# 同一 session 内の直前 assistant turn に `## 📜 rite レビュー結果` セクションを含む
-# /rite:pr:review の出力が残っている場合、下記 bash block を実行する前に会話コンテキストから
-# findings を読み取り、`conversation_review_decision="use"` を literal substitute すること。
-# 会話コンテキストに review 結果がない場合は `conversation_review_decision="none"` を substitute する。
-#
-# 旧実装は noop `:` のみで、Claude が「使う」と判断したのに
-# substitute を忘れた場合と「使わない」と判断した場合が区別できず silent fallthrough する穴があった。
-# Priority 0/3 と対称な defensive check を追加し、literal placeholder のままなら fail-fast する。
-#
-# verified-review H-3 / M-2 (M6) 対応: Phase 1.2.0.1 からの retry 経由で Phase 1.2.0 を再入した場合、
-# 上流の retry counter (.rite/state/fix-fallback-retry-{pr_number}.count) が >= 1 であれば、
-# 前 iteration で Claude が substitute した conversation_review_decision="use" が stale
-# な可能性がある (Phase 1.2.0.1 がファイルパスを変更した後、Priority 0 を再発火させたいのに
-# 前回の "use" が残ったまま Priority 1 が発火して stale conversation source に silent route する
-# Intent Hijack のリスク)。retry counter >= 1 の場合は Claude の substitute に関わらず強制 skip する。
+# ⚠️ Claude への指示: Priority 0 が未発火 (review_source="") の状態で、同一 session 内の直前
+# assistant turn に `## 📜 rite レビュー結果` を含む /rite:pr:review 出力が残っていれば、下記 bash
+# 実行前に会話コンテキストから findings を読み取り `conversation_review_decision="use"` を literal
+# substitute する。会話に review 結果がなければ `conversation_review_decision="none"` を substitute する。
+# substitute 漏れ (literal placeholder 残留) は silent fallthrough / silent P1 hijack を起こすため fail-fast する。
 if [ -z "$review_source" ]; then
-  # verified-review H-3 / M-2 対応: retry counter が >= 1 の場合は Priority 1 を強制 skip する
-  retry_state_file=".rite/state/fix-fallback-retry-${pr_number}.count"
-  retry_current=0
-  if [ -f "$retry_state_file" ]; then
-    # cat の IO エラー (permission denied / inode 破損 / NFS timeout) を
-    # silent に counter=0 にフォールバックさせない。
-    # 真の IO エラーは「未知の状態」として safe side に倒し、retry_current を 999 にして
-    # hard gate を強制発火させる (machine-enforced hard gate 原則)。
-    cat_err=$(mktemp /tmp/rite-fix-retry-cat-err-XXXXXX 2>/dev/null) || cat_err=""
-    if retry_raw=$(cat "$retry_state_file" 2>"${cat_err:-/dev/null}"); then
-      case "$retry_raw" in
-        ''|*[!0-9]*) retry_current=0 ;;
-        *) retry_current=$retry_raw ;;
-      esac
-    else
-      cat_retry_state_rc=$?
-      echo "WARNING: retry state file の読取に失敗 (rc=$cat_retry_state_rc, path=$retry_state_file)" >&2
-      if [ -n "$cat_err" ] && [ -s "$cat_err" ]; then
-        head -3 "$cat_err" | sed 's/^/  /' >&2
-      fi
-      echo "  対処: $retry_state_file の permission / filesystem 健全性を確認してください" >&2
-      echo "[CONTEXT] FIX_FALLBACK_RETRY_READ_FAILED=1; reason=state_file_read_io_error" >&2
-      # IO エラーは「未知の状態」として safe side に倒す: hard gate を確実に発火させる
-      retry_current=999
-    fi
-    [ -n "$cat_err" ] && rm -f "$cat_err"
-  fi
-  # 「レビュー実行」option で新鮮な review が会話コンテキストに乗った経路を識別するため、
-  # Phase 1.2.0.1 Interactive fallback の「レビュー実行」ハンドラは **state file を明示 rm してから**
-  # Phase 1.2 を再入する (下記 "State file cleanup on review_execute" 参照)。state file が削除されていれば
-  # retry_current=0 となり Priority 1 scan が発火する。一方「ファイルパス指定」retry 経路は state file を
-  # 保持したまま Phase 1.2.0 を再入するため、retry_current >= 1 で Priority 1 は強制 skip される。
-  #
-  # 旧実装は `RITE_FIX_P1_BYPASS_COUNTER=1` 環境変数による bypass gate を使っていたが、Claude Code Bash tool は
-  # 呼び出し境界を跨いで env var を継承しないため (anthropics/claude-code#2508)、「レビュー実行」ハンドラが
-  # 環境変数を set しても次の Phase 1.2 bash block には届かず、設計された silent regression になっていた。
-  # state file 自体の明示削除に一元化することで、Bash tool 境界を跨いでも確実に動作する。
-  if [ "$retry_current" -ge 1 ]; then
-    echo "[CONTEXT] P1_SCAN_SKIPPED=1; reason=retry_re_entry; retry_count=$retry_current" >&2
-  else
-    # ⚠️ Claude は以下の literal を Phase 1.2 進入時の判断に基づいて substitute すること
-    #   - 会話に最新の /rite:pr:review 結果あり → `conversation_review_decision="use"`
-    #   - 会話に該当 review 結果なし → `conversation_review_decision="none"`
-    # sentinel は `[A-Z_]` のみで構成し、bash case pattern matching の glob 特殊文字
-    # (`{`, `}`, `*`, `?`, `[]`) を含まない形式とする (review_file_path sentinel と同方針)
-    conversation_review_decision="__RITE_CONVERSATION_DECISION_UNSET__"
-    # machine-readable receipt を必須化する。
-    # Claude は substitute 時に下記 P1_SCAN_TURNS / P1_SCAN_FOUND も同時に substitute すること:
-    #   - use: p1_scan_turns=<N> (scan した assistant turn 数、最低 1)、p1_scan_found="true"
-    #   - none: p1_scan_turns=<N> (scan した assistant turn 数、0 以上)、p1_scan_found="false"
-    # receipt 欠落 (literal placeholder 残留) は silent P1 hijack を起こすため fail-fast する。
-    p1_scan_turns="__RITE_P1_SCAN_TURNS_UNSET__"
-    p1_scan_found="__RITE_P1_SCAN_FOUND_UNSET__"
-    case "$conversation_review_decision" in
-      use)
-        # receipt validation: P1_SCAN_TURNS / FOUND が literal の場合 fail-fast
-        case "$p1_scan_turns" in
-          __RITE_P1_SCAN_TURNS_UNSET__|"")
-            echo "ERROR: Priority 1 receipt p1_scan_turns が literal substitute されていません (decision=use)" >&2
-            echo "  Claude は 'use' を substitute する場合、同時に p1_scan_turns (整数) を substitute する必要があります" >&2
-            echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_missing" >&2
-            exit 1
-            ;;
-          *[!0-9]*)
-            echo "ERROR: Priority 1 receipt p1_scan_turns が数値ではありません: '$p1_scan_turns'" >&2
-            echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_invalid" >&2
-            exit 1
-            ;;
-        esac
-        if [ "$p1_scan_found" != "true" ]; then
-          echo "ERROR: Priority 1 decision=use だが p1_scan_found!=true ('$p1_scan_found')" >&2
-          echo "  Claude は conversation に review 結果を見つけた場合のみ 'use' を substitute し、同時に p1_scan_found='true' も substitute する必要があります" >&2
-          echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_inconsistent" >&2
+  conversation_review_decision="__RITE_CONVERSATION_DECISION_UNSET__"
+  # machine-readable receipt を必須化する。Claude は decision と同時に substitute すること:
+  #   - use:  p1_scan_turns=<N> (scan した assistant turn 数、最低 1)、p1_scan_found="true"
+  #   - none: p1_scan_turns=<N> (0 以上)、p1_scan_found="false"
+  p1_scan_turns="__RITE_P1_SCAN_TURNS_UNSET__"
+  p1_scan_found="__RITE_P1_SCAN_FOUND_UNSET__"
+  case "$conversation_review_decision" in
+    use)
+      case "$p1_scan_turns" in
+        __RITE_P1_SCAN_TURNS_UNSET__|"")
+          echo "ERROR: Priority 1 receipt p1_scan_turns が literal substitute されていません (decision=use)" >&2
+          echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_missing" >&2
           exit 1
-        fi
-        review_source="conversation"
-        echo "[CONTEXT] REVIEW_SOURCE=conversation; pr_number=${pr_number}; p1_scan_turns=$p1_scan_turns; p1_scan_found=$p1_scan_found" >&2
-        ;;
-      none)
-        # decision=none でも receipt は substitute される想定 (p1_scan_found=false でよい)
-        # literal 残留は observability 欠落のため WARNING のみ (fail-fast はしない)
-        case "$p1_scan_turns" in
-          __RITE_P1_SCAN_TURNS_UNSET__|"")
-            echo "WARNING: Priority 1 decision=none だが receipt p1_scan_turns が未設定 (observability 欠落)" >&2
-            ;;
-          *[!0-9]*)
-            echo "WARNING: Priority 1 decision=none だが p1_scan_turns が非数値 ('$p1_scan_turns')" >&2
-            ;;
-        esac
-        # `use` branch は p1_scan_turns と p1_scan_found を
-        # 両方検証し receipt 整合性で fail-fast するが、`none` branch は p1_scan_turns のみ WARNING
-        # で p1_scan_found の sentinel 残留 / 不正値を一切検知しない非対称があった。
-        # receipt 必須化の趣旨 (Claude substitute 漏れを machine-enforced gate で検出) を
-        # `none` 経路にも展開する。fail-fast はせず WARNING のみに留めるのは、decision=none は
-        # legitimate な「会話コンテキストに review 結果なし」経路であり observability loss は許容
-        # できるため (Priority 2 以降に fallthrough して別経路で finding を取得する)。
-        case "$p1_scan_found" in
-          true|false) ;;  # 正常値
-          __RITE_P1_SCAN_FOUND_UNSET__|"")
-            echo "WARNING: Priority 1 decision=none だが p1_scan_found が sentinel 残留/未設定 (observability 欠落)" >&2
-            ;;
-          *)
-            echo "WARNING: Priority 1 decision=none だが p1_scan_found が不正値: '$p1_scan_found' (許容値: true / false)" >&2
-            ;;
-        esac
-        :  # Priority 2 以降に fallthrough
-        ;;
-      __RITE_CONVERSATION_DECISION_UNSET__)
-        # sentinel のまま → Claude が substitute を忘れた
-        echo "ERROR: Priority 1 conversation_review_decision が literal substitute されていません" >&2
-        echo "  Claude は会話コンテキストの review 結果有無を判断し、'use' または 'none' を substitute する必要があります" >&2
-        echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_decision_unset" >&2
+          ;;
+        *[!0-9]*)
+          echo "ERROR: Priority 1 receipt p1_scan_turns が数値ではありません: '$p1_scan_turns'" >&2
+          echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_invalid" >&2
+          exit 1
+          ;;
+      esac
+      if [ "$p1_scan_found" != "true" ]; then
+        echo "ERROR: Priority 1 decision=use だが p1_scan_found!=true ('$p1_scan_found')" >&2
+        echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_receipt_inconsistent" >&2
         exit 1
-        ;;
-      *)
-        echo "ERROR: Priority 1 conversation_review_decision に未知の値: '$conversation_review_decision'" >&2
-        echo "  許容値: use / none" >&2
-        echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_decision_invalid" >&2
-        exit 1
-        ;;
-    esac
-  fi
+      fi
+      review_source="conversation"
+      echo "[CONTEXT] REVIEW_SOURCE=conversation; pr_number=${pr_number}; p1_scan_turns=$p1_scan_turns; p1_scan_found=$p1_scan_found" >&2
+      ;;
+    none)
+      # legitimate な「会話に review 結果なし」経路。receipt 不整合は observability 欠落として
+      # WARNING のみ (fail-fast しない — Priority 2 以降に fallthrough)。
+      case "$p1_scan_turns" in
+        __RITE_P1_SCAN_TURNS_UNSET__|"") echo "WARNING: Priority 1 decision=none だが receipt p1_scan_turns が未設定" >&2 ;;
+        *[!0-9]*) echo "WARNING: Priority 1 decision=none だが p1_scan_turns が非数値 ('$p1_scan_turns')" >&2 ;;
+      esac
+      case "$p1_scan_found" in
+        true|false) ;;
+        *) echo "WARNING: Priority 1 decision=none だが p1_scan_found が不正/未設定 ('$p1_scan_found')" >&2 ;;
+      esac
+      :  # Priority 2 以降に fallthrough
+      ;;
+    __RITE_CONVERSATION_DECISION_UNSET__)
+      echo "ERROR: Priority 1 conversation_review_decision が literal substitute されていません" >&2
+      echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_decision_unset" >&2
+      exit 1
+      ;;
+    *)
+      echo "ERROR: Priority 1 conversation_review_decision に未知の値: '$conversation_review_decision'" >&2
+      echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=priority1_decision_invalid" >&2
+      exit 1
+      ;;
+  esac
 fi
 
 # Priority 2: Local file — lexicographic sort で最新 timestamp を選択
@@ -1025,34 +944,6 @@ fi
 # Priority 3: PR comment (fall through to existing Broad Retrieval path if still unresolved)
 if [ -z "$review_source" ]; then
   review_source="pr_comment"  # Existing Phase 1.2 Broad Retrieval / Fast Path handles this
-fi
-
-# verified-review M-1 (M3) 対応: happy path で state file を unconditional clear する。
-# Priority 0-3 のいずれかが成功して review_source が fallback 以外に set された場合、
-# 前セッションで Phase 1.2.0.1 が残した stale retry counter をクリーンアップする
-# (count==3 で永久 block される経路を防ぐ)。fallback 経路 (review_source="fallback") では
-# Phase 1.2.0.1 の retry カウンタ動作を妨げないため rm を skip する。
-if [ -n "$review_source" ] && [ "$review_source" != "fallback" ]; then
-  # rm 失敗を silent に握り潰さず、失敗時には retained flag を emit する (cleanup.md Phase 2.5 と対称)。
-  # pr_number が空だと state_path=".rite/state/fix-fallback-retry-.count" となり、実在しないので
-  # `[ -f ]` で false → silent skip する経路があった。cleanup.md Phase 2.5 の pr_number guard
-  # と対称に、数値 validation で早期 fail する。
-  case "$pr_number" in
-    ''|*[!0-9]*)
-      echo "WARNING: Phase 1.2.0 happy path cleanup: pr_number が空 or 非数値 ('$pr_number')。state file 削除を skip します" >&2
-      echo "[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1; reason=invalid_pr_number_at_happy_cleanup" >&2
-      ;;
-    *)
-      state_path=".rite/state/fix-fallback-retry-${pr_number}.count"
-      if [ -f "$state_path" ]; then
-        if ! rm -f "$state_path"; then
-          echo "WARNING: happy path の retry state file 削除に失敗 ($state_path)" >&2
-          echo "  対処: 次回 fallback 経路で stale counter により AskUserQuestion が誤動作する可能性があります。手動削除してください" >&2
-          echo "[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1; reason=happy_path_rm_failure" >&2
-        fi
-      fi
-      ;;
-  esac
 fi
 
 # Priority 0/2/3/fallback の最終 review_source 値を
@@ -1576,9 +1467,9 @@ fi
 
 #### 1.2.0.1 Interactive Fallback (when all sources missing — #443) <!-- AC-6 -->
 
-> **Acceptance Criteria anchor**: AC-6 (全ソース欠落時に `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示。ファイルパス指定は最大 3 回リトライ、state file による hard gate で強制終了)。
+> **Acceptance Criteria anchor**: AC-6 (全ソース欠落時に `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示する)。
 
-When `{review_source}=fallback` (all Priority 0-3 sources unavailable or invalid), present a 3-option interactive prompt via `AskUserQuestion`:
+`{review_source}=fallback` (Priority 0-3 が全て不可) の場合、`AskUserQuestion` で 3 択を提示する:
 
 ```
 レビュー結果が見つかりませんでした
@@ -1594,193 +1485,34 @@ When `{review_source}=fallback` (all Priority 0-3 sources unavailable or invalid
 - 中止: /rite:pr:fix の処理を終了する
 ```
 
-**Per-option behavior**:
+**Per-option behavior** (one-shot — retry counter / state file による hard gate は廃止した。止まったら `/rite:resume`):
 
 | User Choice | Action |
 |-------------|--------|
-| **レビュー実行** (Recommended) | **State file を削除してから** `skill: "rite:pr:review", args: "{pr_number}"` を invoke し、Phase 1.2 を再入する。state file を削除することで retry counter が 0 に戻り、Priority 1 の conversation context scan が発火する (下記 "State file cleanup on review_execute" の bash block 参照) |
-| **ファイルパス指定** | Re-run Phase 1.2.0 Priority 0 with the user-provided path. If invalid, re-prompt (max 3 attempts, hard gate enforced via state file). state file は保持したまま Phase 1.2.0 を再入するため、retry_current >= 1 で Priority 1 scan は自動的に skip される |
-| **中止** | Emit `[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_cancelled`, then output `[fix:error]` result pattern and terminate. Do NOT invoke any Phase 2+ logic |
+| **レビュー実行** (Recommended) | `skill: "rite:pr:review", args: "{pr_number}"` を invoke し、完了後 Phase 1.2 を再入する。再入時は会話コンテキストに新鮮な review があるため Priority 1 が `use` で発火する |
+| **ファイルパス指定** | ユーザー入力パスで Phase 1.2.0 Priority 0 を **1 回だけ** 再実行する。再実行でも invalid なら `[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_file_path_invalid` を emit して `[fix:error]` で terminate する (リトライループなし) |
+| **中止** | `[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_cancelled` を emit し `[fix:error]` を出力して terminate する。Phase 2+ のロジックは一切実行しない |
 
-**State file cleanup on review_execute** (「レビュー実行」option 選択時の必須 bash 実装):
-
-```bash
-# 「レビュー実行」option 選択時: state file を明示削除してから Phase 1.2 を再入する。
-# これにより next Phase 1.2 bash block の retry_current が 0 になり、Priority 1 scan が発火する。
-pr_number="{pr_number}"
-if ! rm -f ".rite/state/fix-fallback-retry-${pr_number}.count"; then
-  echo "WARNING: retry counter state file の削除に失敗: .rite/state/fix-fallback-retry-${pr_number}.count" >&2
-  echo "  影響: Priority 1 scan が強制 skip される可能性があります" >&2
-fi
-echo "ℹ️  retry counter state file を削除しました。/rite:pr:review を起動して新しいレビューを生成します" >&2
-# この後 Claude は `skill: "rite:pr:review", args: "{pr_number}"` を invoke し、
-# 完了後に Phase 1.2 を最初から再入する (Priority 1 で新鮮な conversation review を採用)。
-```
-
-**Retry cap for ファイルパス指定**: **最大 3 回まで AskUserQuestion が発火する** (1 回目, 2 回目, 3 回目)。3 回目の応答も invalid だった場合、4 回目の AskUserQuestion は発火せず、`[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_file_path_retries` を emit して `[fix:error]` で terminate する。retry counter は **state file** (`.rite/state/fix-fallback-retry-{pr_number}.count`) で管理し、Claude の自然言語判断に依存しない machine-enforced hard gate として動作する。
-
-> **数え方の正規化**: bash gate (下記) は `current >= 3` で fail する。AskUserQuestion 発火直前に `current` を increment するため、increment 後の値が「これから発火する回数」を表す。`current=0` → increment → `current=1` → 1 回目発火 → `current=1` → increment → `current=2` → 2 回目発火 → `current=2` → increment → `current=3` → 3 回目発火 → `current=3` で 4 回目の gate check が fail。すなわち AskUserQuestion 発火は最大 3 回まで。
-
-**⚠️ Retry counter hard gate — 機械的強制ルール** (state file 方式):
-
-Claude の自然言語判断 / 会話履歴 grep に依存すると、長 context での history truncation / hallucination で無限ループ化するリスクがある。本仕様では retry counter を **ローカル state file** に persistent 保存し、bash レベルで hard gate を強制する。
-
-**State file path**: `.rite/state/fix-fallback-retry-{pr_number}.count` ({pr_number} は Phase 1.0 で正規化済み)
-
-> **State file path は固定** (`fix-fallback-retry-${pr_number}.count`、PID suffix なし)。
->
-> **背景**: 過去の cycle では「並列 fix race 回避」のため `$$` (bash PID) を suffix に追加していたが、Claude Code Bash tool は各呼び出しで別の bash プロセスを起動する (実証: `echo $$` を 3 回連続呼出 → PID が毎回異なる)。`$$` を含む path では retry 毎に別ファイルを参照し counter が永遠に 1 止まりで hard gate が機能しなかった。並列 race については単一 session 内では Bash tool 呼び出しが逐次実行されるため発生しない (sprint team-execute でも同一 issue を 2 セッションで並列実装することはない)。万一の race 懸念は別 Issue で `mkdir` ロック等の defense-in-depth で対応する。
-
-> **⚠️ Counter semantics — Priority 0 と Priority 4 の共有** (verified-review M-2 / M4 対応):
->
-> 本 state file (`fix-fallback-retry-{pr_number}.count`) の counter は **Priority 0 の明示失敗** と **Priority 4 の interactive fallback** で共有される。これは意図的な設計で、両者は「user が valid review path を提供できなかった」という同一の UX 状態を表現する:
->
-> - `/rite:pr:fix --review-file a.json` (invalid) → Priority 0 fail → Phase 1.2.0.1 interactive fallback → 「ファイルパス指定」→ b.json (invalid) → retry 1 → c.json (invalid) → retry 2 → ...
->
-> この経路で counter は 0 → 1 → 2 → 3 と incrementate され、3 で hard gate が発火する。Priority 0 の初回失敗は counter を increment せず (Phase 1.2.0.1 に routing されるだけ)、Phase 1.2.0.1 の retry 発火時にのみ increment される。つまり「Priority 0 失敗 + Phase 1.2.0.1 で 3 回失敗 = 合計 4 回の path 試行」が上限となる (Priority 0 の 1 回はカウント対象外)。
->
-> 別 counter に分ける選択肢 (例: `explicit.count` / `interactive.count`) も検討したが、(a) UX 的には同一の「user がファイルパスを提供する試行」であり分ける必要性が薄い、(b) 分けると lifecycle 管理と state file 命名が複雑化する、(c) 別分岐 retry は Priority 0 初回失敗後に「Priority 0 でも Priority 4 でも counter が incrementate される」とは限らないため既存ユーザーの混乱を招く、という理由で共有を選択した。
-
-**State file lifecycle**:
-
-- **作成**: 「ファイルパス指定」option が初めて選択された時点で `mkdir -p .rite/state && echo 0 > "$state_file"`
-- **増分**: AskUserQuestion 呼び出し**前**に `current=$(cat ...); echo $((current + 1)) > $state_file`
-- **読み出し**: 上記増分前に、cat の **exit code を明示 check して IO エラーとファイル不在を区別** する。cat 成功時は `current=<read value>`、IO エラー時は `current=999` (safe side = hard gate を確実発火)、ファイル不在 (初回) は `current=0`。詳細は下記 bash gate 参照 (Priority 1 skip の I-1 pattern と対称)
-- **削除**: Phase 2+ 進入時 / `[fix:error]` 出力前 / fix loop 終了時 / **AskUserQuestion runtime error 時** (下記「AskUserQuestion failure / abort 経路の state cleanup」参照) のいずれかで `rm -f "$state_file"`
-
-**AskUserQuestion failure / abort 経路の state cleanup**:
-
-AskUserQuestion 自体が runtime error / signal 中断した場合の retry counter state file は、次回 `/rite:pr:fix` 起動時に残留していても hard gate が自動的に発火する方向 (counter >= 3) にしか作用しない。つまり「orphan state file が次回実行で hard gate を skip させる silent regression」は原理的に発生しない (counter は monotonic に増加するのみ)。したがって Phase 1.2.0.1 に独立した trap cleanup は設けない — 状態遷移が不明瞭になり hard gate を誤破壊するリスクの方が高いため。
-
-正常経路での state file 削除は以下の 3 箇所に一元化される:
-1. 「ファイルパス指定」retry が成功した時点 (下記「State file cleanup on success」参照)
-2. 「中止」option が選択された時点 (下記「中止 option の bash 実装」参照)
-3. hard gate が発火 (counter >= 3) した時点 (下記 bash gate 参照)
-
-**1. AskUserQuestion 呼び出し前の必須 bash gate**: 「ファイルパス指定」retry を実行する際、`AskUserQuestion` を呼び出す**直前**に必ず以下の bash を実行する:
+**中止 / file-path invalid の bash 実装** (silent regression 防止 — Phase 8.1 評価順 1 で `[fix:error]` に昇格):
 
 ```bash
-# Retry hard gate: state file による machine-enforced 強制
-# state file は specific path (pr_number suffix 必須、wildcard glob 禁止)
-# pr_number は Claude が Phase 1.0 の値で literal substitute する。block 冒頭で束縛することで、
-# 後続の参照が `${pr_number}` 形式に統一され、placeholder 残留 silent bug を防ぐ。
-pr_number="{pr_number}"
-state_dir=".rite/state"
-# state_file の path は固定 (PID suffix なし)。Claude Code Bash tool は各呼び出しで別 bash
-# プロセスを起動するため、PID suffix を入れると retry 毎に別ファイルを参照し counter が
-# 永遠に 1 止まりで hard gate が機能しない。並列 race については単一 session 内では Bash
-# tool 呼び出しが逐次実行されるため発生しない。
-state_file="${state_dir}/fix-fallback-retry-${pr_number}.count"
-mkdir_err=$(mktemp /tmp/rite-fix-p1201-mkdir-err-XXXXXX 2>/dev/null) || mkdir_err=""
-if ! mkdir -p "$state_dir" 2>"${mkdir_err:-/dev/null}"; then
-  echo "ERROR: $state_dir の作成に失敗しました" >&2
-  if [ -n "$mkdir_err" ] && [ -s "$mkdir_err" ]; then
-    head -3 "$mkdir_err" | sed 's/^/  /' >&2
-  fi
-  echo "  対処: permission denied / read-only filesystem / .rite が通常ファイルでないか確認してください" >&2
-  echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=state_dir_mkdir_failed" >&2
-  [ -n "$mkdir_err" ] && rm -f "$mkdir_err"
-  echo "[fix:error]"
-  exit 1
-fi
-[ -n "$mkdir_err" ] && rm -f "$mkdir_err"
-
-# cat の exit code を明示 check することで、IO エラー (permission denied / NFS timeout / inode 破損 等)
-# を silent に `current=0` に倒す silent regression を防ぐ。Phase 1.2.0 Priority 1 の retry_state_file
-# 読取ブロック (IO エラー時 `retry_current=999` で safe-side 倒し) と対称に、IO エラー時は `current=999`
-# で hard gate を確実発火させる。
-cat_err=$(mktemp /tmp/rite-fix-p1201-cat-err-XXXXXX 2>/dev/null) || cat_err=""
-if [ -f "$state_file" ]; then
-  if current=$(cat "$state_file" 2>"${cat_err:-/dev/null}"); then
-    # cat 成功: 数値 validation (state file 改竄 / 異常値の防御)
-    case "$current" in
-      ''|*[!0-9]*) current=0 ;;
-    esac
-  else
-    cat_p1201_state_rc=$?
-    echo "ERROR: retry state file の読取に失敗 (rc=$cat_p1201_state_rc)" >&2
-    if [ -n "$cat_err" ] && [ -s "$cat_err" ]; then
-      echo "  詳細 (cat stderr):" >&2
-      head -3 "$cat_err" | sed 's/^/  /' >&2
-    fi
-    echo "  影響: safe side に倒して hard gate を確実発火させます (counter=999)" >&2
-    echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=state_file_read_io_error_gate" >&2
-    current=999  # safe side: hard gate を確実発火 (Priority 1 skip I-1 と対称)
-  fi
-else
-  # 初回実行 (ファイル不在) は legitimate な 0 開始
-  current=0
-fi
-[ -n "$cat_err" ] && rm -f "$cat_err"
-
-if [ "$current" -ge 3 ]; then
-  echo "エラー: ファイルパス指定のリトライが 3 回続けて失敗しました" >&2
-  echo "  [CONTEXT] retry counter=$current/3 (state file: $state_file)" >&2
-  echo "" >&2
-  echo "次の対処を検討してください:" >&2
-  echo "  1. /rite:pr:review を実行してローカル JSON を新規生成する (recommended)" >&2
-  echo "  2. .rite/review-results/ ディレクトリに既存ファイルが存在するか確認する:" >&2
-  echo "       ls -la .rite/review-results/${pr_number}-*.json" >&2
-  echo "  3. 既存 JSON の必須フィールド (schema_version, pr_number, findings) をエディタで検証する" >&2
-  echo "  4. schema 定義を参照する: plugins/rite/references/review-result-schema.md" >&2
-  echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_file_path_retries" >&2
-  # rm 失敗を可視化 (旧実装は silent)。
-  # Phase 1.2.0 happy path state file rm (I-2 対応) と対称化する。失敗時は
-  # retained flag を追加 emit し、state file が counter=3 のまま残留する silent 経路を防ぐ。
-  # Non-blocking Contract 準拠: rm 失敗でも `[fix:error]` は既に emit 済みなので hard exit は継続。
-  if ! rm -f "$state_file"; then
-    echo "WARNING: hard gate 発火後の state file 削除に失敗: $state_file" >&2
-    echo "  影響: 次回 fix 起動時に stale counter=3 が残留し Priority 1 skip が発動し続ける可能性があります" >&2
-    echo "  手動削除: rm \"$state_file\"" >&2
-    echo "[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1; reason=hard_gate_rm_failure" >&2
-  fi
-  echo "[fix:error]"
-  exit 1
-fi
-
-new_count=$((current + 1))
-echo "$new_count" > "$state_file" || {
-  echo "ERROR: state file への書き込みに失敗 (disk full / permission)" >&2
-  echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=state_file_write_failed" >&2
-  echo "[fix:error]"
-  exit 1
-}
-echo "[CONTEXT] FIX_FALLBACK_RETRY=$new_count/3" >&2
-```
-
-**2. Phase 2+ 進入禁止**: retry_count >= 3 で `[fix:error]` が emit された時点で Claude は **以降の Phase (Phase 2 Categorization, Phase 3 Commit, Phase 4 Report) への bash tool 呼び出しを一切行ってはならない**。これは bash の `exit 1` と state file による機械的強制ルールであり、自然言語判断による例外を認めない。
-
-**3. State file cleanup on success**: 「ファイルパス指定」が成功 (= valid JSON file が見つかり Phase 1.2.0 Priority 0 が成功) した時点で:
-
-```bash
-pr_number="{pr_number}"
-# 成功時 cleanup の rm 失敗を可視化 (I-2 と対称化)。
-# 旧実装は silent で、失敗時に次回 fix が起動した時点で stale counter が残留し Priority 1 skip が
-# 誤発動する経路があった。
-if ! rm -f ".rite/state/fix-fallback-retry-${pr_number}.count"; then
-  echo "WARNING: 成功時 cleanup の state file 削除に失敗: .rite/state/fix-fallback-retry-${pr_number}.count" >&2
-  echo "  影響: 次回 fix 起動時に stale counter が残留し Priority 1 skip が誤発動する可能性があります" >&2
-  echo "  手動削除: rm \".rite/state/fix-fallback-retry-${pr_number}.count\"" >&2
-  echo "[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1; reason=success_cleanup_rm_failure" >&2
-fi
-```
-
-これにより次回の Interactive Fallback 起動時に counter が clean state から始まる。
-
-**「中止」option の bash 実装**: 「中止」が選択された場合は以下を実行する (silent regression 防止 — Phase 8.1 評価順 1 で `[fix:error]` に昇格させる):
-
-```bash
-pr_number="{pr_number}"
+# 中止が選択された場合:
 echo "ユーザーが Interactive Fallback で「中止」を選択しました" >&2
 echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_cancelled" >&2
-# 中止時 cleanup の rm 失敗を可視化 (I-2 と対称化)。
-if ! rm -f ".rite/state/fix-fallback-retry-${pr_number}.count"; then
-  echo "WARNING: 中止時 cleanup の state file 削除に失敗: .rite/state/fix-fallback-retry-${pr_number}.count" >&2
-  echo "[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1; reason=user_cancel_rm_failure" >&2
-fi
 echo "[fix:error]"
 exit 1
 ```
+
+```bash
+# 「ファイルパス指定」の再実行でも invalid だった場合:
+echo "エラー: 指定されたファイルパスでもレビュー結果を取得できませんでした" >&2
+echo "  /rite:pr:review を実行してローカル JSON を生成するか、有効な JSON path を確認してください" >&2
+echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_file_path_invalid" >&2
+echo "[fix:error]"
+exit 1
+```
+
+**Phase 2+ 進入禁止**: `[fix:error]` が emit された時点で Claude は以降の Phase (Phase 2 Categorization, Phase 3 Commit, Phase 4 Report) への bash tool 呼び出しを一切行ってはならない。bash の `exit 1` による機械的強制ルールであり、自然言語判断による例外を認めない。
 
 **Phase 1.0.1 / 1.2.0 / 1.2.0.1 failure reasons** (reason table drift prevention — see [distributed-fix-drift-check](../../hooks/scripts/distributed-fix-drift-check.sh) Pattern-2 / Pattern-5):
 
@@ -1805,17 +1537,10 @@ exit 1
 | `pr_comment_cross_field_invariant_violated` | Priority 3 で取得した PR コメント Raw JSON の cross-field invariant 違反: `overall_assessment=="mergeable"` だが CRITICAL/HIGH かつ status==open の finding が存在 (legacy Markdown parser へ fallthrough、`REVIEW_SOURCE_CROSS_FIELD_INVARIANT_VIOLATED` flag) |
 | `pr_comment_critical_high_scope_nit_noted` | Priority 3 で取得した PR コメント Raw JSON の cross-field invariant #4 違反 (Issue #1016): `severity ∈ {CRITICAL, HIGH}` × `scope == "nit-noted"` の finding が存在 (legacy Markdown parser へ fallthrough、`REVIEW_SOURCE_CROSS_FIELD_INVARIANT_VIOLATED` flag) |
 | `pr_comment_schema_version_unknown` | Priority 3 で取得した PR コメント Raw JSON の schema_version が未知 (legacy Markdown parser へ fallthrough) |
-| `user_file_path_retries` | Interactive fallback の「ファイルパス指定」が 3 回連続で失敗 (terminate with `[fix:error]`) |
 | `user_cancelled` | Interactive fallback で「中止」option が選択された (Phase 8.1 評価順 1 で `[fix:error]` に昇格) |
-| `state_dir_mkdir_failed` | retry hard gate state directory `.rite/state/` の作成失敗 (permission denied / read-only filesystem) |
-| `state_file_write_failed` | retry hard gate state file への書き込み失敗 (disk full / permission denied) |
-| `state_file_read_io_error_gate` | Phase 1.2.0.1 retry hard gate の state file 読取が IO エラーで失敗 (permission denied / NFS timeout / inode 破損 等)。safe side に倒して counter=999 で hard gate を確実発火させる (Priority 1 skip の I-1 pattern と対称) |
+| `user_file_path_invalid` | Interactive fallback の「ファイルパス指定」で再実行した path でもレビュー結果を取得できなかった (one-shot、retry ループなし、`[fix:error]` 昇格) |
 | `review_source_unset_post_chain` | Phase 1.2.0 Priority chain 終了時に `review_source` が空 (未設定) のまま block 末尾に到達 (設計契約違反、Priority chain の routing bug) |
 | `review_source_invalid_post_chain` | Phase 1.2.0 Priority chain 終了時に `review_source` に未知の値が設定されている (許容値: `explicit_file` / `conversation` / `local_file` / `pr_comment` / `fallback`) |
-| `invalid_pr_number_at_happy_cleanup` | Phase 1.2.0 happy path state cleanup 時に pr_number が空 / 非数値 (cleanup.md Phase 2.5 numeric guard と対称、`[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1` flag を併設) |
-| `hard_gate_rm_failure` | Phase 1.2.0.1 retry hard gate 発火後の state file `rm -f` が失敗 (`[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1` flag を併設、stale counter=3 残留のリスクを WARNING で可視化) |
-| `success_cleanup_rm_failure` | Phase 1.2.0.1 ファイルパス指定成功時 state file `rm -f` が失敗 (`[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1` flag を併設、stale state 残留のリスクを WARNING で可視化) |
-| `user_cancel_rm_failure` | Phase 1.2.0.1 中止選択時 state file `rm -f` が失敗 (`[CONTEXT] FIX_FALLBACK_STATE_CLEAR_FAILED=1` flag を併設) |
 | `review_file_path_empty_value` | Phase 1.0.1 で値を持たない `--review-file` が指定された。Pattern 1 (equals style: `--review-file=`) と Pattern 2 (space style: `--review-file <末尾>`) の両方で検出される。`flag_style=equals` / `flag_style=space` として retained flag に付記される |
 | `comment_body_tempfile_empty` | Phase 1.2.0 Priority 3 で `/tmp/rite-fix-pr-comment-{pr_number}.txt` が存在するが空 (Broad Retrieval が異常終了したか PR コメント本文が完全に空) |
 | `bash_version_incompatible` | Prerequisites の `command -v mapfile` チェックが失敗 (bash 3.2 等の旧バージョン) |
@@ -1831,9 +1556,6 @@ exit 1
 | `local_file_find_io_error` | Priority 2 の `find .rite/review-results/` が IO エラーで failed (L-3 対応) |
 | `mktemp_failure_find_err` | Priority 2 の find stderr 退避用 tempfile の mktemp が失敗 (C-5 対応、cleanup.md Phase 2.5 と対称)。silent skip 防止のため WARNING + retained flag を必ず emit する (Issue #1025 対応) |
 | `latest_file_stat_failure` | Priority 2 で find が見つけた `latest_file` が `-f` check で脱落 (M-4 対応、permission denied / symlink 破壊) |
-| `state_file_read_io_error` | Phase 1.2.0 Priority 1 の retry state file `cat` が IO エラーで失敗 (I-1 対応、hard gate を safe side に倒すため `retry_current=999`) |
-| `happy_path_rm_failure` | Phase 1.2.0 happy path の retry state file 削除が失敗 (I-2 対応、cleanup.md Phase 2.5 と対称) |
-| `retry_re_entry` | Phase 1.2.0 Priority 1 が retry counter >= 1 のため強制 skip された (verified-review H-3 / M-2 対応、stale conversation source の silent route を防ぐ。`P1_SCAN_SKIPPED` flag 専用の reason で fix loop を中断しない) |
 | `jq_duplicate_check_failed` | Priority 0/2 で重複 file:line 検出用 jq が失敗 (silent data loss 検出を skip、非ブロッキング) |
 | `severity_map_build_failed` | Priority 0/2 で severity_map 構築用 jq が失敗 (0 件で正常終了する silent regression 防止、`[fix:error]` 昇格) |
 | `pr_comment_severity_map_build_failed` | Priority 3 で PR コメント Raw JSON からの severity_map 構築用 jq が失敗 (legacy Markdown parser へ fallthrough) |
@@ -1848,7 +1570,7 @@ exit 1
 | `scope_map_build_failed` | Issue #1018 M2: Priority 0/2 (file-based) で scope_map_json 構築用 jq が失敗 (`REVIEW_SOURCE_PARSE_FAILED` flag、非ブロッキング、`scope_map_json="{}"` で legacy blocking 扱いに fallback) |
 | `pr_comment_scope_map_build_failed` | Issue #1018 M2: Priority 3 (pr_comment Raw JSON) で scope_map_json 構築用 jq が失敗 (`REVIEW_SOURCE_PARSE_FAILED` flag、非ブロッキング、`scope_map_json="{}"` で legacy blocking 扱いに fallback) |
 
-**Eval-order enumeration** (for Pattern-5 drift check): 本 enumeration は Pattern-5 drift check の **唯一の入力源** であり、上の Phase 1.2.0 / 1.2.0.1 reason 表と必ず同期させること。reason を追加・削除する際は表と本 enumeration の両方を同時に更新する。emit reasons sequence = (`bash_version_incompatible` / `pr_number_placeholder_residue` / `explicit_file_not_found` / `explicit_file_parse` / `explicit_file_schema_required_fields_missing` / `mergeable_has_open_blockers` / `explicit_file_critical_high_scope_nit_noted` / `overall_assessment_unknown_value` / `explicit_file_schema_version_unknown` / `priority1_decision_unset` / `priority1_decision_invalid` / `priority1_receipt_missing` / `priority1_receipt_invalid` / `priority1_receipt_inconsistent` / `sort_or_mapfile_failure` / `local_file_json_parse_failure` / `local_file_schema_required_fields_missing` / `local_file_cross_field_invariant_violated` / `local_file_critical_high_scope_nit_noted` / `local_file_schema_version_unknown` / `pr_comment_raw_json_awk_failed` / `pr_comment_raw_json_parse_failure` / `pr_comment_schema_required_fields_missing` / `pr_comment_cross_field_invariant_violated` / `pr_comment_critical_high_scope_nit_noted` / `pr_comment_schema_version_unknown` / `user_file_path_retries` / `user_cancelled` / `state_dir_mkdir_failed` / `state_file_write_failed` / `state_file_read_io_error_gate` / `review_source_unset_post_chain` / `review_source_invalid_post_chain` / `invalid_pr_number_at_happy_cleanup` / `hard_gate_rm_failure` / `success_cleanup_rm_failure` / `user_cancel_rm_failure` / `review_file_path_empty_value` / `comment_body_tempfile_empty` / `explicit_file_commit_sha_mismatch` / `local_file_commit_sha_mismatch` / `pr_comment_commit_sha_mismatch` / `jq_error_on_commit_sha` / `local_file_find_io_error` / `mktemp_failure_find_err` / `latest_file_stat_failure` / `state_file_read_io_error` / `happy_path_rm_failure` / `retry_re_entry` / `jq_duplicate_check_failed` / `severity_map_build_failed` / `pr_comment_severity_map_build_failed` / `pr_comment_tempfile_read_io_error` / `review_file_path_placeholder_residue` / `scope_omitted_in_v1_0` / `pre_existing_false_scope_nit_noted` / `jq_mutation_failed` / `mktemp_failure_norm_tmp` / `low_current_pr_demoted_to_nit_noted` / `scope_map_build_failed` / `pr_comment_scope_map_build_failed`)
+**Eval-order enumeration** (for Pattern-5 drift check): 本 enumeration は Pattern-5 drift check の **唯一の入力源** であり、上の Phase 1.2.0 / 1.2.0.1 reason 表と必ず同期させること。reason を追加・削除する際は表と本 enumeration の両方を同時に更新する。emit reasons sequence = (`bash_version_incompatible` / `pr_number_placeholder_residue` / `explicit_file_not_found` / `explicit_file_parse` / `explicit_file_schema_required_fields_missing` / `mergeable_has_open_blockers` / `explicit_file_critical_high_scope_nit_noted` / `overall_assessment_unknown_value` / `explicit_file_schema_version_unknown` / `priority1_decision_unset` / `priority1_decision_invalid` / `priority1_receipt_missing` / `priority1_receipt_invalid` / `priority1_receipt_inconsistent` / `sort_or_mapfile_failure` / `local_file_json_parse_failure` / `local_file_schema_required_fields_missing` / `local_file_cross_field_invariant_violated` / `local_file_critical_high_scope_nit_noted` / `local_file_schema_version_unknown` / `pr_comment_raw_json_awk_failed` / `pr_comment_raw_json_parse_failure` / `pr_comment_schema_required_fields_missing` / `pr_comment_cross_field_invariant_violated` / `pr_comment_critical_high_scope_nit_noted` / `pr_comment_schema_version_unknown` / `user_cancelled` / `user_file_path_invalid` / `review_source_unset_post_chain` / `review_source_invalid_post_chain` / `review_file_path_empty_value` / `comment_body_tempfile_empty` / `explicit_file_commit_sha_mismatch` / `local_file_commit_sha_mismatch` / `pr_comment_commit_sha_mismatch` / `jq_error_on_commit_sha` / `local_file_find_io_error` / `mktemp_failure_find_err` / `latest_file_stat_failure` / `jq_duplicate_check_failed` / `severity_map_build_failed` / `pr_comment_severity_map_build_failed` / `pr_comment_tempfile_read_io_error` / `review_file_path_placeholder_residue` / `scope_omitted_in_v1_0` / `pre_existing_false_scope_nit_noted` / `jq_mutation_failed` / `mktemp_failure_norm_tmp` / `low_current_pr_demoted_to_nit_noted` / `scope_map_build_failed` / `pr_comment_scope_map_build_failed`)
 
 #### Legacy Branching (PR Comment Path Only)
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -141,7 +141,7 @@ bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
 
 **Parsing procedure**:
 
-> **⚠️ 重要 — 単一 Bash tool invocation での実行**: Phase 1.0 の bash block は **1 つの Bash tool 呼び出しで完結させる** こと。旧実装は Step 1 (flag 抽出) と Step 2 (conflict check) を別 invocation に分割し、Step 1 の `[CONTEXT] FLAG_POST=...` emit 値を Claude が literal substitute する方式だった。しかし substitute 漏れが silent regression (AC-8 conflict check の常時 false) を起こすリスクがあり、分割の合理的理由が薄いため本 PR (verified-review C-4) で単一 block に統合した。
+> **⚠️ 重要 — 単一 Bash tool invocation での実行**: Phase 1.0 の bash block は **1 つの Bash tool 呼び出しで完結させる** こと。Step 1 (flag 抽出) と Step 2 (conflict check) を別 invocation に分割すると、emit 値の literal substitute 漏れが silent regression (AC-8 conflict check の常時 false) を起こすため、単一 block で実行する。
 >
 > Claude は下記 bash block **全体**を 1 回の Bash tool 呼び出しで実行し、内部のシェル変数 (`flag_post`, `flag_no_post`, `remaining_args`, `config_post_comment`, `post_comment_mode`) は bash 内で完結させる。literal substitution は bash-compat-guard placeholder 以外一切不要。
 
@@ -1962,8 +1962,6 @@ For **every** item in the "### 推奨事項" section (regardless of `別 Issue` 
 
 - **`recommendation_items`** (本 PR で新設、canonical data): Phase 5.1 が全 reviewer 推奨事項を classification 付きで集約した list (全 item を保持、Source B extraction の元データ)
 - **`candidate_count`** (Phase 7.1 で算出、Phase 7.7 / Phase 8.0.2 で参照): Phase 7.1 が Source A (findings + scope-out keyword) と Source B (`recommendation_items` の `classification ∈ {actionable, boundary}` filter + Phase 7.2 user approval 結果による boundary 採否決定) を **合算 + deduplication した最終件数**。Phase 7.7 post-condition gate と Phase 8.0.2 cross-reference はこの値を参照する
-
-> **Note (Issue #1042 review cycle 4)**: 旧仕様で記述されていた legacy field `recommendation_issue_candidates` (keyword-based subset / classification-based subset の二重定義経路) は本 cycle で完全削除した。consumer は存在せず (scripts/ hooks/ への grep 0 hit、Phase 5.4 推奨事項 table も `recommendation_items` を直接参照していた)、historical context が必要な場合は git history (commit `5aae26e3` 以前) を参照すること。
 
 **Investigation suggestion collection**: Extract items from each reviewer's "### 調査推奨" section. Retain these as `investigation_suggestions` in the conversation context (reviewer_type, file, concern_description, notes). These are NOT findings and NOT Issue candidates — they do not affect the assessment, finding counts, or merge decision, and are never auto-Issue-ified by Phase 7. They are collected solely for Phase 5.4 "調査推奨" section rendering so the user may optionally run `/rite:investigate {file}` afterwards. A reviewer writing nothing in this section is the common case (blocking-worthy issues should go into findings, out-of-scope recommendations with Issue keywords into 推奨事項).
 

--- a/plugins/rite/references/review-result-schema.md
+++ b/plugins/rite/references/review-result-schema.md
@@ -286,7 +286,7 @@ emit の目的は observability — 「どの review-result file が 1.0 schema 
 | 1 | **会話コンテキスト** | 同一セッション内で `/rite:pr:review` が直前に実行されていれば、その結果を直接利用。**採用時は `[CONTEXT] REVIEW_SOURCE=conversation; pr_number={pr_number}` を stderr に emit する義務がある** (observability 義務、後段の provenance log に必要) | Claude が会話履歴に rite review 結果を見つけられなかった場合は次の Priority へ |
 | 2 | **ローカルファイル** | `.rite/review-results/{pr_number}-*.json` の中で最新 `timestamp` のファイル (lexicographic sort) | **4 種の失敗モードいずれも** WARNING を出して **Priority 3 (PR コメント) に直接 routing** する: (a) `local_file_json_parse_failure` (`jq empty` で JSON syntax invalid)、(b) `local_file_schema_required_fields_missing` (parse 可能だが `schema_version` 非空文字列 / `pr_number` 数値型 / `findings[]` 配列型のいずれかが欠落)、(c) `local_file_schema_version_unknown` (schema_version 未知)、(d) `local_file_commit_sha_mismatch` (json commit_sha が現 HEAD と不一致、stale file protection)。古い timestamp ファイルには fallback しない |
 | 3 | **PR コメント (後方互換)** | PR コメントの `## 📜 rite レビュー結果` セクション (新形式: `### 📄 Raw JSON` 付き → awk で Raw JSON section-scoped 抽出。旧形式: Markdown テーブル → 既存パースロジック) | 失敗モード: (a) `pr_comment_raw_json_parse_failure`、(b) `pr_comment_schema_required_fields_missing`、(c) `pr_comment_schema_version_unknown` は legacy Markdown parser へ fallthrough。(d) `pr_comment_commit_sha_mismatch` は **WARNING のみで continue** (Raw JSON の severity_map 構築を続行。PR コメントは最新 push 後に投稿される可能性が高く、legacy parser への fallthrough はむしろ情報損失になるため) |
-| 4 | **対話式 fallback** | 上記すべて欠落時 | `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示 (ファイルパス指定 retry 上限 3 回、state file による hard gate で強制終了) |
+| 4 | **対話式 fallback** | 上記すべて欠落時 | `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示 (ファイルパス指定は 1 回のみ再実行する one-shot。retry ループ・state file hard gate なし。再実行でも invalid なら `[fix:error]` で終了 — #1115) |
 
 **Priority 1 emit 義務の理由**: Priority 1 は Claude の自然言語判断に依存する経路で bash の if-else では捕捉できない。後段の Phase 4.5.3 / 4.6 で `{review_source}` を log に出すため、conversation 経由で取り込んだ場合も他の Priority と同様に provenance を残す必要がある。emit 忘れは silent provenance loss となり、fix 後のトラブルシュートが困難になる。
 
@@ -330,7 +330,7 @@ retained flag: `[CONTEXT] REVIEW_SOURCE_STALE=1; reason={explicit_file|local_fil
 
 1. **レビュー結果ファイル**: `.rite/review-results/{pr_number}-*.json`
 2. **破損レビュー結果ファイル**: `.rite/review-results/{pr_number}-*.json.corrupt-*` (`fix.md` Phase 1.2.0 Priority 2 が corrupt 検出時に `.corrupt-{epoch}` suffix で rename したファイル。長期運用で累積する orphan を防ぐ)
-3. **fix retry state file**: `.rite/state/fix-fallback-retry-{pr_number}.count`
+3. **fix retry state file（legacy）**: `.rite/state/fix-fallback-retry-{pr_number}.count` — 旧 retry-counter 機構が生成した orphan の回収。`fix.md` は #1115 以降このファイルを生成しないが、旧版が残した file を掃除するため削除対象に残す
 
 wildcard は PR 番号 prefix 固定とし、他 PR のファイルを誤って削除しないよう保証する。state file は specific path (`{pr_number}.count` 完全一致) で削除する。
 


### PR DESCRIPTION
## 概要

rite workflow リファクタリング **PR 3 / Step D の part 2（fix + review）**。PR 3a（#1113、cleanup + close）は develop マージ済み。

> **正直な scope 注記**: プラン当初の PR 3b 想定（fix.md → ~3,000 / review.md → ~2,500、各 -48%）は **safe bounded slim では達成できなかった**。理由は本文末尾参照。本 PR は実際に安全に除去できた構造的 scaffolding（fix.md の retry-counter 機構）+ Charter cleanup に限定する。

## 変更内容

| ファイル | 行数 | 削減 |
|---|---:|---:|
| `commands/pr/fix.md` | 5,741 → 5,463 | -278 (-4.8%) |
| `commands/pr/review.md` | 4,838 → 4,836 | -2 |

### fix.md — retry-counter machinery 廃止（構造的簡素化）
- Phase 1.2.0.1 Interactive Fallback: `.rite/state/fix-fallback-retry-{pr}.count` の 3-retry hard gate を廃止し one-shot interactive prompt 化（レビュー実行 / ファイルパス指定 1 回 / 中止）。止まったら `/rite:resume`
- Priority 1 の retry counter >= 1 強制 skip（`retry_re_entry`）を除去
- Phase 1.2.0 happy-path の state file unconditional clear を除去
- reason 表: retry 関連 11 reason 削除 + `user_file_path_invalid` 追加、Eval-order enumeration を同期
- **Priority 0/1/2/3 routing は保持**（bounded — Priority 3 PR コメント後方互換は残す）

### review.md — Charter cleanup（履歴 prose 2 件）
- Phase 1.0 単一 Bash invocation note の「旧実装は…」履歴末尾を除去
- Phase 5.1 の legacy field 削除注記（Issue #1042 cycle 4、git history ポインタ）を除去

## 検証
- fix.md: `fix-fallback-retry` 参照 0、drift-check 30 findings で baseline 一致（reason 同期維持）
- review.md: drift-check 22 findings で baseline 一致
- 両ファイル executable bash block 構文 OK（blockquote 例示・heredoc-with-fence は checker artifact で develop と同一）
- 全 44 hook test PASS

## なぜ -48% に届かなかったか（プラン前提のズレ）
1. **fix.md**: 大幅削減には (a) Priority 3（PR コメント後方互換）削除 = 振る舞い変更、(b) `distributed-fix-drift-check` で守られた core fix ループの prose 大量削減 = drift リスク、のいずれかが必要。bounded/low-risk 方針では retry-counter 機構の廃止が安全な上限だった。
2. **review.md**: プランの「Phase 5.4.1.0 fingerprint dispatcher 廃止」は**現行コードに該当 section が無く moot**（別作業で除去済）。現存 fingerprint 関連（Phase 5.1.2.A accept-suppression / Quality Signal 1·3）は fix.md Phase 2.1.A・convergence monitor・debate と連動する**機能**で除去不可。review.md 本体は大半が load-bearing な LLM 実行命令で、安全に削れる scaffolding が無い。

さらなる削減は behavior change を伴う restructuring が必要で、別途 Issue で方針を再検討するのが妥当。

Part of #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
