### PR TITLE
docs(pr): archive-procedures.md の削除済み Phase 1.7.4 dangling 参照を除去 (#1114)

### DIFF
--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -146,8 +146,6 @@ fi
 
 Automatically append the following to the work memory:
 
-**Note**: If a `### 未完了タスクの処理結果` section was appended in Phase 1.7.4, preserve its content. The update in Phase 3.5 appends to the existing content and must not overwrite the Phase 1.7.4 records.
-
 **Progress section merge method:**
 
 The progress section update in Phase 3.5.2 follows this logic:
@@ -155,15 +153,13 @@ The progress section update in Phase 3.5.2 follows this logic:
 1. Retrieve the existing progress section
 2. Preserve all existing checklist items
 3. Append new items (`- [x] レビュー完了`, `- [x] マージ完了`, `- [x] クリーンアップ完了`) at the end (do not duplicate if already present)
-4. If `- [x] 未完了タスク処理済み` added in Phase 1.7.4 exists, preserve it as well
 
-**Example (merging from a state after Phase 1.7.4 execution):**
+**Example:**
 
 ```markdown
 ### 進捗
 - [x] 実装完了
 - [x] PR マージ済み
-- [x] 未完了タスク処理済み  ← Phase 1.7.4 で追加（保持）
 - [x] レビュー完了           ← Phase 3.5.2 で追加
 - [x] マージ完了             ← Phase 3.5.2 で追加
 - [x] クリーンアップ完了     ← Phase 3.5.2 で追加


### PR DESCRIPTION
## 概要

PR #1113（cleanup.md slim 化）で `commands/pr/cleanup.md` の旧 Phase 1.7.4「Update Work Memory」が削除された。その結果、委譲先 `commands/pr/references/archive-procedures.md` に「Phase 1.7.4 で追加されたものを保持せよ」という空振りの保持指示が 4 箇所残存していた（生成元が消失済みのため常に空振り）。

現行仕様（新 Phase 1.7 は Issue 化のみで作業メモリセクションは書かない）に整合させるため、これらの dangling 参照を除去する。

## 変更内容

- 3.5.2 冒頭の Phase 1.7.4 保持 Note を削除（旧 line 149）
- progress section merge の item 4（`- [x] 未完了タスク処理済み` の保持）を削除（旧 line 158）
- Example を「Phase 1.7.4 execution 後の state からのマージ」前提から非依存の形に簡素化（旧 line 160/166）

`archive-procedures.md` は `cleanup.md:339` が現役で委譲しているため**削除はしない**（プランの「PR 4 で削除」記載は cleanup.md 実態と矛盾するため見送り）。

## 検証

- `grep '未完了タスクの処理結果\|未完了タスク処理済み\|1\.7\.4' archive-procedures.md` → **0 件**
- `cleanup.md:339` の委譲（手順 3.1-3.2 / 3.5 / 3.6 / Phase 4 を参照）は健在 — 削除した 1.7.4 とは無関係のため挙動退行なし

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)