### PR TITLE
docs(architecture): CLAUDE.md / CONTRIBUTING.md のアーキ図 dangling 除去 (PR5a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,19 +26,17 @@ plugins/rite/
 │   └── wiki/           #   Experience Wiki スキル（opt-out）
 ├── agents/           # PR レビュー用サブエージェント定義
 │                     # _reviewer-base.md（共通原則）+ 13 reviewer agent + sprint-teammate
-├── templates/        # config/（rite-config.yml 最小デフォルト）、project-types/、
+├── templates/        # config/（rite-config.yml 最小デフォルト）、
 │                     # issue/, pr/, review/, wiki/ の各フォーマット
 ├── references/       # gh CLI パターン、GraphQL、severity-levels、investigation-protocol、
-│                     # wiki-patterns、workflow-incident-emit-protocol、review-result-schema 等
+│                     # wiki-patterns、review-result-schema 等
 ├── scripts/          # Projects 統合 Issue 作成、Sub-Issue リンク、レビュー結果抽出・計測 等
-├── hooks/            # Claude Code ライフサイクルフック（session / compact /
-│   │                 # preflight / pre-tool-bash-guard / post-tool-wm-sync /
-│   │                 # phase-transition-whitelist /
-│   │                 # wiki-ingest-trigger / wiki-query-inject / workflow-incident-emit /
-│   │                 # session-ownership / hook-preamble 等）+ hooks.json
-│   ├── scripts/      #   Wiki commit / worktree / backlink / gitignore-health check 等のヘルパー
-│   └── tests/        #   hook レベルの自動テストスイート
-└── i18n/             # 多言語対応（ja.yml / en.yml の legacy + ja/, en/ 配下の分割ファイル）
+└── hooks/            # Claude Code ライフサイクルフック（session / compact /
+    │                 # preflight / pre-tool-bash-guard / post-tool-wm-sync /
+    │                 # wiki-ingest-trigger / wiki-query-inject /
+    │                 # session-ownership / hook-preamble 等）+ hooks.json
+    ├── scripts/      #   Wiki commit / worktree / backlink / gitignore-health check 等のヘルパー
+    └── tests/        #   hook レベルの自動テストスイート
 rite-config.yml        # プロジェクト固有設定（ブランチ戦略、Projects連携、Wiki、review loop 等）
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,7 @@ plugins/rite/
 │   └── tests/        #   Shell script tests
 ├── templates/        # Issue/PR/completion report templates
 ├── references/       # gh CLI patterns, GraphQL helpers
-├── scripts/          # Utility scripts (Issue creation with Projects integration)
-└── i18n/             # Internationalization (ja.yml, en.yml)
+└── scripts/          # Utility scripts (Issue creation with Projects integration)
 ```
 
 ## Hook Development Guide

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ plugins/rite/hooks/
 ├── issue-comment-wm-update.py # Python helper for Issue comment work memory updates
 ├── state-path-resolve.sh     # Resolves root directory for rite state files
 ├── cleanup-work-memory.sh    # Deterministic cleanup of local work memory files
-├── flow-state.sh             # Unified flow-state management (set/get/deactivate/migrate subcommands)
+├── flow-state.sh             # Unified per-session flow-state management
 ├── issue-body-safe-update.sh # Safe Issue body fetch/apply with backup and validation
 ├── wiki-ingest-trigger.sh    # Hook: trigger Wiki ingest on review/fix/close events
 ├── wiki-query-inject.sh      # Hook: inject Wiki heuristics at start/review/fix/implement
@@ -114,7 +114,7 @@ plugins/rite/hooks/
 └── tests/                    # Test scripts
 ```
 
-> **Note**: Context pressure monitoring hooks (previously `context-pressure.sh`, `post-compact-guard.sh`) were retired in PR #481 / commit 77f0c49, and the Stop hook (`stop-guard.sh`) was removed in PR #1079. Compact recovery is now handled by `pre-compact.sh` + `post-compact.sh` + `session-start.sh`; workflow stop prevention is enforced by the per-session flow-state structure and the orchestrator-level scaffolding contract rather than a Stop hook.
+> **Note**: There is no Stop hook. A Stop hook that blocked on exit made the LLM stall in thinking loops at phase boundaries, so workflow halting is prevented by the per-session flow-state structure and the orchestrator-level scaffolding contract instead. Compact recovery is handled by `pre-compact.sh` + `post-compact.sh` + `session-start.sh`.
 
 ### Hook Events and Registration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ plugins/rite/
 │   └── wiki/         #   Experience Wiki skill (ingest/query/lint heuristics)
 ├── agents/           # Sub-agent definitions for PR review
 ├── hooks/            # Event handler scripts (Bash)
+│   ├── scripts/      #   Internal helper scripts (drift-check, bang-backtick-check, etc.)
 │   └── tests/        #   Shell script tests
 ├── templates/        # Issue/PR/completion report templates
 ├── references/       # gh CLI patterns, GraphQL helpers
@@ -86,7 +87,6 @@ Hooks are shell scripts that respond to Claude Code lifecycle events. They are r
 
 ```
 plugins/rite/hooks/
-├── stop-guard.sh             # Stop hook: prevents Claude from stopping during active workflow
 ├── session-start.sh          # SessionStart hook: re-injects flow state after compact or resume
 ├── session-end.sh            # SessionEnd hook: saves final state when session ends
 ├── session-ownership.sh      # Helper: session ownership guard for .rite-flow-state writes
@@ -104,18 +104,17 @@ plugins/rite/hooks/
 ├── issue-comment-wm-update.py # Python helper for Issue comment work memory updates
 ├── state-path-resolve.sh     # Resolves root directory for rite state files
 ├── cleanup-work-memory.sh    # Deterministic cleanup of local work memory files
-├── flow-state-update.sh      # Atomic .rite-flow-state create/patch/increment operations
+├── flow-state.sh             # Unified flow-state management (set/get/deactivate/migrate subcommands)
 ├── issue-body-safe-update.sh # Safe Issue body fetch/apply with backup and validation
 ├── wiki-ingest-trigger.sh    # Hook: trigger Wiki ingest on review/fix/close events
 ├── wiki-query-inject.sh      # Hook: inject Wiki heuristics at start/review/fix/implement
-├── workflow-incident-emit.sh # Emit workflow incident sentinel for auto Issue registration (#366)
 ├── work-memory-parse.py      # YAML frontmatter parser for work memory files
 ├── hooks.json                # Native plugin hook registration (managed by Claude Code plugin system)
 ├── scripts/                  # Internal helper scripts (drift-check, bang-backtick-check, etc.)
 └── tests/                    # Test scripts
 ```
 
-> **Note**: Context pressure monitoring hooks (previously `context-pressure.sh`, `post-compact-guard.sh`) were retired in PR #481 / commit 77f0c49. Stop/compact recovery is now handled by `stop-guard.sh` + `pre-compact.sh` + `post-compact.sh` + `session-start.sh` exclusively.
+> **Note**: Context pressure monitoring hooks (previously `context-pressure.sh`, `post-compact-guard.sh`) were retired in PR #481 / commit 77f0c49, and the Stop hook (`stop-guard.sh`) was removed in PR #1079. Compact recovery is now handled by `pre-compact.sh` + `post-compact.sh` + `session-start.sh`; workflow stop prevention is enforced by the per-session flow-state structure and the orchestrator-level scaffolding contract rather than a Stop hook.
 
 ### Hook Events and Registration
 
@@ -126,10 +125,9 @@ For legacy setups or environments where `hooks.json` is unavailable, `/rite:init
 ```json
 {
   "hooks": {
-    "Stop": [
+    "SessionStart": [
       {
-        "matcher": "",
-        "hooks": [{ "type": "command", "command": "bash /path/to/hooks/stop-guard.sh" }]
+        "hooks": [{ "type": "command", "command": "bash /path/to/hooks/session-start.sh" }]
       }
     ],
     "PreToolUse": [
@@ -146,7 +144,6 @@ Available hook events:
 
 | Event | Trigger | Input |
 |-------|---------|-------|
-| `Stop` | Claude attempts to stop responding | JSON via stdin (`cwd`, etc.) |
 | `SessionStart` | Session begins or resumes | JSON via stdin (`cwd`, `source`) |
 | `SessionEnd` | Session ends | JSON via stdin |
 | `PreCompact` | Before context compaction | JSON via stdin |
@@ -183,7 +180,7 @@ fi
 - Always use `set -euo pipefail` at the top
 - Read JSON input from stdin using `INPUT=$(cat)` and parse with `jq`
 - Use `state-path-resolve.sh` to resolve the state root directory
-- For guard hooks (e.g., `stop-guard.sh`, `pre-tool-bash-guard.sh`): exit code `0` means "allow", non-zero means "block"
+- For guard hooks (e.g., `pre-tool-bash-guard.sh`): exit code `0` means "allow", non-zero means "block"
 - For non-guard hooks (e.g., `session-start.sh`, `notification.sh`): exit code `0` indicates successful execution
 - Use `mktemp` for temporary files with `trap 'rm -f "$tmpfile"' EXIT` for cleanup
 - Keep hooks fast — they run on every matching event
@@ -199,7 +196,7 @@ The project uses a lightweight custom test framework (not bats) located in `plug
 bash plugins/rite/hooks/tests/run-tests.sh
 
 # Run a single test
-bash plugins/rite/hooks/tests/stop-guard.test.sh
+bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
 ```
 
 ### Test File Structure

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # rite workflow - Unified flow-state management (schema_version=3)
-# Subcommands: set | get | deactivate | migrate
-# Replaces: flow-state-update.sh, state-read.sh, _resolve-flow-state-path.sh,
-#           _resolve-schema-version.sh, resume-active-flag-restore.sh, phase-transition-whitelist.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -19,7 +19,7 @@ SESSION_DIR="$STATE_ROOT/.rite/sessions"
 LEGACY_STATE="$STATE_ROOT/.rite-flow-state"
 SESSION_ID_FILE="$STATE_ROOT/.rite-session-id"
 
-# Phase enum SoT (13 values) — PR 2a refactor; SoT also referenced from resume.md cross-check.
+# Phase enum SoT (13 values); also referenced from resume.md cross-check.
 PHASE_ENUM_V3="init branch plan implement lint pr review fix ready ready_error cleanup ingest completed"
 SCHEMA_VERSION_V3=3
 


### PR DESCRIPTION
## 概要

リファクタプラン **PR 5（docs）の最初のスライス**。i18n / project-types / phase-transition-whitelist / workflow-incident-emit など、先行リファクタで削除されたコンポーネントがアーキテクチャ図に残存していたため整合させる。

> 本 PR は **CLAUDE.md / CONTRIBUTING.md の narrative ドキュメント**が中心。当初は Project Structure ツリーのみの予定だったが、verified-review 指摘により CONTRIBUTING.md の Hook Directory Structure / Hook Events セクションの dangling 除去、および関連して `flow-state.sh` のコメント整理まで対応した。reference docs（CONFIGURATION / SPEC / i18n-style-guide）の整合は規模が大きいため PR5b に分離（下記）。

## 変更内容

- **CLAUDE.md**: `i18n/` ツリー行削除（`hooks/` を末尾 `└──` に connector 再描画）、templates 説明の `project-types/` 除去、references 説明の `workflow-incident-emit-protocol` 除去、hooks 説明の `phase-transition-whitelist` / `workflow-incident-emit` 除去
- **CONTRIBUTING.md**:
  - Project Structure ツリー: `i18n/` 行削除（`scripts/` を末尾 `└──` に）、`hooks/` 配下に `scripts/` 行追加（CLAUDE.md と対称化）
  - Hook Directory Structure / Hook Events: 削除済み hook の参照を除去 — `workflow-incident-emit.sh` 行、`flow-state-update.sh`（実体 `flow-state.sh` に差し替え）、`stop-guard.sh` / `Stop` イベント（hook 一覧 / Note / JSON fallback 例 / イベント表 / Conventions / テスト例の 6 箇所）
  - Note を Why 化: 「Stop hook が無い理由（exit block による LLM の thinking ループ）」を記述し、PR 番号・commit hash・撤去履歴の羅列を排除
- **plugins/rite/hooks/flow-state.sh**: 上記ツリーの記述を実態に合わせる過程で判明した重複・履歴コメントを除去 — Usage 文字列（コード内 SoT）と重複する `Subcommands` 行、撤去済みファイルを列挙する `Replaces` 行、`Phase enum` コメント内の履歴語。Why（resume.md との cross-check）は保持

## 検証

- 削除対象の実在確認: `phase-transition-whitelist.sh` / `workflow-incident-emit.sh` / `workflow-incident-emit-protocol.md` / `i18n/` / `project-types/` / `stop-guard.sh` / `flow-state-update.sh` すべて削除済みを確認（`flow-state.sh` / `hooks/scripts/` は実在）
- `grep 'i18n|project-types|project.type|phase-transition-whitelist|workflow-incident' CLAUDE.md` → **0 件**
- `grep 'stop-guard|flow-state-update|workflow-incident-emit' CONTRIBUTING.md` → 現役エントリ **0 件**
- CONTRIBUTING.md の Hook Events 表が `hooks.json` の登録 6 イベント（SessionStart / SessionEnd / PreCompact / PostCompact / PreToolUse / PostToolUse）と完全一致することを確認
- `flow-state.sh` の subcommand は dispatch / Usage 文字列（`set|get|deactivate|migrate|path`）を SoT とし、コメント側の重複列挙を排除

## 残（PR5b 以降にスコープ）

精密にマップ済みの dangling:
- **CONFIGURATION.md / .ja.md**: 削除済み config キー（`observed_likelihood_gate` / `fail_fast_first` / `fix.severity_gating`）のサンプル + テーブル行、`project` セクション。891 行の包括 schema リファレンスのため、3キー削除に留まらず現テンプレートとの drift 整合が必要
- **SPEC.md / .ja.md**: Plugin Structure ツリー（`i18n/` / `project-types/` / `i18n-usage.md`）、`Language File Structure` 節、`Project Types` 節
- **i18n-style-guide.md §3**: 削除済み `plugins/rite/i18n/ja/` 前提の節
- **doc-heavy `plugins/rite/i18n/**` 除外 glob**: review.md / tech-writer.md / SKILL.md / internal-consistency.md / devops.md / _reviewer-base.md（vestigial no-op だが internal-consistency.md の3ファイル等価制約 + review.md drift 注意の delicate group）
- **CHANGELOG.md / .ja.md**: MAJOR bump（i18n 全廃 + project.type 廃止 + config slim）

### 本 PR から派生した残作業

- **#1122**: CONTRIBUTING.md Hook Directory Structure の網羅性 rot（`_` プレフィックス hook 6 本未掲載）。「全 hook 列挙 vs 代表例 + 参照方式」の方針判断を伴うため別 Issue に分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)