### PR TITLE
docs(contributing): Hook Directory Structure の網羅性 rot 解消 + 削除済み hook の dead comment 整理

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,34 +85,26 @@ Hooks are shell scripts that respond to Claude Code lifecycle events. They are r
 
 ### Hook Directory Structure
 
+Representative entries (not exhaustive — see the note below):
+
 ```
 plugins/rite/hooks/
-├── session-start.sh          # SessionStart hook: re-injects flow state after compact or resume
-├── session-end.sh            # SessionEnd hook: saves final state when session ends
-├── session-ownership.sh      # Helper: session ownership guard for .rite-flow-state writes
-├── pre-compact.sh            # PreCompact hook: saves work memory snapshot before context compaction
-├── post-compact.sh           # PostCompact hook: restores state after context compaction
-├── pre-tool-bash-guard.sh    # PreToolUse hook (Bash): blocks known-bad Bash command patterns
-├── post-tool-wm-sync.sh      # PostToolUse hook (Bash): auto-creates local work memory when missing
-├── preflight-check.sh        # Guard script called by commands before execution
-├── notification.sh           # Sends notifications to configured channels (Slack, Discord, Teams)
-├── hook-preamble.sh          # Shared preamble sourced by hooks (env, logging, state path)
-├── local-wm-update.sh        # Self-resolving wrapper for local work memory file updates
-├── work-memory-update.sh     # Shared helper for local work memory atomic writes
-├── work-memory-lock.sh       # mkdir-based lock/unlock for issue-level work memory access
-├── issue-comment-wm-sync.sh  # Sync local work memory to Issue comment backup
-├── issue-comment-wm-update.py # Python helper for Issue comment work memory updates
-├── state-path-resolve.sh     # Resolves root directory for rite state files
-├── cleanup-work-memory.sh    # Deterministic cleanup of local work memory files
-├── flow-state.sh             # Unified per-session flow-state management
-├── issue-body-safe-update.sh # Safe Issue body fetch/apply with backup and validation
-├── wiki-ingest-trigger.sh    # Hook: trigger Wiki ingest on review/fix/close events
-├── wiki-query-inject.sh      # Hook: inject Wiki heuristics at start/review/fix/implement
-├── work-memory-parse.py      # YAML frontmatter parser for work memory files
-├── hooks.json                # Native plugin hook registration (managed by Claude Code plugin system)
-├── scripts/                  # Internal helper scripts (drift-check, bang-backtick-check, etc.)
-└── tests/                    # Test scripts
+├── session-start.sh / session-end.sh        # SessionStart / SessionEnd lifecycle hooks
+├── pre-compact.sh / post-compact.sh          # PreCompact / PostCompact (context compaction)
+├── pre-tool-bash-guard.sh                    # PreToolUse (Bash): blocks known-bad command patterns
+├── post-tool-wm-sync.sh                      # PostToolUse (Bash): auto-creates local work memory
+├── flow-state.sh                             # Unified per-session flow-state management
+├── session-ownership.sh / hook-preamble.sh   # Sourced helper libraries (not registered hooks)
+├── work-memory-*.sh / local-wm-update.sh     # Local work memory read / write / lock helpers
+├── issue-body-safe-update.sh                 # Safe Issue body fetch / apply with backup
+├── wiki-ingest-trigger.sh / wiki-query-inject.sh  # Wiki ingest / query helpers (invoked from commands)
+├── _resolve-*.sh / _validate-*.sh            # Internal session-id / state-root helpers
+├── hooks.json                                # Native plugin hook registration (Claude Code reads this)
+├── scripts/                                  # Internal helper scripts (drift-check, wiki commit, etc.)
+└── tests/                                    # Hook test suite
 ```
+
+> **Note**: This is a representative list, not a complete enumeration. The canonical full list is the `plugins/rite/hooks/` directory itself (and the Plugin Structure section of `docs/SPEC.md`). Only the six events above — `SessionStart` / `SessionEnd` / `PreCompact` / `PostCompact` / `PreToolUse` / `PostToolUse` — are registered in `hooks.json` (verify with `jq '.hooks | keys[]' plugins/rite/hooks/hooks.json`); every other `.sh` is a sourced helper library or a script invoked from commands. New hooks are added to the directory and `hooks.json`, so this section does **not** need to be updated for each one.
 
 > **Note**: There is no Stop hook. A Stop hook that blocked on exit made the LLM stall in thinking loops at phase boundaries, so workflow halting is prevented by the per-session flow-state structure and the orchestrator-level scaffolding contract instead. Compact recovery is handled by `pre-compact.sh` + `post-compact.sh` + `session-start.sh`.
 

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -11,10 +11,9 @@ export _RITE_HOOK_RUNNING_SESSIONEND=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
-# Single source of truth for create_* lifecycle phase names (#501 HIGH).
-# 2>/dev/null は parser-level syntax error の場合のみ silent skip するため。
-# whitelist 自身が bash < 4.2 警告を出すため、source 失敗時の追加警告は不要。
-# fail-open 自体は session-end の主処理 (state 保存) を止めない設計 (#675 retire 後の方針)。
+# session-ownership.sh provides the ownership guard consumed below. Sourcing is
+# fail-open (2>/dev/null || true) so a missing or unparsable helper cannot block
+# session-end's main job: persisting / deactivating the flow state.
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -108,12 +107,14 @@ if [ -f "$STATE_FILE" ]; then
         exit 0
     fi
 
-    # Lifecycle unfinished warnings (#475 AC-9, extended #608 follow-up for cleanup_*).
+    # Lifecycle unfinished warnings for create_* / cleanup_* phases.
     # If the session is ending mid-lifecycle (active=true with a non-terminal phase),
     # emit an informational warning so the user knows what flow did NOT complete and
     # how to recover. session-end always proceeds with deactivation regardless.
-    # Phase classification is delegated to phase-transition-whitelist.sh helpers as the
-    # single source of truth (#501 HIGH).
+    # Phase classification is an inline glob match on the phase name (the elif
+    # branches below). The `type … >/dev/null` guards would defer to a sourced
+    # phase-classifier helper if one were loaded; none ships today, so the glob
+    # fallback is the active path.
     # corrupt JSON を silent 流すと lifecycle WARN_MSG が空 phase で抑制され、user は
     # create_*/cleanup_* の中断を知らないまま次セッションへ進む。stderr を capture して
     # operator が原因にたどり着けるようにする。

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -375,10 +375,11 @@ else
 fi
 echo ""
 
-# TC-608-WARN-D: cleanup_post_ingest phase branch coverage (case branch 全網羅)
-# session-end.sh の cleanup lifecycle check は cleanup / cleanup_pre_ingest / cleanup_post_ingest の
-# 3 phase をカバーする必要がある。TC-608-WARN-A は cleanup_pre_ingest のみで、cleanup_post_ingest
-# の case branch が削除されても WARN-A/B/C は pass し続ける false-positive 構造。本 TC で補完。
+# TC-608-WARN-D: cleanup_post_ingest phase branch coverage (ELIF glob 分岐 全網羅)
+# session-end.sh の cleanup lifecycle 判定 ELIF glob (`cleanup` / `cleanup_*` 一致) は cleanup /
+# cleanup_pre_ingest / cleanup_post_ingest の 3 phase をカバーする必要がある。TC-608-WARN-A は
+# cleanup_pre_ingest のみで、cleanup_post_ingest 一致が外れても WARN-A/B/C は pass し続ける
+# false-positive 構造。本 TC で補完。
 echo "TC-608-WARN-D: cleanup_post_ingest active → /rite:pr:cleanup lifecycle warning"
 dir608wd="$TEST_DIR/tc608wd"
 mkdir -p "$dir608wd"

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -398,11 +398,11 @@ echo ""
 # のうち、bare `cleanup` arm が削除されても WARN-A/B/C/D は全 pass する false-positive 構造を補完。
 # Phase 1.0 Activate Flow State が実際に書く phase 名 ("cleanup" bare) を pin する regression guard。
 #
-# NOTE (cycle 10 F-08): 本 TC は **case arm 改変の検出が scope**。関数定義全体が削除された場合は
-# session-end.sh の ELIF fallback (`elif echo "$phase" | grep -q "^cleanup"`) が発火して同じ warning
-# を出すため silently pass する限界あり (関数欠損時は call site が `rite_phase_is_cleanup_lifecycle_in_progress`
-# 自体を呼べない別エラー経路で検出される想定)。関数欠損の regression guard は別 TC (phase-transition-whitelist
-# unit test) で扱う必要あり (F-09 と合わせて別 Issue で tracking 推奨)。
+# NOTE: 本 TC は ELIF glob 分岐の改変検出が scope。phase 分類 helper
+# (rite_phase_is_*_lifecycle_in_progress) は廃止済みのため session-end.sh の
+# `type … >/dev/null` guard は常に false で、ELIF の glob 一致
+# (`[[ "$_state_phase" == "cleanup" || cleanup_* ]]`) が唯一の active path となる。
+# 本 TC はその path を直接 exercise する。
 echo "TC-608-WARN-E: cleanup active → /rite:pr:cleanup lifecycle warning (bare cleanup arm coverage)"
 dir608we="$TEST_DIR/tc608we"
 mkdir -p "$dir608we"

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -393,15 +393,16 @@ else
 fi
 echo ""
 
-# TC-608-WARN-E: bare cleanup phase branch coverage (cycle 9 F-11)
-# rite_phase_is_cleanup_lifecycle_in_progress の case arm `cleanup|cleanup_pre_ingest|cleanup_post_ingest)`
-# のうち、bare `cleanup` arm が削除されても WARN-A/B/C/D は全 pass する false-positive 構造を補完。
-# Phase 1.0 Activate Flow State が実際に書く phase 名 ("cleanup" bare) を pin する regression guard。
+# TC-608-WARN-E: bare cleanup phase branch coverage
+# session-end.sh の cleanup lifecycle 判定 ELIF glob 分岐 (`[[ "$_state_phase" == "cleanup" ||
+# "$_state_phase" == cleanup_* ]]`) のうち、bare `cleanup` 一致が削除されても WARN-A/B/C/D は
+# 全 pass する false-positive 構造を補完。cleanup workflow が実際に書く phase 名 ("cleanup" bare) を
+# pin する regression guard。
 #
 # NOTE: 本 TC は ELIF glob 分岐の改変検出が scope。phase 分類 helper
 # (rite_phase_is_*_lifecycle_in_progress) は廃止済みのため session-end.sh の
 # `type … >/dev/null` guard は常に false で、ELIF の glob 一致
-# (`[[ "$_state_phase" == "cleanup" || cleanup_* ]]`) が唯一の active path となる。
+# (`[[ "$_state_phase" == "cleanup" || "$_state_phase" == cleanup_* ]]`) が唯一の active path となる。
 # 本 TC はその path を直接 exercise する。
 echo "TC-608-WARN-E: cleanup active → /rite:pr:cleanup lifecycle warning (bare cleanup arm coverage)"
 dir608we="$TEST_DIR/tc608we"
@@ -411,7 +412,7 @@ run_hook "$dir608we" >/dev/null || true
 if [ -f "${LAST_STDERR_FILE:-}" ] \
     && grep -q "lifecycle was not completed" "$LAST_STDERR_FILE" \
     && grep -q "/rite:pr:cleanup" "$LAST_STDERR_FILE"; then
-  pass "bare cleanup unfinished → cleanup-specific warning emitted (case arm 全網羅完成)"
+  pass "bare cleanup unfinished → cleanup-specific warning emitted (ELIF glob 分岐 全網羅完成)"
 else
   fail "expected /rite:pr:cleanup lifecycle warning for bare cleanup, got: $(cat "${LAST_STDERR_FILE:-/dev/null}" 2>/dev/null)"
 fi

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -12,7 +12,7 @@
 #
 # Required environment variables:
 #   WM_SOURCE       - Source identifier (e.g., "implement", "lint", "fix")
-#   WM_PHASE        - Phase value (e.g., "lint", "implement", "pr", "review", "fix"; see phase-transition-whitelist.sh for the flat phase enum)
+#   WM_PHASE        - Phase value (e.g., "lint", "implement", "pr", "review", "fix"; see PHASE_ENUM_V3 in flow-state.sh for the flat phase enum)
 #   WM_PHASE_DETAIL - Phase detail description
 #   WM_NEXT_ACTION  - Next action description
 #   WM_BODY_TEXT    - Body text after YAML frontmatter closing ---


### PR DESCRIPTION
## 概要

verified-review で検出された hook 周辺の rot を解消する。`phase-transition-whitelist.sh` は v2→v3 移行で retired 済み（phase enum は `flow-state.sh` PHASE_ENUM_V3 へ移管）だが、削除済みファイルを前提とした記述が複数残存していた。

## 変更内容

- **CONTRIBUTING.md**: Hook Directory Structure を全 hook 網羅列挙から「代表 hook + 完全な一覧は実ディレクトリ / `docs/SPEC.md` 参照」方式（Option B）へ統一。列挙の二重管理を解消し、新規 hook 追加時の更新漏れ（rot）を構造的に防ぐ。登録済み 6 イベントと sourced helper の区別も明記（未掲載だった `_resolve-*` / `_validate-*` / `bang-backtick-edit-hook.sh` も同時に解消）。
- **session-end.sh**: 削除済み `phase-transition-whitelist.sh` を前提とした orphaned コメントを整理。`session-ownership.sh` の fail-open source と inline glob fallback の実挙動を記述する Why コメントへ書き換え、履歴番号を除去。
- **work-memory-update.sh**: flat phase enum の SoT 参照を削除済み whitelist → `flow-state.sh` PHASE_ENUM_V3 へ修正。
- **session-end.test.sh**: 削除済み whitelist unit test への dead reference を整理。

ロジック（session-end.sh の `type` ガード + elif glob fallback）は変更していない。session-end test 34/34 pass。

## 関連 Issue

Closes #1122

### 横展開で検出した別系統の rot（別 Issue として追跡）

- #1123: 削除済み `phase-transition-whitelist.sh` への dead reference が `docs/SPEC.md` / `SPEC.ja.md` / 複数の commands・skills / test docs にも残存（本 PR のスコープ外）

## チェックリスト

- [x] 受け入れ条件 3 項目すべて対応
- [x] session-end test pass（34/34）
- [x] plugin lint（bang-backtick gate pass、変更ファイルに新規 finding なし）
