### PR TITLE
docs(workflow): close.md のタイトル行 mislabel "rite workflow:" を "タイトル:" に統一

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -57,7 +57,7 @@ gh issue view {issue_number} --json number,title,body,state,labels,closedAt
 ```
 Issue #{number} は既にクローズされています
 
-rite workflow: {title}
+タイトル: {title}
 クローズ日時: {closed_at}
 
 追加のアクションは不要です
@@ -220,7 +220,7 @@ lock 失敗時は WARNING を出して続行（best-effort — Phase 5 でどの
 ```
 Issue #{number} をクローズしました
 
-rite workflow: {title}
+タイトル: {title}
 Status: Done
 
 関連 PR: #{pr_number} (Merged)


### PR DESCRIPTION
## 概要

`commands/issue/close.md` の 2 箇所で、Issue タイトルの表示行がブランディング文字列 `rite workflow: {title}` になっていた mislabel を、兄弟ラベル（`クローズ日時:` / `Status:`）と整合する `タイトル: {title}` に統一しました。

- **L60**（Phase 1.3「既にクローズ済み」ブロック）
- **L223**（Phase 4.4 完了レポート）

## 背景

`rite workflow:` は項目ラベルを期待する文脈にブランディング文字列が前置されており、Issue タイトルのラベルとして意味的に不自然でした。隣接する `クローズ日時:` / `Status:` と同様の項目ラベル `タイトル:` が自然です。

## 変更内容

- `plugins/rite/commands/issue/close.md` — L60 / L223 のタイトル行を `タイトル: {title}` に統一（2 箇所同期）

## 関連 Issue

Closes #1119

## チェックリスト

- [x] close.md L60（Phase 1.3）のラベル修正
- [x] close.md L223（Phase 4.4）のラベル修正
- [x] 2 箇所の表記統一を確認（旧文字列 0 件・新文字列 2 件）
