### PR TITLE
docs(workflow): recall.md エラー文の placeholder {branch} を {base_branch} に統一

### DIFF
--- a/plugins/rite/commands/issue/recall.md
+++ b/plugins/rite/commands/issue/recall.md
@@ -84,7 +84,7 @@ Before executing git log, verify the base branch exists:
 git rev-parse --verify {base_branch} 2>/dev/null
 # If fails, try remote:
 git rev-parse --verify origin/{base_branch} 2>/dev/null
-# If both fail: display "ベースブランチ {branch} が見つかりません。rite-config.yml の branch.base を確認してください" and terminate
+# If both fail: display "ベースブランチ {base_branch} が見つかりません。rite-config.yml の branch.base を確認してください" and terminate
 ```
 
 Use `{base_branch}` if local exists, otherwise `origin/{base_branch}`:
@@ -223,6 +223,6 @@ Suggest narrowing with a more specific scope or action type filter.
 | Error | Response |
 |-------|----------|
 | Not in a git repository | `Git リポジトリ内で実行してください` |
-| Base branch not found (mode=branch) | `ベースブランチ {branch} が見つかりません。rite-config.yml の branch.base を確認してください` |
+| Base branch not found (mode=branch) | `ベースブランチ {base_branch} が見つかりません。rite-config.yml の branch.base を確認してください` |
 | No commits in range | Phase 3.2 empty result handling |
 | Git command failure | Display error and terminate |


### PR DESCRIPTION
## 概要

`commands/issue/recall.md` のベースブランチ未検出エラーメッセージ（L87 / L226）が placeholder `{branch}` を使用していたが、周辺の実ロジック（L84 / L86 / L90 / L93）は一貫して `{base_branch}` を使用していた。メッセージ側だけ名前が異なるため、LLM が値を埋める際にどの変数を指すか曖昧だった。両箇所を `{base_branch}` に統一する。

## 変更内容

- `plugins/rite/commands/issue/recall.md` — エラーメッセージ内の `{branch}` → `{base_branch}`
  - L87: base branch 検証ステップの bash コメント内エラー文
  - L226: Error Handling テーブルの「Base branch not found」行

## 関連 Issue

Closes #1120

## チェックリスト

- [x] recall.md L87 の {branch} → {base_branch}
- [x] recall.md L226 の {branch} → {base_branch}
