### PR TITLE
fix(hooks): flow-state.sh の get / set --if-exists の silent failure を解消

### DIFF
--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -49,6 +49,10 @@ _resolve_session_id() {
     local sid; sid=$(tr -d '[:space:]' < "$SESSION_ID_FILE" 2>/dev/null) || sid=""
     [ -n "$sid" ] && printf '%s\n' "$sid" && return 0
   fi
+  # Claude Code runtime exposes CLAUDE_CODE_SESSION_ID; older / non-Code clients used
+  # CLAUDE_SESSION_ID. Accept both so cmd_get / cmd_set --if-exists do not silently
+  # degrade when `.rite-session-id` is absent but the runtime env IS set (Issue #1142).
+  [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && { printf '%s\n' "$CLAUDE_CODE_SESSION_ID"; return 0; }
   [ -n "${CLAUDE_SESSION_ID:-}" ] && { printf '%s\n' "$CLAUDE_SESSION_ID"; return 0; }
   echo "ERROR: cannot resolve session_id" >&2; return 1
 }
@@ -111,7 +115,17 @@ cmd_set() {
   _phase_is_valid "$phase" || echo "WARNING: unknown phase: $phase (allowed: $PHASE_ENUM_V3)" >&2
   local sid path; sid=$(_resolve_session_id "$session") || return 1
   path=$(_state_path "$sid")
-  [ $if_exists -eq 1 ] && [ ! -f "$path" ] && return 0
+  if [ $if_exists -eq 1 ] && [ ! -f "$path" ]; then
+    # `.rite-session-id` exists ⇒ a session-start hook ran and the caller expects an
+    # active session. Resolved path missing means stale/drifted session_id (Issue #1142)
+    # — emit a WARNING so the silent skip is observable. Truly first-time sessions (no
+    # `.rite-session-id`) stay silent to preserve the graceful no-op contract that
+    # `commands/wiki/ingest.md` / `commands/issue/create.md` / etc. depend on.
+    if [ -f "$SESSION_ID_FILE" ]; then
+      echo "WARNING: flow-state.sh cmd_set: --if-exists skipped (resolved session_id=$sid has no state file at $path; possible stale .rite-session-id or sid drift)" >&2
+    fi
+    return 0
+  fi
   # Pull existing values for fields the caller did not specify (merge behavior).
   # `cur_last_synced` は post-tool-wm-sync.sh が runtime-only field として書き続けるため、
   # cmd_set が schema 構築時に既存値を merge しないと毎回 wipe され、wm-sync の diff guard
@@ -180,15 +194,43 @@ cmd_get() {
     *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
   esac; done
   local sid path
-  sid=$(_resolve_session_id "$session" 2>/dev/null) || { printf '%s\n' "$default"; return 0; }
+  # Do not silence _resolve_session_id stderr: when neither `.rite-session-id` nor
+  # the env vars are usable, the helper's ERROR message must surface so the silent
+  # "empty + rc=0" failure path observed in Issue #1142 becomes diagnosable.
+  sid=$(_resolve_session_id "$session") || { printf '%s\n' "$default"; return 0; }
   path=$(_state_path "$sid")
-  [ ! -f "$path" ] && { printf '%s\n' "$default"; return 0; }
-  if [ -n "$jq_filter" ]; then
-    jq -r "$jq_filter" "$path" 2>/dev/null || printf '%s\n' "$default"
+  if [ ! -f "$path" ]; then
+    # Stale `.rite-session-id` pointing to a nonexistent state file is a drift signal —
+    # WARN so it is observable. Truly first-time sessions (no `.rite-session-id`) stay
+    # silent: the caller's --default fallback is the legitimate graceful path.
+    if [ -f "$SESSION_ID_FILE" ]; then
+      echo "WARNING: flow-state.sh cmd_get: state file not found for resolved session_id=$sid (path: $path; possible stale .rite-session-id); returning --default" >&2
+    fi
+    printf '%s\n' "$default"
     return 0
   fi
-  [ -z "$field" ] && { echo "ERROR: --field or --jq-filter required" >&2; return 1; }
-  jq -r --arg d "$default" ".${field} // \$d" "$path" 2>/dev/null || printf '%s\n' "$default"
+  local jq_err
+  jq_err=$(mktemp 2>/dev/null) || jq_err=""
+  if [ -n "$jq_filter" ]; then
+    if ! jq -r "$jq_filter" "$path" 2>"${jq_err:-/dev/null}"; then
+      echo "WARNING: flow-state.sh cmd_get: jq filter failed for $path (filter: $jq_filter); returning --default" >&2
+      [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+      printf '%s\n' "$default"
+    fi
+    [ -n "$jq_err" ] && rm -f "$jq_err"
+    return 0
+  fi
+  if [ -z "$field" ]; then
+    [ -n "$jq_err" ] && rm -f "$jq_err"
+    echo "ERROR: --field or --jq-filter required" >&2
+    return 1
+  fi
+  if ! jq -r --arg d "$default" ".${field} // \$d" "$path" 2>"${jq_err:-/dev/null}"; then
+    echo "WARNING: flow-state.sh cmd_get: jq read failed for $path (field: $field); returning --default" >&2
+    [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+    printf '%s\n' "$default"
+  fi
+  [ -n "$jq_err" ] && rm -f "$jq_err"
 }
 
 cmd_deactivate() {

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -39,21 +39,56 @@ _phase_migrate() {
   esac
 }
 
+# Reject path-traversal characters and control characters (log injection vector).
+# All session_id sources (override, SESSION_ID_FILE content, env vars) MUST pass through
+# this validator before being printed or used in path construction. Control-character
+# rejection prevents attackers from injecting fake "WARNING:" lines into stderr by setting
+# env var to e.g. $'innocent\nWARNING: fake injected'. Path-traversal rejection prevents
+# CLAUDE_CODE_SESSION_ID="../../tmp/owned" from writing state files outside .rite/sessions/.
+_validate_session_id() {
+  local sid="$1" source="$2"
+  case "$sid" in
+    *..*|*/*)
+      echo "ERROR: invalid session_id from $source: contains path-traversal characters ('..' or '/')" >&2
+      return 1
+      ;;
+  esac
+  if [[ "$sid" =~ [[:cntrl:]] ]]; then
+    echo "ERROR: invalid session_id from $source: contains control characters (newline / tab / etc.)" >&2
+    return 1
+  fi
+  return 0
+}
+
 _resolve_session_id() {
   local override="${1:-}"
   if [ -n "$override" ]; then
-    case "$override" in *..*|*/*) echo "ERROR: invalid session_id: $override" >&2; return 1 ;; esac
+    _validate_session_id "$override" "--session override" || return 1
     printf '%s\n' "$override"; return 0
   fi
   if [ -f "$SESSION_ID_FILE" ]; then
     local sid; sid=$(tr -d '[:space:]' < "$SESSION_ID_FILE" 2>/dev/null) || sid=""
-    [ -n "$sid" ] && printf '%s\n' "$sid" && return 0
+    if [ -n "$sid" ]; then
+      _validate_session_id "$sid" "$SESSION_ID_FILE" || return 1
+      printf '%s\n' "$sid"
+      return 0
+    fi
   fi
   # Claude Code runtime exposes CLAUDE_CODE_SESSION_ID; older / non-Code clients used
   # CLAUDE_SESSION_ID. Accept both so cmd_get / cmd_set --if-exists do not silently
   # degrade when `.rite-session-id` is absent but the runtime env IS set (Issue #1142).
-  [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && { printf '%s\n' "$CLAUDE_CODE_SESSION_ID"; return 0; }
-  [ -n "${CLAUDE_SESSION_ID:-}" ] && { printf '%s\n' "$CLAUDE_SESSION_ID"; return 0; }
+  # 両 env-var 経路にも _validate_session_id を適用し、無検証で _state_path に渡る
+  # path-traversal / log-injection 経路を遮断する。
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    _validate_session_id "$CLAUDE_CODE_SESSION_ID" "CLAUDE_CODE_SESSION_ID env" || return 1
+    printf '%s\n' "$CLAUDE_CODE_SESSION_ID"
+    return 0
+  fi
+  if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    _validate_session_id "$CLAUDE_SESSION_ID" "CLAUDE_SESSION_ID env" || return 1
+    printf '%s\n' "$CLAUDE_SESSION_ID"
+    return 0
+  fi
   echo "ERROR: cannot resolve session_id" >&2; return 1
 }
 
@@ -140,8 +175,12 @@ cmd_set() {
   # を分割し、IFS で安全に split (whitespace collapse 防止)。
   local cur_issue=0 cur_branch="" cur_pr=0 cur_parent=0 cur_active=true cur_err=0 cur_last_synced=""
   if [ -f "$path" ]; then
-    local _cur_jq_err _cur_data _cur_rc=0
+    local _cur_jq_err="" _cur_data _cur_rc=0
     _cur_jq_err=$(mktemp 2>/dev/null) || _cur_jq_err=""
+    # SIGINT / set -e / 関数 early return のいずれでも tempfile 削除を保証する RETURN trap。
+    # 旧実装は L158 の `[ -n "$_cur_jq_err" ] && rm -f "$_cur_jq_err"` インライン rm のみで、
+    # set -e 経由の途中 exit や signal 中断で orphan が残る経路があった (F-05 対応)。
+    trap '[ -n "${_cur_jq_err:-}" ] && rm -f "${_cur_jq_err:-}"' RETURN
     _cur_data=$(jq -r '[(.issue_number // 0 | tostring),
                        (.branch // ""),
                        (.pr_number // 0 | tostring),
@@ -193,7 +232,12 @@ cmd_get() {
     --jq-filter) jq_filter="$2"; shift 2 ;;
     *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
   esac; done
-  local sid path
+  local sid path jq_err=""
+  # mktemp tempfile cleanup を RETURN trap に集約する。SIGINT / set -e / 関数 early
+  # return / 関数末尾 fall-through のいずれでも確実に削除される。インライン rm -f を
+  # 関数末尾に置く旧実装は最終 statement が rc=1 を返した際に関数 rc に漏れる silent
+  # failure (Issue #1142 を作った同型 bug の再導入リスク) を持っていた。
+  trap '[ -n "${jq_err:-}" ] && rm -f "${jq_err:-}"' RETURN
   # Do not silence _resolve_session_id stderr: when neither `.rite-session-id` nor
   # the env vars are usable, the helper's ERROR message must surface so the silent
   # "empty + rc=0" failure path observed in Issue #1142 becomes diagnosable.
@@ -203,34 +247,34 @@ cmd_get() {
     # Stale `.rite-session-id` pointing to a nonexistent state file is a drift signal —
     # WARN so it is observable. Truly first-time sessions (no `.rite-session-id`) stay
     # silent: the caller's --default fallback is the legitimate graceful path.
+    # path 全体ではなく basename のみを露出し、multi-tenant 環境での絶対 path leakage
+    # を最小化する。診断に必要な情報 (どのファイル名か / SESSION_DIR は既知) は basename
+    # で十分。
     if [ -f "$SESSION_ID_FILE" ]; then
-      echo "WARNING: flow-state.sh cmd_get: state file not found for resolved session_id=$sid (path: $path; possible stale .rite-session-id); returning --default" >&2
+      echo "WARNING: flow-state.sh cmd_get: state file not found for resolved session_id=$sid (file: $(basename "$path"); possible stale .rite-session-id); returning --default" >&2
     fi
     printf '%s\n' "$default"
     return 0
   fi
-  local jq_err
   jq_err=$(mktemp 2>/dev/null) || jq_err=""
   if [ -n "$jq_filter" ]; then
     if ! jq -r "$jq_filter" "$path" 2>"${jq_err:-/dev/null}"; then
-      echo "WARNING: flow-state.sh cmd_get: jq filter failed for $path (filter: $jq_filter); returning --default" >&2
+      echo "WARNING: flow-state.sh cmd_get: jq filter failed for $(basename "$path") (filter: $jq_filter); returning --default" >&2
       [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
       printf '%s\n' "$default"
     fi
-    [ -n "$jq_err" ] && rm -f "$jq_err"
     return 0
   fi
   if [ -z "$field" ]; then
-    [ -n "$jq_err" ] && rm -f "$jq_err"
     echo "ERROR: --field or --jq-filter required" >&2
     return 1
   fi
   if ! jq -r --arg d "$default" ".${field} // \$d" "$path" 2>"${jq_err:-/dev/null}"; then
-    echo "WARNING: flow-state.sh cmd_get: jq read failed for $path (field: $field); returning --default" >&2
+    echo "WARNING: flow-state.sh cmd_get: jq read failed for $(basename "$path") (field: $field); returning --default" >&2
     [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
     printf '%s\n' "$default"
   fi
-  [ -n "$jq_err" ] && rm -f "$jq_err"
+  return 0
 }
 
 cmd_deactivate() {

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -196,7 +196,6 @@ cmd_set() {
     else
       IFS=$'\x1f' read -r cur_issue cur_branch cur_pr cur_parent cur_active cur_err cur_last_synced <<< "$_cur_data"
     fi
-    # インライン rm は RETURN trap が cover するため削除済 (dead-effect duplication 防止)
   fi
   [ -z "$issue" ] && issue=$cur_issue
   [ -z "$branch" ] && branch=$cur_branch
@@ -235,10 +234,8 @@ cmd_get() {
     *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
   esac; done
   local sid path jq_err=""
-  # mktemp tempfile cleanup を RETURN trap に集約する。SIGINT / set -e / 関数 early
-  # return / 関数末尾 fall-through のいずれでも確実に削除される。インライン rm -f を
-  # 関数末尾に置く旧実装は最終 statement が rc=1 を返した際に関数 rc に漏れる silent
-  # failure (Issue #1142 を作った同型 bug の再導入リスク) を持っていた。
+  # RETURN trap で mktemp tempfile cleanup を集約する。SIGINT / set -e / 関数 early
+  # return / 関数末尾 fall-through すべての経路で確実に削除される。
   trap '[ -n "${jq_err:-}" ] && rm -f "${jq_err:-}"' RETURN
   # Do not silence _resolve_session_id stderr: when neither `.rite-session-id` nor
   # the env vars are usable, the helper's ERROR message must surface so the silent

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -46,15 +46,17 @@ _phase_migrate() {
 # env var to e.g. $'innocent\nWARNING: fake injected'. Path-traversal rejection prevents
 # CLAUDE_CODE_SESSION_ID="../../tmp/owned" from writing state files outside .rite/sessions/.
 _validate_session_id() {
-  local sid="$1" source="$2"
+  # `origin` (引数 2) は session_id の出所 (override / SESSION_ID_FILE / env var) を識別する
+  # エラーメッセージ用ラベル。bash builtin `source` の shadow を避けるため `origin` を採用。
+  local sid="$1" origin="$2"
   case "$sid" in
     *..*|*/*)
-      echo "ERROR: invalid session_id from $source: contains path-traversal characters ('..' or '/')" >&2
+      echo "ERROR: invalid session_id from $origin: contains path-traversal characters ('..' or '/')" >&2
       return 1
       ;;
   esac
   if [[ "$sid" =~ [[:cntrl:]] ]]; then
-    echo "ERROR: invalid session_id from $source: contains control characters (newline / tab / etc.)" >&2
+    echo "ERROR: invalid session_id from $origin: contains control characters (newline / tab / etc.)" >&2
     return 1
   fi
   return 0
@@ -157,7 +159,8 @@ cmd_set() {
     # `.rite-session-id`) stay silent to preserve the graceful no-op contract that
     # `commands/wiki/ingest.md` / `commands/issue/create.md` / etc. depend on.
     if [ -f "$SESSION_ID_FILE" ]; then
-      echo "WARNING: flow-state.sh cmd_set: --if-exists skipped (resolved session_id=$sid has no state file at $path; possible stale .rite-session-id or sid drift)" >&2
+      # basename only — multi-tenant 環境での絶対 path leakage を最小化 (cmd_get と対称化)
+      echo "WARNING: flow-state.sh cmd_set: --if-exists skipped (resolved session_id=$sid has no state file at file: $(basename "$path"); possible stale .rite-session-id or sid drift)" >&2
     fi
     return 0
   fi
@@ -177,9 +180,7 @@ cmd_set() {
   if [ -f "$path" ]; then
     local _cur_jq_err="" _cur_data _cur_rc=0
     _cur_jq_err=$(mktemp 2>/dev/null) || _cur_jq_err=""
-    # SIGINT / set -e / 関数 early return のいずれでも tempfile 削除を保証する RETURN trap。
-    # 旧実装は L158 の `[ -n "$_cur_jq_err" ] && rm -f "$_cur_jq_err"` インライン rm のみで、
-    # set -e 経由の途中 exit や signal 中断で orphan が残る経路があった (F-05 対応)。
+    # インライン rm では set -e / signal 中断時に orphan tempfile が残るため RETURN trap で保証する。
     trap '[ -n "${_cur_jq_err:-}" ] && rm -f "${_cur_jq_err:-}"' RETURN
     _cur_data=$(jq -r '[(.issue_number // 0 | tostring),
                        (.branch // ""),
@@ -189,12 +190,13 @@ cmd_set() {
                        (.error_count // 0 | tostring),
                        (.last_synced_phase // "")] | join("")' "$path" 2>"${_cur_jq_err:-/dev/null}") || _cur_rc=$?
     if [ "$_cur_rc" -ne 0 ]; then
-      echo "WARNING: flow-state.sh cmd_set: existing state read failed for $path (may be corrupt; merged write will use defaults)" >&2
+      # basename only — multi-tenant 環境での絶対 path leakage を最小化 (cmd_get / cmd_set --if-exists と対称化)
+      echo "WARNING: flow-state.sh cmd_set: existing state read failed for $(basename "$path") (may be corrupt; merged write will use defaults)" >&2
       [ -n "$_cur_jq_err" ] && [ -s "$_cur_jq_err" ] && head -3 "$_cur_jq_err" | sed 's/^/  /' >&2
     else
       IFS=$'\x1f' read -r cur_issue cur_branch cur_pr cur_parent cur_active cur_err cur_last_synced <<< "$_cur_data"
     fi
-    [ -n "$_cur_jq_err" ] && rm -f "$_cur_jq_err"
+    # インライン rm は RETURN trap が cover するため削除済 (dead-effect duplication 防止)
   fi
   [ -z "$issue" ] && issue=$cur_issue
   [ -z "$branch" ] && branch=$cur_branch

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -110,9 +110,9 @@ _atomic_write() {
   # 生成されたまま下流の mv が "成功" して target を破損内容で上書きする経路を遮断する。
   # Additionally guard the post-write non-empty invariant: jq filters in this script always
   # produce a non-empty JSON object, so a 0-byte tmpfile is a write-time corruption signal.
-  # printf 失敗分岐と 0-byte invariant 違反分岐は flock timeout 分岐 (L80) と対称的に診断 ERROR を
-  # 必ず emit する。rc=1 だけでは EROFS / ENOSPC / EXDEV / EACCES / 0-byte write のどの失敗種別か
-  # 区別できず、operator がトリアージできない。
+  # printf 失敗分岐と 0-byte invariant 違反分岐は下流の flock+mv の ERROR emission (`flock timeout`
+  # 分岐) と対称的に診断 ERROR を必ず emit する。rc=1 だけでは EROFS / ENOSPC / EXDEV / EACCES /
+  # 0-byte write のどの失敗種別か区別できず、operator がトリアージできない。
   printf '%s' "$content" > "$tmpfile" || {
     echo "ERROR: _atomic_write write failed: $target" >&2
     rm -f "$tmpfile" 2>/dev/null
@@ -217,10 +217,10 @@ cmd_set() {
       parent_issue_number:$parent, next_action:$next, active:$active,
       error_count:$err, updated_at:$ts}
      | (if $lsp != "" then .last_synced_phase = $lsp else . end)') || return 1
-  # `_atomic_write` の header 契約 (L61-64 "Callers MUST check rc") を遵守。現状は cmd_set の
+  # `_atomic_write` の header コメント ("Callers MUST check rc") を遵守。現状は cmd_set の
   # 最終 statement のため set -e で rc が暗黙伝播するが、将来 `_atomic_write` の後に log 行を
   # 1 つ足す等の小修正で silent failure path が即復活する fragile pattern を避けるため、明示的
-  # に `|| return 1` で rc を伝播させる (`_migrate_file` L236 と対称化)。
+  # に `|| return 1` で rc を伝播させる (`_migrate_file` の `_atomic_write` 呼び出し直前と対称化)。
   _atomic_write "$path" "$new" || return 1
 }
 
@@ -307,7 +307,7 @@ _migrate_file() {
   cp=$(jq -r '.phase // ""' "$f" 2>/dev/null) || cp=""
   [ "$sv" = "$SCHEMA_VERSION_V3" ] && { [ "$verbose" = 1 ] && echo "  skip (already v3): $f" >&2; return 1; }
   np=$(_phase_migrate "$cp")
-  # `--dry-run` の preview を stderr に統一する (line 208 の `migrated:` 出力と対称化)。
+  # `--dry-run` の preview を stderr に統一する (本関数末尾の `migrated:` announcement と対称化)。
   # session-start.sh は stdout のみ silence するため、dry-run preview を stderr に出すことで
   # 実際の migration announcement と同じ経路で observability を確保する。
   [ "$dry" = 1 ] && { echo "  would migrate: $f (schema v$sv→v$SCHEMA_VERSION_V3, phase $cp→$np)" >&2; return 0; }

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -372,6 +372,96 @@ else
   fail "TC-12: merged write failed to produce valid JSON"
 fi
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor"; then
+# --- TC-13: AC-4 — CLAUDE_CODE_SESSION_ID env resolves session_id when .rite-session-id is absent ---
+echo ""
+echo "=== TC-13: AC-4 CLAUDE_CODE_SESSION_ID env-only resolution (Issue #1142) ==="
+# Why: Issue #1142 root cause was that `_resolve_session_id` only honored
+# CLAUDE_SESSION_ID, but Claude Code runtime sets CLAUDE_CODE_SESSION_ID. When
+# `.rite-session-id` was absent, get/set silently degraded (empty + rc=0 / silent skip).
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+(cd "$d" && bash "$HOOK" set --phase plan --issue 1142 --branch "fix/issue-1142" --pr 0 --next "n")
+# Remove .rite-session-id to force env-var path.
+rm -f "$d/.rite-session-id"
+got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
+assert "TC-13.1: CLAUDE_CODE_SESSION_ID resolves get correctly" "plan" "$got"
+(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" set --phase pr --next "after-fix" --if-exists)
+got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
+assert "TC-13.2: CLAUDE_CODE_SESSION_ID resolves set --if-exists correctly" "pr" "$got"
+got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field next_action --default "EMPTY")
+assert "TC-13.3: --if-exists write was not silently skipped" "after-fix" "$got"
+
+# --- TC-14: AC-4 backwards-compat — CLAUDE_SESSION_ID still works ---
+echo ""
+echo "=== TC-14: AC-4 backwards-compat CLAUDE_SESSION_ID still resolves ==="
+# Why: keep the legacy env var name working so any out-of-tree tooling that
+# already sets CLAUDE_SESSION_ID does not break.
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+(cd "$d" && bash "$HOOK" set --phase implement --issue 1142 --branch "b" --pr 0 --next "n")
+rm -f "$d/.rite-session-id"
+got=$(cd "$d" && env -u CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
+assert "TC-14: legacy CLAUDE_SESSION_ID still resolves get" "implement" "$got"
+
+# --- TC-15: AC-3 — cmd_get surfaces _resolve_session_id ERROR (no silencing) ---
+echo ""
+echo "=== TC-15: AC-3 cmd_get does not silence resolution ERROR ==="
+# Why: Issue #1142 — cmd_get used `_resolve_session_id ... 2>/dev/null`, hiding the
+# "ERROR: cannot resolve session_id" message. Now stderr must reach the operator.
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 )
+echo "$err" | grep -q "ERROR: cannot resolve session_id" \
+  && pass "TC-15: cmd_get surfaces _resolve_session_id ERROR on stderr" \
+  || fail "TC-15: cmd_get silenced resolution ERROR (regression of Issue #1142 fix): '$err'"
+
+# --- TC-16: AC-3 — cmd_get emits WARNING for stale .rite-session-id drift ---
+echo ""
+echo "=== TC-16: AC-3 cmd_get WARNs on stale .rite-session-id drift ==="
+# Why: When `.rite-session-id` resolves to a sid whose state file does not exist,
+# the caller's "get value" intent silently degrades to default. Issue #1142 fix
+# emits a WARNING to make the drift observable. Truly first-time sessions (no
+# `.rite-session-id`) stay silent (graceful no-op).
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+echo "deadbeef-0000-0000-0000-000000000000" > "$d/.rite-session-id"
+err=$( (cd "$d" && bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 )
+echo "$err" | grep -q "WARNING: flow-state.sh cmd_get: state file not found" \
+  && pass "TC-16.1: cmd_get WARNs on stale sid drift" \
+  || fail "TC-16.1: cmd_get silent on stale sid drift: '$err'"
+# Truly first-time (no .rite-session-id) must stay silent (graceful contract).
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+# The resolution-ERROR is expected here; WARNING about state-file-not-found must NOT
+# fire because we never resolved a sid.
+echo "$err" | grep -q "WARNING: flow-state.sh cmd_get: state file not found" \
+  && fail "TC-16.2: cmd_get emitted state-file WARNING when sid was not resolved (regression)" \
+  || pass "TC-16.2: cmd_get silent about state-file-not-found when sid resolution itself failed"
+
+# --- TC-17: AC-2 + AC-3 — cmd_set --if-exists WARNs on stale .rite-session-id drift ---
+echo ""
+echo "=== TC-17: AC-2/AC-3 cmd_set --if-exists WARNs on stale sid; first-time silent ==="
+# Why: Issue #1142 — `--if-exists` silently skipped when sid resolved to a file
+# that did not exist (stale `.rite-session-id`). Caller's intent (update active
+# session state) was violated without any signal. Fix emits WARNING only when
+# `.rite-session-id` exists (caller expected a session), staying silent for the
+# truly first-time case that wiki/ingest.md and issue/create.md rely on.
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+echo "deadbeef-0000-0000-0000-000000000000" > "$d/.rite-session-id"
+err=$( (cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 )
+echo "$err" | grep -q "WARNING: flow-state.sh cmd_set: --if-exists skipped" \
+  && pass "TC-17.1: cmd_set --if-exists WARNs on stale sid drift" \
+  || fail "TC-17.1: cmd_set --if-exists silent on stale sid drift: '$err'"
+# First-time session (no .rite-session-id, no env): silent no-op (legitimate graceful path).
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+# Must succeed silently with rc=0 — the truly-first-time graceful contract.
+combined=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 || true )
+# When session_id cannot be resolved at all, cmd_set returns rc=1 with ERROR (not
+# silent). This is correct: --if-exists's silent-skip contract applies after sid
+# resolution succeeds, not before. The WARNING about "--if-exists skipped" must
+# NOT appear because we never reached that branch.
+echo "$combined" | grep -q "WARNING: flow-state.sh cmd_set: --if-exists skipped" \
+  && fail "TC-17.2: emitted --if-exists WARNING when sid resolution itself failed (regression)" \
+  || pass "TC-17.2: silent about --if-exists skip when sid resolution failed (ERROR surfaces instead)"
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -751,6 +751,6 @@ else
   fail "TC-22.2: env-set first-time で stdout に default 返却なし: '$combined'"
 fi
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + PR #1148 security/observability fixes"; then
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -382,12 +382,14 @@ result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 (cd "$d" && bash "$HOOK" set --phase plan --issue 1142 --branch "fix/issue-1142" --pr 0 --next "n")
 # Remove .rite-session-id to force env-var path.
 rm -f "$d/.rite-session-id"
-got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
+# `env -u CLAUDE_SESSION_ID` で legacy env も明示 unset し、TC-14 と完全対称化。
+# precedence regression (CLAUDE_CODE_SESSION_ID 分岐削除) を TC-13 単体で検出可能にする。
+got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
 assert "TC-13.1: CLAUDE_CODE_SESSION_ID resolves get correctly" "plan" "$got"
-(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" set --phase pr --next "after-fix" --if-exists)
-got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
+(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" set --phase pr --next "after-fix" --if-exists)
+got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "EMPTY")
 assert "TC-13.2: CLAUDE_CODE_SESSION_ID resolves set --if-exists correctly" "pr" "$got"
-got=$(cd "$d" && CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field next_action --default "EMPTY")
+got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field next_action --default "EMPTY")
 assert "TC-13.3: --if-exists write was not silently skipped" "after-fix" "$got"
 
 # --- TC-14: AC-4 backwards-compat — CLAUDE_SESSION_ID still works ---
@@ -409,9 +411,13 @@ echo "=== TC-15: AC-3 cmd_get does not silence resolution ERROR ==="
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
 err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 )
-echo "$err" | grep -q "ERROR: cannot resolve session_id" \
-  && pass "TC-15: cmd_get surfaces _resolve_session_id ERROR on stderr" \
-  || fail "TC-15: cmd_get silenced resolution ERROR (regression of Issue #1142 fix): '$err'"
+# ERE pattern: 文言の軽微なリネーム (e.g. cmd_get→get、prefix 変更) でも brittle に
+# silent regression しないようにする (cmd_get と "cannot resolve" の組合せのみ assert)
+if echo "$err" | grep -qE 'ERROR:.*cannot resolve session_id'; then
+  pass "TC-15: cmd_get surfaces _resolve_session_id ERROR on stderr"
+else
+  fail "TC-15: cmd_get silenced resolution ERROR (regression of Issue #1142 fix): '$err'"
+fi
 
 # --- TC-16: AC-3 — cmd_get emits WARNING for stale .rite-session-id drift ---
 echo ""
@@ -423,17 +429,23 @@ echo "=== TC-16: AC-3 cmd_get WARNs on stale .rite-session-id drift ==="
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 echo "deadbeef-0000-0000-0000-000000000000" > "$d/.rite-session-id"
 err=$( (cd "$d" && bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 )
-echo "$err" | grep -q "WARNING: flow-state.sh cmd_get: state file not found" \
-  && pass "TC-16.1: cmd_get WARNs on stale sid drift" \
-  || fail "TC-16.1: cmd_get silent on stale sid drift: '$err'"
+# ERE pattern で文言 drift に耐性。F-09 修正で `path:` → `file:` (basename only) に
+# リネームしたが、ERE は両方マッチ可能 (`(path|file):` を含めない柔軟な anchor)。
+if echo "$err" | grep -qE 'WARNING:.*cmd_get.*state file not found'; then
+  pass "TC-16.1: cmd_get WARNs on stale sid drift"
+else
+  fail "TC-16.1: cmd_get silent on stale sid drift: '$err'"
+fi
 # Truly first-time (no .rite-session-id) must stay silent (graceful contract).
 rm -f "$d/.rite-session-id"
 err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
 # The resolution-ERROR is expected here; WARNING about state-file-not-found must NOT
 # fire because we never resolved a sid.
-echo "$err" | grep -q "WARNING: flow-state.sh cmd_get: state file not found" \
-  && fail "TC-16.2: cmd_get emitted state-file WARNING when sid was not resolved (regression)" \
-  || pass "TC-16.2: cmd_get silent about state-file-not-found when sid resolution itself failed"
+if echo "$err" | grep -qE 'WARNING:.*cmd_get.*state file not found'; then
+  fail "TC-16.2: cmd_get emitted state-file WARNING when sid was not resolved (regression)"
+else
+  pass "TC-16.2: cmd_get silent about state-file-not-found when sid resolution itself failed"
+fi
 
 # --- TC-17: AC-2 + AC-3 — cmd_set --if-exists WARNs on stale .rite-session-id drift ---
 echo ""
@@ -446,22 +458,71 @@ echo "=== TC-17: AC-2/AC-3 cmd_set --if-exists WARNs on stale sid; first-time si
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 echo "deadbeef-0000-0000-0000-000000000000" > "$d/.rite-session-id"
 err=$( (cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 )
-echo "$err" | grep -q "WARNING: flow-state.sh cmd_set: --if-exists skipped" \
-  && pass "TC-17.1: cmd_set --if-exists WARNs on stale sid drift" \
-  || fail "TC-17.1: cmd_set --if-exists silent on stale sid drift: '$err'"
-# First-time session (no .rite-session-id, no env): silent no-op (legitimate graceful path).
+if echo "$err" | grep -qE 'WARNING:.*cmd_set:.*if-exists skipped'; then
+  pass "TC-17.1: cmd_set --if-exists WARNs on stale sid drift"
+else
+  fail "TC-17.1: cmd_set --if-exists silent on stale sid drift: '$err'"
+fi
+# First-time session (no .rite-session-id, no env): cmd_set returns rc=1 + ERROR
+# (resolution failure surfaces). The --if-exists silent-skip contract applies AFTER
+# sid resolution succeeds, not before. First-time graceful means "no WARNING about
+# --if-exists skip", not "rc=0". 旧 L455 コメントの "rc=0 graceful" 記述は obsolete
+# だったため Issue #1019 で修正 (実機: env 両方 unset で set --if-exists → rc=1 + ERROR)。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
-# Must succeed silently with rc=0 — the truly-first-time graceful contract.
 combined=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 || true )
-# When session_id cannot be resolved at all, cmd_set returns rc=1 with ERROR (not
-# silent). This is correct: --if-exists's silent-skip contract applies after sid
-# resolution succeeds, not before. The WARNING about "--if-exists skipped" must
-# NOT appear because we never reached that branch.
-echo "$combined" | grep -q "WARNING: flow-state.sh cmd_set: --if-exists skipped" \
-  && fail "TC-17.2: emitted --if-exists WARNING when sid resolution itself failed (regression)" \
-  || pass "TC-17.2: silent about --if-exists skip when sid resolution failed (ERROR surfaces instead)"
+# WARNING about "--if-exists skipped" must NOT appear because we never reached that branch.
+if echo "$combined" | grep -qE 'WARNING:.*cmd_set:.*if-exists skipped'; then
+  fail "TC-17.2: emitted --if-exists WARNING when sid resolution itself failed (regression)"
+else
+  pass "TC-17.2: silent about --if-exists skip when sid resolution failed (ERROR surfaces instead)"
+fi
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes"; then
+# --- TC-18: F-02 path traversal regression guard (Issue #1148) ---
+echo ""
+echo "=== TC-18: F-02 env-var session_id path-traversal validation ==="
+# Why: CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID env-var paths were resolving sid
+# without validation, allowing CLAUDE_CODE_SESSION_ID="../../tmp/owned" to write
+# state files outside .rite/sessions/. Pin the validator with negative tests for
+# both env vars and direct override.
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="../../tmp/pwned" bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*path-traversal'; then
+  pass "TC-18.1: CLAUDE_CODE_SESSION_ID rejects '..' path traversal"
+else
+  fail "TC-18.1: path traversal not rejected: '$err'"
+fi
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID="abc/def" bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*path-traversal'; then
+  pass "TC-18.2: CLAUDE_SESSION_ID rejects '/' path traversal"
+else
+  fail "TC-18.2: path traversal not rejected: '$err'"
+fi
+
+# --- TC-19: F-03 log injection regression guard (Issue #1148) ---
+echo ""
+echo "=== TC-19: F-03 env-var session_id control-character validation ==="
+# Why: WARNING messages embedded $sid without escaping, allowing
+# CLAUDE_CODE_SESSION_ID=$'innocent\nWARNING: fake injected' to inject fake
+# WARNING lines into stderr (log injection vector). Pin rejection of newline /
+# tab / NUL etc.
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID=$'sid-with\nnewline' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.1: CLAUDE_CODE_SESSION_ID rejects embedded newline (log injection)"
+else
+  fail "TC-19.1: newline not rejected: '$err'"
+fi
+# tab も same code path (any [[:cntrl:]] char) で reject される
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID=$'sid\twith-tab' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.2: CLAUDE_SESSION_ID rejects embedded tab (log injection)"
+else
+  fail "TC-19.2: tab not rejected: '$err'"
+fi
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + Issue #1148 security/observability fixes"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -391,6 +391,15 @@ got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$H
 assert "TC-13.2: CLAUDE_CODE_SESSION_ID resolves set --if-exists correctly" "pr" "$got"
 got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field next_action --default "EMPTY")
 assert "TC-13.3: --if-exists write was not silently skipped" "after-fix" "$got"
+# TC-13.4: 両 env-var 同時 set 時の precedence (CLAUDE_CODE_SESSION_ID が primary)
+# 2 種類の sid を用意し、CCSID 側の state file が選択されることを assert する。
+# これにより `_resolve_session_id` の if-branch 順序入れ替え regression を catch する。
+result2=$(new_sandbox); d2="${result2%|*}"; sid2="${result2#*|}"
+(cd "$d2" && bash "$HOOK" set --phase ready --issue 9999 --branch "br-ccsid" --pr 0 --next "ccsid-state")
+rm -f "$d2/.rite-session-id"
+# 別 sid (= 別 state file path) を CLAUDE_SESSION_ID に渡し、CCSID 側が勝つことを確認
+got=$(cd "$d2" && env CLAUDE_CODE_SESSION_ID="$sid2" CLAUDE_SESSION_ID="deadbeef-0000-0000-0000-000000000000" bash "$HOOK" get --field next_action --default "EMPTY")
+assert "TC-13.4: CLAUDE_CODE_SESSION_ID takes precedence over CLAUDE_SESSION_ID (primary)" "ccsid-state" "$got"
 
 # --- TC-14: AC-4 backwards-compat — CLAUDE_SESSION_ID still works ---
 echo ""
@@ -429,8 +438,8 @@ echo "=== TC-16: AC-3 cmd_get WARNs on stale .rite-session-id drift ==="
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 echo "deadbeef-0000-0000-0000-000000000000" > "$d/.rite-session-id"
 err=$( (cd "$d" && bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 )
-# ERE pattern で文言 drift に耐性。F-09 修正で `path:` → `file:` (basename only) に
-# リネームしたが、ERE は両方マッチ可能 (`(path|file):` を含めない柔軟な anchor)。
+# ERE pattern で文言 drift に耐性 (`(path|file):` を含めない柔軟な anchor で
+# WARNING 文言が path/file/その他に変わっても match する)。
 if echo "$err" | grep -qE 'WARNING:.*cmd_get.*state file not found'; then
   pass "TC-16.1: cmd_get WARNs on stale sid drift"
 else
@@ -466,8 +475,7 @@ fi
 # First-time session (no .rite-session-id, no env): cmd_set returns rc=1 + ERROR
 # (resolution failure surfaces). The --if-exists silent-skip contract applies AFTER
 # sid resolution succeeds, not before. First-time graceful means "no WARNING about
-# --if-exists skip", not "rc=0". 旧 L455 コメントの "rc=0 graceful" 記述は obsolete
-# だったため Issue #1019 で修正 (実機: env 両方 unset で set --if-exists → rc=1 + ERROR)。
+# --if-exists skip", not "rc=0" (実機: env 両方 unset で set --if-exists → rc=1 + ERROR)。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
 combined=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 || true )
@@ -478,13 +486,16 @@ else
   pass "TC-17.2: silent about --if-exists skip when sid resolution failed (ERROR surfaces instead)"
 fi
 
-# --- TC-18: F-02 path traversal regression guard (Issue #1148) ---
+# --- TC-18: env-var session_id path-traversal validation ---
 echo ""
-echo "=== TC-18: F-02 env-var session_id path-traversal validation ==="
-# Why: CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID env-var paths were resolving sid
-# without validation, allowing CLAUDE_CODE_SESSION_ID="../../tmp/owned" to write
-# state files outside .rite/sessions/. Pin the validator with negative tests for
-# both env vars and direct override.
+echo "=== TC-18: env-var session_id path-traversal validation ==="
+# Why: env-var paths and override path were resolving sid without validation,
+# allowing "../../tmp/owned" to write state files outside .rite/sessions/.
+# Pin the validator with negative tests for 4 entry points:
+#  TC-18.1/2: env-var (CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID)
+#  TC-18.3:   --session override
+#  TC-18.4:   SESSION_ID_FILE content
+# This ensures `_validate_session_id` chokepoint protects all 4 sources symmetrically.
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
 err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="../../tmp/pwned" bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
@@ -499,14 +510,35 @@ if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*path-traversal'; then
 else
   fail "TC-18.2: path traversal not rejected: '$err'"
 fi
+# TC-18.3: --session override 経路。validator が chokepoint で発火することを pin
+err=$( (cd "$d" && bash "$HOOK" get --session "../../tmp/pwned" --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*path-traversal'; then
+  pass "TC-18.3: --session override rejects '..' path traversal"
+else
+  fail "TC-18.3: override path traversal not rejected: '$err'"
+fi
+# TC-18.4: SESSION_ID_FILE 経路。.rite-session-id 内容も同じ validator を通る
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+echo "../../tmp/pwned-from-file" > "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*path-traversal'; then
+  pass "TC-18.4: SESSION_ID_FILE content rejects '..' path traversal"
+else
+  fail "TC-18.4: SESSION_ID_FILE path traversal not rejected: '$err'"
+fi
 
-# --- TC-19: F-03 log injection regression guard (Issue #1148) ---
+# --- TC-19: env-var session_id control-character validation (log injection guard) ---
 echo ""
-echo "=== TC-19: F-03 env-var session_id control-character validation ==="
+echo "=== TC-19: env-var session_id control-character validation (log injection guard) ==="
 # Why: WARNING messages embedded $sid without escaping, allowing
 # CLAUDE_CODE_SESSION_ID=$'innocent\nWARNING: fake injected' to inject fake
-# WARNING lines into stderr (log injection vector). Pin rejection of newline /
-# tab / NUL etc.
+# WARNING lines into stderr (CRLF / log injection vector). Pin rejection of
+# the 4 main control-char vectors:
+#  TC-19.1: \n (newline — CRLF splitting primary vector)
+#  TC-19.2: \t (tab)
+#  TC-19.3: \r (CR — HTTP-style CRLF injection primary vector)
+# Plus TC-19.5: 「reject 発生」だけでなく fake WARNING 行が **stderr に存在しない** ことを negative-assert
+# (validator が partial regression した場合に injection が漏出しても rejection が出れば pass する穴を塞ぐ)
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
 err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID=$'sid-with\nnewline' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
@@ -515,12 +547,26 @@ if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
 else
   fail "TC-19.1: newline not rejected: '$err'"
 fi
-# tab も same code path (any [[:cntrl:]] char) で reject される
 err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID=$'sid\twith-tab' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
 if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
   pass "TC-19.2: CLAUDE_SESSION_ID rejects embedded tab (log injection)"
 else
   fail "TC-19.2: tab not rejected: '$err'"
+fi
+# TC-19.3: \r (CR) — CRLF splitting attack の primary vector
+err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID=$'sid\rwith-cr' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.3: CLAUDE_CODE_SESSION_ID rejects embedded CR (CRLF injection)"
+else
+  fail "TC-19.3: CR not rejected: '$err'"
+fi
+# TC-19.4 (negative assertion): injection 内容が stderr に**漏出していない**ことを assert
+# validator partial regression (例: [[:cntrl:]] を `\n` のみに狭めた変更) に対する直接 guard
+inj_err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID=$'sid\nWARNING: fake injected by attacker' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$inj_err" | grep -qE 'WARNING:.*fake injected by attacker'; then
+  fail "TC-19.4: injection content leaked into stderr (validator regression): '$inj_err'"
+else
+  pass "TC-19.4: injection content not present in stderr (validator chokepoint pin)"
 fi
 
 if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + Issue #1148 security/observability fixes"; then

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -365,6 +365,20 @@ if grep -q "WARNING: flow-state.sh cmd_set: existing state read failed" "$d/tc12
 else
   fail "TC-12: no WARNING for corrupt JSON (silent overwrite regression)"
 fi
+# 他 4 経路 (TC-16.1 / TC-17.1 / TC-20.1 / TC-20.2) と対称化。cmd_set corrupt-JSON 経路に
+# 導入された $(basename) 化と head -3 | sed 's/^/  /' indented diagnostic を pin する。
+# 前者が抜けると multi-tenant 絶対 path leak が silent に復活し、後者が抜けると
+# observability 喪失 (jq parse error の中身が見えなくなる) が silent に復活する。
+if grep -qE 'WARNING:.*\.rite/sessions/' "$d/tc12.stderr"; then
+  fail "TC-12: WARNING に絶対 path (.rite/sessions/) が leak"
+else
+  pass "TC-12: WARNING に絶対 path leak なし"
+fi
+if grep -qE '^  [^ ]' "$d/tc12.stderr"; then
+  pass "TC-12: corrupt JSON で診断 stderr の indented 行が出力される"
+else
+  fail "TC-12: 診断 stderr の indented 行が欠落"
+fi
 # Resulting file must be valid JSON (write proceeded with defaults).
 if jq -e . "$state_file" >/dev/null 2>&1; then
   pass "TC-12: merged write produced valid JSON with defaults"
@@ -679,8 +693,9 @@ echo "=== TC-21: cmd_get --field/--jq-filter required (contract pin) ==="
 # 成立しないため、事前に set で state file を作成する。将来引数 parser を loose にして default
 # field を導入した場合の silent な behavioral drift を pin する。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
-# state file を作成する (state file 不在では L245 の `[ ! -f "$path" ]` 分岐で WARNING + default + rc=0
-# に流れるため、L267 の ERROR + rc=1 経路に到達しない)
+# state file を作成する (state file 不在では cmd_get の "state file not found" WARNING + default + rc=0
+# 分岐に流れて `--field or --jq-filter required` ERROR + rc=1 経路に到達しないため、本 TC では事前に
+# state file を生成しておく)
 (cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n") >/dev/null
 # get は意図的に rc=1 を返す経路 → 外側 set -e で abort しないよう || true を付与し
 # subshell 内で得た rc を直接 capture する

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -445,6 +445,12 @@ if echo "$err" | grep -qE 'WARNING:.*cmd_get.*state file not found'; then
 else
   fail "TC-16.1: cmd_get silent on stale sid drift: '$err'"
 fi
+# basename leak 抑制 (multi-tenant 環境での絶対 path leak を防ぐ negative-assert)
+if echo "$err" | grep -qE 'WARNING:.*\.rite/sessions/'; then
+  fail "TC-16.1: stale sid WARNING に絶対 path (.rite/sessions/) が leak: '$err'"
+else
+  pass "TC-16.1: stale sid WARNING に絶対 path leak なし"
+fi
 # Truly first-time (no .rite-session-id) must stay silent (graceful contract).
 rm -f "$d/.rite-session-id"
 err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
@@ -471,6 +477,12 @@ if echo "$err" | grep -qE 'WARNING:.*cmd_set:.*if-exists skipped'; then
   pass "TC-17.1: cmd_set --if-exists WARNs on stale sid drift"
 else
   fail "TC-17.1: cmd_set --if-exists silent on stale sid drift: '$err'"
+fi
+# basename leak 抑制 (multi-tenant 環境での絶対 path leak を防ぐ negative-assert)
+if echo "$err" | grep -qE 'WARNING:.*\.rite/sessions/'; then
+  fail "TC-17.1: stale sid WARNING に絶対 path (.rite/sessions/) が leak: '$err'"
+else
+  pass "TC-17.1: stale sid WARNING に絶対 path leak なし"
 fi
 # First-time session (no .rite-session-id, no env): cmd_set returns rc=1 + ERROR
 # (resolution failure surfaces). The --if-exists silent-skip contract applies AFTER
@@ -568,20 +580,39 @@ if echo "$inj_err" | grep -qE 'WARNING:.*fake injected by attacker'; then
 else
   pass "TC-19.4: injection content not present in stderr (validator chokepoint pin)"
 fi
+# TC-19.5: --session override 経路 control-char rejection (TC-18 と symmetric な 4 entry point pin)
+err=$( (cd "$d" && bash "$HOOK" get --session $'sid\nwith-newline' --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.5: --session override rejects embedded newline (control-char chokepoint)"
+else
+  fail "TC-19.5: --session override で control-char not rejected: '$err'"
+fi
+# TC-19.6: SESSION_ID_FILE 経路 control-char rejection
+# 注: _resolve_session_id は SESSION_ID_FILE 内容に `tr -d '[:space:]'` を適用するため、
+# tab / newline / CR は事前削除される。non-whitespace control char (\x01 = SOH、ASCII control) を使い、
+# tr では削除されず validator に到達することを確認する (cntrl class chokepoint の symmetric pin)
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+printf 'sid\x01with-soh' > "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.6: SESSION_ID_FILE 内容 rejects embedded SOH (4 entry point の対称 pin 完成)"
+else
+  fail "TC-19.6: SESSION_ID_FILE control-char not rejected: '$err'"
+fi
 
 # --- TC-20: cmd_get jq failure WARNING paths (corrupt JSON state file) ---
 echo ""
 echo "=== TC-20: cmd_get jq failure WARNING paths (silent-failure regression guard) ==="
-# Why: Phase 4.5.1 で追加された jq-filter failure / field-read failure の WARNING 経路は
-# Issue #1142 root cause と同型の silent-failure 解消経路。corrupt JSON で発火させ、
-# 将来 `2>/dev/null || printf '%s\n' "$default"` の旧パターンへ silent revert された場合の
-# regression を catch する。
+# Why: cmd_get の jq 失敗経路 (--field / --jq-filter 両方) は WARNING + rc=0 + default 出力の
+# 3 点を契約とする。corrupt JSON で発火させて 3 点同時に pin することで、stderr suppress +
+# silent fallback への regression を検出する。診断 stderr の indented 行 (jq エラー内容) も
+# 別 assert で pin し、診断行 silent 欠落も catch する。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 # state file を作成してから内容を corrupt JSON に上書きする
 (cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n") >/dev/null
 state_file="$d/.rite/sessions/${sid}.flow-state"
 echo "{this is not valid JSON" > "$state_file"
-# TC-20.1: --field path で jq read failed WARNING + rc=0 + stdout に default 返却
+# TC-20.1: --field path で jq read failed WARNING + rc=0 + stdout に default 返却 + 診断行 (2-space indent)
 combined=$( (cd "$d" && bash "$HOOK" get --field phase --default "DEF") 2>&1 )
 get_rc=$?
 if echo "$combined" | grep -qE 'WARNING:.*cmd_get: jq read failed'; then
@@ -599,7 +630,19 @@ if echo "$combined" | grep -qE '^DEF$'; then
 else
   fail "TC-20.1: default not returned on jq read failure: '$combined'"
 fi
-# TC-20.2: --jq-filter 経路の jq filter failed WARNING + rc=0 + stdout に default 返却
+# 診断 stderr の indented 行 (jq error 内容、`sed 's/^/  /'` で prefix される) が出ること
+if echo "$combined" | grep -qE '^  [^ ]'; then
+  pass "TC-20.1: jq read failure 時に診断 stderr の indented 行が出力される (observability 確保)"
+else
+  fail "TC-20.1: 診断 stderr の indented 行が欠落: '$combined'"
+fi
+# basename leak 抑制 (multi-tenant 環境での絶対 path leak を防ぐ negative-assert)
+if echo "$combined" | grep -qE 'WARNING:.*\.rite/sessions/'; then
+  fail "TC-20.1: WARNING に絶対 path (.rite/sessions/) が leak: '$combined'"
+else
+  pass "TC-20.1: WARNING に絶対 path leak なし (basename 化が機能している)"
+fi
+# TC-20.2: --jq-filter 経路の jq filter failed WARNING + rc=0 + stdout に default 返却 + 診断行
 combined=$( (cd "$d" && bash "$HOOK" get --jq-filter '.phase' --default "DEF") 2>&1 )
 get_rc=$?
 if echo "$combined" | grep -qE 'WARNING:.*cmd_get: jq filter failed'; then
@@ -617,13 +660,24 @@ if echo "$combined" | grep -qE '^DEF$'; then
 else
   fail "TC-20.2: default not returned on jq filter failure: '$combined'"
 fi
+if echo "$combined" | grep -qE '^  [^ ]'; then
+  pass "TC-20.2: jq filter failure 時に診断 stderr の indented 行が出力される"
+else
+  fail "TC-20.2: 診断 stderr の indented 行が欠落: '$combined'"
+fi
+if echo "$combined" | grep -qE 'WARNING:.*\.rite/sessions/'; then
+  fail "TC-20.2: WARNING に絶対 path (.rite/sessions/) が leak: '$combined'"
+else
+  pass "TC-20.2: WARNING に絶対 path leak なし"
+fi
 
 # --- TC-21: cmd_get --field/--jq-filter 両方未指定の ERROR rc=1 経路 ---
 echo ""
 echo "=== TC-21: cmd_get --field/--jq-filter required (contract pin) ==="
-# Why: --field / --jq-filter 両方未指定時の ERROR + rc=1 経路 (flow-state.sh L267-270) は
-# Phase 4.5.1 で if 文形式に refactor された契約。将来引数 parser を loose にして default field
-# を導入した場合の silent な behavioral drift を pin する。
+# Why: --field / --jq-filter 両方未指定時は cmd_get が ERROR + rc=1 を返す契約。state file が
+# 存在する経路で発火させないと「state file 不在」分岐の WARNING + rc=0 path に流れて契約 pin が
+# 成立しないため、事前に set で state file を作成する。将来引数 parser を loose にして default
+# field を導入した場合の silent な behavioral drift を pin する。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 # state file を作成する (state file 不在では L245 の `[ ! -f "$path" ]` 分岐で WARNING + default + rc=0
 # に流れるため、L267 の ERROR + rc=1 経路に到達しない)
@@ -660,12 +714,26 @@ if echo "$combined" | grep -qE 'WARNING:.*cmd_set:.*if-exists skipped'; then
 else
   pass "TC-22.1: env-set first-time で cmd_set --if-exists が graceful silent (依存先契約保持)"
 fi
-# TC-22.2: cmd_get の symmetric pin (gate は cmd_get L252 の同 [ -f "$SESSION_ID_FILE" ])
-combined=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "DEF") 2>&1 )
+# TC-22.2: cmd_get の symmetric pin (gate は cmd_get 側の同 [ -f "$SESSION_ID_FILE" ] 判定)
+combined=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "DEF"; echo "__RC=$?") 2>&1 || true )
+get_rc=$(printf '%s' "$combined" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
+combined="${combined%__RC=*}"
 if echo "$combined" | grep -qE 'WARNING:.*cmd_get:.*state file not found'; then
   fail "TC-22.2: env-set first-time で state-file-not-found WARNING が漏出 (gate 除去 regression): '$combined'"
 else
   pass "TC-22.2: env-set first-time で cmd_get が graceful silent (依存先契約保持)"
+fi
+# graceful 完了 invariant: rc=0 + stdout に default 返却 (依存先 wiki/ingest.md / issue/create.md の契約)
+if [ "$get_rc" = "0" ]; then
+  pass "TC-22.2: env-set first-time で cmd_get が rc=0 (graceful contract)"
+else
+  fail "TC-22.2: env-set first-time で cmd_get rc=$get_rc (expected 0)"
+fi
+stdout_only=$(printf '%s' "$combined" | grep -E '^DEF$' || true)
+if [ -n "$stdout_only" ]; then
+  pass "TC-22.2: env-set first-time で stdout に default 返却 (graceful contract)"
+else
+  fail "TC-22.2: env-set first-time で stdout に default 返却なし: '$combined'"
 fi
 
 if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + PR #1148 security/observability fixes"; then

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -537,7 +537,7 @@ echo "=== TC-19: env-var session_id control-character validation (log injection 
 #  TC-19.1: \n (newline — CRLF splitting primary vector)
 #  TC-19.2: \t (tab)
 #  TC-19.3: \r (CR — HTTP-style CRLF injection primary vector)
-# Plus TC-19.5: 「reject 発生」だけでなく fake WARNING 行が **stderr に存在しない** ことを negative-assert
+# Plus TC-19.4: 「reject 発生」だけでなく fake WARNING 行が **stderr に存在しない** ことを negative-assert
 # (validator が partial regression した場合に injection が漏出しても rejection が出れば pass する穴を塞ぐ)
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 rm -f "$d/.rite-session-id"
@@ -569,6 +569,105 @@ else
   pass "TC-19.4: injection content not present in stderr (validator chokepoint pin)"
 fi
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + Issue #1148 security/observability fixes"; then
+# --- TC-20: cmd_get jq failure WARNING paths (corrupt JSON state file) ---
+echo ""
+echo "=== TC-20: cmd_get jq failure WARNING paths (silent-failure regression guard) ==="
+# Why: Phase 4.5.1 で追加された jq-filter failure / field-read failure の WARNING 経路は
+# Issue #1142 root cause と同型の silent-failure 解消経路。corrupt JSON で発火させ、
+# 将来 `2>/dev/null || printf '%s\n' "$default"` の旧パターンへ silent revert された場合の
+# regression を catch する。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+# state file を作成してから内容を corrupt JSON に上書きする
+(cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n") >/dev/null
+state_file="$d/.rite/sessions/${sid}.flow-state"
+echo "{this is not valid JSON" > "$state_file"
+# TC-20.1: --field path で jq read failed WARNING + rc=0 + stdout に default 返却
+combined=$( (cd "$d" && bash "$HOOK" get --field phase --default "DEF") 2>&1 )
+get_rc=$?
+if echo "$combined" | grep -qE 'WARNING:.*cmd_get: jq read failed'; then
+  pass "TC-20.1: corrupt JSON で --field 経路の jq read failed WARNING が発火"
+else
+  fail "TC-20.1: WARNING missing on corrupt JSON --field: '$combined'"
+fi
+if [ "$get_rc" = "0" ]; then
+  pass "TC-20.1: jq read failed でも rc=0 (silent-failure 解消経路の non-blocking 契約)"
+else
+  fail "TC-20.1: jq read failure で rc=$get_rc (expected 0)"
+fi
+if echo "$combined" | grep -qE '^DEF$'; then
+  pass "TC-20.1: jq read failure でも stdout に default 返却"
+else
+  fail "TC-20.1: default not returned on jq read failure: '$combined'"
+fi
+# TC-20.2: --jq-filter 経路の jq filter failed WARNING + rc=0 + stdout に default 返却
+combined=$( (cd "$d" && bash "$HOOK" get --jq-filter '.phase' --default "DEF") 2>&1 )
+get_rc=$?
+if echo "$combined" | grep -qE 'WARNING:.*cmd_get: jq filter failed'; then
+  pass "TC-20.2: corrupt JSON で --jq-filter 経路の jq filter failed WARNING が発火"
+else
+  fail "TC-20.2: WARNING missing on corrupt JSON --jq-filter: '$combined'"
+fi
+if [ "$get_rc" = "0" ]; then
+  pass "TC-20.2: jq filter failed でも rc=0"
+else
+  fail "TC-20.2: jq filter failure で rc=$get_rc (expected 0)"
+fi
+if echo "$combined" | grep -qE '^DEF$'; then
+  pass "TC-20.2: jq filter failure でも stdout に default 返却"
+else
+  fail "TC-20.2: default not returned on jq filter failure: '$combined'"
+fi
+
+# --- TC-21: cmd_get --field/--jq-filter 両方未指定の ERROR rc=1 経路 ---
+echo ""
+echo "=== TC-21: cmd_get --field/--jq-filter required (contract pin) ==="
+# Why: --field / --jq-filter 両方未指定時の ERROR + rc=1 経路 (flow-state.sh L267-270) は
+# Phase 4.5.1 で if 文形式に refactor された契約。将来引数 parser を loose にして default field
+# を導入した場合の silent な behavioral drift を pin する。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+# state file を作成する (state file 不在では L245 の `[ ! -f "$path" ]` 分岐で WARNING + default + rc=0
+# に流れるため、L267 の ERROR + rc=1 経路に到達しない)
+(cd "$d" && bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n") >/dev/null
+# get は意図的に rc=1 を返す経路 → 外側 set -e で abort しないよう || true を付与し
+# subshell 内で得た rc を直接 capture する
+combined=$( (cd "$d" && bash "$HOOK" get --default "DEF"; echo "__RC=$?") 2>&1 || true )
+get_rc=$(printf '%s' "$combined" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
+combined="${combined%__RC=*}"
+if echo "$combined" | grep -qE 'ERROR: --field or --jq-filter required'; then
+  pass "TC-21.1: --field/--jq-filter 両方未指定で ERROR メッセージが stderr に出る"
+else
+  fail "TC-21.1: ERROR missing: '$combined'"
+fi
+if [ "$get_rc" = "1" ]; then
+  pass "TC-21.1: --field/--jq-filter 両方未指定で rc=1 (契約 pin)"
+else
+  fail "TC-21.1: rc=$get_rc (expected 1)"
+fi
+
+# --- TC-22: env-set + state file 不在 + .rite-session-id 不在 の graceful 沈黙契約 ---
+echo ""
+echo "=== TC-22: env-set first-time silent contract (wiki/ingest.md / issue/create.md 依存) ==="
+# Why: env で sid 解決成功 + state file 不在 + .rite-session-id 不在 (Claude Code 起動直後 /
+# wiki/ingest.md 初回呼び出し) では `[ -f "$SESSION_ID_FILE" ]` gate が false で graceful silent。
+# 将来 gate が除去され「path 不在で常に WARN」に変わると、依存先で WARNING ノイズが大量発生
+# する silent contract break を pin する。symmetric pin として cmd_set / cmd_get 両方を test する。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+# TC-22.1: cmd_set --if-exists の symmetric pin
+combined=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" set --phase plan --issue 1 --branch "b" --pr 0 --next "n" --if-exists) 2>&1 )
+if echo "$combined" | grep -qE 'WARNING:.*cmd_set:.*if-exists skipped'; then
+  fail "TC-22.1: env-set first-time で if-exists skipped WARNING が漏出 (gate 除去 regression): '$combined'"
+else
+  pass "TC-22.1: env-set first-time で cmd_set --if-exists が graceful silent (依存先契約保持)"
+fi
+# TC-22.2: cmd_get の symmetric pin (gate は cmd_get L252 の同 [ -f "$SESSION_ID_FILE" ])
+combined=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$sid" bash "$HOOK" get --field phase --default "DEF") 2>&1 )
+if echo "$combined" | grep -qE 'WARNING:.*cmd_get:.*state file not found'; then
+  fail "TC-22.2: env-set first-time で state-file-not-found WARNING が漏出 (gate 除去 regression): '$combined'"
+else
+  pass "TC-22.2: env-set first-time で cmd_get が graceful silent (依存先契約保持)"
+fi
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + PR #1148 security/observability fixes"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/flow-state.sh` の `get` / `set --if-exists` が rc=0 のまま silent failure する 2 種類の bug を修正。Issue #1142 で報告された PR #1139 cycle 8-15 の `next_action` 固着 (古い cycle 番号のまま `flow-state.sh set --if-exists` が連続 silent skip) の root cause。

## Root Cause

- **B1 (AC-1 / AC-2 / AC-4)**: `_resolve_session_id` が Claude Code runtime の `CLAUDE_CODE_SESSION_ID` を読まず `CLAUDE_SESSION_ID` のみを check していた。`.rite-session-id` 不在で session-id resolution が失敗 → `cmd_get` の `2>/dev/null` が ERROR を握りつぶし default+rc=0 に縮退 → `cmd_set --if-exists` も path 解決失敗で silent skip
- **B2 (AC-3)**: `cmd_get` の jq 失敗 path、state file 不在 path、`cmd_set --if-exists` の skip path がいずれも silent (WARNING/ERROR ゼロ) で operator が drift を観測できなかった

## 変更内容

- `_resolve_session_id`: `CLAUDE_CODE_SESSION_ID` を primary、`CLAUDE_SESSION_ID` を fallback として両方受け付ける
- `cmd_get`: `_resolve_session_id` の stderr silence を解除し ERROR を通す。state file 不在で `.rite-session-id` が存在する drift シナリオ + jq 失敗で WARNING を emit (stderr 頭 3 行付き)
- `cmd_set --if-exists`: `.rite-session-id` 存在時の skip で WARNING (stale sid drift 観測可能化)。truly first-time (sid file 不在) は graceful no-op を維持 — `wiki/ingest.md` / `issue/create.md` 等の依存契約を保持
- `flow-state.test.sh`: TC-13〜TC-17 を追加 (env-only / legacy env / resolution ERROR / stale drift / first-time silent — 44 → 54 tests)

## 関連 Issue

Closes #1142

## チェックリスト

- [x] AC-1: get の rc=0+空 silent failure 解消
- [x] AC-2: set --if-exists silent skip 解消
- [x] AC-3: WARNING/ERROR を stderr に出力 (silent failure 禁止)
- [x] AC-4: CLAUDE_CODE_SESSION_ID で session-id 解決
- [x] AC-5: regression test 追加 (TC-13〜TC-17)

## Test Plan

- [x] `bash plugins/rite/hooks/tests/flow-state.test.sh` で 54 PASS / 0 FAIL
- [x] `bash plugins/rite/hooks/tests/run-tests.sh` で 44 / 44 suite pass (既存 hook test に regression なし)
- [x] 手動再現 4 scenario: (1) env-only / (2) stale `.rite-session-id` / (3) unresolvable / (4) normal — すべて期待通りの WARNING/ERROR/正常完了

## Known Issues

なし
