### PR TITLE
feat(hooks): consume-handoff の corrupt JSON 読取時に WARNING を emit

### DIFF
--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -322,7 +322,21 @@ cmd_consume_handoff() {
   esac; done
   local sid path; sid=$(_resolve_session_id "$session") || return 0
   path=$(_state_path "$sid"); [ ! -f "$path" ] && return 0
-  local handoff; handoff=$(jq -r '.handoff // ""' "$path" 2>/dev/null) || handoff=""
+  # corrupt JSON でも空 handoff に縮退して停止を許可するのは AC-3 の fail-open (安全側) で正しい。
+  # 欠落しているのは observability のみ — 無診断だと corrupt を検出できないため、jq rc を捕捉し
+  # cmd_set / cmd_get と対称に WARNING + stderr スニペットを emit する。関数内は無条件 emit とし、
+  # RITE_DEBUG gate は唯一の呼び出し元 stop-loop-continuation.sh の 2>/dev/null に委譲する
+  # (本関数の handoff-clear ERROR と同じ方式)。`handoff` キー欠落の正常系は `// ""` で rc=0 のまま
+  # WARNING を出さない。
+  local handoff _ho_jq_err="" _ho_rc=0
+  _ho_jq_err=$(mktemp 2>/dev/null) || _ho_jq_err=""
+  trap '[ -n "${_ho_jq_err:-}" ] && rm -f "${_ho_jq_err:-}"' RETURN
+  handoff=$(jq -r '.handoff // ""' "$path" 2>"${_ho_jq_err:-/dev/null}") || _ho_rc=$?
+  if [ "$_ho_rc" -ne 0 ]; then
+    echo "WARNING: flow-state.sh consume-handoff: handoff read failed for $(basename "$path") (may be corrupt; treating as empty → stop allowed)" >&2
+    [ -n "$_ho_jq_err" ] && [ -s "$_ho_jq_err" ] && head -3 "$_ho_jq_err" | sed 's/^/  /' >&2
+    handoff=""
+  fi
   [ -z "$handoff" ] && return 0
   local updated; updated=$(jq 'del(.handoff)' "$path" 2>/dev/null) || {
     echo "ERROR: consume-handoff: jq del(.handoff) failed for $(basename "$path") (handoff not cleared; value withheld to avoid re-block)" >&2

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -781,14 +781,28 @@ assert "TC-H3: phase preserved through consume" "fix" "$(jq -r .phase "$state_fi
 assert "TC-H3: pr_number preserved through consume" "99" "$(jq -r .pr_number "$state_file")"
 
 echo ""
-echo "=== TC-H4: consume-handoff on file without handoff → empty + rc 0 ==="
+echo "=== TC-H4: consume-handoff on file without handoff → empty + rc 0, WARNING 非発火 ==="
+# Why: valid JSON だが handoff キー欠落の正常系。`// ""` で rc=0 のまま空 handoff を返し WARNING を出さない
+# (corrupt 側 TC-H7 の WARNING 発火と対になる happy-path 側)。corrupt-read 対称化 (cmd_set / cmd_get /
+# consume-handoff) の片側だけを pin すると、無条件 WARNING emit への revert を検出できないため、
+# stderr を capture して WARNING 非発火を negative-assert する。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 (cd "$d" && bash "$HOOK" set --phase review --issue 1168 --branch b --pr 99 --next n)
-out=$(cd "$d" && bash "$HOOK" consume-handoff; echo "__RC=$?")
+_tch4_stderr=$(mktemp /tmp/rite-tch4-stderr-XXXXXX 2>/dev/null) || _tch4_stderr="/dev/null"
+out=$( (cd "$d" && bash "$HOOK" consume-handoff 2>"$_tch4_stderr"); echo "__RC=$?" )
 rc=$(printf '%s' "$out" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
 val="${out%__RC=*}"; val="${val%$'\n'}"
 assert "TC-H4: no handoff → empty output" "" "$val"
 assert "TC-H4: no handoff → rc 0" "0" "$rc"
+if [ "$_tch4_stderr" = "/dev/null" ]; then
+  pass "TC-H4: WARNING 非発火 assert を skip (stderr capture tempfile 取得不可)"
+elif grep -qE 'WARNING:.*consume-handoff.*handoff read failed' "$_tch4_stderr"; then
+  fail "TC-H4: handoff キー欠落の正常系で corrupt-read WARNING が誤発火: '$(cat "$_tch4_stderr" 2>/dev/null)'"
+else
+  pass "TC-H4: handoff キー欠落の正常系で WARNING 非発火 (cmd_set / cmd_get 対称化の happy-path 側を pin)"
+fi
+[ "${_tch4_stderr:-/dev/null}" != "/dev/null" ] && rm -f "$_tch4_stderr"
+unset _tch4_stderr
 
 echo ""
 echo "=== TC-H5: set --handoff then set without --handoff clears it (terminal transition) ==="

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -864,6 +864,33 @@ else
 fi
 unset _dac_probe_err _dac_probe_parent _dac_probe _dac_probe_diag 2>/dev/null || true
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker"; then
+echo ""
+echo "=== TC-H7: consume-handoff on corrupt JSON → WARNING + empty + rc 0 (Issue #1170 observability) ==="
+# Why: corrupt JSON 時の fail-open (空 + rc=0 → Stop hook が停止許可) は AC-3 上正しい安全側挙動だが、
+# 旧実装 (`|| handoff=""`) は無診断で corrupt を検出できなかった。cmd_set / cmd_get と対称に WARNING を
+# stderr へ emit することを pin し、silent fallback への revert を検出する。stdout 空 + rc=0 の
+# fail-open 不変も同時に固定する (WARNING 追加で停止許可挙動が崩れていないこと)。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+state_file="$d/.rite/sessions/${sid}.flow-state"
+# 正規 set で sessions dir + valid file を作ってから corrupt JSON で上書き (実際の FS corruption を模倣)
+(cd "$d" && bash "$HOOK" set --phase fix --issue 1170 --branch b --pr 99 --next n --handoff "/rite:pr:review 99")
+printf '{ this is not valid json' > "$state_file"
+_tch7_stderr=$(mktemp /tmp/rite-tch7-stderr-XXXXXX 2>/dev/null) || _tch7_stderr="/dev/null"
+out=$( (cd "$d" && bash "$HOOK" consume-handoff 2>"$_tch7_stderr"); echo "__RC=$?" )
+rc=$(printf '%s' "$out" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
+val="${out%__RC=*}"; val="${val%$'\n'}"
+assert "TC-H7: corrupt JSON → empty output (fail-open)" "" "$val"
+assert "TC-H7: corrupt JSON → rc 0 (Stop hook will allow stop)" "0" "$rc"
+if [ "$_tch7_stderr" = "/dev/null" ]; then
+  pass "TC-H7: WARNING assert を skip (stderr capture tempfile 取得不可)"
+elif grep -qE 'WARNING:.*consume-handoff.*handoff read failed' "$_tch7_stderr"; then
+  pass "TC-H7: corrupt JSON 時に WARNING が stderr に emit される (cmd_set / cmd_get と対称)"
+else
+  fail "TC-H7: corrupt JSON 時の WARNING が欠落: '$(cat "$_tch7_stderr" 2>/dev/null)'"
+fi
+[ "${_tch7_stderr:-/dev/null}" != "/dev/null" ] && rm -f "$_tch7_stderr"
+unset _tch7_stderr
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker + Issue #1170 consume-handoff corrupt-read WARNING"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`flow-state.sh` の `cmd_consume_handoff` で、state file が corrupt JSON だった場合に空 handoff へ silent に縮退していた経路 (`|| handoff=""`) に WARNING を追加し、同一ファイル内の `cmd_set` / `cmd_get` と診断方針を対称化する。observability の補完のみで動作変更はない。

## 関連 Issue

Closes #1170

## 変更内容

- `plugins/rite/hooks/flow-state.sh`: `cmd_consume_handoff` の handoff read に jq rc 捕捉分岐を追加。corrupt 時のみ WARNING + jq stderr スニペット (`head -3`) を stderr emit (`cmd_set` / `cmd_get` と同一の tempfile + RETURN trap パターン)
- `plugins/rite/hooks/tests/flow-state.test.sh`: corrupt JSON 時の WARNING + fail-open 不変を pin する TC-H7 を追加

## 設計判断

- 関数内は **無条件 stderr WARNING** とし、RITE_DEBUG gate は唯一の呼び出し元 `stop-loop-continuation.sh` の既存 `2>/dev/null` に委譲した。Issue 当初提案の「関数内に RITE_DEBUG 分岐を追加」は `cmd_set` / `cmd_get` との対称が崩れ、caller の gate と二重になるため却下。本関数の handoff-clear ERROR と同方式。
- corrupt 時も `handoff=""` → rc=0 の fail-open (停止許可 / AC-3) を維持。WARNING 追加による動作変更はない。

## 動作確認

- `flow-state.test.sh`: 103 assert green (TC-H7 含む)
- 全 hook test suite: 49/49 green
- 3 ケース手動検証: corrupt JSON → WARNING + rc=0、handoff キー欠落 → 無 WARNING、handoff あり → 値出力 + クリア

## チェックリスト

- [x] プロジェクト規約に準拠
- [x] テスト green (flow-state 103 assert / 全 49 hook suite)
- [x] ドキュメント更新 (コード内 WHY コメントのみ、新規 doc 不要)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
