### PR TITLE
refactor(hooks): flow-state.sh の jq stderr スニペットに control-char 中和を追加

### DIFF
--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -129,6 +129,20 @@ _atomic_write() {
   return $rc
 }
 
+# Emit up to 3 lines of a jq stderr capture ($1 = error file) to stderr, 2-space
+# indented, with control characters neutralized to '?'. Centralizes the diagnostic-
+# snippet idiom shared by cmd_set / cmd_get / cmd_consume_handoff so the control-char
+# neutralization lives in one place: a corrupt state file fragment can carry ANSI
+# escape / control bytes that, echoed raw, would let the corrupt content drive the
+# operator's terminal (cursor moves, color, title rewrites) via the diagnostic path.
+# No-op when the file is unset or empty (preserves the prior -n/-s guard); always
+# returns 0 so a caller under `set -e` never aborts on the diagnostic line.
+_emit_jq_err_snippet() {
+  if [ -n "${1:-}" ] && [ -s "$1" ]; then
+    head -3 "$1" | sed 's/^/  /; s/[[:cntrl:]]/?/g' >&2 || true
+  fi
+}
+
 cmd_set() {
   # Merge semantics: unspecified scalar fields preserve existing values (旧 patch 互換).
   # Required: --phase, --next. Optional fields fall back to existing JSON or defaults.
@@ -193,7 +207,7 @@ cmd_set() {
     if [ "$_cur_rc" -ne 0 ]; then
       # basename only — multi-tenant 環境での絶対 path leakage を最小化 (cmd_get / cmd_set --if-exists と対称化)
       echo "WARNING: flow-state.sh cmd_set: existing state read failed for $(basename "$path") (may be corrupt; merged write will use defaults)" >&2
-      [ -n "$_cur_jq_err" ] && [ -s "$_cur_jq_err" ] && head -3 "$_cur_jq_err" | sed 's/^/  /' >&2
+      _emit_jq_err_snippet "$_cur_jq_err"
     else
       IFS=$'\x1f' read -r cur_issue cur_branch cur_pr cur_parent cur_active cur_err cur_last_synced <<< "$_cur_data"
     fi
@@ -272,7 +286,7 @@ cmd_get() {
   if [ -n "$jq_filter" ]; then
     if ! jq -r "$jq_filter" "$path" 2>"${jq_err:-/dev/null}"; then
       echo "WARNING: flow-state.sh cmd_get: jq filter failed for $(basename "$path") (filter: $jq_filter); returning --default" >&2
-      [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+      _emit_jq_err_snippet "$jq_err"
       printf '%s\n' "$default"
     fi
     return 0
@@ -283,7 +297,7 @@ cmd_get() {
   fi
   if ! jq -r --arg d "$default" ".${field} // \$d" "$path" 2>"${jq_err:-/dev/null}"; then
     echo "WARNING: flow-state.sh cmd_get: jq read failed for $(basename "$path") (field: $field); returning --default" >&2
-    [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+    _emit_jq_err_snippet "$jq_err"
     printf '%s\n' "$default"
   fi
   return 0
@@ -338,7 +352,7 @@ cmd_consume_handoff() {
   handoff=$(jq -r '.handoff // ""' "$path" 2>"${_ho_jq_err:-/dev/null}") || _ho_rc=$?
   if [ "$_ho_rc" -ne 0 ]; then
     echo "WARNING: flow-state.sh consume-handoff: handoff read failed for $(basename "$path") (may be corrupt; treating as empty → stop allowed)" >&2
-    [ -n "$_ho_jq_err" ] && [ -s "$_ho_jq_err" ] && head -3 "$_ho_jq_err" | sed 's/^/  /' >&2
+    _emit_jq_err_snippet "$_ho_jq_err"
     handoff=""
   fi
   [ -z "$handoff" ] && return 0

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -905,6 +905,46 @@ fi
 [ "${_tch7_stderr:-/dev/null}" != "/dev/null" ] && rm -f "$_tch7_stderr"
 unset _tch7_stderr
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker + Issue #1170 consume-handoff corrupt-read WARNING"; then
+# --- TC-23: jq stderr スニペットの control-char 中和 (Issue #1173) ---
+echo ""
+echo "=== TC-23: _emit_jq_err_snippet が jq stderr の制御文字を中和する (Issue #1173) ==="
+# Why: corrupt state file 断片には ANSI escape / 制御バイトが含まれうる。これが jq stderr スニペット
+# 経由で operator terminal に生のまま到達すると、カーソル移動 / 色 / タイトル書換え等で端末を駆動され
+# うる。cmd_set / cmd_get(×2) / cmd_consume_handoff の 4 emission site を共通 helper
+# `_emit_jq_err_snippet` に集約し `sed 's/[[:cntrl:]]/?/g'` で `?` に 1:1 中和する。4 site が同一
+# helper 経由のため 1 経路で中和ロジックを pin すれば全 site を固定できる (対称位置への伝播漏れを
+# 構造的に回避)。jq 1.7 の parse error は入力バイトを echo しないため、`--jq-filter 'error("...")'`
+# で jq の error builtin に生 ESC を載せて確実に jq stderr (= スニペット) へ出させる。
+# assertion は 2-space indent の snippet 行に限定する: WARNING 行の `(filter: ...)` echo は caller
+# 供給の filter 文字列 (corrupt-file 由来ではない) を含むため #1173 のスコープ外。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+# valid な state file を作成 (error() は valid JSON に対しても runtime error を起こす)
+(cd "$d" && bash "$HOOK" set --phase plan --issue 1173 --branch "b" --pr 0 --next "n") >/dev/null
+esc=$(printf '\033')  # ESC (0x1b) を runtime 構築 —  等の表記揺れに依存せず決定論的
+filter="error(\"${esc}[31mINJECTED${esc}[0m\")"
+combined=$( (cd "$d" && bash "$HOOK" get --jq-filter "$filter" --default "DEF") 2>&1 )
+# snippet = helper が emit する 2-space indent 診断行 (= jq stderr の corrupt-fragment 相当)
+snippet=$(printf '%s\n' "$combined" | grep '^  ' || true)
+# TC-23.1: jq filter failed WARNING 発火 (中和 helper を呼ぶ経路に到達した sanity pin)
+if echo "$combined" | grep -qE 'WARNING:.*cmd_get: jq filter failed'; then
+  pass "TC-23.1: jq filter failed WARNING 発火 (中和 helper 経路に到達)"
+else
+  fail "TC-23.1: WARNING missing: '$combined'"
+fi
+# TC-23.2 (core): snippet 行に生 ESC (0x1b) が残らない = 制御文字が中和されている
+if printf '%s' "$snippet" | LC_ALL=C grep -q "$esc"; then
+  fail "TC-23.2: snippet 行に生 ESC が残存 (control-char 中和が機能していない): '$(printf '%s' "$snippet" | cat -v)'"
+else
+  pass "TC-23.2: snippet 行の生 ESC が中和されている (Issue #1173)"
+fi
+# TC-23.3: 制御文字が中和マーカー '?' へ 1:1 置換され可読テキストは保持される
+# (空削除 `s/[[:cntrl:]]//g` への revert と snippet 全体 drop の両方を catch する)
+if printf '%s' "$snippet" | grep -qF '?[31mINJECTED?[0m'; then
+  pass "TC-23.3: 制御文字が '?' へ 1:1 置換され可読テキストが保持される"
+else
+  fail "TC-23.3: 中和マーカー '?' パターンが不在: '$(printf '%s' "$snippet" | cat -v)'"
+fi
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker + Issue #1170 consume-handoff corrupt-read WARNING + Issue #1173 jq stderr snippet control-char neutralization"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`flow-state.sh` の corrupt-read 診断 (`cmd_set` / `cmd_get` / `cmd_consume_handoff`) が jq stderr スニペットを emit する際、corrupt state file 断片に含まれうる ANSI escape / 制御バイトが operator terminal に生のまま到達する経路を遮断する。4 つの emission site を共通 helper `_emit_jq_err_snippet` に集約し、`sed 's/[[:cntrl:]]/?/g'` で制御文字を `?` に 1:1 中和する。

## 関連 Issue

Closes #1173

## 変更内容

- `plugins/rite/hooks/flow-state.sh`: private helper `_emit_jq_err_snippet()` を新設（2-space indent + 制御文字 → `?` 中和、全経路 rc=0 で `set -e` 下の call site を保護）。cmd_set / cmd_get (×2) / cmd_consume_handoff の 4 emission site を helper 呼び出しに置換し、中和ロジックを単一ソース化（Wiki 経験則「Asymmetric Fix Transcription」= 対称位置への伝播漏れを構造的に回避）。
- `plugins/rite/hooks/tests/flow-state.test.sh`: TC-23 を追加。jq 1.7 の parse error は入力バイトを echo しないため `--jq-filter 'error("…ESC…")'` で jq stderr に生 ESC を載せ、snippet 行で中和される（生 ESC 不在 + `?` への 1:1 置換 + 可読テキスト保持）ことを pin。

## スコープ

- Issue スコープ通り flow-state.sh の 3 関数に限定。同イディオムは他 hook にも存在するが本 PR では対象外。
- WARNING 行の `(filter:...)` echo は caller 供給の filter 文字列（corrupt-file 由来ではない）でスコープ外のため snippet 行に限定して assert。

## テスト

- `flow-state.test.sh`: 107 件全 pass（新規 TC-23 含む）
- `run-tests.sh`（全 hook テスト）: 49/49 pass、リグレッションなし
- `bash -n` 構文チェック pass

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (flow-state.test.sh 107 + 全 hook 49/49)
- [x] Documentation updated (内部 refactor のため doc 変更不要)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
