### PR TITLE
fix(issue:list): Phase 4.2 を GraphQL cursor paging 化し 500 件超 Projects の Status 取りこぼしを解消

### DIFF
--- a/plugins/rite/commands/issue/list.md
+++ b/plugins/rite/commands/issue/list.md
@@ -154,17 +154,19 @@ Display Projects information when `rite-config.yml` exists and Projects integrat
 Read `rite-config.yml` using the Read tool to check if Projects integration is enabled (`github.projects.enabled: true`).
 If the file does not exist, skip Phase 4 entirely.
 
+Also read `github.projects.project_number` and `github.projects.owner` from `rite-config.yml`. These two values are substituted into the `{project_number}` / `{owner}` placeholders on the `gh project view` line of Phase 4.2 Tool call 1 before the script runs (the only substitution the verbatim script permits).
+
 ### 4.2 Fetch Projects Data and Build Status Map
 
-> **CRITICAL**: Execute Tool call 1 exactly as written — copy the entire script block verbatim. Do NOT edit the GraphQL query, change the `jq` filters, add `--jq` flags to `gh api graphql`, insert inline comments, or alter any line. The script pages through **all** Project items via GraphQL cursor pagination, so Projects with more than 100/500 items are not silently truncated (the bug that a fixed `--limit` caused).
+> **CRITICAL**: Execute Tool call 1 exactly as written — copy the entire script block verbatim. The **only** edit allowed is substituting the `{project_number}` and `{owner}` placeholders on the `gh project view` line with the values from `rite-config.yml` (`github.projects.project_number` / `github.projects.owner`, read in Phase 4.1). Do NOT edit the GraphQL query, change the `jq` filters, add `--jq` flags to `gh api graphql`, insert inline comments, or alter any other line. The script pages through **all** Project items via GraphQL cursor pagination, so Projects with more than 100/500 items are not silently truncated (the bug that a fixed `--limit` caused).
 
 **Tool call 1 (Bash)**: Run this script verbatim. It resolves the Project node ID (owner-type agnostic — works for both user and organization owners), pages through every item with `pageInfo.hasNextPage` / `endCursor`, normalizes each node to `{content:{number}, status}`, and prints the temp file path on success. On any failure it prints `[projects:fetch-failed] <reason>` and no path.
 
 ```bash
-tmpfile=$(mktemp); pages=$(mktemp)
-pid=$(gh project view {project_number} --owner {owner} --format json 2>/dev/null | jq -r '.id')
-if [ -z "$pid" ] || [ "$pid" = "null" ]; then echo "[projects:fetch-failed] could not resolve project id"; rm -f "$tmpfile" "$pages"; exit 0; fi
-cursor=""; : > "$pages"; ok=1
+tmpfile=$(mktemp); pages=$(mktemp); err=$(mktemp)
+pid=$(gh project view {project_number} --owner {owner} --format json 2>"$err" | jq -r '.id')
+if [ -z "$pid" ] || [ "$pid" = "null" ]; then echo "[projects:fetch-failed] could not resolve project id: $(tr '\n' ' ' < "$err")"; rm -f "$tmpfile" "$pages" "$err"; exit 0; fi
+cursor=""; : > "$pages"; ok=1; fail_reason=""
 QUERY='
 query($pid: ID!, $cursor: String) {
   node(id: $pid) {
@@ -188,19 +190,21 @@ query($pid: ID!, $cursor: String) {
 }'
 while : ; do
   if [ -n "$cursor" ]; then
-    page=$(gh api graphql -f query="$QUERY" -F pid="$pid" -F cursor="$cursor" 2>/dev/null) || { ok=0; break; }
+    page=$(gh api graphql -f query="$QUERY" -f pid="$pid" -f cursor="$cursor" 2>"$err") || { ok=0; fail_reason="gh api graphql failed: $(tr '\n' ' ' < "$err")"; break; }
   else
-    page=$(gh api graphql -f query="$QUERY" -F pid="$pid" 2>/dev/null) || { ok=0; break; }
+    page=$(gh api graphql -f query="$QUERY" -f pid="$pid" 2>"$err") || { ok=0; fail_reason="gh api graphql failed: $(tr '\n' ' ' < "$err")"; break; }
   fi
-  echo "$page" | jq -e '.data.node.items' >/dev/null 2>&1 || { ok=0; break; }
+  gqe=$(echo "$page" | jq -r '.errors // [] | map(.message) | join("; ")' 2>/dev/null)
+  if [ -n "$gqe" ]; then ok=0; fail_reason="graphql errors: $gqe"; break; fi
+  echo "$page" | jq -e '.data.node.items' >/dev/null 2>&1 || { ok=0; fail_reason="missing .data.node.items (possible partial response)"; break; }
   echo "$page" | jq -c '.data.node.items.nodes[]?' >> "$pages"
   hn=$(echo "$page" | jq -r '.data.node.items.pageInfo.hasNextPage')
   cursor=$(echo "$page" | jq -r '.data.node.items.pageInfo.endCursor')
   [ "$hn" = "true" ] && [ -n "$cursor" ] && [ "$cursor" != "null" ] || break
 done
-if [ "$ok" != "1" ]; then echo "[projects:fetch-failed] graphql paging error"; rm -f "$tmpfile" "$pages"; exit 0; fi
+if [ "$ok" != "1" ]; then echo "[projects:fetch-failed] ${fail_reason:-graphql paging error}"; rm -f "$tmpfile" "$pages" "$err"; exit 0; fi
 jq -s '{items: ([ .[] | { content: { number: (.content.number // null) }, status: ([ .fieldValues.nodes[]? | select(.field.name? == "Status") | .name ] | first // null) } ] | map(select(.content.number == null | not)))}' "$pages" > "$tmpfile"
-rm -f "$pages"
+rm -f "$pages" "$err"
 echo "$tmpfile"
 ```
 

--- a/plugins/rite/commands/issue/list.md
+++ b/plugins/rite/commands/issue/list.md
@@ -156,11 +156,55 @@ If the file does not exist, skip Phase 4 entirely.
 
 ### 4.2 Fetch Projects Data and Build Status Map
 
-> **CRITICAL**: Execute each tool call exactly as described. Do NOT add `--jq` flags, inline comments, or any extra text to bash commands.
+> **CRITICAL**: Execute Tool call 1 exactly as written — copy the entire script block verbatim. Do NOT edit the GraphQL query, change the `jq` filters, add `--jq` flags to `gh api graphql`, insert inline comments, or alter any line. The script pages through **all** Project items via GraphQL cursor pagination, so Projects with more than 100/500 items are not silently truncated (the bug that a fixed `--limit` caused).
 
-**Tool call 1 (Bash)**: Run this single-line command verbatim — `tmpfile=$(mktemp) && gh project item-list {project_number} --owner {owner} --format json --limit 500 > "$tmpfile" && echo "$tmpfile"`
+**Tool call 1 (Bash)**: Run this script verbatim. It resolves the Project node ID (owner-type agnostic — works for both user and organization owners), pages through every item with `pageInfo.hasNextPage` / `endCursor`, normalizes each node to `{content:{number}, status}`, and prints the temp file path on success. On any failure it prints `[projects:fetch-failed] <reason>` and no path.
 
-**Tool call 2 (Read)**: Use the Read tool to open the temp file path printed by Tool call 1. The JSON contains an `items` array; each element has `.status` (string) and `.content.number` (int). Build an in-memory map of Issue number → Status. On failure, skip Projects info and show the Phase 3 list without a Status column.
+```bash
+tmpfile=$(mktemp); pages=$(mktemp)
+pid=$(gh project view {project_number} --owner {owner} --format json 2>/dev/null | jq -r '.id')
+if [ -z "$pid" ] || [ "$pid" = "null" ]; then echo "[projects:fetch-failed] could not resolve project id"; rm -f "$tmpfile" "$pages"; exit 0; fi
+cursor=""; : > "$pages"; ok=1
+QUERY='
+query($pid: ID!, $cursor: String) {
+  node(id: $pid) {
+    ... on ProjectV2 {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content { ... on Issue { number } ... on PullRequest { number } }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+while : ; do
+  if [ -n "$cursor" ]; then
+    page=$(gh api graphql -f query="$QUERY" -F pid="$pid" -F cursor="$cursor" 2>/dev/null) || { ok=0; break; }
+  else
+    page=$(gh api graphql -f query="$QUERY" -F pid="$pid" 2>/dev/null) || { ok=0; break; }
+  fi
+  echo "$page" | jq -e '.data.node.items' >/dev/null 2>&1 || { ok=0; break; }
+  echo "$page" | jq -c '.data.node.items.nodes[]?' >> "$pages"
+  hn=$(echo "$page" | jq -r '.data.node.items.pageInfo.hasNextPage')
+  cursor=$(echo "$page" | jq -r '.data.node.items.pageInfo.endCursor')
+  [ "$hn" = "true" ] && [ -n "$cursor" ] && [ "$cursor" != "null" ] || break
+done
+if [ "$ok" != "1" ]; then echo "[projects:fetch-failed] graphql paging error"; rm -f "$tmpfile" "$pages"; exit 0; fi
+jq -s '{items: ([ .[] | { content: { number: (.content.number // null) }, status: ([ .fieldValues.nodes[]? | select(.field.name? == "Status") | .name ] | first // null) } ] | map(select(.content.number == null | not)))}' "$pages" > "$tmpfile"
+rm -f "$pages"
+echo "$tmpfile"
+```
+
+**Tool call 2 (Read)**: Use the Read tool to open the temp file path printed by Tool call 1. The JSON contains an `items` array; each element has `.status` (string or null) and `.content.number` (int). Build an in-memory map of Issue number → Status. If Tool call 1 printed `[projects:fetch-failed]` instead of a path (or the Read fails), skip Projects info and show the Phase 3 list without a Status column.
 
 Add a Status column to the list display:
 


### PR DESCRIPTION
## Summary

`/rite:issue:list` の Phase 4.2 が `gh project item-list --limit 500` 固定でアイテムを取得していたため、Project に 500 件超のアイテムが蓄積すると古い順に打ち切られ、新しい Open Issue が status map から漏れて `[—]` (未登録扱い) と誤表示されていた。Phase 4.2 の Tool call 1 を GraphQL cursor paging に置き換え、全アイテムを取得するよう修正する。

owner が user / organization のどちらでも動くよう、`gh project view` で Project node ID を解決してから `node(id:)` で `items(first:100, after:$cursor)` をページングする方式を採用した（`user(login:)` / `organization(login:)` の分岐を構造的に回避）。

## Related Issue

Closes #1145

## Changes

- `plugins/rite/commands/issue/list.md` Phase 4.2:
  - Tool call 1 を `gh project item-list --limit 500` から GraphQL cursor paging スクリプトへ置換（`pageInfo.hasNextPage` / `endCursor` でループ）
  - 各ページの nodes を tmpfile に追記し、`jq -s` で `{items:[{content:{number}, status}]}` 形式へ正規化（Tool call 2 の `.status` / `.content.number` 契約を維持）
  - 取得失敗時は `[projects:fetch-failed]` マーカーを emit し、Tool call 2 が Status 列なしで表示する fallback を維持（AC-3）
  - 冒頭の CRITICAL 警告を「スクリプトを verbatim 実行し query / jq を編集しない」旨へ更新

## 検証

ローカルで Project #6（実測 621 アイテム、500 件超）に対し新スクリプトを実行し、全 621 件を取得・主要 Issue (#1145 / #673 / #1144 / #1142 / #1141) すべてに Status が解決されることを確認済み。

## 未完了の Issue チェック項目

以下のチェック項目が Issue 本文で未完了です:

- [ ] AC-4: 手動検証 — Project #6 に対して `/rite:issue:list` を実行し、Open Issue 群に Status が表示されることを確認する（コマンド end-to-end の手動実行が必要なため、レビュー時に確認）

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable) — テストコマンド未設定 (`commands.test: null`)
- [x] Documentation updated (if applicable) — 変更対象が仕様ドキュメント (list.md) 自体

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
