### PR TITLE
refactor(docs): wiki-patterns.md の sibling literal 行番号 citation を semantic anchor 化

### DIFF
--- a/plugins/rite/references/wiki-patterns.md
+++ b/plugins/rite/references/wiki-patterns.md
@@ -265,15 +265,15 @@ fi
 - `plugins/rite/commands/issue/implement.md` (Wiki query 起動条件)
 - `plugins/rite/commands/issue/close.md` (Wiki ingest 起動条件)
 - `plugins/rite/hooks/wiki-query-inject.sh` (auto_query 注入の前提判定、ローカル helper `_extract_yaml_value`)
-- `plugins/rite/hooks/wiki-ingest-trigger.sh` (raw source staging の事前ゲート、`wiki.enabled` のみ参照、独自 inline 実装 — wiki-config.sh とは別経路。trigger.sh L226-231 self-comment で「3 sites still re-implement inline」の 1 つとして自身を列挙)
+- `plugins/rite/hooks/wiki-ingest-trigger.sh` (raw source staging の事前ゲート、`wiki.enabled` のみ参照、独自 inline 実装 — wiki-config.sh とは別経路。self-comment「Three sites still re-implement YAML parsing inline」で 3 sites の 1 つとして自身を列挙)
 - `plugins/rite/hooks/scripts/wiki-growth-check.sh` (layer 3 growth stall 判定、独自 inline 実装 lenient)
 - `plugins/rite/hooks/scripts/gitignore-health-check.sh` (gitignore drift 判定、独自 inline 実装 lenient)
 - `plugins/rite/hooks/scripts/lib/wiki-config.sh` (共通 helper `parse_wiki_scalar`、lenient — callers: wiki-ingest-commit.sh / wiki-worktree-commit.sh / wiki-worktree-setup.sh が `source` 経由で再利用)
 
 **設計差異**:
 - **lenient 経路**: ingest.md / lint.md / query.md / inject.sh / wiki-config.sh / 各 caller (cleanup.md / fix.md / review.md / implement.md / close.md / init.md) と独立 inline 実装 (growth-check.sh / gitignore-health-check.sh) は **lenient** — `false`/`no`/`0` のみ reject、それ以外 (`true`/`yes`/`1` も不明値も空文字も) は `true` として opt-out default 化する (#483)。ingest.md / lint.md は `case "$wiki_enabled" in false|no|0) wiki_enabled=false ;; *) wiki_enabled=true ;; esac` の 2-arm 形式
-- **fail-fast 経路**: `wiki-ingest-trigger.sh` のみ意図的に **strict 3-arm with fail-fast `*`** (L308-320 `case ... *) ... exit 2 ;;`) — staging hook の safe-default policy violation 防止のため、`ture` / `yse` 等の typo / 不明値を即座に reject する。本 site だけが lenient ファミリと意図的に非対称
-- **`branch_strategy` 検証**: ingest.md ステップ 1.1 では silent default で fill (probe 段階)、ステップ 5.1 / 5.2 で `*` arm の fail-fast 検証を行う 2 段階構造。lint.md L72-86 も同型 fail-fast
+- **fail-fast 経路**: `wiki-ingest-trigger.sh` のみ意図的に **strict 3-arm with fail-fast `*`** (`case "$wiki_enabled"` の `*) ... exit 2` 分岐) — staging hook の safe-default policy violation 防止のため、`ture` / `yse` 等の typo / 不明値を即座に reject する。本 site だけが lenient ファミリと意図的に非対称
+- **`branch_strategy` 検証**: ingest.md ステップ 1.1 では silent default で fill (probe 段階)、ステップ 5.1 / 5.2 で `*` arm の fail-fast 検証を行う 2 段階構造。lint.md ステップ 1.1 (Wiki 設定の読み取りとブランチ戦略判定) の `branch_strategy` 検証 case (`*) ... exit 1`) も同型 fail-fast
 
 ## Wiki 初期化判定パターン
 


### PR DESCRIPTION
## 概要

`plugins/rite/references/wiki-patterns.md` の「Boolean 解釈の設計差異」記述に残存していた literal 行番号 citation 3 件 (L268/L275/L276) を semantic anchor に書き換え、参照先ファイルの編集による drift を防止する。

## 関連 Issue

Closes #1186

## 変更内容

- **L268**: 行番号 `L226-231` を除去し、`wiki-ingest-trigger.sh` の self-comment を実コメント文言「Three sites still re-implement YAML parsing inline」で参照。引用が実態（"Three sites ... YAML parsing inline"）と drift していたため正確な文言へ補正
- **L275**: `(L308-320 case ... exit 2)` → `case "$wiki_enabled"` の `*) ... exit 2` 分岐参照（同ファイル内に 1 箇所のみ存在することを確認）
- **L276**: `lint.md L72-86` → lint.md ステップ 1.1 (Wiki 設定の読み取りとブランチ戦略判定) の `branch_strategy` 検証 case (`*) ... exit 1`) 参照

ファイル全体を再スキャンし、`L<digits>` / 英語散文形式 / `file:line` いずれの literal 行番号 citation も残存ゼロを確認。hardcoded-line-number-check も exit=0 でクリーン。

## 規約根拠

- PR #617「line 番号 literal 禁止」規約
- `docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md` の line 番号 literal 規約

## チェックリスト

- [x] プロジェクト規約に準拠（semantic anchor の参照先を全件 verify 済み）
- [x] 行番号 citation 残存ゼロを lint (hardcoded-line-number-check) で確認
- [x] ドキュメント更新（本変更自体が doc 修正）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
