### PR TITLE
docs(refs): rite command/reference の参照パス drift を一括解消

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -220,7 +220,7 @@ If the user selects "set up later", proceed to Phase 4 with `iteration.enabled: 
 
 ### 4.1 Generate rite-config.yml
 
-> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1. This resolved path is used by 4.1.1 (template schema_version read), 4.1.2 (template-based generation), and 4.1.3 (upgrade).
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1. This resolved path is used by 4.1.1 (template schema_version read), 4.1.2 (template-based generation), and 4.1.3 (upgrade).
 
 #### 4.1.1 Check for Existing Configuration
 
@@ -292,7 +292,7 @@ Generate `rite-config.yml` from the template config file.
 
 Display "rite-config.yml のアップグレードを開始します" and "スキーマバージョンを確認しています...".
 
-Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) (required when entering via `--upgrade` skip, which bypasses the Phase 4.1 blockquote).
+Resolve `{plugin_root}` per [Plugin Path Resolution](../references/plugin-path-resolution.md#resolution-script-full-version) (required when entering via `--upgrade` skip, which bypasses the Phase 4.1 blockquote).
 
 Read both files with the Read tool:
 - `rite-config.yml` (project root)

--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -134,11 +134,11 @@ git switch {base_branch} && git pull --ff-only origin {base_branch} && git switc
 
 ### 2.4 GitHub Projects Status 更新
 
-`rite-config.yml.github.projects.enabled: true` の場合、Projects の Status を `In Progress` に更新。詳細は `references/projects-integration.md` 参照。
+`rite-config.yml.github.projects.enabled: true` の場合、Projects の Status を `In Progress` に更新。詳細は `../../references/projects-integration.md` 参照。
 
 ### 2.5 Work Memory 初期化
 
-Issue の comment として work memory を初期投稿する。`コマンド:` 行は `rite:pr:open` を記載。詳細は `skills/rite-workflow/references/work-memory-format.md` 参照。
+Issue の comment として work memory を初期投稿する。`コマンド:` 行は `rite:pr:open` を記載。詳細は `../../skills/rite-workflow/references/work-memory-format.md` 参照。
 
 ### 2.6 flow-state 更新
 

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -257,7 +257,7 @@ fi
 current_body=$(cat "$updated_tmp")
 ```
 
-**Note for Claude**: ⚠️ awk は使用禁止。Python インラインスクリプトでセクション追記を行うこと。更新前バックアップ・空body検証・ヘッダー検証を必ず実行すること。参照: [gh-cli-patterns.md の Work Memory Update Safety Patterns](../../references/gh-cli-patterns.md#work-memory-update-safety-patterns)。
+**Note for Claude**: ⚠️ awk は使用禁止。Python インラインスクリプトでセクション追記を行うこと。更新前バックアップ・空body検証・ヘッダー検証を必ず実行すること。参照: [gh-cli-patterns.md の Work Memory Update Safety Patterns](../../../references/gh-cli-patterns.md#work-memory-update-safety-patterns)。
 
 **Standard update template:**
 
@@ -330,7 +330,7 @@ When a child Issue's PR is merged and cleanup runs, update the parent Issue's Ta
 
 Replace `- [ ] #{issue_number}` with `- [x] #{issue_number}` in the parent Issue body. The pattern matches any text after the Issue number on the same line (e.g., `- [ ] #661 - description text`).
 
-**Implementation**: Use the 3-step pattern (Bash → Read+Write → Bash) per [gh-cli-patterns.md](../../references/gh-cli-patterns.md).
+**Implementation**: Use the 3-step pattern (Bash → Read+Write → Bash) per [gh-cli-patterns.md](../../../references/gh-cli-patterns.md).
 
 **Step 1: Bash tool call -- retrieve and validate the body**
 
@@ -568,7 +568,7 @@ if ls .rite-work-memory/issue-*.md 1>/dev/null 2>&1; then
 fi
 ```
 
-Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) if not already resolved.
+Resolve `{plugin_root}` per [Plugin Path Resolution](../../../references/plugin-path-resolution.md#resolution-script-full-version) if not already resolved.
 
 **Note**: This is a defense-in-depth mechanism. If Phase 4 executes correctly, this check is a no-op.
 
@@ -579,7 +579,7 @@ After the Fail-Closed Gate, run the cleanup-work-memory script. This script perf
 3. Deletes ALL `.rite-work-memory/issue-*.md` files and their lockdirs (both current Issue and stale leftovers)
 4. Reports deletion results (deleted/failed/remaining counts)
 
-Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) if not already resolved.
+Resolve `{plugin_root}` per [Plugin Path Resolution](../../../references/plugin-path-resolution.md#resolution-script-full-version) if not already resolved.
 
 ```bash
 bash {plugin_root}/hooks/cleanup-work-memory.sh

--- a/plugins/rite/skills/rite-workflow/references/session-detection.md
+++ b/plugins/rite/skills/rite-workflow/references/session-detection.md
@@ -62,7 +62,7 @@ Issue: #288 - checkpoint.json を廃止し Issue 作業メモリに統合
 
 ## Prerequisites
 
-- The `/rite:resume` command must be available (defined in [resume.md](../../commands/resume.md))
+- The `/rite:resume` command must be available (defined in [resume.md](../../../commands/resume.md))
 
 ## Related
 

--- a/plugins/rite/templates/README.md
+++ b/plugins/rite/templates/README.md
@@ -202,7 +202,7 @@ Commands should check for these variables and handle their absence gracefully.
 
 ## References
 
-- [Work Memory Format](../references/work-memory-format.md) — Work memory structure
+- [Work Memory Format](../skills/rite-workflow/references/work-memory-format.md) — Work memory structure
 - [gh CLI Patterns](../references/gh-cli-patterns.md) — GitHub CLI command patterns
 
 ---


### PR DESCRIPTION
## 概要

rite plugin の command / reference / skill / template ファイル内に散在していた、`references/` 等への相対参照パスの drift（深さ誤り・誤サブディレクトリ・bare パス）を一括解消する。PR #1190（Issue #1182）の `/rite:pr:review` で副次的に検出された pre-existing 事項。

prose 参照（「詳細は X 参照」）や Markdown リンクは LLM が文脈で解決可能なため実害は限定的だが、仕様ドキュメントの整合性として解消する。

## 関連 Issue

Closes #1191

## 変更内容（5 ファイル・10 箇所）

| ファイル | AC | 修正 |
|----------|----|----|
| `commands/pr/open.md` (L137/L141) | AC-1 | bare `references/` / `skills/` を `../../references/` / `../../skills/` に（同ファイル L190 のスタイルに整合） |
| `commands/pr/references/archive-procedures.md` (L260/L333/L571/L582) | AC-2 + AC-3 | depth-3 で不足していた `../../references/` を `../../../references/` に（既存の正しい L52 と一致） |
| `commands/init.md` (L223/L295) | AC-3 | depth-2 で過剰だった `../../references/` を `../references/` に（`lint.md`/`resume.md` のスタイルに整合） |
| `skills/rite-workflow/references/session-detection.md` (L65) | AC-3 | depth 不足の `../../commands/` を `../../../commands/` に |
| `templates/README.md` (L205) | AC-3 | 誤サブディレクトリの `../references/work-memory-format.md` を実在する `../skills/rite-workflow/references/` に |

## AC-3 網羅調査の結論

全 `.md` を機械的にスキャンし相対パス解決をチェック。真の drift（壊れた相対リンク）= 上記 6 箇所のみで全件修正。以下は drift ではないと判定し意図的に据え置き（スコープ creep 回避）:

- **bare `commands/...md` 等の記述的パス**: rite 確立の plugin-root 相対の記述慣習（内部一貫・clickable link ではない）
- **reviewer skill 内の `[API Reference](./reference.md)` 等**: 「リンク切れ指摘例」の教材コンテンツ
- **workflow-identity.md の `../../skills/...`**: caller depth 可変のテンプレート例（固定の正解なし）

修正後の再スキャンで本 PR が新規 drift を 1 件も導入していないことを確認済み。`/rite:lint` の warning（drift/comment-journal/comment-line-ref/sh-cross-ref）は全て pre-existing かつ本 diff 外のファイルで、非ブロッキング。

## チェックリスト

- [x] プロジェクト規約に準拠（rite 参照規約: depth-2=`../references/`, depth-3=`../../../references/`）
- [x] テスト（lint 未設定のためテスト対象なし。rite plugin checks は通過）
- [x] ドキュメント更新（本変更自体がドキュメント整合性の修正）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
