### PR TITLE
refactor(pr:cleanup): archive-procedures §3.5.1 の WM 完了情報追記を issue-comment-wm-sync.sh へ委譲 (#1195 #7)

### DIFF
--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -103,7 +103,10 @@ If a work memory comment exists on the Issue, automatically append a completion 
 # 完了情報セクションを content-file に生成し append-eof transform で委譲追記する。
 # {merged_at} 等は cleanup.md コンテキストの実値で置換する（heredoc malform 回避のため printf を使用）。
 completion_tmp=$(mktemp)
-trap 'rm -f "$completion_tmp"' EXIT
+# helper stderr（auth/rate/network/safety-check 詳細 + backup path）を退避し、失敗時に surface する。
+# canonical caller fix.md 4.5.2 / review.md 6.2 と同じ stderr-capture 規約（2>/dev/null 破棄をしない）。
+wm_sync_err=$(mktemp 2>/dev/null) || wm_sync_err=""
+trap 'rm -f "$completion_tmp" "${wm_sync_err:-}"' EXIT
 printf '%s\n' \
   "### 完了情報" \
   "- **マージ日時**: {merged_at}" \
@@ -115,16 +118,19 @@ printf '%s\n' \
 
 wm_status=$(bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
   --issue {issue_number} \
-  --transform append-eof --content-file "$completion_tmp" 2>/dev/null) || true
+  --transform append-eof --content-file "$completion_tmp" 2>"${wm_sync_err:-/dev/null}") || true
 rm -f "$completion_tmp"
 
 # 非ブロッキング: cleanup は work memory 更新失敗で停止してはならない（§3.5 は automatic final update）。
 # no_comment（作業メモリ不在 = legitimate no-op）以外の skipped/error は WARNING 表示にとどめる。
+# 失敗時は helper stderr の root-cause（先頭 5 行）も surface し、backup path / API エラー詳細を operator に残す。
 case "$wm_status" in
   status=success)      echo "作業メモリに完了情報を追記しました" ;;
   *reason=no_comment*) echo "作業メモリ comment が無いため完了情報の追記をスキップしました" ;;
-  *)                   echo "警告: 作業メモリ更新が完了しませんでした (${wm_status:-no-status})。cleanup は続行します。" >&2 ;;
+  *)                   echo "警告: 作業メモリ更新が完了しませんでした (${wm_status:-no-status})。cleanup は続行します。" >&2
+                       [ -n "$wm_sync_err" ] && [ -s "$wm_sync_err" ] && { echo "  helper stderr (root-cause、先頭 5 行):" >&2; head -5 "$wm_sync_err" | sed 's/^/    /' >&2; } ;;
 esac
+rm -f "${wm_sync_err:-}"
 ```
 
 **Note for Claude**: comment 取得・body 変換・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない（旧 inline 実装のクロスプロセス変数参照制約は解消済み）。`{merged_at}` / `{pr_number}` / `{pr_title}` / `{pr_url}` / `{timestamp}` / `{branch_name}` を cleanup.md コンテキストの実値で置換すること。`{plugin_root}` はリテラル値で埋め込む。

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -95,54 +95,43 @@ If a work memory comment exists on the Issue, automatically append a completion 
 
 #### 3.5.1 Retrieve and Update Work Memory Comment
 
+完了情報の追記は `issue-comment-wm-sync.sh` の `append-eof` transform へ委譲する（canonical caller パターン: `commands/pr/create.md` 4.1.2 / `commands/pr/fix.md` 4.5.2）。comment 取得・backup・空body/ヘッダー/50% safety check・PATCH は helper 内部で完結するため、cleanup 側は完了情報の content-file を生成して helper を呼び、機械可読な `status=...` 行を読むだけでよい。
+
+`### 完了情報` は WM 初期テンプレに存在しない**新規セクション**のため、既存セクション専用の `append-section`（不在時 no-op）ではなく EOF へ raw 追記する `append-eof` を用いる（原 inline 実装の heredoc 追記挙動を忠実に再現）。
+
 ```bash
-# ⚠️ このブロック全体を単一の Bash ツール呼び出しで実行すること（クロスプロセス変数参照を防止）
-# comment_data の取得・追記内容の heredoc 定義・PATCH を分割すると変数が失われる
-comment_data=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | {id: .id, body: .body}')
-comment_id=$(echo "$comment_data" | jq -r '.id // empty')
-current_body=$(echo "$comment_data" | jq -r '.body // empty')
+# 完了情報セクションを content-file に生成し append-eof transform で委譲追記する。
+# {merged_at} 等は cleanup.md コンテキストの実値で置換する（heredoc malform 回避のため printf を使用）。
+completion_tmp=$(mktemp)
+trap 'rm -f "$completion_tmp"' EXIT
+printf '%s\n' \
+  "### 完了情報" \
+  "- **マージ日時**: {merged_at}" \
+  "- **PR**: #{pr_number} - {pr_title}" \
+  "- **PR URL**: {pr_url}" \
+  "- **クリーンアップ完了**: {timestamp}" \
+  "- **削除したブランチ**: {branch_name}" \
+  "- **最終 Status**: Done" > "$completion_tmp"
 
-if [ -n "$comment_id" ]; then
-  if [ -z "$current_body" ]; then
-    echo "ERROR: 作業メモリの本文取得に失敗。更新をスキップします。" >&2
-  else
-    backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
-    printf '%s' "$current_body" > "$backup_file"
-    original_length=$(printf '%s' "$current_body" | wc -c)
+wm_status=$(bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform append-eof --content-file "$completion_tmp" 2>/dev/null) || true
+rm -f "$completion_tmp"
 
-    tmpfile=$(mktemp)
-    trap 'rm -f "$tmpfile"' EXIT
-    printf '%s\n\n' "$current_body" > "$tmpfile"
-    cat >> "$tmpfile" << 'NEW_SECTION_EOF'
-{3.5.2の内容を実際の値で置換して記述}
-NEW_SECTION_EOF
-
-    # Safety checks before PATCH (see gh-cli-patterns.md)
-    if [ ! -s "$tmpfile" ] || [[ "$(wc -c < "$tmpfile")" -lt 10 ]]; then
-      echo "ERROR: Updated body is empty or too short. Aborting PATCH. Backup: $backup_file" >&2
-      exit 1
-    fi
-    if ! grep -q '📜 rite 作業メモリ' "$tmpfile"; then
-      echo "ERROR: Updated body missing work memory header. Backup: $backup_file" >&2
-      exit 1
-    fi
-    updated_length=$(wc -c < "$tmpfile")
-    if [[ "${updated_length:-0}" -lt $(( ${original_length:-1} / 2 )) ]]; then
-      echo "ERROR: Updated body < 50% of original (${updated_length}/${original_length}). Aborting PATCH. Backup: $backup_file" >&2
-      exit 1
-    fi
-
-    jq -n --rawfile body "$tmpfile" '{"body": $body}' \
-      | gh api repos/{owner}/{repo}/issues/comments/"$comment_id" \
-        -X PATCH --input -
-  fi
-fi
+# 非ブロッキング: cleanup は work memory 更新失敗で停止してはならない（§3.5 は automatic final update）。
+# no_comment（作業メモリ不在 = legitimate no-op）以外の skipped/error は WARNING 表示にとどめる。
+case "$wm_status" in
+  status=success)      echo "作業メモリに完了情報を追記しました" ;;
+  *reason=no_comment*) echo "作業メモリ comment が無いため完了情報の追記をスキップしました" ;;
+  *)                   echo "警告: 作業メモリ更新が完了しませんでした (${wm_status:-no-status})。cleanup は続行します。" >&2 ;;
+esac
 ```
 
-**Note for Claude**: ⚠️ このブロック全体を**1つの Bash ツール呼び出し**で実行すること。`current_body` 取得・追記内容の heredoc 定義・PATCH を別の Bash ツール呼び出しに分割すると、前の呼び出しのシェル変数（`current_body` 等）が失われてヘッダーが消失する。`{3.5.2の内容を実際の値で置換して記述}` を 3.5.2 のテンプレートから生成した実際の追記内容で置換し、**すべてを1ブロックで**実行する。
+**Note for Claude**: comment 取得・body 変換・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない（旧 inline 実装のクロスプロセス変数参照制約は解消済み）。`{merged_at}` / `{pr_number}` / `{pr_title}` / `{pr_url}` / `{timestamp}` / `{branch_name}` を cleanup.md コンテキストの実値で置換すること。`{plugin_root}` はリテラル値で埋め込む。
 
 #### 3.5.2 Update Content
+
+> **委譲状況（#1195）**: §3.5.1 は本節「Standard update template」の `### 完了情報` ブロックを `append-eof` transform で委譲追記する（実装済み）。下記の **進捗チェックリスト merge**（`### 進捗` への dedup 追記）は未委譲で、`issue-comment-wm-sync.sh` の transform 化を **#1195 #8** で対応する。それまで progress-checklist merge は cleanup 実行経路に組み込まれず、§3.5.1 は `### 完了情報` の追記のみを行う。
 
 Automatically append the following to the work memory:
 
@@ -168,9 +157,9 @@ The progress section update in Phase 3.5.2 follows this logic:
 **Bash implementation (Python-based section merge):**
 
 ```bash
-# ⚠️ 以下の処理は 3.5.1 の単一 Bash ブロック内に組み込むこと。
-# 挿入位置: 3.5.1 の current_body=$(echo "$comment_data" | jq -r '.body // empty') の直後。
-# こうすることで $current_body を再利用し、追加の API コールを回避できる。
+# ⚠️ 未委譲（#1195 #8 の参照仕様）。§3.5.1 は append-eof で `### 完了情報` のみを追記し、
+# この progress-checklist merge は現状 cleanup 実行経路に組み込まれていない。
+# #8 で issue-comment-wm-sync.sh の transform として委譲する（下記ロジックがその仕様）。
 body_tmp=$(mktemp)
 filtered_items_file=$(mktemp)
 updated_tmp=$(mktemp)

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -97,7 +97,7 @@ If a work memory comment exists on the Issue, automatically append a completion 
 
 完了情報の追記は `issue-comment-wm-sync.sh` の `append-eof` transform へ委譲する（canonical caller パターン: `commands/pr/create.md` 4.1.2 / `commands/pr/fix.md` 4.5.2）。comment 取得・backup・空body/ヘッダー/50% safety check・PATCH は helper 内部で完結するため、cleanup 側は完了情報の content-file を生成して helper を呼び、機械可読な `status=...` 行を読むだけでよい。
 
-`### 完了情報` は WM 初期テンプレに存在しない**新規セクション**のため、既存セクション専用の `append-section`（不在時 no-op）ではなく EOF へ raw 追記する `append-eof` を用いる（原 inline 実装の heredoc 追記挙動を忠実に再現）。
+`### 完了情報` は WM 初期テンプレに存在しない**新規セクション**のため、既存セクション専用の `append-section`（不在時 no-op）ではなく EOF へ raw 追記する `append-eof` を用いる（原 inline 実装の heredoc 追記挙動を再現。末尾改行は `\n\n` セパレータに正規化する意図的差異があるが、レンダリング結果は同一）。
 
 ```bash
 # 完了情報セクションを content-file に生成し append-eof transform で委譲追記する。

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -20,6 +20,9 @@
 #     bash issue-comment-wm-sync.sh update --issue 42 \
 #       --transform append-section --section "品質チェック履歴" --content-file /tmp/lint.md
 #
+#     bash issue-comment-wm-sync.sh update --issue 42 \
+#       --transform append-eof --content-file /tmp/completion.md
+#
 # Options:
 #   --issue          Issue number (required)
 #   --branch         Branch name (init mode)
@@ -193,9 +196,9 @@ safety_check() {
   fi
 
   # 50% rule (only for update-progress, update-phase, update-plan-status, update-checkboxes)
-  # Skip for append-section and replace-section (content grows or changes size unpredictably)
+  # Skip for append-section, replace-section, and append-eof (content grows or changes size unpredictably)
   case "$transform" in
-    append-section|replace-section)
+    append-section|replace-section|append-eof)
       ;;
     *)
       local updated_length

--- a/plugins/rite/hooks/issue-comment-wm-update.py
+++ b/plugins/rite/hooks/issue-comment-wm-update.py
@@ -178,9 +178,14 @@ def append_eof(body: str, content: str) -> str:
 
     Unlike append_section (which appends *within* an existing section and is a
     no-op when the section is absent), this adds a brand-new section that does
-    not yet exist in the work memory. Replicates the heredoc behaviour of the
+    not yet exist in the work memory. Reproduces the heredoc behaviour of the
     original archive-procedures §3.5.1 inline block
-    (`printf '%s\\n\\n' "$body"` followed by `cat >> ... <<EOF`).
+    (`printf '%s\\n\\n' "$body"` followed by `cat >> ... <<EOF`), with one
+    intentional difference: trailing newlines on ``body`` are normalised to a
+    single ``\\n\\n`` separator instead of being preserved. The original could
+    emit a stray extra blank line when ``body`` already ended in a newline; the
+    rendered Markdown is identical either way, so this only suppresses the
+    redundant blank line.
     """
     return body.rstrip("\n") + "\n\n" + content.rstrip("\n") + "\n"
 

--- a/plugins/rite/hooks/issue-comment-wm-update.py
+++ b/plugins/rite/hooks/issue-comment-wm-update.py
@@ -21,6 +21,9 @@ Usage:
     cat body.txt | python3 issue-comment-wm-update.py replace-section \
         --section "次のステップ" --content-file /tmp/next.md > updated.txt
 
+    cat body.txt | python3 issue-comment-wm-update.py append-eof \
+        --content-file /tmp/completion.md > updated.txt
+
     cat body.txt | python3 issue-comment-wm-update.py update-checkboxes \
         --tasks "task1,task2" > updated.txt
 
@@ -170,6 +173,18 @@ def replace_section(body: str, section_name: str, content: str) -> str:
     return body
 
 
+def append_eof(body: str, content: str) -> str:
+    """Append raw content at end-of-body, after a blank-line separator.
+
+    Unlike append_section (which appends *within* an existing section and is a
+    no-op when the section is absent), this adds a brand-new section that does
+    not yet exist in the work memory. Replicates the heredoc behaviour of the
+    original archive-procedures §3.5.1 inline block
+    (`printf '%s\\n\\n' "$body"` followed by `cat >> ... <<EOF`).
+    """
+    return body.rstrip("\n") + "\n\n" + content.rstrip("\n") + "\n"
+
+
 def update_checkboxes(body: str, task_names: list[str]) -> str:
     """Update specified tasks from - [ ] to - [x]."""
     for task_name in task_names:
@@ -297,6 +312,13 @@ def main():
             sys.exit(1)
         content = read_file_content(opts["content_file"])
         body = replace_section(body, opts["section"], content)
+
+    elif subcommand == "append-eof":
+        if "content_file" not in opts:
+            print("ERROR: --content-file is required for append-eof", file=sys.stderr)
+            sys.exit(1)
+        content = read_file_content(opts["content_file"])
+        body = append_eof(body, content)
 
     elif subcommand == "update-checkboxes":
         if "tasks" not in opts:


### PR DESCRIPTION
## 概要

umbrella Issue #1195 の **#7**（`pr/references/archive-procedures.md` Phase 3.5.1 "Retrieve and Update Work Memory Comment", ~39 行 inline bash）を helper へ委譲する。

調査の結果、WM 更新ブロックは 3 箇所あり、うち 2 箇所（`create.md` 4.1.2 / `fix.md` 4.5.2 #1201）は既に `issue-comment-wm-sync.sh` へ委譲済みで、`archive-procedures.md` 3.5.1 が唯一 inline bash で残っていた。Issue は「新規 `wm-completion-append.sh`」を指示していたが、それは 19KB の orchestration（comment 取得・backup・safety check・PATCH・status 出力）を丸ごと重複させ、WM 更新ブロックで唯一 canonical helper を使わない例外を生む。CLAUDE.md「シンプルさを死守する」に従い、**既存 helper を再利用する Option B**（ユーザー承認済み）を採用した。

## スコープ（#7 のみ）

各ブロックは独立 PR の契約（一度に全件は dogfooding 自己参照ループで危険）。本 PR は **#7 のみ**。進捗チェックリスト merge（§3.5.2）は **#8 pending**。

## 変更内容

- **`hooks/issue-comment-wm-update.py`**: 新規 transform `append-eof` を追加。既存セクション専用の `append-section`（不在時 no-op）では追記できない新規 `### 完了情報` を EOF へ raw 追記し、原 inline 実装の heredoc 追記挙動を忠実に再現。既存 `append_section`/`replace_section` は**無改変**（`品質チェック履歴` 等で既に no-op になっている他 caller への波及回避）。
- **`hooks/issue-comment-wm-sync.sh`**: `safety_check` の 50%-rule 免除 case に `append-eof` を追加 + usage 例追記。
- **`commands/pr/references/archive-procedures.md` §3.5.1**: ~40 行 inline orchestration を `issue-comment-wm-sync.sh update --transform append-eof` への委譲に置換。非ブロッキング status 処理（cleanup の「失敗してはならない」契約を維持・強化）。§3.5.2 の「3.5.1 に embed」旧指示を解消し progress-merge を #8 pending として明記。
- **Issue #1195 body**: #7 注記を Option B に更新、#8 の前提変化を注記。

## 検証

- `python3 -m py_compile` / `bash -n` 構文 OK。
- `append-eof` の手動テスト（EOF 追記・引数検証）pass、`append-section` 回帰（不在セクション no-op）維持。
- `issue-comment-wm-sync.test.sh` pass（3/3）。
- **drift baseline 一致**: `distributed-fix-drift-check.sh --all` が develop と同じ 88 件（新規 finding なし）。
- rite plugin lint checks（bang-backtick / doc-heavy / backlink / hardcoded-line / comment-journal / comment-line-ref / sh-cross-ref / orphan / direct-gh-issue）: 全て既存 baseline warning のみで、**変更 3 ファイルに新規 finding なし**。

## Known Issues

- lint 未実行（project lint コマンド未設定: `commands.lint: null`、言語 manifest 無し）。rite plugin 固有チェックは全て実行・pass。

refs #1195
