### PR TITLE
refactor(wiki:init): §1.3.4 negation verification を gitignore-health-check.sh --verify-negation へ委譲 (#1195 #11)

### DIFF
--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -250,125 +250,30 @@ Edit ツールで `.gitignore` の既存 anchor `# <<< gitignore-wiki-section-en
 
 #### 1.3.4 verification
 
-> **Reference**: `.gitignore` の `DRIFT-CHECK ANCHOR: negation verification canonical` 節（「動作確認の正典」 + `git check-ignore -v` を sanity check に使わない理由）。`git add --dry-run` を使用し、`git check-ignore -v` は使わない（rc と出力の両方が negation 成立と単純 match で同じ値を取り得るため決定論的判別不能）。canonical impl は `plugins/rite/hooks/scripts/gitignore-health-check.sh` の `DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check` 節の `grep -qF` パターン参照。
+> **Reference**: negation 注入が効いているかの検証は `plugins/rite/hooks/scripts/gitignore-health-check.sh --verify-negation` に委譲する。`git add --dry-run` を使い `git check-ignore -v` は使わない理由（rc と出力の両方が negation 成立と不在で同じ値を取り得るため決定論的判別不能）・canonical impl は同 helper の `DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check` 節（および対の `(verify-negation copy)` 節）と `.gitignore` の `DRIFT-CHECK ANCHOR: negation verification canonical` 節を参照。
+
+ステップ 1.3.3 の Edit が完了したら、negation override が実際に効いているかを helper で検証する。helper は probe ファイルの作成・`git add --dry-run` 検証・signal-specific trap cleanup・non-blocking 判定をすべて内包する（旧 ~110 行 inline 実装を `--verify-negation` モードへ委譲）。`plugin_root` はステップ 2.1 で解決されるが本ステップ (1.3) はそれより前にあるため、ここで前倒し解決する:
 
 ```bash
-# signal-specific trap で probe ファイルの残留を防ぐ
-# (canonical: plugins/rite/commands/pr/references/bash-trap-patterns.md
-#  の `#signal-specific-trap-template` anchor)。
-#
-# SIGINT/SIGTERM/SIGHUP で rm -f がスキップされ、ステップ 3.1 の same_branch ブロックの
-# `git add .rite/wiki/` に probe (.negation-probe) が混入する経路を塞ぐ。
-# 関数名は上記 canonical の命名規約 `_rite_<scope>_<phase>_cleanup` に準拠。
-# (ステップ 3.1 の `_rite_wiki_init_cleanup` は規約確立前の旧命名維持対象。本 ステップ 1.3 は
-#  新規追加なので規約準拠の `_rite_wiki_init_phase13_cleanup` を採用。)
-#
-# canonical instantiation 順序 (re-review cycle 3 F-A 対応):
-#   (1) パス変数を空文字で先行宣言
-#   (2) cleanup 関数と 4 行 trap を設定
-#   (3) その後で mktemp を実行
-# これにより trap arm と mktemp の間に signal が到達しても、cleanup 関数が未定義変数
-# を参照する経路を閉じる。
-probe_mkdir_err=""
-probe_touch_err=""
-dry_run_err=""
+# plugin_root 解決 (ステップ 2.1 の inline one-liner を前倒し。
+#  canonical: references/plugin-path-resolution.md#inline-one-liner-for-command-files)
+plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
 
-_rite_wiki_init_phase13_cleanup() {
-  rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" "${dry_run_err:-}" .rite/wiki/raw/.negation-probe
-}
-trap 'rc=$?; _rite_wiki_init_phase13_cleanup; exit $rc' EXIT
-trap '_rite_wiki_init_phase13_cleanup; exit 130' INT
-trap '_rite_wiki_init_phase13_cleanup; exit 143' TERM
-trap '_rite_wiki_init_phase13_cleanup; exit 129' HUP
-
-# mkdir / touch の失敗を明示的にハンドリング + stderr を退避。
-# permission/disk full/readonly 等で probe 作成失敗時、verification 自体を skip して
-# WARNING を表示する (non-blocking、ステップ 2 へ進行)。silent に `git add --dry-run` を
-# 実行して pathspec mismatch 警告 (rc=128) を「negation 不在」と誤認することを防ぐ。
-# stderr は tempfile に退避し、失敗時に head -3 で先頭行を stderr に流す
-# (canonical: plugins/rite/hooks/scripts/gitignore-health-check.sh の probe 作成 +
-#  stderr 退避パターン参照)。
-probe_mkdir_err=$(mktemp /tmp/rite-wiki-init-p13-mkdir-err-XXXXXX 2>/dev/null) || probe_mkdir_err=""
-probe_touch_err=$(mktemp /tmp/rite-wiki-init-p13-touch-err-XXXXXX 2>/dev/null) || probe_touch_err=""
-probe_created="false"
-if mkdir -p .rite/wiki/raw 2>"${probe_mkdir_err:-/dev/null}" && \
-   touch .rite/wiki/raw/.negation-probe 2>"${probe_touch_err:-/dev/null}"; then
-  probe_created="true"
-else
-  echo "WARNING: negation probe の作成に失敗しました (read-only fs / permission / disk full の可能性)" >&2
-  if [ -n "$probe_mkdir_err" ] && [ -s "$probe_mkdir_err" ]; then
-    echo "  mkdir stderr (先頭 3 行):" >&2
-    head -3 "$probe_mkdir_err" | sed 's/^/    /' >&2
-  fi
-  if [ -n "$probe_touch_err" ] && [ -s "$probe_touch_err" ]; then
-    echo "  touch stderr (先頭 3 行):" >&2
-    head -3 "$probe_touch_err" | sed 's/^/    /' >&2
-  fi
-  echo "  verification を skip して ステップ 2 に進行します (non-blocking)" >&2
+if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/gitignore-health-check.sh" ]; then
+  # non-blocking: plugin_root 解決失敗時も verification を skip して ステップ 2 へ進行する
+  # (ステップ 3.1 の git add で negation 不在ならそこで改めてエラーが出る)。
+  echo "WARNING: plugin_root 解決に失敗したため negation verification を skip します (non-blocking)" >&2
   echo "  ステップ 3.1 の git add で negation が効いていなければそこで改めてエラーが出ます" >&2
+else
+  bash "$plugin_root/hooks/scripts/gitignore-health-check.sh" --verify-negation
 fi
-
-if [ "$probe_created" = "true" ]; then
-  # verification: rc=0 かつ stdout に canonical pattern `add '<path>'` (probe フルパス) を含めば OK
-  # `grep -q "^add '"` (単純プレフィックス) では偶然 `add '...'` で始まる任意パスが出ると
-  # false positive になるため、`grep -qF "add '<probe path 全体>'"` で完全パス fixed-string
-  # match に統一する (canonical: plugins/rite/hooks/scripts/gitignore-health-check.sh の
-  # `grep -qF "add '${negation_probe}'"` パターン)。
-  #
-  # PR #586 F-02 対応: stderr を独立 tempfile に退避し stdout に merge しない。
-  # 同一ファイル内 ステップ 3.5.1 のプロジェクト規約「2>&1 は付けない: 構造化 stdout と WARNING stderr
-  # の分離を維持する」に準拠する。canonical 参照実装 gitignore-health-check.sh の
-  # `DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture` 節の
-  # `add_dry_err=$(mktemp ...) ... if add_dry_out=$(...); then add_dry_rc=0; else add_dry_rc=$?; fi`
-  # パターンに **rc capture 構造ごと** 揃える (canonical drift 防止)。実害として、success path で
-  # git が emit する stderr 警告 (例: `warning: in the working copy of '...', LF will be replaced
-  # by CRLF`) が success メッセージに混入することを防ぎ、`grep -qF "add '...'"` の false positive
-  # リスクを排除する。
-  #
-  # PR #586 F-01 (cycle 5) 対応: cycle 4 で stderr 退避部分のみ canonical に揃え rc capture
-  # 構造を簡略な `var=$(cmd); rc=$?` に留めていたが、コメントは「一字一句揃える」と謳っており
-  # 主張と実装が乖離していた。cycle 6 で if-wrapper 構造に統一して drift を解消する。
-  # `set -e` 不在の bash block 内では機能等価だが、Wiki 経験則「canonical reference 文書の
-  # サンプルコードは canonical 実装と一字一句同期する」(patterns/high) を厳守する。
-  dry_run_err=$(mktemp /tmp/rite-wiki-init-p13-dryrun-err-XXXXXX 2>/dev/null) || dry_run_err=""
-  dry_run_out=""
-  dry_run_rc=0
-  if dry_run_out=$(git add --dry-run -- .rite/wiki/raw/.negation-probe 2>"${dry_run_err:-/dev/null}"); then
-    dry_run_rc=0
-  else
-    dry_run_rc=$?
-  fi
-
-  if [ "$dry_run_rc" -eq 0 ] && printf '%s' "$dry_run_out" | grep -qF "add '.rite/wiki/raw/.negation-probe'"; then
-    echo "✅ .gitignore negation verification OK: $dry_run_out"
-  else
-    echo "WARNING: .gitignore negation verification failed (rc=$dry_run_rc)" >&2
-    echo "  stdout: $dry_run_out" >&2
-    if [ -n "$dry_run_err" ] && [ -s "$dry_run_err" ]; then
-      echo "  stderr (先頭 3 行):" >&2
-      head -3 "$dry_run_err" | sed 's/^/    /' >&2
-    fi
-    echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
-    echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
-  fi
-fi
-
-# 明示 rm → trap 解除 の順序 (canonical: bash-trap-patterns.md `#signal-specific-trap-template`)。
-# 役割分離:
-#   - 明示 rm (通常パス): ステップ 1.3.4 の処理完了時点で同期的に probe を削除。script は
-#     ステップ 2 以降を継続するため、EXIT trap に delegate するだけでは処理途中の cleanup
-#     にならない (EXIT trap は script 終了時のみ発火する)。
-#   - trap cleanup (signal 経路 defense-in-depth): SIGINT/SIGTERM/SIGHUP で明示 rm に
-#     到達できなかった場合の保険として動作する。
-# 明示 rm を trap 解除より前に置くことで、rm〜trap 解除間の micro-race window を排除する。
-# trap 解除後は EXIT trap が発火しないため、script 終了時に冗長 rm が走らない。
-rm -f "${probe_mkdir_err:-}" "${probe_touch_err:-}" "${dry_run_err:-}" .rite/wiki/raw/.negation-probe
-trap - EXIT INT TERM HUP
 ```
 
-**成功時**: `✅ .gitignore に negation エントリを追記しました` を追加で表示し ステップ 2 へ。
+`--verify-negation` モードは post-injection 専用で、config 読込・strategy 判定・parent-exclusion check をスキップし、全分岐 non-blocking (exit 0) で結果を stdout / stderr に出す。probe の親ディレクトリ (`.rite/wiki/raw/`) は rmdir せず残すため、後続ステップ 2 のディレクトリ作成と衝突しない。
 
-**失敗時 (non-blocking)**: WARNING 表示のみで ステップ 2 に進行する。ステップ 3.1 の `git add .rite/wiki/` で改めてエラーが出れば、そこでユーザーに手動対応を促す。
+**成功時**: helper が `✅ .gitignore negation verification OK: ...` を **stdout** に出力する。続けて `✅ .gitignore に negation エントリを追記しました` を表示して ステップ 2 へ。
+
+**失敗時 (non-blocking)**: helper が `WARNING: .gitignore negation verification failed ...` を **stderr** に出力する。WARNING 表示のみで ステップ 2 に進行する。ステップ 3.1 の `git add .rite/wiki/` で改めてエラーが出れば、そこでユーザーに手動対応を促す。
 
 ## ステップ 2: ディレクトリ構造の作成
 

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -34,23 +34,36 @@
 #
 # Usage:
 #   gitignore-health-check.sh [--repo-root DIR] [--quiet]
-#                             [--branch-strategy-override STRATEGY] [-h|--help]
+#                             [--branch-strategy-override STRATEGY]
+#                             [--verify-negation] [-h|--help]
 #
 # Options:
 #   --repo-root DIR                   Repository root (default: git rev-parse --show-toplevel)
 #   --quiet                           Suppress informational output
 #   --branch-strategy-override VAL    Override wiki.branch_strategy from rite-config.yml
 #                                     (one of: separate_branch | same_branch) — smoke test only
+#   --verify-negation                 Post-injection negation verification mode for
+#                                     wiki/init.md ステップ 1.3.4 (delegation target).
+#                                     Skips config/strategy/parent-exclusion checks (caller
+#                                     is same_branch + just injected the negation) and is
+#                                     fully non-blocking: every outcome exits 0 and the
+#                                     result is surfaced via stdout `✅ ... OK` / stderr
+#                                     `WARNING`. See the dedicated block below.
 #   -h, --help                        Show this help
 #
 # Exit codes (non-blocking contract, identical to drift-check / wiki-growth-check):
 #   0  Health verified (or wiki disabled / legitimate no-op — skip silently)
 #   1  Drift detected (warning — caller MUST keep [lint:success])
 #   2  Invocation error (bad args, missing repo)
+#   NOTE: --verify-negation overrides this table — it ALWAYS exits 0 (non-blocking),
+#         matching wiki/init.md ステップ 1.3.4 which proceeds to ステップ 2 regardless.
 #
 # Output:
-#   Always prints `==> Total gitignore-health-check findings: N` on stdout.
-#   On drift (exit 1), additionally prints a plain `WARNING: ...` line to stderr.
+#   Default (lint) mode: always prints `==> Total gitignore-health-check findings: N`
+#   on stdout; on drift (exit 1) additionally prints a plain `WARNING: ...` to stderr.
+#   --verify-negation mode: prints `✅ .gitignore negation verification OK: ...` to stdout
+#   on success, or `WARNING: ...` to stderr on failure/skip. Does NOT print the
+#   `==> Total ... findings: N` line (it is not a drift-count aggregator).
 #
 set -uo pipefail
 
@@ -71,7 +84,15 @@ _rite_gitignore_cleanup() {
   # Also remove the probe parent directories (.rite/wiki/raw/, .rite/wiki/) if this
   # script created them and they are empty. `rmdir` fails on non-empty directories,
   # which protects pre-existing raw source files from being unintentionally removed.
-  rmdir .rite/wiki/raw .rite/wiki 2>/dev/null || true
+  #
+  # rmdir suppression for --verify-negation (rmdir 副作用抑止): wiki/init.md ステップ
+  # 1.3.4 runs DURING init, right before ステップ 2 creates the wiki directory tree.
+  # Its original inline block removed only the probe file (not the dirs) so the
+  # freshly-created .rite/wiki/raw/ survives for downstream steps. Skip rmdir here to
+  # preserve that contract; default (lint) mode keeps the empty-dir cleanup.
+  if [ "${VERIFY_NEGATION:-0}" -eq 0 ]; then
+    rmdir .rite/wiki/raw .rite/wiki 2>/dev/null || true
+  fi
 }
 trap 'rc=$?; _rite_gitignore_cleanup; exit $rc' EXIT
 trap '_rite_gitignore_cleanup; exit 130' INT
@@ -81,6 +102,7 @@ trap '_rite_gitignore_cleanup; exit 129' HUP
 REPO_ROOT=""
 QUIET=0
 STRATEGY_OVERRIDE=""
+VERIFY_NEGATION=0
 
 usage() {
   cat <<'EOF'
@@ -91,10 +113,12 @@ Options:
   --quiet                           Suppress informational output
   --branch-strategy-override VAL    Override wiki.branch_strategy (separate_branch | same_branch)
                                     Used for smoke testing only; production runs read rite-config.yml.
+  --verify-negation                 Post-injection negation verification for wiki/init.md
+                                    ステップ 1.3.4 (non-blocking, always exits 0).
   -h, --help                        Show this help
 
 Exit codes:
-  0  Health verified (or wiki disabled / legitimate no-op)
+  0  Health verified (or wiki disabled / legitimate no-op; --verify-negation always)
   1  Drift detected (warning, non-blocking)
   2  Invocation error
 EOF
@@ -105,6 +129,7 @@ while [ $# -gt 0 ]; do
     --repo-root)                 REPO_ROOT="$2"; shift 2 ;;
     --quiet)                     QUIET=1; shift ;;
     --branch-strategy-override)  STRATEGY_OVERRIDE="$2"; shift 2 ;;
+    --verify-negation)           VERIFY_NEGATION=1; shift ;;
     -h|--help)                   usage; exit 0 ;;
     *) echo "ERROR: Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -127,6 +152,61 @@ cd "$REPO_ROOT" || {
   echo "==> Total gitignore-health-check findings: 0"
   exit 2
 }
+
+# --- --verify-negation mode (wiki/init.md ステップ 1.3.4 delegation target) ---
+# init.md §1.3.4 は same_branch 戦略の negation 注入「直後」に呼ばれる post-injection
+# verification。caller が same_branch 確定 + negation を inject 済みなので、config 読込 /
+# strategy 判定 / Layer 1 parent-exclusion は不要 — それらを全てスキップして early-exit する。
+# lint.md Phase 3.9 経路 (drift guard; exit 1=drift / exit 2=env error) とは契約が異なり、
+# 本モードは全分岐 non-blocking (exit 0) で、結果は stdout `✅ ... OK` / stderr `WARNING`
+# として surface する (init.md は exit code を読まず stdout/stderr で分岐し ステップ 2 へ進む)。
+#
+# コア検証 (git add --dry-run + grep -qF "add '<probe>'") は同ファイル same_branch case の
+# `DRIFT-CHECK ANCHOR: same_branch ...` 節と意図的に同型。旧構成では init.md がこのロジックの
+# inline copy を持ち両者を「一字一句同期」していたが、本モード導入で init.md は委譲呼び出しに
+# 置換され、同期対象は同一ファイル内の 2 箇所に閉じた (cross-file drift を解消)。
+if [ "$VERIFY_NEGATION" -eq 1 ]; then
+  negation_probe=".rite/wiki/raw/.rite-lint-negation-probe"
+  # probe 作成失敗は non-blocking skip (init.md §1.3.4 契約: WARNING + ステップ 2 進行)。
+  # lint 経路の same_branch case が exit 2 (invocation error) にするのとは対照的に exit 0。
+  if ! { mkdir -p "$(dirname "$negation_probe")" 2>/dev/null && touch "$negation_probe" 2>/dev/null; }; then
+    echo "WARNING: negation probe の作成に失敗しました (read-only fs / permission / disk full の可能性)" >&2
+    echo "  negation verification を skip して呼び出し元の次ステップに進行します (non-blocking)" >&2
+    echo "  same_branch 戦略の git add で negation が効いていなければそこで改めてエラーが出ます" >&2
+    exit 0
+  fi
+
+  # >>> DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture (verify-negation copy) <<<
+  # Keep one-for-one with the same_branch case copy below (mktemp stderr capture +
+  # if-wrapper rc capture). Wiki 経験則 patterns/high「canonical 実装と一字一句同期」.
+  add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
+  add_dry_out=""
+  add_dry_rc=0
+  if add_dry_out=$(git add --dry-run -- "$negation_probe" 2>"${add_dry_err:-/dev/null}"); then
+    add_dry_rc=0
+  else
+    add_dry_rc=$?
+  fi
+  # >>> DRIFT-CHECK ANCHOR END: same_branch add_dry_run rc capture (verify-negation copy) <<<
+
+  # >>> DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check (verify-negation copy) <<<
+  if [ "$add_dry_rc" -eq 0 ] && printf '%s' "$add_dry_out" | grep -qF "add '${negation_probe}'"; then
+    echo "✅ .gitignore negation verification OK: $add_dry_out"
+  else
+    echo "WARNING: .gitignore negation verification failed (rc=$add_dry_rc)" >&2
+    echo "  stdout: $add_dry_out" >&2
+    if [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ]; then
+      echo "  stderr (先頭 3 行):" >&2
+      head -3 "$add_dry_err" | sed 's/^/    /' >&2
+    fi
+    echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
+    echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
+  fi
+  # >>> DRIFT-CHECK ANCHOR END: same_branch negation grep-qF healthy check (verify-negation copy) <<<
+  # probe + tempfile cleanup は EXIT trap が担う (rmdir は VERIFY_NEGATION ガードで抑止し、
+  # init.md が後続ステップで使う .rite/wiki/raw/ を残す)。
+  exit 0
+fi
 
 # --- Read config ---
 config_file="rite-config.yml"
@@ -259,10 +339,11 @@ case "$branch_strategy" in
     }
 
     # >>> DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture <<<
-    # Downstream reference: plugins/rite/commands/wiki/init.md:ステップ 1.3.4 verification
-    # block. Keep the mktemp stderr capture + if-wrapper rc capture structure one-for-one
-    # with init.md's copy — Wiki 経験則 patterns/high「canonical reference 文書のサンプル
-    # コードは canonical 実装と一字一句同期する」.
+    # Sibling reference: the `--verify-negation` early-exit block above (its
+    # `(verify-negation copy)` ANCHOR). Keep the mktemp stderr capture + if-wrapper rc
+    # capture structure one-for-one with that copy — Wiki 経験則 patterns/high
+    # 「canonical 実装と一字一句同期」. (wiki/init.md ステップ 1.3.4 no longer holds an
+    # inline copy; it delegates here via `gitignore-health-check.sh --verify-negation`.)
     add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
     add_dry_out=""
     add_dry_rc=0
@@ -274,10 +355,10 @@ case "$branch_strategy" in
     # >>> DRIFT-CHECK ANCHOR END: same_branch add_dry_run rc capture <<<
 
     # >>> DRIFT-CHECK ANCHOR: same_branch negation grep-qF healthy check <<<
-    # Downstream reference: plugins/rite/commands/wiki/init.md:ステップ 1.3.4 verification
-    # block. Keep the `grep -qF "add '${negation_probe}'"` full-path fixed-string match
-    # one-for-one with init.md's copy — simple `grep -q "^add '"` 単純 prefix は
-    # false positive を招く.
+    # Sibling reference: the `--verify-negation` early-exit block above (its
+    # `(verify-negation copy)` ANCHOR). Keep the `grep -qF "add '${negation_probe}'"`
+    # full-path fixed-string match one-for-one with that copy — simple `grep -q "^add '"`
+    # 単純 prefix は false positive を招く. (wiki/init.md ステップ 1.3.4 delegates here.)
     # Healthy negation: rc=0 + stdout like `add '.rite/wiki/raw/.rite-lint-negation-probe'`
     # Broken negation: rc=1 + stderr contains "paths are ignored"
     if [ "$add_dry_rc" -eq 0 ] && printf '%s' "$add_dry_out" | grep -qF "add '${negation_probe}'"; then

--- a/plugins/rite/hooks/tests/gitignore-health-check-verify-negation.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-health-check-verify-negation.test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# gitignore-health-check-verify-negation.test.sh
+#
+# Smoke tests for the `--verify-negation` mode of gitignore-health-check.sh
+# (wiki/init.md ステップ 1.3.4 delegation target, Issue #1195 block #11).
+#
+# The mode is post-injection verification: caller (wiki/init.md ステップ 1.3.4) is
+# same_branch + has just injected the `!.rite/wiki/` negation, so the mode skips
+# config/strategy/parent-exclusion checks and is fully non-blocking (every outcome
+# exits 0; result surfaces via stdout `✅ ... OK` / stderr `WARNING`).
+#
+# Coverage:
+#   TC-1  healthy negation        → stdout `✅ ... OK`, exit 0
+#   TC-2  absent/broken negation  → stderr WARNING, exit 0 (non-blocking contract)
+#   TC-3  rmdir 副作用抑止          → .rite/wiki/raw/ survives, probe removed
+#   TC-4  no rite-config.yml       → still runs (config read is skipped in this mode)
+#
+# NOT covered (environment-dependent; verified manually): probe-creation failure on
+# a read-only filesystem. The mode emits a WARNING + exit 0 in that case too, but
+# simulating it portably (chmod is a no-op under root) is brittle for a smoke test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+SCRIPT="$PLUGIN_ROOT/hooks/scripts/gitignore-health-check.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "ERROR: helper not executable: $SCRIPT" >&2
+  exit 1
+fi
+
+cleanup_dirs=()
+err_files=()
+cleanup() {
+  local p
+  for p in "${cleanup_dirs[@]:-}"; do [ -n "$p" ] && rm -rf "$p"; done
+  for p in "${err_files[@]:-}"; do [ -n "$p" ] && rm -f "$p"; done
+}
+trap cleanup EXIT
+
+# Healthy same_branch .gitignore: parent exclusion + negation override (the canonical
+# setup from the repo .gitignore `DRIFT-CHECK ANCHOR: same_branch verification-first` steps).
+write_healthy_gitignore() {
+  printf '.rite/wiki/\n!.rite/wiki/\n!.rite/wiki/**\n' > "$1/.gitignore"
+}
+
+# Broken/absent negation: parent exclusion only, no negation override.
+write_broken_gitignore() {
+  printf '.rite/wiki/\n' > "$1/.gitignore"
+}
+
+mk_errfile() {
+  local f
+  f=$(mktemp /tmp/rite-vn-err-XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  err_files+=("$f")
+  printf '%s' "$f"
+}
+
+# === TC-1: healthy negation → ✅ OK on stdout, exit 0 ===
+echo "=== TC-1: healthy negation ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_healthy_gitignore "$sbx"
+errf=$(mk_errfile)
+out=$(cd "$sbx" && bash "$SCRIPT" --verify-negation 2>"$errf"); rc=$?
+assert "TC-1 exit 0" "0" "$rc"
+if printf '%s' "$out" | grep -qF "✅ .gitignore negation verification OK"; then
+  pass "TC-1 stdout に ✅ negation OK"
+else
+  fail "TC-1 stdout に ✅ negation OK (out='$out' err='$(cat "$errf")')"
+fi
+
+# === TC-2: absent negation → WARNING on stderr, exit 0 (non-blocking) ===
+echo "=== TC-2: absent negation (non-blocking) ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_broken_gitignore "$sbx"
+errf=$(mk_errfile)
+out=$(cd "$sbx" && bash "$SCRIPT" --verify-negation 2>"$errf"); rc=$?
+err=$(cat "$errf")
+assert "TC-2 exit 0 (non-blocking)" "0" "$rc"
+if printf '%s' "$err" | grep -qF "WARNING: .gitignore negation verification failed"; then
+  pass "TC-2 stderr に WARNING"
+else
+  fail "TC-2 stderr に WARNING (err='$err' out='$out')"
+fi
+if printf '%s' "$out" | grep -qF "✅"; then
+  fail "TC-2 success メッセージが出てはいけない (out='$out')"
+else
+  pass "TC-2 stdout に ✅ 不在"
+fi
+
+# === TC-3: rmdir 副作用抑止 — .rite/wiki/raw/ survives, probe removed ===
+echo "=== TC-3: rmdir 副作用抑止 ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_healthy_gitignore "$sbx"
+(cd "$sbx" && bash "$SCRIPT" --verify-negation >/dev/null 2>&1)
+if [ -d "$sbx/.rite/wiki/raw" ]; then
+  pass "TC-3 .rite/wiki/raw/ が残存 (rmdir 抑止)"
+else
+  fail "TC-3 .rite/wiki/raw/ が rmdir された (rmdir 抑止が効いていない)"
+fi
+if [ ! -e "$sbx/.rite/wiki/raw/.rite-lint-negation-probe" ]; then
+  pass "TC-3 probe は cleanup 済み"
+else
+  fail "TC-3 probe が残留している"
+fi
+
+# === TC-4: no rite-config.yml — mode still runs (config read skipped) ===
+echo "=== TC-4: config 不在でも動作 ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_healthy_gitignore "$sbx"
+rm -f "$sbx/rite-config.yml"  # make_sandbox は作らないが念のため
+errf=$(mk_errfile)
+out=$(cd "$sbx" && bash "$SCRIPT" --verify-negation 2>"$errf"); rc=$?
+assert "TC-4 exit 0 (config 不在)" "0" "$rc"
+if printf '%s' "$out" | grep -qF "✅ .gitignore negation verification OK"; then
+  pass "TC-4 config 不在でも ✅ OK"
+else
+  fail "TC-4 config 不在で ✅ OK (out='$out' err='$(cat "$errf")')"
+fi
+
+if ! print_summary "$(basename "$0")" \
+  "drift: gitignore-health-check.sh --verify-negation の挙動が変わった可能性。wiki/init.md ステップ 1.3.4 委譲契約 (Issue #1195 #11) を参照。"; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

umbrella Issue #1195 の **#11 ブロック**。`wiki/init.md` ステップ 1.3.4 の .gitignore negation verification（~110 行の inline bash）を `gitignore-health-check.sh` の新規 `--verify-negation` モードへ委譲し、init.md ↔ helper の cross-file 二重管理を解消する。

## 関連 Issue

Refs #1195（#11 ブロック）

> umbrella #1195 は他ブロック（#2/#8/#9/#10）が残るため close しない。本 PR は #11 のみが対象（各ブロックは独立 PR で実装する設計）。

## 変更内容

- **`hooks/scripts/gitignore-health-check.sh`**: `--verify-negation` モード新設。config/strategy/layer1（parent-exclusion）をスキップする独立早期パスで、全分岐 non-blocking（exit 0）、init.md 向けに `✅ ... OK`（stdout）/ `WARNING`（stderr）を出す。cleanup の `rmdir .rite/wiki/raw .rite/wiki` を `VERIFY_NEGATION` ガードし、後続ステップ 2 が使う `.rite/wiki/raw/` を残す（rmdir 副作用抑止）。既存 same_branch path（lint.md Phase 3.9 経路、exit 1/2）は無変更。DRIFT-CHECK ANCHOR の downstream reference を「init.md inline copy」から「同一ファイル内 verify-negation copy」へ更新。
- **`commands/wiki/init.md`**: §1.3.4 を helper 委譲呼び出しに置換（~110 行 → ~17 行）。`plugin_root` 解決を §1.3.4 へ前倒し（解決失敗時も non-blocking skip でステップ 2 へ進行）。
- **`hooks/tests/gitignore-health-check-verify-negation.test.sh`**: smoke test 新規（healthy negation / absent negation の non-blocking / rmdir 副作用抑止 / config 不在）。

## 検証

- 新 smoke test: **9/9 pass**
- `run-tests.sh`: **50/50 pass**（回帰なし）
- lint モード回帰なし（separate_branch healthy→exit 0 / same_branch override drift→exit 1、既存挙動維持）
- `distributed-fix-drift-check.sh --all`: baseline 一致（gitignore/wiki/init は監視対象外）
- 本 PR の diff に新規 lint finding なし（既存 warning はすべて baseline）

## チェックリスト

- [x] smoke test 追加
- [x] 既存テストスイート回帰確認（50/50）
- [x] non-blocking / rmdir 副作用抑止 / plugin_root 前倒し の各契約を verbatim 保持
- [ ] レビュー
