### PR TITLE
refactor(pr:cleanup): archive-procedures §3.5.2 の WM 進捗 merge を merge-checklist transform へ委譲 (#1195 #8)

### DIFF
--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -137,17 +137,17 @@ rm -f "${wm_sync_err:-}"
 
 #### 3.5.2 Update Content
 
-> **委譲状況（#1195）**: §3.5.1 は本節「Standard update template」の `### 完了情報` ブロックを `append-eof` transform で委譲追記する（実装済み）。下記の **進捗チェックリスト merge**（`### 進捗` への dedup 追記）は未委譲で、`issue-comment-wm-sync.sh` の transform 化を **#1195 #8** で対応する。それまで progress-checklist merge は cleanup 実行経路に組み込まれず、§3.5.1 は `### 完了情報` の追記のみを行う。
+> **委譲状況（#1195 #8 完了）**: §3.5.1（`### 完了情報` の `append-eof` 追記）に続き、本節の **進捗チェックリスト merge**（`### 進捗` への dedup 追記）も `issue-comment-wm-sync.sh` の `merge-checklist` transform へ委譲済み。cleanup ステップ 11 が §3.5 全体を実行する経路で wired され、§3.5.1（完了情報）とは独立した fetch→transform→PATCH として走る（touch するセクションが異なるため順序非依存）。
 
 Automatically append the following to the work memory:
 
 **Progress section merge method:**
 
-The progress section update in Phase 3.5.2 follows this logic:
+The progress section update in Phase 3.5.2 follows this logic（`merge-checklist` transform 内 Python が担う）:
 
 1. Retrieve the existing progress section
 2. Preserve all existing checklist items
-3. Append new items (`- [x] レビュー完了`, `- [x] マージ完了`, `- [x] クリーンアップ完了`) at the end (do not duplicate if already present)
+3. Append new items (`- [x] レビュー完了`, `- [x] マージ完了`, `- [x] クリーンアップ完了`) at the end (do not duplicate if already present anywhere in the body — full-line exact match, 冪等)
 
 **Example:**
 
@@ -160,99 +160,41 @@ The progress section update in Phase 3.5.2 follows this logic:
 - [x] クリーンアップ完了     ← Phase 3.5.2 で追加
 ```
 
-**Bash implementation (Python-based section merge):**
+**Bash implementation (helper 委譲):**
+
+進捗チェックリストの完了項目を `merge-checklist` transform で委譲追記する。全文・完全行 dedup（既出項目スキップ＝冪等）・`### 進捗` セクション末尾への挿入・backup・空body/ヘッダー/safety check・PATCH はすべて helper 内部で完結する（§3.5.1 と同じ canonical caller パターン）。
 
 ```bash
-# ⚠️ 未委譲（#1195 #8 の参照仕様）。§3.5.1 は append-eof で `### 完了情報` のみを追記し、
-# この progress-checklist merge は現状 cleanup 実行経路に組み込まれていない。
-# #8 で issue-comment-wm-sync.sh の transform として委譲する（下記ロジックがその仕様）。
-body_tmp=$(mktemp)
-filtered_items_file=$(mktemp)
-updated_tmp=$(mktemp)
-# backup_file is intentionally excluded from trap — preserved for post-mortem investigation
-backup_file="/tmp/rite-wm-backup-${issue_number}-$(date +%s).md"
-trap 'rm -f "$body_tmp" "$filtered_items_file" "$updated_tmp"' EXIT
+# 進捗セクションの完了項目を content-file に生成し merge-checklist transform で委譲追記する。
+# {issue_number} は cleanup.md コンテキストの実値で置換する（heredoc malform 回避のため printf を使用）。
+progress_tmp=$(mktemp)
+# helper stderr（auth/rate/network/safety-check 詳細 + backup path）を退避し、失敗時に surface する。
+# canonical caller §3.5.1 / fix.md 4.5.2 と同じ stderr-capture 規約（2>/dev/null 破棄をしない）。
+wm_sync_err=$(mktemp 2>/dev/null) || wm_sync_err=""
+trap 'rm -f "$progress_tmp" "${wm_sync_err:-}"' EXIT
+printf '%s\n' \
+  "- [x] レビュー完了" \
+  "- [x] マージ完了" \
+  "- [x] クリーンアップ完了" > "$progress_tmp"
 
-# Step 1: Backup current body
-printf '%s' "$current_body" > "$backup_file"
-printf '%s' "$current_body" > "$body_tmp"
+wm_progress_status=$(bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
+  --issue {issue_number} \
+  --transform merge-checklist --section 進捗 --content-file "$progress_tmp" 2>"${wm_sync_err:-/dev/null}") || true
+rm -f "$progress_tmp"
 
-# 追加済みでない項目のみを filtered_items_file に書き込む（完全行マッチで重複防止）
-for item in "- [x] レビュー完了" "- [x] マージ完了" "- [x] クリーンアップ完了"; do
-  if ! grep -qxF "$item" "$body_tmp"; then
-    printf '%s\n' "$item" >> "$filtered_items_file"
-  fi
-done
-
-# Step 2: Python-based section append (awk-free)
-python3 -c '
-import sys
-
-body_path = sys.argv[1]
-items_path = sys.argv[2]
-out_path = sys.argv[3]
-
-with open(body_path, "r") as f:
-    body = f.read()
-
-try:
-    with open(items_path, "r") as f:
-        new_items = [l for l in f.read().strip().split("\n") if l.strip()]
-except FileNotFoundError:
-    new_items = []
-
-if not new_items:
-    with open(out_path, "w") as f:
-        f.write(body)
-    sys.exit(0)
-
-lines = body.split("\n")
-result = []
-in_section = False
-
-for i, line in enumerate(lines):
-    if line.rstrip() == "### 進捗":
-        in_section = True
-        result.append(line)
-        continue
-    if in_section and line.startswith("### "):
-        for item in new_items:
-            result.append(item)
-        in_section = False
-        result.append(line)
-        continue
-    result.append(line)
-
-# If section was at EOF, append items
-if in_section:
-    for item in new_items:
-        result.append(item)
-
-output = "\n".join(result)
-if body.endswith("\n") and not output.endswith("\n"):
-    output += "\n"
-with open(out_path, "w") as f:
-    f.write(output)
-' "$body_tmp" "$filtered_items_file" "$updated_tmp"
-
-# Step 3: Validate updated content
-# On failure: restore backup and continue — section append failure is non-critical,
-# the original content is still valid for subsequent PATCH
-if [ ! -s "$updated_tmp" ] || [[ "$(wc -c < "$updated_tmp")" -lt 10 ]]; then
-  echo "WARNING: Updated body is empty or too short. Restoring backup." >&2
-  cp "$backup_file" "$updated_tmp"
-fi
-if grep -q -- '📜 rite 作業メモリ' "$updated_tmp"; then
-  : # Header present, proceed
-else
-  echo "WARNING: Updated body missing header. Restoring backup." >&2
-  cp "$backup_file" "$updated_tmp"
-fi
-
-current_body=$(cat "$updated_tmp")
+# 非ブロッキング: cleanup は work memory 更新失敗で停止してはならない（§3.5 は automatic final update）。
+# no_comment（作業メモリ不在 = legitimate no-op）以外の skipped/error は WARNING 表示にとどめる。
+# 失敗時は helper stderr の root-cause（先頭 5 行）も surface し、backup path / API エラー詳細を operator に残す。
+case "$wm_progress_status" in
+  status=success)      echo "作業メモリの進捗セクションを更新しました" ;;
+  *reason=no_comment*) echo "作業メモリ comment が無いため進捗更新をスキップしました" ;;
+  *)                   echo "警告: 作業メモリ進捗更新が完了しませんでした (${wm_progress_status:-no-status})。cleanup は続行します。" >&2
+                       [ -n "$wm_sync_err" ] && [ -s "$wm_sync_err" ] && { echo "  helper stderr (root-cause、先頭 5 行):" >&2; head -5 "$wm_sync_err" | sed 's/^/    /' >&2; } ;;
+esac
+rm -f "${wm_sync_err:-}"
 ```
 
-**Note for Claude**: ⚠️ awk は使用禁止。Python インラインスクリプトでセクション追記を行うこと。更新前バックアップ・空body検証・ヘッダー検証を必ず実行すること。参照: [gh-cli-patterns.md の Work Memory Update Safety Patterns](../../../references/gh-cli-patterns.md#work-memory-update-safety-patterns)。
+**Note for Claude**: comment 取得・body 変換（全文 dedup + `### 進捗` セクション末尾挿入）・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない（旧 inline 実装のクロスプロセス変数 `$current_body` 参照制約は解消済み）。`{plugin_root}` はリテラル値で埋め込み、`{issue_number}` を cleanup.md コンテキストの実値で置換すること。`### 進捗` セクション不在時は項目を drop し body を変更しない（既存 §3.5 の no-op 契約。`merge-checklist` transform がこれを保証）。参照: §3.5.1 の canonical caller パターン。
 
 **Standard update template:**
 

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -196,6 +196,8 @@ rm -f "${wm_sync_err:-}"
 
 **Note for Claude**: comment 取得・body 変換（全文 dedup + `### 進捗` セクション末尾挿入）・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない（旧 inline 実装のクロスプロセス変数 `$current_body` 参照制約は解消済み）。`{plugin_root}` はリテラル値で埋め込み、`{issue_number}` を cleanup.md コンテキストの実値で置換すること。`### 進捗` セクション不在時は項目を drop し body を変更しない（既存 §3.5 の no-op 契約。`merge-checklist` transform がこれを保証）。参照: §3.5.1 の canonical caller パターン。
 
+> **適用範囲の注記**: `### 進捗` は **v1 (legacy) WM フォーマット限定**のセクションで、現行 default フォーマットは `### 進捗サマリー` (table) である（SoT: `skills/rite-workflow/references/work-memory-format.md`、init テンプレ: `issue-comment-wm-sync.sh`、v1/v2 分岐: `issue-comment-wm-update.py` の `update_progress` v1 fallback `"### 進捗" in body and "### 進捗サマリー" not in body`）。したがって **v2 WM では本 merge は常に no-op** になり、`### 進捗` を持つ v1 WM が残存する Issue でのみ実効する。これは原 §3.5.2 inline 実装の target section (`### 進捗`) を verbatim 保持した結果であり、`### 進捗サマリー` table 対応への変更は本委譲のスコープ外（§3.5.1 が section-novelty を明記しているのと対称の適用範囲記述）。
+
 **Standard update template:**
 
 ```markdown

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -23,6 +23,9 @@
 #     bash issue-comment-wm-sync.sh update --issue 42 \
 #       --transform append-eof --content-file /tmp/completion.md
 #
+#     bash issue-comment-wm-sync.sh update --issue 42 \
+#       --transform merge-checklist --section 進捗 --content-file /tmp/items.md
+#
 # Options:
 #   --issue          Issue number (required)
 #   --branch         Branch name (init mode)
@@ -196,9 +199,9 @@ safety_check() {
   fi
 
   # 50% rule (only for update-progress, update-phase, update-plan-status, update-checkboxes)
-  # Skip for append-section, replace-section, and append-eof (content grows or changes size unpredictably)
+  # Skip for append-section, replace-section, append-eof, and merge-checklist (content grows or changes size unpredictably)
   case "$transform" in
-    append-section|replace-section|append-eof)
+    append-section|replace-section|append-eof|merge-checklist)
       ;;
     *)
       local updated_length

--- a/plugins/rite/hooks/issue-comment-wm-update.py
+++ b/plugins/rite/hooks/issue-comment-wm-update.py
@@ -24,6 +24,9 @@ Usage:
     cat body.txt | python3 issue-comment-wm-update.py append-eof \
         --content-file /tmp/completion.md > updated.txt
 
+    cat body.txt | python3 issue-comment-wm-update.py merge-checklist \
+        --section 進捗 --content-file /tmp/items.md > updated.txt
+
     cat body.txt | python3 issue-comment-wm-update.py update-checkboxes \
         --tasks "task1,task2" > updated.txt
 
@@ -190,6 +193,45 @@ def append_eof(body: str, content: str) -> str:
     return body.rstrip("\n") + "\n\n" + content.rstrip("\n") + "\n"
 
 
+def merge_checklist(body: str, section_name: str, items: list[str]) -> str:
+    """Merge checklist items into the end of a named section, skipping any item
+    already present as an exact full line anywhere in the body.
+
+    Ports the progress-section merge from archive-procedures.md §3.5.2: full-body
+    exact-line dedup (matching the original ``grep -qxF``), insertion at the end
+    of the section (before the next ``### `` header, or at EOF when the section is
+    last). When the section is absent the items are dropped and the body returned
+    unchanged — matching both the original block and append_section's
+    no-op-on-absent contract. Idempotent: re-running with the same items is a
+    no-op. Trailing-newline state of the input is preserved.
+    """
+    existing = set(body.split("\n"))
+    new_items = [item for item in items if item not in existing]
+    if not new_items:
+        return body
+
+    result: list[str] = []
+    in_section = False
+    for line in body.split("\n"):
+        if line.rstrip() == "### " + section_name:
+            in_section = True
+            result.append(line)
+            continue
+        if in_section and line.startswith("### "):
+            result.extend(new_items)
+            in_section = False
+            result.append(line)
+            continue
+        result.append(line)
+    if in_section:
+        result.extend(new_items)
+
+    output = "\n".join(result)
+    if body.endswith("\n") and not output.endswith("\n"):
+        output += "\n"
+    return output
+
+
 def update_checkboxes(body: str, task_names: list[str]) -> str:
     """Update specified tasks from - [ ] to - [x]."""
     for task_name in task_names:
@@ -324,6 +366,14 @@ def main():
             sys.exit(1)
         content = read_file_content(opts["content_file"])
         body = append_eof(body, content)
+
+    elif subcommand == "merge-checklist":
+        if "section" not in opts or "content_file" not in opts:
+            print("ERROR: --section and --content-file are required for merge-checklist", file=sys.stderr)
+            sys.exit(1)
+        content = read_file_content(opts["content_file"])
+        items = [line for line in content.split("\n") if line.strip()]
+        body = merge_checklist(body, opts["section"], items)
 
     elif subcommand == "update-checkboxes":
         if "tasks" not in opts:

--- a/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
@@ -119,6 +119,53 @@ else
 fi
 echo ""
 
+# ─── TC-006: empty content-file → body unchanged (no-op) ─────────────────
+echo "TC-006: empty content-file → no-op"
+: > "$TEST_DIR/empty.txt"
+body6=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 実装完了\n'
+printf '%s' "$body6" > "$TEST_DIR/body6"
+python3 "$PY" merge-checklist --section 進捗 --content-file "$TEST_DIR/empty.txt" < "$TEST_DIR/body6" > "$TEST_DIR/out6"
+if cmp -s "$TEST_DIR/body6" "$TEST_DIR/out6"; then
+  pass "TC-006: body unchanged when content-file is empty"
+else
+  fail "TC-006: body changed despite empty content-file"
+fi
+echo ""
+
+# ─── TC-007: input without trailing newline → output also lacks it ───────
+echo "TC-007: no trailing newline preserved (negative branch of the newline guard)"
+body7=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 実装完了'
+printf '%s' "$body7" | python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" > "$TEST_DIR/out7"
+if grep -qxF -- "- [x] クリーンアップ完了" "$TEST_DIR/out7"; then
+  pass "TC-007a: items appended (EOF section, no trailing newline input)"
+else
+  fail "TC-007a: items not appended"
+fi
+if [ -n "$(tail -c1 "$TEST_DIR/out7")" ]; then
+  pass "TC-007b: no trailing newline added when input had none"
+else
+  fail "TC-007b: a trailing newline was incorrectly added"
+fi
+echo ""
+
+# ─── TC-008: multiple ### 進捗 sections → items go to the LAST block ──────
+echo "TC-008: multiple 進捗 sections → insert at last block (verbatim with original)"
+body8=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 古い進捗\n\n### 進捗\n- [x] 新しい進捗\n\n### 完了情報\n- x\n'
+printf '%s' "$body8" | python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" > "$TEST_DIR/out8"
+old_ln=$(grep -nF -- "- [x] 古い進捗" "$TEST_DIR/out8" | head -1 | cut -d: -f1 || true)
+new_ln=$(grep -nF -- "- [x] 新しい進捗" "$TEST_DIR/out8" | head -1 | cut -d: -f1 || true)
+item_ln8=$(grep -nF -- "- [x] レビュー完了" "$TEST_DIR/out8" | head -1 | cut -d: -f1 || true)
+done_ln8=$(grep -nF -- "### 完了情報" "$TEST_DIR/out8" | head -1 | cut -d: -f1 || true)
+# items must land after the SECOND (last) 進捗 block's content (after 新しい進捗) and before 完了情報,
+# NOT immediately after the first block (古い進捗)
+if [ -n "$item_ln8" ] && [ -n "$new_ln" ] && [ -n "$done_ln8" ] \
+   && [ "$item_ln8" -gt "$new_ln" ] && [ "$item_ln8" -lt "$done_ln8" ]; then
+  pass "TC-008: items inserted at last 進捗 block (after 新しい進捗, before 完了情報)"
+else
+  fail "TC-008: insertion at wrong 進捗 block (古い=$old_ln, 新しい=$new_ln, item=$item_ln8, 完了情報=$done_ln8)"
+fi
+echo ""
+
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then
   exit 1

--- a/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# issue-comment-wm-update-merge-checklist.test.sh
+#
+# Pins the `merge-checklist` transform added in #1195 #8 (archive-procedures
+# §3.5.2 progress-merge delegation). Verifies the verbatim-fidelity contract
+# ported from the original inline Python block:
+#   - full-body exact-line dedup (idempotency / partial dedup)
+#   - insertion at the end of the named section (before next `### ` / at EOF)
+#   - section-absent → body unchanged, items dropped
+#   - trailing-newline state of the input preserved
+#
+# The transform is a pure stdin→stdout text op (no gh API), so it is driven
+# end-to-end here. run-tests.sh auto-discovers this file via the *.test.sh glob.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY="$SCRIPT_DIR/../issue-comment-wm-update.py"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required but not installed" >&2
+  exit 1
+fi
+
+# The standard 3 completion items the §3.5.2 caller merges into ### 進捗.
+items_file="$TEST_DIR/items.txt"
+printf '%s\n' "- [x] レビュー完了" "- [x] マージ完了" "- [x] クリーンアップ完了" > "$items_file"
+
+echo "=== issue-comment-wm-update.py merge-checklist tests ==="
+echo ""
+
+# ─── TC-001: new items appended at end of section, existing preserved ────
+echo "TC-001: append new items at end of 進捗 (before next ###), existing kept"
+body1=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 実装完了\n- [x] PR マージ済み\n\n### 完了情報\n- **PR**: #1\n'
+printf '%s' "$body1" | python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" > "$TEST_DIR/out1"
+
+if grep -qxF -- "- [x] 実装完了" "$TEST_DIR/out1" && grep -qxF -- "- [x] PR マージ済み" "$TEST_DIR/out1"; then
+  pass "TC-001a: existing 進捗 items preserved"
+else
+  fail "TC-001a: existing items lost"
+fi
+
+if grep -qxF -- "- [x] レビュー完了" "$TEST_DIR/out1" \
+   && grep -qxF -- "- [x] マージ完了" "$TEST_DIR/out1" \
+   && grep -qxF -- "- [x] クリーンアップ完了" "$TEST_DIR/out1"; then
+  pass "TC-001b: 3 new completion items appended"
+else
+  fail "TC-001b: new items missing"
+fi
+
+item_ln=$(grep -nF -- "- [x] クリーンアップ完了" "$TEST_DIR/out1" | head -1 | cut -d: -f1 || true)
+done_ln=$(grep -nF -- "### 完了情報" "$TEST_DIR/out1" | head -1 | cut -d: -f1 || true)
+if [ -n "$item_ln" ] && [ -n "$done_ln" ] && [ "$item_ln" -lt "$done_ln" ]; then
+  pass "TC-001c: new items inserted within 進捗 (before ### 完了情報)"
+else
+  fail "TC-001c: insertion position wrong (item=$item_ln, 完了情報=$done_ln)"
+fi
+echo ""
+
+# ─── TC-002: idempotent — re-run is byte-identical ───────────────────────
+echo "TC-002: idempotent re-run (byte-identical, no duplicates)"
+python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" < "$TEST_DIR/out1" > "$TEST_DIR/out2"
+dup_count=$(grep -cxF -- "- [x] レビュー完了" "$TEST_DIR/out2" || true)
+if cmp -s "$TEST_DIR/out1" "$TEST_DIR/out2" && [ "$dup_count" = "1" ]; then
+  pass "TC-002: re-run is a no-op (byte-identical, レビュー完了 count=1)"
+else
+  fail "TC-002: not idempotent (cmp differs or count=$dup_count)"
+fi
+echo ""
+
+# ─── TC-003: partial dedup — only missing items appended ─────────────────
+echo "TC-003: partial dedup (already-present item skipped)"
+body3=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 実装完了\n- [x] レビュー完了\n\n### 次\n'
+printf '%s' "$body3" | python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" > "$TEST_DIR/out3"
+rev_count=$(grep -cxF -- "- [x] レビュー完了" "$TEST_DIR/out3" || true)
+if [ "$rev_count" = "1" ] \
+   && grep -qxF -- "- [x] マージ完了" "$TEST_DIR/out3" \
+   && grep -qxF -- "- [x] クリーンアップ完了" "$TEST_DIR/out3"; then
+  pass "TC-003: existing レビュー完了 not duplicated; other 2 appended"
+else
+  fail "TC-003: partial dedup wrong (レビュー完了 count=$rev_count)"
+fi
+echo ""
+
+# ─── TC-004: section absent → body unchanged, items dropped ──────────────
+echo "TC-004: section absent → no-op (verbatim with original block)"
+body4=$'## 📜 rite 作業メモリ\n\n### 完了情報\n- **PR**: #1\n'
+printf '%s' "$body4" > "$TEST_DIR/body4"
+python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" < "$TEST_DIR/body4" > "$TEST_DIR/out4"
+if cmp -s "$TEST_DIR/body4" "$TEST_DIR/out4"; then
+  pass "TC-004: body unchanged when 進捗 section absent"
+else
+  fail "TC-004: body changed despite absent section"
+fi
+echo ""
+
+# ─── TC-005: section at EOF → items appended, trailing newline preserved ─
+echo "TC-005: section at EOF → items appended, trailing newline preserved"
+body5=$'## 📜 rite 作業メモリ\n\n### 進捗\n- [x] 実装完了\n'
+printf '%s' "$body5" | python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" > "$TEST_DIR/out5"
+if grep -qxF -- "- [x] クリーンアップ完了" "$TEST_DIR/out5"; then
+  pass "TC-005a: items appended to EOF section"
+else
+  fail "TC-005a: items not appended at EOF"
+fi
+if [ -z "$(tail -c1 "$TEST_DIR/out5")" ]; then
+  pass "TC-005b: trailing newline preserved"
+else
+  fail "TC-005b: trailing newline lost"
+fi
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Issue #1195（umbrella）ブロック **#8** を実装。`pr/references/archive-procedures.md` §3.5.2 の進捗チェックリスト merge（~75 行の inline Python section-merge）を、`issue-comment-wm-sync.sh` の新規 `merge-checklist` transform へ委譲する。

直前のブロック #7（§3.5.1 完了情報の `append-eof` 委譲）と同じ canonical caller パターンに揃え、新規 `scripts/wm-progress-merge.py` は作らず orchestration（comment 取得・backup・safety check・PATCH）の重複を回避する。この方針は archive-procedures.md §3.5.2 の委譲状況注記で確定済み。

## 関連 Issue

refs #1195（ブロック #8）

> umbrella の他ブロック（#2 / #9 / #10）は各々独立 PR で対応する方針のため、本 PR では umbrella をクローズしない。

## 変更内容

- **`hooks/issue-comment-wm-update.py`**: `merge_checklist()` 追加。全文・完全行 dedup（原 `grep -qxF` 等価）＋ `### {section}` セクション末尾挿入。原 §3.5.2 アルゴリズムの忠実移植で、冪等・末尾改行保持・セクション不在 no-op。
- **`hooks/issue-comment-wm-sync.sh`**: 50% rule 免除 case に `merge-checklist` を追加（content が grow するため append-section / replace-section / append-eof と同列）+ usage。
- **`commands/pr/references/archive-procedures.md` §3.5.2**: inline Python → §3.5.1 対称の thin caller に置換。委譲状況注記を「実装済み」に更新。#8 完了で §3.5.2 は参照仕様から「実行される thin caller」になり、cleanup ステップ 11 の §3.5 実行経路で wired される（§3.5.1 と独立した fetch→transform→PATCH、touch セクションが異なるため順序非依存）。
- **`hooks/tests/issue-comment-wm-update-merge-checklist.test.sh`**: 新規。dedup 冪等性・セクション末尾挿入・不在 no-op・末尾改行保持を pin。

## 検証

- 新規 test: 8/8 pass
- 原 §3.5.2 アルゴリズムとの差分比較: 7 エッジケース全 byte 一致（verbatim fidelity）
- hook テストスイート: 51/51 pass
- `distributed-fix-drift-check.sh --all`: baseline 88 不変、編集ファイルの新規 finding 0
- 他プラグインチェック群（bang-backtick / doc-heavy / orphan 等）: 編集ファイル参照の新規 finding 0

## チェックリスト

- [x] 既存ワークフロー契約（dedup 挙動・非ブロッキング・no-op）を verbatim 保持
- [x] テスト追加
- [x] drift baseline 一致確認
