### PR TITLE
refactor(wiki:lint): §6.2 all_source_refs 集合構築を wiki-lint-source-refs.sh へ委譲 (#1195 #10)

### DIFF
--- a/plugins/rite/commands/wiki/lint.md
+++ b/plugins/rite/commands/wiki/lint.md
@@ -716,249 +716,38 @@ fi
    - **(b) 未登録だが skip 記録あり**: ステップ 6.0 の `skipped_refs` 集合に含まれる → ステップ 6.3 の `unregistered_raw` として記録
    - **(c) 真の欠落**: 上記いずれにも該当しない → LLM が Raw Source 本文を読み経験則として価値がある内容か判定した上で ステップ 6.3 の `missing_concept` として記録 (単なるエラーログや空コメントは除外)
 
-**`all_source_refs` の bash 実装** (ステップ 6.0 の `skipped_refs` と対称な marker block + io_error 3 値 enum):
+**`all_source_refs` の集合構築** (ステップ 6.0 の `skipped_refs` と対称な marker block + io_error 3 値 enum) は `wiki-lint-source-refs.sh` に委譲する。
+
+> **Reference**: 集合構築の canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-source-refs.sh`。helper は per-page の `git show`(separate_branch) / `cat`(same_branch) 読出・`sources[].ref` 抽出 (legacy 単行形式 `- ref:` と canonical multi-line 形式 ` ref:` の両対応)・legitimate absence と真の io_error の `LC_ALL=C` 固定 stderr pattern 判別・`sort -u` 重複排除・marker block / read_ok enum 出力・signal-specific trap cleanup をすべて内包する (旧 ~240 行 inline 実装を委譲)。placeholder residue gate / partial pollution gate も helper 内に移設済み。state machine 契約 (marker block + io_error 3 値 enum) は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2 を参照。
+
+**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` と ステップ 2.2 の `pages_list` は別 Bash tool 呼び出しで定義されているため、Claude は会話コンテキストから literal substitute する。`branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、`pages_list` は stdin (HEREDOC、single-quoted delimiter で shell expansion 抑制) で渡す。
+
+**`{pages_list}` substitute 契約**: ステップ 2.2 stdout は「pages_list 行 → '---' separator → raw_list 行」の 3 部構成。LLM は **pages_list ブロックのみ** (separator より前の `.rite/wiki/pages/...` 行のみ) を HEREDOC に substitute する。`.rite/wiki/raw/...` 行を含めると helper の partial pollution gate が fail-fast (exit 1) する (旧 silent missing_concept 誤分類の再発防止契約)。空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate。
 
 ```bash
-# signal-specific trap (per-iteration mktemp の orphan 防止)
-page_err=""
-awk_diag=""
-sort_err=""
-_cleanup() {
-  [ -n "${page_err:-}" ] && rm -f "$page_err"
-  [ -n "${awk_diag:-}" ] && rm -f "$awk_diag"
-  [ -n "${sort_err:-}" ] && rm -f "$sort_err"
-  return 0
-}
-trap 'rc=$?; _cleanup; exit $rc' EXIT
-trap '_cleanup; exit 130' INT
-trap '_cleanup; exit 143' TERM
-trap '_cleanup; exit 129' HUP
+# plugin_root 解決 (ステップ 2.1 の inline one-liner。
+#  canonical: references/plugin-path-resolution.md#inline-one-liner-for-command-files)
+plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
 
-# Bash tool 呼び出し境界での state 伝達: ステップ 1.1 の wiki_branch / branch_strategy と ステップ 2.2 の
-# pages_list は別 Bash tool 呼び出しで定義されているため、Claude は会話コンテキストから literal substitute する。
-# pages_list は複数行のため HEREDOC (single-quoted delimiter) で shell expansion を抑制する。
-#
-# `{pages_list}` substitute 契約: ステップ 2.2 stdout は「pages_list 行 → '---' separator → raw_list 行」
-# の 3 部構成。LLM は **pages_list ブロックのみ** (separator より前の `.rite/wiki/pages/...` 行のみ) を
-# 本 HEREDOC に substitute する。`.rite/wiki/raw/...` 行を含めると全 ingested raw が step 3(c) で
-# missing_concept に誤分類される silent regression が再発する。
-branch_strategy="{branch_strategy}"
-wiki_branch="{wiki_branch}"
-pages_list=$(cat <<'PAGES_LIST_EOF'
+if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/wiki-lint-source-refs.sh" ]; then
+  # helper 不在: all_source_refs を io_error 扱いにして ステップ 9.1 の false positive note を展開する。
+  # silent 空集合だと真の欠落 (missing_concept) 判定が false positive になるため、
+  # 「marker 未受信 → io_error 同等扱い」契約 (本節末尾) と整合する形で io_error を明示出力する。
+  echo "WARNING: wiki-lint-source-refs.sh が見つからないため all_source_refs を io_error 扱いにします (plugin_root='${plugin_root:-<empty>}')" >&2
+  echo "  対処: rite プラグインのソースツリーから実行するか、.rite-plugin-root を確認してください" >&2
+  echo "---all_source_refs_begin---"
+  echo "---all_source_refs_end---"
+  echo "all_source_refs_read_ok=io_error"
+  echo "all_source_refs_read_errors=0"
+else
+  # branch_strategy / wiki_branch は arg、pages_list は stdin。
+  # placeholder residue gate / partial pollution gate は helper 内で実行される。
+  bash "$plugin_root/hooks/scripts/wiki-lint-source-refs.sh" \
+    --branch-strategy "{branch_strategy}" \
+    --wiki-branch "{wiki_branch}" <<'PAGES_LIST_EOF'
 {pages_list}
 PAGES_LIST_EOF
-)
-
-# Placeholder residue fail-fast gate (5 site で同型: ステップ 1.1 / 1.3 / 6.2 / 8.1 / 8.3)
-case "$branch_strategy" in
-  "{"*"}")
-    echo "ERROR: ステップ 6.2 の {branch_strategy} placeholder が literal substitute されていません (値: '$branch_strategy')" >&2
-    echo "  LLM は ステップ 1.1 の stdout から会話コンテキストに保持された branch_strategy 値を literal substitute する必要があります" >&2
-    echo "[CONTEXT] LINT_PHASE_6_2_PLACEHOLDER_RESIDUE=1; reason=branch_strategy_unsubstituted; value=$branch_strategy" >&2
-    exit 1
-    ;;
-esac
-case "$wiki_branch" in
-  "{"*"}")
-    echo "ERROR: ステップ 6.2 の {wiki_branch} placeholder が literal substitute されていません (値: '$wiki_branch')" >&2
-    exit 1
-    ;;
-esac
-# pages_list は空 HEREDOC が legitimate (Wiki 初期化直後 / 0 件) のため、literal 完全一致のみ error
-case "$pages_list" in
-  "{pages_list}")
-    echo "ERROR: ステップ 6.2 の {pages_list} placeholder が literal substitute されていません (値: '$pages_list')" >&2
-    echo "  LLM は ステップ 2.2 stdout から separator より前の '.rite/wiki/pages/...' 行のみを substitute する必要があります" >&2
-    exit 1
-    ;;
-esac
-
-# Partial pollution 検出 gate (silent missing_concept 誤分類再発防止): LLM が ステップ 2.2 stdout の 3 部構造を
-# 全体 substitute すると `.rite/wiki/raw/...` path が混入し、本来 pages 用の git show で legitimate
-# absence (blob not found) として処理され、全 ingested raw が step 3(c) で missing_concept 誤分類される。
-# 既存の literal 残留 gate は「未 substitute」のみ検出し partial pollution を捕捉できないため、本 runtime 契約を追加。
-if [ -n "$pages_list" ]; then
-  partial_pollution_line=""
-  while IFS= read -r pollution_check_line; do
-    [ -z "$pollution_check_line" ] && continue  # blank line guard
-    case "$pollution_check_line" in
-      .rite/wiki/pages/*) ;;  # OK: 正当な pages_list 行
-      *)
-        partial_pollution_line="$pollution_check_line"
-        break
-        ;;
-    esac
-  done <<< "$pages_list"
-  if [ -n "$partial_pollution_line" ]; then
-    echo "ERROR: ステップ 6.2 の \$pages_list に '.rite/wiki/pages/' prefix を持たない行が含まれています (partial pollution 検出)" >&2
-    echo "  違反行: '$partial_pollution_line'" >&2
-    echo "  原因: LLM が ステップ 2.2 stdout の separator ('---') より後 (raw_list) を含めて HEREDOC に substitute した可能性があります" >&2
-    echo "  対処: ステップ 2.2 stdout から separator より前の '.rite/wiki/pages/...' 行のみを substitute してください" >&2
-    exit 1
-  fi
 fi
-
-all_source_refs_read_ok="unknown"  # 3 値 enum: unknown / true / io_error
-all_source_refs_read_errors=0
-all_source_refs=""
-awk_diag_mktemp_failed=0  # accumulator (失敗件数)
-page_err_mktemp_failed=0  # accumulator (失敗件数)
-
-# `while IFS= read -r` 形式: ページパスに空白が含まれた場合の word-split 脆弱性排除
-while IFS= read -r page; do
-  [ -z "$page" ] && continue  # blank line guard
-
-  page_err=$(mktemp /tmp/rite-lint-page-err-XXXXXX 2>/dev/null) || { page_err=""; page_err_mktemp_failed=$((page_err_mktemp_failed + 1)); }
-
-  # branch_strategy ごとに 2 経路:
-  #   separate_branch: git show (worktree には存在しない、ref から読取)
-  #   same_branch:     cat (filesystem 上の tracked file を直接読む)
-  # 分岐欠落で全 ingested raw が missing_concept 誤分類される regression を防ぐ。
-  # LC_ALL=C で locale 固定 (legitimate absence regex との不一致による誤分類防止)
-  case "$branch_strategy" in
-    separate_branch)
-      page_read_cmd_result=$(LC_ALL=C git show "${wiki_branch}:$page" 2>"${page_err:-/dev/null}")
-      page_read_cmd_rc=$?
-      ;;
-    same_branch)
-      page_read_cmd_result=$(LC_ALL=C cat "$page" 2>"${page_err:-/dev/null}")
-      page_read_cmd_rc=$?
-      ;;
-    *)
-      echo "ERROR: 未知の branch_strategy 値を検出しました: '$branch_strategy' (ステップ 6.2)" >&2
-      [ -n "$page_err" ] && rm -f "$page_err"
-      exit 1
-      ;;
-  esac
-
-  if [ "$page_read_cmd_rc" -eq 0 ]; then
-    page_content="$page_read_cmd_result"
-    # frontmatter YAML list から sources[].ref を抽出。
-    # awk diag mktemp で sources_seen / extracted のカウントを stderr 経由で per-page 可視化
-    # (「sources: 節は検出したが ref が 0 件」という YAML 破損を可視化)
-    awk_diag=$(mktemp /tmp/rite-lint-p62-awk-diag-XXXXXX 2>/dev/null) || awk_diag=""
-    if [ -z "$awk_diag" ]; then
-      awk_diag_mktemp_failed=$((awk_diag_mktemp_failed + 1))
-    fi
-    # page-template.md の canonical YAML は multi-line 形式 (`- type: "..."\n  ref: "..."`)。
-    # 同一行 `- ref:` の legacy 単行形式と multi-line 形式 ` ref:` (dash なしインデント付き) の両方を support する。
-    page_refs=$(printf '%s\n' "$page_content" | awk -v diag="${awk_diag:-/dev/null}" -v page="$page" '
-      /^sources:/ { in_sources=1; sources_seen++; next }
-      # frontmatter terminator (`---`) を明示検出。
-      # minimal frontmatter (sources: 直後に `---` で閉じる、tags:/confidence: なし) でも
-      # sources 節が確実に閉じ、body 内 YAML code block の ` ref:` 誤抽出を防ぐ。
-      in_sources && /^---[[:space:]]*$/ { in_sources=0; next }
-      in_sources && /^[a-zA-Z]/ { in_sources=0 }
-      in_sources && /^[[:space:]]*-[[:space:]]*ref:[[:space:]]/ {
-        # legacy 単行形式: `- ref: "..."`
-        sub(/^[[:space:]]*-[[:space:]]*ref:[[:space:]]*/, "")
-        gsub(/["\x27]/, "")
-        sub(/^\.rite\/wiki\//, "")  # prefix 正規化
-        extracted++
-        print
-        next
-      }
-      in_sources && /^[[:space:]]+ref:[[:space:]]/ {
-        # canonical multi-line 形式: `  ref: "..."` (前行が `- type: ...`)
-        sub(/^[[:space:]]+ref:[[:space:]]*/, "")
-        gsub(/["\x27]/, "")
-        sub(/^\.rite\/wiki\//, "")
-        extracted++
-        print
-      }
-      END {
-        if (sources_seen > 0 && extracted == 0) {
-          if (diag == "/dev/null") {
-            # mktemp 失敗 fallback: bash 側 check が false になるため awk から直接 stderr に emit
-            printf "WARNING: %s の frontmatter に sources: 節が存在しますが ref が 1 件も抽出できませんでした (awk_diag mktemp 失敗経路 fallback)\n", page > "/dev/stderr"
-            printf "  原因候補: YAML 構造破損 (改行混入 / quote 不整合 / インデント不正)\n" > "/dev/stderr"
-            printf "  影響: 本ページが参照する raw source が all_source_refs 集合から欠落し、登録済み raw が missing_concept に誤分類される可能性\n" > "/dev/stderr"
-          } else {
-            printf "sources_section_empty\n" > diag
-          }
-        }
-      }
-    ')
-    if [ -n "$awk_diag" ] && [ -s "$awk_diag" ]; then
-      echo "WARNING: $page の frontmatter に sources: 節が存在しますが ref が 1 件も抽出できませんでした" >&2
-      echo "  原因候補: YAML 構造破損 (改行混入 / quote 不整合 / インデント不正)" >&2
-      echo "  影響: 本ページが参照する raw source が all_source_refs 集合から欠落し、登録済み raw が missing_concept に誤分類される可能性" >&2
-    fi
-    [ -n "$awk_diag" ] && rm -f "$awk_diag"
-    awk_diag=""  # 次 iteration の trap cleanup で stale path を二重 rm しないため明示 reset
-    if [ -n "$page_refs" ]; then
-      all_source_refs=$(printf '%s\n%s' "$all_source_refs" "$page_refs")
-    fi
-  else
-    # ステップ 6.0 と同じ stderr pattern matching で legitimate absence と io_error を判別。
-    # branch_strategy ごとに legitimate absence の文言が異なるため両経路の pattern を OR する:
-    #   separate_branch (git show): blob 不在
-    #   same_branch (cat):          ENOENT / No such file
-    if [ -n "$page_err" ] && [ -s "$page_err" ] && grep -qE "does not exist|path '.+' exists on disk, but not in|Not a valid object name|fatal: invalid object name '[^']*:|No such file or directory|cannot open .* for reading" "$page_err"; then
-      # legitimate absence: 集合には追加しないが read_ok は下げない
-      :
-    else
-      # 真の IO error: all_source_refs_read_errors を increment (後段で io_error に畳み込み)
-      all_source_refs_read_errors=$((all_source_refs_read_errors + 1))
-      echo "WARNING: $page の sources[].ref 抽出に失敗 (rc=$page_read_cmd_rc, branch_strategy=$branch_strategy)" >&2
-      [ -n "$page_err" ] && [ -s "$page_err" ] && head -3 "$page_err" | sed 's/^/  /' >&2
-    fi
-  fi
-  [ -n "$page_err" ] && rm -f "$page_err"
-  page_err=""
-done <<< "$pages_list"
-
-# mktemp 失敗の集約 WARNING (per-iteration spam 回避のため post-loop で 1 回のみ emit)
-if [ "$awk_diag_mktemp_failed" -gt 0 ]; then
-  echo "WARNING: awk_diag tempfile の mktemp が $awk_diag_mktemp_failed 件失敗しました。per-page WARNING は awk END block から /dev/stderr 経由で emit 済みです" >&2
-  echo "  対処: /tmp の容量 / 権限 / readonly filesystem を確認してください" >&2
-fi
-if [ "$page_err_mktemp_failed" -gt 0 ]; then
-  echo "WARNING: page_err tempfile の mktemp が $page_err_mktemp_failed 件失敗しました" >&2
-  echo "  対処: /tmp の容量 / 権限 / inode 枯渇 / readonly filesystem を確認してください" >&2
-  echo "  影響: 本 Block の legitimate absence / io_error 判別は失敗経路でのみ精度低下 (io_error 側に倒す defense で silent 0 件は防止済み)" >&2
-fi
-
-# 終状態の enum 決定 (部分成功を silent に 0 件扱いしない)
-if [ "$all_source_refs_read_errors" -gt 0 ]; then
-  all_source_refs_read_ok="io_error"
-else
-  all_source_refs_read_ok="true"
-fi
-
-# sort -u で重複排除 (ステップ 6.0 awk/sort と対称に pipefail + stderr 捕捉)
-if [ -n "$all_source_refs" ]; then
-  set -o pipefail
-  sort_err=$(mktemp /tmp/rite-lint-p62-sort-err-XXXXXX 2>/dev/null) || {
-    echo "WARNING: stderr 退避 tempfile (sort_err) の mktemp に失敗しました。sort/awk pipeline の詳細エラー情報は失われます" >&2
-    echo "  対処: /tmp の容量 / permission / inode 枯渇を確認してください" >&2
-    echo "  影響: pipeline 失敗時の根本原因 (sort バイナリ異常 / OOM / SIGPIPE 等) が不可視になり、all_source_refs が io_error 降格しても理由が追えません" >&2
-    sort_err=""
-  }
-  # 末尾 `awk 'NF>0'` は grep -c の no-match (rc=1) 問題を回避 (空行 only の edge case 対応)
-  normalized=$(printf '%s\n' "$all_source_refs" | LC_ALL=C sort -u 2>"${sort_err:-/dev/null}" | awk 'NF>0' 2>>"${sort_err:-/dev/null}")
-  sort_rc=$?
-  if [ "$sort_rc" -ne 0 ]; then
-    echo "WARNING: ステップ 6.2 の all_source_refs 正規化 pipeline が失敗しました (rc=$sort_rc)" >&2
-    [ -n "$sort_err" ] && [ -s "$sort_err" ] && head -3 "$sort_err" | sed 's/^/  /' >&2
-    echo "  対処: sort バイナリ / /tmp の容量 / 権限を確認してください" >&2
-    echo "  影響: all_source_refs が部分出力で populate されると真の欠落判定が false positive になるため io_error に降格します" >&2
-    all_source_refs_read_ok="io_error"
-  else
-    all_source_refs="$normalized"
-  fi
-  [ -n "$sort_err" ] && rm -f "$sort_err"
-  sort_err=""
-  set +o pipefail
-fi
-
-# marker block で集合を出力 (ステップ 6.0 の skipped_refs と同じパターン)
-echo "---all_source_refs_begin---"
-[ -n "$all_source_refs" ] && printf '%s\n' "$all_source_refs"
-echo "---all_source_refs_end---"
-
-echo "all_source_refs_read_ok=$all_source_refs_read_ok"
-echo "all_source_refs_read_errors=$all_source_refs_read_errors"
 ```
 
 **`skipped_refs` 集合の参照方法**: ステップ 6.0 の bash block 終了後、LLM は stdout から `---skipped_refs_begin---` と `---skipped_refs_end---` で囲まれた行を抽出して会話コンテキストに集合として保持する。ファイルパスの比較は両辺を `raw/{type}/{filename}` 形式に正規化してから完全一致で判定する。

--- a/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# wiki-lint-source-refs.sh
+#
+# Build the `all_source_refs` set consumed by wiki/lint.md ステップ 6.2
+# (対応ページの存在確認と 3 分岐). For each Wiki page in the supplied
+# pages_list, read its body (via `git show` for separate_branch, `cat` for
+# same_branch), extract frontmatter `sources[].ref` entries, dedup, and emit
+# the set inside a marker block alongside a 3-value read_ok enum.
+#
+# Why a helper (Issue #1195 #10 / #1193 Where #10):
+#   The inline implementation in lint.md was a ~240-line HIGH-weight bash
+#   block. Delegating it removes a heredoc-malform / drift source while
+#   keeping the cross-Bash-tool-boundary state-transfer contract verbatim.
+#   See ../../commands/wiki/references/bash-cross-boundary-state-transfer.md
+#   (Pattern 2: marker-delimited block, Pattern 1: multi-value enum via
+#   key=value stdout).
+#
+# Symmetry note: this is the step 6.2 counterpart to step 6.0's `skipped_refs`
+# block (Issue #1195 #14, still inline in lint.md and out of this PR's scope).
+# Both share the marker block + io_error enum shape; keep them aligned.
+#
+# Inputs:
+#   --branch-strategy {separate_branch|same_branch}  (required)
+#   --wiki-branch BRANCH                              (required for separate_branch)
+#   --repo-root DIR                                   (default: git rev-parse --show-toplevel)
+#   pages_list                                        (stdin; one `.rite/wiki/pages/...` path per line)
+#
+# stdout contract (LLM holds these in conversation context; see lint.md step 3
+# and step 9.1 で `all_source_refs_read_ok` を false-positive note 展開に使う):
+#   ---all_source_refs_begin---
+#   {ref}            # 0..N lines, sort -u 済み
+#   ---all_source_refs_end---
+#   all_source_refs_read_ok={unknown|true|io_error}
+#   all_source_refs_read_errors={n}
+#
+# Exit codes:
+#   0  正常 (read_ok / read_errors は stdout enum で表現、IO 失敗は io_error 降格)
+#   1  fail-fast (placeholder residue / partial pollution / unknown branch_strategy)
+#   2  invocation error (引数欠落 / repo-root cd 失敗)
+#
+# NOTE on shell flags: this is a faithful port of the inline block which
+# manages `$?` explicitly per command. A global `set -e` would break those
+# explicit rc checks (git show / cat / sort failures are handled, not fatal),
+# so it is intentionally NOT set. `set -o pipefail` is toggled locally around
+# the sort/awk pipelines exactly as the inline block did. `set -u` is likewise
+# omitted to preserve verbatim behavior; all variable refs are `${var:-}`-guarded.
+
+branch_strategy=""
+wiki_branch=""
+REPO_ROOT=""
+
+usage() {
+  cat <<'EOF'
+Usage: wiki-lint-source-refs.sh --branch-strategy STRATEGY [--wiki-branch BRANCH] [--repo-root DIR]
+
+Reads pages_list from stdin (one `.rite/wiki/pages/...` path per line) and emits
+the all_source_refs marker block + read_ok enum on stdout.
+
+Options:
+  --branch-strategy STRATEGY  separate_branch | same_branch (required)
+  --wiki-branch BRANCH        Wiki branch ref (required for separate_branch)
+  --repo-root DIR             Repository root (default: git rev-parse --show-toplevel)
+  -h, --help                  Show this help
+
+Exit codes:
+  0  Normal (read_ok / read_errors expressed via stdout enum)
+  1  Fail-fast (placeholder residue / partial pollution / unknown branch_strategy)
+  2  Invocation error
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --branch-strategy) branch_strategy="${2:-}"; shift 2 ;;
+    --wiki-branch) wiki_branch="${2:-}"; shift 2 ;;
+    --repo-root) REPO_ROOT="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$branch_strategy" ]; then
+  echo "ERROR: --branch-strategy は必須です" >&2
+  usage >&2
+  exit 2
+fi
+
+# pages_list を stdin から全量読み込む (placeholder residue / partial pollution
+# gate を集合全体に対して走らせるため、iteration 前に変数へ確定させる)。
+pages_list="$(cat)"
+
+# ---- Placeholder residue fail-fast gate -------------------------------------
+# (lint.md の 5 site 同型 gate: ステップ 1.1 / 1.3 / 6.2 / 8.1 / 8.3。
+#  LLM が `{branch_strategy}` / `{wiki_branch}` / `{pages_list}` を literal
+#  substitute せずに helper を呼んだ場合の検出。)
+case "$branch_strategy" in
+  "{"*"}")
+    echo "ERROR: ステップ 6.2 の {branch_strategy} placeholder が literal substitute されていません (値: '$branch_strategy')" >&2
+    echo "  LLM は ステップ 1.1 の stdout から会話コンテキストに保持された branch_strategy 値を literal substitute する必要があります" >&2
+    echo "[CONTEXT] LINT_PHASE_6_2_PLACEHOLDER_RESIDUE=1; reason=branch_strategy_unsubstituted; value=$branch_strategy" >&2
+    exit 1
+    ;;
+esac
+case "$wiki_branch" in
+  "{"*"}")
+    echo "ERROR: ステップ 6.2 の {wiki_branch} placeholder が literal substitute されていません (値: '$wiki_branch')" >&2
+    exit 1
+    ;;
+esac
+# pages_list は空 (Wiki 初期化直後 / 0 件) が legitimate のため、literal 完全一致のみ error
+case "$pages_list" in
+  "{pages_list}")
+    echo "ERROR: ステップ 6.2 の {pages_list} placeholder が literal substitute されていません (値: '$pages_list')" >&2
+    echo "  LLM は ステップ 2.2 stdout から separator より前の '.rite/wiki/pages/...' 行のみを substitute する必要があります" >&2
+    exit 1
+    ;;
+esac
+
+# ---- Partial pollution 検出 gate --------------------------------------------
+# (silent missing_concept 誤分類再発防止): LLM が ステップ 2.2 stdout の 3 部構造を
+# 全体 substitute すると `.rite/wiki/raw/...` path が混入し、本来 pages 用の git show で
+# legitimate absence (blob not found) として処理され、全 ingested raw が step 3(c) で
+# missing_concept 誤分類される。既存の literal 残留 gate は「未 substitute」のみ検出し
+# partial pollution を捕捉できないため、本 runtime 契約を追加。
+if [ -n "$pages_list" ]; then
+  partial_pollution_line=""
+  while IFS= read -r pollution_check_line; do
+    [ -z "$pollution_check_line" ] && continue  # blank line guard
+    case "$pollution_check_line" in
+      .rite/wiki/pages/*) ;;  # OK: 正当な pages_list 行
+      *)
+        partial_pollution_line="$pollution_check_line"
+        break
+        ;;
+    esac
+  done <<< "$pages_list"
+  if [ -n "$partial_pollution_line" ]; then
+    echo "ERROR: ステップ 6.2 の \$pages_list に '.rite/wiki/pages/' prefix を持たない行が含まれています (partial pollution 検出)" >&2
+    echo "  違反行: '$partial_pollution_line'" >&2
+    echo "  原因: LLM が ステップ 2.2 stdout の separator ('---') より後 (raw_list) を含めて HEREDOC に substitute した可能性があります" >&2
+    echo "  対処: ステップ 2.2 stdout から separator より前の '.rite/wiki/pages/...' 行のみを substitute してください" >&2
+    exit 1
+  fi
+fi
+
+# branch_strategy を early に case 検証 (unknown は fail-fast、loop に入る前に弾く)
+case "$branch_strategy" in
+  separate_branch|same_branch) ;;
+  *)
+    echo "ERROR: 未知の branch_strategy 値を検出しました: '$branch_strategy' (ステップ 6.2)" >&2
+    echo "  対処: rite-config.yml の wiki.branch_strategy を 'separate_branch' または 'same_branch' に設定してください" >&2
+    exit 1
+    ;;
+esac
+
+# repo root へ移動 (separate_branch の git show / same_branch の cat はいずれも
+# repo-relative path を前提とする)。
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root '$REPO_ROOT'" >&2; exit 2; }
+
+# ---- 集合構築本体 (inline block の faithful port) ---------------------------
+# signal-specific trap (per-iteration mktemp の orphan 防止)
+page_err=""
+awk_diag=""
+sort_err=""
+_cleanup() {
+  [ -n "${page_err:-}" ] && rm -f "$page_err"
+  [ -n "${awk_diag:-}" ] && rm -f "$awk_diag"
+  [ -n "${sort_err:-}" ] && rm -f "$sort_err"
+  return 0
+}
+trap 'rc=$?; _cleanup; exit $rc' EXIT
+trap '_cleanup; exit 130' INT
+trap '_cleanup; exit 143' TERM
+trap '_cleanup; exit 129' HUP
+
+all_source_refs_read_ok="unknown"  # 3 値 enum: unknown / true / io_error
+all_source_refs_read_errors=0
+all_source_refs=""
+awk_diag_mktemp_failed=0  # accumulator (失敗件数)
+page_err_mktemp_failed=0  # accumulator (失敗件数)
+
+# `while IFS= read -r` 形式: ページパスに空白が含まれた場合の word-split 脆弱性排除
+while IFS= read -r page; do
+  [ -z "$page" ] && continue  # blank line guard
+
+  page_err=$(mktemp /tmp/rite-lint-page-err-XXXXXX 2>/dev/null) || { page_err=""; page_err_mktemp_failed=$((page_err_mktemp_failed + 1)); }
+
+  # branch_strategy ごとに 2 経路:
+  #   separate_branch: git show (worktree には存在しない、ref から読取)
+  #   same_branch:     cat (filesystem 上の tracked file を直接読む)
+  # 分岐欠落で全 ingested raw が missing_concept 誤分類される regression を防ぐ。
+  # LC_ALL=C で locale 固定 (legitimate absence regex との不一致による誤分類防止)
+  case "$branch_strategy" in
+    separate_branch)
+      page_read_cmd_result=$(LC_ALL=C git show "${wiki_branch}:$page" 2>"${page_err:-/dev/null}")
+      page_read_cmd_rc=$?
+      ;;
+    same_branch)
+      page_read_cmd_result=$(LC_ALL=C cat "$page" 2>"${page_err:-/dev/null}")
+      page_read_cmd_rc=$?
+      ;;
+  esac
+
+  if [ "$page_read_cmd_rc" -eq 0 ]; then
+    page_content="$page_read_cmd_result"
+    # frontmatter YAML list から sources[].ref を抽出。
+    # awk diag mktemp で sources_seen / extracted のカウントを stderr 経由で per-page 可視化
+    # (「sources: 節は検出したが ref が 0 件」という YAML 破損を可視化)
+    awk_diag=$(mktemp /tmp/rite-lint-p62-awk-diag-XXXXXX 2>/dev/null) || awk_diag=""
+    if [ -z "$awk_diag" ]; then
+      awk_diag_mktemp_failed=$((awk_diag_mktemp_failed + 1))
+    fi
+    # page-template.md の canonical YAML は multi-line 形式 (`- type: "..."\n  ref: "..."`)。
+    # 同一行 `- ref:` の legacy 単行形式と multi-line 形式 ` ref:` (dash なしインデント付き) の両方を support する。
+    page_refs=$(printf '%s\n' "$page_content" | awk -v diag="${awk_diag:-/dev/null}" -v page="$page" '
+      /^sources:/ { in_sources=1; sources_seen++; next }
+      # frontmatter terminator (`---`) を明示検出。
+      # minimal frontmatter (sources: 直後に `---` で閉じる、tags:/confidence: なし) でも
+      # sources 節が確実に閉じ、body 内 YAML code block の ` ref:` 誤抽出を防ぐ。
+      in_sources && /^---[[:space:]]*$/ { in_sources=0; next }
+      in_sources && /^[a-zA-Z]/ { in_sources=0 }
+      in_sources && /^[[:space:]]*-[[:space:]]*ref:[[:space:]]/ {
+        # legacy 単行形式: `- ref: "..."`
+        sub(/^[[:space:]]*-[[:space:]]*ref:[[:space:]]*/, "")
+        gsub(/["\x27]/, "")
+        sub(/^\.rite\/wiki\//, "")  # prefix 正規化
+        extracted++
+        print
+        next
+      }
+      in_sources && /^[[:space:]]+ref:[[:space:]]/ {
+        # canonical multi-line 形式: `  ref: "..."` (前行が `- type: ...`)
+        sub(/^[[:space:]]+ref:[[:space:]]*/, "")
+        gsub(/["\x27]/, "")
+        sub(/^\.rite\/wiki\//, "")
+        extracted++
+        print
+      }
+      END {
+        if (sources_seen > 0 && extracted == 0) {
+          if (diag == "/dev/null") {
+            # mktemp 失敗 fallback: bash 側 check が false になるため awk から直接 stderr に emit
+            printf "WARNING: %s の frontmatter に sources: 節が存在しますが ref が 1 件も抽出できませんでした (awk_diag mktemp 失敗経路 fallback)\n", page > "/dev/stderr"
+            printf "  原因候補: YAML 構造破損 (改行混入 / quote 不整合 / インデント不正)\n" > "/dev/stderr"
+            printf "  影響: 本ページが参照する raw source が all_source_refs 集合から欠落し、登録済み raw が missing_concept に誤分類される可能性\n" > "/dev/stderr"
+          } else {
+            printf "sources_section_empty\n" > diag
+          }
+        }
+      }
+    ')
+    if [ -n "$awk_diag" ] && [ -s "$awk_diag" ]; then
+      echo "WARNING: $page の frontmatter に sources: 節が存在しますが ref が 1 件も抽出できませんでした" >&2
+      echo "  原因候補: YAML 構造破損 (改行混入 / quote 不整合 / インデント不正)" >&2
+      echo "  影響: 本ページが参照する raw source が all_source_refs 集合から欠落し、登録済み raw が missing_concept に誤分類される可能性" >&2
+    fi
+    [ -n "$awk_diag" ] && rm -f "$awk_diag"
+    awk_diag=""  # 次 iteration の trap cleanup で stale path を二重 rm しないため明示 reset
+    if [ -n "$page_refs" ]; then
+      all_source_refs=$(printf '%s\n%s' "$all_source_refs" "$page_refs")
+    fi
+  else
+    # ステップ 6.0 と同じ stderr pattern matching で legitimate absence と io_error を判別。
+    # branch_strategy ごとに legitimate absence の文言が異なるため両経路の pattern を OR する:
+    #   separate_branch (git show): blob 不在
+    #   same_branch (cat):          ENOENT / No such file
+    if [ -n "$page_err" ] && [ -s "$page_err" ] && grep -qE "does not exist|path '.+' exists on disk, but not in|Not a valid object name|fatal: invalid object name '[^']*:|No such file or directory|cannot open .* for reading" "$page_err"; then
+      # legitimate absence: 集合には追加しないが read_ok は下げない
+      :
+    else
+      # 真の IO error: all_source_refs_read_errors を increment (後段で io_error に畳み込み)
+      all_source_refs_read_errors=$((all_source_refs_read_errors + 1))
+      echo "WARNING: $page の sources[].ref 抽出に失敗 (rc=$page_read_cmd_rc, branch_strategy=$branch_strategy)" >&2
+      [ -n "$page_err" ] && [ -s "$page_err" ] && head -3 "$page_err" | sed 's/^/  /' >&2
+    fi
+  fi
+  [ -n "$page_err" ] && rm -f "$page_err"
+  page_err=""
+done <<< "$pages_list"
+
+# mktemp 失敗の集約 WARNING (per-iteration spam 回避のため post-loop で 1 回のみ emit)
+if [ "$awk_diag_mktemp_failed" -gt 0 ]; then
+  echo "WARNING: awk_diag tempfile の mktemp が $awk_diag_mktemp_failed 件失敗しました。per-page WARNING は awk END block から /dev/stderr 経由で emit 済みです" >&2
+  echo "  対処: /tmp の容量 / 権限 / readonly filesystem を確認してください" >&2
+fi
+if [ "$page_err_mktemp_failed" -gt 0 ]; then
+  echo "WARNING: page_err tempfile の mktemp が $page_err_mktemp_failed 件失敗しました" >&2
+  echo "  対処: /tmp の容量 / 権限 / inode 枯渇 / readonly filesystem を確認してください" >&2
+  echo "  影響: 本 Block の legitimate absence / io_error 判別は失敗経路でのみ精度低下 (io_error 側に倒す defense で silent 0 件は防止済み)" >&2
+fi
+
+# 終状態の enum 決定 (部分成功を silent に 0 件扱いしない)
+if [ "$all_source_refs_read_errors" -gt 0 ]; then
+  all_source_refs_read_ok="io_error"
+else
+  all_source_refs_read_ok="true"
+fi
+
+# sort -u で重複排除 (ステップ 6.0 awk/sort と対称に pipefail + stderr 捕捉)
+if [ -n "$all_source_refs" ]; then
+  set -o pipefail
+  sort_err=$(mktemp /tmp/rite-lint-p62-sort-err-XXXXXX 2>/dev/null) || {
+    echo "WARNING: stderr 退避 tempfile (sort_err) の mktemp に失敗しました。sort/awk pipeline の詳細エラー情報は失われます" >&2
+    echo "  対処: /tmp の容量 / permission / inode 枯渇を確認してください" >&2
+    echo "  影響: pipeline 失敗時の根本原因 (sort バイナリ異常 / OOM / SIGPIPE 等) が不可視になり、all_source_refs が io_error 降格しても理由が追えません" >&2
+    sort_err=""
+  }
+  # 末尾 `awk 'NF>0'` は grep -c の no-match (rc=1) 問題を回避 (空行 only の edge case 対応)
+  normalized=$(printf '%s\n' "$all_source_refs" | LC_ALL=C sort -u 2>"${sort_err:-/dev/null}" | awk 'NF>0' 2>>"${sort_err:-/dev/null}")
+  sort_rc=$?
+  if [ "$sort_rc" -ne 0 ]; then
+    echo "WARNING: ステップ 6.2 の all_source_refs 正規化 pipeline が失敗しました (rc=$sort_rc)" >&2
+    [ -n "$sort_err" ] && [ -s "$sort_err" ] && head -3 "$sort_err" | sed 's/^/  /' >&2
+    echo "  対処: sort バイナリ / /tmp の容量 / 権限を確認してください" >&2
+    echo "  影響: all_source_refs が部分出力で populate されると真の欠落判定が false positive になるため io_error に降格します" >&2
+    all_source_refs_read_ok="io_error"
+  else
+    all_source_refs="$normalized"
+  fi
+  [ -n "$sort_err" ] && rm -f "$sort_err"
+  sort_err=""
+  set +o pipefail
+fi
+
+# marker block で集合を出力 (ステップ 6.0 の skipped_refs と同じパターン)
+echo "---all_source_refs_begin---"
+[ -n "$all_source_refs" ] && printf '%s\n' "$all_source_refs"
+echo "---all_source_refs_end---"
+
+echo "all_source_refs_read_ok=$all_source_refs_read_ok"
+echo "all_source_refs_read_errors=$all_source_refs_read_errors"

--- a/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# wiki-lint-source-refs.test.sh
+#
+# Smoke tests for wiki-lint-source-refs.sh (wiki/lint.md ステップ 6.2 delegation
+# target, Issue #1195 block #10). The helper builds the `all_source_refs` set
+# from Wiki page frontmatter and emits a marker block + io_error 3-value enum.
+#
+# Coverage:
+#   TC-1  same_branch 抽出 (canonical multi-line + legacy 単行、prefix 正規化、sort -u)
+#   TC-2  same_branch 欠落ページ (legitimate absence) → read_ok=true, 空集合
+#   TC-3  空 pages_list → 空 marker block, read_ok=true, errors=0
+#   TC-4  placeholder residue (--branch-strategy "{...}") → exit 1 + LINT_PHASE_6_2_PLACEHOLDER_RESIDUE marker
+#   TC-5  partial pollution (.rite/wiki/raw/ 行混入) → exit 1
+#   TC-6  unknown branch_strategy → exit 1
+#   TC-7  sources: 節あるが ref 0 件 → WARNING + read_ok=true (空集合)
+#   TC-8  separate_branch 抽出 (git show)
+#   TC-9  separate_branch io_error (存在しない wiki_branch ref) → read_ok=io_error
+#   TC-10 --branch-strategy 欠落 → exit 2 (invocation error)
+#
+# NOT covered (environment-dependent): mktemp failure on read-only /tmp,
+# sort/awk pipeline OOM. Both downgrade to io_error and are verified by reading.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+SCRIPT="$PLUGIN_ROOT/hooks/scripts/wiki-lint-source-refs.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "ERROR: helper not executable: $SCRIPT" >&2
+  exit 1
+fi
+
+cleanup_dirs=()
+tmp_files=()
+cleanup() {
+  local p
+  for p in "${cleanup_dirs[@]:-}"; do [ -n "$p" ] && rm -rf "$p"; done
+  for p in "${tmp_files[@]:-}"; do [ -n "$p" ] && rm -f "$p"; done
+}
+trap cleanup EXIT
+
+mk_tmp() {
+  local f
+  f=$(mktemp /tmp/rite-wlsr-XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  tmp_files+=("$f")
+  printf '%s' "$f"
+}
+
+# canonical multi-line + legacy 単行の sources を持つページ群を sandbox に書く。
+write_pages() {
+  local root="$1"
+  mkdir -p "$root/.rite/wiki/pages"
+  # canonical multi-line 形式 + `.rite/wiki/` prefix 付き ref (正規化対象)
+  cat > "$root/.rite/wiki/pages/p1.md" <<'EOF'
+---
+title: "Page 1"
+sources:
+  - type: "review"
+    ref: ".rite/wiki/raw/reviews/20260410T000000Z.md"
+  - type: "fix"
+    ref: "raw/fixes/20260411T000000Z.md"
+tags: ["x"]
+---
+body
+EOF
+  # legacy 単行形式 `- ref:`
+  cat > "$root/.rite/wiki/pages/p2.md" <<'EOF'
+---
+title: "Page 2"
+sources:
+- ref: "raw/issues/20260412T000000Z.md"
+---
+EOF
+}
+
+# === TC-1: same_branch 抽出 (multi-line + legacy、prefix 正規化、sort -u) ===
+echo "=== TC-1: same_branch 抽出 ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_pages "$sbx"
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" ".rite/wiki/pages/p2.md" \
+  | bash "$SCRIPT" --branch-strategy same_branch --wiki-branch "" --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-1 exit 0" "0" "$rc"
+assert_grep     "TC-1 multi-line ref 抽出 (review)"  "$outf" '^raw/reviews/20260410T000000Z\.md$'
+assert_grep     "TC-1 multi-line ref 抽出 (fix)"     "$outf" '^raw/fixes/20260411T000000Z\.md$'
+assert_grep     "TC-1 legacy 単行 ref 抽出"          "$outf" '^raw/issues/20260412T000000Z\.md$'
+assert_not_grep "TC-1 prefix 正規化 (.rite/wiki/ 残留なし)" "$outf" '\.rite/wiki/raw/'
+assert_grep     "TC-1 marker begin"  "$outf" '^---all_source_refs_begin---$'
+assert_grep     "TC-1 marker end"    "$outf" '^---all_source_refs_end---$'
+assert_grep     "TC-1 read_ok=true"  "$outf" '^all_source_refs_read_ok=true$'
+assert_grep     "TC-1 errors=0"      "$outf" '^all_source_refs_read_errors=0$'
+
+# === TC-2: same_branch 欠落ページ (legitimate absence) → read_ok=true ===
+echo "=== TC-2: same_branch legitimate absence ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/missing.md" \
+  | bash "$SCRIPT" --branch-strategy same_branch --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-2 exit 0" "0" "$rc"
+assert_grep "TC-2 read_ok=true (absence は降格しない)" "$outf" '^all_source_refs_read_ok=true$'
+assert_grep "TC-2 errors=0"                            "$outf" '^all_source_refs_read_errors=0$'
+
+# === TC-3: 空 pages_list → 空 marker block, read_ok=true, errors=0 ===
+echo "=== TC-3: 空 pages_list ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '' | bash "$SCRIPT" --branch-strategy same_branch --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-3 exit 0" "0" "$rc"
+assert_grep "TC-3 marker begin (0 件でも emit)" "$outf" '^---all_source_refs_begin---$'
+assert_grep "TC-3 marker end (0 件でも emit)"   "$outf" '^---all_source_refs_end---$'
+assert_grep "TC-3 read_ok=true"                 "$outf" '^all_source_refs_read_ok=true$'
+
+# === TC-4: placeholder residue (branch_strategy) → exit 1 + marker ===
+echo "=== TC-4: placeholder residue ==="
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" \
+  | bash "$SCRIPT" --branch-strategy "{branch_strategy}" --wiki-branch "main" 2>"$errf" >/dev/null
+rc=$?
+assert "TC-4 exit 1 (fail-fast)" "1" "$rc"
+assert_grep "TC-4 PLACEHOLDER_RESIDUE marker" "$errf" 'LINT_PHASE_6_2_PLACEHOLDER_RESIDUE=1'
+
+# === TC-5: partial pollution (raw 行混入) → exit 1 ===
+echo "=== TC-5: partial pollution ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+write_pages "$sbx"
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" ".rite/wiki/raw/reviews/x.md" \
+  | bash "$SCRIPT" --branch-strategy same_branch --repo-root "$sbx" 2>"$errf" >/dev/null
+rc=$?
+assert "TC-5 exit 1 (fail-fast)" "1" "$rc"
+assert_grep "TC-5 partial pollution エラー" "$errf" 'partial pollution 検出'
+
+# === TC-6: unknown branch_strategy → exit 1 ===
+echo "=== TC-6: unknown branch_strategy ==="
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" \
+  | bash "$SCRIPT" --branch-strategy bogus 2>"$errf" >/dev/null
+rc=$?
+assert "TC-6 exit 1 (fail-fast)" "1" "$rc"
+assert_grep "TC-6 unknown branch_strategy エラー" "$errf" '未知の branch_strategy'
+
+# === TC-7: sources: 節あるが ref 0 件 → WARNING + read_ok=true ===
+echo "=== TC-7: sources 節あるが ref 0 件 ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+mkdir -p "$sbx/.rite/wiki/pages"
+cat > "$sbx/.rite/wiki/pages/empty-src.md" <<'EOF'
+---
+title: "Empty sources"
+sources:
+tags: ["x"]
+---
+EOF
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/empty-src.md" \
+  | bash "$SCRIPT" --branch-strategy same_branch --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-7 exit 0" "0" "$rc"
+assert_grep "TC-7 read_ok=true (空集合は io_error ではない)" "$outf" '^all_source_refs_read_ok=true$'
+assert_grep "TC-7 sources_section_empty WARNING" "$errf" 'ref が 1 件も抽出できませんでした'
+
+# === TC-8: separate_branch 抽出 (git show) ===
+echo "=== TC-8: separate_branch 抽出 ==="
+sbx=$(make_sandbox --branch wikibranch); cleanup_dirs+=("$sbx")
+write_pages "$sbx"
+git -C "$sbx" add -A >/dev/null 2>&1
+git -C "$sbx" -c user.email=t@test.local -c user.name=test commit -q -m pages >/dev/null 2>&1
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" ".rite/wiki/pages/p2.md" \
+  | bash "$SCRIPT" --branch-strategy separate_branch --wiki-branch wikibranch --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-8 exit 0" "0" "$rc"
+assert_grep "TC-8 git show で multi-line ref 抽出" "$outf" '^raw/reviews/20260410T000000Z\.md$'
+assert_grep "TC-8 git show で legacy ref 抽出"     "$outf" '^raw/issues/20260412T000000Z\.md$'
+assert_grep "TC-8 read_ok=true" "$outf" '^all_source_refs_read_ok=true$'
+
+# === TC-9: separate_branch io_error (存在しない wiki_branch ref) ===
+echo "=== TC-9: separate_branch io_error ==="
+sbx=$(make_sandbox --branch wikibranch); cleanup_dirs+=("$sbx")
+write_pages "$sbx"
+git -C "$sbx" add -A >/dev/null 2>&1
+git -C "$sbx" -c user.email=t@test.local -c user.name=test commit -q -m pages >/dev/null 2>&1
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" \
+  | bash "$SCRIPT" --branch-strategy separate_branch --wiki-branch nonexistent-ref-xyz --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-9 exit 0 (非ブロッキング、io_error は stdout enum で表現)" "0" "$rc"
+assert_grep "TC-9 read_ok=io_error" "$outf" '^all_source_refs_read_ok=io_error$'
+if grep -qE '^all_source_refs_read_errors=0$' "$outf"; then
+  fail "TC-9 errors>0 であるべき (io_error 降格)"
+else
+  pass "TC-9 errors>0 (io_error 降格)"
+fi
+
+# === TC-10: --branch-strategy 欠落 → exit 2 (invocation error) ===
+echo "=== TC-10: --branch-strategy 欠落 ==="
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" | bash "$SCRIPT" 2>"$errf" >/dev/null
+rc=$?
+assert "TC-10 exit 2 (invocation error)" "2" "$rc"
+assert_grep "TC-10 --branch-strategy 必須エラー" "$errf" 'branch-strategy は必須'
+
+if ! print_summary "$(basename "$0")" \
+  "drift: wiki-lint-source-refs.sh の挙動が変わった可能性。wiki/lint.md ステップ 6.2 委譲契約 (Issue #1195 #10) と marker block / io_error enum の出力契約を参照。"; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Issue #1195 (umbrella) の残ブロック **#10**。`wiki/lint.md` ステップ 6.2 の `all_source_refs` 集合構築 (~240 行 inline bash) を新規 `hooks/scripts/wiki-lint-source-refs.sh` へ委譲する。1 ブロック = 1 PR 方針 (dogfooding 自己参照ループ回避) に従い #10 のみを対象とする。

## 関連 Issue

Refs #1195 (block #10)

## 変更内容

- **`plugins/rite/hooks/scripts/wiki-lint-source-refs.sh`** (新規): per-page の `git show`(separate_branch) / `cat`(same_branch) 読出、`sources[].ref` 抽出 (legacy 単行 `- ref:` + canonical multi-line ` ref:` 両対応)、`LC_ALL=C` 固定 stderr pattern による legitimate absence と真の io_error の判別、`sort -u` 重複排除、marker block + read_ok 3 値 enum 出力、signal-specific trap cleanup を内包。interface は `--branch-strategy` / `--wiki-branch` arg + `pages_list` stdin。
- **`plugins/rite/commands/wiki/lint.md`**: ステップ 6.2 の inline bash を plugin_root 解決 + helper invoke へ置換 (-237/+26 行)。placeholder residue gate / partial pollution gate を helper 内へ移設。
- **`plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh`** (新規): 34 assertions。

## 契約保持

- 出力契約 (`---all_source_refs_begin/end---` / `all_source_refs_read_ok` enum / `all_source_refs_read_errors`) を **verbatim 保持** → 下流 step 3 の 3 分岐 / step 9.1 の false positive note は不変。
- ステップ 6.0 `skipped_refs` (#14) とは marker block + io_error enum の構造を対称に保つ (step 6.0 自体は inline 据置、本 PR スコープ外)。
- branch_strategy 別 legitimate-absence regex (git show / cat 両経路) を厳密に移植。
- helper 不在時は `all_source_refs_read_ok=io_error` を明示出力し step 9.1 false positive note を展開 (silent 空集合回避)。

## 検証

- 新規 test: **34 assertions pass** (same/separate_branch 抽出・legitimate absence・io_error 降格・空集合・placeholder residue・partial pollution・unknown strategy・invocation error)。
- `distributed-fix-drift-check.sh --all` baseline 不変。`lint.md` 自体の drift findings は 36→29 に減少 (新規 drift ゼロ)。
- hook test suite: 50/52 pass。

## 注記 (pre-existing、本 PR 無関係)

- hook suite の失敗 2 件 (`create-md-invocation-symmetry` / `link-sub-issue`) は #9 領域の pre-existing 失敗で develop でも失敗。本変更とは無関係。
- umbrella #1195 は残ブロック **#2** (`pr/fix.md`) が未着手のため open のまま (本 PR は `Closes` しない)。

## チェックリスト

- [x] 新規 helper のテスト追加 (34 assertions)
- [x] 出力契約 (marker block / read_ok enum) を verbatim 保持
- [x] drift baseline 確認 (`--all` 不変、lint.md drift 減少)
