### PR TITLE
fix(scripts): decompose-issues.sh の stderr 分離で Sub-Issue 誤カウントを解消

### DIFF
--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -102,9 +102,15 @@ spec_get() { printf '%s' "$SPEC_JSON" | jq -r "$1"; }
 # live under /tmp/rite-issue-body-* — outside workdir — so they survive for the
 # caller's apply step. ---
 workdir=$(spec_get '.workdir // empty')
-if [ -n "$workdir" ] && [ -d "$workdir" ]; then
-  trap 'rm -rf "$workdir"' EXIT INT TERM
-fi
+# Per-iteration helper stderr is captured to this scratch file so it is never
+# merged into the helper's stdout JSON (Issue #1206): create-issue-with-projects.sh
+# emits `ERROR: ...` on stderr while still printing valid JSON on stdout with
+# exit 0 on partial-Projects failures (Issue #669). A `2>&1` capture would splice
+# that ERROR ahead of the JSON and break the downstream `jq -r .issue_number`,
+# silently miscounting an actually-created Sub-Issue as failed (#514 contract break).
+helper_err_file=$(mktemp "${TMPDIR:-/tmp}/rite-decompose-helper-err.XXXXXX") \
+  || helper_err_file="${TMPDIR:-/tmp}/rite-decompose-helper-err.$$"
+trap 'rm -f "$helper_err_file"; if [ -n "$workdir" ] && [ -d "$workdir" ]; then rm -rf "$workdir"; fi' EXIT INT TERM
 
 # --- Resolve shared projects fields ---
 proj_enabled=$(spec_get '.projects.enabled // true')
@@ -190,10 +196,14 @@ while IFS= read -r sub_json; do
     echo "WARNING: Sub-Issue '$sub_title' body が空、skip" >&2
     failed_count=$((failed_count + 1))
   else
-    sub_result=$(bash "$CREATE_SCRIPT" "$(build_payload "$sub_title" "$sub_body_file" "$sub_labels_json" "$sub_complexity")" 2>&1)
+    # stderr を helper_err_file へ分離する (Issue #1206)。`2>&1` だと partial-Projects
+    # 失敗時の stderr ERROR が stdout JSON 前方へ混入し、直後の jq parse が壊れて
+    # 実際には作成された Sub-Issue を failed_count に誤カウントする (silent data loss)。
+    sub_result=$(bash "$CREATE_SCRIPT" "$(build_payload "$sub_title" "$sub_body_file" "$sub_labels_json" "$sub_complexity")" 2>"$helper_err_file")
     create_rc=$?
     if [ $create_rc -ne 0 ]; then
-      echo "WARNING: Sub-Issue '$sub_title' の作成に失敗: $sub_result" >&2
+      create_err=$(cat "$helper_err_file" 2>/dev/null)
+      echo "WARNING: Sub-Issue '$sub_title' の作成に失敗: ${sub_result}${create_err:+ | stderr: $create_err}" >&2
       failed_count=$((failed_count + 1))
     else
       sub_number=$(printf '%s' "$sub_result" | jq -r '.issue_number // empty')
@@ -201,6 +211,12 @@ while IFS= read -r sub_json; do
         echo "WARNING: Sub-Issue '$sub_title' の result に issue_number 無し: $sub_result" >&2
         failed_count=$((failed_count + 1))
       else
+        # 成功時でも create-issue-with-projects.sh は partial-Projects 失敗を
+        # exit 0 + JSON の .warnings[] で返す (Issue #669)。jq parse が clean に
+        # なった今、その warning を silent に捨てず link-warning と同形式で surface
+        # する (Wiki: stderr ノイズは truncate でなく selective surface で解く)。
+        printf '%s' "$sub_result" | jq -r '.warnings[]?' 2>/dev/null \
+          | while read -r w; do echo "⚠️ Sub-Issue #$sub_number 作成時の警告: $w" >&2; done
         # Sub-issues API linkage — canonical SoT [`sub-issue-link-handler.md`](../references/sub-issue-link-handler.md)
         # Variant B (counting). link-sub-issue.sh は非 blocking failure 時に exit 0 + status="failed"
         # を返す契約のため、bash exit code ではなく JSON stdout の `.status` を inspect すること。
@@ -210,9 +226,13 @@ while IFS= read -r sub_json; do
         # non-blocking failures). Only construct fallback JSON on fatal exit.
         # Build it via `jq -n --arg` so embedded `"` in stderr cannot break the
         # JSON the caller will parse.
+        # 対称修正 (Issue #1206 / Wiki: Asymmetric Fix Transcription)。link-sub-issue.sh は
+        # 現状 stderr に書かないため JSON 破損は起きないが、create と同じく stderr を
+        # helper_err_file へ分離して将来の regression を防ぐ。fatal exit 時の fallback err は
+        # stdout (link_result) と stderr を結合し、診断情報を取りこぼさない。
         link_result=$(bash "$LINK_SCRIPT" \
-            "$owner" "$repo" "$parent_issue_number" "$sub_number" 2>&1) || link_result=$(jq -n \
-              --arg err "$link_result" \
+            "$owner" "$repo" "$parent_issue_number" "$sub_number" 2>"$helper_err_file") || link_result=$(jq -n \
+              --arg err "${link_result}$(cat "$helper_err_file" 2>/dev/null)" \
               '{status:"failed",message:"link-sub-issue.sh fatal exit",warnings:[$err]}')
         link_status=$(printf '%s' "$link_result" | jq -r '.status // "failed"' 2>/dev/null || echo "failed")
         link_msg=$(printf '%s' "$link_result" | jq -r '.message // ""' 2>/dev/null || echo "")

--- a/plugins/rite/scripts/tests/decompose-issues.test.sh
+++ b/plugins/rite/scripts/tests/decompose-issues.test.sh
@@ -52,6 +52,15 @@ if [ -n "${STUB_CREATE_FAIL_TITLE:-}" ] && [ "$title" = "$STUB_CREATE_FAIL_TITLE
 fi
 n=$(cat "$STUB_NUM_FILE")
 echo "$((n + 1))" > "$STUB_NUM_FILE"
+# Partial-Projects mode (#1206 / #669 reproduction): emit `ERROR: ...` on stderr
+# AND a valid JSON (with issue_number + warnings) on stdout, then exit 0. A caller
+# that captures with `2>&1` would splice the ERROR ahead of the JSON and break the
+# downstream `jq -r .issue_number`, miscounting this created sub as failed.
+if [ -n "${STUB_CREATE_PARTIAL_TITLE:-}" ] && [ "$title" = "$STUB_CREATE_PARTIAL_TITLE" ]; then
+  printf 'ERROR: Projects registration failed: stub partial for %s\n' "$title" >&2
+  jq -n --argjson num "$n" '{issue_number:$num, issue_url:("https://example/\($num)"), project_registration:"failed", warnings:["stub partial projects warning"]}'
+  exit 0
+fi
 jq -n --argjson num "$n" '{issue_number:$num, issue_url:("https://example/\($num)"), project_registration:"ok", warnings:[]}'
 STUB_CREATE
 
@@ -200,6 +209,25 @@ run_decompose "$spec5"
 assert_rc 1 "exit 1 on parent create failure"
 assert_err_contains "親 Issue 作成失敗" "parent create failure ERROR"
 unset STUB_CREATE_FAIL_TITLE
+
+# -----------------------------------------------------------------
+echo "--- Test 7: partial-Projects (stderr ERROR + stdout JSON + exit 0) counts as created, not failed (#1206) ---"
+wd7="$TEST_DIR/wd7"; mkdir -p "$wd7"
+printf '%s' "Parent" > "$wd7/parent.md"; printf '%s' "Sub 1" > "$wd7/s1.md"; printf '%s' "Sub 2" > "$wd7/s2.md"
+spec7=$(build_spec "$wd7" "Epic7" "$wd7/parent.md" "refactor" \
+  "Sub One" "$wd7/s1.md" "M" "Sub Partial" "$wd7/s2.md" "S")
+STUB_NUM_FILE="$TEST_DIR/num7"; echo 700 > "$STUB_NUM_FILE"; export STUB_NUM_FILE
+STUB_CREATE_PARTIAL_TITLE="Sub Partial"; export STUB_CREATE_PARTIAL_TITLE
+unset STUB_CREATE_LOG STUB_CREATE_FAIL_TITLE STUB_LINK_FAIL_CHILD 2>/dev/null || true
+run_decompose "$spec7"
+# parent=700, Sub One=701, Sub Partial=702 → both subs created (partial-Projects is exit 0), none failed
+assert_rc 0 "exit 0 on partial-Projects sub"
+assert_out_contains "[CONTEXT] SUB_ISSUE_RESULT created=2 failed=0 link_failures=0" "partial-Projects sub counted as created, not failed"
+assert_out_contains "[CONTEXT] SUB_ISSUE_NUMBERS=701 702" "partial-Projects sub present in SUB_ISSUE_NUMBERS (no silent drop)"
+assert_err_contains "stub partial projects warning" "partial-Projects warning surfaced on stderr (selective surface, not silent)"
+# The create stderr ERROR must NOT corrupt stdout (no jq parse-error leakage into markers)
+assert_out_missing "parse error" "no jq parse error leaked into stdout markers"
+unset STUB_CREATE_PARTIAL_TITLE
 
 # -----------------------------------------------------------------
 echo "--- Test 6: usage / spec validation errors ---"


### PR DESCRIPTION
## 概要

`decompose-issues.sh` の Sub-Issue 作成ループが `create-issue-with-projects.sh` を `$(... 2>&1)` で capture していたため、Projects 登録の**部分失敗** (non-blocking, exit 0) 経路で stderr の `ERROR:` 行が stdout の JSON 前方へ混入し、直後の `jq -r '.issue_number'` が parse error で空を返していました。結果、**実際には作成された Sub-Issue が `failed_count` に誤カウント**され、`created_numbers` / `SUB_ISSUE_NUMBERS` marker / 完了レポート Tasklist から脱落していました (silent data loss / #514 counting contract 破れ)。

stderr を専用 tempfile (`helper_err_file`) へ分離して stdout JSON を clean に保ち、誤カウントを解消します。

## 関連 Issue

Closes #1206

## 変更点

- **`scripts/decompose-issues.sh`**
  - `helper_err_file` を `mktemp` で確保し、既存の workdir cleanup と統合した単一 `EXIT/INT/TERM` trap に変更
  - Sub-Issue 作成: `2>&1` → `2>"$helper_err_file"`。`create_rc != 0` 時のみ stderr 内容を WARNING に含める（成功パスの `jq` parse が clean になり誤カウント解消）
  - 成功パス: clean になった JSON の `.warnings[]` を既存 link-warning と同形式で `⚠️` surface し、partial-Projects 警告の silent drop を防止（Wiki 経験則「stderr は truncate でなく selective surface で解く」）
  - link 呼び出しの同型 `2>&1` を**対称修正**（Wiki 経験則「Asymmetric Fix Transcription」）。fatal fallback の `err` は stdout + stderr を結合して診断情報を保持
- **`scripts/tests/decompose-issues.test.sh`**
  - stub に partial-Projects モード（stderr ERROR + stdout JSON + exit 0）を追加
  - Test 7 を追加: partial-Projects Sub-Issue が `created` にカウントされ `SUB_ISSUE_NUMBERS` に出現すること、warning が surface されること、stdout に jq parse error が漏れないことを検証（旧コードでは fail する回帰テスト）

## 横断調査（Issue 推奨）

`create-issue-with-projects.sh` を呼ぶ全 caller を確認した結果、**`2>&1` + `jq` parse の同型パターンを持つ本番 caller は `decompose-issues.sh` のみ**でした。他の caller（`commands/issue/create.md`, `commands/pr/create.md`, `commands/pr/cleanup.md`, `commands/pr/review.md`, `commands/issue/references/fingerprint-cycling.md`, `references/issue-create-with-projects.md`）はいずれも `2>&1` を付けず stdout の clean JSON から `issue_number` を取得しており、影響なし。親 Issue 作成行（`decompose-issues.sh:161`）も元々 `2>&1` なしで安全なため変更していません。

## テスト

- `bash plugins/rite/scripts/tests/decompose-issues.test.sh` → **32 passed, 0 failed**（新規 Test 7 含む）
- 関連: `create-md-invocation-symmetry.test.sh`（16 passed）、`link-sub-issue.test.sh`（12 passed, TC-04 で fallback JSON が quoted stderr でも clean parse することを確認）
- 旧 `2>&1` 挙動を最小再現し、jq parse error → 空 issue_number になることを実証（fix 後は正しく取得）

## Checklist

- [x] プロジェクト規約に準拠（既存の stderr 分離・selective surface パターンに合わせた）
- [x] テスト pass（回帰テスト Test 7 追加 + 既存テスト全 pass）
- [ ] ドキュメント更新（不要: 内部バグ修正のみで command/config/出力契約・CONTEXT marker・exit code に変化なし）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
