### PR TITLE
feat(lint): operational bash ブロック heaviness guard を /rite:lint Phase 3.17 に追加

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -932,6 +932,52 @@ fi
 - `sh_cross_ref_finding_count`: Extract from `sh_cross_ref_output` by matching the summary line `==> Total sh-cross-ref findings: N` (regex: `/Total sh-cross-ref findings: (\d+)/`). If no match found, default to 0
 - `sh_cross_ref_output`: Script output (truncated if >50 lines)
 
+### 3.17 Plugin-specific Checks (Operational Bash Block Heaviness) — Issue #1197
+
+Execute the operational bash block heaviness check to detect "heavy" bash blocks in command markdown under **`plugins/rite/commands/**/*.md`** that violate the "operational bash block heaviness convention" added to `skills/rite-workflow/references/coding-principles.md` by PR #1193. Issue #1193 observed that large operational bash blocks (python inline / nested `$()` / multiple heredocs / long line counts) malformed Claude's tool-call parsing and silently ended the turn with no error. The convention was added as prose, but prose-only enforcement cannot stop new drift — this check surfaces it mechanically. See the script header at `plugins/rite/hooks/scripts/bash-heaviness-check.sh` for the heaviness model.
+
+A block is flagged only when it exhibits **2 or more** of these signals (a single signal — e.g. a lone helper call passing one JSON heredoc, or one block writing a long template — is intentionally not flagged, keeping false positives low):
+
+- **python-inline**: a line invokes python with inline code (`python3 -c ...` or a python heredoc)
+- **nested-cmdsub**: a line nests command substitution, e.g. `$(cmd "$(inner)")`
+- **multi-heredoc**: the block opens 2 or more heredocs
+- **long-block**: the block body is >= 25 lines (the convention 目安)
+
+Heredoc bodies are treated as data: the python-inline / nested-cmdsub signals are evaluated only on real shell lines, so a template heredoc containing `$(...)` or `python3 -c` example text does not produce a finding.
+
+Exclusions: `plugins/rite/commands/**/tests/` fixtures, and any block containing the `drift-check-ignore` marker on one of its lines (exempts intentional / already-reviewed heavy blocks).
+
+**Condition**: Always execute when the script exists. This check is independent of `commands.lint` configuration — it is a rite-workflow internal quality check.
+
+**Skip condition**: Script file does not exist (e.g., marketplace install without hooks/scripts directory).
+
+**Execution:**
+
+```bash
+if [ -f {plugin_root}/hooks/scripts/bash-heaviness-check.sh ]; then
+  bash_heaviness_output=$(bash {plugin_root}/hooks/scripts/bash-heaviness-check.sh --all 2>&1)
+  bash_heaviness_exit_code=$?
+else
+  bash_heaviness_exit_code=-1  # script not found
+fi
+```
+
+**Result handling:**
+
+| Exit Code | `bash_heaviness_status` | Action |
+|-----------|-------------------------|--------|
+| 0 | `success` | No heavy blocks — continue to Phase 4 |
+| 1 | `warning` | Heavy block(s) detected — record as **warning** (does NOT cause `[lint:error]`). Display findings but allow flow to continue |
+| 2 | `error` | Invocation error (usage error / missing repo-root / empty `--all` expansion) — record as warning, display error message |
+| -1 | `skipped` | Script not found — skip silently |
+
+**Important**: Operational bash block heaviness check results are treated as **warnings**, not errors — same policy as Phase 3.5–3.16 checks. A finding does NOT change `[lint:success]`. Pre-existing heavy blocks are surfaced for incremental cleanup (refactoring an existing heavy block to a helper call is separate work, out of scope for the block's owning change); intentional or already-reviewed heavy blocks can be exempted with an inline `drift-check-ignore` marker.
+
+**Record bash heaviness check results** for Phase 4 reporting:
+- `bash_heaviness_status`: `success` / `warning` / `error` / `skipped`
+- `bash_heaviness_finding_count`: Extract from `bash_heaviness_output` by matching the summary line `==> Total bash-heaviness findings: N` (regex: `/Total bash-heaviness findings: (\d+)/`). If no match found, default to 0
+- `bash_heaviness_output`: Script output (truncated if >50 lines)
+
 ---
 
 ## Phase 4: Report Results
@@ -1084,7 +1130,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 {sh_cross_ref_output}
 ```
 
-These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, gitignore-health, backlink-format, hardcoded-line-number, comment-journal, comment-line-ref, direct-gh-issue-create, orphan-reference-check, or sh-cross-ref warnings/invocation errors.
+**Operational bash block heaviness appendix (Issue #1197)** (both standalone and E2E): When `bash_heaviness_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as Phase 3.5–3.16 checks. When status is `warning` (exit 1, heavy block detected), the appendix output includes each finding line (`[bash-heaviness] file:NN: heavy operational bash block — N signals: ...`) so authors can refactor the heavy block to a helper call or exempt an intentional one with `drift-check-ignore`:
+
+```
+⚠️ Operational bash block heaviness check: {bash_heaviness_finding_count} findings detected ({bash_heaviness_status}, non-blocking)
+{bash_heaviness_output}
+```
+
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, gitignore-health, backlink-format, hardcoded-line-number, comment-journal, comment-line-ref, direct-gh-issue-create, orphan-reference-check, sh-cross-ref, or bash-heaviness warnings/invocation errors.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 
@@ -1167,6 +1220,7 @@ Analyze the error content and present fix suggestions when possible:
 | Direct gh issue create check (#958) | {direct_gh_issue_status} ({direct_gh_issue_finding_count} findings) |
 | Orphan reference check (#1159) | {orphan_check_status} ({orphan_check_finding_count} findings) |
 | Shell-prose cross-ref check (#1160) | {sh_cross_ref_status} ({sh_cross_ref_finding_count} findings) |
+| Operational bash block heaviness check (#1197) | {bash_heaviness_status} ({bash_heaviness_finding_count} findings) |
 | 所要時間 | {duration} |
 
 次のステップ:
@@ -1177,7 +1231,7 @@ Analyze the error content and present fix suggestions when possible:
 > **注**: `/rite:pr:open` の一気通貫フローから呼び出された場合、この「次のステップ」案内は**スキップ**されます。呼び出し元が出力パターン（`[lint:success]` 等）を検出し、自動的に次のアクション（PR 作成）に進みます。**この案内は単独実行時のみ参照してください**。
 ```
 
-**Note**: The `テスト` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `Drift チェック` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Gitignore health check (#567)` row follows the same policy: omit when `gitignore_health_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = healthy rule / legitimate no-op; `warning` = drift detected; `error` = invocation failure). The `Backlink format check (#627)` row follows the same policy: omit when `backlink_format_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no dialect violations; `warning` = legacy dialect detected; `error` = invocation failure). The `Hardcoded line-number check (#666)` row follows the same policy: omit when `hardcoded_line_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no hardcoded references; `warning` = P-A/P-B/P-C reference detected; `error` = invocation failure). **Asymmetry note**: The `Drift チェック` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. The `Comment journal narration (#702)` row follows the same policy: omit when `comment_journal_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no journal narration; `warning` = P1/P2/P3/P4 pattern detected; `error` = invocation failure). The `Comment line-ref check (#702)` row follows the same policy: omit when `comment_line_ref_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no comment line-number references; `warning` = `<file>.<ext>:<NN>` pattern detected in shell comments; `error` = invocation failure). The `Direct gh issue create check (#958)` row follows the same policy: omit when `direct_gh_issue_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no direct invocations; `warning` = direct `gh issue create` invocation detected; `error` = invocation failure / usage error / missing commands directory). The `Orphan reference check (#1159)` row follows the same policy: omit when `orphan_check_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no orphans; `warning` = orphan file(s) detected; `error` = invocation failure / usage error / missing repo-root / empty --all expansion). The `Shell-prose cross-ref check (#1160)` row follows the same policy: omit when `sh_cross_ref_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no inconsistent references; `warning` = dangling number / keyword mismatch detected; `error` = invocation failure / usage error / missing repo-root / empty --all expansion). All Phase 3.x lint checks added after Phase 3.5 (3.7 `Doc-heavy patterns drift check`, 3.8 `Wiki growth check`, 3.9 `Gitignore health check`, 3.10 `Backlink format check`, 3.11 `Hardcoded line-number check`, 3.12 `Comment journal narration`, 3.13 `Comment line-ref check`, 3.14 `Direct gh issue create check`, 3.15 `Orphan reference check`, 3.16 `Shell-prose cross-ref check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
+**Note**: The `テスト` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. The `Drift チェック` row is only shown when the drift check script exists and was executed. When `drift_status` is `skipped`, omit the row. The `Bang-backtick check` row follows the same rule: omit when `bang_backtick_status` is `skipped`. When `bang_backtick_status` is `error` (exit code 2 invocation error), display the row with the `error` status so the failure is surfaced rather than silently dropped. The `Doc-heavy patterns drift check` row follows the same policy as `Bang-backtick check`: omit when `doc_heavy_drift_status` is `skipped`, and display with the `error` status when exit code 2 surfaces an invocation failure. The `Wiki growth check (#524)` row follows the same policy: omit when `wiki_growth_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` is the healthy state showing 0 findings; `warning` indicates threshold exceeded; `error` indicates exit code 2 invocation failure). The `Gitignore health check (#567)` row follows the same policy: omit when `gitignore_health_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = healthy rule / legitimate no-op; `warning` = drift detected; `error` = invocation failure). The `Backlink format check (#627)` row follows the same policy: omit when `backlink_format_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no dialect violations; `warning` = legacy dialect detected; `error` = invocation failure). The `Hardcoded line-number check (#666)` row follows the same policy: omit when `hardcoded_line_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no hardcoded references; `warning` = P-A/P-B/P-C reference detected; `error` = invocation failure). **Asymmetry note**: The `Drift チェック` row does NOT have an equivalent `error`-status display rule because Phase 3.5 drift check's observability gap is out of scope for this PR (tracked as a follow-up). This asymmetry is intentional and temporary — both rows should converge when drift check receives the same fix in a follow-up PR. The `Comment journal narration (#702)` row follows the same policy: omit when `comment_journal_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no journal narration; `warning` = P1/P2/P3/P4 pattern detected; `error` = invocation failure). The `Comment line-ref check (#702)` row follows the same policy: omit when `comment_line_ref_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no comment line-number references; `warning` = `<file>.<ext>:<NN>` pattern detected in shell comments; `error` = invocation failure). The `Direct gh issue create check (#958)` row follows the same policy: omit when `direct_gh_issue_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no direct invocations; `warning` = direct `gh issue create` invocation detected; `error` = invocation failure / usage error / missing commands directory). The `Orphan reference check (#1159)` row follows the same policy: omit when `orphan_check_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no orphans; `warning` = orphan file(s) detected; `error` = invocation failure / usage error / missing repo-root / empty --all expansion). The `Shell-prose cross-ref check (#1160)` row follows the same policy: omit when `sh_cross_ref_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no inconsistent references; `warning` = dangling number / keyword mismatch detected; `error` = invocation failure / usage error / missing repo-root / empty --all expansion). The `Operational bash block heaviness check (#1197)` row follows the same policy: omit when `bash_heaviness_status` is `skipped`, display with `success` / `warning` / `error` otherwise (`success` = no heavy blocks; `warning` = block with >= 2 heaviness signals detected; `error` = invocation failure / usage error / missing repo-root / empty --all expansion). All Phase 3.x lint checks added after Phase 3.5 (3.7 `Doc-heavy patterns drift check`, 3.8 `Wiki growth check`, 3.9 `Gitignore health check`, 3.10 `Backlink format check`, 3.11 `Hardcoded line-number check`, 3.12 `Comment journal narration`, 3.13 `Comment line-ref check`, 3.14 `Direct gh issue create check`, 3.15 `Orphan reference check`, 3.16 `Shell-prose cross-ref check`, 3.17 `Operational bash block heaviness check`) were added with the fixed appendix + summary-row pattern from the start, so they match Phase 3.6 rather than Phase 3.5.
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 

--- a/plugins/rite/hooks/scripts/bash-heaviness-check.sh
+++ b/plugins/rite/hooks/scripts/bash-heaviness-check.sh
@@ -206,7 +206,7 @@ else
   total=0
 fi
 total=$(printf '%s' "$total" | tr -d '[:space:]')
-echo "==> Total bash-heaviness findings: ${total}"
+log "==> Total bash-heaviness findings: ${total}"
 
 if [ "$total" -gt 0 ]; then
   exit 1

--- a/plugins/rite/hooks/scripts/bash-heaviness-check.sh
+++ b/plugins/rite/hooks/scripts/bash-heaviness-check.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# bash-heaviness-check.sh
+#
+# Detect "heavy" operational bash blocks in command markdown under
+# plugins/rite/commands/**/*.md and flag them as non-blocking warnings.
+# Mechanically enforces the "operational bash block heaviness convention"
+# documented in skills/rite-workflow/references/coding-principles.md (added by
+# PR #1193), which prose-only enforcement cannot prevent from drifting.
+#
+# Why a separate hook (Issue #1197 / #1193 提案 c):
+#   Issue #1193 observed that large operational bash blocks in command bodies
+#   (python inline / nested $() / multiple heredocs / long line counts) caused
+#   Claude's tool-call parsing to malform and silently end the turn with no
+#   error. The writing convention was added to coding-principles.md, but prose
+#   alone does not stop new drift. This hook surfaces the drift on every
+#   /rite:lint run as a non-blocking warning (it never changes [lint:success]).
+#
+# Heaviness model (4 independent signals per fenced ```bash / ```sh block):
+#   (1) python-inline  — a line invokes python with inline code (`python3 -c ...`
+#                        or `python3 - <<PY` / `python3 <<PY`). Calling a `.py`
+#                        helper script (no `-c`, no heredoc) is NOT a signal.
+#   (2) nested-cmdsub  — a line nests command substitution, e.g.
+#                        `$(cmd "$(inner)")` or `$(a $(b))`.
+#   (3) multi-heredoc  — the block opens 2 or more heredocs.
+#   (4) long-block     — the block body is >= 25 lines (the convention 目安).
+#
+# A block is flagged only when it exhibits >= 2 distinct signals. A single
+# signal is intentionally NOT flagged: a lone helper invocation that passes one
+# JSON heredoc, or a single block that writes a long template, is legitimate and
+# matches the precedents (projects-status-update.sh callers etc.). Requiring two
+# signals keeps the false-positive rate low while still catching the #1193
+# incident blocks, which combined all four signals at once. Heredoc *bodies* are
+# treated as data: signals (1)/(2) are evaluated only on real shell lines, not on
+# the literal content inside a heredoc, so a template heredoc that happens to
+# contain `$(...)` or `python3 -c` example text does not produce a finding.
+#
+# Exclusions:
+#   - plugins/rite/commands/**/tests/ (any test fixtures, if present).
+#   - Any block containing the marker `drift-check-ignore` on one of its lines
+#     (exempts intentional / already-reviewed heavy blocks, mirroring
+#     sh-cross-ref-check.sh).
+#
+# Usage:
+#   bash-heaviness-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
+#
+# Exit codes: 0 = clean, 1 = heaviness detected, 2 = invocation error.
+
+set -uo pipefail
+
+REPO_ROOT=""
+QUIET=0
+declare -a TARGETS=()
+USE_ALL=0
+
+# Tunables (kept in sync with the coding-principles.md convention).
+LINE_THRESHOLD=25   # block body lines that count as the "long-block" signal
+MIN_SIGNALS=2       # number of distinct signals required to flag a block
+
+usage() {
+  cat <<'EOF'
+Usage: bash-heaviness-check.sh [options]
+
+Options:
+  --all              Scan plugins/rite/commands/**/*.md (excluding tests/)
+  --target FILE      Check FILE (repeatable). Path relative to repo root.
+  --repo-root DIR    Repository root (default: git rev-parse --show-toplevel)
+  --quiet            Suppress progress output on stderr
+  -h, --help         Show this help
+
+Detected (heavy operational bash blocks; flagged at >= 2 signals):
+  python-inline  — python invoked with inline code (`-c` or heredoc)
+  nested-cmdsub  — nested command substitution `$( ... $( ... )`
+  multi-heredoc  — 2 or more heredocs opened in one block
+  long-block     — block body >= 25 lines
+
+Exclusions: tests/ fixtures / blocks containing 'drift-check-ignore'.
+
+Exit codes:
+  0  No heavy block detected
+  1  Heavy block detected
+  2  Invocation error
+EOF
+}
+
+log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*" >&2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) USE_ALL=1; shift ;;
+    --target) TARGETS+=("$2"); shift 2 ;;
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --quiet) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+if [ ! -d "$REPO_ROOT" ]; then
+  echo "ERROR: repo-root not a directory: $REPO_ROOT" >&2
+  exit 2
+fi
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to $REPO_ROOT" >&2; exit 2; }
+
+if [ "$USE_ALL" -eq 1 ]; then
+  base="plugins/rite/commands"
+  if [ ! -d "$base" ]; then
+    echo "ERROR: --all requested but $base does not exist under $REPO_ROOT" >&2
+    echo "  Likely cause: invoked outside the rite plugin repo (e.g. marketplace install)" >&2
+    echo "  Recovery: run from the rite plugin source tree, or pass --target FILE explicitly" >&2
+    exit 2
+  fi
+  while IFS= read -r f; do
+    # Test fixtures may intentionally embed heavy blocks — skip any tests/ dir.
+    case "$f" in */tests/*) continue ;; esac
+    TARGETS+=("$f")
+  done < <(find "$base" -type f -name '*.md' 2>/dev/null | sort)
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "ERROR: no targets specified (use --all or --target FILE)" >&2
+  usage >&2
+  exit 2
+fi
+
+WORKDIR=""
+_bash_heaviness_cleanup() { rm -rf "${WORKDIR:-}"; }
+trap 'rc=$?; _bash_heaviness_cleanup; exit $rc' EXIT
+trap '_bash_heaviness_cleanup; exit 130' INT
+trap '_bash_heaviness_cleanup; exit 143' TERM
+trap '_bash_heaviness_cleanup; exit 129' HUP
+WORKDIR="$(mktemp -d)" || { echo "ERROR: mktemp failed" >&2; exit 2; }
+AWK_PROG="$WORKDIR/heaviness.awk"
+FINDINGS_FILE="$WORKDIR/findings"
+: > "$FINDINGS_FILE"
+
+# Block scanner. Tracks fenced bash/sh/shell blocks, evaluates the 4 heaviness
+# signals on real shell lines (heredoc bodies are skipped as data), and prints
+# one finding line per flagged block. `fname` labels the source file;
+# `line_threshold` / `min_signals` are passed in from the shell tunables.
+cat > "$AWK_PROG" <<'AWK'
+BEGIN { in_block = 0 }
+{
+  line = $0
+  if (in_block == 0) {
+    if (line ~ /^[[:space:]]*(```|~~~)[[:space:]]*(bash|sh|shell)[[:space:]]*$/) {
+      in_block = 1; block_start = NR
+      nlines = 0; has_python = 0; heredoc_count = 0; nested = 0; exempt = 0
+      in_heredoc = 0; heredoc_delim = ""
+    }
+    next
+  }
+  # Inside a block. A bare fence closes it, but only when not inside a heredoc
+  # body (a fence-looking line inside a heredoc body is literal data).
+  if (in_heredoc == 0 && line ~ /^[[:space:]]*(```|~~~)[[:space:]]*$/) {
+    evaluate(); in_block = 0; next
+  }
+  nlines++
+  if (in_heredoc == 1) {
+    tl = line; sub(/^[[:space:]]+/, "", tl)   # <<- terminators may be tab-indented
+    if (tl == heredoc_delim) in_heredoc = 0
+    next
+  }
+  if (line ~ /drift-check-ignore/) exempt = 1
+  if (line ~ /python3?[[:space:]]+.*(-c([[:space:]]|=|$)|<<)/) has_python = 1
+  if (line ~ /\$\([^)]*\$\(/) nested = 1
+  if (line ~ /<</ && line !~ /<<</ && line ~ /<<-?[^A-Za-z0-9_]*[A-Za-z_]/) {
+    heredoc_count++
+    if (match(line, /<<-?[^A-Za-z0-9_]*[A-Za-z_][A-Za-z0-9_]*/)) {
+      d = substr(line, RSTART, RLENGTH); sub(/^<<-?[^A-Za-z0-9_]*/, "", d)
+      heredoc_delim = d; in_heredoc = 1
+    }
+  }
+  next
+}
+END { if (in_block == 1) evaluate() }
+function evaluate(   score, parts) {
+  if (exempt == 1) return
+  score = 0; parts = ""
+  if (has_python == 1)            { score++; parts = parts (parts == "" ? "" : ", ") "python-inline" }
+  if (nested == 1)                { score++; parts = parts (parts == "" ? "" : ", ") "nested-cmdsub" }
+  if (heredoc_count >= 2)         { score++; parts = parts (parts == "" ? "" : ", ") "multi-heredoc(" heredoc_count ")" }
+  if (nlines >= line_threshold)   { score++; parts = parts (parts == "" ? "" : ", ") "long-block(" nlines ")" }
+  if (score >= min_signals) {
+    printf "[bash-heaviness] %s:%d: heavy operational bash block — %d signals: %s\n", fname, block_start, score, parts
+  }
+}
+AWK
+
+log "Scanning ${#TARGETS[@]} file(s)..."
+for t in "${TARGETS[@]}"; do
+  if [ ! -f "$t" ]; then
+    echo "WARNING: target not found: $t" >&2
+    continue
+  fi
+  awk -v fname="$t" -v line_threshold="$LINE_THRESHOLD" -v min_signals="$MIN_SIGNALS" \
+    -f "$AWK_PROG" "$t" >> "$FINDINGS_FILE" 2>/dev/null || true
+done
+
+if [ -s "$FINDINGS_FILE" ]; then
+  cat "$FINDINGS_FILE"
+  total=$(wc -l < "$FINDINGS_FILE")
+else
+  total=0
+fi
+total=$(printf '%s' "$total" | tr -d '[:space:]')
+echo "==> Total bash-heaviness findings: ${total}"
+
+if [ "$total" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+++ b/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# Tests for bash-heaviness-check.sh (Issue #1197 — #1193 提案 c)
+# Usage: bash plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/../scripts/bash-heaviness-check.sh"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT INT TERM HUP
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+echo "=== bash-heaviness-check.sh tests (Issue #1197) ==="
+echo ""
+
+mkdir -p "$TEST_DIR/plugins/rite/commands/pr"
+mkdir -p "$TEST_DIR/plugins/rite/commands/tests"
+(cd "$TEST_DIR" && git init -q 2>/dev/null || true)
+
+F="$TEST_DIR/plugins/rite/commands/fixture.md"
+REL="plugins/rite/commands/fixture.md"
+run() { bash "$TARGET" --repo-root "$TEST_DIR" --target "$1" 2>&1; }
+
+# Helper: emit N plain echo lines (filler to cross the long-block threshold).
+filler() { local n="$1" i; for ((i = 1; i <= n; i++)); do echo "echo \"line $i\""; done; }
+
+# --------------------------------------------------------------------------
+# TC-001: No arguments → exit 2 (usage error)
+# --------------------------------------------------------------------------
+echo "TC-001: No arguments → exit 2"
+rc=0; output=$(bash "$TARGET" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then pass "no args → exit 2"; else fail "expected rc=2, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-002: non-existent --repo-root → exit 2
+# --------------------------------------------------------------------------
+echo "TC-002: non-existent repo-root → exit 2"
+rc=0; output=$(bash "$TARGET" --all --repo-root "$TEST_DIR/nope" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ] && echo "$output" | grep -q "repo-root not a directory"; then
+  pass "bad repo-root → exit 2"
+else fail "expected rc=2 + message, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-003: clean short block (helper call, no signals) → exit 0, 0 findings
+# --------------------------------------------------------------------------
+echo "TC-003: clean short helper-call block → exit 0"
+{
+  echo '```bash'
+  echo 'bash plugins/rite/hooks/local-wm-update.sh "$arg"'
+  echo 'echo "done"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "clean block not flagged → exit 0"
+else fail "expected rc=0 + 0 findings, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-004: python-inline + long-block (2 signals) → exit 1
+# --------------------------------------------------------------------------
+echo "TC-004: python-inline + long-block → exit 1"
+{
+  echo '```bash'
+  echo "python3 -c 'import sys; print(sys.argv)' a b"
+  filler 26
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "python-inline" \
+   && echo "$output" | grep -q "long-block"; then
+  pass "python-inline + long-block flagged → exit 1"
+else fail "expected rc=1 + both signals, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-005: nested-cmdsub + long-block (2 signals) → exit 1
+# --------------------------------------------------------------------------
+echo "TC-005: nested-cmdsub + long-block → exit 1"
+{
+  echo '```bash'
+  echo 'msg=$(printf "%s" "$(head -1 file)")'
+  filler 26
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "nested-cmdsub"; then
+  pass "nested-cmdsub + long-block flagged → exit 1"
+else fail "expected rc=1 + nested-cmdsub, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-006: multi-heredoc (2 heredocs) + long-block → exit 1
+# --------------------------------------------------------------------------
+echo "TC-006: multi-heredoc + long-block → exit 1"
+{
+  echo '```bash'
+  echo "cat > a <<'EOF'"
+  echo 'aaa'
+  echo 'EOF'
+  echo "cat > b <<'EOF'"
+  echo 'bbb'
+  echo 'EOF'
+  filler 26
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "multi-heredoc(2)"; then
+  pass "two heredocs flagged → exit 1"
+else fail "expected rc=1 + multi-heredoc(2), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-007: long-block ONLY (single signal) → NOT flagged → exit 0
+#         The min-2-signals rule must not flag a long but simple block.
+# --------------------------------------------------------------------------
+echo "TC-007: long-block alone (1 signal) → exit 0"
+{
+  echo '```bash'
+  filler 40
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "single signal not flagged → exit 0"
+else fail "expected rc=0 (1 signal), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-008: single heredoc, short block (single signal at most) → exit 0
+# --------------------------------------------------------------------------
+echo "TC-008: single short heredoc → exit 0"
+{
+  echo '```bash'
+  echo "cat > a <<'EOF'"
+  echo 'content'
+  echo 'EOF'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ]; then pass "single heredoc not flagged → exit 0"
+else fail "expected rc=0, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-009: drift-check-ignore marker exempts a heavy block → exit 0
+# --------------------------------------------------------------------------
+echo "TC-009: drift-check-ignore exempts heavy block → exit 0"
+{
+  echo '```bash'
+  echo '# drift-check-ignore — intentional heavy example'
+  echo "python3 -c 'print(1)'"
+  filler 26
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ]; then pass "exempted block skipped → exit 0"
+else fail "expected rc=0 (exempted), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-010: heredoc BODY data must not produce python/nested signals.
+#         The body holds `$(a $(b))` and `python3 -c` text, but as literal
+#         data it is skipped — only long-block remains (1 signal) → exit 0.
+# --------------------------------------------------------------------------
+echo "TC-010: heredoc body data not counted → exit 0"
+{
+  echo '```bash'
+  echo "cat > tpl <<'EOF'"
+  echo 'example: msg=$(printf "%s" "$(inner)")'
+  echo "example: python3 -c 'print()'"
+  filler 26
+  echo 'EOF'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "heredoc body data ignored → exit 0"
+else fail "expected rc=0 (body is data), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-011: python invoking a .py script (no -c, no heredoc) is NOT python-inline.
+#         With only a long block it stays at 1 signal → exit 0.
+# --------------------------------------------------------------------------
+echo "TC-011: python script call (no -c) not python-inline → exit 0"
+{
+  echo '```bash'
+  echo 'python3 plugins/rite/hooks/work-memory-parse.py "$file"'
+  filler 30
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ]; then pass "script call not flagged as python-inline → exit 0"
+else fail "expected rc=0 (no -c), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-012: three signals (python-inline + nested + long) → exit 1, score 3
+# --------------------------------------------------------------------------
+echo "TC-012: three signals → exit 1"
+{
+  echo '```bash'
+  echo "python3 -c 'print(1)'"
+  echo 'x=$(echo "$(date)")'
+  filler 26
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "3 signals"; then
+  pass "three signals reported → exit 1"
+else fail "expected rc=1 + 3 signals, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-013: non-bash fenced block (e.g. ```text) is ignored → exit 0
+# --------------------------------------------------------------------------
+echo "TC-013: non-bash fence ignored → exit 0"
+{
+  echo '```text'
+  echo "python3 -c 'print(1)'"
+  echo 'y=$(a "$(b)")'
+  filler 30
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "non-bash fence skipped → exit 0"
+else fail "expected rc=0 (non-bash), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-014: --all excludes commands/**/tests/ fixtures
+# --------------------------------------------------------------------------
+echo "TC-014: --all excludes tests/"
+{
+  echo '```bash'
+  echo "python3 -c 'print(1)'"
+  filler 26
+  echo '```'
+} > "$TEST_DIR/plugins/rite/commands/tests/bad-fixture.md"
+# Keep the top-level fixture clean so --all stays non-empty but finds nothing.
+{
+  echo '```bash'
+  echo 'echo ok'
+  echo '```'
+} > "$F"
+rc=0; output=$(bash "$TARGET" --all --repo-root "$TEST_DIR" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ] && ! echo "$output" | grep -q "bad-fixture.md"; then
+  pass "tests/ fixtures excluded from --all → exit 0"
+else fail "expected rc=0 with no tests/ finding, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "=== Test Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+echo "TOTAL: $((PASS + FAIL))"
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+++ b/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
@@ -245,6 +245,45 @@ if [ "$rc" -eq 0 ] && ! echo "$output" | grep -q "bad-fixture.md"; then
 else fail "expected rc=0 with no tests/ finding, got rc=$rc: $output"; fi
 
 # --------------------------------------------------------------------------
+# TC-015: long-block boundary — body of exactly 24 lines (< threshold 25).
+#         python-inline is the only other signal, so long-block alone decides
+#         the outcome: 24 lines must NOT fire long-block → 1 signal → exit 0.
+#         Pins the LINE_THRESHOLD off-by-one (a 25→24 regression would fire
+#         long-block here, reaching 2 signals → exit 1, failing this TC).
+# --------------------------------------------------------------------------
+echo "TC-015: long-block boundary 24 lines (< 25) → exit 0"
+{
+  echo '```bash'
+  echo "python3 -c 'print(1)'"   # body line 1 (python-inline)
+  filler 23                       # body lines 2-24 → nlines = 24
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0" \
+   && ! echo "$output" | grep -q "long-block"; then
+  pass "24-line body below threshold → exit 0, no long-block"
+else fail "expected rc=0 + no long-block (24 lines), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-016: long-block boundary — body of exactly 25 lines (== threshold 25).
+#         python-inline + long-block → 2 signals → exit 1. Asserts the
+#         labelled line count long-block(25) to pin both the `>=` boundary
+#         (a >=25→>=26 regression would leave 25 lines at 1 signal → exit 0,
+#         failing this TC) and the nlines counting logic.
+# --------------------------------------------------------------------------
+echo "TC-016: long-block boundary 25 lines (== 25) → exit 1"
+{
+  echo '```bash'
+  echo "python3 -c 'print(1)'"   # body line 1 (python-inline)
+  filler 24                       # body lines 2-25 → nlines = 25
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "long-block(25)"; then
+  pass "25-line body at threshold → exit 1 + long-block(25)"
+else fail "expected rc=1 + long-block(25), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -505,6 +505,17 @@ OK patterns:
 **Where to Apply**:
 - `commands/**/*.md` の operational bash ブロックを新規記述 / 編集するとき。
 
+**Mechanical enforcement** (Issue #1197): 上記 Rules は `/rite:lint` Phase 3.17 (`hooks/scripts/bash-heaviness-check.sh`) が `commands/**/*.md` を走査して非ブロッキング warning として機械的に surface する (`[lint:success]` は不変)。各 bash ブロックを 4 シグナルで評価し、これは Rules と対応する:
+
+| シグナル | 判定 | 対応 Rule |
+|---------|------|----------|
+| `python-inline` | `python3 -c` / python heredoc を含む | Rule 2 |
+| `nested-cmdsub` | 入れ子 `$( … $( … )`（同一行） | Rule 3 |
+| `multi-heredoc` | heredoc が 2 つ以上 | Rule 4 |
+| `long-block` | ブロック本文が >= 25 行 | Rule 1 |
+
+**2 シグナル以上**該当したブロックのみ flag する (single signal — 単発の helper 呼び出し + 1 個の JSON heredoc、または 1 個の長文テンプレート heredoc — は誤検知を避けるため flag しない)。heredoc 本文はデータ扱いで python-inline / nested-cmdsub の評価対象外。意図的・レビュー済の重いブロックは行内 `drift-check-ignore` marker で除外できる。既存の重いブロックの helper 切り出しは段階的 cleanup であり、本 guard は awareness のための warning に留める。
+
 ---
 
 ## Phase Checklists


### PR DESCRIPTION
## 概要

`coding-principles.md` の "operational bash block heaviness convention" (#1193 で追記) を機械的に enforce する非ブロッキング lint guard を追加。`commands/**/*.md` の operational bash ブロックを静的検出し、`python3 -c` インライン / 入れ子 `$()` / 複数 heredoc / 25 行超の重さを surface する。prose-only enforcement では防げない新規 drift と、#1193 で観測された「巨大 bash ブロックが LLM のツール解析を malform させ無言停止する」failure mode の再発を予防する。

## 関連 Issue

Closes #1197

### フォローアップ（別 Issue として追跡）

- #1221: guard が surface した既存 heavy ブロック 8 件の段階的解消（#1197 スコープ外の既存負債）

## 変更内容

- **新規** `plugins/rite/hooks/scripts/bash-heaviness-check.sh`: `commands/**/*.md` の `bash`/`sh` ブロックを走査し 4 シグナル（`python-inline` / `nested-cmdsub` / `multi-heredoc` / `long-block`>=25行）を評価。**2 シグナル以上**で warning とし、単発 helper 呼び出しや単一 heredoc を誤検知しない FP 抑制設計。heredoc 本文はデータ扱いで評価対象外。`drift-check-ignore` marker で exempt 可。`--all`/`--target`/`--repo-root`/`--quiet`、exit 0/1/2、`==> Total bash-heaviness findings: N`。`sh-cross-ref-check.sh` の構造を踏襲。
- **新規** `plugins/rite/hooks/tests/bash-heaviness-check.test.sh`: 14 TC（各シグナル / 2 シグナル境界 / heredoc body データ非検知 / python スクリプト呼び出し非検知 / exemption / `--all` の tests/ 除外 / clean block）。全 PASS。
- **編集** `plugins/rite/commands/lint.md`: Phase 3.17 として非ブロッキング統合。Wiki 経験則「Asymmetric Fix Transcription」の 4-site 対称更新契約（Phase 3.X 手順 / 4.1 appendix / 4.3 summary 行 / Note policy 列挙）を遵守。
- **編集** `plugins/rite/skills/rite-workflow/references/coding-principles.md`: heaviness convention 節に機械的 enforcement（Phase 3.17）と判定基準（4 シグナル ↔ Rules 対応表、>= 2 シグナル方針）を追記し prose ↔ guard を整合。

## 検証

- 新規テスト `bash-heaviness-check.test.sh`: **14/14 PASS**
- 現行 tree への実行: 8 findings、**すべて真陽性（false-positive 0）**。AC-3（FP 許容範囲）を実測で確認。
- peer script contract の runtime 検証（`--all` 受理 / summary 行が lint.md regex と一致）済。
- 本 PR の変更 4 ファイルは他の lint self-check（drift / comment-journal / sh-cross-ref 等）に新規 warning を発生させないことを確認。

## Known Issues（非ブロッキング）

- `commands.lint: null` のため base lint は `[lint:skipped]`（プラグイン固有チェックは config 非依存で実行）。
- guard が surface した既存 heavy ブロック 8 件は #1221 で追跡。lint warning として恒常的に surface されるが `[lint:success]` は不変。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass（14/14、新規テスト追加）
- [x] Documentation updated（lint.md / coding-principles.md）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
