### PR TITLE
fix(scripts): wiki-lint-source-refs.sh の引数処理を堅牢化

### DIFF
--- a/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
@@ -69,11 +69,14 @@ Exit codes:
 EOF
 }
 
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定下で無限ループに陥る。1 回目の shift で $# を
+# 確実に 0 にし、2 回目は no-op で安全に抜ける (値欠落は下流の必須チェックが exit 2 で検出)。
 while [ $# -gt 0 ]; do
   case "$1" in
-    --branch-strategy) branch_strategy="${2:-}"; shift 2 ;;
-    --wiki-branch) wiki_branch="${2:-}"; shift 2 ;;
-    --repo-root) REPO_ROOT="${2:-}"; shift 2 ;;
+    --branch-strategy) branch_strategy="${2:-}"; shift; shift ;;
+    --wiki-branch) wiki_branch="${2:-}"; shift; shift ;;
+    --repo-root) REPO_ROOT="${2:-}"; shift; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -152,6 +155,16 @@ case "$branch_strategy" in
     exit 1
     ;;
 esac
+
+# separate_branch では --wiki-branch が必須。空のまま進むと git show "${wiki_branch}:$page" が
+# git show ":$page" となり、ref ではなく git index (staging area) を読む別 semantics に陥り、
+# legitimate absence と区別できない誤集合を構築する。header の "required for separate_branch"
+# 契約を runtime で enforce する (引数欠落 → exit 2)。
+if [ "$branch_strategy" = "separate_branch" ] && [ -z "$wiki_branch" ]; then
+  echo "ERROR: branch_strategy=separate_branch では --wiki-branch が必須です (空のため fail-fast)" >&2
+  usage >&2
+  exit 2
+fi
 
 # repo root へ移動 (separate_branch の git show / same_branch の cat はいずれも
 # repo-relative path を前提とする)。

--- a/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
@@ -229,6 +229,7 @@ else
   pass "TC-12 timeout なし (無限ループ回避)"
 fi
 assert "TC-12 exit 2 (値なしフラグは branch_strategy 空 → 必須チェックで exit 2)" "2" "$rc"
+assert_grep "TC-12 branch-strategy 必須エラー (経路固定)" "$errf" 'branch-strategy は必須'
 
 if ! print_summary "$(basename "$0")" \
   "drift: wiki-lint-source-refs.sh の挙動が変わった可能性。wiki/lint.md ステップ 6.2 委譲契約 (Issue #1195 #10) と marker block / io_error enum の出力契約を参照。"; then

--- a/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
@@ -16,6 +16,8 @@
 #   TC-8  separate_branch 抽出 (git show)
 #   TC-9  separate_branch io_error (存在しない wiki_branch ref) → read_ok=io_error
 #   TC-10 --branch-strategy 欠落 → exit 2 (invocation error)
+#   TC-11 separate_branch + 空 --wiki-branch → exit 2 (invocation error)
+#   TC-12 値なしフラグ末尾 (--branch-strategy 値なし) → exit 2、無限ループしない (timeout ガード)
 #
 # NOT covered (environment-dependent): mktemp failure on read-only /tmp,
 # sort/awk pipeline OOM. Both downgrade to io_error and are verified by reading.
@@ -203,6 +205,30 @@ printf '%s\n' ".rite/wiki/pages/p1.md" | bash "$SCRIPT" 2>"$errf" >/dev/null
 rc=$?
 assert "TC-10 exit 2 (invocation error)" "2" "$rc"
 assert_grep "TC-10 --branch-strategy 必須エラー" "$errf" 'branch-strategy は必須'
+
+# === TC-11: separate_branch + 空 --wiki-branch → exit 2 (invocation error) ===
+# (空のまま git show ":$page" が index を読む別 semantics に陥るのを fail-fast で防ぐ)
+echo "=== TC-11: separate_branch + 空 --wiki-branch ==="
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" \
+  | bash "$SCRIPT" --branch-strategy separate_branch --wiki-branch "" 2>"$errf" >/dev/null
+rc=$?
+assert "TC-11 exit 2 (invocation error)" "2" "$rc"
+assert_grep "TC-11 --wiki-branch 必須エラー" "$errf" 'separate_branch では --wiki-branch が必須'
+
+# === TC-12: 値なしフラグ末尾 → exit 2、無限ループしない (timeout ガード) ===
+# (`shift 2` のままだと $# を減らせず set -e 非設定下で無限ループ。timeout で hang を検出)
+echo "=== TC-12: 値なしフラグ末尾 (無限ループ耐性) ==="
+errf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/p1.md" \
+  | timeout 5 bash "$SCRIPT" --branch-strategy 2>"$errf" >/dev/null
+rc=$?
+if [ "$rc" -eq 124 ]; then
+  fail "TC-12 timeout (無限ループ検出) — shift 2 retが残存している可能性"
+else
+  pass "TC-12 timeout なし (無限ループ回避)"
+fi
+assert "TC-12 exit 2 (値なしフラグは branch_strategy 空 → 必須チェックで exit 2)" "2" "$rc"
 
 if ! print_summary "$(basename "$0")" \
   "drift: wiki-lint-source-refs.sh の挙動が変わった可能性。wiki/lint.md ステップ 6.2 委譲契約 (Issue #1195 #10) と marker block / io_error enum の出力契約を参照。"; then


### PR DESCRIPTION
## 概要

`wiki-lint-source-refs.sh`（wiki/lint.md ステップ 6.2 委譲先）の引数処理を堅牢化する。いずれも faithful-port の挙動を変えない hardening。

## 関連 Issue

Closes #1210

## 変更内容

### 1. separate_branch 時の空 `--wiki-branch` fail-fast
- `branch_strategy=separate_branch` かつ `wiki_branch` が空のまま進むと、`git show "${wiki_branch}:$page"` が `git show ":$page"` となり ref ではなく git index (staging area) を読む別 semantics に陥り、legitimate absence と区別できない誤集合を構築する。
- ヘッダーの "required for separate_branch" 契約を runtime で enforce し、引数欠落として `exit 2`（invocation error）で早期 fail-fast する。

### 2. 値なしフラグ末尾の `shift 2` 無限ループ耐性
- arg-parse ループの `shift 2` は、フラグが値なしで末尾に来た場合（例: `--branch-strategy` のみ）に `$#` を減らせず、`set -e` 非設定下で無限ループに陥り得た（実機検証で `rc=124` timeout を確認）。
- 各値付きフラグを `shift; shift` に変更。1 回目の shift で `$#` を確実に減らし、2 回目は no-op で安全に抜ける（値欠落は下流の必須チェックが `exit 2` で検出）。

### テスト
- TC-11: `separate_branch` + 空 `--wiki-branch` → `exit 2`
- TC-12: 値なしフラグ末尾 → `exit 2`、無限ループ非発生を `timeout` ガードで保証
- 既存 TC-1〜10 を含め全 38 ケース pass

## チェックリスト

- [x] プロジェクト規約に準拠
- [x] テスト pass（38/38）
- [ ] ドキュメント更新（不要 — 内部ヘルパーの引数 hardening、ヘッダー契約と整合）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
