### PR TITLE
fix(scripts): sibling helper の shift 2 無限ループ素因を shift; shift で遮断

### DIFF
--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -52,13 +52,16 @@ JSON_SAVED=""
 ISO_TIMESTAMP=""
 CONTENT_FILE=""
 
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --pr)                PR_NUMBER="${2:-}"; shift 2 ;;
-    --post-comment-mode) POST_COMMENT_MODE="${2:-}"; shift 2 ;;
-    --json-saved)        JSON_SAVED="${2:-}"; shift 2 ;;
-    --iso-timestamp)     ISO_TIMESTAMP="${2:-}"; shift 2 ;;
-    --content-file)      CONTENT_FILE="${2:-}"; shift 2 ;;
+    --pr)                PR_NUMBER="${2:-}"; shift; shift ;;
+    --post-comment-mode) POST_COMMENT_MODE="${2:-}"; shift; shift ;;
+    --json-saved)        JSON_SAVED="${2:-}"; shift; shift ;;
+    --iso-timestamp)     ISO_TIMESTAMP="${2:-}"; shift; shift ;;
+    --content-file)      CONTENT_FILE="${2:-}"; shift; shift ;;
     *) echo "ERROR: review-comment-post: unknown option: $1" >&2; exit 1 ;;
   esac
 done

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -47,11 +47,14 @@ PR_NUMBER=""
 CONTENT_FILE=""
 REVIEW_RESULTS_DIR=".rite/review-results"
 
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --pr)           PR_NUMBER="${2:-}"; shift 2 ;;
-    --content-file) CONTENT_FILE="${2:-}"; shift 2 ;;
-    --results-dir)  REVIEW_RESULTS_DIR="${2:-}"; shift 2 ;;
+    --pr)           PR_NUMBER="${2:-}"; shift; shift ;;
+    --content-file) CONTENT_FILE="${2:-}"; shift; shift ;;
+    --results-dir)  REVIEW_RESULTS_DIR="${2:-}"; shift; shift ;;
     *) echo "ERROR: review-result-save: unknown option: $1" >&2; exit 1 ;;
   esac
 done

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -44,23 +44,27 @@ ORIGINAL_STASH_COUNT=""
 ORIGINAL_BRANCH_LIST_HASH=""
 AUTO_RECOVER="true"
 
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
+# (--original-branch 欠落はループ後の必須チェックが exit 2 で検出)。
 while [ $# -gt 0 ]; do
   case "$1" in
     --original-branch)
       ORIGINAL_BRANCH="${2:-}"
-      shift 2
+      shift; shift
       ;;
     --original-stash-count)
       ORIGINAL_STASH_COUNT="${2:-}"
-      shift 2
+      shift; shift
       ;;
     --original-branch-list-hash)
       ORIGINAL_BRANCH_LIST_HASH="${2:-}"
-      shift 2
+      shift; shift
       ;;
     --auto-recover)
       AUTO_RECOVER="${2:-true}"
-      shift 2
+      shift; shift
       ;;
     *)
       echo "ERROR: unknown argument: $1" >&2

--- a/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
+++ b/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# shift2-loop-hardening.test.sh
+#
+# Regression tests for Issue #1224: sibling helper の `shift 2` 無限ループ素因の横展開 hardening。
+#
+# PR #1223 が wiki-lint-source-refs.sh に適用した `shift 2` → `shift; shift` 化を、同型脆弱性を
+# 持つ全 sibling helper (hooks/scripts/ に留まらず hooks/ と scripts/ にも存在) へ横展開した。
+#
+# 脆弱性の成立条件 (3つ全て揃うと値なしフラグ末尾で無限ループ):
+#   1. グローバル `set -e` がない (`shift 2` の rc=1 で exit しない)
+#   2. 値代入が `"${2:-}"` (デフォルト展開 → `set -u` の nounset が発火しない)
+#   3. `shift 2` 到達前に required-value ガードがない
+# (1つでも欠ければ安全: set -u+bare $2 は nounset で fail-fast / set -e は即 exit / 明示ガードは exit)
+#
+# Coverage (脆弱だった 5 スクリプト, 計 18 箇所):
+#   TC-1 post-review-state-verify.sh (hooks/scripts/, 4 箇所) — 値なしフラグ末尾 → no-hang + exit 2
+#   TC-2 review-comment-post.sh      (hooks/,         5 箇所) — 値なしフラグ末尾 → no-hang
+#   TC-3 review-result-save.sh       (hooks/,         3 箇所) — 値なしフラグ末尾 → no-hang
+#   TC-4 review-source-resolve.sh    (scripts/,       5 箇所) — 値なしフラグ末尾 → no-hang
+#   TC-5 decompose-issues.sh         (scripts/,       1 箇所) — 値なしフラグ末尾 → no-hang + exit 2
+#   TC-6 anti-pattern guard — 5 スクリプトに実 `shift 2` 文が残存しないこと (comment 参照は許容)
+#
+# 各 TC は `timeout 5` で hang (exit 124) を検出する。値なしフラグはいずれも required value を
+# 空にし、ループ完了後のローカル guard で exit する経路 (network/git に触れない) を選択している。
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+
+# 値なしフラグ末尾で no-hang を検証。expect_rc 非空ならその exit code も assert。
+# 引数: <label> <plugin-relative script path> <値なしで末尾に置くフラグ> <expect_rc|"">
+run_no_hang() {
+  local label="$1" script="$2" flag="$3" expect_rc="$4"
+  local path="$PLUGIN_ROOT/$script"
+  if [ ! -f "$path" ]; then
+    echo "ERROR: script not found: $path" >&2
+    fail "$label (script not found)"
+    return
+  fi
+  local rc=0
+  timeout 5 bash "$path" "$flag" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 124 ]; then
+    fail "$label: 値なしフラグ '$flag' 末尾で timeout=124 (無限ループ検出 — shift 2 残存の可能性)"
+  else
+    pass "$label: 値なしフラグ '$flag' 末尾で no-hang (rc=$rc)"
+  fi
+  if [ -n "$expect_rc" ]; then
+    assert "$label: exit $expect_rc (required-value guard 到達)" "$expect_rc" "$rc"
+  fi
+}
+
+echo "=== TC-1〜TC-5: 値なしフラグ末尾の無限ループ耐性 ==="
+run_no_hang "TC-1 post-review-state-verify" "hooks/scripts/post-review-state-verify.sh" "--original-branch" "2"
+run_no_hang "TC-2 review-comment-post"      "hooks/review-comment-post.sh"             "--pr"              ""
+run_no_hang "TC-3 review-result-save"       "hooks/review-result-save.sh"              "--pr"              ""
+run_no_hang "TC-4 review-source-resolve"    "scripts/review-source-resolve.sh"         "--pr-number"       ""
+run_no_hang "TC-5 decompose-issues"         "scripts/decompose-issues.sh"              "--spec"            "2"
+
+# === TC-6: anti-pattern guard — 実 `shift 2` 文が再混入していないこと ===
+# comment 内の `shift 2` 参照 (backtick 囲み) は許容し、実際の statement だけを検出する。
+# 実 statement は行頭 or `;` の直後に現れる: (^|;)<空白>*shift 2<空白/;/行末>。
+echo "=== TC-6: anti-pattern guard (実 shift 2 文の不在) ==="
+for script in \
+  "hooks/scripts/post-review-state-verify.sh" \
+  "hooks/review-comment-post.sh" \
+  "hooks/review-result-save.sh" \
+  "scripts/review-source-resolve.sh" \
+  "scripts/decompose-issues.sh"; do
+  path="$PLUGIN_ROOT/$script"
+  real_hits=$(grep -nE '(^|;)[[:space:]]*shift 2([[:space:]]|;|$)' "$path" || true)
+  if [ -n "$real_hits" ]; then
+    fail "TC-6 $(basename "$script"): 実 shift 2 文が残存"
+    printf '%s\n' "$real_hits"
+  else
+    pass "TC-6 $(basename "$script"): 実 shift 2 文なし (comment 参照のみ)"
+  fi
+done
+
+if ! print_summary "$(basename "$0")" \
+  "drift: shift-2 loop hardening (Issue #1224) が後退した可能性。値付きフラグは set -e 非設定 + \${2:-} の下では \`shift; shift\` で消費しないと値なしフラグ末尾 (\$#=1) で無限ループに陥る。"; then
+  exit 1
+fi

--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -58,10 +58,14 @@ LINK_SCRIPT="$SCRIPT_DIR/link-sub-issue.sh"
 ISSUE_BODY_SCRIPT="$SCRIPT_DIR/../hooks/issue-body-safe-update.sh"
 
 # --- Argument parsing ---
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
+# (--spec 欠落はループ後の必須チェックが exit 2 で検出)。
 SPEC=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --spec) SPEC="${2:-}"; shift 2 ;;
+    --spec) SPEC="${2:-}"; shift; shift ;;
     *) echo "ERROR: unknown argument: $1" >&2; echo "Usage: $0 --spec <spec.json>" >&2; exit 2 ;;
   esac
 done

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -75,13 +75,16 @@ review_file_path=""
 conversation_review_decision=""
 p1_scan_turns=""
 p1_scan_found=""
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pr-number)             pr_number="${2:-}"; shift 2 ;;
-    --review-file-path)      review_file_path="${2:-}"; shift 2 ;;
-    --conversation-decision) conversation_review_decision="${2:-}"; shift 2 ;;
-    --p1-scan-turns)         p1_scan_turns="${2:-}"; shift 2 ;;
-    --p1-scan-found)         p1_scan_found="${2:-}"; shift 2 ;;
+    --pr-number)             pr_number="${2:-}"; shift; shift ;;
+    --review-file-path)      review_file_path="${2:-}"; shift; shift ;;
+    --conversation-decision) conversation_review_decision="${2:-}"; shift; shift ;;
+    --p1-scan-turns)         p1_scan_turns="${2:-}"; shift; shift ;;
+    --p1-scan-found)         p1_scan_found="${2:-}"; shift; shift ;;
     *)
       echo "ERROR: review-source-resolve.sh: 未知の引数: $1" >&2
       exit 2


### PR DESCRIPTION
## 概要

PR #1223 が `wiki-lint-source-refs.sh` に適用した `shift 2` → `shift; shift` hardening を、同型脆弱性を持つ全 sibling helper へ横展開する。値なしフラグが argv 末尾 (`$#=1`) に来た場合に `shift 2` が `$#` を減らせず無限ループに陥る素因を遮断する（計 18 箇所）。

## 関連 Issue

Closes #1224

## 脆弱性の成立条件（実機検証で確定）

3 条件が全て揃うと値なしフラグ末尾で無限ループに陥る:

1. グローバル `set -e` が**ない**（`shift 2` の rc=1 で exit しない）
2. 値代入が `"${2:-}"`（デフォルト展開 → `set -u` の nounset が発火しない）
3. `shift 2` 到達前に required-value ガードが**ない**

1 つでも欠ければ安全。各スクリプトを `timeout` ガード付きで実行し、修正前は exit 124（hang）、修正後は no-hang（required は exit 2、optional は exit 1）であることを実証した。

## 変更内容

`shift 2` → `shift; shift` 化（1 回目で `$#` を 0 にし、2 回目は no-op で安全に抜ける）+ hazard コメント追加:

| スクリプト | 場所 | 箇所 |
|-----------|------|------|
| `post-review-state-verify.sh` | `hooks/scripts/` | 4 |
| `review-comment-post.sh` | `hooks/` | 5 |
| `review-result-save.sh` | `hooks/` | 3 |
| `review-source-resolve.sh` | `scripts/` | 5 |
| `decompose-issues.sh` | `scripts/` | 1 |

加えて回帰テスト `hooks/tests/shift2-loop-hardening.test.sh` を新規追加（値なしフラグ末尾の no-hang × 5 + anti-pattern guard）。

## スコープに関する補足

元レビュー推奨と Issue body の file glob は `hooks/scripts/*.sh` のみだったが、調査の結果、同型脆弱性は sibling ディレクトリ（`hooks/`, `scripts/`）にも存在した（全件 hang を実証）。修正が全件機械的に同一なため、既知の hang を残さないよう全 5 件を本 PR で対応した（スコープ拡張は事前に合意済み）。

## 横展開不要と判断したもの（理由記録）

- 修正済（PR #1223）: `wiki-lint-source-refs.sh`
- `set -euo`（-e 有効、即 exit）: `comment-journal` / `comment-line-ref` / `hardcoded-line-number` / `wiki-worktree-commit`
- `set -u` + bare `$2`（nounset で fail-fast）: `backlink-format` / `bang-backtick` / `bash-heaviness` / `distributed-fix-drift` / `doc-heavy-patterns` / `gitignore-health` / `sh-cross-ref` / `wiki-growth`
- 明示ガード（exit）: `review-schema-version-check`（`-z "${2:-}"` → exit 2） / `wiki-query-inject`（`_require_option_value` → exit 1）

## チェックリスト

- [x] プロジェクト規約に準拠（`shift; shift` パターンは PR #1223 を踏襲、faithful hardening）
- [x] 回帰テスト追加・全テスト pass（hook テストスイート 54/54）
- [x] 通常系（複数フラグ）の挙動が壊れないことを smoke 検証

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
