### PR TITLE
docs(review): json_invalid 経路の runtime WARNING を実挙動コメントと整合

### DIFF
--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -208,7 +208,7 @@ fi
 # effectively unreachable (その経路の実発火 reason は write_failure)。
 jq_val_err_r=$(mktemp /tmp/rite-jq-val-err-r-XXXXXX 2>/dev/null) || jq_val_err_r=""
 if ! jq empty "$json_tmp" 2>"${jq_val_err_r:-/dev/null}"; then
-  echo "WARNING: JSON 一時ファイルが syntactically invalid です (literal substitute 漏れの可能性)" >&2
+  echo "WARNING: JSON 一時ファイルが syntactically invalid です (注入後に外部要因で破損した稀ケース。通常の literal substitute 漏れは upstream の write_failure で検出済)" >&2
   [ -n "${jq_val_err_r:-}" ] && [ -s "$jq_val_err_r" ] && head -3 "$jq_val_err_r" | sed 's/^/  jq: /' >&2
   echo "  内容 preview (先頭 5 行):" >&2
   head -5 "$json_tmp" 2>/dev/null | sed 's/^/  /' >&2


### PR DESCRIPTION
## 概要

`review-result-save.sh` の `json_invalid` 経路（`jq empty` post-condition backstop）の runtime WARNING 文言を、PR #1226 で追加した実挙動コメントと整合させた。括弧書きを「(literal substitute 漏れの可能性)」から「(注入後に外部要因で破損した稀ケース。通常の literal substitute 漏れは upstream の write_failure で検出済)」に補足し、runtime メッセージ・inline コメント・review.md doc の三者の語感を揃えた。

`json_invalid` 経路は jq timestamp 注入が入力 JSON を parse・再シリアライズして valid JSON を保証するため syntactic invalidity では到達不能であり、実発火 reason は upstream の `write_failure`。旧文言はこの実挙動と語感がずれていた。

## 関連 Issue

Closes #1227

## 変更内容

- `plugins/rite/hooks/review-result-save.sh` - `json_invalid` 経路 WARNING 文言の補足（line 211、1 行）

reason 文字列 (`json_invalid`) / `[CONTEXT] LOCAL_SAVE_FAILED` emit / 非ブロッキング契約 (`exit 0`) は不変。validation chain の制御フローおよび `jq empty` check 自体は変更なし。

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし — commands.test 未設定）
- [x] ドキュメント整合（runtime WARNING と inline コメント / review.md doc の語感を統一）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
