### PR TITLE
refactor(init): init.md の python-inline JSON 編集を helper script へ切り出し (refs #1221)

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -682,7 +682,7 @@ fi
    bash "{hooks_dir}/scripts/settings-local-rite-hook-cleanup.sh" ".claude/settings.local.json"
    ```
 
-   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は python3 不在・file 不在・対象 hook 不在のいずれでも `NO_RITE_HOOKS` を返し silent skip 相当となる。rite hook を実際に除去したときのみ `CLEANED` を返す (`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠)。
+   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は **rite hook を実際に除去したときのみ** `CLEANED` を返し、それ以外の安全側ケース (python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む) ではすべて `NO_RITE_HOOKS` を返して silent skip 相当となる。`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
 
    - If `CLEANED` → display `ℹ️ settings.local.json からレガシー rite hook エントリを削除しました。`
    - If `NO_RITE_HOOKS` → no output (already clean)

--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -678,51 +678,11 @@ fi
 2. **Clean up stale rite hooks from `settings.local.json`**: Read `.claude/settings.local.json` and remove all hook entries whose command contains `rite/hooks/`. Non-rite hooks must be preserved. If the file does not exist or has no rite hooks, skip this step silently.
 
    ```bash
-   # settings.local.json から rite hook エントリを削除
-   _settings_local=".claude/settings.local.json"
-   if [ -f "$_settings_local" ] && command -v python3 &>/dev/null; then
-     _tmp=$(mktemp "${_settings_local}.XXXXXX" 2>/dev/null) || _tmp=""
-     if [ -n "$_tmp" ] && python3 -c '
-   import json, sys, re
-   settings_path = sys.argv[1]
-   out_path = sys.argv[2]
-   with open(settings_path, "r") as f:
-       data = json.load(f)
-   hooks = data.get("hooks", {})
-   if not hooks:
-       sys.exit(1)
-   rite_hook_re = re.compile(r"rite.*?/hooks/")
-   changed = False
-   for event_name in list(hooks.keys()):
-       entries = hooks[event_name]
-       if not isinstance(entries, list):
-           continue
-       new_entries = []
-       for entry in entries:
-           hook_list = entry.get("hooks", [])
-           has_rite = any(rite_hook_re.search(h.get("command", "")) for h in hook_list)
-           if has_rite:
-               changed = True
-           else:
-               new_entries.append(entry)
-       if new_entries:
-           hooks[event_name] = new_entries
-       else:
-           del hooks[event_name]
-   if not changed:
-       sys.exit(1)
-   with open(out_path, "w") as f:
-       json.dump(data, f, indent=2, ensure_ascii=False)
-       f.write("\n")
-   ' "$_settings_local" "$_tmp" 2>/dev/null; then
-       mv "$_tmp" "$_settings_local" 2>/dev/null
-       echo "CLEANED"
-     else
-       rm -f "$_tmp" 2>/dev/null
-       echo "NO_RITE_HOOKS"
-     fi
-   fi
+   # settings.local.json から rite hook エントリを削除 (python3 guard・atomic write・JSON 変換は helper に委譲)
+   bash "{hooks_dir}/scripts/settings-local-rite-hook-cleanup.sh" ".claude/settings.local.json"
    ```
+
+   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は python3 不在・file 不在・対象 hook 不在のいずれでも `NO_RITE_HOOKS` を返し silent skip 相当となる。rite hook を実際に除去したときのみ `CLEANED` を返す (`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠)。
 
    - If `CLEANED` → display `ℹ️ settings.local.json からレガシー rite hook エントリを削除しました。`
    - If `NO_RITE_HOOKS` → no output (already clean)

--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.py
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""rite workflow - settings.local.json rite hook cleanup transform
+
+Pure JSON transformation: reads .claude/settings.local.json from stdin, removes
+every hook entry whose command references a rite hook (matches `rite.../hooks/`),
+and writes the cleaned JSON to stdout. Non-rite hooks are preserved. Hook events
+left with no entries are dropped. No file I/O, no API calls — the atomic write is
+handled by the calling bash wrapper (settings-local-rite-hook-cleanup.sh).
+
+Used by commands/init.md Phase 4.5.0.2 when native hooks.json management is in
+effect, to clear stale legacy rite hook registrations.
+
+Usage:
+    python3 settings-local-rite-hook-cleanup.py < settings.local.json > cleaned.json
+
+Exit codes:
+    0: rite hook entries removed — cleaned JSON written to stdout
+    1: no change (no `hooks` section, or no rite hook entries) — nothing written
+    2: stdin is not valid JSON — nothing written
+"""
+import json
+import re
+import sys
+
+RITE_HOOK_RE = re.compile(r"rite.*?/hooks/")
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 2
+
+    hooks = data.get("hooks", {})
+    if not hooks:
+        return 1
+
+    changed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        new_entries = []
+        for entry in entries:
+            hook_list = entry.get("hooks", [])
+            has_rite = any(
+                RITE_HOOK_RE.search(h.get("command", "")) for h in hook_list
+            )
+            if has_rite:
+                changed = True
+            else:
+                new_entries.append(entry)
+        if new_entries:
+            hooks[event_name] = new_entries
+        else:
+            del hooks[event_name]
+
+    if not changed:
+        return 1
+
+    json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# rite workflow - settings.local.json rite hook cleanup
+#
+# Removes stale legacy rite hook entries from .claude/settings.local.json when
+# native hooks.json management is in effect (commands/init.md Phase 4.5.0.2).
+# The JSON transform is delegated to settings-local-rite-hook-cleanup.py
+# (stdin->stdout); this wrapper owns the python3 guard and the atomic
+# mktemp+mv write so the file is never left half-written.
+#
+# Usage:
+#   bash settings-local-rite-hook-cleanup.sh <settings_local_path>
+#
+# Output (stdout) — machine-readable token for the init.md caller:
+#   CLEANED        rite hook entries removed; file rewritten atomically
+#   NO_RITE_HOOKS  nothing removed (no hooks / no rite hooks / file absent /
+#                  python3 unavailable / invalid JSON) — file left untouched
+#
+# Exit codes:
+#   0  always (non-blocking; status conveyed via the stdout token)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_SCRIPT="$SCRIPT_DIR/settings-local-rite-hook-cleanup.py"
+
+settings="${1:-}"
+if [ -z "$settings" ] || [ ! -f "$settings" ] || ! command -v python3 >/dev/null 2>&1; then
+  echo "NO_RITE_HOOKS"
+  exit 0
+fi
+
+# tmp in the same dir as the target so mv is an atomic same-filesystem rename
+tmp=$(mktemp "${settings}.XXXXXX" 2>/dev/null) || tmp=""
+if [ -z "$tmp" ]; then
+  echo "NO_RITE_HOOKS"
+  exit 0
+fi
+trap 'rm -f "$tmp"' EXIT
+
+# python3 exit 0 = changed (cleaned JSON on stdout); non-zero = no change / invalid
+if python3 "$PYTHON_SCRIPT" < "$settings" > "$tmp" 2>/dev/null; then
+  if mv "$tmp" "$settings" 2>/dev/null; then
+    echo "CLEANED"
+  else
+    echo "NO_RITE_HOOKS"
+  fi
+else
+  echo "NO_RITE_HOOKS"
+fi


### PR DESCRIPTION
## 概要

`bash-heaviness-check.sh` (/rite:lint Phase 3.17) が surface した heavy operational bash ブロック 8 件のうち、`commands/init.md` の python-inline ブロック (`python3 -c` インライン JSON 編集 + long-block 44 行) 1 件を helper 切り出しで解消する。

`settings.local.json` から rite hook エントリを削除するロジックを `hooks/scripts/settings-local-rite-hook-cleanup.{py,sh}` へ切り出し、`init.md` 本文を 2 行の wrapper 呼び出しに置換した。coding-principles の "operational bash block heaviness convention" Rule 2 (python は `.py` を `.sh` wrapper 経由で呼ぶ) に準拠。

## 関連 Issue

Refs #1221

> この PR は Issue #1221 (8 ブロック) のうち **1 件のみ**を解消する部分対応です。Issue 本文の方針「スコープが膨らむため一括は非推奨」に従い、残り 7 件は別 PR で対応します。**マージしても Issue #1221 は閉じません** (`Closes` を意図的に使用していません)。

## 変更内容

- `hooks/scripts/settings-local-rite-hook-cleanup.py` (新規): stdin→stdout の純粋 JSON transform。rite hook エントリを除去 (exit 0=変更 / 1=変更なし / 2=不正JSON)
- `hooks/scripts/settings-local-rite-hook-cleanup.sh` (新規): wrapper。path 検証・python3 guard・mktemp+mv atomic write・`CLEANED`/`NO_RITE_HOOKS` token を担当
- `commands/init.md`: ~44 行の python-inline ブロックを wrapper 呼び出し 2 行に置換 (`CLEANED`/`NO_RITE_HOOKS` 解釈プローズは不変)

## 検証

- 元の `python3 -c` インラインと新 helper の**挙動等価性**を 5 fixture で確認 (出力・exit code 完全一致。silent skip・atomic write・エントリ単位削除を保持)
- `bash-heaviness-check.sh --all`: findings **8 → 7** (init.md ブロック消滅)
- `/rite:lint` Phase 3.5–3.17 全実行: **新規 warning ゼロ** (残存 warning は本 PR 範囲外の既存負債)

## 未完了の Issue チェック項目

Issue #1221 の残り 7 ブロック (別 PR で対応予定):

- [ ] `commands/issue/close.md` (nested-cmdsub + long 77)
- [ ] `commands/issue/create.md` (nested-cmdsub + long 51)
- [ ] `commands/issue/references/fingerprint-cycling.md` (nested-cmdsub + long 40)
- [ ] `commands/pr/cleanup.md` (nested-cmdsub + long 78)
- [ ] `commands/pr/create.md` (nested-cmdsub + long 56)
- [ ] `commands/pr/review.md` (multi-heredoc 2 + long 142)
- [ ] `commands/pr/review.md` (nested-cmdsub + long 67)

## チェックリスト

- [x] プロジェクト規約に準拠 (coding-principles Rule 2 の .py+.sh wrapper 先例)
- [x] 既存ワークフロー契約を verbatim 継承 (fixture 等価性確認済)
- [x] ドキュメント更新 (init.md 本文 + helper contract 注記)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
