### PR TITLE
refactor(issue): bash-heaviness の issue/* グループ 3 ブロックを解消 (refs #1221)

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -541,6 +541,9 @@ fi
 
 ```bash
 set -uo pipefail
+# drift-check-ignore: 親 Status→Done + close + 不整合サマリ (Step 1-3) を単一 atomic block に
+#   保つのは意図的な設計 (#517 silent-corruption 可視化 / #658 substep 間 attention 喪失回避)。
+#   phase 分割は両不変条件を壊すため不可。refs #1221。
 parent_number="{parent_number}"
 owner="{owner}"
 repo="{repo}"

--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -151,6 +151,9 @@ AskUserQuestion で Issue の以下を確認/補完する:
 `create-issue-with-projects.sh` に委譲（Issue 作成 + Projects 追加 + status / priority / complexity 設定を 1 ステップで実行）。実 interface は JSON 単一引数 + body は tmpfile 経由（canonical SoT: [`issue-create-with-projects.md`](../../references/issue-create-with-projects.md)）:
 
 ```bash
+# drift-check-ignore: この canonical な「JSON を helper へ単一引数で渡す nested 形態」は
+#   create-md-invocation-symmetry.test.sh (TC-1/TC-2/TC-4/TC-1e) と SoT が test 強制しているため
+#   pipe 形式へ書き換えられない。heaviness は意図的に許容する (refs #1221)。
 # body を tmpfile に書く (LLM が {body} 部分を実 markdown に展開してから heredoc に流す)
 tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT

--- a/plugins/rite/commands/issue/references/fingerprint-cycling.md
+++ b/plugins/rite/commands/issue/references/fingerprint-cycling.md
@@ -187,7 +187,8 @@ cat <<'BODY_EOF' > "$tmpfile"
 - 元の PR: #{pr_number}
 BODY_EOF
 
-result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
+# jq -n の出力を stdin で create-issue-with-projects.sh に渡す (pr/review.md §3992 / Issue #1193 #5 と同じ pipe 形式、入れ子 $() を回避)
+result=$(jq -n \
   --arg title "review-split: {short_summary}" \
   --arg body_file "$tmpfile" \
   --argjson projects_enabled {projects_enabled} \
@@ -207,8 +208,7 @@ result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
       iteration: { mode: "none" }
     },
     options: { source: "fingerprint_split", non_blocking_projects: true }
-  }'
-)")
+  }' | bash {plugin_root}/scripts/create-issue-with-projects.sh)
 new_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
 echo "✅ Fingerprint 循環 finding を #$(printf '%s' "$result" | jq -r '.issue_number') として切り出しました: $new_issue_url"
 ```


### PR DESCRIPTION
## 概要

Issue #1221（bash-heaviness-check が検出した重い operational bash ブロック 8 件の段階的解消）のうち、**`issue/*` グループ 3 ブロック**を解消します。

`init.md` 1 件は既に #1229 で解消済み。本 PR で 3 件、残り `pr/*` 4 件は別 PR で対応予定（Issue 本文の「一括は非推奨」方針に従いグループ単位で分割）。

## 変更内容（ブロックごとに最適解が異なる）

| ブロック | シグナル | 方針 | 理由 |
|---|---|---|---|
| `issue/references/fingerprint-cycling.md` §4 | nested-cmdsub, long-block(40) | **pipe 形式へ refactor** | `jq -n … \| bash create-issue-with-projects.sh` 化で入れ子 `$()` を除去。`pr/review.md` §3992（#1193 #5）に同一先例。helper は元々 stdin 入力対応済 |
| `issue/create.md` §4.3 | nested-cmdsub, long-block(51) | **`drift-check-ignore` で exempt** | この `"$(jq -n …)"` nested 形式は `create-md-invocation-symmetry.test.sh`（TC-1/TC-2/TC-4/TC-1e）と SoT が canonical として test 強制しており、pipe 化すると CI が割れる。「意図的・レビュー済の重いブロック」に該当 |
| `issue/close.md` §4.6.3 | nested-cmdsub, long-block(77) | **`drift-check-ignore` で exempt** | 親 Status→Done + close + 不整合サマリ(Step 1-3)を単一 atomic block に保つ意図的設計。#517（silent data corruption 可視化）/ #658（substep 間 attention 喪失回避）を満たすため。phase 分割は両不変条件を壊すため不可 |

exempt 2 件はいずれも marker 行に**理由コメント**を併記し、単なる silence でなく意図表明にしています。

## 検証

- `bash-heaviness-check.sh --all` findings: **7 → 4**（issue/* の 3 件が消失、残り 4 件は pr/*）
- `create-md-invocation-symmetry.test.sh`: **16 PASS / 0 FAIL**（canonical 形式の test 強制が維持されていることを確認）
- hooks/tests: **54/54 PASS** / scripts/tests: **37/37 PASS**

## Acceptance Criteria（本 PR 分）

- [x] issue/* の 3 ブロックを helper 切り出し(1) / exempt(2) で解消
- [x] heaviness findings が 3 件減少（7→4）
- [x] 既存ワークフロー契約（symmetry test / #517 invariant）が保たれていることを確認

## 関連

- 親 Issue: #1221（残り pr/* 4 件は別 PR）
- 既解消: #1229（init.md）
- guard 追加: #1197 / 規約: #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
