### PR TITLE
fix(hooks): settings.local.json cleanup の rite hook regex を path 境界で厳密化

### DIFF
--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.py
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.py
@@ -2,7 +2,8 @@
 """rite workflow - settings.local.json rite hook cleanup transform
 
 Pure JSON transformation: reads .claude/settings.local.json from stdin, removes
-every hook entry whose command references a rite hook (matches `rite.../hooks/`),
+every hook entry whose command references a rite hook (command path contains
+`rite` as a full segment immediately above the hooks dir — see RITE_HOOK_RE),
 and writes the cleaned JSON to stdout. Non-rite hooks are preserved. Hook events
 left with no entries are dropped. No file I/O, no API calls — the atomic write is
 handled by the calling bash wrapper (settings-local-rite-hook-cleanup.sh).
@@ -22,7 +23,14 @@ import json
 import re
 import sys
 
-RITE_HOOK_RE = re.compile(r"rite.*?/hooks/")
+# Match `rite` only as a complete path segment directly above the hooks dir,
+# allowing one optional segment (the plugin version) in between. This covers both
+# real command shapes — cache install `.../rite-marketplace/rite/<version>/hooks/`
+# and dev/relative `.../rite/hooks/` — while rejecting look-alikes where `rite` is
+# merely a substring of another segment (`favorite/hooks/`, `prerite/hooks/`,
+# `rite-something/hooks/`), which the old `rite.*?/hooks/` over-matched and could
+# silently strip user-defined non-rite hooks from settings.local.json (Issue #1231).
+RITE_HOOK_RE = re.compile(r"(?:^|/)rite/(?:[^/]+/)?hooks/")
 
 
 def main():

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -193,7 +193,12 @@ hooks = data.get("hooks", {})
 if not hooks:
     sys.exit(1)
 
-rite_hook_re = re.compile(r"rite.*?/hooks/")
+# Anchor `rite` to a full path segment (optional version segment between it and
+# the hooks dir) so cache `.../rite/<version>/hooks/` and dev `.../rite/hooks/`
+# match while look-alikes (favorite/, prerite/, rite-something/) do not — the old
+# `rite.*?/hooks/` over-matched user non-rite hooks. Kept in sync with
+# scripts/settings-local-rite-hook-cleanup.py:RITE_HOOK_RE (Issue #1231).
+rite_hook_re = re.compile(r"(?:^|/)rite/(?:[^/]+/)?hooks/")
 changed = False
 
 for event_name in list(hooks.keys()):

--- a/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
@@ -11,6 +11,9 @@
 #   2. `.py` selective removal of mixed rite/non-rite entries + event-key deletion
 #   3. `.sh` token folding: python3 exit 1/2 both collapse to NO_RITE_HOOKS
 #   4. `.sh` mv-failure path (guarded mv → NO_RITE_HOOKS), atomic write, trap cleanup
+#   5. RITE_HOOK_RE over-match boundary (#1231): `rite` must be a full path segment,
+#      so look-alikes (favorite/, prerite/, rite-something/) are preserved while the
+#      real cache form `rite-marketplace/rite/<version>/hooks/` is still removed
 #
 # The mv-failure case reuses the PATH-shimmed `mv` technique from the precedent
 # test issue-comment-wm-sync.test.sh (a `bin/mv` that exits non-zero, prepended to
@@ -140,6 +143,39 @@ assert_not_grep "P-5: rite entry (pre-tool-bash-guard) は除去" "$out" 'pre-to
 assert_grep     "P-5: 混在 event key (PreToolUse) は残存" "$out" 'PreToolUse'
 assert_not_grep "P-6: 全 rite event key (SessionStart) は削除" "$out" 'SessionStart'
 
+# ─── over-match 境界 (#1231): look-alike 保持 / cache version 形除去 (B-1〜B-3) ─
+echo ""
+echo "=== over-match 境界 regex (#1231) (B-1〜B-3) ==="
+
+# B-1: `rite` を部分文字列に含むだけの非 rite hook は除去対象外 (exit 1, 無出力)。
+# 旧 regex `rite.*?/hooks/` はこれらを誤マッチしユーザー hook を silent 除去していた。
+out="$(fresh)/out.json"
+printf '%s' '{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"bash /home/u/projects/favorite/hooks/foo.sh"}]},{"hooks":[{"type":"command","command":"node /opt/prerite/hooks/lint.js"}]},{"hooks":[{"type":"command","command":"bash /path/rite-something/hooks/bar.sh"}]}]}}' \
+  | python3 "$PY" > "$out" 2>/dev/null
+rc=$?
+assert "B-1: look-alike (favorite/prerite/rite-something) は非 rite → exit 1" "1" "$rc"
+assert_empty_file "B-1: stdout 空 (誤除去なし)" "$out"
+
+# B-2: 実 cache install 形 `.../rite-marketplace/rite/<version>/hooks/` は除去対象
+# (false-negative ガード — version segment を挟んでも rite segment を正しく検出)。
+out="$(fresh)/out.json"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /home/u/.claude/plugins/cache/rite-marketplace/rite/0.2.0/hooks/session-start.sh"}]}]}}' \
+  | python3 "$PY" > "$out" 2>/dev/null
+rc=$?
+assert "B-2: cache version 形 (rite/0.2.0/hooks/) は除去 → exit 0" "0" "$rc"
+
+# B-3: cache 形 rite hook と 3 種の look-alike を混在 → rite のみ除去、look-alike は保持。
+out="$(fresh)/out.json"
+printf '%s' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /home/u/.claude/plugins/cache/rite-marketplace/rite/0.2.0/hooks/pre-tool-bash-guard.sh"}]},{"matcher":"A","hooks":[{"type":"command","command":"bash /home/u/projects/favorite/hooks/foo.sh"}]},{"matcher":"B","hooks":[{"type":"command","command":"node /opt/prerite/hooks/lint.js"}]},{"matcher":"C","hooks":[{"type":"command","command":"bash /path/rite-something/hooks/bar.sh"}]}]}}' \
+  | python3 "$PY" > "$out" 2>/dev/null
+rc=$?
+assert "B-3: 混在 (cache rite + look-alike) → exit 0" "0" "$rc"
+assert_valid_json "B-3: cleaned JSON valid" "$out"
+assert_not_grep "B-3: cache rite hook (rite-marketplace) は除去" "$out" 'rite-marketplace'
+assert_grep     "B-3: look-alike favorite は保持" "$out" 'favorite'
+assert_grep     "B-3: look-alike prerite は保持" "$out" 'prerite'
+assert_grep     "B-3: look-alike rite-something は保持" "$out" 'rite-something'
+
 # ─── .sh token folding + atomic write (S-1〜S-3) ─────────────────────────
 echo ""
 echo "=== .sh token 畳み込み / atomic write (S-1〜S-3) ==="
@@ -215,6 +251,6 @@ assert_no_leftover_tmp "S-5: trap cleanup で残留 tmp なし" "$f"
 
 echo ""
 if ! print_summary "$(basename "$0")" \
-  "drift: settings-local-rite-hook-cleanup helper (#1230) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup を確認。"; then
+  "drift: settings-local-rite-hook-cleanup helper (#1230 / #1231) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、over-match 境界 (#1231: look-alike favorite/prerite/rite-something は保持・cache version 形 rite/0.2.0/hooks/ は除去)、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup を確認。"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`settings.local.json` から rite hook エントリを除去する cleanup の正規表現 `rite.*?/hooks/` は `rite` を path segment 境界に固定していないため、`favorite/hooks/`・`prerite/hooks/`・`rite-something/hooks/` といったユーザー定義の非 rite hook を誤マッチし、silent に除去しうる（user-controlled security config の integrity リスク）。これを path 境界 anchor で厳密化する。

## 関連 Issue

Closes #1231

(親 Issue: #1221 — bash-heaviness 8 ブロック解消)

## 変更内容

### 正規表現の厳密化
- Before: `rite.*?/hooks/`
- After: `(?:^|/)rite/(?:[^/]+/)?hooks/`

`rite` を完全な path segment（先頭が文字列頭か `/`）に固定し、間に version segment を 0 個 or 1 個許容する。これは実 hook command の 2 形状を両方カバーする:

| 形状 | 例 | 判定 |
|------|-----|------|
| cache install | `.../rite-marketplace/rite/0.2.0/hooks/...` = `rite/<version>/hooks/` | ✅ 除去 |
| dev/相対 | `plugins/rite/hooks/...` = `rite/hooks/` | ✅ 除去 |
| look-alike | `favorite/hooks/`, `prerite/hooks/`, `rite-something/hooks/` | ❌ 保持 |

> Issue が例示した素朴な anchor `(?:^|/)rite/hooks/` は cache 形の version segment を考慮しておらず、本番インストール形を取りこぼして rite hook を消し残す false-negative を生むため採用していない。

### 同一正規表現の双子も同期修正
同じ over-match 正規表現が 2 箇所に存在したため両方を修正し、相互参照コメントを付した:
- `plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.py`（Issue 主対象）
- `plugins/rite/hooks/session-start.sh`（毎 session-start の auto-cleanup で発火する経路）

### テスト
`settings-local-rite-hook-cleanup.test.sh` に over-match 境界の回帰ケース（B-1〜B-3）を追加:
- look-alike 3 形は保持（exit 1 / 誤除去なし）
- cache version 形は除去（false-negative ガード）
- 混在時は rite のみ選択除去・look-alike は保持

旧正規表現へ revert すると FAIL する境界を固定した。

## 検証

- `settings-local-rite-hook-cleanup.test.sh`: 45 assertion 全緑
- hook テストスイート全体（run-tests.sh）: 55/55 passed（回帰なし）
- 正規表現の挙動を python で直接検証（must-match 全通過 / look-alike 全拒否 / 未展開 `${CLAUDE_PLUGIN_ROOT}/hooks/` は従来どおり対象外）
- プラグイン内部 drift チェック群: 本 diff による新規 finding ゼロ

## 補足（follow-up 候補）

`session-start.sh` の inline python は `settings-local-rite-hook-cleanup.py` helper と同一ロジックを重複保持している。本 PR では正規表現を同期修正したが、helper 呼び出しへの consolidation（DRY 化）は親 Issue #1221（bash-heaviness 解消）系統の別作業として残す。
