### PR TITLE
fix(hooks): session-start.sh の settings.local.json 修復を set -e 免除文脈へ移し報告分岐の dead code 化を解消

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -185,9 +185,16 @@ if [ "$SOURCE" = "startup" ]; then
       _repair_tmp=$(mktemp "${_settings_local}.XXXXXX" 2>/dev/null) || _repair_tmp=""
       _py_err=$(mktemp 2>/dev/null) || _py_err=""
       if [ -n "$_repair_tmp" ]; then
-        python3 "$SCRIPT_DIR/scripts/settings-local-rite-hook-cleanup.py" \
-          < "$_settings_local" > "$_repair_tmp" 2>"${_py_err:-/dev/null}"
-        _py_rc=$?
+        # python3 must run in a set -e-exempt context (an if-condition) so a non-zero
+        # exit (rc=1 no-op / rc=2 invalid JSON / missing script) does NOT abort the
+        # whole hook before the rc branches below run. A bare statement here would trip
+        # `set -euo pipefail` and turn the entire else branch into dead code (Issue #1241).
+        if python3 "$SCRIPT_DIR/scripts/settings-local-rite-hook-cleanup.py" \
+          < "$_settings_local" > "$_repair_tmp" 2>"${_py_err:-/dev/null}"; then
+          _py_rc=0
+        else
+          _py_rc=$?
+        fi
         if [ "$_py_rc" -eq 0 ]; then
           # mv must capture both rc and stderr so EXDEV / EACCES / ENOSPC / EROFS
           # / SELinux deny is distinguishable; silent failure here would leave
@@ -206,14 +213,18 @@ if [ "$SOURCE" = "startup" ]; then
         else
           rm -f "$_repair_tmp" 2>/dev/null
           # rc=1 is the intentional no-op branch (no hooks key / no rite entries).
-          # Any other rc indicates a real failure — invalid JSON surfaces as rc=2 from
-          # the cleanup script (a missing/unreadable script yields its own non-zero rc),
-          # so report whenever rc != 1, and also when stderr is non-empty, letting the
-          # user disambiguate corruption from the no-op.
+          # Any other rc indicates a real failure — report whenever rc != 1, and also
+          # when stderr is non-empty, letting the user disambiguate corruption from the no-op.
           if [ "$_py_rc" -ne 1 ] || { [ -n "$_py_err" ] && [ -s "$_py_err" ]; }; then
             echo "rite: session-start: settings.local.json repair python3 failed (rc=$_py_rc)" >&2
             if [ -n "$_py_err" ] && [ -s "$_py_err" ]; then
+              # Non-empty stderr means python3 itself failed (missing/unreadable cleanup
+              # script, import error) — surface its diagnostic but NOT the JSON hint, which
+              # would misdirect: the fault is not the settings.local.json content (Issue #1241).
               head -3 "$_py_err" | sed 's/^/  /' >&2
+            elif [ "$_py_rc" -eq 2 ]; then
+              # The cleanup script ran, returned 2, and wrote nothing to stderr → invalid
+              # JSON (its only rc=2 path). This is the one case where the JSON hint is correct.
               echo "  hint: settings.local.json の JSON 形式 / encoding を確認してください" >&2
             fi
           fi

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -963,6 +963,119 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-1241-INVALID-JSON (Issue #1241, subtask 2a): behavioral verification that an
+# invalid settings.local.json drives the cleanup script's rc=2 path WITHOUT
+# aborting the hook (set -e regression guard), surfaces the corruption WARNING,
+# and shows the JSON-format hint (the cleanup script writes nothing to stderr on
+# invalid JSON, so _py_err is empty → the hint is the correct disambiguation).
+# Pre-fix (python3 as a bare statement under set -e) the hook aborted rc=2 here.
+# --------------------------------------------------------------------------
+echo "TC-1241-INVALID-JSON: invalid settings.local.json → hook continues + corruption surfaces + JSON hint"
+dir_1241a="$TEST_DIR/tc1241a"
+mkdir -p "$dir_1241a/.claude"
+# No .rite-settings-hooks-cleaned marker → _needs_cleanup=true; source=startup gates the repair path.
+# Run the hook directly in the main shell rather than via the run_hook_* helpers:
+# those capture stderr into LAST_STDERR_FILE *inside* a command-substitution subshell,
+# so the assignment never reaches this shell and a later cat would read a stale file.
+printf '%s' '{ this is not valid json' > "$dir_1241a/.claude/settings.local.json"
+stderr_1241a="$(mktemp "$TEST_DIR/stderr.1241a.XXXXXX")"
+echo "{\"cwd\": \"$dir_1241a\", \"source\": \"startup\"}" \
+  | bash "$HOOK" >/dev/null 2>"$stderr_1241a" && rc_1241a=0 || rc_1241a=$?
+err_1241a="$(cat "$stderr_1241a")"
+if [ "$rc_1241a" -eq 0 ]; then
+  pass "TC-1241-INVALID-JSON: hook exits 0 (set -e did not abort on python3 rc=2)"
+else
+  fail "TC-1241-INVALID-JSON: hook aborted (rc=$rc_1241a) — set -e regression on python3 non-zero exit"
+fi
+if printf '%s' "$err_1241a" | grep -qF 'settings.local.json repair python3 failed (rc=2)'; then
+  pass "TC-1241-INVALID-JSON: invalid JSON corruption surfaces on stderr (rc=2 reported, not dead code)"
+else
+  fail "TC-1241-INVALID-JSON: corruption not surfaced (report branch is dead code); stderr: $err_1241a"
+fi
+if printf '%s' "$err_1241a" | grep -qF 'settings.local.json の JSON 形式 / encoding'; then
+  pass "TC-1241-INVALID-JSON: JSON-format hint shown for genuine invalid JSON (empty script stderr)"
+else
+  fail "TC-1241-INVALID-JSON: JSON hint missing for invalid JSON; stderr: $err_1241a"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-1241-NOOP-DOWNSTREAM (Issue #1241, subtask 2b): behavioral verification that
+# a rc=1 no-op repair (valid settings.local.json with no rite hooks) does NOT
+# abort, stays silent (no failure WARNING), and lets the hook proceed to the
+# downstream STATE_FILE resolution + defensive reset (the reset message proves
+# the post-repair code path executed). Pre-fix the hook aborted rc=1 at python3.
+# --------------------------------------------------------------------------
+echo "TC-1241-NOOP-DOWNSTREAM: rc=1 no-op repair → hook continues silently to STATE_FILE resolution"
+dir_1241b="$TEST_DIR/tc1241b"
+sid_1241b="11112222-3333-4444-5555-666677778888"
+mkdir -p "$dir_1241b/.claude"
+# Valid JSON with no rite hook entries → cleanup script returns rc=1 (intentional no-op).
+printf '%s' '{"permissions":{"allow":["Bash(ls:*)"]}}' > "$dir_1241b/.claude/settings.local.json"
+# Active flow-state so the downstream defensive reset (line ~414) fires and prints a
+# reset message — the observable proof that the hook reached past the repair block.
+create_state_file "$dir_1241b" '{"active":true,"issue_number":1241,"phase":"implement","branch":"fix/issue-1241-test","session_id":"'"$sid_1241b"'"}' "$sid_1241b"
+# Direct main-shell invocation (see TC-1241-INVALID-JSON note on LAST_STDERR_FILE/subshell).
+stderr_1241b="$(mktemp "$TEST_DIR/stderr.1241b.XXXXXX")"
+out_1241b=$(jq -n --arg cwd "$dir_1241b" --arg src "startup" --arg sid "$sid_1241b" \
+  '{cwd: $cwd, source: $src, session_id: $sid}' \
+  | bash "$HOOK" 2>"$stderr_1241b") && rc_1241b=0 || rc_1241b=$?
+err_1241b="$(cat "$stderr_1241b")"
+if [ "$rc_1241b" -eq 0 ]; then
+  pass "TC-1241-NOOP-DOWNSTREAM: hook exits 0 (set -e did not abort on python3 rc=1)"
+else
+  fail "TC-1241-NOOP-DOWNSTREAM: hook aborted (rc=$rc_1241b) — set -e regression on rc=1 no-op"
+fi
+if printf '%s' "$err_1241b" | grep -qF 'settings.local.json repair python3 failed'; then
+  fail "TC-1241-NOOP-DOWNSTREAM: rc=1 no-op misreported as failure; stderr: $err_1241b"
+else
+  pass "TC-1241-NOOP-DOWNSTREAM: rc=1 no-op stays silent (no false failure WARNING)"
+fi
+if printf '%s' "$out_1241b" | grep -qF '前回のセッション状態が残っていたためリセットしました' \
+   && printf '%s' "$out_1241b" | grep -qF 'Issue #1241'; then
+  pass "TC-1241-NOOP-DOWNSTREAM: downstream STATE_FILE resolution + defensive reset reached"
+else
+  fail "TC-1241-NOOP-DOWNSTREAM: downstream not reached (hook stopped before reset); stdout: $out_1241b"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-1241-MISSING-SCRIPT (Issue #1241, subtask 3): behavioral verification that a
+# missing/unreadable cleanup script (python3 emits its OWN diagnostic to stderr,
+# exit 2) is reported WITHOUT the JSON-format hint — that hint is invalid-JSON
+# specific and would misdirect here. Run against a sandbox copy with the cleanup
+# script removed so python3 fails to open it.
+# --------------------------------------------------------------------------
+echo "TC-1241-MISSING-SCRIPT: missing cleanup script → reported without misdirecting JSON hint"
+HOOKS_REAL_DIR_1241="$(cd "$SCRIPT_DIR/.." && pwd)"
+sbx_1241c="$(mktemp -d "$TEST_DIR/sbx-1241c-XXXXXX")"
+cp -a "$HOOKS_REAL_DIR_1241/." "$sbx_1241c/"
+rm -f "$sbx_1241c/scripts/settings-local-rite-hook-cleanup.py"
+dir_1241c="$TEST_DIR/tc1241c"
+mkdir -p "$dir_1241c/.claude"
+printf '%s' '{"permissions":{"allow":[]}}' > "$dir_1241c/.claude/settings.local.json"
+stderr_1241c="$(mktemp "$TEST_DIR/stderr.1241c.XXXXXX")"
+echo "{\"cwd\": \"$dir_1241c\", \"source\": \"startup\"}" \
+  | bash "$sbx_1241c/session-start.sh" >/dev/null 2>"$stderr_1241c" && rc_1241c=0 || rc_1241c=$?
+err_1241c="$(cat "$stderr_1241c")"
+if [ "$rc_1241c" -eq 0 ]; then
+  pass "TC-1241-MISSING-SCRIPT: hook exits 0 (set -e did not abort on missing-script python3 rc)"
+else
+  fail "TC-1241-MISSING-SCRIPT: hook aborted (rc=$rc_1241c) — set -e regression on missing script"
+fi
+if printf '%s' "$err_1241c" | grep -qF 'settings.local.json repair python3 failed'; then
+  pass "TC-1241-MISSING-SCRIPT: python3 failure reported on stderr"
+else
+  fail "TC-1241-MISSING-SCRIPT: missing-script failure not reported; stderr: $err_1241c"
+fi
+if printf '%s' "$err_1241c" | grep -qF 'settings.local.json の JSON 形式 / encoding'; then
+  fail "TC-1241-MISSING-SCRIPT: JSON hint misdirects on missing-script (subtask 3 regression); stderr: $err_1241c"
+else
+  pass "TC-1241-MISSING-SCRIPT: JSON hint suppressed when python3 emits its own stderr (no misdirection)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # TC-YAML-LITERAL-PREFIX: _rite_read_yaml_key uses literal-prefix match
 # --------------------------------------------------------------------------
 # A regression to the regex form `$0 ~ k` would let YAML keys containing regex


### PR DESCRIPTION
## 概要

`session-start.sh` の settings.local.json 修復経路で、`python3` 呼び出しが `set -euo pipefail` 下の **単独文** として実行されていたため、python3 が非ゼロ終了（rc=1 no-op / rc=2 不正JSON / スクリプト欠落）すると `set -e` が hook 全体を abort し、直後の `_py_rc=$?` 以降のエラー報告分岐が dead code 化していた。python3 を `if` 条件（set -e 免除文脈）へ移し、報告分岐を復活させる。

## 関連 Issue

Closes #1241

## 変更内容

- **subtask1（set -e 免除）**: `session-start.sh` の python3 を `if python3 ...; then _py_rc=0; else _py_rc=$?; fi` へ変更。rc=1 no-op / rc=2 corruption の報告分岐と、下流（marker 書き込み・flow-state migrate・STATE_FILE 解決・recovery 注入）が abort せず到達するようになった。
- **subtask3（hint 誤誘導修正）**: 報告分岐の JSON 形式 hint を、cleanup script が stderr 無しで rc=2 を返す「真の不正JSON」時のみ表示。missing/unreadable script（python3 自身が stderr 出力）時は python3 の診断のみ表示し JSON hint を抑止。
- **subtask2 / subtask3-test（実行ベーステスト）**: `session-start.test.sh` に integration test を 3 件追加。(a) 不正JSON→継続+報告+hint、(b) rc=1 no-op→継続+下流到達、(c) missing-script→JSON hint 抑止。修正前 bare-statement 版で全 fail することを検証済み。
- **subtask4（横断調査）**: 「set -e 下の外部コマンド単独文 + 直後 rc=$?」アンチパターンを全 hook 横断調査。`session-start.sh` が唯一の該当箇所（他は if/else・set+e 等で安全）と確認。コード変更なし。

## テスト

- hook テストスイート全 55 ファイル pass（`run-tests.sh`）。session-start.test.sh 単体は 51 件 pass。
- 新規 3 テストは修正を revert すると全 fail することを確認済み（回帰検出器として機能）。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [ ] Documentation updated (if applicable) — 内部 hook の挙動修正のため doc 変更なし（init.md の既存記述は正確なまま）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
