### PR TITLE
fix(hooks): settings-local-rite-hook-cleanup の mv 失敗 WARNING と CLEANED 経路 exit-code leak を解消

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -684,7 +684,7 @@ fi
    bash "{hooks_dir}/scripts/settings-local-rite-hook-cleanup.sh" ".claude/settings.local.json"
    ```
 
-   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は **rite hook を実際に除去したときのみ** `CLEANED` を返し、それ以外の安全側ケース (python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む) ではすべて `NO_RITE_HOOKS` を返して silent skip 相当となる。`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
+   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は **rite hook を実際に除去したときのみ** `CLEANED` を返し、それ以外の安全側ケース (python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む) ではすべて `NO_RITE_HOOKS` を返す。ただし **mv 失敗** だけは「変換は成功したが swap-in できず stale な rite hook が残る」ケースであり真の silent skip ではないため、`NO_RITE_HOOKS` (+ exit 0 非ブロッキング) を保ったまま stderr に `[rite] WARNING: ... mv failed` を emit する (Issue #1232、先例 `issue-comment-wm-sync.sh:99-104` の error-surfacing pattern 準拠)。`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
 
    - If `CLEANED` → display `ℹ️ settings.local.json からレガシー rite hook エントリを削除しました。`
    - If `NO_RITE_HOOKS` → no output (already clean)

--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
@@ -60,3 +60,8 @@ if python3 "$PYTHON_SCRIPT" < "$settings" > "$tmp" 2>/dev/null; then
 else
   echo "NO_RITE_HOOKS"
 fi
+
+# Non-blocking contract: exit 0 explicitly so the script status never leaks the
+# trailing `[ -n "$mv_err" ] && rm` result, which is 1 when the mv_err mktemp
+# failed on the CLEANED path (the settings file was still rewritten correctly).
+exit 0

--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
@@ -13,7 +13,10 @@
 # Output (stdout) — machine-readable token for the init.md caller:
 #   CLEANED        rite hook entries removed; file rewritten atomically
 #   NO_RITE_HOOKS  nothing removed (no hooks / no rite hooks / file absent /
-#                  python3 unavailable / invalid JSON) — file left untouched
+#                  python3 unavailable / invalid JSON / mv failed) — file left
+#                  untouched. On mv failure a stderr WARNING is also emitted:
+#                  the cleaned content was computed but could not be swapped in,
+#                  so stale rite hooks remain (not actually "already clean").
 #
 # Exit codes:
 #   0  always (non-blocking; status conveyed via the stdout token)
@@ -38,11 +41,22 @@ trap 'rm -f "$tmp"' EXIT
 
 # python3 exit 0 = changed (cleaned JSON on stdout); non-zero = no change / invalid
 if python3 "$PYTHON_SCRIPT" < "$settings" > "$tmp" 2>/dev/null; then
-  if mv "$tmp" "$settings" 2>/dev/null; then
+  # Capture mv's stderr so EXDEV / EACCES / ENOSPC / SELinux deny stays
+  # distinguishable (mktemp may fail under disk pressure — fall back to /dev/null).
+  mv_err=$(mktemp 2>/dev/null) || mv_err=""
+  if mv "$tmp" "$settings" 2>"${mv_err:-/dev/null}"; then
     echo "CLEANED"
   else
+    # $? must be grabbed first — any later command would overwrite it. The file
+    # is NOT clean here (stale rite hooks remain), so surface the failure on
+    # stderr instead of silently folding to a misleading "already clean" token.
+    # Pattern per issue-comment-wm-sync.sh:99-104.
+    mv_rc=$?
     echo "NO_RITE_HOOKS"
+    echo "[rite] WARNING: settings-local-rite-hook-cleanup: mv failed (rc=$mv_rc); legacy rite hooks left in place" >&2
+    [ -n "$mv_err" ] && [ -s "$mv_err" ] && head -3 "$mv_err" | sed 's/^/  /' >&2
   fi
+  [ -n "$mv_err" ] && rm -f "$mv_err"
 else
   echo "NO_RITE_HOOKS"
 fi

--- a/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
@@ -277,8 +277,35 @@ assert "S-6: exit 0 (非ブロッキング契約維持)" "0" "$rc"
 assert_grep "S-6: mv 失敗が stderr WARNING に surface される" "$err" 'WARNING.*mv failed'
 assert_no_leftover_tmp "S-6: trap cleanup で残留 tmp なし" "$f"
 
+# ─── .sh CLEANED path + mv_err mktemp failure → exit 0 contract (#1232) (S-7) ──
+echo ""
+echo "=== .sh CLEANED 経路で mv_err 用 mktemp 失敗時も exit 0 (#1232) (S-7) ==="
+
+# Regression guard for the exit-code leak: on the CLEANED path the wrapper allocates
+# a second mktemp (no-arg) to capture mv's stderr. If that mktemp fails, the trailing
+# `[ -n "$mv_err" ] && rm` evaluates false (rc=1) and — without the explicit final
+# `exit 0` — leaks a non-zero script status even though the file was rewritten
+# correctly (token=CLEANED). This shim fails only the no-arg mktemp (mv_err); the
+# template-form mktemp (atomic temp) and the real mv still succeed, so the wrapper
+# reaches CLEANED and must still exit 0. Pins the non-blocking contract end-to-end.
+d="$(fresh)"; f="$d/settings.local.json"
+mkdir -p "$d/bin"
+real_mktemp="$(command -v mktemp)"
+cat > "$d/bin/mktemp" <<MKTEMP_SHIM
+#!/bin/bash
+# Fail the no-arg form (mv_err capture); delegate the template form (atomic temp).
+if [ \$# -eq 0 ]; then exit 1; fi
+exec "$real_mktemp" "\$@"
+MKTEMP_SHIM
+chmod +x "$d/bin/mktemp"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /opt/rite/hooks/session-start.sh"}]}]}}' > "$f"
+out=$(PATH="$d/bin:$PATH" bash "$SH" "$f" 2>/dev/null); rc=$?
+assert "S-7: CLEANED 経路で mv_err mktemp 失敗でも token = CLEANED" "CLEANED" "$out"
+assert "S-7: exit 0 (末尾 exit 0 がないと rc=1 に leak する非ブロッキング契約)" "0" "$rc"
+assert_no_leftover_tmp "S-7: trap cleanup で残留 tmp なし" "$f"
+
 echo ""
 if ! print_summary "$(basename "$0")" \
-  "drift: settings-local-rite-hook-cleanup helper (#1230 / #1231 / #1232) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、over-match 境界 (#1231: look-alike favorite/prerite/rite-something は保持・cache version 形 rite/0.2.0/hooks/ は除去)、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup・mv 失敗時の stderr WARNING surfacing (#1232) を確認。"; then
+  "drift: settings-local-rite-hook-cleanup helper (#1230 / #1231 / #1232) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、over-match 境界 (#1231: look-alike favorite/prerite/rite-something は保持・cache version 形 rite/0.2.0/hooks/ は除去)、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup・mv 失敗時の stderr WARNING surfacing (#1232)・CLEANED 経路で mv_err 用 mktemp 失敗時も末尾 exit 0 で非ブロッキング契約維持 (#1232) を確認。"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh
@@ -14,6 +14,10 @@
 #   5. RITE_HOOK_RE over-match boundary (#1231): `rite` must be a full path segment,
 #      so look-alikes (favorite/, prerite/, rite-something/) are preserved while the
 #      real cache form `rite-marketplace/rite/<version>/hooks/` is still removed
+#   6. `.sh` mv-failure stderr WARNING (#1232): mv failure keeps the NO_RITE_HOOKS
+#      token + exit 0, but must surface a `[rite] WARNING: ... mv failed` diagnostic
+#      (the file is NOT actually clean — stale rite hooks remain), so the failure is
+#      not silently indistinguishable from "already clean"
 #
 # The mv-failure case reuses the PATH-shimmed `mv` technique from the precedent
 # test issue-comment-wm-sync.test.sh (a `bin/mv` that exits non-zero, prepended to
@@ -249,8 +253,32 @@ assert "S-5: exit 0" "0" "$rc"
 assert_unchanged "S-5: 原ファイル保持 (mv 失敗で未置換)" "$f" "$d/ref"
 assert_no_leftover_tmp "S-5: trap cleanup で残留 tmp なし" "$f"
 
+# ─── .sh mv failure stderr WARNING (#1232) (S-6) ─────────────────────────
+echo ""
+echo "=== .sh mv 失敗時 stderr WARNING (#1232) (S-6) ==="
+
+# Same PATH-shimmed mv as S-5, but this time capture stderr. On mv failure the
+# helper must surface a diagnostic WARNING — the file is NOT actually clean (stale
+# rite hooks remain) — while keeping the NO_RITE_HOOKS token + exit 0 non-blocking
+# contract. Without it the failure is indistinguishable from "already clean"; this
+# case pins the surfacing (per the issue-comment-wm-sync.sh canonical pattern).
+d="$(fresh)"; f="$d/settings.local.json"
+mkdir -p "$d/bin"
+cat > "$d/bin/mv" <<'MV_SHIM'
+#!/bin/bash
+exit 1
+MV_SHIM
+chmod +x "$d/bin/mv"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /opt/rite/hooks/session-start.sh"}]}]}}' > "$f"
+err="$d/stderr.txt"
+out=$(PATH="$d/bin:$PATH" bash "$SH" "$f" 2>"$err"); rc=$?
+assert "S-6: mv 失敗でも token = NO_RITE_HOOKS (契約不変)" "NO_RITE_HOOKS" "$out"
+assert "S-6: exit 0 (非ブロッキング契約維持)" "0" "$rc"
+assert_grep "S-6: mv 失敗が stderr WARNING に surface される" "$err" 'WARNING.*mv failed'
+assert_no_leftover_tmp "S-6: trap cleanup で残留 tmp なし" "$f"
+
 echo ""
 if ! print_summary "$(basename "$0")" \
-  "drift: settings-local-rite-hook-cleanup helper (#1230 / #1231) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、over-match 境界 (#1231: look-alike favorite/prerite/rite-something は保持・cache version 形 rite/0.2.0/hooks/ は除去)、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup を確認。"; then
+  "drift: settings-local-rite-hook-cleanup helper (#1230 / #1231 / #1232) の挙動契約が後退した可能性。.py の exit code (0=削除 / 1=変更なし / 2=不正JSON)、混在時の選択的除去・全 rite event の key 削除、over-match 境界 (#1231: look-alike favorite/prerite/rite-something は保持・cache version 形 rite/0.2.0/hooks/ は除去)、.sh の token 畳み込み (py exit 1/2 → NO_RITE_HOOKS)・検査付き mv 失敗経路・atomic write・trap cleanup・mv 失敗時の stderr WARNING surfacing (#1232) を確認。"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`settings-local-rite-hook-cleanup.sh` の非ブロッキング契約・エラー surfacing 周りの 2 つの不備を解消した（いずれも #1232）。

1. **mv 失敗経路に stderr WARNING を追加** — cited 先例 `issue-comment-wm-sync.sh:99-104` の error-surfacing canonical pattern に準拠
2. **CLEANED 経路の exit-code leak を解消** — script 末尾に `exit 0` を追加し「Exit codes: 0 always」の自身の契約を保証

`NO_RITE_HOOKS` / `CLEANED` の stdout token と非ブロッキング契約（exit 0）は維持している。

Closes #1232

## 背景

### 1. mv 失敗時の silent 進行

mv 失敗時に `NO_RITE_HOOKS`（"already clean"）だけを返すと、実際には変換成功済みの内容を swap-in できず **stale な rite hook が残存**しているのに、init.md からは「clean だった」のと区別できず silent に進行してしまう（EXDEV / ENOSPC / EACCES / SELinux deny 等）。canonical 先例 `issue-comment-wm-sync.sh:99-104` は同種の mv 失敗で `[rite] WARNING: ... mv failed` を stderr に emit する設計であり、本 helper はこの規約に未準拠だった。

### 2. CLEANED 経路の exit-code leak

mv stderr 退避用の mktemp が失敗した場合、末尾文 `[ -n "$mv_err" ] && rm` が `[ -n "" ]`=false で rc=1 を返し、明示 `exit 0` がないため CLEANED（ファイルは正しく書換済）でも script 全体が exit 1 を leak していた。自身の文書「Exit codes: 0 always」と #1232 の非ブロッキング契約に違反していた（本 helper のみ `fi` 終端の outlier だった）。

## 変更内容

- **`plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh`**
  - mv 失敗の else 分岐で `$?` を即捕捉（`mv_rc`）し、stdout token=`NO_RITE_HOOKS`・`exit 0` を保ったまま stderr に `[rite] WARNING: settings-local-rite-hook-cleanup: mv failed (rc=…); legacy rite hooks left in place` を emit
  - mv の stderr を `mktemp` 経由で捕捉し `head -3` で表示（EXDEV/EACCES/ENOSPC/SELinux deny を distinguishable に）。既存の `trap 'rm -f "$tmp"'` で tmp は cleanup 済みのため tmp の明示 rm は追加しない
  - **script 末尾に `exit 0` を追加** — sibling helper 全てが従う末尾 `exit 0` 規約に統一し、最終文の rc に依存せず非ブロッキング契約を保証（本 helper のみ `fi` 終端の outlier だった）
  - ヘッダーコメントの `NO_RITE_HOOKS` 説明に mv 失敗ケース（+ stderr WARNING）を追記
- **`plugins/rite/hooks/tests/settings-local-rite-hook-cleanup.test.sh`**
  - S-6 を追加: PATH-shim した mv で stderr を捕捉し、`token=NO_RITE_HOOKS`・`exit 0`（契約不変）と WARNING surfacing を pin
  - S-7 を追加: CLEANED 経路 + mv_err 用 mktemp 失敗時の `token=CLEANED`・`exit 0` を pin（no-arg mktemp shim で再現、既存 S-1/S-6 が捕捉しない edge の回帰防止）
  - regression point リスト / print_summary も #1232 を反映
- **`plugins/rite/commands/init.md`**
  - Helper contract（Phase 4.5.0.2 周辺）の記述を更新。mv 失敗は真の silent skip ではなく stderr WARNING を伴う旨を明記（ドキュメント影響調査 5.1.0.7）

## 設計判断

- **スコープ限定**: stdout token（`NO_RITE_HOOKS` / `CLEANED`）と非ブロッキング契約（exit 0）は不変。init.md 側の token routing を壊さず、stderr 診断と末尾 exit 0 のみ追加
- **先例準拠**: `$?` を else 分岐の先頭で捕捉（`if ! mv` 形式だと bash 仕様で `$?` が 0 化するのを回避）
- **末尾 exit 0 規約への統一**: sibling helper 全てが従う末尾 `exit 0` 規約に揃え、最終文の rc に依存しない非ブロッキング保証にする

## テスト

- `settings-local-rite-hook-cleanup.test.sh`: **52 ケース全 pass**（新規 S-6 / S-7 含む）
- `session-start.test.sh`（同 helper 参照）: **51 ケース全 pass**（回帰なし）
- 手動確認: mv 失敗時に WARNING を stderr へ emit / happy path は stderr 0 bytes / CLEANED 経路で mktemp 失敗時も exit 0

## チェックリスト

- [x] 実装（mv 失敗経路に stderr WARNING）
- [x] 実装（CLEANED 経路の exit-code leak 解消 — 末尾 exit 0）
- [x] テスト追加（S-6 / S-7）
- [x] ドキュメント更新（init.md Helper contract）
- [x] テストスイート全 pass 確認

## 関連

- 元の PR: #1229
- 親 Issue: #1221（bash-heaviness ブロック解消）
- 参照先例: `plugins/rite/hooks/issue-comment-wm-sync.sh:99-104`
