### PR TITLE
docs(init): NO_RITE_HOOKS routing 行の (already clean) を中立表現へ調整

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -687,7 +687,7 @@ fi
    > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は **rite hook を実際に除去したときのみ** `CLEANED` を返し、それ以外の安全側ケース (python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む) ではすべて `NO_RITE_HOOKS` を返す。ただし **mv 失敗** だけは「変換は成功したが swap-in できず stale な rite hook が残る」ケースであり真の silent skip ではないため、`NO_RITE_HOOKS` (+ exit 0 非ブロッキング) を保ったまま stderr に `[rite] WARNING: ... mv failed` を emit する (Issue #1232、先例 `issue-comment-wm-sync.sh:99-104` の error-surfacing pattern 準拠)。`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
 
    - If `CLEANED` → display `ℹ️ settings.local.json からレガシー rite hook エントリを削除しました。`
-   - If `NO_RITE_HOOKS` → no output (already clean)
+   - If `NO_RITE_HOOKS` → no output (no rite hooks removed)
 
 3. Write cleanup marker:
    ```bash


### PR DESCRIPTION
## 概要

`plugins/rite/commands/init.md:690` の NO_RITE_HOOKS routing 行の説明的括弧書き `(already clean)` を中立表現 `(no rite hooks removed)` へ調整する。`(already clean)` は mv 失敗サブケース（変換成功後 swap-in できず stale rite hook が残る = 真の clean ではない）を包含しない軽微な散文不整合があり、これを解消する。

## 関連 Issue

Closes #1247

## 変更内容

- `plugins/rite/commands/init.md:690`: `(already clean)` → `(no rite hooks removed)`（ルーティング指示 `no output` 自体は不変更）

## 設計判断

- 中立表現 `(no rite hooks removed)` は全 NO_RITE_HOOKS サブケース（python3 不在 / file 不在 / 対象 hook 不在 / 不正 JSON / mv 失敗）で正確。ヘルパー header `settings-local-rite-hook-cleanup.sh:15` の `nothing removed` 語彙とも整合
- mv 失敗時の stderr WARNING surfacing は直上 line 687 の Helper contract が既に明示済みのため、690 への cross-ref 追記は冗長として見送り（最小変更）

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし: ドキュメント文言のみの変更）
- [x] ドキュメント更新（本変更自体がドキュメント）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
