### PR TITLE
refactor(review): 6.1.c を helper 化し review.md の bash-heaviness 2 件を解消

### DIFF
--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3167,153 +3167,25 @@ bash {plugin_root}/hooks/review-comment-post.sh \
 
 When `{post_comment_mode}=false`, inform the user that PR comment posting was skipped (for observability — this is not an error).
 
-下記 bash block は machine-enforced gate として `[CONTEXT] LOCAL_SAVE_FAILED=...` flag を bash 側で読み取りケース分岐する (Claude が自然言語で読み取る設計は flag 見落としで silent fallthrough する経路があり silent data loss 防止が骨抜きになるため bash 側に gate を昇格)。Claude は下記 block を実行するだけで適切なメッセージが stderr に emit される。
+下記 bash block (`hooks/review-skip-notification.sh` 呼び出し) は machine-enforced gate として `[CONTEXT] LOCAL_SAVE_FAILED=...` flag を helper 側で読み取りケース分岐する (Claude が自然言語で読み取る設計は flag 見落としで silent fallthrough する経路があり silent data loss 防止が骨抜きになるため helper 側に gate を昇格)。Claude は下記 block を実行するだけで適切なメッセージが stderr に emit される。
 
 **Machine-enforced case selection**:
 
 ```bash
-# ステップ 6.1.c: Skip Notification (machine-enforced case split)
-#
-# 実行条件: {post_comment_mode}=false の経路のみ (true 経路では ステップ 6.1.b の成功/失敗ログで完結する)
-# 依存: ステップ 6.1.a が [CONTEXT] FILE_TIMESTAMP=... / LOCAL_SAVE_FAILED=... を emit 済み
-#
-# Claude は以下 4 変数を literal substitute する:
-# - post_comment_mode: ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE= の値 (Issue #510 対応)
-# - pr_number: {pr_number}
-# - file_timestamp: ステップ 6.1.a の [CONTEXT] FILE_TIMESTAMP= の値 (成功時: YYYYMMDDHHMMSS、失敗時: "unknown")
-# - local_save_failed: ステップ 6.1.a の [CONTEXT] LOCAL_SAVE_FAILED= の値 ("1" または未 emit=空)
-#
-# 変数宣言順序: 「1 変数 1 gate」原則で fail-fast の局所性を最大化する (6.1.b と対称化)。
-# post_comment_mode を先行宣言 → gate 通過後に残り 3 変数を宣言することで、gate 失敗時の
-# 観測値混線リスクを最小化する (gate で exit 1 する経路では pr_number / file_timestamp /
-# local_save_failed は参照されないため、未宣言で問題ない)。
-post_comment_mode="{post_comment_mode}"
-
-# post_comment_mode machine-enforced gate (Issue #510 対応、6.1.b と対称)。
-# 6.1.c は post_comment_mode=false 経路専用。true 経路で誤呼出された場合、本来 6.1.b で
-# 成功/失敗ログが完結すべきところ skip notification を出すと観測値が混線する。caller の
-# branch selection ミスを bash レベルで fail-fast 遮断する。
-case "$post_comment_mode" in
- false)
- ;;
- true)
- echo "ERROR: ステップ 6.1.c が post_comment_mode=true の経路で呼び出されました (本来 6.1.b の成功/失敗ログで完結すべき経路)" >&2
- echo " 真因: caller (LLM) が ステップ 6.1 の branch selection を誤りました。post_comment_mode=true の場合は 6.1.b のみを実行し 6.1.c は skip すべきです。" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_post_comment_mode_invalid; value=true" >&2
- echo "[review:error]"
- exit 1
- ;;
- *)
- echo "ERROR: ステップ 6.1.c の post_comment_mode が literal substitute されていません (値: '$post_comment_mode', 期待: true/false)" >&2
- echo " Claude は ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE=true|false emit 値を会話コンテキストから読み取り、" >&2
- echo " この bash block 冒頭の post_comment_mode=... 行を実際の値で置換する必要があります。" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_post_comment_mode_invalid; value=$post_comment_mode" >&2
- echo "[review:error]"
- exit 1
- ;;
-esac
-
-# gate 通過後、残り 3 変数を宣言 (legitimate false 経路でのみ評価される)
-pr_number="{pr_number}"
-file_timestamp="{file_timestamp_from_p61a}"
-local_save_failed="{local_save_failed_from_p61a}"
-
-# pr_number の数値 fail-fast gate (ステップ 6.1.a の pr_number guard と対称化)。
-# Claude が substitute を忘れると、ケース 1 のローカルファイル path が
-# `.rite/review-results/{pr_number}-...json` (literal) となり、ユーザー向けメッセージに placeholder
-# がそのまま出力される silent UX regression を防ぐ。file_timestamp / local_save_failed は下記の
-# sentinel check で保護される。
-#
-# reason drift 対策: ステップ 6.1.a が pr_number 不正を検出した場合は `LOCAL_SAVE_FAILED=1;
-# reason=pr_number_placeholder_residue` を emit して exit 0 (non-blocking) するが、ステップ 6.1.c
-# は別 bash invocation のため ステップ 6.1.a の retained flag を参照できない。pr_number が不正なまま
-# ステップ 6.1.c まで到達した場合、真因は ステップ 6.1.a の Claude substitution 忘れなので、エラー
-# メッセージで 6.1.a の再実行を明示的に促す (真因が 6.1.c の bug ではないことを root cause
-# 伝達する)。
-case "$pr_number" in
- ''|*[!0-9]*)
- echo "ERROR: ステップ 6.1.c の pr_number が literal substitute されていません (値: '$pr_number', 期待: 数値のみ非空)" >&2
- echo " 真因: ステップ 6.1.a の bash block で Claude が pr_number を literal substitute せず、同じ placeholder が" >&2
- echo " 本 block まで連鎖している可能性が高いです。" >&2
- echo " 対処: ステップ 1.0 で正規化された pr_number を ステップ 6.1.a の bash block 冒頭で literal substitute" >&2
- echo " してから再実行してください (ステップ 6.1.a が exit 0 non-blocking で完了すると ステップ 6.1.c に" >&2
- echo " substitution 忘れが連鎖します)" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_pr_number_invalid; upstream_hint=phase_6_1_a_substitution_missing" >&2
- exit 1
- ;;
-esac
-
-# sentinel check: placeholder 残留は silent fallthrough せず fail-fast (H-5 と同パターン)
-case "$file_timestamp" in
- "{"*|*"}")
- echo "ERROR: ステップ 6.1.c の file_timestamp が literal substitute されていません (値: '$file_timestamp')" >&2
- echo " Claude は ステップ 6.1.a の [CONTEXT] FILE_TIMESTAMP=... を読み取って substitute する必要があります" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_file_timestamp_unset" >&2
- exit 1
- ;;
- "unknown")
- # ステップ 6.1.a の trap handler は date 失敗時に `[CONTEXT] FILE_TIMESTAMP=unknown` を emit する。
- # その経路では LOCAL_SAVE_FAILED=1 も併設される設計だが、万一片方だけが set された不整合状態
- # (観測値混線 / race) では、ケース 1 に流れると
- # `.rite/review-results/${pr_number}-unknown.json` という実在しないファイルパスをユーザーに
- # 誤提示する UX regression が起きる。整合性違反として明示的に ERROR 化する。
- if [ "$local_save_failed" != "1" ]; then
- echo "ERROR: ステップ 6.1.c の file_timestamp='unknown' だが local_save_failed が '1' ではありません (整合性違反)" >&2
- echo " ステップ 6.1.a の trap handler は date 失敗時に FILE_TIMESTAMP=unknown と LOCAL_SAVE_FAILED=1 を同時に emit するはずです" >&2
- echo " 単独 emit 経路は観測値混線 / race の兆候であり、ユーザーに誤ったファイルパスを提示する経路を遮断します" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_file_timestamp_unknown_without_failure" >&2
- exit 1
- fi
- # local_save_failed=1 が併設されている場合は legitimate な失敗経路のため、下流のケース 2 分岐
- # (LOCAL_SAVE_FAILED=1 hard fail) に流す。case 文は何もせず pass する。
- ;;
-esac
-case "$local_save_failed" in
- ""|0|1) ;;
- *)
- echo "ERROR: ステップ 6.1.c の local_save_failed が不正 (許容: 空文字 / 0 / 1、値: '$local_save_failed')" >&2
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_local_save_failed_invalid" >&2
- exit 1
- ;;
-esac
-
-# ケース分岐: LOCAL_SAVE_FAILED=1 が set されていればケース 2 (WARNING 昇格 + hard fail)、それ以外はケース 1 (INFO)
-if [ "$local_save_failed" = "1" ]; then
- # ケース 2: local save 失敗 (findings が会話コンテキストにのみ存在する異常経路)
- #
- # silent data loss 防止のため WARNING のみの exit 0 ではなく、以下 2 段階で hard fail させる:
- # 1. WARNING + 復旧方法 4 種を表示 (ユーザー可視性の維持)
- # 2. `[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable` を retained flag
- # として emit し、ステップ 6.1 全体を `exit 2` で fail させる (CI / caller が silent pass しない)
- #
- # 「review 成功 = findings が観測可能な場所に届いた」という invariant を維持する。
- # `exit 2` は retained flag mapping table で documented された hard fail 経路。
- cat >&2 <<EOF
-⚠️ ERROR: レビュー結果が永続化されませんでした (silent data loss 防止のため ステップ 6 を fail させます)
- PR コメント: スキップ (pr_review.post_comment=false)
- ローカルファイル: 保存失敗 ([CONTEXT] LOCAL_SAVE_FAILED の reason を確認してください)
-
- 影響: 本レビュー結果は現在の会話コンテキストのみに存在します。
- 次のセッション開始時 (会話 compaction / terminal close / session restart) に完全に失われます。
- この経路を silent pass にしないため、ステップ 6 全体を exit 2 で fail させます。
-
- 復旧方法 (いずれかを選択):
- 1. このセッション内で即座に /rite:pr:fix を実行する (Priority 1: 会話コンテキストから直接読取)
- 2. /rite:pr:review --post-comment で PR コメントに投稿して永続化する
- 3. rite-config.yml で pr_review.post_comment: true を設定して全 review を永続化する
- 4. LOCAL_SAVE_FAILED の reason を解決してから /rite:pr:review を再実行する
-EOF
- echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable; local_save_failed=1; post_comment_mode=false" >&2
- echo "[review:error]"
- exit 2
-else
- # ケース 1: local save 成功 (通常経路)
- cat >&2 <<EOF
-ℹ️ PR コメント記録はスキップされました (pr_review.post_comment=false)
- ローカルファイル: .rite/review-results/${pr_number}-${file_timestamp}.json
- コメント記録を有効化するには --post-comment フラグまたは rite-config.yml で pr_review.post_comment: true を設定してください
-EOF
-fi
+# ステップ 6.1.c: Skip Notification (post_comment_mode=false 経路専用)。
+# 旧 ~142 行の inline bash (4 gate + 2 ケース分岐 heredoc) は hooks/review-skip-notification.sh へ
+# 委譲済 (Issue #1221、6.1.b の review-comment-post.sh 切り出しと対称)。契約 (post_comment_mode gate /
+# pr_number・file_timestamp・local_save_failed の fail-fast gate / reason 語彙 p61c_* / ケース 1 INFO
+# exit 0 / ケース 2 ⚠️ + reason=p61c_persistence_unrecoverable + exit 2 で ステップ 6 全体を fail) は
+# helper header と下記 Prose spec 参照。
+# Claude は [CONTEXT] marker から 4 値を literal substitute する (local_save_failed は空文字を渡すため
+# 必ずクォートすること): post_comment_mode=ステップ 1.0 の POST_COMMENT_MODE / pr_number /
+# file_timestamp=ステップ 6.1.a の FILE_TIMESTAMP / local_save_failed=ステップ 6.1.a の LOCAL_SAVE_FAILED。
+bash {plugin_root}/hooks/review-skip-notification.sh \
+  --post-comment-mode {post_comment_mode} \
+  --pr {pr_number} \
+  --file-timestamp "{file_timestamp_from_p61a}" \
+  --local-save-failed "{local_save_failed_from_p61a}"
 ```
 
 **Prose spec (参考)**:
@@ -3321,7 +3193,7 @@ fi
 - **ケース 1** (`LOCAL_SAVE_FAILED` 未 emit、通常経路): `ℹ️ PR コメント記録はスキップされました` + ローカルファイル path を表示、`exit 0`
 - **ケース 2** (`LOCAL_SAVE_FAILED=1` ∧ `post_comment_mode=false`、findings が会話コンテキストにのみ存在する異常経路): `⚠️ ERROR: レビュー結果が永続化されませんでした` + 復旧方法 4 種を表示、`[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable` を emit、**`exit 2` で ステップ 6 を fail させる** (silent data loss 防止のため hard fail)
 
-**`post_comment_mode=false` と `LOCAL_SAVE_FAILED=1` が同時に成立する場合**: 上記 bash block の machine-enforced gate により必ずケース 2 (⚠️ ERROR) が選択され、ステップ 6 は `exit 2` で終了する。Claude の自然言語判断には依存しない (silent data loss 防止)。WARNING のみの exit 0 経路はユーザー可視性と CI 検出性を両立できないため hard fail に統一する。
+**`post_comment_mode=false` と `LOCAL_SAVE_FAILED=1` が同時に成立する場合**: `review-skip-notification.sh` の machine-enforced gate により必ずケース 2 (⚠️ ERROR) が選択され、ステップ 6 は `exit 2` で終了する。Claude の自然言語判断には依存しない (silent data loss 防止)。WARNING のみの exit 0 経路はユーザー可視性と CI 検出性を両立できないため hard fail に統一する。
 
 ### 6.2 Update Work Memory Phase
 
@@ -3967,7 +3839,8 @@ if [ ! -s "$tmpfile" ]; then
 fi
 
 # jq -n の出力を stdin で create-issue-with-projects.sh に渡す (Issue #1193 #5)。
-# 旧 `$(bash ... "$(jq -n ...)")` の入れ子 $() を 1 段に削減し malform 確率を下げる。
+# 旧コードは jq 出力をコマンド置換でスクリプト引数に入れ子展開していたが、パイプ + 1 段の
+# コマンド置換に削減して malform 確率を下げた (入れ子コマンド置換の literal 例は除去済 — Issue #1221)。
 result=$(jq -n \
  --arg title "{type}: {summary}" \
  --arg body_file "$tmpfile" \

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3019,17 +3019,11 @@ Output the review results via two independent paths. Use `mktemp` + `--body-file
 
 ステップ 6 failure reasons (reason 表の本文は `common-error-handling.md#jq-required-fields-snippet-canonical` の canonical jq snippet を参照):
 
-| reason (ステップ 5.1.2.A / 6.1.c、review.md 本文が emit) | Description |
+| reason (ステップ 5.1.2.A、review.md 本文が emit) | Description |
 |--------|-------------|
 | `pr_number_placeholder_residue` | ステップ 5.1.2.A (fingerprint, `FINGERPRINT_COMPUTE_FAILED`) で `pr_number` が数値以外のとき emit。ステップ 6.1.a (`review-result-save.sh`, `LOCAL_SAVE_FAILED`) も同名 reason を emit する (下記 6.1.a bullet 参照) |
-| `p61c_pr_number_invalid` | ステップ 6.1.c の `pr_number` が literal substitute されていない / 数値以外 |
-| `p61c_post_comment_mode_invalid` | ステップ 6.1.c の `post_comment_mode` が literal substitute されていない / `true` (誤呼出) / 不正値 (Issue #510 対応、`p61b_post_comment_mode_invalid` と対称) |
-| `p61c_persistence_unrecoverable` | ステップ 6.1.c ケース 2 (`post_comment_mode=false` ∧ `LOCAL_SAVE_FAILED=1`) で silent data loss 防止のため ステップ 6 全体を `exit 2` で fail させる |
-| `p61c_file_timestamp_unset` | ステップ 6.1.c で `file_timestamp` placeholder が literal substitute されていない |
-| `p61c_local_save_failed_invalid` | ステップ 6.1.c で `local_save_failed` が不正値 (空文字/0/1 以外) |
-| `p61c_file_timestamp_unknown_without_failure` | ステップ 6.1.c で `file_timestamp='unknown'` だが `local_save_failed != '1'` (整合性違反、ケース 1 での `.../unknown.json` 誤提示を遮断) |
 
-> **Note (Issue #1193 #3/#4)**: ステップ 6.1.a / 6.1.b の reason は委譲先 helper が emit する (`hooks/review-result-save.sh` / `hooks/review-comment-post.sh`、SoT は各 helper の docstring)。`distributed-fix-drift-check.sh` Pattern 2 は「同一ファイル内に `| reason |` table 行があれば同ファイル内で `reason=` emit される」ことを前提とするため、委譲済 reason は **markdown table 行にせず bullet 形式**で列挙する (emit 先が helper へ移ったことを反映)。helper の stderr `[CONTEXT]` emit は caller の bash 出力として LLM コンテキストに surface するため、下記 reason はレビュー flow 上で従来どおり観測される。
+> **Note (Issue #1193 #3/#4 / #1221)**: ステップ 6.1.a / 6.1.b / 6.1.c の reason は委譲先 helper が emit する (`hooks/review-result-save.sh` / `hooks/review-comment-post.sh` / `hooks/review-skip-notification.sh`、SoT は各 helper の docstring)。`distributed-fix-drift-check.sh` Pattern 2 は「同一ファイル内に `| reason |` table 行があれば同ファイル内で `reason=` emit される」ことを前提とするため、委譲済 reason は **markdown table 行にせず bullet 形式**で列挙する (emit 先が helper へ移ったことを反映)。同じ理由で、委譲済 reason は本文 prose でも `reason=...` 構文を使わず bare backtick 名で参照する (`reason=X` 構文は emit-side 検出に拾われ「table にあるが emit されない」逆 drift を誘発するため)。helper の stderr `[CONTEXT]` emit は caller の bash 出力として LLM コンテキストに surface するため、下記 reason はレビュー flow 上で従来どおり観測される。
 
 **ステップ 6.1.a reasons** (`review-result-save.sh` が `[CONTEXT] LOCAL_SAVE_FAILED=1; reason=...` を emit、全て **WARNING only / 非ブロッキング**):
 - `pr_number_placeholder_residue`: `--pr` が数値以外 (空文字 / placeholder 残留) のまま渡された (cleanup.md ステップ 6 の numeric gate と対称化し永久 orphan 化を防ぐ)
@@ -3056,13 +3050,21 @@ Output the review results via two independent paths. Use `mktemp` + `--body-file
 - `raw_json_timestamp_injection_failed`: Raw JSON セクション内 sentinel の awk 置換 / post-condition (Raw JSON 内残留なし / Markdown 不変) が失敗
 - `gh_comment_post_failure`: `gh pr comment` 投稿が exit != 0 で失敗 (network / auth / rate-limit / permission、rc>=128 時は signal 番号併記)
 
+**ステップ 6.1.c reasons** (`review-skip-notification.sh` が `[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=...` を emit。ケース 2 の `p61c_persistence_unrecoverable` は **hard error として ステップ 6 を `exit 2` で fail**、その他の gate 違反は exit 1。正常経路 `post_comment_mode=false` は続行):
+- `p61c_post_comment_mode_invalid`: `--post-comment-mode` が `false` 以外 (`true` 誤呼出 / 不正値、Issue #510 対応、`p61b_post_comment_mode_invalid` と対称)
+- `p61c_pr_number_invalid`: `--pr` が literal substitute されていない / 数値以外 (`p61b_pr_number_invalid` と対称)
+- `p61c_file_timestamp_unset`: `--file-timestamp` placeholder が literal substitute されていない
+- `p61c_file_timestamp_unknown_without_failure`: `file_timestamp='unknown'` だが `local_save_failed != '1'` (整合性違反、ケース 1 での `.../unknown.json` 誤提示を遮断)
+- `p61c_local_save_failed_invalid`: `--local-save-failed` が不正値 (空文字/0/1 以外)
+- `p61c_persistence_unrecoverable`: ケース 2 (`post_comment_mode=false` ∧ `LOCAL_SAVE_FAILED=1`) で silent data loss 防止のため ステップ 6 全体を `exit 2` で fail
+
 **Non-blocking contract**: ステップ 6.1.a の全 14 種の reason (`pr_number_placeholder_residue` / `date_command_failure` / `mkdir_failure` / `mktemp_failure` / `write_failure` / `timestamp_injection_mv_failure` / `json_invalid` / `schema_required_fields_missing` / `finding_id_format_or_uniqueness_violation` / `scope_enum_violation` / `critical_high_scope_nit_noted_invariant` / `mktemp_failure_mv_err` / `mv_failure` / `collision_resolution_exhausted`) are all logged as WARNING and MUST NOT cause ステップ 6 to fail. Only `tmpfile_write_failure` (which affects the PR comment post path, not the local file save) causes a hard error. Canonical 定義は [common-error-handling.md#non-blocking-contract-canonical-定義](../../references/common-error-handling.md#non-blocking-contract-canonical-定義) を参照。
 
 **Retained flag mapping**:
 
 - **ステップ 6.1.a** は `[CONTEXT] LOCAL_SAVE_FAILED=1` flag を emit する。reason 値は以下 14 種のいずれか: `pr_number_placeholder_residue` / `date_command_failure` / `mkdir_failure` / `mktemp_failure` / `write_failure` / `timestamp_injection_mv_failure` / `json_invalid` / `schema_required_fields_missing` / `finding_id_format_or_uniqueness_violation` / `scope_enum_violation` / `critical_high_scope_nit_noted_invariant` / `mktemp_failure_mv_err` / `mv_failure` / `collision_resolution_exhausted`。この flag は ステップ 6.1.c の skip notification で「ローカル保存失敗」メッセージを表示する条件として参照される。ステップ 6 全体の exit code には影響しない (非ブロッキング契約)。
 - **ステップ 6.1.b** は `[CONTEXT] REVIEW_OUTPUT_FAILED=1` flag を emit する。reason 値は `tmpfile_write_failure` / `gh_comment_post_failure` / `json_saved_from_p61a_unset` / `p61b_post_comment_mode_invalid` のいずれか。この flag は PR コメント投稿経路の失敗を示し、hard error として ステップ 6 を fail させる (ステップ 6.1.a の非ブロッキング契約とは対照的)。なお `post_comment_mode=false` で 6.1.b に誤呼出された場合は gate が **silent skip (exit 0)** するため、caller branch selection ミスは retained flag emit せずに吸収される (データ破壊なし、gh pr comment も実行されない)。
-- **ステップ 6.1.c** は case 2 (`post_comment_mode=false` ∧ `LOCAL_SAVE_FAILED=1` の組み合わせ) で `[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable` を emit し、ステップ 6 全体を `exit 2` で fail させる (silent data loss 防止)。
+- **ステップ 6.1.c** は case 2 (`post_comment_mode=false` ∧ `LOCAL_SAVE_FAILED=1` の組み合わせ) で `[CONTEXT] REVIEW_OUTPUT_FAILED=1` (reason 値 `p61c_persistence_unrecoverable`) を emit し、ステップ 6 全体を `exit 2` で fail させる (silent data loss 防止)。
 
 **Eval-order enumeration** (for Pattern-5 drift check): ステップ 6.1.a emit sequence = (`pr_number_placeholder_residue` / `date_command_failure` / `mkdir_failure` / `mktemp_failure` / `write_failure` / `timestamp_injection_mv_failure` / `json_invalid` / `schema_required_fields_missing` / `finding_id_format_or_uniqueness_violation` / `scope_enum_violation` / `critical_high_scope_nit_noted_invariant` / `mktemp_failure_mv_err` / `collision_resolution_exhausted` / `mv_failure`) — 14 件、bash block 内の実 emit 順 (`scope_enum_violation` / `critical_high_scope_nit_noted_invariant` は Issue #1018 M2 で finding_id_format_or_uniqueness_violation の直後に elif chain で配置); ステップ 6.1.b emit = (`p61b_post_comment_mode_invalid` / `p61b_pr_number_invalid` / `tmpfile_write_failure` / `iso_timestamp_from_p61a_unset` / `raw_json_timestamp_injection_failed` / `gh_comment_post_failure` / `json_saved_from_p61a_unset`) — `p61b_post_comment_mode_invalid` は post_comment_mode gate が bash block 冒頭で最初に評価されるため先頭に配置; ステップ 6.1.c emit = (`p61c_post_comment_mode_invalid` / `p61c_pr_number_invalid` / `p61c_file_timestamp_unset` / `p61c_file_timestamp_unknown_without_failure` / `p61c_local_save_failed_invalid` / `p61c_persistence_unrecoverable`) — `p61c_post_comment_mode_invalid` を先頭に配置 (6.1.b と対称).
 
@@ -3176,7 +3178,7 @@ When `{post_comment_mode}=false`, inform the user that PR comment posting was sk
 # 旧 ~142 行の inline bash (4 gate + 2 ケース分岐 heredoc) は hooks/review-skip-notification.sh へ
 # 委譲済 (Issue #1221、6.1.b の review-comment-post.sh 切り出しと対称)。契約 (post_comment_mode gate /
 # pr_number・file_timestamp・local_save_failed の fail-fast gate / reason 語彙 p61c_* / ケース 1 INFO
-# exit 0 / ケース 2 ⚠️ + reason=p61c_persistence_unrecoverable + exit 2 で ステップ 6 全体を fail) は
+# exit 0 / ケース 2 ⚠️ + reason 値 p61c_persistence_unrecoverable + exit 2 で ステップ 6 全体を fail) は
 # helper header と下記 Prose spec 参照。
 # Claude は [CONTEXT] marker から 4 値を literal substitute する (local_save_failed は空文字を渡すため
 # 必ずクォートすること): post_comment_mode=ステップ 1.0 の POST_COMMENT_MODE / pr_number /
@@ -3191,7 +3193,7 @@ bash {plugin_root}/hooks/review-skip-notification.sh \
 **Prose spec (参考)**:
 
 - **ケース 1** (`LOCAL_SAVE_FAILED` 未 emit、通常経路): `ℹ️ PR コメント記録はスキップされました` + ローカルファイル path を表示、`exit 0`
-- **ケース 2** (`LOCAL_SAVE_FAILED=1` ∧ `post_comment_mode=false`、findings が会話コンテキストにのみ存在する異常経路): `⚠️ ERROR: レビュー結果が永続化されませんでした` + 復旧方法 4 種を表示、`[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable` を emit、**`exit 2` で ステップ 6 を fail させる** (silent data loss 防止のため hard fail)
+- **ケース 2** (`LOCAL_SAVE_FAILED=1` ∧ `post_comment_mode=false`、findings が会話コンテキストにのみ存在する異常経路): `⚠️ ERROR: レビュー結果が永続化されませんでした` + 復旧方法 4 種を表示、`[CONTEXT] REVIEW_OUTPUT_FAILED=1` (reason 値 `p61c_persistence_unrecoverable`) を emit、**`exit 2` で ステップ 6 を fail させる** (silent data loss 防止のため hard fail)
 
 **`post_comment_mode=false` と `LOCAL_SAVE_FAILED=1` が同時に成立する場合**: `review-skip-notification.sh` の machine-enforced gate により必ずケース 2 (⚠️ ERROR) が選択され、ステップ 6 は `exit 2` で終了する。Claude の自然言語判断には依存しない (silent data loss 防止)。WARNING のみの exit 0 経路はユーザー可視性と CI 検出性を両立できないため hard fail に統一する。
 

--- a/plugins/rite/hooks/review-skip-notification.sh
+++ b/plugins/rite/hooks/review-skip-notification.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# rite workflow - Review Result Skip Notification
+# Deterministic helper for commands/pr/review.md ステップ 6.1.c (Skip Notification)。
+#
+# review.md ステップ 6.1.c の skip notification 処理 (post_comment_mode gate + pr_number /
+# file_timestamp / local_save_failed の fail-fast gate + LOCAL_SAVE_FAILED に基づく 2 ケース分岐)
+# を担う。本文側の巨大 inline bash (機械強制 case 分割 + 2 つの cat heredoc) を helper に切り出す
+# ことで、単一 Bash invocation での malform 無言停止を回避する (Issue #1221、6.1.b の
+# review-comment-post.sh 切り出しと対称)。
+#
+# Usage:
+#   bash review-skip-notification.sh \
+#     --post-comment-mode <true|false> \
+#     --pr <number> \
+#     --file-timestamp <YYYYMMDDHHMMSS|unknown> \
+#     --local-save-failed <0|1|"">
+#
+#   caller (review.md ステップ 6.1.c) は以下を会話コンテキストから読み取り literal substitute する:
+#     - --post-comment-mode: ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE= の値 (Issue #510)
+#     - --pr: 正規化済 pr_number
+#     - --file-timestamp: ステップ 6.1.a の [CONTEXT] FILE_TIMESTAMP= の値 (成功時 YYYYMMDDHHMMSS、失敗時 "unknown")
+#     - --local-save-failed: ステップ 6.1.a の [CONTEXT] LOCAL_SAVE_FAILED= の値 ("1" または未 emit=空文字)。
+#       空文字を確実に渡すため caller は必ずクォートして渡すこと (例: --local-save-failed "")。
+#
+# 契約 (review.md ステップ 6.1.c と verbatim 一致):
+#   - 実行条件: post_comment_mode=false の経路専用 (true 経路は 6.1.b の成功/失敗ログで完結する)。
+#   - post_comment_mode machine-enforced gate (Issue #510、6.1.b と対称): false→続行 /
+#     true→ERROR + [review:error] + exit 1 / その他→ERROR + [review:error] + exit 1。
+#   - 「1 変数 1 gate」原則で fail-fast の局所性を最大化 (post_comment_mode gate 通過後に
+#     pr_number / file_timestamp / local_save_failed を順に検証)。reason 語彙:
+#       p61c_post_comment_mode_invalid / p61c_pr_number_invalid /
+#       p61c_file_timestamp_unset / p61c_file_timestamp_unknown_without_failure /
+#       p61c_local_save_failed_invalid / p61c_persistence_unrecoverable
+#   - ケース 1 (LOCAL_SAVE_FAILED 未 emit、通常経路): ℹ️ INFO + ローカルファイル path 表示、exit 0。
+#   - ケース 2 (LOCAL_SAVE_FAILED=1 ∧ post_comment_mode=false、findings が会話コンテキストにのみ
+#     存在する異常経路): ⚠️ ERROR + 復旧方法 4 種を表示し、
+#     [CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable を emit、
+#     exit 2 で ステップ 6 全体を fail させる (silent data loss 防止のため hard fail)。
+#   - [CONTEXT] / WARNING / [review:error] 以外の人間向けログは stderr。
+#
+# Exit codes:
+#   0: 通常の skip notification (ケース 1) 完了。
+#   1: gate 違反 (REVIEW_OUTPUT_FAILED emit 済) / 引数エラー。
+#   2: ケース 2 (persistence_unrecoverable) の hard fail。ステップ 6 全体を fail させる documented 経路。
+set -uo pipefail
+
+# --- Argument parsing ---
+POST_COMMENT_MODE=""
+PR_NUMBER=""
+FILE_TIMESTAMP=""
+LOCAL_SAVE_FAILED=""
+
+# 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
+# `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
+# 陥る (Issue #1224、review-comment-post.sh と対称)。1 回目の shift で $# を確実に 0 にし、
+# 2 回目は no-op で安全に抜ける。
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --post-comment-mode) POST_COMMENT_MODE="${2:-}"; shift; shift ;;
+    --pr)                PR_NUMBER="${2:-}"; shift; shift ;;
+    --file-timestamp)    FILE_TIMESTAMP="${2:-}"; shift; shift ;;
+    --local-save-failed) LOCAL_SAVE_FAILED="${2:-}"; shift; shift ;;
+    *) echo "ERROR: review-skip-notification: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# post_comment_mode machine-enforced gate (Issue #510 対応、6.1.b と対称)。
+# 6.1.c は post_comment_mode=false 経路専用。true 経路で誤呼出された場合、本来 6.1.b で
+# 成功/失敗ログが完結すべきところ skip notification を出すと観測値が混線する。caller の
+# branch selection ミスを fail-fast 遮断する。
+case "$POST_COMMENT_MODE" in
+  false) ;;
+  true)
+    echo "ERROR: review-skip-notification: ステップ 6.1.c が post_comment_mode=true の経路で呼び出されました (本来 6.1.b の成功/失敗ログで完結すべき経路)" >&2
+    echo "  真因: caller (LLM) が ステップ 6.1 の branch selection を誤りました。post_comment_mode=true の場合は 6.1.b のみを実行し 6.1.c は skip すべきです。" >&2
+    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_post_comment_mode_invalid; value=true" >&2
+    echo "[review:error]"
+    exit 1
+    ;;
+  *)
+    echo "ERROR: review-skip-notification: post_comment_mode が literal substitute されていません (値: '$POST_COMMENT_MODE', 期待: true/false)" >&2
+    echo "  caller は ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE=true|false emit 値を --post-comment-mode に渡す必要があります" >&2
+    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_post_comment_mode_invalid; value=$POST_COMMENT_MODE" >&2
+    echo "[review:error]"
+    exit 1
+    ;;
+esac
+
+# pr_number の数値 fail-fast gate (ステップ 6.1.a の pr_number guard と対称化)。
+# substitute 漏れ時、ケース 1 のローカルファイル path に placeholder がそのまま出力される
+# silent UX regression を防ぐ。
+#
+# reason drift 対策: ステップ 6.1.a が pr_number 不正を検出した場合は exit 0 (non-blocking) するが、
+# ステップ 6.1.c は別 bash invocation のため retained flag を参照できない。pr_number が不正なまま
+# 本 helper に到達した場合、真因は ステップ 6.1.a の substitution 忘れなので、その再実行を促す。
+case "$PR_NUMBER" in
+  ''|*[!0-9]*)
+    echo "ERROR: review-skip-notification: pr_number が literal substitute されていません (値: '$PR_NUMBER', 期待: 数値のみ非空)" >&2
+    echo "  真因: ステップ 6.1.a で Claude が pr_number を literal substitute せず、同じ placeholder が本 helper まで連鎖している可能性が高いです。" >&2
+    echo "  対処: ステップ 1.0 で正規化された pr_number を ステップ 6.1.a の bash block 冒頭で literal substitute してから再実行してください" >&2
+    echo "  (ステップ 6.1.a が exit 0 non-blocking で完了すると ステップ 6.1.c に substitution 忘れが連鎖します)" >&2
+    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_pr_number_invalid; upstream_hint=phase_6_1_a_substitution_missing" >&2
+    exit 1
+    ;;
+esac
+
+# file_timestamp gate: placeholder 残留は silent fallthrough せず fail-fast。
+case "$FILE_TIMESTAMP" in
+  "{"*|*"}")
+    echo "ERROR: review-skip-notification: file_timestamp が literal substitute されていません (値: '$FILE_TIMESTAMP')" >&2
+    echo "  caller は ステップ 6.1.a の [CONTEXT] FILE_TIMESTAMP=... を読み取って --file-timestamp に渡す必要があります" >&2
+    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_file_timestamp_unset" >&2
+    exit 1
+    ;;
+  "unknown")
+    # ステップ 6.1.a の trap handler は date 失敗時に FILE_TIMESTAMP=unknown と LOCAL_SAVE_FAILED=1 を
+    # 同時に emit する設計。片方だけが set された不整合状態 (観測値混線 / race) でケース 1 に流れると、
+    # `.rite/review-results/${pr_number}-unknown.json` という実在しないファイルパスを誤提示する UX
+    # regression が起きる。整合性違反として明示的に ERROR 化する。
+    if [ "$LOCAL_SAVE_FAILED" != "1" ]; then
+      echo "ERROR: review-skip-notification: file_timestamp='unknown' だが local_save_failed が '1' ではありません (整合性違反)" >&2
+      echo "  ステップ 6.1.a の trap handler は date 失敗時に FILE_TIMESTAMP=unknown と LOCAL_SAVE_FAILED=1 を同時に emit するはずです" >&2
+      echo "  単独 emit 経路は観測値混線 / race の兆候であり、ユーザーに誤ったファイルパスを提示する経路を遮断します" >&2
+      echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_file_timestamp_unknown_without_failure" >&2
+      exit 1
+    fi
+    # local_save_failed=1 が併設されている場合は legitimate な失敗経路のため、下記ケース 2 分岐に流す。
+    ;;
+esac
+
+# local_save_failed の値検証 (許容: 空文字 / 0 / 1)。
+case "$LOCAL_SAVE_FAILED" in
+  ""|0|1) ;;
+  *)
+    echo "ERROR: review-skip-notification: local_save_failed が不正 (許容: 空文字 / 0 / 1、値: '$LOCAL_SAVE_FAILED')" >&2
+    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_local_save_failed_invalid" >&2
+    exit 1
+    ;;
+esac
+
+# ケース分岐: LOCAL_SAVE_FAILED=1 が set されていればケース 2 (WARNING 昇格 + hard fail)、
+# それ以外はケース 1 (INFO)。
+if [ "$LOCAL_SAVE_FAILED" = "1" ]; then
+  # ケース 2: local save 失敗 (findings が会話コンテキストにのみ存在する異常経路)。
+  #
+  # silent data loss 防止のため WARNING のみの exit 0 ではなく、以下 2 段階で hard fail させる:
+  # 1. WARNING + 復旧方法 4 種を表示 (ユーザー可視性の維持)
+  # 2. `[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable` を retained flag
+  #    として emit し、ステップ 6 全体を `exit 2` で fail させる (CI / caller が silent pass しない)
+  #
+  # 「review 成功 = findings が観測可能な場所に届いた」という invariant を維持する。
+  cat >&2 <<EOF
+⚠️ ERROR: レビュー結果が永続化されませんでした (silent data loss 防止のため ステップ 6 を fail させます)
+  PR コメント: スキップ (pr_review.post_comment=false)
+  ローカルファイル: 保存失敗 ([CONTEXT] LOCAL_SAVE_FAILED の reason を確認してください)
+
+  影響: 本レビュー結果は現在の会話コンテキストのみに存在します。
+  次のセッション開始時 (会話 compaction / terminal close / session restart) に完全に失われます。
+  この経路を silent pass にしないため、ステップ 6 全体を exit 2 で fail させます。
+
+  復旧方法 (いずれかを選択):
+  1. このセッション内で即座に /rite:pr:fix を実行する (Priority 1: 会話コンテキストから直接読取)
+  2. /rite:pr:review --post-comment で PR コメントに投稿して永続化する
+  3. rite-config.yml で pr_review.post_comment: true を設定して全 review を永続化する
+  4. LOCAL_SAVE_FAILED の reason を解決してから /rite:pr:review を再実行する
+EOF
+  echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=p61c_persistence_unrecoverable; local_save_failed=1; post_comment_mode=false" >&2
+  echo "[review:error]"
+  exit 2
+else
+  # ケース 1: local save 成功 (通常経路)。
+  cat >&2 <<EOF
+ℹ️ PR コメント記録はスキップされました (pr_review.post_comment=false)
+  ローカルファイル: .rite/review-results/${PR_NUMBER}-${FILE_TIMESTAMP}.json
+  コメント記録を有効化するには --post-comment フラグまたは rite-config.yml で pr_review.post_comment: true を設定してください
+EOF
+fi
+
+exit 0

--- a/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
+++ b/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
@@ -12,13 +12,14 @@
 #   3. `shift 2` 到達前に required-value ガードがない
 # (1つでも欠ければ安全: set -u+bare $2 は nounset で fail-fast / set -e は即 exit / 明示ガードは exit)
 #
-# Coverage (脆弱だった 5 スクリプト, 計 18 箇所):
+# Coverage (Issue #1224 で hardening した脆弱だった 5 スクリプト 計 18 箇所 + 新規 helper 1 件 計 4 箇所):
 #   TC-1 post-review-state-verify.sh (hooks/scripts/, 4 箇所) — 値なしフラグ末尾 → no-hang + exit 2
 #   TC-2 review-comment-post.sh      (hooks/,         5 箇所) — 値なしフラグ末尾 → no-hang
 #   TC-3 review-result-save.sh       (hooks/,         3 箇所) — 値なしフラグ末尾 → no-hang
 #   TC-4 review-source-resolve.sh    (scripts/,       5 箇所) — 値なしフラグ末尾 → no-hang
 #   TC-5 decompose-issues.sh         (scripts/,       1 箇所) — 値なしフラグ末尾 → no-hang + exit 2
-#   TC-6 anti-pattern guard — 5 スクリプトに実 `shift 2` 文が残存しないこと (comment 参照は許容)
+#   TC-6 review-skip-notification.sh (hooks/,         4 箇所) — 値なしフラグ末尾 → no-hang (新規 helper、当初から shift; shift 採用)
+#   TC-7 anti-pattern guard — 6 スクリプトに実 `shift 2` 文が残存しないこと (comment 参照は許容)
 #
 # 各 TC は `timeout 5` で hang (exit 124) を検出する。値なしフラグはいずれも required value を
 # 空にし、ループ完了後のローカル guard で exit する経路 (network/git に触れない) を選択している。
@@ -57,24 +58,26 @@ run_no_hang "TC-2 review-comment-post"      "hooks/review-comment-post.sh"      
 run_no_hang "TC-3 review-result-save"       "hooks/review-result-save.sh"              "--pr"              ""
 run_no_hang "TC-4 review-source-resolve"    "scripts/review-source-resolve.sh"         "--pr-number"       ""
 run_no_hang "TC-5 decompose-issues"         "scripts/decompose-issues.sh"              "--spec"            "2"
+run_no_hang "TC-6 review-skip-notification" "hooks/review-skip-notification.sh"         "--pr"              ""
 
-# === TC-6: anti-pattern guard — 実 `shift 2` 文が再混入していないこと ===
+# === TC-7: anti-pattern guard — 実 `shift 2` 文が再混入していないこと ===
 # comment 内の `shift 2` 参照 (backtick 囲み) は許容し、実際の statement だけを検出する。
 # 実 statement は行頭 or `;` の直後に現れる: (^|;)<空白>*shift 2<空白/;/行末>。
-echo "=== TC-6: anti-pattern guard (実 shift 2 文の不在) ==="
+echo "=== TC-7: anti-pattern guard (実 shift 2 文の不在) ==="
 for script in \
   "hooks/scripts/post-review-state-verify.sh" \
   "hooks/review-comment-post.sh" \
   "hooks/review-result-save.sh" \
+  "hooks/review-skip-notification.sh" \
   "scripts/review-source-resolve.sh" \
   "scripts/decompose-issues.sh"; do
   path="$PLUGIN_ROOT/$script"
   real_hits=$(grep -nE '(^|;)[[:space:]]*shift 2([[:space:]]|;|$)' "$path" || true)
   if [ -n "$real_hits" ]; then
-    fail "TC-6 $(basename "$script"): 実 shift 2 文が残存"
+    fail "TC-7 $(basename "$script"): 実 shift 2 文が残存"
     printf '%s\n' "$real_hits"
   else
-    pass "TC-6 $(basename "$script"): 実 shift 2 文なし (comment 参照のみ)"
+    pass "TC-7 $(basename "$script"): 実 shift 2 文なし (comment 参照のみ)"
   fi
 done
 


### PR DESCRIPTION
## 概要

Issue #1221（`bash-heaviness-check` が surface した heavy operational bash ブロック 8 件の解消、#1197 follow-up）のうち、**`pr/review.md` の 2 ブロック**を解消する部分対応 PR。

- **6.1.c Skip Notification**（142 行・multi-heredoc(2) + long-block）→ `hooks/review-skip-notification.sh` へ委譲。6.1.b の `review-comment-post.sh` 切り出しと対称構造。
- **7.4.2 Issue 作成ブロック**（nested-cmdsub + long-block(67)）→ nested-cmdsub signal は実コードではなく「過去の入れ子コマンド置換」を説明する**コメント中の literal による false-positive** だったため、実コードを変更せずコメントを散文化して除去（checker 精度の回復）。

`bash-heaviness-check.sh --all` の findings は `review.md` 由来の 2 件が消え、全体 4→2 に減少。

## 関連 Issue

Refs #1221（**部分対応** — `pr/cleanup.md` / `pr/create.md` の 2 ブロックが残るため Issue は open のまま。「一括は非推奨」の Issue 方針に従い別 PR で対応）

## 変更内容

- `plugins/rite/hooks/review-skip-notification.sh`（新規）: 6.1.c の 4 gate + LOCAL_SAVE_FAILED に基づく 2 ケース分岐を担う helper。`set -uo pipefail`、#1224 対策の `shift;shift`、reason 語彙 `p61c_*`・`[review:error]` emit 有無・exit 0/1/2 を旧 inline block から verbatim 移植。
- `plugins/rite/commands/pr/review.md`:
  - 6.1.c の inline bash（142 行）を helper 呼び出し（~16 行）へ置換し、周辺 prose を委譲明記へ更新。
  - 7.4.2 のコメント nested-cmdsub literal を散文化（実コード不変）。
  - 委譲に伴い 6.1.c の reason を markdown table → bullet 形式へ変換（#1193 #3/#4 で確立した「委譲済 reason は bullet・prose も bare backtick 名」規約に準拠、6.1.a/6.1.b と対称化）。helper 化が誘発する「table にあるが emit されない」新規 drift を構造的に解消。

## 検証

- helper の全 5 経路をスモークテストで確認: case1（exit 0）/ post_comment_mode=true 誤呼出（exit 1）/ pr_number placeholder（exit 1）/ persistence_unrecoverable（exit 2）/ file_timestamp residue（exit 1）。#1224 の value-less flag 無限ループ非発生も確認。
- `bash-heaviness-check.sh`: review.md 0 件（全体 2 件、残りは別ブロック）。
- `distributed-fix-drift-check.sh`: review.md の findings を develop baseline（25 件、すべて pre-existing）へ復帰させ、新規 drift ゼロ・既存 finding 維持を before/after diff で確認。
- `bang-backtick-check.sh`（pre-PR hard gate）clean、`bash -n` 構文チェック pass。

## Issue #1221 チェックリスト進捗

本 PR で解消（マージ後に Issue 側でチェック予定）:
- [x] `pr/review.md`（multi-heredoc 2 + long-block 142）→ helper 化
- [x] `pr/review.md`（nested-cmdsub + long-block 67）→ コメント false-positive 除去

別 PR で対応予定（本 PR スコープ外・未着手）:
- [ ] `pr/cleanup.md`（nested-cmdsub + long-block 78）
- [ ] `pr/create.md`（nested-cmdsub + long-block 56）

## Checklist

- [x] プロジェクト規約に準拠（Conventional Commits / Contextual Commits）
- [x] 既存ワークフロー契約を verbatim 保持（reason 語彙・sentinel・exit code）
- [x] lint（plugin-specific checks）で本 PR 由来の新規 finding ゼロを確認

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
