### PR TITLE
fix(issue): fingerprint-cycling §4 split に empty-result 等 3 ガードを追加

### DIFF
--- a/plugins/rite/commands/issue/references/fingerprint-cycling.md
+++ b/plugins/rite/commands/issue/references/fingerprint-cycling.md
@@ -174,7 +174,7 @@ Signal 3 または Signal 4 が発火した場合、**§3 の 4-option AskUserQu
 tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT
 
-cat <<'BODY_EOF' > "$tmpfile"
+if ! cat <<'BODY_EOF' > "$tmpfile"
 ## 概要
 
 レビューサイクル中に持続した finding を別 Issue として切り出しました (Quality Signal 1 発火)。
@@ -186,6 +186,17 @@ cat <<'BODY_EOF' > "$tmpfile"
 
 - 元の PR: #{pr_number}
 BODY_EOF
+then
+  echo "ERROR: Issue 本文テンプレートの一時ファイル書き込みに失敗" >&2
+  echo "[CONTEXT] ISSUE_CREATE_FAILED=1; reason=body_tmpfile_write_failure" >&2
+  exit 1
+fi
+
+if [ ! -s "$tmpfile" ]; then
+  echo "ERROR: Issue 本文の生成に失敗" >&2
+  echo "[CONTEXT] ISSUE_CREATE_FAILED=1; reason=empty_body_tmpfile" >&2
+  exit 1
+fi
 
 # jq -n の出力を stdin で create-issue-with-projects.sh に渡す (pr/review.md §3992 / Issue #1193 #5 と同じ pipe 形式、入れ子 $() を回避)
 result=$(jq -n \
@@ -209,6 +220,12 @@ result=$(jq -n \
     },
     options: { source: "fingerprint_split", non_blocking_projects: true }
   }' | bash {plugin_root}/scripts/create-issue-with-projects.sh)
+
+if [ -z "$result" ]; then
+  echo "ERROR: create-issue-with-projects.sh returned empty result" >&2
+  echo "[CONTEXT] ISSUE_CREATE_FAILED=1; reason=empty_script_result" >&2
+  exit 1
+fi
 new_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
 echo "✅ Fingerprint 循環 finding を #$(printf '%s' "$result" | jq -r '.issue_number') として切り出しました: $new_issue_url"
 ```


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/references/fingerprint-cycling.md` の §4 split ブロックに、同等処理を行う先例 `pr/review.md` ステップ 7.4.2 が持つ 3 つのエラーガードを追加し、構造を対称化しました。pipe 形式（pipefail なし）で jq または helper が失敗した際に `result` が空となり、直後の `jq -r '.issue_url'` が無言で空 URL を echo する silent failure 経路を遮断します（Asymmetric Fix Transcription の解消）。

## 関連 Issue

Closes #1234

## 変更内容

- heredoc を `if ! cat <<'BODY_EOF' > "$tmpfile" ... fi` で包み、write-failure guard を追加（`reason=body_tmpfile_write_failure`）
- heredoc 直後に empty-body guard（`[ ! -s "$tmpfile" ]`）を追加（`reason=empty_body_tmpfile`）
- `result=` 代入直後・`new_issue_url=` 代入前に empty-result guard（`[ -z "$result" ]`）を追加（`reason=empty_script_result`）
- 各 guard は先例 7.4.2 と同一の `[CONTEXT] ISSUE_CREATE_FAILED=1` marker + `exit 1` を踏襲。§4 固有要素（`review-split:` title / `fingerprint_split` source / ✅ echo / `new_issue_url`）は保持

## チェックリスト

- [x] プロジェクト規約に準拠（インデントは §4 ローカル 2-space に統一）
- [x] bash 構文検証済み（プレースホルダ置換版で `bash -n` 成功）
- [ ] テスト追加（該当なし: 手順書 markdown のためテストコードなし）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
