### PR TITLE
refactor(issue): fingerprint-cycling §4 split に post-result error surfacing を移植

### DIFF
--- a/plugins/rite/commands/issue/references/fingerprint-cycling.md
+++ b/plugins/rite/commands/issue/references/fingerprint-cycling.md
@@ -227,7 +227,23 @@ if [ -z "$result" ]; then
   exit 1
 fi
 new_issue_url=$(printf '%s' "$result" | jq -r '.issue_url')
+# create-issue-with-projects.sh は失敗時も非空の failed JSON (issue_url=="") を emit してから
+# exit する契約のため、上の empty-result ガードは通過する。空 URL のまま ✅ を echo する silent
+# failure を防ぐため issue_url を guard し warnings[] を surface する (先例 review.md ステップ
+# 7.4.2 の post-result handling を移植、refs #1252)
+if [ -z "$new_issue_url" ] || [ "$new_issue_url" = "null" ]; then
+  echo "ERROR: Fingerprint 循環 finding の Issue 化に失敗しました (issue_url が空)" >&2
+  printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w" >&2; done
+  echo "[CONTEXT] ISSUE_CREATE_FAILED=1; reason=empty_issue_url" >&2
+  exit 1
+fi
 echo "✅ Fingerprint 循環 finding を #$(printf '%s' "$result" | jq -r '.issue_number') として切り出しました: $new_issue_url"
+# Issue 作成は成功。Projects 登録の partial/failed と warnings[] を surface する (silent にしない)
+project_reg=$(printf '%s' "$result" | jq -r '.project_registration')
+printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do echo "⚠️ $w"; done
+if [ "$project_reg" = "partial" ] || [ "$project_reg" = "failed" ]; then
+  echo "⚠️ Projects 登録が完全に完了しませんでした（status: $project_reg）。手動登録: gh project item-add {project_number} --owner {owner} --url $new_issue_url"
+fi
 ```
 
 Signal 3 / Signal 4 由来の split では title prefix を `review-split:` のまま (Signal 1 と統一)、body の冒頭 "Quality Signal 1 発火" を実発火 signal 名に置換する。`options.source` も `fingerprint_split` → `quality_signal_3_split` / `quality_signal_4_split` に変更する。


### PR DESCRIPTION
## 概要

`fingerprint-cycling.md` の §4 split bash に、先例 `review.md` ステップ 7.4.2 が持つ post-result error surfacing を移植し、残存していた silent failure 経路を遮断する。

`create-issue-with-projects.sh` は失敗時も非空の failed JSON（`issue_url==""`）を stdout に emit してから exit する契約のため、既存の `[ -z "$result" ]` ガードは通過し、後続で **空 URL のまま `✅` 成功メッセージを echo** していた。PR #1251 の 3 ガード（heredoc write-failure / empty-body / empty-result）では塞げない pre-existing な残差。

## 関連 Issue

Closes #1252

## 変更内容

- `plugins/rite/commands/issue/references/fingerprint-cycling.md`（§4 split bash, 16 行追加）
  - `new_issue_url` 抽出直後に `issue_url==""` / `null` ガードを追加し、空 URL での `✅` echo を遮断（`warnings[]` を stderr に surface + `[CONTEXT] ISSUE_CREATE_FAILED=1; reason=empty_issue_url` emit + `exit 1`）
  - Issue 作成成功時に `project_registration` 抽出 + `warnings[]` の `⚠️` surfacing + partial/failed 時の手動登録ヒントを追加（先例 7.4.2 と同等）
  - 既存の empty-result ガードと PR #1251 の 3 ガードは温存

## 検証

- 3 シナリオ（成功 / Projects partial / failed JSON 空 URL）で post-result ロジックを動作確認：空 URL 時に `✅` を出さず `exit 1` する silent failure 遮断を確認
- caller contract `issue-create-with-projects.md` の Step 3 / Silent Fail Prohibition と整合（stale doc なし）

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（`commands.test` 未設定のため該当なし）
- [x] ドキュメント影響調査済み（caller contract と整合、stale doc なし）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
