### PR TITLE
docs(issue): fingerprint-cycling §4 split に single-invocation 注記と placeholder 表を追加

### DIFF
--- a/plugins/rite/commands/issue/references/fingerprint-cycling.md
+++ b/plugins/rite/commands/issue/references/fingerprint-cycling.md
@@ -170,7 +170,7 @@ Signal 3 または Signal 4 が発火した場合、**§3 の 4-option AskUserQu
 
 ## §4 — Split bash for "別 Issue として切り出す"
 
-**Important**: 以下の bash ブロックは **単一の Bash tool 呼び出し** で実行すること。本ブロックは一時ファイル cleanup の `trap 'rm -f "$tmpfile"' EXIT` と、write / empty / empty-result / empty-url の各失敗で中断する `exit 1` ガード (PR #1251 で追加) を含む。複数の Bash 呼び出しに分割すると trap が中間状態で発火して cleanup 契約が崩れ、`exit 1` も後続呼び出しへ伝播せず guard が機能しなくなる (先例 review.md ステップ 7.4.2 の single-invocation 注記と同契約)。
+**Important**: 以下の bash ブロックは **単一の Bash tool 呼び出し** で実行すること。本ブロックは一時ファイル cleanup の `trap 'rm -f "$tmpfile"' EXIT` と、write / empty / empty-result の各失敗で中断する `exit 1` ガード (PR #1251) および empty-url 失敗で中断する `exit 1` ガード (PR #1252) を含む。複数の Bash 呼び出しに分割すると trap が中間状態で発火して cleanup 契約が崩れ、`exit 1` も後続呼び出しへ伝播せず guard が機能しなくなる (先例 review.md ステップ 7.4.2 の single-invocation 注記と同契約)。
 
 **Placeholder value sources** (Claude はスクリプト生成前に必ず以下のソースから値を取得してプレースホルダーを置換すること。これらはシェル変数ではない):
 

--- a/plugins/rite/commands/issue/references/fingerprint-cycling.md
+++ b/plugins/rite/commands/issue/references/fingerprint-cycling.md
@@ -170,6 +170,20 @@ Signal 3 または Signal 4 が発火した場合、**§3 の 4-option AskUserQu
 
 ## §4 — Split bash for "別 Issue として切り出す"
 
+**Important**: 以下の bash ブロックは **単一の Bash tool 呼び出し** で実行すること。本ブロックは一時ファイル cleanup の `trap 'rm -f "$tmpfile"' EXIT` と、write / empty / empty-result / empty-url の各失敗で中断する `exit 1` ガード (PR #1251 で追加) を含む。複数の Bash 呼び出しに分割すると trap が中間状態で発火して cleanup 契約が崩れ、`exit 1` も後続呼び出しへ伝播せず guard が機能しなくなる (先例 review.md ステップ 7.4.2 の single-invocation 注記と同契約)。
+
+**Placeholder value sources** (Claude はスクリプト生成前に必ず以下のソースから値を取得してプレースホルダーを置換すること。これらはシェル変数ではない):
+
+| Placeholder | Source | Example |
+|-------------|--------|---------|
+| `{persistent_finding_body}` | 持続した finding の body (review 結果コンテキスト) | (finding 本文) |
+| `{short_summary}` | finding の要約 (動詞始まり、50 文字以内) | `fix XYZ guard` |
+| `{pr_number}` | 現在の PR 番号 (review-fix ループのコンテキスト) | `1253` |
+| `{projects_enabled}` | `rite-config.yml` → `github.projects.enabled` | `true` |
+| `{project_number}` | `rite-config.yml` → `github.projects.project_number` | `6` |
+| `{owner}` | `rite-config.yml` → `github.projects.owner` | `B16B1RD` |
+| `{plugin_root}` | [Plugin Path Resolution](../../../references/plugin-path-resolution.md#resolution-script-full-version) | `/home/user/.claude/plugins/rite` |
+
 ```bash
 tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT


### PR DESCRIPTION
## 概要

`plugins/rite/commands/issue/references/fingerprint-cycling.md` の §4 split ブロックに、先例 `plugins/rite/commands/pr/review.md` ステップ 7.4.2 が持つ 2 つの構造的要素を追加し、対称化を完成させた。

## 関連 Issue

Closes #1253

## 変更内容

- §4 heading 直後に **single Bash tool invocation 注記** を追加。§4 の `trap ... EXIT` と PR #1251 で追加された `exit 1` ガードが単一実行に依存することを明示し、ブロック分割時に cleanup/guard が機能しなくなる failure mode を予防。
- §4 に **placeholder source 表** を追加。§4 bash で実際に使用する 7 placeholder（`{persistent_finding_body}` / `{short_summary}` / `{pr_number}` / `{projects_enabled}` / `{project_number}` / `{owner}` / `{plugin_root}`）の値源を明記。

## 設計判断

- placeholder 表は §4 bash の**実使用分のみ**を列挙。先例 7.4.2 が持つ `{iteration_mode}` は §4 が `iteration: { mode: "none" }` をハードコードしており使用しないため、あえて含めない（表と実態の乖離を防止）。
- §4 bash 本体・契約は一切変更せず、heading と bash ブロック間への説明追記のみ（pre-existing な構造欠如の補完）。

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし: docs のみの変更）
- [x] ドキュメント更新（本変更自体が docs）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
