### PR TITLE
docs(spec): SPEC.md に flow-state の session-scoped / 離散コマンド非依存再定義を明記

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1381,6 +1381,8 @@ A system that performs unified pre-validation before every `/rite:*` command exe
 
 The flow state for `/rite:*` workflows uses a **per-session file** structure (`.rite/sessions/{session_id}.flow-state`) introduced by Issue #672 and landed across PR #686 / #747 / #748 + #756 / #750 / #751 / #757 / #759. Each Claude Code session writes only to its own file, so concurrent sessions on the same repository are structurally race-free without lock acquisition.
 
+> **Authority scope — session-scoped continuation hint, not a cross-`/clear` source of truth**: flow state is **session-scoped** and treats `/clear` as its continuation terminus — a session started after a `/clear` resolves a fresh `session_id` and therefore reads a different (structurally empty) state file. Consequently, **discrete commands** invoked standalone across a `/clear` (e.g. `/rite:pr:merge`) **must not** treat flow state as the authoritative cross-`/clear` state. Their authority lives in the persistent SoT — `gh pr view` (`isDraft` / `mergeable` / `mergeStateStatus`), GitHub Projects Status, and `.rite-work-memory/issue-{n}.md`. flow state, when present, is consumed only as a **same-session continuation hint**, and its absence is the normal (un-warned) case for discrete operation. Conversely, the **continuation-loop subsystems** — `/rite:pr:iterate`'s review↔fix loop, the `Stop` hook + `handoff` field, `/rite:pr:review` / `/rite:pr:fix`, sprint e2e orchestration, compact recovery, and `/rite:resume` — are single-session by nature and are precisely the domain where session-scoped flow state functions correctly; they are left untouched. See [`docs/designs/clear-per-command-flow-state-decoupling.md`](designs/clear-per-command-flow-state-decoupling.md) (Issue #1256) for the full discrete-command-vs-continuation-loop decoupling analysis and per-command breakdown; `commands/pr/merge.md` Step 1 is the first application of this boundary.
+
 **File path:**
 
 ```
@@ -1839,7 +1841,7 @@ Long-running commands such as the end-to-end flow `/rite:pr:open` → `/rite:pr:
 
 **Why this works:**
 
-- Work memory (Issue comments) and the per-session flow state file persist workflow state across sessions
+- Work memory (Issue comments + the local `.rite-work-memory/issue-{n}.md` file) and git/PR artifacts persist workflow state across sessions. The per-session flow state file is session-scoped (see [Multi-Session State Management](#multi-session-state-management)), so the post-`/clear` session reads a fresh empty file; `/rite:resume` reconstructs the resume point from work memory + git/PR cross-check, using flow state only as the same-session signal when present
 - All git artifacts (branches, commits, PRs) are preserved — nothing is lost
 - `/rite:resume` reads the persisted state and resumes the appropriate phase
 
@@ -1851,7 +1853,7 @@ Long-running commands such as the end-to-end flow `/rite:pr:open` → `/rite:pr:
 | Commits | Git | Yes |
 | Draft PR | GitHub | Yes |
 | Work memory | Issue comment | Yes |
-| Flow state | `.rite/sessions/{session_id}.flow-state` (see [Multi-Session State Management](#multi-session-state-management)) | Yes |
+| Flow state | `.rite/sessions/{session_id}.flow-state` (see [Multi-Session State Management](#multi-session-state-management)) | Partial — the file persists on disk, but the post-`/clear` session reads a fresh empty file (session-scoped); `/rite:resume` falls back to work memory + git/PR |
 
 ### API Error Handling
 


### PR DESCRIPTION
## 概要

`docs/SPEC.md` の「Multi-Session State Management」節に、flow-state の権威スコープを明確化する再定義ノートを追加した。離散コマンド（`/clear` を挟む単発実行、例: `/rite:pr:merge`）は永続 SoT（`gh pr view` の isDraft/mergeable/mergeStateStatus・Projects Status・`.rite-work-memory/issue-{n}.md`）を権威とし、flow-state は同一セッション内の continuation hint と位置付ける。継続ループ系（review↔fix / Stop hook+handoff / `pr:review`・`pr:fix` / sprint e2e / compact recovery / resume）は single-session 前提で flow-state が正しく機能する領域として整理した。

設計ドキュメント #1256（Issue A は PR #1260 でマージ済み）の §AC-5 Issue B に対応。

## 関連 Issue

Closes #1259

## 変更内容

- `docs/SPEC.md` Multi-Session State Management 節に「Authority scope」再定義ノートを追加（session-scoped / `/clear` 継続終端 / 離散コマンドは永続 SoT 権威・flow-state は同一セッション continuation hint・不在は正常系で無警告 / 継続ループ系は single-session 前提）
- 設計ドキュメント `docs/designs/clear-per-command-flow-state-decoupling.md` への相互参照リンクを追加
- AC-3 整合のため、Context-limit recovery 節（prose 1 行 + 保全テーブルの Flow state 行）の「flow-state が across-session 永続 / Survives=Yes」記述を新定義と矛盾しないよう reconcile（実際の `/clear` 越し復旧は work memory + git/PR フォールバック）

## チェックリスト

- [x] プロジェクト規約に準拠（既存の note blockquote パターンに整合、英語散文）
- [x] AC-1〜AC-3 をすべて満たす
- [x] `/rite:lint` ブロッキング指摘なし（既存の非ブロッキング warning は本変更と無関係）
- [x] Issue A（#1260）とは独立にマージ可能

## 補足

`docs/SPEC.md` のみの変更（コード・hook・設計ドキュメント本体の変更なし）。merge.md Step 1（#1260）の実装と記述が整合していることを確認済み。

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
