### PR TITLE
test(hooks): cleanup WIKICHAIN parity test にステップ 9〜12 間の intervening set 検出 TC-6 を追加

### DIFF
--- a/plugins/rite/hooks/tests/cleanup-wikichain-handoff-parity.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-wikichain-handoff-parity.test.sh
@@ -20,6 +20,9 @@
 #   (d) cleanup.md ステップ 12 の terminal set に `--handoff` が付与された (default-clear 喪失
 #       = 完走後も handoff が残存し、次の停止で誤 block する)
 #   (e) チェーン各段 (lint / ingest / cleanup) の returned-to-caller sentinel 宣言の削除/rename 漏れ
+#   (f) ステップ 9 の handoff set とステップ 12 の terminal set の間に `--handoff` なしの
+#       executable な flow-state.sh set が追加された (handoff の premature default-clear —
+#       gate が silent に外れる。prose の「制約」note のみが guard だった経路の機械化、Issue #1268)
 #
 # 検出しない drift (本 test の scope 外、他 test が担当):
 #   - hook の block / one-shot consume / reason 文面の runtime 挙動
@@ -126,6 +129,40 @@ for f in "$LINT_MD" "$INGEST_MD" "$CLEANUP_MD"; do
   fi
 done
 
-if ! print_summary "cleanup-wikichain-handoff-parity.test.sh" "drift hint: cleanup.md ステップ 9 (WIKICHAIN handoff set) / ステップ 12 (terminal set の default-clear) と stop-loop-continuation.sh の WIKICHAIN:* case arm、チェーン 3 段の return sentinel を同期させてください (Issue #1245)"; then
+# ──────────────────────────────────────────────────────────────────────
+# TC-6: ステップ 9〜12 間に --handoff なしの executable intervening set が存在しない
+# ──────────────────────────────────────────────────────────────────────
+# ステップ 9 直下の「制約」note (prose guard) の機械版 (Issue #1268)。intervening
+# `flow-state.sh set` (--handoff なし) が挟まると handoff が premature default-clear され
+# gate が silent に外れる。anchor は TC-2 の handoff_line / TC-4 の terminal_set_line を
+# 再利用し、新規 anchor 追加による drift コストを避ける (anchor 不在時は skip して
+# TC-1/TC-4 の fail と重複させない)。
+# 判定対象は executable 行のみ: prose の backtick 言及 (`flow-state.sh set`) は
+# `{plugin_root}/hooks/` path prefix を持たないため、path 付き literal で区別する。
+terminal_line=""
+if [ -n "$terminal_set_line" ]; then
+  terminal_line=$(printf '%s' "$terminal_set_line" | cut -d: -f1)
+fi
+
+if [ -z "$handoff_line" ] || [ -z "$terminal_line" ]; then
+  echo "  ⏭️  TC-6 skipped (TC-1/TC-4 で anchor 不在を検出済み)"
+elif [ "$handoff_line" -ge "$terminal_line" ]; then
+  fail "TC-6 handoff set (line $handoff_line) が terminal set (line $terminal_line) より後にあります (ステップ 9 → 12 の構造順序が崩れています)"
+else
+  # 行末 \ の継続行を join してから判定する (multi-line set の継続行に --handoff が
+  # ある場合、行単位 grep では --handoff なしと誤判定されるため)
+  intervening_sets=$(sed -n "$((handoff_line + 1)),$((terminal_line - 1))p" "$CLEANUP_MD" \
+    | sed -e ':a' -e '/\\$/N; s/\\\n//; ta' \
+    | grep -F -- '/hooks/flow-state.sh set' \
+    | grep -vF -- '--handoff' || true)
+
+  if [ -z "$intervening_sets" ]; then
+    pass "TC-6 ステップ 9〜12 間に --handoff なしの intervening flow-state.sh set は存在しない"
+  else
+    fail "TC-6 ステップ 9〜12 間に --handoff なしの executable flow-state.sh set が存在します (handoff が premature default-clear され gate が silent に外れます)。cleanup.md ステップ 9 の「制約」note に従い、同じ WIKICHAIN handoff 値を --handoff で再指定してください: $intervening_sets"
+  fi
+fi
+
+if ! print_summary "cleanup-wikichain-handoff-parity.test.sh" "drift hint: cleanup.md ステップ 9 (WIKICHAIN handoff set) / ステップ 12 (terminal set の default-clear) と stop-loop-continuation.sh の WIKICHAIN:* case arm、チェーン 3 段の return sentinel を同期させてください (Issue #1245)。ステップ 9〜12 間に新規 flow-state.sh set を挟む場合は同じ WIKICHAIN handoff 値の --handoff 再指定が必要です (cleanup.md ステップ 9 の制約 note / Issue #1268)"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`cleanup-wikichain-handoff-parity.test.sh` に TC-6 を追加し、cleanup.md ステップ 9 (WIKICHAIN handoff set) とステップ 12 (terminal set) の間に `--handoff` なしの executable な intervening `flow-state.sh set` が存在しないことを機械検証する。

従来この回帰は cleanup.md ステップ 9 直下の prose「制約」note でしか守られておらず、intervening set が将来追加されると handoff が premature default-clear され Stop-hook 継続保証 gate (Issue #1245) が silent に外れる経路を parity test は機械検出しなかった (PR #1267 test reviewer 指摘の follow-up)。

## 関連 Issue

Closes #1268

## 変更内容

- header「検出する drift」リストに (f) intervening set 検出を追記
- TC-6 を実装:
  - anchor は TC-2 の `handoff_line` / TC-4 の `terminal_set_line` を再利用 (新規 anchor 追加による drift コストを回避。anchor 不在時は skip して TC-1/TC-4 の fail と重複させない)
  - 行末 `\` の継続行を join してから `--handoff` なしの executable set のみ fail (prose の backtick 言及は `{plugin_root}/hooks/` path literal で除外)
  - `--handoff` 再指定済みの intervening set は TC-6 では許容 (その場合 TC-1 の単一 site assert が catch し、意識的なテスト更新を強制)
- print_summary の drift hint に intervening set を挟む場合の対処を追記

## 設計判断

- Issue 検討事項の候補案「handoff set / terminal set の 2 行のみ assert」は、cleanup.md「制約」note が許容する handoff 再指定経路を一律 fail にするため不採用

## 検証

- 本テスト単体: 8/8 pass
- sandbox negative test:
  - Case A (`--handoff` なし intervening set 注入) → TC-6 FAIL (rc=1) を確認
  - Case B (継続行 `--handoff` 再指定) → TC-6 PASS / TC-1 FAIL (期待動作) を確認
- run-tests.sh 全 suite: 57/57 pass

## チェックリスト

- [x] コードはプロジェクト規約に準拠
- [x] テスト pass (hook テスト全 suite 57/57)
- [x] ドキュメント更新 (該当なし — test-only change)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
