### PR TITLE
fix(hooks): cleanup.md ステップ 9 制約 note と TC-1/TC-6 の remediation 指示矛盾を intervening set 禁止へ収束 (refs #1271)

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -382,7 +382,7 @@ bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --active true \
 
 > **Why (mechanical gate)**: cleanup → wiki:ingest → wiki:lint の 2 段ネスト skill return 直後に LLM が turn を閉じる implicit stop が累積再発している (#604〜#1144 lineage、#1245)。iterate ループの Stop-hook 継続保証 (#1168 / #1176) と同型の one-shot handoff を移植し、チェーン途中で turn が閉じた場合は Stop hook (`stop-loop-continuation.sh`) が `WIKICHAIN:*` を consume して停止を差し戻し、残り step (ingest 残処理 → ステップ 10-12) の継続を強制する。チェーンがステップ 12 まで完走した場合はステップ 12 末尾の `flow-state.sh set` (`--handoff` なし) が handoff を default-clear するため block は発生しない。consume は one-shot のため無限 block しない。
 >
-> **制約**: 本 set からステップ 12 末尾の set までの間に別の `flow-state.sh set` を挟むと handoff が default-clear されて gate が外れる。本コマンドのステップ 10-11 に `flow-state.sh set` を追加する変更を入れる場合は、同じ WIKICHAIN チェーン handoff 値を `--handoff` で再指定すること。
+> **制約**: 本 set からステップ 12 末尾の set までの間に別の `flow-state.sh set` を挟むと handoff が default-clear されて gate が外れる。このため、ステップ 10-11 への `flow-state.sh set` の追加自体を禁止する (`--handoff` 再指定での回避は TC-1 の単一 SoT 制約と矛盾するため不可)。intervening set が必要になる設計変更では、本 note と `cleanup-wikichain-handoff-parity.test.sh` TC-1/TC-6 を含む handoff lifecycle 全体を同時に見直すこと。
 
 handoff セット後に invoke する:
 

--- a/plugins/rite/hooks/tests/cleanup-wikichain-handoff-parity.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-wikichain-handoff-parity.test.sh
@@ -159,10 +159,10 @@ else
   if [ -z "$intervening_sets" ]; then
     pass "TC-6 ステップ 9〜12 間に --handoff なしの intervening flow-state.sh set は存在しない"
   else
-    fail "TC-6 ステップ 9〜12 間に --handoff なしの executable flow-state.sh set が存在します (handoff が premature default-clear され gate が silent に外れます)。cleanup.md ステップ 9 の「制約」note に従い、同じ WIKICHAIN handoff 値を --handoff で再指定してください: $intervening_sets"
+    fail "TC-6 ステップ 9〜12 間に --handoff なしの executable flow-state.sh set が存在します (handoff が premature default-clear され gate が silent に外れます)。cleanup.md ステップ 9 の「制約」note によりステップ 10-11 への flow-state.sh set 追加自体が禁止です — 該当 set を削除してください (--handoff 再指定は TC-1 の単一 SoT 制約と矛盾するため不可。intervening set が必要な設計変更は制約 note と TC-1/TC-6 を同時に見直すこと): $intervening_sets"
   fi
 fi
 
-if ! print_summary "cleanup-wikichain-handoff-parity.test.sh" "drift hint: cleanup.md ステップ 9 (WIKICHAIN handoff set) / ステップ 12 (terminal set の default-clear) と stop-loop-continuation.sh の WIKICHAIN:* case arm、チェーン 3 段の return sentinel を同期させてください (Issue #1245)。ステップ 9〜12 間に新規 flow-state.sh set を挟む場合は同じ WIKICHAIN handoff 値の --handoff 再指定が必要です (cleanup.md ステップ 9 の制約 note / Issue #1268)"; then
+if ! print_summary "cleanup-wikichain-handoff-parity.test.sh" "drift hint: cleanup.md ステップ 9 (WIKICHAIN handoff set) / ステップ 12 (terminal set の default-clear) と stop-loop-continuation.sh の WIKICHAIN:* case arm、チェーン 3 段の return sentinel を同期させてください (Issue #1245)。ステップ 9〜12 間への新規 flow-state.sh set 追加は禁止です — --handoff 再指定は TC-1 の単一 SoT と矛盾するため不可 (cleanup.md ステップ 9 の制約 note / Issue #1268, #1271)"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`cleanup-wikichain-handoff-parity.test.sh` TC-6 の remediation 指示（「同じ WIKICHAIN handoff 値を `--handoff` で再指定せよ」）に従うと TC-1（handoff set の単一 site 強制）が count=2 で fail する、SoT レベルの guidance 矛盾を解消する。

Issue の対応候補 2（再指定経路を塞ぐ）を採用し、3 site を「intervening set 追加自体を禁止」へ対称同期した:

- cleanup.md ステップ 9「制約」note: 「`--handoff` で再指定すること」→「追加自体を禁止（再指定は TC-1 の単一 SoT 制約と矛盾するため不可）。intervening set が必要な設計変更では note + TC-1/TC-6 を含む handoff lifecycle 全体を同時に見直す」
- TC-6 fail メッセージ: 同 remediation へ同期（「該当 set を削除してください」）
- print_summary drift hint: 「--handoff 再指定が必要です」→「追加は禁止です」

TC-1 / TC-6 の検出ロジック自体は不変（文言のみの変更）。

## 関連 Issue

Closes #1271

## 変更内容

- `plugins/rite/commands/pr/cleanup.md`: ステップ 9「制約」note の remediation 文言を「追加禁止」へ変更
- `plugins/rite/hooks/tests/cleanup-wikichain-handoff-parity.test.sh`: TC-6 fail メッセージ + print_summary drift hint を同期

## 検証

- `cleanup-wikichain-handoff-parity.test.sh`: 8/8 PASS
- mutation A（`--handoff` なし intervening set 挿入）: TC-6 が新メッセージ「追加自体が禁止 — 該当 set を削除」で fail（検出力維持）
- mutation B（`--handoff` 付き intervening set 挿入）: TC-1 が count=2「単一 SoT を保て」で fail
- 両 mutation の fail メッセージが「追加するな」という同方向 guidance になり、矛盾解消を実証
- 旧 guidance「で再指定すること」の残存 0 件（repo 全体 grep）

## Known Issues

- lint 未実行（lint コマンド未検出。plugin-specific checks 13 種は実行済み、本 PR 変更箇所由来の新規 finding 0 件）

## チェックリスト

- [x] コードはプロジェクトの規約に従っている
- [x] テストが通る（parity test 8/8 PASS + mutation A/B 検証）
- [x] ドキュメント更新（cleanup.md 制約 note 自体が変更対象）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
