### PR TITLE
fix(hooks): stop-loop-continuation の未知 prefix WARNING に制御文字 neutralize を適用 (refs #1269)

### DIFF
--- a/plugins/rite/hooks/stop-loop-continuation.sh
+++ b/plugins/rite/hooks/stop-loop-continuation.sh
@@ -100,7 +100,9 @@ handoff は consume 済みのため、進捗なく再度停止した場合は次
   *)
     # 未知 prefix: 新 prefix 追加時の case 分岐漏れを silent 吸収しない (fail-loud)。block 自体は
     # 「handoff 非空 → block」の設計軸を維持し、handoff 値を verbatim で差し戻す。
-    echo "WARNING: stop-loop-continuation: unknown handoff prefix (re-injecting verbatim; add an explicit case arm for new prefixes): ${HANDOFF}" >&2
+    # WARNING への埋め込みは制御文字を neutralize する (flow-state.sh _emit_jq_err_snippet の
+    # [[:cntrl:]] → ? 規約と対称。ANSI escape による operator 端末乗っ取り防止 / Issue #1269)。
+    echo "WARNING: stop-loop-continuation: unknown handoff prefix (re-injecting verbatim; add an explicit case arm for new prefixes): ${HANDOFF//[[:cntrl:]]/?}" >&2
     _reason="rite の handoff マーカーが未消化のまま残っていました。停止せず、次を実行してください: ${HANDOFF}
 
 handoff は consume 済みのため、進捗なく再度停止した場合は次回は停止が許可されます (無限 block しません)。"

--- a/plugins/rite/hooks/tests/stop-loop-continuation.test.sh
+++ b/plugins/rite/hooks/tests/stop-loop-continuation.test.sh
@@ -265,6 +265,38 @@ rm -f "$err13"
 out_b=$(stop_payload "$d13" "$SID" true | bash "$HOOK")
 assert "TC-13: second stop allows (one-shot)" "" "$out_b"
 
+# --- TC-14: unknown-prefix WARNING neutralizes control bytes (Issue #1269) ---
+# The stderr WARNING must not pass raw control bytes (ANSI escapes etc.) to the operator's
+# terminal — same [[:cntrl:]] → ? convention as flow-state.sh _emit_jq_err_snippet. The
+# decision:block reason keeps the handoff verbatim (TC-13 contract): neutralize scope is
+# the WARNING line only.
+echo ""
+echo "=== TC-14: unknown-prefix WARNING neutralizes control bytes (WARNING-only scope) ==="
+d14=$(new_sandbox)
+RITE_STATE_ROOT="$d14" bash "$FS" set --phase cleanup --issue 1269 --branch b --pr 99 \
+  --next n --handoff "$(printf 'EVILPREFIX:\x1b[31mred\x1b[0m:99')" --session "$SID" >/dev/null
+err14=$(mktemp)
+out14=$(stop_payload "$d14" | bash "$HOOK" 2>"$err14")
+assert "TC-14: decision=block (block axis unaffected by neutralize)" "block" "$(printf '%s' "$out14" | jq -r '.decision // "NONE"')"
+if grep -q $'\x1b' "$err14"; then
+  fail "TC-14: WARNING leaked a raw ESC byte to stderr: $(cat -v "$err14")"
+else
+  pass "TC-14: WARNING contains no raw control bytes"
+fi
+if grep -qF 'EVILPREFIX:?[31mred?[0m:99' "$err14"; then
+  pass "TC-14: control bytes replaced with ? in the WARNING"
+else
+  fail "TC-14: neutralized handoff missing from WARNING: $(cat -v "$err14")"
+fi
+# Scope pin: the reason keeps the raw handoff verbatim (re-injection contract). If the
+# neutralize scope is ever widened to the reason, update this pin deliberately.
+if printf '%s' "$out14" | jq -r '.reason // ""' | grep -q $'\x1b'; then
+  pass "TC-14: reason keeps the handoff verbatim (neutralize does not widen to re-injection)"
+else
+  fail "TC-14: reason lost the verbatim handoff bytes: $out14"
+fi
+rm -f "$err14"
+
 if ! print_summary "$(basename "$0")" "stop-loop-continuation.sh (Issue #1168 review↔fix loop continuation + #1176 FINALIZE terminal backstop + #1245 WIKICHAIN cleanup-chain gate)"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`stop-loop-continuation.sh` の未知 handoff prefix WARNING が `${HANDOFF}` を制御文字 neutralize せず raw で stderr へ出力していた問題を修正。`flow-state.sh` の `_emit_jq_err_snippet()` が確立した `[[:cntrl:]]` → `?` neutralize 規約と対称化し、ANSI escape / 制御バイトによる operator 端末乗っ取り経路を遮断する。

## 関連 Issue

Closes #1269

## 変更内容

- `plugins/rite/hooks/stop-loop-continuation.sh`: 未知 prefix WARNING の `${HANDOFF}` を `${HANDOFF//[[:cntrl:]]/?}` に変更（インライン bash パラメータ展開。適用箇所 1 行のためヘルパー化は不採用）
- `plugins/rite/hooks/tests/stop-loop-continuation.test.sh`: TC-14 を追加 — 制御文字（ESC）入り未知 prefix handoff で (1) stderr WARNING に raw 制御バイトが漏れない (2) `?` 置換が適用される (3) decision:block reason は verbatim 維持（neutralize スコープは WARNING のみ、TC-13 契約保護）を検証

## スコープ外（意図的に変更しない）

- `_reason` への `${HANDOFF}` verbatim 埋め込み（再注入契約）: Issue 本文の通り、モデルコンテキストへの反射は既存 `/rite:*` arm と同等で本 Issue のスコープ外。TC-14 の scope pin で保護

## 検証

- hook テストスイート `stop-loop-continuation.test.sh`: 43 件全パス（TC-1〜TC-14、regression なし）
- `/rite:lint`: プラグイン固有チェック 13 種実行 — 今回の変更起因の finding 0 件（既存 warning は progressive cleanup 対象として別途トラッキング済み）

## Known Issues

- 外部 lint 未実行（lint コマンド未検出 — `commands.lint: null`）。プラグイン固有チェック 13 種は実行済み

## チェックリスト

- [x] プロジェクト規約に準拠（`_emit_jq_err_snippet` の neutralize 規約と対称）
- [x] テストパス（43/43）
- [x] ドキュメント更新不要を確認（docs は handoff 値系統のみ記述で WARNING 出力形式に言及なし）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
