### PR TITLE
fix(hooks): 検出用途の制御文字 validation に C1 8-bit バイト検出を追加

### DIFF
--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -2,7 +2,10 @@
 # rite workflow - Control Character Neutralization (shared)
 # Provides the single source of truth for the "control chars → ?" diagnostic
 # neutralization convention shared by flow-state.sh (_emit_jq_err_snippet) and
-# stop-loop-continuation.sh (unknown handoff prefix WARNING).
+# stop-loop-continuation.sh (unknown handoff prefix WARNING), plus the
+# detection-side counterpart contains_ctrl() for reject-purpose validation
+# (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh SOURCE_REF /
+# TITLE — Issue #1276).
 #
 # WHY a shared helper (Issue #1274): the POSIX class [[:cntrl:]] on glibc
 # (C and UTF-8 locales, byte-wise verified) does NOT classify C1 8-bit control
@@ -25,6 +28,7 @@
 #   printf '%s' "$value" | neutralize_ctrl                  # \n も ? 化 (1 行 WARNING 埋め込み用)
 #   head -3 "$file" | neutralize_ctrl --keep-newline        # \n は保持 (行構造を保つ snippet 用)
 #   printf '%s' "$value" | neutralize_ctrl --c0-only        # C0+DEL のみ (UTF-8 本文を保持する JSON 用)
+#   contains_ctrl "$value" && reject                        # 検出 (reject) 用 — 範囲は default と同一
 #
 # Contract:
 #   - stdin → stdout byte filter; LC_ALL=C tr なので NUL を含む任意バイト列を扱える
@@ -49,4 +53,40 @@ neutralize_ctrl() {
   else
     LC_ALL=C tr '\000-\037\177\200-\237' '[?*]'
   fi
+}
+
+# Detection-side counterpart (Issue #1276): reject-purpose call sites
+# (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh SOURCE_REF /
+# TITLE) previously used bash `=~ [[:cntrl:]]`, which on glibc misses the same
+# C1 8-bit range the neutralize side closes — letting e.g. 0x9b slip through
+# validation. Sharing the byte-range definition here keeps detection and
+# replacement symmetric.
+#
+# Usage: contains_ctrl "$value"   # rc 0 = C0/DEL/C1 byte present, rc 1 = clean
+#
+# Contract:
+#   - argument-based, not a stdin filter: every call site tests a bash
+#     variable, and bash variables cannot carry NUL — so 0x00 is structurally
+#     unreachable here (the stdin-filter neutralize_ctrl still covers it)
+#   - byte-wise under LC_ALL=C: UTF-8 continuation bytes overlapping 0x80-0x9f
+#     (e.g. most Japanese characters) are detected as control bytes — accepted
+#     (Issue #1276 設計判断): all call sites are ASCII-identifier / ASCII-title
+#     fields. 日本語 TITLE が必要になったら UTF-8 セーフモードを別途追加する
+#   - implementation reuses the exact neutralize_ctrl default tr range and
+#     compares byte counts before/after deletion. grep は使わない — grep 実装に
+#     よっては (例: ugrep) LC_ALL=C でも raw 8-bit バイトを UTF-8 として扱い
+#     リテラル 0x9b にすらマッチしないため、検出が環境依存で silent に壊れる
+#   - fail-closed: pipeline failure / non-numeric wc output counts as
+#     "detected" so the reject path cannot silently degrade into pass-through
+contains_ctrl() {
+  local _in_bytes _stripped_bytes
+  _in_bytes=$(printf '%s' "$1" | LC_ALL=C wc -c) || _in_bytes=""
+  _stripped_bytes=$(printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\177\200-\237' | LC_ALL=C wc -c) || _stripped_bytes=""
+  # BSD wc は数値を空白パディングするため除去してから数値検証する
+  _in_bytes=${_in_bytes//[[:space:]]/}
+  _stripped_bytes=${_stripped_bytes//[[:space:]]/}
+  case "${_in_bytes}:${_stripped_bytes}" in
+    *[!0-9:]*|:*|*:) return 0 ;;
+  esac
+  [ "$_in_bytes" -ne "$_stripped_bytes" ]
 }

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -57,8 +57,11 @@ _validate_session_id() {
       return 1
       ;;
   esac
-  if [[ "$sid" =~ [[:cntrl:]] ]]; then
-    echo "ERROR: invalid session_id from $origin: contains control characters (newline / tab / etc.)" >&2
+  # contains_ctrl (control-char-neutralize.sh) は C0 + DEL + C1 8-bit (0x80-0x9f)
+  # をバイト単位で検出する。旧 `=~ [[:cntrl:]]` は glibc が C1 を cntrl と分類しない
+  # ため 0x9b (8-bit CSI) 入り session_id を素通ししていた (Issue #1276)。
+  if contains_ctrl "$sid"; then
+    echo "ERROR: invalid session_id from $origin: contains control characters (newline / tab / C1 8-bit bytes / etc.)" >&2
     return 1
   fi
   return 0

--- a/plugins/rite/hooks/tests/control-char-neutralize.test.sh
+++ b/plugins/rite/hooks/tests/control-char-neutralize.test.sh
@@ -24,6 +24,14 @@
 #   TC-11: --c0-only: C1 境界 (0x80 / 0x9b / 0x9f) は素通し (default との差分 pin)
 #   TC-12: --c0-only: UTF-8 マルチバイト (日本語) が無傷 (JSON フォールバック reason 保護の本丸 pin)
 #   TC-13: --c0-only: \n も ? 化 (C0 範囲 — caller は改行を先にエスケープしてから呼ぶ契約)
+#   TC-14: contains_ctrl: C0 (0x01 / TAB / \n / ESC) を検出 (Issue #1276)
+#   TC-15: contains_ctrl: DEL (0x7f) を検出
+#   TC-16: contains_ctrl: C1 境界 (0x80 / 0x9b CSI / 0x9f) を検出 (Issue #1276 本丸 pin —
+#          旧 `=~ [[:cntrl:]]` は glibc が C1 を cntrl と分類しないため素通し)
+#   TC-17: contains_ctrl: 0xa0 (C1 上限 +1) / printable ASCII は clean (過剰検出しない境界 pin)
+#   TC-18: contains_ctrl: UTF-8 U+009B (0xc2 0x9b) を 2 バイト目で検出
+#   TC-19: contains_ctrl: empty string は clean / UTF-8 マルチバイト (日本語) は検出
+#          (byte-wise 設計判断 pin — 継続バイト 0x80-0x9f 重複は accepted trade-off)
 #
 # Usage: bash plugins/rite/hooks/tests/control-char-neutralize.test.sh
 set -euo pipefail
@@ -106,6 +114,46 @@ echo ""
 echo "=== TC-13: --c0-only — \\n も ? 化 (C0 範囲 — caller は改行を先にエスケープする契約) ==="
 assert "TC-13: newline neutralized in c0-only mode" "l1?l2" "$(printf 'l1\nl2' | neutralize_ctrl --c0-only)"
 
-if ! print_summary "$(basename "$0")" "control-char-neutralize.sh — Issue #1274 C0+DEL+C1 byte-wise neutralization shared helper"; then
+# contains_ctrl の rc を assert 可能な文字列へ (rc 0 = detected / rc 1 = clean)
+ctrl_verdict() { if contains_ctrl "$1"; then echo detected; else echo clean; fi; }
+
+echo ""
+echo "=== TC-14: contains_ctrl — C0 (0x01 / TAB / \\n / ESC) を検出 (Issue #1276) ==="
+assert "TC-14: SOH (0x01) detected" "detected" "$(ctrl_verdict $'a\x01b')"
+assert "TC-14: TAB detected" "detected" "$(ctrl_verdict $'a\tb')"
+assert "TC-14: newline detected" "detected" "$(ctrl_verdict $'a\nb')"
+assert "TC-14: ESC (0x1b) detected" "detected" "$(ctrl_verdict $'a\x1bb')"
+
+echo ""
+echo "=== TC-15: contains_ctrl — DEL (0x7f) を検出 ==="
+assert "TC-15: DEL detected" "detected" "$(ctrl_verdict $'a\x7fb')"
+
+echo ""
+echo "=== TC-16: contains_ctrl — C1 境界 (0x80 / 0x9b CSI / 0x9f) を検出 (Issue #1276 本丸) ==="
+# 旧 `=~ [[:cntrl:]]` (flow-state.sh / wiki-ingest-trigger.sh の reject 経路) は
+# glibc が C/UTF-8 両ロケールで C1 を cntrl と分類しないためこの 3 バイトを素通ししていた。
+assert "TC-16: C1 lower bound (0x80) detected" "detected" "$(ctrl_verdict $'a\x80b')"
+assert "TC-16: CSI introducer (0x9b) detected" "detected" "$(ctrl_verdict $'a\x9bb')"
+assert "TC-16: C1 upper bound (0x9f) detected" "detected" "$(ctrl_verdict $'a\x9fb')"
+
+echo ""
+echo "=== TC-17: contains_ctrl — 0xa0 / printable ASCII は clean (過剰検出しない境界 pin) ==="
+assert "TC-17: byte just above C1 (0xa0) clean" "clean" "$(ctrl_verdict $'a\xa0b')"
+assert "TC-17: printable ASCII clean" "clean" "$(ctrl_verdict 'pr-123 TEXT_ok~')"
+
+echo ""
+echo "=== TC-18: contains_ctrl — UTF-8 U+009B (0xc2 0x9b) を 2 バイト目で検出 ==="
+# valid UTF-8 の U+009B は jq / YAML パーサを素通りして call site まで届く現実の攻撃
+# バイト列 (TC-5 と同じ脅威モデルの検出側 pin)。
+assert "TC-18: U+009B detected via second byte" "detected" "$(ctrl_verdict $'x\xc2\x9by')"
+
+echo ""
+echo "=== TC-19: contains_ctrl — empty は clean / 日本語は検出 (byte-wise 設計判断 pin) ==="
+assert "TC-19: empty string clean" "clean" "$(ctrl_verdict '')"
+# UTF-8 継続バイト (0x80-0x9f 重複) の検出は accepted trade-off (Issue #1276 設計判断)。
+# この assert が fail し始めたら byte-wise 契約自体が変わったことを意味する。
+assert "TC-19: multibyte (Japanese) detected via continuation bytes" "detected" "$(ctrl_verdict 'あ')"
+
+if ! print_summary "$(basename "$0")" "control-char-neutralize.sh — Issue #1274/#1276 C0+DEL+C1 byte-wise neutralization + detection shared helper"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -613,6 +613,18 @@ if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
 else
   fail "TC-19.6: SESSION_ID_FILE control-char not rejected: '$err'"
 fi
+# TC-19.7: C1 8-bit 制御バイト (0x9b = 8-bit CSI introducer) rejection (Issue #1276)
+# 旧 `=~ [[:cntrl:]]` は glibc が C/UTF-8 両ロケールで C1 (0x80-0x9f) を cntrl と
+# 分類しないため 0x9b 入り session_id を素通ししていた。contains_ctrl
+# (control-char-neutralize.sh と共有のバイト範囲定義) への置換で reject されることを pin。
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID=$'sid\x9bwith-csi' bash "$HOOK" get --field phase --default "DEF" >/dev/null) 2>&1 || true )
+if echo "$err" | grep -qE 'ERROR:.*invalid session_id.*control characters'; then
+  pass "TC-19.7: CLAUDE_CODE_SESSION_ID rejects C1 0x9b byte (Issue #1276 detection-side pin)"
+else
+  fail "TC-19.7: C1 0x9b not rejected: '$err'"
+fi
 
 # --- TC-20: cmd_get jq failure WARNING paths (corrupt JSON state file) ---
 echo ""

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1027,6 +1027,42 @@ rm -rf "$dir48"
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-049: C1 8-bit byte (0x9b CSI) in --source-ref → exit 1 (Issue #1276)
+# --------------------------------------------------------------------------
+# 旧 `=~ [[:cntrl:]]` は glibc が C1 (0x80-0x9f) を cntrl と分類しないため
+# 0x9b 入り SOURCE_REF が validation を素通りしていた (TC-017 の newline pin と
+# 対になる C1 側 pin)。contains_ctrl (control-char-neutralize.sh) への置換で
+# reject されることを確認する。
+echo "TC-049: C1 0x9b in --source-ref → exit 1 (Issue #1276)"
+dir49="$TEST_DIR/tc49"
+mkdir -p "$dir49"
+echo "x" > "$dir49/body.md"
+( cd "$dir49" && bash "$HOOK" --type reviews --source-ref $'pr-1\x9bcsi' --content-file body.md >/dev/null 2>err.log ) && rc=0 || rc=$?
+if [ $rc -eq 1 ] && grep -q 'control characters' "$dir49/err.log"; then
+  pass "C1 0x9b in source-ref → exit 1 (formerly slipped through [[:cntrl:]])"
+else
+  fail "Expected exit 1 'control characters', got rc=$rc, stderr=$(cat "$dir49/err.log")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-050: C1 8-bit byte (0x9b CSI) in --title → exit 1 (Issue #1276)
+# --------------------------------------------------------------------------
+# TC-018 (newline in title) と対になる C1 側 pin。SOURCE_REF / TITLE は隣接する
+# YAML キーに着地するため、検出範囲も対称であることを保証する。
+echo "TC-050: C1 0x9b in --title → exit 1 (Issue #1276)"
+dir50="$TEST_DIR/tc50"
+mkdir -p "$dir50"
+echo "x" > "$dir50/body.md"
+( cd "$dir50" && bash "$HOOK" --type reviews --source-ref pr-1 --content-file body.md --title $'foo\x9bbar' >/dev/null 2>err.log ) && rc=0 || rc=$?
+if [ $rc -eq 1 ] && grep -q 'control characters' "$dir50/err.log"; then
+  pass "C1 0x9b in title → exit 1 (SOURCE_REF と対称の C1 reject)"
+else
+  fail "Expected exit 1 'control characters', got rc=$rc, stderr=$(cat "$dir50/err.log")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -45,6 +45,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Resolve project root (git root anchored) — matches the session-start.sh /
 # _resolve-schema-version.sh / notification.sh convention. Without this anchor,
@@ -121,12 +123,14 @@ if [[ -z "$SOURCE_REF" ]]; then
   echo "ERROR: --source-ref is required" >&2
   exit 1
 fi
-# Any ASCII control char can break YAML frontmatter (early --- close, key
-# injection, escape sequences). Reject the entire `[:cntrl:]` class — limiting
-# to LF/CR/TAB would leave 0x00-0x08 / 0x0B / 0x0C / 0x0E-0x1F / 0x7F as
-# bypass vectors.
-if [[ "$SOURCE_REF" =~ [[:cntrl:]] ]]; then
-  echo "ERROR: --source-ref must not contain control characters (newlines, tabs, or other ASCII control chars)" >&2
+# Any control char can break YAML frontmatter (early --- close, key
+# injection, escape sequences). Limiting to LF/CR/TAB would leave
+# 0x00-0x08 / 0x0B / 0x0C / 0x0E-0x1F / 0x7F as bypass vectors.
+# contains_ctrl (control-char-neutralize.sh) は C0 + DEL に加え C1 8-bit
+# (0x80-0x9f) もバイト単位で検出する — 旧 `=~ [[:cntrl:]]` は glibc が C1 を
+# cntrl と分類しないため 0x9b (8-bit CSI) を素通ししていた (Issue #1276)。
+if contains_ctrl "$SOURCE_REF"; then
+  echo "ERROR: --source-ref must not contain control characters (newlines, tabs, or other C0/DEL/C1 control bytes)" >&2
   echo "  reason: control characters can break YAML frontmatter (early --- close, key injection, escape sequences)" >&2
   exit 1
 fi
@@ -152,10 +156,12 @@ fi
 
 # Mirror the SOURCE_REF control-char rejection on TITLE — the two fields land
 # in adjacent YAML keys, so an asymmetric guard would leak the same injection
-# class through whichever side is unprotected.
+# class through whichever side is unprotected. Byte-wise C1 detection also
+# rejects multibyte (e.g. Japanese) titles via their 0x80-0x9f continuation
+# bytes — accepted: all in-repo callers pass ASCII-fixed titles (Issue #1276).
 if [[ -n "$TITLE" ]]; then
-  if [[ "$TITLE" =~ [[:cntrl:]] ]]; then
-    echo "ERROR: --title must not contain control characters (newlines, tabs, or other ASCII control chars)" >&2
+  if contains_ctrl "$TITLE"; then
+    echo "ERROR: --title must not contain control characters (newlines, tabs, or other C0/DEL/C1 control bytes)" >&2
     exit 1
   fi
   # reject odd trailing backslashes (escape ambiguity)


### PR DESCRIPTION
## 概要

検出 (reject) 用途の `=~ [[:cntrl:]]` 3 箇所が C1 8-bit 制御バイト (0x80–0x9f、特に 8-bit CSI introducer 0x9b) を素通ししていた問題を修正する。共通ヘルパー `control-char-neutralize.sh` に検出用関数 `contains_ctrl()` を追加し、置換 (neutralize) 側と同一のバイト範囲定義 (C0 + DEL + C1) で 3 call site を統一した。

Closes #1276

## 変更内容

- `plugins/rite/hooks/control-char-neutralize.sh` - 検出用共通関数 `contains_ctrl()` を追加 (neutralize_ctrl default と同一の tr レンジ + バイト数比較、fail-closed)
- `plugins/rite/hooks/flow-state.sh` - `_validate_session_id()` の `=~ [[:cntrl:]]` を `contains_ctrl` へ置換
- `plugins/rite/hooks/wiki-ingest-trigger.sh` - ヘルパー source 追加 + SOURCE_REF / TITLE 検証を `contains_ctrl` へ置換 + エラー文言更新
- `plugins/rite/hooks/tests/control-char-neutralize.test.sh` - `contains_ctrl()` 単体テスト TC-14〜TC-19 追加
- `plugins/rite/hooks/tests/flow-state.test.sh` - TC-19.7 (session_id C1 0x9b reject) 追加
- `plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh` - TC-049/TC-050 (SOURCE_REF / TITLE C1 reject) 追加

## 設計判断

- **一律 byte-wise C0+DEL+C1**: TITLE も含め 3 call site とも byte-wise 検出。UTF-8 継続バイト (日本語等) を誤検出するが、現呼び出し元 (close.md / fix.md / review.md) と SKILL.md のドキュメント例はすべて ASCII 固定 title で実害なし。日本語 TITLE が必要になった時点で UTF-8 セーフモードを追加する。
- **grep でなく tr + バイト数比較**: ugrep 等の grep 実装は LC_ALL=C でも raw 8-bit バイト (invalid UTF-8) にリテラルパターンですらマッチせず、検出が環境依存で silent に壊れるため。tr は neutralize_ctrl と同一コマンド・同一レンジ定義で、「同じバイト範囲定義」という規約対称性が文字どおりになる。
- **fail-closed**: pipeline 失敗 / 非数値 wc 出力は「detected」扱いで reject 側に倒し、reject 経路が silent pass-through に劣化しないことを優先。

## テスト

- [x] hook テストスイート全体 58/58 PASS
- [x] control-char-neutralize.test.sh 27 PASS (新規 TC-14〜TC-19 含む)
- [x] flow-state.test.sh 109 PASS (新規 TC-19.7 含む) / wiki-ingest-trigger.test.sh 53 PASS (新規 TC-049/TC-050 含む)

## Known Issues

- lint 未実行（lint コマンド未検出 — `commands.lint: null`。代替として plugin checks 13 種 + hook テストスイートを実行済み。warning はすべて pre-existing で本 PR 変更ファイル起因 0 件）
