### PR TITLE
fix(hooks): pre-tool-bash-guard の deny フォールバック JSON で改行と C0 制御バイトをエスケープ

### DIFF
--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # rite workflow - Control Character Neutralization (shared)
 # Provides the single source of truth for the "control chars → ?" diagnostic
-# neutralization convention shared by flow-state.sh (_emit_jq_err_snippet) and
-# stop-loop-continuation.sh (unknown handoff prefix WARNING), plus the
-# detection-side counterpart contains_ctrl() for reject-purpose validation
-# (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh SOURCE_REF /
-# TITLE — Issue #1276).
+# neutralization convention shared by flow-state.sh (_emit_jq_err_snippet),
+# stop-loop-continuation.sh (unknown handoff prefix WARNING / JSON emit
+# fallback), and pre-tool-bash-guard.sh (deny fallback JSON — Issue #1278),
+# plus the detection-side counterpart contains_ctrl() for reject-purpose
+# validation (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh
+# SOURCE_REF / TITLE — Issue #1276).
 #
 # WHY a shared helper (Issue #1274): the POSIX class [[:cntrl:]] on glibc
 # (C and UTF-8 locales, byte-wise verified) does NOT classify C1 8-bit control

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -22,8 +22,32 @@ export _RITE_HOOK_RUNNING_PRETOOL=1
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
-# neutralize_ctrl --c0-only (deny フォールバックの JSON エスケープ用 — Issue #1278)
+# neutralize_ctrl --c0-only (deny フォールバックの JSON エスケープ用 — Issue #1278)。
+# guard なし source は意図的な設計判断: 本 hook は Pattern 1-3 の ERR trap
+# (_rite_btg_pattern13_fail_open) が exit 0 = allow を選ぶ設計上 fail-open であり、helper
+# 欠落 (= plugin 破損) による source 失敗の exit 1 も PreToolUse では non-blocking = allow
+# として同じ fail-open に収束する (flow-state.sh / stop-loop-continuation.sh の必須依存
+# precedent と同一)。`|| true` を付けてはならない — neutralize_ctrl 未定義のまま deny
+# フォールバックに到達すると command not found で reason を失い placeholder へ縮退する
+# だけで、guard を付ける利点がない。
 source "$SCRIPT_DIR/control-char-neutralize.sh"
+
+# Deny フォールバック JSON 用の reason エスケープ (Issue #1278)。適用順序が契約:
+# backslash → double-quote → 改行 \n 化 → neutralize_ctrl --c0-only (残存 C0+DEL を ? 化)。
+# backslash エスケープが先頭でないと、後続が生成する \" / \n の backslash を二重に
+# エスケープしてしまう。--c0-only なのは byte 単位の C1 置換が UTF-8 マルチバイト本文を
+# 破壊するため (RFC 8259 が生バイトを禁じるのは U+0000-001F のみ)。neutralize_ctrl 失敗時は
+# 非ゼロ exit し、caller が static placeholder へ縮退する (fail-closed)。
+# tests/pre-tool-bash-guard.test.sh の TC-117 が本関数定義を境界行
+# (`_bash_guard_escape_deny_reason() {` / `}`) で抽出して改行 / raw C0 実入力の変換を
+# 直接 pin する — シグネチャ・境界行を変える際はテスト側の抽出パターンも更新すること。
+_bash_guard_escape_deny_reason() {
+  local _r="$1"
+  _r="${_r//\\/\\\\}"
+  _r="${_r//\"/\\\"}"
+  _r="${_r//$'\n'/\\n}"
+  printf '%s' "$_r" | neutralize_ctrl --c0-only
+}
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 
@@ -527,11 +551,9 @@ echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PA
 # Deny with reason and alternative. jq is required to emit the final permission
 # payload; an intermittent jq failure here would silently downgrade the deny to
 # allow. Fall back to a literal JSON envelope + exit 2 so the deny is fail-closed.
-# 手動エスケープが \ / " のみだと、reason 内の改行・C0 生バイトが JSON 文字列リテラルに
-# 残り RFC 8259 違反の invalid JSON になる — 改行は \n エスケープ、残存 C0+DEL は
-# neutralize_ctrl --c0-only で ? 化する (stop-loop-continuation.sh の JSON emit
-# フォールバックと対称 — Issue #1278 / #1275)。default モードを使わないのは、バイト単位の
-# C1 置換が UTF-8 マルチバイト本文を破壊するため。neutralize 失敗時は raw を emit せず
+# reason のエスケープ連鎖 (改行 \n 化 + 残存 C0 の ? 化 — Issue #1278 / #1275、
+# stop-loop-continuation.sh の JSON emit フォールバックと対称) は
+# _bash_guard_escape_deny_reason に集約。neutralize 失敗時は raw を emit せず
 # static placeholder へ縮退し、deny + exit 2 の fail-closed 契約を維持する。
 _deny_reason="BLOCKED ($BLOCKED_PATTERN): $BLOCKED_REASON $BLOCKED_ALTERNATIVE"
 if ! jq -n --arg reason "$_deny_reason" '{
@@ -541,10 +563,7 @@ if ! jq -n --arg reason "$_deny_reason" '{
       permissionDecisionReason: $reason
     }
   }'; then
-  _deny_reason_escaped="${_deny_reason//\\/\\\\}"
-  _deny_reason_escaped="${_deny_reason_escaped//\"/\\\"}"
-  _deny_reason_escaped="${_deny_reason_escaped//$'\n'/\\n}"
-  _deny_reason_escaped=$(printf '%s' "$_deny_reason_escaped" | neutralize_ctrl --c0-only) \
+  _deny_reason_escaped=$(_bash_guard_escape_deny_reason "$_deny_reason") \
     || _deny_reason_escaped="BLOCKED: command denied (reason neutralization failed, fail-closed). Check the bash-guard stderr log for the blocked pattern."
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$_deny_reason_escaped"
   exit 2

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -22,6 +22,8 @@ export _RITE_HOOK_RUNNING_PRETOOL=1
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+# neutralize_ctrl --c0-only (deny フォールバックの JSON エスケープ用 — Issue #1278)
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 
@@ -525,6 +527,12 @@ echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PA
 # Deny with reason and alternative. jq is required to emit the final permission
 # payload; an intermittent jq failure here would silently downgrade the deny to
 # allow. Fall back to a literal JSON envelope + exit 2 so the deny is fail-closed.
+# 手動エスケープが \ / " のみだと、reason 内の改行・C0 生バイトが JSON 文字列リテラルに
+# 残り RFC 8259 違反の invalid JSON になる — 改行は \n エスケープ、残存 C0+DEL は
+# neutralize_ctrl --c0-only で ? 化する (stop-loop-continuation.sh の JSON emit
+# フォールバックと対称 — Issue #1278 / #1275)。default モードを使わないのは、バイト単位の
+# C1 置換が UTF-8 マルチバイト本文を破壊するため。neutralize 失敗時は raw を emit せず
+# static placeholder へ縮退し、deny + exit 2 の fail-closed 契約を維持する。
 _deny_reason="BLOCKED ($BLOCKED_PATTERN): $BLOCKED_REASON $BLOCKED_ALTERNATIVE"
 if ! jq -n --arg reason "$_deny_reason" '{
     hookSpecificOutput: {
@@ -535,6 +543,9 @@ if ! jq -n --arg reason "$_deny_reason" '{
   }'; then
   _deny_reason_escaped="${_deny_reason//\\/\\\\}"
   _deny_reason_escaped="${_deny_reason_escaped//\"/\\\"}"
+  _deny_reason_escaped="${_deny_reason_escaped//$'\n'/\\n}"
+  _deny_reason_escaped=$(printf '%s' "$_deny_reason_escaped" | neutralize_ctrl --c0-only) \
+    || _deny_reason_escaped="BLOCKED: command denied (reason neutralization failed, fail-closed). Check the bash-guard stderr log for the blocked pattern."
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$_deny_reason_escaped"
   exit 2
 fi

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1201,6 +1201,7 @@ echo ""
 #   先に失敗して fail-open するため、現実的な fallback トリガーは emit-only の jq 失敗。
 #   _deny_reason の構成要素は現状ハードコード文字列だが、fallback が改行 \n エスケープ +
 #   neutralize_ctrl --c0-only を経由して valid JSON を emit し deny + exit 2 を維持することを pin する。
+#   エスケープ連鎖そのものの非 vacuous 検証 (改行 / raw C0 実入力) は TC-117 が担う。
 # --------------------------------------------------------------------------
 echo "TC-116: deny fallback (jq -n emit failure) → valid JSON, deny preserved"
 rc=0
@@ -1245,6 +1246,61 @@ else
   pass "TC-116 fallback JSON contains no raw ESC byte"
 fi
 rm -rf "$fake_bin_116"
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-117: _bash_guard_escape_deny_reason — 改行/C0 実入力の非 vacuous 変換 pin (Issue #1278)
+#   TC-116 は fallback 経路の構造契約 (到達 / rc=2 / deny 生存) を pin するが、現行の
+#   _deny_reason は静的 ASCII のみで構成されるため、エスケープ連鎖そのものは no-op の
+#   まま pass する (vacuous)。本 TC は hook から関数定義を境界行
+#   (`_bash_guard_escape_deny_reason() {` 〜 `}`) で抽出し、改行 + raw ESC + CR + TAB +
+#   backslash + double-quote を含む入力を直接流して変換を非 vacuous に検証する。
+#   エスケープ連鎖のどの 1 行を欠落させても assertion が落ちる (mutation 耐性):
+#   \\ 行欠落 → (3) invalid JSON (\s は invalid escape)、\" 行欠落 → (3) 構造破壊、
+#   \n 行欠落 → (1) literal \n 不在 (改行は --c0-only で ? 化されるため)、
+#   neutralize 行欠落 → (2) raw ESC 残存。
+# --------------------------------------------------------------------------
+echo "TC-117: _bash_guard_escape_deny_reason neutralizes newline/C0 input (non-vacuous)"
+real_jq=$(command -v jq)
+# 依存 helper (neutralize_ctrl) を source し、関数定義を hook から抽出して取り込む
+source "$SCRIPT_DIR/../control-char-neutralize.sh"
+eval "$(awk '/^_bash_guard_escape_deny_reason\(\) \{$/,/^\}$/' "$HOOK")"
+if declare -f _bash_guard_escape_deny_reason >/dev/null 2>&1; then
+  pass "TC-117 function extracted from hook"
+  tc117_input=$(printf 'line1 "quoted" back\\slash\nline2 \x1b[31mred\x1b[0m tab:\there cr:\r.')
+  tc117_out=$(_bash_guard_escape_deny_reason "$tc117_input") || tc117_out=""
+  # (1) raw 改行ゼロ + literal \n 保存 (改行が neutralize で ? 化される mutation も検出)
+  tc117_nl_count=$(printf '%s' "$tc117_out" | LC_ALL=C wc -l | tr -d ' ')
+  if [ "$tc117_nl_count" = "0" ] && [[ "$tc117_out" == *'line1'*'\n'*'line2'* ]]; then
+    pass "TC-117 newline escaped to literal \\n (no raw newline)"
+  else
+    fail "TC-117 newline not escaped (raw_nl=$tc117_nl_count): $(printf '%s' "$tc117_out" | cat -v)"
+  fi
+  # (2) raw ESC/TAB/CR バイトの非漏出 (? 化)
+  tc117_c0_count=$(printf '%s' "$tc117_out" | LC_ALL=C tr -cd '\033\011\015' | LC_ALL=C wc -c | tr -d ' ')
+  if [ "$tc117_c0_count" = "0" ]; then
+    pass "TC-117 raw C0 bytes (ESC/TAB/CR) neutralized"
+  else
+    fail "TC-117 $tc117_c0_count raw C0 byte(s) leaked: $(printf '%s' "$tc117_out" | cat -v)"
+  fi
+  # (3) JSON 文字列リテラル埋め込みで valid JSON (RFC 8259)
+  tc117_json=$(printf '{"reason":"%s"}' "$tc117_out")
+  if printf '%s' "$tc117_json" | "$real_jq" -e . >/dev/null 2>&1; then
+    pass "TC-117 escaped output embeds as valid JSON"
+  else
+    fail "TC-117 invalid JSON after embedding: $(printf '%s' "$tc117_json" | cat -v)"
+  fi
+  # (4) decode round-trip: " と \ の構造保持 + \n の実改行復元 + ESC の ? 化
+  tc117_decoded=$(printf '%s' "$tc117_json" | "$real_jq" -r '.reason // empty' 2>/dev/null) || tc117_decoded=""
+  if [[ "$tc117_decoded" == *'"quoted"'* ]] && [[ "$tc117_decoded" == *'back\slash'* ]] \
+     && [[ "$tc117_decoded" == *$'\n'* ]] && [[ "$tc117_decoded" == *'?[31mred?[0m'* ]]; then
+    pass "TC-117 quote/backslash/newline survive round-trip, ESC degraded to ?"
+  else
+    fail "TC-117 round-trip mismatch: $(printf '%s' "$tc117_decoded" | cat -v)"
+  fi
+else
+  fail "TC-117 could not extract _bash_guard_escape_deny_reason from hook (boundary lines changed?)"
+fi
 echo ""
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1195,6 +1195,57 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-116: deny fallback (jq -n emit failure) → valid JSON, deny preserved (Issue #1278)
+#   stop-loop-continuation.test.sh TC-16 と同じ fake jq パターン: `jq -n` のみ exit 1 させ、
+#   それ以外 (hook 冒頭の payload parse 等) は real jq へ委譲する。jq 全欠落は payload parse が
+#   先に失敗して fail-open するため、現実的な fallback トリガーは emit-only の jq 失敗。
+#   _deny_reason の構成要素は現状ハードコード文字列だが、fallback が改行 \n エスケープ +
+#   neutralize_ctrl --c0-only を経由して valid JSON を emit し deny + exit 2 を維持することを pin する。
+# --------------------------------------------------------------------------
+echo "TC-116: deny fallback (jq -n emit failure) → valid JSON, deny preserved"
+rc=0
+real_jq=$(command -v jq)
+tc116_input=$("$real_jq" -n '{tool_name: "Bash", tool_input: {command: "gh pr diff 123 --stat"}, cwd: "/tmp"}')
+fake_bin_116=$(mktemp -d)
+cat > "$fake_bin_116/jq" <<EOF
+#!/bin/bash
+if [ "\$1" = "-n" ]; then exit 1; fi
+exec "$real_jq" "\$@"
+EOF
+chmod +x "$fake_bin_116/jq"
+output=$(echo "$tc116_input" | PATH="$fake_bin_116:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+# Sanity pin: fallback 経路が emit した (primary jq 経路ではない)
+if [ -n "$output" ]; then
+  pass "TC-116 fallback emitted output despite jq -n failure"
+else
+  fail "TC-116 no output — fallback path not reached: $(cat -v "$STDERR_FILE")"
+fi
+if [ "$rc" = "2" ]; then
+  pass "TC-116 fallback exits 2 (fail-closed deny contract)"
+else
+  fail "TC-116 expected rc=2, got rc=$rc"
+fi
+# RFC 8259 validity — 改行/C0 生バイトが文字列リテラルに残ると parse が失敗する
+if printf '%s' "$output" | "$real_jq" -e . >/dev/null 2>&1; then
+  pass "TC-116 fallback output is valid JSON"
+else
+  fail "TC-116 fallback output is not parseable JSON: $(printf '%s' "$output" | cat -v)"
+fi
+decision=$(printf '%s' "$output" | "$real_jq" -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | "$real_jq" -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"gh-pr-diff-stat"* ]]; then
+  pass "TC-116 deny decision and pattern name survive the fallback"
+else
+  fail "TC-116 expected deny with gh-pr-diff-stat via fallback, got decision=$decision reason=$reason"
+fi
+# raw C0 バイト (ESC 等) の非漏出 — neutralize_ctrl --c0-only の挙動 pin
+if printf '%s' "$output" | LC_ALL=C grep -q $'\x1b'; then
+  fail "TC-116 fallback JSON leaked a raw ESC byte: $(printf '%s' "$output" | cat -v)"
+else
+  pass "TC-116 fallback JSON contains no raw ESC byte"
+fi
+rm -rf "$fake_bin_116"
+echo ""
 
 # --------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 概要

`pre-tool-bash-guard.sh` の deny フォールバック（`jq -n` emit 失敗時の literal JSON envelope）の手動エスケープが `\` / `"` のみで、改行と C0 制御バイト（raw ESC 0x1b 等）を JSON 文字列リテラルに残し、RFC 8259 違反の invalid JSON で consumer parse を壊しうる経路を閉じる。`stop-loop-continuation.sh` の同型修正（#1275）と対称化する。

## 関連 Issue

Closes #1278

## 変更内容

- `plugins/rite/hooks/pre-tool-bash-guard.sh`
  - `control-char-neutralize.sh` を source（stop-loop-continuation.sh と同形式）
  - deny フォールバックのエスケープ連鎖を対称化: `\` / `"`（既存）→ 改行 `\n` エスケープ（新規）→ `neutralize_ctrl --c0-only` で残存 C0+DEL を `?` 化（新規）
  - neutralize 失敗時は raw を emit せず static placeholder へ縮退し、deny + exit 2 の fail-closed 契約を維持
- `plugins/rite/hooks/control-char-neutralize.sh`
  - ヘッダーの利用箇所 SoT 一覧に pre-tool-bash-guard.sh（deny fallback JSON）を追記
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`
  - TC-116 追加: stop-loop-continuation.test.sh TC-16 の fake jq パターン（`jq -n` のみ exit 1、他は real jq へ委譲）で fallback 経路を発火させ、fallback emit / rc=2 / valid JSON / deny 維持 / raw ESC 非漏出の 5 点を pin

## テスト

- `pre-tool-bash-guard.test.sh`: 151 passed, 0 failed（TC-116 の 5 assertion 含む）
- 回帰確認: `stop-loop-continuation.test.sh` 53 passed / `control-char-neutralize.test.sh` 27 passed

## チェックリスト

- [x] コードがプロジェクトの規約に従っている
- [x] テストがパスする
- [x] ドキュメント更新（control-char-neutralize.sh の利用箇所一覧コメント — 対象ドキュメントはこれのみ、影響調査で他は 0 hits）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
