### PR TITLE
test(hooks): neutralize 失敗時の placeholder 縮退経路に fail-closed テストを追加

### DIFF
--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1304,6 +1304,75 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-118: deny fallback neutralize 失敗 → static placeholder 縮退、deny + exit 2 維持 (Issue #1282)
+#   TC-116 は fallback 経路のエスケープ成功側 (reason に pattern 名が残る) を pin する。本 TC は
+#   その先の二重障害 — fallback 内で _bash_guard_escape_deny_reason (neutralize_ctrl = 固定引数の
+#   tr パイプ) まで失敗した場合 — の static placeholder 縮退を pin する。helper header が
+#   「実質失敗しない」と明記する経路のため、fake tr で強制発火させる: neutralize_ctrl の
+#   3 モードはいずれも第 1 引数に `\000-` レンジ文字列を持つので $1 マッチでのみ exit 1 し、
+#   hook 内の他の tr 用途 (jq parse error path の `tr '\n' ' '` / flow-state contains_ctrl の
+#   `tr -d ...` は $1=-d) は real tr へ委譲して巻き添えを防ぐ。
+#   非 vacuous 性 (TC-116 の vacuous 教訓): neutralize 成功時は reason に pattern 名
+#   (gh-pr-diff-stat) が入るため、「placeholder 文言あり + pattern 名なし」の両方向 assert で
+#   縮退の発生そのものを証明する。
+# --------------------------------------------------------------------------
+echo "TC-118: deny fallback neutralize failure → static placeholder, deny + exit 2 preserved"
+rc=0
+real_jq=$(command -v jq)
+real_tr=$(command -v tr)
+tc118_input=$("$real_jq" -n '{tool_name: "Bash", tool_input: {command: "gh pr diff 123 --stat"}, cwd: "/tmp"}')
+fake_bin_118=$(mktemp -d)
+cat > "$fake_bin_118/jq" <<EOF
+#!/bin/bash
+if [ "\$1" = "-n" ]; then exit 1; fi
+exec "$real_jq" "\$@"
+EOF
+cat > "$fake_bin_118/tr" <<EOF
+#!/bin/bash
+case "\$1" in *000-*) exit 1 ;; esac
+exec "$real_tr" "\$@"
+EOF
+chmod +x "$fake_bin_118/jq" "$fake_bin_118/tr"
+output=$(echo "$tc118_input" | PATH="$fake_bin_118:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+# Sanity pin: placeholder 縮退経路でも JSON を emit した (silent allow へ降格していない)
+if [ -n "$output" ]; then
+  pass "TC-118 placeholder path emitted output despite jq -n + tr failure"
+else
+  fail "TC-118 no output — placeholder path not reached: $(cat -v "$STDERR_FILE")"
+fi
+if [ "$rc" = "2" ]; then
+  pass "TC-118 placeholder path exits 2 (fail-closed deny contract)"
+else
+  fail "TC-118 expected rc=2, got rc=$rc"
+fi
+if printf '%s' "$output" | "$real_jq" -e . >/dev/null 2>&1; then
+  pass "TC-118 placeholder output is valid JSON"
+else
+  fail "TC-118 placeholder output is not parseable JSON: $(printf '%s' "$output" | cat -v)"
+fi
+decision=$(printf '%s' "$output" | "$real_jq" -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | "$real_jq" -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-118 deny decision survives the placeholder degradation"
+else
+  fail "TC-118 expected deny via placeholder path, got decision=$decision"
+fi
+# 縮退の発生証明 (非 vacuous): placeholder 文言あり + 通常 fallback の pattern 名なし
+if [[ "$reason" == *"reason neutralization failed, fail-closed"* ]] && [[ "$reason" != *"gh-pr-diff-stat"* ]]; then
+  pass "TC-118 reason degraded to the static placeholder (no pattern name leak)"
+else
+  fail "TC-118 expected static placeholder reason, got: $reason"
+fi
+# placeholder が案内する stderr ログの前提を pin (pattern 名はこちらに残る)
+if grep -q "BLOCKED pattern=gh-pr-diff-stat" "$STDERR_FILE"; then
+  pass "TC-118 stderr BLOCKED log keeps the pattern name (placeholder's referenced log)"
+else
+  fail "TC-118 stderr missing BLOCKED log: $(cat -v "$STDERR_FILE")"
+fi
+rm -rf "$fake_bin_118"
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/stop-loop-continuation.test.sh
+++ b/plugins/rite/hooks/tests/stop-loop-continuation.test.sh
@@ -387,6 +387,71 @@ rm -rf "$fake_bin" "$err16"
 out_b=$(stop_payload "$d16" "$SID" true | bash "$HOOK")
 assert "TC-16: second stop allows (one-shot)" "" "$out_b"
 
-if ! print_summary "$(basename "$0")" "stop-loop-continuation.sh (Issue #1168 review↔fix loop continuation + #1176 FINALIZE terminal backstop + #1245 WIKICHAIN cleanup-chain gate + #1274 C1 8-bit coverage via shared neutralize_ctrl + #1275 JSON emit fallback C0 neutralization)"; then
+# --- TC-17: JSON emit fallback neutralize failure → static placeholder, block preserved (Issue #1282) ---
+# TC-16 pins the escape-succeeded side of the fallback (handoff re-injected with C0 → ?).
+# This TC pins the next failure layer: the fallback's own `neutralize_ctrl --c0-only` (a
+# fixed-argument tr pipe the helper header calls "実質失敗しない") also fails, forcing the
+# `_r_esc` static placeholder degradation. Forced via a fake tr that exits 1 only when $1
+# carries the neutralize_ctrl `\000-` range string — other tr uses inside the hook chain
+# (flow-state contains_ctrl's `tr -d ...` has $1=-d) delegate to the real tr, so the
+# consume-handoff path stays intact. A known prefix (`/rite:pr:fix 99`) is used instead of
+# TC-16's EVILPREFIX: the unknown-prefix arm would hit the WARNING-side neutralize (its own
+# placeholder) first, entangling two degradations — the known prefix isolates the JSON emit
+# placeholder. Non-vacuous proof (TC-116 vacuous lesson): the normal reason carries the
+# handoff command + Japanese directive, so asserting "placeholder text present + normal
+# reason absent" proves the degradation actually fired.
+echo ""
+echo "=== TC-17: JSON emit fallback neutralize failure → placeholder degradation, block preserved ==="
+d17=$(new_sandbox)
+RITE_STATE_ROOT="$d17" bash "$FS" set --phase review --issue 1282 --branch b --pr 99 \
+  --next n --handoff "/rite:pr:fix 99" --session "$SID" >/dev/null
+fake_bin17=$(mktemp -d)
+real_jq=$(command -v jq)
+real_tr=$(command -v tr)
+cat > "$fake_bin17/jq" <<EOF
+#!/bin/bash
+if [ "\$1" = "-n" ]; then exit 1; fi
+exec "$real_jq" "\$@"
+EOF
+cat > "$fake_bin17/tr" <<EOF
+#!/bin/bash
+case "\$1" in *000-*) exit 1 ;; esac
+exec "$real_tr" "\$@"
+EOF
+chmod +x "$fake_bin17/jq" "$fake_bin17/tr"
+err17=$(mktemp)
+out17=$(stop_payload "$d17" | PATH="$fake_bin17:$PATH" bash "$HOOK" 2>"$err17")
+# Sanity pin: the placeholder path still emitted (did not degrade into a silent allow).
+if [ -n "$out17" ]; then
+  pass "TC-17: placeholder path emitted output despite jq -n + tr failure"
+else
+  fail "TC-17: no output — placeholder path not reached: $(cat -v "$err17")"
+fi
+if printf '%s' "$out17" | "$real_jq" -e . >/dev/null 2>&1; then
+  pass "TC-17: placeholder output is valid JSON"
+else
+  fail "TC-17: placeholder output is not parseable JSON: $(printf '%s' "$out17" | cat -v)"
+fi
+assert "TC-17: decision=block survives the placeholder degradation" "block" "$(printf '%s' "$out17" | "$real_jq" -r '.decision // "NONE"')"
+_reason17=$(printf '%s' "$out17" | "$real_jq" -r '.reason // ""')
+# 縮退の発生証明 (非 vacuous): placeholder 文言 + /rite:resume 案内あり、通常 reason
+# (handoff コマンド再注入 / 日本語継続指示) なし。
+if printf '%s' "$_reason17" | grep -q "rite handoff continuation pending (reason neutralization failed)" \
+   && printf '%s' "$_reason17" | grep -qF "/rite:resume"; then
+  pass "TC-17: reason degraded to the static placeholder with recovery guidance"
+else
+  fail "TC-17: expected static placeholder reason, got: $out17"
+fi
+if printf '%s' "$_reason17" | grep -qF "/rite:pr:fix 99" || printf '%s' "$_reason17" | grep -q "停止せず"; then
+  fail "TC-17: normal-path reason leaked into the placeholder degradation: $out17"
+else
+  pass "TC-17: normal-path reason absent (degradation actually fired, non-vacuous)"
+fi
+rm -rf "$fake_bin17" "$err17"
+# one-shot: second stop allows (the placeholder path still consumes the handoff)
+out17b=$(stop_payload "$d17" "$SID" true | bash "$HOOK")
+assert "TC-17: second stop allows (one-shot consume preserved through placeholder path)" "" "$out17b"
+
+if ! print_summary "$(basename "$0")" "stop-loop-continuation.sh (Issue #1168 review↔fix loop continuation + #1176 FINALIZE terminal backstop + #1245 WIKICHAIN cleanup-chain gate + #1274 C1 8-bit coverage via shared neutralize_ctrl + #1275 JSON emit fallback C0 neutralization + #1282 neutralize-failure placeholder degradation)"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

deny / JSON emit フォールバックの neutralize 失敗時 static placeholder 縮退経路に fail-closed テストを追加する。`neutralize_ctrl` は固定引数の `tr` パイプで「実質失敗しない」経路のため、fake tr / PATH 操作で強制発火させ、二重障害 (jq -n 失敗 + neutralize 失敗) 下でも deny + exit 2 / block 契約が維持されることを pin する。

## 関連 Issue

Closes #1282

## 変更内容

- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`: **TC-118** 追加 — fake jq (`-n` のみ exit 1) + fake tr (neutralize_ctrl の `\000-` レンジ引数のみ exit 1) で deny フォールバックの placeholder 縮退を強制発火。fallback 出力 / **rc=2 維持** / valid JSON / **deny 維持** / placeholder reason (pattern 名不含 = 非 vacuous) / stderr BLOCKED ログ維持の 6 assertion
- `plugins/rite/hooks/tests/stop-loop-continuation.test.sh`: **TC-17** 追加 — 既知 prefix handoff (`/rite:pr:fix 99`) + 同型 fake jq / fake tr で `_r_esc` placeholder 縮退を分離検証 (unknown prefix は WARNING 側 neutralize の別 placeholder が先に発火するため既知 prefix で分離)。fallback 出力 / valid JSON / **block 維持** / placeholder reason (通常 reason 不含 = 非 vacuous) / one-shot consume 維持の 6 assertion。`print_summary` 説明文字列に #1282 を追記

hook 本体 (`pre-tool-bash-guard.sh` / `stop-loop-continuation.sh`) は無変更 (テスト追加のみ)。

## テスト結果

- `pre-tool-bash-guard.test.sh`: 162 passed, 0 failed
- `stop-loop-continuation.test.sh`: 59 passed, 0 failed
- fake tr の巻き添え調査済: `flow-state.sh` の `tr -d '[:space:]'` / `contains_ctrl` の `tr -d` は `$1` 不一致で real tr へ委譲

## チェックリスト

- [x] プロジェクト規約に準拠
- [x] テスト pass (162 + 59、全 TC)
- [x] ドキュメント更新 (不要 — test-only change)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
