### PR TITLE
refactor(commands): pr/cleanup.md / pr/create.md の create-issue 呼び出しを args_json 分離形式に統一

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -204,7 +204,9 @@ fi
 # 2. create-issue-with-projects.sh 呼び出し (result capture + rc check)
 # iter_mode は "none" hardcode (peer file commands/issue/create.md と対称、
 # 残作業 Issue を特定 iteration に紐付ける要件なし — default Todo backlog で十分)
-result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
+# args_json を入れ子 $() から分離して構築する (Issue #1284 — 深い入れ子 quoting の malform 源を削減。
+# 単一 JSON 引数契約は不変)
+args_json=$(jq -n \
   --arg title "残作業: {task_title}" \
   --arg body_file "$tmpfile" \
   --argjson projects_enabled {projects_enabled} \
@@ -225,7 +227,11 @@ result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
       iteration: { mode: $iter_mode }
     },
     options: { source: "cleanup", non_blocking_projects: true }
-  }')")
+  }') || {
+  echo "ERROR: ステップ 3 args_json の jq 構築に失敗しました (タスク: {task_title})" >&2
+  exit 1  # fail-fast (peer file commands/issue/create.md と対称)
+}
+result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$args_json")
 if [ -z "$result" ]; then
   echo "ERROR: ステップ 3 create-issue-with-projects.sh が空 result を返しました (タスク: {task_title})" >&2
   echo "  対処: スクリプト stderr / GitHub API 認証 / Projects 設定を確認してください" >&2

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -562,7 +562,9 @@ if [ ! -s "$tmpfile" ]; then
   exit 1
 fi
 
-result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
+# args_json を入れ子 $() から分離して構築する (Issue #1284 — 深い入れ子 quoting の malform 源を削減。
+# 単一 JSON 引数契約は不変)
+args_json=$(jq -n \
   --arg title "fix: {problem_summary}" \
   --arg body_file "$tmpfile" \
   --argjson projects_enabled {projects_enabled} \
@@ -583,8 +585,9 @@ result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$(jq -n \
       iteration: { mode: $iter_mode }
     },
     options: { source: "pr_create", non_blocking_projects: true }
-  }'
-)")
+  }') || { echo "ERROR: args_json の jq 構築に失敗しました" >&2; exit 1; }
+
+result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$args_json")
 
 if [ -z "$result" ]; then
   echo "ERROR: create-issue-with-projects.sh returned empty result" >&2

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -46,8 +46,6 @@ fi
 
 The script accepts the input JSON either as a **single positional argument** or via **stdin**. Command markdown callers MUST avoid nesting the `jq -n` command substitution inside the invocation (`"$(jq -n ...)"` 形式) — deep nested quoting is a known LLM tool-call malform source (Issue #1193 / #1196). Build `args_json` first, then pass it:
 
-> **Note (漸進移行)**: 上記 "Referenced from" に列挙した caller のうち `commands/pr/create.md` Phase 2.5.5 と `commands/pr/cleanup.md` ステップ 3 は依然 nested `"$(jq -n ...)"` 形式を使用している (#1196 のスコープ外、#1284 で移行を追跡中)。本 MUST は新規・改修するコマンドに適用される — 未移行 caller を編集する際は args_json 分離形 (または下記 pipe-stdin 形) へ移行すること。
-
 ```bash
 # args_json を入れ子 $() から分離して構築する (単一 JSON 引数契約は不変)
 args_json=$(jq -n \


### PR DESCRIPTION
## 概要

`pr/cleanup.md` ステップ 3 と `pr/create.md` Phase 2.5.5 の `create-issue-with-projects.sh` 呼び出しに残存していた nested `"$(jq -n ...)"` 形態を、SoT (`references/issue-create-with-projects.md`) が #1196 で canonical 化した args_json 分離形式に統一する。深い入れ子 quoting は LLM ツール呼び出し解析の malform 無言停止源 (#1193)。単一 JSON 引数契約は不変。

## 関連 Issue

Closes #1284

### 検出された問題（別 Issue として追跡）

- #1291: projects-status-update.sh caller の nested jq 呼び出しが args_json 分離形式に未統一

## 変更内容

- `plugins/rite/commands/pr/create.md` (Phase 2.5.5): nested `"$(jq -n ...)"` → args_json 分離形式（jq 構築失敗時の error guard 付き、issue/create.md 4.3 と対称）
- `plugins/rite/commands/pr/cleanup.md` (ステップ 3): 同上（fail-fast の error guard 付き）
- `plugins/rite/references/issue-create-with-projects.md`: 「漸進移行」Note を削除（本 PR で両 caller の移行が完了し陳腐化するため）

## 検証

- `bash-heaviness-check.sh --all`: findings **2 → 0**（残存していた nested-cmdsub + long-block の 2 findings を解消）
- `create-md-invocation-symmetry.test.sh`: **17 PASS / 0 FAIL**（対象外ファイルのため test 変更不要の見込みも確認）
- 旧/新形式の生成 JSON byte 等価を機械検証（jq 呼び出し列は verbatim 不変、外側の呼び出し形式のみ変更）

## チェックリスト

- [x] プロジェクト規約に準拠（SoT canonical 形式と対称）
- [x] テスト pass（symmetry test 17/17）
- [x] ドキュメント更新（SoT の陳腐化 Note 削除）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
