### PR TITLE
test(tests): 委譲 helper テストの網羅性 follow-up — TC-9 glob 隔離 / pif jq 失敗経路 / io_error fault injection (refs #1287)

### DIFF
--- a/plugins/rite/hooks/tests/wiki-lint-skipped-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-skipped-refs.test.sh
@@ -18,10 +18,13 @@
 #   TC-9  --branch-strategy 欠落 → exit 2 (invocation error)
 #   TC-10 separate_branch + 空 --wiki-branch → exit 2 (invocation error)
 #   TC-11 値なしフラグ末尾 → no-hang (timeout ガード)
+#   TC-12 same_branch io_error (log.md が directory で cat 失敗) → log_read_ok=io_error
+#   TC-13 separate_branch io_error (blob path なし invalid object name) → log_read_ok=io_error
 #   TC-D  differential equivalence — 旧 inline block (参照実装) と stdout byte 一致
 #
 # NOT covered (environment-dependent): mktemp failure on read-only /tmp,
-# awk/sort pipeline OOM。いずれも io_error 降格経路で reading により検証済み。
+# awk/sort pipeline OOM。これらの io_error 降格経路は reading により検証済み
+# (log.md 読出失敗の io_error 経路自体は TC-12/TC-13 の fault injection でカバー)。
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -392,6 +395,36 @@ else
   fail "hang detected (timeout)"
 fi
 
+# === TC-12: same_branch io_error (log.md が directory) → log_read_ok=io_error ===
+# cat は rc≠0 で stderr "Is a directory" を出し、absent 判別 regex
+# (No such file or directory|cannot open) に match しないため io_error に降格する (Issue #1287)。
+echo "TC-12: same_branch io_error (fault injection)"
+repo=$(make_same_branch_sandbox tc12 0)
+mkdir -p "$repo/.rite/wiki/log.md"
+run_helper "$repo" --branch-strategy same_branch --wiki-branch wiki
+if [ "$HELPER_RC" = "0" ] && grep -q '^log_read_ok=io_error$' <<<"$HELPER_STDOUT" \
+   && grep -q '^skipped_refs_count=0$' <<<"$HELPER_STDOUT" \
+   && grep -q 'cat に失敗しました' <<<"$HELPER_STDERR"; then
+  pass "io_error + 空集合 + WARNING (exit 0 非ブロッキング)"
+else
+  fail "unexpected (rc=$HELPER_RC): stdout=$HELPER_STDOUT / stderr=$HELPER_STDERR"
+fi
+
+# === TC-13: separate_branch io_error (不在 wiki branch) → log_read_ok=io_error ===
+# blob path なしの "fatal: invalid object name '<branch>'" は absent 4 pattern の
+# いずれにも match しない (helper コメント記載の典型例: wiki_branch 自体の race 消失) ため
+# io_error に降格する (Issue #1287)。
+echo "TC-13: separate_branch io_error (fault injection)"
+repo=$(make_separate_branch_sandbox tc13 1)
+run_helper "$repo" --branch-strategy separate_branch --wiki-branch no-such-branch
+if [ "$HELPER_RC" = "0" ] && grep -q '^log_read_ok=io_error$' <<<"$HELPER_STDOUT" \
+   && grep -q '^skipped_refs_count=0$' <<<"$HELPER_STDOUT" \
+   && grep -q 'git show に失敗しました' <<<"$HELPER_STDERR"; then
+  pass "io_error + 空集合 + WARNING (exit 0 非ブロッキング)"
+else
+  fail "unexpected (rc=$HELPER_RC): stdout=$HELPER_STDOUT / stderr=$HELPER_STDERR"
+fi
+
 # === TC-D: differential equivalence — 旧 inline block と stdout/stderr/rc 一致 ===
 echo "TC-D: differential equivalence vs original inline block"
 # シナリオ: <label> <sandbox-kind> <with_log> <strategy> <wiki>
@@ -418,6 +451,7 @@ run_differential "same-with-log"     same 1 same_branch wiki
 run_differential "same-absent"       same 0 same_branch wiki
 run_differential "separate-with-log" sep  1 separate_branch wiki
 run_differential "separate-absent"   sep  0 separate_branch wiki
+run_differential "separate-io-error" sep  1 separate_branch no-such-branch
 run_differential "unknown-strategy"  same 1 bogus_strategy wiki
 
 echo ""

--- a/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
@@ -18,6 +18,7 @@
 #   TC-10 --branch-strategy 欠落 → exit 2 (invocation error)
 #   TC-11 separate_branch + 空 --wiki-branch → exit 2 (invocation error)
 #   TC-12 値なしフラグ末尾 (--branch-strategy 値なし) → exit 2、無限ループしない (timeout ガード)
+#   TC-13 same_branch io_error (page path が directory で cat 失敗) → read_ok=io_error
 #
 # NOT covered (environment-dependent): mktemp failure on read-only /tmp,
 # sort/awk pipeline OOM. Both downgrade to io_error and are verified by reading.
@@ -230,6 +231,22 @@ else
 fi
 assert "TC-12 exit 2 (値なしフラグは branch_strategy 空 → 必須チェックで exit 2)" "2" "$rc"
 assert_grep "TC-12 branch-strategy 必須エラー (経路固定)" "$errf" 'branch-strategy は必須'
+
+# === TC-13: same_branch io_error (page path が directory) → read_ok=io_error ===
+# cat は rc≠0 で stderr "Is a directory" を出し、absent 判別 regex に match しない
+# ため read_errors increment → io_error に降格する (Issue #1287。TC-9 の separate_branch
+# io_error と対になる same_branch 側 fault injection — sibling skipped-refs TC-12 と対称)。
+echo "=== TC-13: same_branch io_error (fault injection) ==="
+sbx=$(make_sandbox); cleanup_dirs+=("$sbx")
+mkdir -p "$sbx/.rite/wiki/pages/dirpage.md"
+errf=$(mk_tmp); outf=$(mk_tmp)
+printf '%s\n' ".rite/wiki/pages/dirpage.md" \
+  | bash "$SCRIPT" --branch-strategy same_branch --repo-root "$sbx" >"$outf" 2>"$errf"
+rc=$?
+assert "TC-13 exit 0 (非ブロッキング、io_error は stdout enum で表現)" "0" "$rc"
+assert_grep "TC-13 read_ok=io_error" "$outf" '^all_source_refs_read_ok=io_error$'
+assert_grep "TC-13 errors=1" "$outf" '^all_source_refs_read_errors=1$'
+assert_grep "TC-13 抽出失敗 WARNING" "$errf" '抽出に失敗'
 
 if ! print_summary "$(basename "$0")" \
   "drift: wiki-lint-source-refs.sh の挙動が変わった可能性。wiki/lint.md ステップ 6.2 委譲契約 (Issue #1195 #10) と marker block / io_error enum の出力契約を参照。"; then

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -45,6 +45,8 @@
 #   "pif_graphql_fail"         - items query fails (stderr + exit 1)
 #   "pif_graphql_errors"       - items query returns top-level errors array
 #   "pif_missing_items"        - items query returns data.node = null (partial response)
+#   "pif_normalize_fail"       - gh succeeds (default shapes); the failure is injected by the
+#                                jq shim in projects-items-fetch.test.sh (final `jq -s` exits 2)
 #
 # The projects-status-update.sh script uses a different GraphQL shape
 # (`data.repository.issue.projectItems`) than create-issue-with-projects.sh

--- a/plugins/rite/scripts/tests/projects-items-fetch.test.sh
+++ b/plugins/rite/scripts/tests/projects-items-fetch.test.sh
@@ -28,6 +28,25 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# jq fault-injection shim: pif_normalize_fail シナリオでのみ最終正規化の `jq -s` を失敗させる。
+# 最終 jq -s は gh の出力ではなく中間 pages file を読むため mock-gh.sh では駆動できない
+# (helper 固有 hardening — 旧 inline block に jq -s 失敗 handling が無いため TC-D 対象外。Issue #1287)。
+# 他のシナリオ / `-s` なしの jq 呼び出しは real jq に pass-through する。
+REAL_JQ="$(command -v jq)"
+cat > "$MOCK_BIN_DIR/jq" <<SHIM_EOF
+#!/bin/bash
+if [ "\${MOCK_GH_SCENARIO:-}" = "pif_normalize_fail" ]; then
+  for arg in "\$@"; do
+    if [ "\$arg" = "-s" ]; then
+      echo "jq: error: simulated normalization failure (pif_normalize_fail)" >&2
+      exit 2
+    fi
+  done
+fi
+exec "$REAL_JQ" "\$@"
+SHIM_EOF
+chmod +x "$MOCK_BIN_DIR/jq"
+
 cleanup() {
   rm -rf "$TEST_DIR"
 }
@@ -262,6 +281,25 @@ if [ "$remain_count" = "1" ] && [ -f "$LAST_OUTPUT" ]; then
   pass "success path hands off exactly one result file"
 else
   fail "expected exactly 1 handed-off file, got $remain_count"
+fi
+
+# --------------------------------------------------------------------------
+# TC-12: jq normalization 失敗 → fetch-failed sentinel + tempfile 非 leak
+#        (jq shim による fault injection。旧 inline block は jq -s 失敗を
+#         handling しないため TC-D 差分比較の対象外 — Issue #1287)
+# --------------------------------------------------------------------------
+echo "TC-12: jq normalization failure"
+run_fetch pif_normalize_fail --project-number 6 --owner test-owner
+if [ "$LAST_RC" = "0" ] && [[ "$LAST_OUTPUT" == "[projects:fetch-failed] jq normalization failed:"* ]]; then
+  pass "fetch-failed sentinel on jq normalization failure"
+else
+  fail "unexpected (rc=$LAST_RC): $LAST_OUTPUT"
+fi
+norm_leak_count=$(find "$ISOLATED_TMP" -type f | wc -l)
+if [ "$norm_leak_count" = "0" ]; then
+  pass "normalization failure path leaves no tempfiles"
+else
+  fail "normalization failure path leaked $norm_leak_count tempfile(s): $(find "$ISOLATED_TMP" -type f)"
 fi
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/scripts/tests/review-findings-maps.test.sh
+++ b/plugins/rite/scripts/tests/review-findings-maps.test.sh
@@ -363,15 +363,20 @@ fi
 # TC-9: normalization tempfile が leak しない (script 終了時 trap 削除契約)
 # --------------------------------------------------------------------------
 echo "TC-9: norm_tmp leak なし"
-before_count=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | wc -l)
+# 共有 /tmp glob の count delta は並列実行時に他プロセスの同 glob tempfile 生成/削除で
+# 両方向に flaky 化する (Issue #1287)。helper の mktemp template は
+# /tmp/rite-fix-normalized-XXXXXX の絶対 path 固定で TMPDIR 隔離が効かないため、
+# before/after の path 集合差分 (after にのみ存在する path) で leak を判定する。
+before_paths=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
 repo=$(make_sandbox tc9 default)
 write_fixture "$repo/review.json" v10_missing_scope
 run_helper "$repo" local_file "$repo/review.json"
-after_count=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | wc -l)
-if [ "$before_count" = "$after_count" ]; then
+after_paths=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
+leaked_paths=$(LC_ALL=C comm -13 <(printf '%s\n' "$before_paths") <(printf '%s\n' "$after_paths"))
+if [ -z "$leaked_paths" ]; then
   pass "handed_off_norm_tmp が trap EXIT で削除される (leak なし)"
 else
-  fail "norm_tmp leaked (before=$before_count after=$after_count)"
+  fail "norm_tmp leaked: $(tr '\n' ' ' <<<"$leaked_paths")"
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

PR #1286 (Issue #1196) の test reviewer が検出したテスト網羅性 follow-up 3 件に対応する。委譲 helper のテストのみを変更し、helper 本体の挙動は変更しない。

1. **TC-9 の /tmp glob 隔離** (review-findings-maps.test.sh): leak 検査を共有 glob の count delta から **path 集合差分方式 (`comm -13`)** に変更。helper の mktemp template が `/tmp/rite-fix-normalized-XXXXXX` の絶対 path 固定で `TMPDIR` 隔離 (ISOLATED_TMP 方式) が効かないため、Issue 提示の 2 択のうち差分方式を採用。leak 注入 (正方向) / 他プロセス削除 (逆方向) の双方向 mutation で検出能力を実証済み。
2. **pif `jq normalization failed` 経路 TC** (projects-items-fetch.test.sh): `pif_normalize_fail` シナリオを jq fault-injection shim (`MOCK_GH_SCENARIO=pif_normalize_fail` かつ `-s` 引数時のみ exit 2、他は real jq へ pass-through) で追加し、sentinel + tempfile 非 leak を pin (TC-12)。最終 `jq -s` は gh 出力に依存しないため mock-gh.sh では駆動不能。旧 inline block に失敗 handling が無いため TC-D 差分比較の対象外。
3. **io_error fault injection TC** (wiki-lint-skipped-refs.test.sh / wiki-lint-source-refs.test.sh): `log_read_ok=io_error` を same_branch (log.md の directory 化 → cat 失敗) と separate_branch (blob path なし invalid object name) の実 fault injection で駆動 (TC-12/TC-13)。TC-D に `separate-io-error` シナリオも追加。sibling の source-refs には same_branch io_error の TC-13 を対称追加 (separate_branch 側は既存 TC-9 でカバー済み)。

## 関連 Issue

Closes #1287

## 変更内容

- `plugins/rite/scripts/tests/review-findings-maps.test.sh` — TC-9 leak 検査を path 集合差分方式に変更
- `plugins/rite/scripts/tests/projects-items-fetch.test.sh` — jq fault-injection shim + TC-12 (pif_normalize_fail)
- `plugins/rite/scripts/tests/mock-gh.sh` — pif_normalize_fail シナリオの registry コメント 1 行追記 (挙動変更なし)
- `plugins/rite/hooks/tests/wiki-lint-skipped-refs.test.sh` — TC-12 (same_branch io_error) / TC-13 (separate_branch io_error) + TC-D separate-io-error
- `plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh` — TC-13 (same_branch io_error)

## テスト

- `review-findings-maps.test.sh`: 19 passed, 0 failed
- `projects-items-fetch.test.sh`: 21 passed, 0 failed
- `wiki-lint-skipped-refs.test.sh`: 19 passed, 0 failed
- `wiki-lint-source-refs.test.sh`: 43 passed, 0 failed

## チェックリスト

- [x] コードはプロジェクトの規約に従っている
- [x] テストが通る (変更 4 スイート全 green)
- [x] ドキュメント更新 (該当なし — テストのみの変更)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
