### PR TITLE
docs(scripts): review-findings-maps の stdout contract と TC-D 観測性制約を明文化

### DIFF
--- a/plugins/rite/scripts/review-findings-maps.sh
+++ b/plugins/rite/scripts/review-findings-maps.sh
@@ -24,6 +24,9 @@
 #   local_file / explicit_file : normalization + maps build を実行
 #   その他 (pr_comment 等)      : no-op で exit 0 (旧 inline block の外側 if guard と同一)
 #
+# stdout contract: なし (severity_map_json / scope_map_json は構築検証のみ、値は emit しない。
+#   fix.md 下流の map 参照は LLM が review JSON から conceptual map を再構築する契約)
+#
 # stderr contract (旧 inline block から verbatim 移設。LLM は caller の bash 出力として観測する):
 #   [CONTEXT] REVIEW_SOURCE_SCOPE_DEFAULTED=1; reason=scope_omitted_in_v1_0; ...
 #   [CONTEXT] REVIEW_SOURCE_AUTO_CORRECTED=1; reason=pre_existing_false_scope_nit_noted; ...

--- a/plugins/rite/scripts/tests/review-findings-maps.test.sh
+++ b/plugins/rite/scripts/tests/review-findings-maps.test.sh
@@ -384,6 +384,11 @@ fi
 # 注: 旧 block は fail-fast 時に [fix:error] を stdout に emit していたが、委譲後は
 #     caller 責務に分離した ([fix:error] stdout 分離契約)。比較時は参照実装の stdout
 #     から [fix:error] 行のみを除外する (それ以外は byte 一致を要求)。
+# 注: 本 test が比較するのは外部観測可能な挙動 (rc/stdout/stderr/file) のみで、
+#     in-process validation 変数 severity_map_json / scope_map_json の値は観測できない。
+#     当該値は production で非消費 (helper の stdout contract: なし) のため、現契約では
+#     機能 regression の検出漏れにはならない。将来 map を stdout emit する契約に変更する
+#     場合は、clean fixture に対する期待 map 値 assert (test pin) を同時整備すること。
 # --------------------------------------------------------------------------
 echo "TC-D: differential equivalence vs original inline block"
 run_differential() {


### PR DESCRIPTION
## 概要

PR #1286 のレビュー討論フェーズで合意された follow-up として、`review-findings-maps.sh` の map 契約を文書化し、TC-D (differential equivalence test) の観測性制約を明文化する。

- docstring に stdout contract を追記: severity_map_json / scope_map_json は構築検証のみで、値は stdout に emit しない (fix.md 下流の map 参照は LLM が review JSON から conceptual map を再構築する契約)
- TC-D 注記に観測性制約を追記: in-process validation 変数は differential test (rc/stdout/stderr/file の byte 比較) では観測できない。将来 map を stdout emit する契約に変更する場合は、clean fixture に対する期待 map 値 assert (test pin) を同時整備する方針を記録

## 関連 Issue

Closes #1288

## 変更内容

- `plugins/rite/scripts/review-findings-maps.sh` - docstring に stdout contract を追記 (stderr contract 見出しと対称の位置・文体、+3 行)
- `plugins/rite/scripts/tests/review-findings-maps.test.sh` - TC-D 注記に map 観測性制約と test pin 整備方針を追記 (+5 行、テストロジック変更なし)

## チェックリスト

- [x] コードはプロジェクトの規約に従っている
- [x] テストが通る (review-findings-maps.test.sh: 19 passed, 0 failed)
- [x] ドキュメントを更新した (本 PR 自体が文書化変更)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
