### PR TITLE
fix(security): wiki-branch-init に leading-dash gate を追加し caller placeholder quoting を統一

### DIFF
--- a/plugins/rite/commands/issue/list.md
+++ b/plugins/rite/commands/issue/list.md
@@ -172,7 +172,7 @@ if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/scripts/projects-items-fetch.sh
   # helper 不在も旧実装の失敗契約と同じ sentinel に倒し、Status 列なし表示への fallback を発火させる
   echo "[projects:fetch-failed] projects-items-fetch.sh not found (plugin_root='${plugin_root:-<empty>}')"
 else
-  bash "$plugin_root/scripts/projects-items-fetch.sh" --project-number {project_number} --owner {owner}
+  bash "$plugin_root/scripts/projects-items-fetch.sh" --project-number "{project_number}" --owner "{owner}"
 fi
 ```
 

--- a/plugins/rite/hooks/scripts/wiki-branch-init.sh
+++ b/plugins/rite/hooks/scripts/wiki-branch-init.sh
@@ -20,7 +20,8 @@
 #
 # Exit codes:
 #   0  初期コミット完了
-#   1  git 操作失敗 / 未知の branch_strategy / 引数異常 (旧 inline block と同じ blocking 契約)
+#   1  git 操作失敗 / 未知の branch_strategy / 引数異常 (leading-`-` の wiki_branch 拒否を
+#      含む; 旧 inline block と同じ blocking 契約)
 #
 # Notes:
 #   - 旧 inline block と同じく global `set -e` は使わない (各 git 操作の失敗を
@@ -47,6 +48,20 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# --- Leading-dash fail-fast gate (Issue #1290) ---
+# wiki_branch は rite-config.yml の wiki.branch_name 由来 (開発者管理) だが、leading-`-` の
+# 値は `git push -u origin` で refspec ではなく option として解釈される (例: `--force`; 実測)。
+# `git checkout --orphan` 側は git 自身の branch name validation で fail するため実害はないが、
+# エラー文言が本 helper の契約外経路になる。両 call site への到達前にここで引数異常として
+# 統一的に fail-fast する (wiki-lint-skipped-refs.sh の placeholder residue gate と同型)。
+case "$wiki_branch" in
+  -*)
+    echo "ERROR: --wiki-branch が '-' で始まる値は受け付けられません (値: '$wiki_branch')" >&2
+    echo "  対処: rite-config.yml の wiki.branch_name を確認してください" >&2
+    exit 1
+    ;;
+esac
 
 # 共通の初期コミットメッセージ (separate_branch / same_branch で同一 — 旧 inline block から verbatim)
 WIKI_INIT_COMMIT_MSG="feat(wiki): initialize Wiki structure

--- a/plugins/rite/hooks/tests/wiki-branch-init.test.sh
+++ b/plugins/rite/hooks/tests/wiki-branch-init.test.sh
@@ -352,6 +352,27 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-8: leading-`-` の wiki_branch → fail-fast gate + exit 1 (Issue #1290)
+#   `--force` が `git push -u origin` の option として解釈される argument injection
+#   経路を git 操作到達前に遮断することの検証。gate は git 操作より前に発火するため
+#   ブランチ未作成・main 滞在の end state も pin する。
+# --------------------------------------------------------------------------
+echo "TC-8: leading-dash wiki-branch rejected"
+repo=$(make_sandbox tc8)
+run_helper "$repo" --branch-strategy separate_branch --wiki-branch "--force"
+state=$(dump_state "$repo")
+if [ "$HELPER_RC" = "1" ] && [[ "$HELPER_OUTPUT" == *"ERROR: --wiki-branch が '-' で始まる値は受け付けられません"* ]]; then
+  pass "leading-dash value → ERROR + exit 1"
+else
+  fail "unexpected (rc=$HELPER_RC): $HELPER_OUTPUT"
+fi
+if grep -q "^current=main$" <<<"$state" && grep -q "^branches=main,$" <<<"$state" && grep -q "wiki_tree=<none>" <<<"$state"; then
+  pass "no branch created, still on main"
+else
+  fail "unexpected end state: $state"
+fi
+
+# --------------------------------------------------------------------------
 # TC-D: differential equivalence — 旧 inline block (参照実装) と出力 / end state 一致
 # --------------------------------------------------------------------------
 echo "TC-D: differential equivalence vs original inline block"


### PR DESCRIPTION
## 概要

PR #1286 のレビューで security reviewer が検出した防御一貫性 follow-up 2 件に対応する。

1. **wiki-branch-init.sh の leading-`-` sanitization**: 引数解析直後に `case "$wiki_branch" in -*)` の fail-fast gate を追加。leading-`-` の値が `git push -u origin` で option として解釈される argument injection の理論的余地を git 操作到達前に遮断する (`git checkout --orphan` 側は git 自身の branch name validation で reject されることを sandbox 実測)。`--` セパレータ硬化案は `git checkout --orphan` が `--` を pathspec 区切りに解釈するため不採用とし、sibling script (wiki-lint-skipped-refs.sh) の placeholder residue gate と同型の入力 gate 方式を採用。
2. **caller placeholder quoting 統一**: `issue/list.md` の `projects-items-fetch.sh` 呼び出しの `{project_number}` / `{owner}` placeholder を wiki 系 caller と対称の quoted 形式 `"{...}"` に統一。

## 関連 Issue

Closes #1290

## 変更内容

- `plugins/rite/hooks/scripts/wiki-branch-init.sh`: leading-`-` fail-fast gate 追加 + header Exit codes 列挙の同期
- `plugins/rite/hooks/tests/wiki-branch-init.test.sh`: TC-8 (leading-dash 値 → ERROR + exit 1 + ブランチ未作成の end state pin) 追加
- `plugins/rite/commands/issue/list.md`: caller placeholder quoting を `"{...}"` 形式に統一

## テスト

- `wiki-branch-init.test.sh`: 26 passed / 0 failed (TC-8 含む。TC-D differential equivalence 維持 — gate は正常系に非干渉)

## チェックリスト

- [x] コードはプロジェクトの規約に準拠
- [x] テスト通過 (wiki-branch-init.test.sh 26/26)
- [x] ドキュメント更新 (stale ドキュメントなし — wiki/init.md の出力契約は generic な `ERROR: ... + exit 1` で新 gate も被覆)

## 備考

- /rite:lint の plugin 内部チェックで surface した warnings (drift 84 / comment-journal 88 / comment-line-ref 17 / sh-cross-ref 2) はいずれも本 PR の変更ファイル外の pre-existing findings (non-blocking、既存の cleanup 追跡対象)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
