### PR TITLE
refactor(commands): projects-status-update.sh caller の nested jq を status_json_args 分離形式に統一

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -25,11 +25,12 @@ Phase 1.3.2 / 4.2 / 4.6.3 はいずれも Projects Status を **Done** に更新
 **委譲呼び出し**（`{issue}` は対象 Issue 番号、`auto_add false`・`non_blocking true`）:
 
 ```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+status_json_args=$(jq -n \
   --argjson issue {issue} --arg owner "{owner}" --arg repo "{repo}" \
   --argjson project_number {project_number} --arg status "Done" \
   --argjson auto_add false --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
+bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args"
 ```
 
 **`.result` による分岐**（全分岐 non-blocking — Status 更新失敗は close フローを止めない）:

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -374,7 +374,7 @@ gh pr view {pr_number} --json body,headRefName
 Skip Phase 4.2 if `github.projects.enabled: false` in `rite-config.yml` or if no related Issue was identified in Phase 4.1, and proceed to Phase 4.6. Otherwise, invoke the shared script to transition the Issue Status to **In Review**:
 
 ```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+status_json_args=$(jq -n \
   --argjson issue {issue_number} \
   --arg owner "{owner}" \
   --arg repo "{repo}" \
@@ -382,7 +382,8 @@ bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
   --arg status "In Review" \
   --argjson auto_add false \
   --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
+bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args"
 ```
 
 `auto_add: false` because by ready time the Issue is already registered in the Project (`pr/open.md` ステップ 2.4 auto-added it if missing). The script internally executes the GraphQL `projectItems` query → `gh project field-list` → `gh project item-edit` triple in a single fail-fast pipeline. The query uses GraphQL の `repository(owner:)` 形式 (User / Organization どちらの owner でも透過的に解決されるため、client-side type detection は不要)。旧 ready.md inline 経路は `user(login:)` を直接 query して Organization fallback を行う実装だったが、`repository(owner:)` への delegation でこの分岐自体が不要になった。

--- a/plugins/rite/commands/pr/references/archive-procedures.md
+++ b/plugins/rite/commands/pr/references/archive-procedures.md
@@ -24,7 +24,7 @@ github:
 Skip Phase 3.2 if `github.projects.enabled: false` in `rite-config.yml` or if no related Issue was identified in `cleanup.md` ステップ 2, and proceed to Phase 3.5 (work memory update). Otherwise, invoke the shared script to transition the Issue Status to **Done**:
 
 ```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+status_json_args=$(jq -n \
   --argjson issue {issue_number} \
   --arg owner "{owner}" \
   --arg repo "{repo}" \
@@ -32,7 +32,8 @@ bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
   --arg status "Done" \
   --argjson auto_add false \
   --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
+bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args"
 ```
 
 `auto_add: false` because by cleanup time the Issue is already registered in the Project (`pr/open.md` ステップ 2.4 auto-added it if missing).
@@ -360,7 +361,7 @@ If all child Issues are complete, auto-close the parent Issue without user confi
 Skip this substep if `github.projects.enabled: false` in `rite-config.yml` and proceed to 3.7.2.2 (close processing). Otherwise, invoke the shared script to transition the parent Issue Status to **Done** (same delegate pattern as Phase 3.2):
 
 ```bash
-bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
+status_json_args=$(jq -n \
   --argjson issue {parent_issue_number} \
   --arg owner "{owner}" \
   --arg repo "{repo}" \
@@ -368,7 +369,8 @@ bash {plugin_root}/scripts/projects-status-update.sh "$(jq -n \
   --arg status "Done" \
   --argjson auto_add false \
   --argjson non_blocking true \
-  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')"
+  '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}')
+bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args"
 ```
 
 Inspect the script's stdout JSON:


### PR DESCRIPTION
## 概要

`projects-status-update.sh` を呼び出す command markdown caller のうち、nested `"$(jq -n ...)"` 形態で残っていた 4 箇所を `status_json_args` 分離形式に統一する。深い入れ子 quoting は LLM ツール呼び出し解析の malform 源（#1193）であり、SoT (`references/issue-create-with-projects.md`) が MUST 化した「nested 回避」方針に未統一だった。

## 関連 Issue

Closes #1291

## 変更内容

| ファイル | 箇所 | status |
|---|---|---|
| `plugins/rite/commands/pr/ready.md` | Phase 4.2 (In Review 遷移) | `In Review` |
| `plugins/rite/commands/issue/close.md` | Shared delegate pattern | `Done` |
| `plugins/rite/commands/pr/references/archive-procedures.md` | Phase 3.2 (cleanup) ×1 / Phase 3.7.2.1 (親 Issue auto-close) ×1 | `Done` |

各 primary「委譲呼び出し」ブロックを次の形へ変換（単一 JSON 引数契約は不変）:

```bash
status_json_args=$(jq -n ... '{...}')
bash {plugin_root}/scripts/projects-status-update.sh "$status_json_args"
```

## 設計判断

- **変数名**: #1284 の `args_json` ではなく、各ファイルの既存 skeleton / Bash 実装パターンが参照する `status_json_args` に揃えた。`args_json` を導入すると同一ファイル内で 2 つの変数名が併存し、かえって不整合が増えるため。
- **error guard**: projects-status-update は non-blocking 契約のため `|| exit 1` ガードは付けない（既存分離形と同形）。
- **コメント**: 対象ファイルは Simplification Charter 適用下のため、Issue 番号引用コメントは付けない。

## 検証

- nested 残存 grep = 0、生成 JSON は jq filter 文字一致で byte 等価
- `bash-heaviness-check`（#1197、nested-cmdsub signal）: 変更 3 ファイル 0 findings
- 既存 hook テストは post-compact 側のフックを対象としており本変更と独立

## チェックリスト

- [x] 変更を確認した
- [x] lint（プラグイン固有チェック）を実行し、変更ファイルに findings なし
- [ ] レビュー実施
