### PR TITLE
docs(gh-cli-patterns): checkbox 更新 3 段階パターンの Step 1 EXIT trap を削除

### DIFF
--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -743,7 +743,7 @@ git push -u origin {branch_name}
 
 **Update procedure** (3-step safe update pattern):
 
-Execute in 3 stages (Bash → Read+Write → Bash). Since `trap` is only effective within the same process, all sub-steps in Step 1 must be executed within the same Bash tool call. On any validation failure, output a WARNING and skip remaining steps (do NOT `exit 1` — subsequent phase processing must continue).
+Execute in 3 stages (Bash → Read+Write → Bash). Shell variables do not persist across Bash tool calls, so the temp file paths output by Step 1 are passed to Step 3 as literals. On any validation failure, output a WARNING and skip remaining steps (do NOT `exit 1` — subsequent phase processing must continue).
 
 **Step 1: Bash tool call — Fetch body and validate**
 
@@ -902,15 +902,19 @@ Execute in 3 stages (Bash → Read+Write → Bash). On any validation failure, o
 
 ```bash
 # Create temp files (for reading and writing)
+# Do NOT set an EXIT trap here: Step 1 is its own Bash tool call, so an EXIT trap
+# would fire when Step 1 exits and delete the temp files before Step 2's Read tool
+# can read them. The files are cleaned up explicitly instead — in Step 3 on success,
+# and in the failure branch below on a Step 1 failure.
 tmpfile_read=$(mktemp)
 tmpfile_write=$(mktemp)
-trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
 
 gh issue view {parent_issue_number} --json body --jq '.body' > "$tmpfile_read"
 
 # Validate retrieval result
 if [ ! -s "$tmpfile_read" ]; then
   echo "WARNING: Parent Issue body の取得に失敗。タスクリスト更新をスキップします" >&2
+  rm -f "$tmpfile_read" "$tmpfile_write"
   exit 0  # Skip — do not abort workflow
 fi
 
@@ -956,7 +960,7 @@ fi
 
 gh issue edit {parent_issue_number} --body-file "$tmpfile_write"
 
-# trap does not carry over between processes (Bash tool calls), so delete explicitly
+# No EXIT trap is set in Step 1 (it would delete these before Step 2), so clean up here
 rm -f "$tmpfile_read" "$tmpfile_write"
 ```
 

--- a/plugins/rite/commands/issue/references/checklist-auto-check.md
+++ b/plugins/rite/commands/issue/references/checklist-auto-check.md
@@ -91,13 +91,17 @@ Root Cause を調査しますか?
 
    ```bash
    # Step 1: Retrieve current body and validate
+   # Do NOT set an EXIT trap here: Step 1 is its own Bash tool call, so an EXIT trap
+   # would fire when Step 1 exits and delete the temp files before Step 2's Read tool
+   # can read them. The files are cleaned up explicitly instead — in Step 3 on success,
+   # and in the failure branch below on a Step 1 failure.
    tmpfile_read=$(mktemp)
    tmpfile_write=$(mktemp)
-   trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
    gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"
 
    if [ ! -s "$tmpfile_read" ]; then
      echo "ERROR: Issue body の取得に失敗" >&2
+     rm -f "$tmpfile_read" "$tmpfile_write"
      exit 1
    fi
 
@@ -112,14 +116,19 @@ Root Cause を調査しますか?
 
    ```bash
    # Replace with actual paths from Step 1 output (e.g., /tmp/tmp.XXXXXXXXXX)
-   tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Step 1 の出力値に置換
+   tmpfile_read="/tmp/tmp.XXXXXXXXXX"   # ← Step 1 の tmpfile_read= 出力値に置換
+   tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Step 1 の tmpfile_write= 出力値に置換
 
    if [ ! -s "$tmpfile_write" ]; then
      echo "ERROR: Updated content is empty" >&2
+     rm -f "$tmpfile_read" "$tmpfile_write"
      exit 1
    fi
 
    gh issue edit {issue_number} --body-file "$tmpfile_write"
+
+   # No EXIT trap is set in Step 1 (it would delete these before Step 2), so clean up here
+   rm -f "$tmpfile_read" "$tmpfile_write"
    ```
 
 4. **Re-check**: After updating, re-run the checklist check:

--- a/plugins/rite/references/gh-cli-patterns.md
+++ b/plugins/rite/references/gh-cli-patterns.md
@@ -327,7 +327,7 @@ gh issue view {issue_number} --json body --jq '.body' | grep -E '^- \[[ xX]\] ' 
 
 ### Checkbox Update
 
-Execute in 3 stages (Bash → Read+Write → Bash). Since `trap` is only effective within the same process, all sub-steps in Step 1 must be executed within the same Bash tool call.
+Execute in 3 stages (Bash → Read+Write → Bash). Shell variables do not persist across Bash tool calls, so all of Step 1 (`mktemp` + fetch + validation) must run within a single Bash tool call, and the resulting temp file paths are passed to Step 3 as literals.
 
 > **🔴 CRITICAL**: NEVER use `echo "$body" | sed` for checkbox updates. See [gh CLI Error Catalog - Category 1](./gh-cli-error-catalog.md#category-1-nil-is-not-an-object-http-422--27-sessions).
 
@@ -335,15 +335,19 @@ Execute in 3 stages (Bash → Read+Write → Bash). Since `trap` is only effecti
 
 ```bash
 # Create temp files (for reading and writing)
+# Do NOT set an EXIT trap here: Step 1 is its own Bash tool call, so an EXIT trap
+# would fire when Step 1 exits and delete the temp files before Step 2's Read tool
+# can read them. The files are cleaned up explicitly instead — in Step 3 on success,
+# and in the failure branch below on a Step 1 failure.
 tmpfile_read=$(mktemp)
 tmpfile_write=$(mktemp)
-trap 'rm -f "$tmpfile_read" "$tmpfile_write"' EXIT
 
 gh issue view {issue_number} --json body --jq '.body' > "$tmpfile_read"
 
 # Validate retrieval result
 if [ ! -s "$tmpfile_read" ]; then
   echo "ERROR: Failed to retrieve Issue body" >&2
+  rm -f "$tmpfile_read" "$tmpfile_write"
   exit 1  # May be overridden by the calling workflow (pr/open.md / pr/iterate.md 等)
 fi
 
@@ -368,12 +372,13 @@ tmpfile_write="/tmp/tmp.XXXXXXXXXX"  # ← Replace with the tmpfile_write= value
 # Validate update content before applying
 if [ ! -s "$tmpfile_write" ]; then
   echo "ERROR: Updated content is empty" >&2
+  rm -f "$tmpfile_read" "$tmpfile_write"
   exit 1
 fi
 
 gh issue edit {issue_number} --body-file "$tmpfile_write"
 
-# trap does not carry over between processes (Bash tool calls), so delete explicitly
+# No EXIT trap is set in Step 1 (it would delete these before Step 2), so clean up here
 rm -f "$tmpfile_read" "$tmpfile_write"
 ```
 


### PR DESCRIPTION
## 概要

Issue body checklist 更新の 3 段階パターン（Step 1: Bash → Step 2: Read/Write → Step 3: Bash）の **Step 1** が `mktemp` 後に `trap 'rm -f ...' EXIT` を設定していたため、Claude Code の Bash tool がプロセスを呼び出しごとに分離する前提下で、Step 1 の Bash 呼び出し成功終了時に EXIT trap が発火し tmpfile を即削除していた。結果、Step 2 の Read tool が「File does not exist」で失敗する。本 PR はこの矛盾（trap の存在自体が 3 段階パターンと非整合）を解消する。

## 関連 Issue

Closes #1297

## 変更内容

生 trap を持つ同型 3 パターンを横断修正:

- `references/gh-cli-patterns.md`（Checkbox Update / SoT）
- `commands/issue/implement.md`（5.1.2.1 Tasklist Update）
- `commands/issue/references/checklist-auto-check.md`

各パターンで:

- **Step 1 の EXIT trap を削除**し、「Step 1 は独立 Bash 呼び出しのため EXIT trap は tmpfile を Step 2 前に消す。明示 cleanup する」旨の注記に置換
- 旧 trap が担っていた**失敗時 cleanup を Step 1 失敗パスの明示 `rm` で保全**（trap 削除で leak させない）
- Step 3 成功パスの明示 `rm` と合わせ**全パス leak-free** 化。`checklist-auto-check.md` は Step 3 に明示 `rm` が無かったため新設（`tmpfile_read` リテラル追加）
- intro の「Since trap is only effective within the same process …」rationale を、単一 Bash 呼び出しが必要な真の理由（シェル変数がプロセスを跨いで持続しない）へ書換

正しい設計の helper `hooks/issue-body-safe-update.sh`（trap を安全網に設定し成功パスで `trap - EXIT` 解除）は対象外。

## 検証

- 生 3 段階 trap = 0 件 / 旧 rationale 文 = 0 件 / helper 無変更を grep で確認
- plugin 固有 lint チェック: 変更3ファイルに直接関連する hardcoded-line-number / bash-heaviness / doc-heavy-drift / backlink-format / bang-backtick はすべて 0 findings
- 既存の repo 全体 warning（distributed-fix-drift 等）は非ブロッキングかつ本変更3ファイルに非該当

## Checklist

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし: ドキュメントパターン修正）
- [x] ドキュメント更新（本変更自体がドキュメント）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
