### PR TITLE
test(tests): symmetry test の canonical grep に bash anchor を付与し subset 関係を保証 (refs #1302)

### DIFF
--- a/plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh
@@ -62,7 +62,7 @@ done
 #       create-issue-with-projects.sh callsite using the separated
 #       `"$args_json"` pattern (Issue #1196).
 # ──────────────────────────────────────────────────────────────────────
-create_md_canonical=$(grep -c 'create-issue-with-projects\.sh "\$args_json"' "$CREATE_MD" || true)
+create_md_canonical=$(grep -cE 'bash [^|]*create-issue-with-projects\.sh "\$args_json"' "$CREATE_MD" || true)
 if [ "$create_md_canonical" -ge 1 ]; then
   pass "TC-1 Single-Issue path (create.md 4.3) has canonical JSON callsite (count=$create_md_canonical)"
 else
@@ -197,7 +197,7 @@ assert_single_create_caller() {
   local file="$2"
   # (a) canonical single-arg callsite present (>= 1)
   local canonical
-  canonical=$(grep -c 'create-issue-with-projects\.sh "\$args_json"' "$file" || true)
+  canonical=$(grep -cE 'bash [^|]*create-issue-with-projects\.sh "\$args_json"' "$file" || true)
   if [ "$canonical" -ge 1 ]; then
     pass "$label: canonical 'create-issue-with-projects.sh \"\$args_json\"' callsite present (count=$canonical)"
   else


### PR DESCRIPTION
## 概要

`create-md-invocation-symmetry.test.sh` の canonical callsite カウント用 grep が `bash [^|]*` anchor を持たず、invocation grep の真部分集合になることが構造的に保証されない問題を塞ぐ。canonical を伴わない prose 行（例: 復旧ガイダンス）が追加されると `non_canonical = invocations - canonical` が負値化し `[ "$non_canonical" -eq 0 ]` が誤って FAIL する偽陽性経路があった。

## 関連 Issue

Closes #1302

## 変更内容

- `plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh` - 変更
  - canonical カウント grep 2 箇所に invocation grep と同一の `bash [^|]*` anchor を付与し subset 関係を保証:
    - TC-1/TC-2 共用の `create_md_canonical`（`grep -c` → `grep -cE 'bash [^|]*...'`）
    - TC-9/TC-10 共用 helper `assert_single_create_caller` の `canonical`（同上）
  - Issue 指定通り TC-1/TC-2/TC-9/TC-10 を同一 commit で同時統一し、symmetry test 自身の内部対称性を維持

## スコープ外（意図的に非変更）

- 診断用 `grep -v`: 既に `bash` anchor 済みの invocation リストへのフィルタで負値計算に非関与
- decompose 系（`$CREATE_SCRIPT` 別 anchor）: subset 関係が既に保証されているため対象外

## チェックリスト

- [x] プロジェクト規約に準拠
- [x] テスト pass（symmetry test 25/25 pass、TC-1 count=1 / TC-2 non_canonical=0 / TC-9・TC-10 維持を実行確認）
- [ ] ドキュメント更新（不要 — テスト内部ロジックのみ）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
