### PR TITLE
fix(workflow): pr:create のインライン body/title 由来 malformed tool-call を抑制

### DIFF
--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -748,20 +748,20 @@ echo "[CONTEXT] PR_CREATE_WORKDIR=$pr_workdir"
 
 **(C) gh pr create（単一 bash block）**
 
-> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。冒頭で literal を shell 変数 `pr_workdir` に束縛し、以降の cat / `--body-file` / cleanup すべてで `$pr_workdir` を参照する（literal placeholder 置換漏れ時の `rm -rf "{...}"` 誤動作を防ぐ）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。workdir の cleanup は inline `rm -rf` ではなく **signal-specific trap** で行い、空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP のすべての exit 経路で確実に削除する（同一ファイル他ブロック・`coding-principles.md` Rule 5・[bash-trap-patterns.md](../../references/bash-trap-patterns.md#signal-specific-trap-template) の canonical 形に準拠）。空 body / 空 title チェックは title / body が動的生成のため必須（body と title は対称にガードする）。
+> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。冒頭で literal を shell 変数 `pr_workdir` に束縛し、以降の cat / `--body-file` / cleanup すべてで `$pr_workdir` を参照する（literal placeholder 置換漏れ時の `rm -rf "{...}"` 誤動作を防ぐ）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。workdir の cleanup は inline `rm -rf` ではなく **signal-specific trap** で行い、空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP のすべての exit 経路で確実に削除する（同一ファイル他ブロック・`coding-principles.md` Rule 5・[bash-trap-patterns.md](references/bash-trap-patterns.md#signal-specific-trap-template) の canonical 形に準拠）。空 body / 空 title チェックは title / body が動的生成のため必須（body と title は対称にガードする）。
 >
 > **既知の trade-off (Cause A、refs #1307 AC-5)**: 3 段プロトコルは workdir を (A)/(B Write)/(C) の **別プロセス**に跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了した場合（Cause A: harness/transport 側ゆらぎ、rite では除去不能）、`mktemp -d` した空 workdir が orphan として残る。本 trap は (C) 自身の中断のみカバーし、この cross-process orphan は救えない（OS の `/tmp` reaping と `/rite:resume` 再開で実害は限定的）。`rite-pr-create-*` 孤児 workdir の能動的 GC（`pr-cycle-cleanup.sh` への追加等）は本 PR scope 外の follow-up とする。
 
 ```bash
 pr_workdir="{PR_CREATE_WORKDIR}"
-pr_workdir_cleanup() {
+_rite_create_phase34_cleanup() {
   [ -n "${pr_workdir:-}" ] && [ -d "$pr_workdir" ] && rm -rf "$pr_workdir"
   return 0
 }
-trap 'rc=$?; pr_workdir_cleanup; exit $rc' EXIT
-trap 'pr_workdir_cleanup; exit 130' INT
-trap 'pr_workdir_cleanup; exit 143' TERM
-trap 'pr_workdir_cleanup; exit 129' HUP
+trap 'rc=$?; _rite_create_phase34_cleanup; exit $rc' EXIT
+trap '_rite_create_phase34_cleanup; exit 130' INT
+trap '_rite_create_phase34_cleanup; exit 143' TERM
+trap '_rite_create_phase34_cleanup; exit 129' HUP
 
 pr_title=$(cat "$pr_workdir/pr_title.txt")
 if [ -z "$pr_title" ]; then

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -748,18 +748,32 @@ echo "[CONTEXT] PR_CREATE_WORKDIR=$pr_workdir"
 
 **(C) gh pr create（単一 bash block）**
 
-> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。空 body チェックは body が動的生成のため必須。
+> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。冒頭で literal を shell 変数 `pr_workdir` に束縛し、以降の cat / `--body-file` / cleanup すべてで `$pr_workdir` を参照する（literal placeholder 置換漏れ時の `rm -rf "{...}"` 誤動作を防ぐ）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。workdir の cleanup は inline `rm -rf` ではなく **signal-specific trap** で行い、空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP のすべての exit 経路で確実に削除する（同一ファイル他ブロック・`coding-principles.md` Rule 5・[bash-trap-patterns.md](../../references/bash-trap-patterns.md#signal-specific-trap-template) の canonical 形に準拠）。空 body / 空 title チェックは title / body が動的生成のため必須（body と title は対称にガードする）。
+>
+> **既知の trade-off (Cause A、refs #1307 AC-5)**: 3 段プロトコルは workdir を (A)/(B Write)/(C) の **別プロセス**に跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了した場合（Cause A: harness/transport 側ゆらぎ、rite では除去不能）、`mktemp -d` した空 workdir が orphan として残る。本 trap は (C) 自身の中断のみカバーし、この cross-process orphan は救えない（OS の `/tmp` reaping と `/rite:resume` 再開で実害は限定的）。`rite-pr-create-*` 孤児 workdir の能動的 GC（`pr-cycle-cleanup.sh` への追加等）は本 PR scope 外の follow-up とする。
 
 ```bash
-pr_title=$(cat "{PR_CREATE_WORKDIR}/pr_title.txt")
-if [ ! -s "{PR_CREATE_WORKDIR}/pr_body.md" ]; then
+pr_workdir="{PR_CREATE_WORKDIR}"
+pr_workdir_cleanup() {
+  [ -n "${pr_workdir:-}" ] && [ -d "$pr_workdir" ] && rm -rf "$pr_workdir"
+  return 0
+}
+trap 'rc=$?; pr_workdir_cleanup; exit $rc' EXIT
+trap 'pr_workdir_cleanup; exit 130' INT
+trap 'pr_workdir_cleanup; exit 143' TERM
+trap 'pr_workdir_cleanup; exit 129' HUP
+
+pr_title=$(cat "$pr_workdir/pr_title.txt")
+if [ -z "$pr_title" ]; then
+  echo "ERROR: PR title is empty (pr_title.txt missing or empty — (B) Write step 漏れの可能性)" >&2
+  exit 1
+fi
+if [ ! -s "$pr_workdir/pr_body.md" ]; then
   echo "ERROR: PR body is empty" >&2
-  rm -rf "{PR_CREATE_WORKDIR}"
   exit 1
 fi
 
-gh pr create --draft --base "{base_branch}" --title "$pr_title" --body-file "{PR_CREATE_WORKDIR}/pr_body.md"
-rm -rf "{PR_CREATE_WORKDIR}"
+gh pr create --draft --base "{base_branch}" --title "$pr_title" --body-file "$pr_workdir/pr_body.md"
 ```
 
 ### 3.5 Update Work Memory Phase

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -730,24 +730,36 @@ git push -u origin {branch_name}
 
 ### 3.4 Create Draft PR
 
-**Sanitization**: Explicit escaping is not required here. The 3-layer defense pattern (mktemp + HEREDOC with quoted delimiter + empty check + --body-file) prevents shell variable expansion issues. Claude substitutes placeholders directly without manual escaping.
+> **3 段プロトコル** (refs #1307 / 先例: `issue/create.md` 5.5 decompose path): PR title / body をインライン heredoc・インライン `--title` で bash ブロックに埋め込むと、特殊文字（全角記号・`≠`・括弧・コロン等）を含む長文で Claude のツールコール解析が malform し、エラーなく無言でターンが終了する（Issue #1193 と同一 failure mode）。これを構造的に避けるため、LLM は (A) workdir を `mktemp -d` で確保 → (B) **Write tool** で title / body を raw ファイル化（heredoc を使わない）→ (C) bash は変数 / `--body-file` 経由で `gh pr create` を実行、の 3 段で行う。title 特殊文字を bash ブロックに一切インライン展開しないのがこの設計の要点。
+
+**(A) workdir 確保**
 
 ```bash
-# Generate body content from Phase 3.2 template and work memory (structure is consistent regardless of optimization)
-# Note: Empty check is required because {body} is dynamically generated.
-tmpfile=$(mktemp)
-trap 'rm -f "$tmpfile"' EXIT
+pr_workdir=$(mktemp -d -t rite-pr-create-XXXXXX)
+echo "[CONTEXT] PR_CREATE_WORKDIR=$pr_workdir"
+```
 
-cat <<'BODY_EOF' > "$tmpfile"
-{body}
-BODY_EOF
+**(B) title / body の生成（Write tool）**
 
-if [ ! -s "$tmpfile" ]; then
+直前の `[CONTEXT] PR_CREATE_WORKDIR=` から `{PR_CREATE_WORKDIR}` を読み取り、以下を **Write tool** で書く（heredoc を使わない）:
+
+1. `{PR_CREATE_WORKDIR}/pr_title.txt` ← Phase 3.1 で生成した PR title の raw 内容（1 行）
+2. `{PR_CREATE_WORKDIR}/pr_body.md` ← Phase 3.2 で生成した PR body の raw 内容
+
+**(C) gh pr create（単一 bash block）**
+
+> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。空 body チェックは body が動的生成のため必須。
+
+```bash
+pr_title=$(cat "{PR_CREATE_WORKDIR}/pr_title.txt")
+if [ ! -s "{PR_CREATE_WORKDIR}/pr_body.md" ]; then
   echo "ERROR: PR body is empty" >&2
+  rm -rf "{PR_CREATE_WORKDIR}"
   exit 1
 fi
 
-gh pr create --draft --base "{base_branch}" --title "{title}" --body-file "$tmpfile"
+gh pr create --draft --base "{base_branch}" --title "$pr_title" --body-file "{PR_CREATE_WORKDIR}/pr_body.md"
+rm -rf "{PR_CREATE_WORKDIR}"
 ```
 
 ### 3.5 Update Work Memory Phase
@@ -941,6 +953,8 @@ Output the following pattern based on PR creation result:
 - Do **NOT** invoke `rite:pr:review` via the Skill tool
 - Return control to the caller (orchestrator — caller-name agnostic, e.g. `/rite:pr:open` / `sprint/execute.md`)
 - The caller determines the next action based on this output pattern
+
+> **Missing-sentinel recovery contract** (refs #1307): Phase 3.4 で `gh pr create` が malformed tool-call により sentinel を 1 つも emit せず無言でターンが終了する（Cause A: harness/transport 側のゆらぎ。rite では除去不能）ことがある。この場合 caller（orchestrator）は `[pr:created:{N}]` / `[pr:create-failed]` のいずれも context に観測できないため **missing-sentinel** として扱う。本 Skill は flow-state を所有せず caller が `phase` を保持するため、caller 側の missing-sentinel 検出 → `/rite:resume` 再開で PR 作成ステップを安全にやり直せる（重複 draft PR の検出・再構成は orchestrator の resume 経路が担う。`commands/pr/open.md` ステップ 0 phase=pr / ステップ 6 参照）。Phase 3.4 の Write tool 委譲はこの Cause A 自体を消すものではなく、Cause B（インライン heredoc / 特殊文字 title による malform 増幅）を除去して発生確率を下げる対策である。
 
 **Example output:**
 ```

--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -263,7 +263,22 @@ git push -u origin {branch_name}
 skill: rite:pr:create
 ```
 
-`[pr:created:N]` sentinel から PR 番号を抽出して `{pr_number}` として retain。`[pr:create-failed]` の場合は AskUserQuestion で「再試行 / 中止」を提示。
+`rite:pr:create` の出力 sentinel を会話 context から検証する:
+
+| Sentinel | 次のアクション |
+|---------|--------------|
+| `[pr:created:N]` | PR 番号 `N` を `{pr_number}` として retain → ステップ 6.3 へ |
+| `[pr:create-failed]` | AskUserQuestion で「再試行 / 中止」を提示 |
+| **sentinel 不在 (missing-sentinel)** | `[pr:created:N]` / `[pr:create-failed]` のいずれも context に無い。Phase 3.4 の `gh pr create` が malformed tool-call で無言終了した可能性 (Cause A: harness/transport 側ゆらぎ、rite では除去不能 — 詳細は下記「malformed tool-call 回復契約」)。下記手順で回復する |
+
+**malformed tool-call 回復契約** (refs #1307):
+
+sub-skill (`rite:pr:create` / `rite:issue:implement` / `rite:lint`) のターンが sentinel を 1 つも emit せず無言で終了した場合、flow-state には直前 phase が保持されているため作業は失われない。orchestrator は以下で回復する:
+
+1. **既存 draft PR の検出**: `gh pr list --head {branch_name} --json number,url,isDraft` で当該ブランチの PR が既に作成済みか確認する。存在すれば実質 `[pr:created:N]` 相当として `{pr_number}` を再構成し、ステップ 6.3 へ進む (push/PR は冪等に再開可能)
+2. **未作成の場合**: AskUserQuestion で「PR 作成を再試行 / 中止」を提示する。中止時は flow-state の phase が保持されるため `/rite:resume` で本ステップから再開できる旨を案内する
+
+> Phase 3.4 の Write tool 委譲 (#1307) は Cause B (インライン heredoc / 特殊文字 title による malform 増幅) を除去して発生確率を下げる対策であり、Cause A 自体は消せない。そのため本回復契約が最終的な堅牢化の担保となる。
 
 ### 6.3 flow-state 更新
 
@@ -302,3 +317,4 @@ draft PR の作成が完了したら、ユーザーに以下を案内する:
 - どこで止まっても flow-state.json に phase が記録されている
 - `/rite:resume` 経由で本コマンドの該当ステップから再開する
 - sub-skill (`rite:issue:implement` / `rite:lint` / `rite:pr:create`) の sentinel drop に備え、各 invoke 後に sentinel 検出を確認、不在なら AskUserQuestion で「再試行 / 中止」
+- **malformed tool-call による無言終了** (sub-skill が sentinel を 1 つも emit せずターン終了。Cause A: harness/transport 側ゆらぎ、rite では除去不能) も missing-sentinel として同様に扱う。PR 作成ステップの具体的な回復手順 (既存 draft PR 検出 → `/rite:resume`) はステップ 6.2「malformed tool-call 回復契約」を参照 (refs #1307)

--- a/plugins/rite/hooks/scripts/bash-heaviness-check.sh
+++ b/plugins/rite/hooks/scripts/bash-heaviness-check.sh
@@ -37,11 +37,16 @@
 # Standalone detection (Issue #1307 — separate from the >= 2 score model):
 #   inline-gh-create-title — a real shell line that runs `gh {pr,issue} create`
 #     with a LITERAL `--title "..."` / `--title '...'` (the first char inside the
-#     quote is not `$`). `--title "$var"` is sanctioned and NOT flagged. Unlike
-#     the four heaviness signals, a single inline special-char/long title on one
-#     line is itself a dominant malformed-tool-call trigger (#1307), so it is
-#     flagged on its own — it does not need a second signal. The canonical fix is
-#     to write the title via the Write tool to a file and read it into a variable
+#     quote is neither `$` nor the closing quote). `--title "$var"` is sanctioned
+#     and an empty `--title ""` / `--title ''` is ignored — both are NOT flagged.
+#     The command may span multiple physical lines via backslash continuation (the
+#     canonical multi-line `gh pr create --draft \` <newline> `  --title "..."` form
+#     in references/gh-cli-commands.md), so the literal-title check stays armed across
+#     continuation lines until the logical line ends. Unlike the four heaviness
+#     signals, a single inline special-char/long title is itself a dominant
+#     malformed-tool-call trigger (#1307), so it is flagged on its own — it does not
+#     need a second signal. The canonical fix is to write the title via the Write
+#     tool to a file and read it into a variable
 #     (`pr_title=$(cat title.txt)` → `--title "$pr_title"`), or pass it through a
 #     helper's `--arg title`. As with the heaviness signals, the detection runs
 #     only on real shell lines (heredoc bodies are data), so example titles in a
@@ -88,7 +93,8 @@ Detected (heavy operational bash blocks; flagged at >= 2 signals):
 
 Detected standalone (flagged on its own, separate from the >= 2 score model):
   inline-gh-create-title — `gh {pr,issue} create` with a literal `--title "..."`
-                           (`--title "$var"` is allowed)
+                           (`--title "$var"` and empty `--title ""` are allowed;
+                            backslash line-continuation forms are also detected)
 
 Exclusions: tests/ fixtures / blocks containing 'drift-check-ignore'.
 
@@ -166,6 +172,7 @@ BEGIN { in_block = 0 }
       in_block = 1; block_start = NR
       nlines = 0; has_python = 0; heredoc_count = 0; nested = 0; exempt = 0
       gh_title_inline = 0; gh_title_line = 0
+      gh_create_active = 0; gh_create_line = 0
       in_heredoc = 0; heredoc_delim = ""
     }
     next
@@ -185,9 +192,23 @@ BEGIN { in_block = 0 }
   if (line ~ /python3?[[:space:]]+.*(-c([[:space:]]|=|$)|<<)/) has_python = 1
   if (line ~ /\$\([^)]*\$\(/) nested = 1
   # Standalone trigger (#1307): inline `gh {pr,issue} create` with a LITERAL
-  # --title. `--title "$var"` (first char after the quote is `$`) is allowed.
-  if (line ~ /gh[[:space:]]+(pr|issue)[[:space:]]+create/ && line ~ /--title[[:space:]=]+["'][^$]/) {
-    gh_title_inline = 1; gh_title_line = NR
+  # --title. `--title "$var"` (first char after the quote is `$`) and an empty
+  # `--title ""` / `--title ''` (first char after the quote is the closing quote)
+  # are both allowed — the bracket expression `[^$"']` excludes `$` and both quote
+  # chars. A `gh ... create` command may span multiple physical lines via backslash
+  # continuation (the canonical multi-line form in references/gh-cli-commands.md), so
+  # the literal-title check stays armed across continuation lines until the command's
+  # logical line ends (a line not ending in `\`). This keeps the detection from
+  # missing `gh pr create --draft \` <newline> `  --title "{title}"`.
+  if (line ~ /gh[[:space:]]+(pr|issue)[[:space:]]+create/) {
+    gh_create_active = 1; gh_create_line = NR
+  }
+  if (gh_create_active == 1 && line ~ /--title[[:space:]=]+["'][^$"']/) {
+    gh_title_inline = 1
+    if (gh_title_line == 0) gh_title_line = gh_create_line
+  }
+  if (gh_create_active == 1 && line !~ /\\[[:space:]]*$/) {
+    gh_create_active = 0
   }
   if (line ~ /<</ && line !~ /<<</ && line ~ /<<-?[^A-Za-z0-9_]*[A-Za-z_]/) {
     heredoc_count++

--- a/plugins/rite/hooks/scripts/bash-heaviness-check.sh
+++ b/plugins/rite/hooks/scripts/bash-heaviness-check.sh
@@ -34,6 +34,19 @@
 # the literal content inside a heredoc, so a template heredoc that happens to
 # contain `$(...)` or `python3 -c` example text does not produce a finding.
 #
+# Standalone detection (Issue #1307 — separate from the >= 2 score model):
+#   inline-gh-create-title — a real shell line that runs `gh {pr,issue} create`
+#     with a LITERAL `--title "..."` / `--title '...'` (the first char inside the
+#     quote is not `$`). `--title "$var"` is sanctioned and NOT flagged. Unlike
+#     the four heaviness signals, a single inline special-char/long title on one
+#     line is itself a dominant malformed-tool-call trigger (#1307), so it is
+#     flagged on its own — it does not need a second signal. The canonical fix is
+#     to write the title via the Write tool to a file and read it into a variable
+#     (`pr_title=$(cat title.txt)` → `--title "$pr_title"`), or pass it through a
+#     helper's `--arg title`. As with the heaviness signals, the detection runs
+#     only on real shell lines (heredoc bodies are data), so example titles in a
+#     heredoc body or a non-```bash fence do not produce a finding.
+#
 # Exclusions:
 #   - plugins/rite/commands/**/tests/ (any test fixtures, if present).
 #   - Any block containing the marker `drift-check-ignore` on one of its lines
@@ -72,6 +85,10 @@ Detected (heavy operational bash blocks; flagged at >= 2 signals):
   nested-cmdsub  — nested command substitution `$( ... $( ... )`
   multi-heredoc  — 2 or more heredocs opened in one block
   long-block     — block body >= 25 lines
+
+Detected standalone (flagged on its own, separate from the >= 2 score model):
+  inline-gh-create-title — `gh {pr,issue} create` with a literal `--title "..."`
+                           (`--title "$var"` is allowed)
 
 Exclusions: tests/ fixtures / blocks containing 'drift-check-ignore'.
 
@@ -148,6 +165,7 @@ BEGIN { in_block = 0 }
     if (line ~ /^[[:space:]]*(```|~~~)[[:space:]]*(bash|sh|shell)[[:space:]]*$/) {
       in_block = 1; block_start = NR
       nlines = 0; has_python = 0; heredoc_count = 0; nested = 0; exempt = 0
+      gh_title_inline = 0; gh_title_line = 0
       in_heredoc = 0; heredoc_delim = ""
     }
     next
@@ -166,6 +184,11 @@ BEGIN { in_block = 0 }
   if (line ~ /drift-check-ignore/) exempt = 1
   if (line ~ /python3?[[:space:]]+.*(-c([[:space:]]|=|$)|<<)/) has_python = 1
   if (line ~ /\$\([^)]*\$\(/) nested = 1
+  # Standalone trigger (#1307): inline `gh {pr,issue} create` with a LITERAL
+  # --title. `--title "$var"` (first char after the quote is `$`) is allowed.
+  if (line ~ /gh[[:space:]]+(pr|issue)[[:space:]]+create/ && line ~ /--title[[:space:]=]+["'][^$]/) {
+    gh_title_inline = 1; gh_title_line = NR
+  }
   if (line ~ /<</ && line !~ /<<</ && line ~ /<<-?[^A-Za-z0-9_]*[A-Za-z_]/) {
     heredoc_count++
     if (match(line, /<<-?[^A-Za-z0-9_]*[A-Za-z_][A-Za-z0-9_]*/)) {
@@ -178,6 +201,10 @@ BEGIN { in_block = 0 }
 END { if (in_block == 1) evaluate() }
 function evaluate(   score, parts) {
   if (exempt == 1) return
+  # Standalone finding (#1307): independent of the >= 2 heaviness score.
+  if (gh_title_inline == 1) {
+    printf "[bash-heaviness] %s:%d: inline-gh-create-title — literal --title in gh {pr,issue} create; delegate the title to a file (Write tool) or a variable to avoid malformed tool-call (refs #1307)\n", fname, gh_title_line
+  }
   score = 0; parts = ""
   if (has_python == 1)            { score++; parts = parts (parts == "" ? "" : ", ") "python-inline" }
   if (nested == 1)                { score++; parts = parts (parts == "" ? "" : ", ") "nested-cmdsub" }

--- a/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+++ b/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
@@ -284,6 +284,84 @@ if [ "$rc" -eq 1 ] && echo "$output" | grep -q "long-block(25)"; then
 else fail "expected rc=1 + long-block(25), got rc=$rc: $output"; fi
 
 # --------------------------------------------------------------------------
+# TC-017: inline-gh-create-title — literal --title in a single short block must
+#         flag ON ITS OWN (no second signal needed). Issue #1307.
+# --------------------------------------------------------------------------
+echo "TC-017: literal --title standalone → exit 1"
+{
+  echo '```bash'
+  echo 'gh pr create --draft --base develop --title "feat(pr): 全角 (≠) コロン: 実装"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "inline-gh-create-title"; then
+  pass "literal --title flagged standalone → exit 1"
+else fail "expected rc=1 + inline-gh-create-title, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-018: variable --title ("$var") is the sanctioned form → NOT flagged.
+#         Pins that the refactored pr/create.md Phase 3.4 stays clean.
+# --------------------------------------------------------------------------
+echo "TC-018: variable --title → exit 0"
+{
+  echo '```bash'
+  echo 'pr_title=$(cat title.txt)'
+  echo 'gh pr create --draft --base develop --title "$pr_title" --body-file body.md'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "variable --title not flagged → exit 0"
+else fail "expected rc=0 (variable title), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-019: `gh issue create` with a literal --title is flagged too (both
+#         pr and issue create are covered). Also `--title=` equals form.
+# --------------------------------------------------------------------------
+echo "TC-019: gh issue create + --title= equals form → exit 1"
+{
+  echo '```bash'
+  echo 'gh issue create --title="fix: bug" --body-file b.md'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "inline-gh-create-title"; then
+  pass "gh issue create literal (equals form) flagged → exit 1"
+else fail "expected rc=1 + inline-gh-create-title, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-020: a literal --title inside a heredoc BODY is data, not a real shell
+#         line → NOT flagged. Mirrors the heredoc-body-as-data rule.
+# --------------------------------------------------------------------------
+echo "TC-020: literal --title in heredoc body → exit 0"
+{
+  echo '```bash'
+  echo "cat > tpl <<'EOF'"
+  echo 'gh pr create --title "example literal title"'
+  echo 'EOF'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "heredoc-body literal title ignored → exit 0"
+else fail "expected rc=0 (body is data), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-021: drift-check-ignore exempts inline-gh-create-title too (same exempt
+#         path as the heaviness signals).
+# --------------------------------------------------------------------------
+echo "TC-021: drift-check-ignore exempts literal --title → exit 0"
+{
+  echo '```bash'
+  echo '# drift-check-ignore — intentional inline title example'
+  echo 'gh pr create --title "feat: documented example"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ]; then pass "exempted inline title skipped → exit 0"
+else fail "expected rc=0 (exempted), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""

--- a/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+++ b/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
@@ -362,6 +362,73 @@ if [ "$rc" -eq 0 ]; then pass "exempted inline title skipped → exit 0"
 else fail "expected rc=0 (exempted), got rc=$rc: $output"; fi
 
 # --------------------------------------------------------------------------
+# TC-022: `gh issue edit` with a literal --title must NOT be flagged — the
+#         `create` anchor is load-bearing (it guards real `gh issue edit
+#         --title "{new_title}"` lines in commands/issue/edit.md). Pins that a
+#         regression loosening `(pr|issue) create` → `(pr|issue)` does not start
+#         flagging edit. Issue #1307 (F-02).
+# --------------------------------------------------------------------------
+echo "TC-022: gh issue edit literal --title → exit 0 (not flagged)"
+{
+  echo '```bash'
+  echo 'gh issue edit 12 --title "literal: x"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "gh issue edit literal title not flagged → exit 0"
+else fail "expected rc=0 (edit is not create), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-023: `gh pr edit` with a literal --title must NOT be flagged either (same
+#         create-anchor guard, pr variant). Issue #1307 (F-02).
+# --------------------------------------------------------------------------
+echo "TC-023: gh pr edit literal --title → exit 0 (not flagged)"
+{
+  echo '```bash'
+  echo 'gh pr edit 34 --title "feat: rename"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "gh pr edit literal title not flagged → exit 0"
+else fail "expected rc=0 (edit is not create), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-024: backslash line-continuation — a `gh pr create` whose literal --title is
+#         on a continuation line (the canonical multi-line form) MUST be flagged.
+#         Pins that the detection is armed across `\`-terminated lines. Issue
+#         #1307 (F-04).
+# --------------------------------------------------------------------------
+echo "TC-024: multi-line gh create + continuation literal --title → exit 1"
+{
+  echo '```bash'
+  echo 'gh pr create --draft --base develop \'
+  echo '  --title "feat: special (≠) title" \'
+  echo '  --body-file body.md'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "inline-gh-create-title"; then
+  pass "continuation-line literal --title flagged → exit 1"
+else fail "expected rc=1 + inline-gh-create-title, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-025: empty `--title ""` is a degenerate non-special title → NOT flagged.
+#         The `[^$"']` bracket excludes the closing quote. Issue #1307 (F-06).
+# --------------------------------------------------------------------------
+echo "TC-025: empty --title \"\" → exit 0 (not flagged)"
+{
+  echo '```bash'
+  echo 'gh pr create --draft --title "" --body-file body.md'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "empty --title not flagged → exit 0"
+else fail "expected rc=0 (empty title), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -499,6 +499,7 @@ OK patterns:
 3. 入れ子 `$()` (`$(cmd "$(jq -n ...)")` 等) を避ける。pipe (`jq -n ... | cmd`) もしくは stdin / tmpfile を読む helper を優先する。
 4. 1 ブロック内の複数 heredoc を避ける。file body が必要なら Write tool で tmpfile に書き出し、helper には `--content-file <tmp>` / `--body-file <tmp>` で渡す。
 5. 値を process 境界を跨いで渡す必要があるときは helper へ切り出す (work-memory / state 系は `hooks/`、issue / projects 系は `scripts/`)。その際**既存のワークフロー契約 (sentinel emit / non-blocking / trap cleanup) を verbatim で引き継ぐ**こと。
+6. `gh {pr,issue} create` の `--title` に長文 / 特殊文字（全角記号・`≠`・括弧・コロン等）の literal を**インライン展開しない**。title を **Write tool** でファイル化して bash で変数に読み込む（`pr_title=$(cat title.txt)` → `--title "$pr_title"`）か、helper の `--arg title` 経由で渡す。`gh` に `--title-file` は無い（body の `--body-file` と非対称）ため「変数経由」が canonical。先例: `pr/create.md` Phase 3.4 / `issue/create.md` 5.5 decompose path（refs #1307 — `gh {pr,issue} create` のインライン特殊文字 title が malformed tool-call の dominant trigger だった）。
 
 **Precedents**: `projects-status-update.sh` / `local-wm-update.sh` / `issue-body-safe-update.sh` / `issue-comment-wm-sync.sh` / `create-issue-with-projects.sh` — 重い操作を positional-JSON または stdin 入力 + tmpfile body file で helper に委譲済の前例。
 
@@ -513,8 +514,11 @@ OK patterns:
 | `nested-cmdsub` | 入れ子 `$( … $( … )`（同一行） | Rule 3 |
 | `multi-heredoc` | heredoc が 2 つ以上 | Rule 4 |
 | `long-block` | ブロック本文が >= 25 行 | Rule 1 |
+| `inline-gh-create-title` | `gh {pr,issue} create` 行に literal な `--title "…"` を inline（`--title "$var"` は対象外） | Rule 6 |
 
 **2 シグナル以上**該当したブロックのみ flag する (single signal — 単発の helper 呼び出し + 1 個の JSON heredoc、または 1 個の長文テンプレート heredoc — は誤検知を避けるため flag しない)。heredoc 本文はデータ扱いで python-inline / nested-cmdsub の評価対象外。意図的・レビュー済の重いブロックは行内 `drift-check-ignore` marker で除外できる。既存の重いブロックの helper 切り出しは段階的 cleanup であり、本 guard は awareness のための warning に留める。
+
+**例外: `inline-gh-create-title` は単独でも flag する**。これは複数シグナルの密集（heaviness）ではなく、単一行でも malform を誘発する高確度の独立パターンのため、2-signal モデルとは別に扱う（refs #1307）。example / template の title は plain ` ``` ` fence（` ```bash ` 以外は走査対象外）や heredoc 本文（データ扱い）に置くことで誤検知を避ける。`drift-check-ignore` marker による除外は他シグナルと同様に効く。
 
 ---
 

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -506,7 +506,7 @@ OK patterns:
 **Where to Apply**:
 - `commands/**/*.md` の operational bash ブロックを新規記述 / 編集するとき。
 
-**Mechanical enforcement** (Issue #1197): 上記 Rules は `/rite:lint` Phase 3.17 (`hooks/scripts/bash-heaviness-check.sh`) が `commands/**/*.md` を走査して非ブロッキング warning として機械的に surface する (`[lint:success]` は不変)。各 bash ブロックを 4 シグナルで評価し、これは Rules と対応する:
+**Mechanical enforcement** (Issue #1197): 上記 Rules は `/rite:lint` Phase 3.17 (`hooks/scripts/bash-heaviness-check.sh`) が `commands/**/*.md` を走査して非ブロッキング warning として機械的に surface する (`[lint:success]` は不変)。各 bash ブロックを 4 つの heaviness シグナル (+ standalone 検出 `inline-gh-create-title`) で評価し、これは Rules と対応する:
 
 | シグナル | 判定 | 対応 Rule |
 |---------|------|----------|


### PR DESCRIPTION
## Summary

`/rite:pr:open` の一気通貫フローで sub-skill `rite:pr:create` の PR 作成ステップ (Phase 3.4) が、**インライン heredoc body 生成**と**インライン `--title` 特殊文字展開**を抱えており、特殊文字（全角記号・`≠`・括弧・コロン等）を含む長文で Claude のツールコール解析が malform し、エラーなく無言でターンが終了する事象（Issue #1193 と同一 failure mode）の増幅要因になっていた。

`issue:create` decompose path（5.5）と同方式の **3 段プロトコル**へ置換し、bash ブロックへの特殊文字インライン展開を撤廃した。あわせて malformed tool-call による無言終了からの**回復契約**を明文化し、再発時にも `/rite:resume` で確実に復旧できることを保証する。

> 📌 **この PR 自体が、新しい Phase 3.4 プロトコル（mktemp -d workdir → Write tool で title/body をファイル化 → 変数 / `--body-file` で `gh pr create`）で作成されている**（ドッグフーディング）。

## Cause 切り分け

| Cause | 内容 | rite の管轄 |
|-------|------|------------|
| **Cause A** | harness / transport 側のツールコール解析ゆらぎ（単純な Write でも稀に発生） | **除去不能**（スコープ外）。担保は flow-state + `/rite:resume` による回復堅牢化 |
| **Cause B** | インライン heredoc / 特殊文字 `--title` が malform 率を押し上げる増幅要因 | **除去可能**（本 PR のスコープ）。ファイル委譲・変数経由で除去 |

本 PR は Cause B の除去 + Cause A への回復堅牢化に**スコープを限定**し、過剰約束をしない。

## Changes

- **`commands/pr/create.md` Phase 3.4** (AC-1, AC-2): インライン heredoc body + inline `--title "{title}"` を 3 段プロトコル（(A) `mktemp -d` workdir + `[CONTEXT]` marker → (B) **Write tool** で `pr_title.txt` / `pr_body.md` をファイル化 → (C) bash は `pr_title=$(cat …)` 変数 + `--body-file` で `gh pr create`）へ置換。title 特殊文字を bash ブロックに一切インライン展開しない。
- **`skills/rite-workflow/references/coding-principles.md`** (AC-3 規約): heaviness convention に Rule 6（`gh {pr,issue} create --title` の literal/特殊文字 title はファイル/変数委譲）と `inline-gh-create-title` シグナル行を追記。`gh` に `--title-file` が無い非対称性も明記。
- **`hooks/scripts/bash-heaviness-check.sh`** (AC-3 機械的強制): `inline-gh-create-title` を**単独 flag** する専用検出を追加（既存 2-signal モデルとは別扱い）。`--title "literal"` / `--title=…` を検出し、`--title "$var"` は許可。heredoc body・`drift-check-ignore` は除外。header / usage も更新。
- **`hooks/tests/bash-heaviness-check.test.sh`**: 新検出のテスト TC-017〜021 を追加（literal→flag / variable→pass / `gh issue create`+equals 形→flag / heredoc body→ignore / `drift-check-ignore`→exempt）。
- **`commands/pr/open.md` + `commands/pr/create.md`** (AC-4): sub-skill が sentinel を 1 つも emit せず無言終了した場合の **missing-sentinel 回復契約**（既存 draft PR 検出 → flow-state 保持 → `/rite:resume` 再開）を明文化。

## Acceptance Criteria

- [x] AC-1: `pr/create.md` Phase 3.4 の PR body 生成をインライン heredoc → Write tool ファイル化 + `--body-file` に変更
- [x] AC-2: `gh pr create` の `--title` を特殊文字含む場合でもインライン展開しない経路（変数経由）に統一
- [x] AC-3: heaviness convention に明記 + `bash-heaviness-check.sh` に `inline-gh-create-title` 検出を追加
- [x] AC-4: malformed tool-call で sentinel 無し終了時の回復契約を `pr/open.md` / sub-skill に明文化
- [x] AC-5: Cause A は rite 除去不能でスコープ外である旨を Issue / PR に明記（本節 + 上記「Cause 切り分け」）

## 検証

- `bash-heaviness-check.test.sh`: **21/21 pass**（既存 16 + 新規 5）
- 全 hook テストスイート（`run-tests.sh`）: **61/61 pass**、回帰なし
- `bash-heaviness-check.sh --all`: 0 findings（refactor 後の `--title "$pr_title"` は対象外、ベースラインはクリーン）
- `create-md-invocation-symmetry.test.sh`: 25/25 pass（`--title` 近接チェックは create-issue callsite 対象で `gh pr create` とは別物のため非影響）
- `bang-backtick-check.sh --all`: 0 findings
- 既存の非ブロッキング warning（distributed-fix-drift / comment-journal / comment-line-ref / sh-cross-ref）は本変更ファイルに新規 finding を出していない（すべて pre-existing）

## Out of Scope

- Cause A（harness / transport 側のツールコール解析ゆらぎ）そのものの修正（rite 管轄外）
- `/rite:pr:open` 以外のコマンドの全 bash block 一括 refactor（#1221 の延長。必要なら別 Issue）

Closes #1307
