### PR TITLE
fix(lint): lint.md result-pattern 列挙の terminal-output orphan エントリを除去

### DIFF
--- a/plugins/rite/commands/lint.md
+++ b/plugins/rite/commands/lint.md
@@ -1109,14 +1109,14 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 {wiki_growth_output}
 ```
 
-**Gitignore health check appendix (Issue #567)** (both standalone and E2E): When `gitignore_health_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output. When status is `warning` (exit 1, drift detected), the appendix output includes the stderr WARNING describing the drift so the operator can triage it. When status is `error` (exit 2, invocation failure), the appendix contains the stderr ERROR diagnostic:
+**Gitignore health check appendix (Issue #567)** (both standalone and E2E): When `gitignore_health_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth. When status is `warning` (exit 1, drift detected), the appendix output includes the stderr WARNING describing the drift so the operator can triage it. When status is `error` (exit 2, invocation failure), the appendix contains the stderr ERROR diagnostic:
 
 ```
 ⚠️ Gitignore health check: {gitignore_health_finding_count} findings detected ({gitignore_health_status}, non-blocking)
 {gitignore_health_output}
 ```
 
-**Backlink format check appendix (Issue #627)** (both standalone and E2E): When `backlink_format_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / terminal-output / gitignore-health. When status is `warning` (exit 1, dialect violations detected), the appendix output includes each violation line (`[backlink-format][P1] file:NN: ...`) so reviewers can identify and fix the offending backlink format. When status is `error` (exit 2, invocation failure), the appendix contains the stderr diagnostic:
+**Backlink format check appendix (Issue #627)** (both standalone and E2E): When `backlink_format_status` is `warning` **or `error`**, append findings (for `warning`) or the invocation failure detail (for `error`) after the lint result output. Same warning+error appendix policy as bang-backtick / doc-heavy / wiki-growth / gitignore-health. When status is `warning` (exit 1, dialect violations detected), the appendix output includes each violation line (`[backlink-format][P1] file:NN: ...`) so reviewers can identify and fix the offending backlink format. When status is `error` (exit 2, invocation failure), the appendix contains the stderr diagnostic:
 
 ```
 ⚠️ Backlink format check: {backlink_format_finding_count} findings detected ({backlink_format_status}, non-blocking)
@@ -1179,7 +1179,7 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 {projects_board_drift_output}
 ```
 
-These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, terminal-output, gitignore-health, backlink-format, hardcoded-line-number, comment-journal, comment-line-ref, direct-gh-issue-create, orphan-reference-check, sh-cross-ref, bash-heaviness, or projects-board-drift warnings/invocation errors.
+These appendices do NOT change the result pattern — `[lint:success]` remains the pattern even with drift, bang-backtick, doc-heavy-patterns-drift, wiki-growth, gitignore-health, backlink-format, hardcoded-line-number, comment-journal, comment-line-ref, direct-gh-issue-create, orphan-reference-check, sh-cross-ref, bash-heaviness, or projects-board-drift warnings/invocation errors.
 
 > **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/lint.md` の result-pattern 非変更を述べる 3 つの列挙から、実体のない orphan トークン `terminal-output` を除去した。

`terminal-output` は元々 `hooks/verify-terminal-output.sh`（HTML コメント化の regression guard、Issue #561 / #582）を指す実在チェックだったが、PR #1079（implicit-stop 対策層撤去）でスクリプト・実行ブロック・変数 (`terminal_output` 等) がすべて削除された。その際、列挙内のクロス参照トークン `terminal-output` だけが取り残され leftover orphan となっていた。PR #1306 のレビューで prompt-engineer reviewer が pre-existing 不整合として検出した指摘に対応する。

## Related Issue

Closes #1308

## Changes

- `lint.md:1112`（Gitignore health check appendix）の cross-ref から `terminal-output` を除去 → `bang-backtick / doc-heavy / wiki-growth.`
- `lint.md:1119`（Backlink format check appendix）の cross-ref から `terminal-output` を除去 → `bang-backtick / doc-heavy / wiki-growth / gitignore-health.`
- `lint.md:1182`（result-pattern 列挙）から `terminal-output` を除去（残る列挙は Phase 3.5–3.18 の 14 チェックと一致）

## 補足

- 除去対象は完全一致トークン `terminal-output` のみ。別文字列 `verify-terminal-output`（git 履歴の PR 本文等）には触れていない。
- 除去後、`terminal-output` は lint.md・リポジトリ全体で 0 件。外部テストによる列挙 pin は無く、破壊される参照はない。
- Issue 記載の「Phase 4.3 Note 列挙」(lint.md:1277 付近) は調査の結果、既に `terminal-output` を含まず正しい状態だったため変更不要。

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable) — 本リポジトリは `commands.test` 未設定。plugin-specific lint チェックは全て非ブロッキング warning のみで、本変更由来の新規 finding なし
- [x] Documentation updated (if applicable) — 変更対象自体がワークフロー仕様ドキュメント

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
