### PR TITLE
test(tests): projects-board-drift の jq 検出 pipeline に behavioral fixture test を追加

### DIFF
--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -9,6 +9,10 @@
 #   T-5: documented flags + detection logic present in source
 #   T-6: config-aware no-op (projects disabled / rite-config absent) exits 0 with a
 #        0-findings summary line — exercised offline, no gh required (AC-4)
+#   T-7: behavioral fixture — the jq detection pipeline (extracted from source, not a
+#        copy) classifies all six cases correctly (drift / Done / NOT_PLANNED /
+#        not-on-board / other-project / <no-status>), catching semantic breaks that
+#        preserve jq literals but flip scoping (offline, jq-only, no gh)
 #
 # Usage: bash plugins/rite/hooks/tests/projects-board-drift-check.test.sh
 set -euo pipefail
@@ -27,6 +31,26 @@ assert_file_contains() {
     PASS=$((PASS + 1)); echo "  ✓ $description"
   else
     FAIL=$((FAIL + 1)); FAILURES+=("$description (pattern: $pattern)"); echo "  ✗ $description" >&2
+  fi
+}
+
+# Assert a fixed string is present / absent in a captured multi-line value (used by the
+# T-7 behavioral fixture, where the value is the jq pipeline's TSV output).
+assert_present() {
+  local haystack="$1" needle="$2" description="$3"
+  if printf '%s\n' "$haystack" | grep -qF -- "$needle"; then
+    PASS=$((PASS + 1)); echo "  ✓ $description"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$description"); echo "  ✗ $description" >&2
+  fi
+}
+
+assert_absent() {
+  local haystack="$1" needle="$2" description="$3"
+  if printf '%s\n' "$haystack" | grep -qF -- "$needle"; then
+    FAIL=$((FAIL + 1)); FAILURES+=("$description"); echo "  ✗ $description" >&2
+  else
+    PASS=$((PASS + 1)); echo "  ✓ $description"
   fi
 }
 
@@ -138,6 +162,86 @@ if [ "$noop2_rc" -eq 0 ] && printf '%s' "$noop2_out" | grep -q '==> Total projec
 else
   FAIL=$((FAIL + 1)); FAILURES+=("rite-config absent no-op (rc=$noop2_rc)"); echo "  ✗ rite-config absent no-op (rc=$noop2_rc)" >&2
 fi
+
+echo ""
+echo "[T-7] Behavioral fixture: jq detection pipeline classifies all six cases (semantic-break guard)"
+# Extract the EXACT jq detection program from the source so this exercises the real
+# pipeline, not a copy. A semantic break that T-5's literal grep cannot see — e.g.
+# $pitem != null -> == null, select($st != "Done") -> == "Done", or dropping the
+# `.project.number == $pn` board scoping — changes the classification below and fails
+# here. Capture the lines between the `jq -r --argjson pn` invocation and its
+# `2>"${jq_err...}"` redirect (the only post-marker line containing `jq_err`).
+jq_prog=$(awk '
+  /jq -r --argjson pn/ { capturing=1; next }
+  capturing && /jq_err/ { capturing=0; next }
+  capturing { print }
+' "$DRIFT_SH")
+
+if [ -z "$jq_prog" ]; then
+  FAIL=$((FAIL + 1)); FAILURES+=("could not extract jq detection program from source")
+  echo "  ✗ could not extract jq detection program from source" >&2
+else
+  PASS=$((PASS + 1)); echo "  ✓ extracted jq detection program from source"
+  # GraphQL-shaped fixture (models `gh api graphql` output) covering all six cases.
+  # project_number ($pn) = 6. Titles are unique so present/absent asserts key on them.
+  # #101 / #106 are drift; #102 / #103 / #104 / #105 must be excluded. The bare {} node
+  # in #101 mirrors GraphQL emitting non-single-select fieldValues as empty objects.
+  fixture=$(cat <<'JSON'
+{ "data": { "repository": { "issues": { "nodes": [
+  { "number": 101, "title": "drift case", "stateReason": "COMPLETED",
+    "projectItems": { "nodes": [ { "project": { "number": 6 },
+      "fieldValues": { "nodes": [ {}, { "field": { "name": "Status" }, "name": "In Review" } ] } } ] } },
+  { "number": 102, "title": "done excluded", "stateReason": "COMPLETED",
+    "projectItems": { "nodes": [ { "project": { "number": 6 },
+      "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "Done" } ] } } ] } },
+  { "number": 103, "title": "not_planned excluded", "stateReason": "NOT_PLANNED",
+    "projectItems": { "nodes": [ { "project": { "number": 6 },
+      "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "In Review" } ] } } ] } },
+  { "number": 104, "title": "not on board", "stateReason": "COMPLETED",
+    "projectItems": { "nodes": [] } },
+  { "number": 105, "title": "other project", "stateReason": "COMPLETED",
+    "projectItems": { "nodes": [ { "project": { "number": 99 },
+      "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "Todo" } ] } } ] } },
+  { "number": 106, "title": "no-status boundary", "stateReason": "COMPLETED",
+    "projectItems": { "nodes": [ { "project": { "number": 6 },
+      "fieldValues": { "nodes": [ { "field": { "name": "Iteration" }, "name": "Sprint 1" } ] } } ] } }
+] } } } }
+JSON
+)
+  set +e
+  actual=$(printf '%s' "$fixture" | jq -r --argjson pn 6 "$jq_prog" 2>/dev/null); jq_rc=$?
+  set -e
+  if [ "$jq_rc" -eq 0 ]; then
+    PASS=$((PASS + 1)); echo "  ✓ jq pipeline runs without error"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("jq pipeline errored (rc=$jq_rc)"); echo "  ✗ jq pipeline errored (rc=$jq_rc)" >&2
+  fi
+  # Exactly two drift rows — guards over-detection (e.g. a broken on-board scope letting
+  # not-on-board / other-project issues through). Count lines carrying a TAB separator.
+  line_count=$(printf '%s\n' "$actual" | grep -c $'\t' || true)
+  if [ "$line_count" -eq 2 ]; then
+    PASS=$((PASS + 1)); echo "  ✓ exactly 2 drift rows emitted"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("expected 2 drift rows, got $line_count"); echo "  ✗ expected 2 drift rows, got $line_count" >&2
+  fi
+  # Case 1: COMPLETED + on-board(6) + Status="In Review" -> drift, status carried through.
+  assert_present "$actual" "$(printf '101\tIn Review\tdrift case')" "case1: COMPLETED on-board non-Done -> drift row"
+  # Case 6: COMPLETED + on-board(6) + no Status field -> drift as <no-status> (boundary).
+  assert_present "$actual" "$(printf '106\t<no-status>\tno-status boundary')" "case6: on-board without Status field -> <no-status> drift"
+  # Case 2: Status already Done -> excluded.
+  assert_absent "$actual" "done excluded" "case2: Status=Done excluded (AC-1)"
+  # Case 3: NOT_PLANNED closure -> excluded.
+  assert_absent "$actual" "not_planned excluded" "case3: NOT_PLANNED excluded (AC-2)"
+  # Case 4: not on the board (empty projectItems) -> excluded.
+  assert_absent "$actual" "not on board" "case4: not-on-board excluded"
+  # Case 5: on a different project (number != pn) -> excluded.
+  assert_absent "$actual" "other project" "case5: other-project excluded"
+fi
+
+# GraphQL-level board-membership scope: the projectItems page size must be positive. The
+# jq fixture above cannot reach a `projectItems(first: 10)` -> `first: 0` break (that
+# empties the GraphQL result before jq runs), so guard that literal statically here.
+assert_file_contains "$DRIFT_SH" 'projectItems\(first: [1-9]' "GraphQL projectItems page size is positive (guards first: 0 break)"
 
 echo ""
 echo "==============================="


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/projects-board-drift-check.test.sh` に behavioral fixture test (T-7) を追加し、`projects-board-drift-check.sh` の jq 検出 pipeline を実行検証する。現行テストは静的 grep (T-5) と config-aware no-op (T-6) の offline 実行のみで、jq 述語 literal を保ったまま board-membership scoping を壊す semantic break を捕捉できなかった。

## 関連 Issue

Closes #1309

## 変更内容

- `plugins/rite/hooks/tests/projects-board-drift-check.test.sh` — 変更（+104 行、テストのみ）

### T-7 の設計

- **ソースから jq 検出 program を awk 抽出**してから fixture に対して実行する。コピーではなく実体 (`select($i.stateReason == "COMPLETED" and $pitem ...)` → `select($st != "Done")` の pipeline) を検証するため、literal を保ったまま scoping を壊す mutation を確実に捕捉する
- **GraphQL-shaped fixture (`gh api graphql` 出力を模した JSON)** を stdin で流すため gh / network 非依存。既存テストの offline 制約と両立する
- 6 検証ケースを単一 fixture (project_number=6) に格納:
  | # | ケース | 期待 |
  |---|--------|------|
  | 1 | COMPLETED + on-board + Status≠Done | drift 検出 |
  | 2 | Status=Done | 除外 |
  | 3 | NOT_PLANNED | 除外 |
  | 4 | board 未登録 (projectItems 空) | 除外 |
  | 5 | 別 project (number≠pn) | 除外 |
  | 6 | on-board + Status field 未設定 | `<no-status>` drift（境界） |
- assert: drift 2 行のみ・jq exit 0・各ケースの present/absent
- jq fixture では届かない GraphQL `projectItems(first: 0)` break は `first:[1-9]` の静的ガードで補完

## 検証

- テストスイート全 29 件 pass（従来 19 + T-7 で 10 件追加）
- **mutation test で 4 種の semantic break を kill 確認**:
  - `$pitem` の null 判定反転（on-board scoping）→ FAIL
  - `select($st != "Done")` → `== "Done"`（drift 述語）→ FAIL
  - `.project.number == $pn` → `!= $pn`（project scoping）→ FAIL
  - GraphQL `first: 10` → `first: 0` → 静的ガードが FAIL
- `/rite:lint`: 主 lint コマンド未設定（このリポジトリの構成）、プラグイン固有チェック全実行。本変更起因の findings は 0

## スコープ外

- 本体 `projects-board-drift-check.sh` は無変更
- lint が報告した既存の非ブロッキング warning（distributed-fix-drift / comment-journal / comment-line-ref / sh-cross-ref）は本変更と無関係で、別 Issue 管轄

## チェックリスト

- [x] テスト追加（behavioral fixture test）
- [x] テストスイート全 pass
- [x] mutation test で検出能力を実証
- [x] 本体スクリプトは無変更（スコープ厳守）
