### PR TITLE
chore(hooks): pr-cycle-cleanup.sh に rite-pr-create-* 孤児 workdir の age ベース GC を追加

### DIFF
--- a/docs/SPEC.ja.md
+++ b/docs/SPEC.ja.md
@@ -1516,7 +1516,7 @@ orchestrator コマンドや他の hook から呼び出される non-hook ヘル
 | `sh-cross-ref-check.sh` | shell prose (echo 文字列 / comment) 内の cross-file step/phase 参照の実在を検証 | #1160 |
 | `orphan-reference-check.sh` | plugins/rite/ 配下の未参照 (orphan) ファイル検出 | #1162 |
 | `post-review-state-verify.sh` | reviewer subagent の READ-ONLY 契約違反 (working tree / branch / stash 変更) の検出 + recovery | #995 |
-| `pr-cycle-cleanup.sh` | 残留 `pr-{N}-cycle{X}` worktree / branch の冪等掃除 | #995 |
+| `pr-cycle-cleanup.sh` | 残留 `pr-{N}-cycle{X}` worktree / branch の冪等掃除 + `${TMPDIR:-/tmp}/rite-pr-create-*` 孤児 workdir の age ベース GC (mtime > 24h) | #995, #1311 |
 | `review-schema-version-check.sh` | review-result JSON の `schema_version` drift 検出 | #1021 |
 | `settings-local-rite-hook-cleanup.sh` | `.claude/settings.local.json` の stale legacy rite hook entry 削除 (`.py` 実体への wrapper、init.md Phase 4.5.0.2) | — |
 | `lib/` (`wiki-config.sh` / `worktree-git.sh`) | wiki 系 helper の共有ライブラリ (config 読取 / worktree git 操作) | #549 |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1373,7 +1373,7 @@ Non-hook helper scripts invoked either directly from orchestrator commands or by
 | `sh-cross-ref-check.sh` | shell prose (echo 文字列 / comment) 内の cross-file step/phase 参照の実在を検証 | #1160 |
 | `orphan-reference-check.sh` | plugins/rite/ 配下の未参照 (orphan) ファイル検出 | #1162 |
 | `post-review-state-verify.sh` | reviewer subagent の READ-ONLY 契約違反 (working tree / branch / stash 変更) の検出 + recovery | #995 |
-| `pr-cycle-cleanup.sh` | 残留 `pr-{N}-cycle{X}` worktree / branch の冪等掃除 | #995 |
+| `pr-cycle-cleanup.sh` | 残留 `pr-{N}-cycle{X}` worktree / branch の冪等掃除 + `${TMPDIR:-/tmp}/rite-pr-create-*` 孤児 workdir の age ベース GC (mtime > 24h) | #995, #1311 |
 | `review-schema-version-check.sh` | review-result JSON の `schema_version` drift 検出 | #1021 |
 | `settings-local-rite-hook-cleanup.sh` | `.claude/settings.local.json` の stale legacy rite hook entry 削除 (`.py` 実体への wrapper、init.md Phase 4.5.0.2) | — |
 | `lib/` (`wiki-config.sh` / `worktree-git.sh`) | wiki 系 helper の共有ライブラリ (config 読取 / worktree git 操作) | #549 |

--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -750,7 +750,7 @@ echo "[CONTEXT] PR_CREATE_WORKDIR=$pr_workdir"
 
 > `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。冒頭で literal を shell 変数 `pr_workdir` に束縛し、以降の cat / `--body-file` / cleanup すべてで `$pr_workdir` を参照する（literal placeholder 置換漏れ時の `rm -rf "{...}"` 誤動作を防ぐ）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。workdir の cleanup は inline `rm -rf` ではなく **signal-specific trap** で行い、空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP のすべての exit 経路で確実に削除する（同一ファイル他ブロック・`coding-principles.md` Rule 5・[bash-trap-patterns.md](references/bash-trap-patterns.md#signal-specific-trap-template) の canonical 形に準拠）。空 body / 空 title チェックは title / body が動的生成のため必須（body と title は対称にガードする）。
 >
-> **既知の trade-off (Cause A、refs #1307 AC-5)**: 3 段プロトコルは workdir を (A)/(B Write)/(C) の **別プロセス**に跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了した場合（Cause A: harness/transport 側ゆらぎ、rite では除去不能）、`mktemp -d` した空 workdir が orphan として残る。本 trap は (C) 自身の中断のみカバーし、この cross-process orphan は救えない（OS の `/tmp` reaping と `/rite:resume` 再開で実害は限定的）。`rite-pr-create-*` 孤児 workdir の能動的 GC（`pr-cycle-cleanup.sh` への追加等）は本 PR scope 外の follow-up とする。
+> **既知の trade-off (Cause A、refs #1307 AC-5)**: 3 段プロトコルは workdir を (A)/(B Write)/(C) の **別プロセス**に跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了した場合（Cause A: harness/transport 側ゆらぎ、rite では除去不能）、`mktemp -d` した空 workdir が orphan として残る。本 trap は (C) 自身の中断のみカバーし、この cross-process orphan は救えない（OS の `/tmp` reaping と `/rite:resume` 再開で実害は限定的）。この `rite-pr-create-*` 孤児 workdir の能動的 GC は `pr-cycle-cleanup.sh` Step 3 で実装済み（refs #1311）— review/fix/cleanup の各サイクルで `${TMPDIR:-/tmp}/rite-pr-create-*` のうち age 超過 (mtime > 24h) のものを回収する。age ガードにより in-flight workdir は誤回収されない。
 
 ```bash
 pr_workdir="{PR_CREATE_WORKDIR}"

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -8,6 +8,15 @@
 # READ-ONLY contract forbids `git worktree remove` / `git branch -D`, so
 # cleanup MUST run from the orchestrator side.
 #
+# Additionally, reaps orphaned `rite-pr-create-*` workdirs left in
+# `${TMPDIR:-/tmp}` by pr/create.md Phase 3.4 (Issue #1311). Its 3-step protocol
+# (mktemp -d -> Write tool -> gh pr create) spans separate processes, so a
+# malformed tool-call between workdir allocation and `gh pr create` leaves an
+# empty (or partially written) workdir behind. create.md's own signal-specific
+# trap only covers the gh-create block, so this cross-process orphan is swept
+# here. An age guard (mtime > 24h) ensures only true orphans are reaped, never
+# an in-flight workdir held by a paused concurrent session.
+#
 # Strict regex `^pr-[0-9]+-(cycle[0-9]+|test|experiment|mutation|verify|check|sandbox)$`
 # protects unrelated branches (e.g. `pr-918-cycle4-feature`,
 # `feature/pr-918-cycle4`, `pr-994-testing-suite`) from accidental deletion
@@ -30,7 +39,7 @@
 #   bash pr-cycle-cleanup.sh [--dry-run]
 #
 # Output (stdout): one structured status line per invocation
-#   [pr-cycle-cleanup] status=<cleaned|noop|failed>; worktrees=<N>; branches=<N>
+#   [pr-cycle-cleanup] status=<cleaned|noop|failed>; worktrees=<N>; branches=<N>; workdirs=<N>
 #
 # Exit codes:
 #   0  cleanup completed (or nothing to clean)
@@ -77,6 +86,7 @@ readonly WIKI_WORKTREE_PATH=".rite/wiki-worktree"
 
 worktrees_removed=0
 branches_deleted=0
+workdirs_reaped=0
 errors=0
 
 # trap + cleanup パターン (canonical: references/bash-trap-patterns.md#signal-specific-trap-template)
@@ -197,16 +207,50 @@ else
 fi
 
 # -----------------------------------------------------------------------
+# Step 3: Reap orphaned `rite-pr-create-*` workdirs (refs #1311).
+# pr/create.md Phase 3.4 の 3 段プロトコル (A: mktemp -d -> B: Write tool ->
+# C: gh pr create) は workdir を別プロセスに跨がせるため、(A) 確保後・(C) 到達前の
+# malformed tool-call 無言終了 (Cause A) で `${TMPDIR:-/tmp}/rite-pr-create-*` が
+# orphan として残る。create.md の signal-specific trap は (C) 自身の中断しか
+# カバーできないため、この cross-process orphan は orchestrator 側の本 GC で回収する。
+#
+# age ガード (mtime > WORKDIR_REAP_AGE_MINUTES) が安全性の核心: 健全な実行では
+# workdir は当該ターン (数分) で trap 削除されるため、閾値を超える workdir は確実に
+# orphan。マルチセッションで session A が (A)->(C) 間で長時間ポーズしている in-flight
+# workdir を session B の cleanup が誤回収しないよう、24h の保守的マージンを取る。
+# 内容の有無 (空 / title・body ファイル入り) を問わず `rm -rf` で回収する —
+# (B) Write 後に中断した non-empty orphan も age ガードで in-flight 非該当が保証
+# されるため安全に掃除できる。走査先は `mktemp -d -t` と同じ `${TMPDIR:-/tmp}` を
+# 尊重し create.md と一致させる (テスト時の隔離も可能になる)。
+# -----------------------------------------------------------------------
+readonly WORKDIR_REAP_AGE_MINUTES=1440  # 24h
+workdir_tmp_base="${TMPDIR:-/tmp}"
+workdir_tmp_base="${workdir_tmp_base%/}"  # strip trailing slash
+while IFS= read -r orphan_workdir; do
+  [ -z "$orphan_workdir" ] && continue
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[dry-run] would reap orphan workdir: $orphan_workdir"
+  else
+    if rm -rf "$orphan_workdir" 2>/dev/null; then
+      workdirs_reaped=$((workdirs_reaped + 1))
+    else
+      echo "WARNING: failed to reap orphan workdir '$orphan_workdir'" >&2
+      errors=$((errors + 1))
+    fi
+  fi
+done < <(find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)
+
+# -----------------------------------------------------------------------
 # Status line
 # -----------------------------------------------------------------------
 if [ "$DRY_RUN" = "1" ]; then
   echo "[pr-cycle-cleanup] status=dry-run; pattern=$PATTERN"
 elif [ "$errors" -gt 0 ]; then
-  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; errors=$errors"
-elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ]; then
-  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0"
+  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; errors=$errors"
+elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ]; then
+  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0"
 else
-  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted"
+  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped"
 fi
 
 exit 0

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -95,8 +95,9 @@ errors=0
 wt_list_err=""
 prune_err=""
 ref_err=""
+workdir_find_err=""
 _rite_pr_cycle_cleanup() {
-  rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}"
+  rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}" "${workdir_find_err:-}"
 }
 trap 'rc=$?; _rite_pr_cycle_cleanup; exit $rc' EXIT
 trap '_rite_pr_cycle_cleanup; exit 130' INT
@@ -226,19 +227,36 @@ fi
 readonly WORKDIR_REAP_AGE_MINUTES=1440  # 24h
 workdir_tmp_base="${TMPDIR:-/tmp}"
 workdir_tmp_base="${workdir_tmp_base%/}"  # strip trailing slash
-while IFS= read -r orphan_workdir; do
-  [ -z "$orphan_workdir" ] && continue
-  if [ "$DRY_RUN" = "1" ]; then
-    echo "[dry-run] would reap orphan workdir: $orphan_workdir"
-  else
-    if rm -rf "$orphan_workdir" 2>/dev/null; then
-      workdirs_reaped=$((workdirs_reaped + 1))
+# find は process substitution `< <(find ...)` ではなく command substitution + here-string で
+# 呼ぶ。process substitution は subshell の exit code がシェルに伝播しないため、$TMPDIR 不在 /
+# 権限なし / IO エラーで find が wholesale 失敗しても空ループ → 無言 no-op になり、本ファイルが
+# Step 1/2 (wt_list / prune / ref) で確立した「失敗を silent に握り潰さず errors カウンタに加算する」
+# 方針 (上記 prune block 参照) と非対称になる。command substitution で rc を捕捉し、失敗時は
+# WARNING + errors++ で sibling と対称化する。空 stdout 時の here-string は単一空行を生むが、
+# ループ先頭の `[ -z ]` ガードが branch-loop と同様に skip する。
+workdir_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-err-XXXXXX 2>/dev/null) || workdir_find_err=""
+if workdir_list=$(find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>"${workdir_find_err:-/dev/null}"); then
+  while IFS= read -r orphan_workdir; do
+    [ -z "$orphan_workdir" ] && continue
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "[dry-run] would reap orphan workdir: $orphan_workdir"
     else
-      echo "WARNING: failed to reap orphan workdir '$orphan_workdir'" >&2
-      errors=$((errors + 1))
+      if rm -rf "$orphan_workdir" 2>/dev/null; then
+        workdirs_reaped=$((workdirs_reaped + 1))
+      else
+        echo "WARNING: failed to reap orphan workdir '$orphan_workdir'" >&2
+        errors=$((errors + 1))
+      fi
     fi
+  done <<< "$workdir_list"
+else
+  workdir_find_rc=$?
+  echo "WARNING: find による orphan workdir 走査が失敗しました (rc=$workdir_find_rc, base=$workdir_tmp_base)" >&2
+  if [ -n "$workdir_find_err" ] && [ -s "$workdir_find_err" ]; then
+    head -3 "$workdir_find_err" | sed 's/^/  /' >&2
   fi
-done < <(find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)
+  errors=$((errors + 1))
+fi
 
 # -----------------------------------------------------------------------
 # Status line

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -42,6 +42,17 @@ trap '_cleanup_all_test_repos; exit 130' INT
 trap '_cleanup_all_test_repos; exit 143' TERM
 trap '_cleanup_all_test_repos; exit 129' HUP
 
+# Isolate TMPDIR so the orphan-workdir GC (Step 3 of the cleanup script, #1311)
+# scans an empty, test-owned directory instead of the developer's real /tmp.
+# Without this, a real /tmp/rite-pr-create-* orphan on the host would make T-05
+# (noop assertion) flaky and could even delete a developer's in-flight workdir.
+# The workdir tests (T-06+) populate this directory explicitly. `mktemp -d
+# /tmp/...` and make_temp_repo both use explicit /tmp paths, so they are
+# unaffected by the TMPDIR export below.
+WORKDIR_SCAN_TMP=$(mktemp -d /tmp/rite-pr-cleanup-tmpdir-XXXXXX)
+TEST_REPOS+=("$WORKDIR_SCAN_TMP")
+export TMPDIR="$WORKDIR_SCAN_TMP"
+
 # -----------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------
@@ -291,6 +302,98 @@ if echo "$output" | grep -q 'status=noop'; then
 else
   fail "T-05: expected status=noop, got: $output"
 fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-06: orphan workdir reaping (refs #1311)
+# Given: aged `rite-pr-create-*` workdirs (one empty = after-(A) orphan, one with
+#        files = after-(B) orphan) older than the age threshold exist in TMPDIR
+# When: Cleanup runs
+# Then: Both are reaped via rm -rf and the status line reports workdirs=2
+# Uses `touch -t 202001010000` (POSIX-portable, far older than 24h) to backdate
+# the directory mtime AFTER writing contents (writing a file bumps the dir mtime).
+# -----------------------------------------------------------------------
+echo "T-06: 古い orphan workdir 回収 (refs #1311)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-create-old1"
+echo "stale title" > "$WORKDIR_SCAN_TMP/rite-pr-create-old1/pr_title.txt"  # after-(B) orphan: has files
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-create-old2"                          # after-(A) orphan: empty
+touch -t 202001010000 "$WORKDIR_SCAN_TMP/rite-pr-create-old1" "$WORKDIR_SCAN_TMP/rite-pr-create-old2"
+TEST_REPO=$(make_temp_repo)
+t06_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ ! -d "$WORKDIR_SCAN_TMP/rite-pr-create-old1" ] && [ ! -d "$WORKDIR_SCAN_TMP/rite-pr-create-old2" ] \
+   && echo "$t06_output" | grep -q 'status=cleaned' && echo "$t06_output" | grep -q 'workdirs=2'; then
+  pass "T-06: 古い orphan workdir 2 件 (空 + 非空) が回収され workdirs=2"
+else
+  fail "T-06: old1=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-create-old1" ] && echo present || echo gone), old2=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-create-old2" ] && echo present || echo gone). Output: $t06_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-07: age 未満の workdir は保護 (in-flight 誤回収防止) (refs #1311)
+# Given: a freshly-created `rite-pr-create-*` workdir (mtime = now) exists
+# When: Cleanup runs
+# Then: The workdir survives (age guard) and status=noop (nothing reaped)
+# This is the core safety assertion: a concurrent session's in-flight workdir is
+# never reaped by another session's cleanup.
+# -----------------------------------------------------------------------
+echo "T-07: age 未満の workdir は保護 (in-flight 誤回収防止) (refs #1311)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-create-fresh"  # just created -> mtime now -> must survive
+TEST_REPO=$(make_temp_repo)
+t07_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ -d "$WORKDIR_SCAN_TMP/rite-pr-create-fresh" ] && echo "$t07_output" | grep -q 'status=noop'; then
+  pass "T-07: age 未満の workdir が保護され status=noop"
+else
+  fail "T-07: fresh=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-create-fresh" ] && echo present || echo gone). Output: $t07_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-08: 無関係 prefix のディレクトリは age 超過でも保護 (refs #1311)
+# Given: an aged matching `rite-pr-create-victim` plus aged non-matching dirs
+#        (`rite-pr-cleanup-test-*` — the test-repo prefix — and `unrelated-dir`)
+# When: Cleanup runs
+# Then: Only `rite-pr-create-*` is reaped; the name-glob boundary protects others
+# -----------------------------------------------------------------------
+echo "T-08: 無関係 prefix のディレクトリは age 超過でも保護 (refs #1311)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz" "$WORKDIR_SCAN_TMP/unrelated-dir" 2>/dev/null || true
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-create-victim"      # match -> reaped
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz"   # different prefix -> survive
+mkdir -p "$WORKDIR_SCAN_TMP/unrelated-dir"             # unrelated -> survive
+touch -t 202001010000 "$WORKDIR_SCAN_TMP/rite-pr-create-victim" "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz" "$WORKDIR_SCAN_TMP/unrelated-dir"
+TEST_REPO=$(make_temp_repo)
+( cd "$TEST_REPO" && bash "$CLEANUP" >/dev/null 2>&1 )
+if [ ! -d "$WORKDIR_SCAN_TMP/rite-pr-create-victim" ] \
+   && [ -d "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz" ] \
+   && [ -d "$WORKDIR_SCAN_TMP/unrelated-dir" ]; then
+  pass "T-08: rite-pr-create-* のみ回収、無関係 prefix は保護"
+else
+  fail "T-08: victim=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-create-victim" ] && echo present || echo gone), test-xyz=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz" ] && echo present || echo gone), unrelated=$([ -d "$WORKDIR_SCAN_TMP/unrelated-dir" ] && echo present || echo gone)"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* "$WORKDIR_SCAN_TMP/rite-pr-cleanup-test-xyz" "$WORKDIR_SCAN_TMP/unrelated-dir" 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-09: --dry-run は orphan workdir を削除しない (refs #1311)
+# Given: an aged matching `rite-pr-create-*` workdir exists
+# When: Cleanup runs with --dry-run
+# Then: The workdir survives and a `[dry-run] would reap ...` line is printed
+# -----------------------------------------------------------------------
+echo "T-09: --dry-run は orphan workdir を削除しない (refs #1311)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+mkdir -p "$WORKDIR_SCAN_TMP/rite-pr-create-dry"
+touch -t 202001010000 "$WORKDIR_SCAN_TMP/rite-pr-create-dry"
+TEST_REPO=$(make_temp_repo)
+t09_output=$( cd "$TEST_REPO" && bash "$CLEANUP" --dry-run 2>&1 )
+if [ -d "$WORKDIR_SCAN_TMP/rite-pr-create-dry" ] && echo "$t09_output" | grep -q 'would reap orphan workdir'; then
+  pass "T-09: dry-run は削除せず候補をリスト"
+else
+  fail "T-09: dry=$([ -d "$WORKDIR_SCAN_TMP/rite-pr-create-dry" ] && echo present || echo gone). Output: $t09_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -397,6 +397,26 @@ rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
+# T-10: find wholesale 失敗が silent でない (refs #1311)
+# Given: TMPDIR が存在しないパスを指し、Step 3 の find が wholesale 失敗する
+# When: Cleanup runs
+# Then: find 失敗は WARNING + errors++ で surface され status=failed になる
+#       (process substitution の rc 非伝播による silent no-op 化を防ぐ回帰テスト)
+# TMPDIR override はこの 1 実行に限定する。cleanup script の mktemp は /tmp 直書きのため
+# bogus TMPDIR の影響を受けず、find の base 走査のみが失敗する。
+# -----------------------------------------------------------------------
+echo "T-10: find wholesale 失敗が silent でない (refs #1311)"
+TEST_REPO=$(make_temp_repo)
+t10_output=$( cd "$TEST_REPO" && TMPDIR=/nonexistent/rite-pr-cleanup-does-not-exist bash "$CLEANUP" 2>&1 )
+if echo "$t10_output" | grep -q 'status=failed' \
+   && echo "$t10_output" | grep -q 'find による orphan workdir 走査が失敗'; then
+  pass "T-10: find 失敗が WARNING + status=failed で surface される (silent 化しない)"
+else
+  fail "T-10: status=failed と find WARNING を期待。Output: $t10_output"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 echo


### PR DESCRIPTION
## 概要

`pr/create.md` Phase 3.4 の 3 段プロトコル（(A) `mktemp -d` → (B) Write tool → (C) `gh pr create`）は workdir を別プロセスに跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了（Cause A: harness/transport 側ゆらぎ、rite では除去不能）すると、`rite-pr-create-*` workdir が orphan として `/tmp` に残る。create.md の signal-specific trap は (C) 自身の中断しかカバーできず、この cross-process orphan は救えない。

本 PR は `pr-cycle-cleanup.sh` に **Step 3: orphan workdir reaping** を追加し、review/fix/cleanup の各サイクルで能動的に回収する（#1310 で follow-up 宣言した #1307 AC-5 の能動的 GC）。

## 変更内容

- **`plugins/rite/hooks/scripts/pr-cycle-cleanup.sh`**: `find "${TMPDIR:-/tmp}" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +1440` で age 超過 (mtime > 24h) の orphan を検出し `rm -rf` で回収。status 行に `workdirs=N` を追加（noop 判定にも反映）、header の Responsibility コメントを更新
- **`plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh`**: T-06〜T-09 を追加（古い orphan 回収 / age 未満の in-flight 保護 / 無関係 prefix 保護 / dry-run）。テスト全体で隔離 `$TMPDIR` を export し、host の実 `/tmp` に依存しない決定性を確保
- **`plugins/rite/commands/pr/create.md`**: trade-off note を「scope 外 follow-up」→「`pr-cycle-cleanup.sh` Step 3 で実装済み」へ更新
- **`docs/SPEC.md` / `docs/SPEC.ja.md`**: script responsibility テーブルに workdir reaping を追記（en/ja 対称）

## 設計判断

- **回収範囲（内容問わず `rm -rf`）**: Issue 本文は「空ディレクトリ」と記述するが、(B) Write 後に中断した orphan は title/body ファイルを含む。age ガードが in-flight 非該当を保証するため、内容問わず回収する方が完全かつ同等に安全。Issue 文言を「age ベース回収」へ一般化
- **age 閾値 24h**: 健全な実行では workdir は当該ターン（数分）で trap 削除される。マルチセッションで session A が (A)→(C) 間で長時間ポーズしている in-flight workdir を、session B の cleanup が誤回収しないための保守的マージン
- **走査先 `${TMPDIR:-/tmp}`**: create.md の `mktemp -d -t` と同じ解決規則に統一（テスト隔離も可能化）

## テスト

`bash plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh` → **11/11 PASS**（既存 T-01〜T-05 + 新規 T-06〜T-09）。

## 関連 Issue

Closes #1311

- 元の PR: #1310
- 元の Issue: #1307
