### PR TITLE
test(tests): bash-heaviness inline-gh-create-title の single-quote / 非bashフェンス TC を補強

### DIFF
--- a/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
+++ b/plugins/rite/hooks/tests/bash-heaviness-check.test.sh
@@ -429,6 +429,62 @@ if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0
 else fail "expected rc=0 (empty title), got rc=$rc: $output"; fi
 
 # --------------------------------------------------------------------------
+# TC-026: inline-gh-create-title — a SINGLE-QUOTE literal --title flags standalone
+#         too. Pins the opening-quote `["']` `'` alternative, which TC-017/019/024
+#         (all double-quote) never exercise: a `["']`→`["]` regression would still
+#         pass every existing TC. The equals separator is already pinned by TC-019,
+#         so this is the space+single-quote twin of TC-017. Issue #1312.
+# --------------------------------------------------------------------------
+echo "TC-026: single-quote literal --title standalone → exit 1"
+{
+  echo '```bash'
+  echo "gh pr create --draft --base develop --title 'feat(pr): single-quote literal'"
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "inline-gh-create-title"; then
+  pass "single-quote literal --title flagged standalone → exit 1"
+else fail "expected rc=1 + inline-gh-create-title, got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-027: a single-quoted `--title '$pr_title'` is, in bash, a LITERAL `$pr_title`
+#         (single quotes suppress expansion). The detector nonetheless treats the
+#         leading `$` as a variable sentinel — the `[^$"']` bracket excludes `$` on
+#         the single-quote path too — so it is NOT flagged. This errs toward a false
+#         negative (safe: it never blocks a real variable form). Pinning it records
+#         that intentional choice rather than leaving it as undocumented behavior.
+#         Issue #1312.
+# --------------------------------------------------------------------------
+echo "TC-027: single-quote '\$pr_title' (literal but sentinel-skipped) → exit 0"
+{
+  echo '```bash'
+  echo "gh pr create --draft --title '\$pr_title' --body-file body.md"
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "single-quote \$-title sentinel-skipped → exit 0"
+else fail "expected rc=0 (single-quote \$ skipped), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
+# TC-028: a literal `gh pr create --title "..."` inside a NON-bash fence (```text)
+#         is documentation data, not a real shell line, so it is NOT flagged.
+#         TC-013 pins the non-bash fence skip for the heaviness signals; this is the
+#         title-specific twin, completing AC-3 ("fenced code is data") traceability
+#         for inline-gh-create-title. Issue #1312.
+# --------------------------------------------------------------------------
+echo "TC-028: literal --title inside non-bash fence → exit 0"
+{
+  echo '```text'
+  echo 'gh pr create --title "feat: documented example title"'
+  echo '```'
+} > "$F"
+rc=0; output=$(run "$REL") || rc=$?
+if [ "$rc" -eq 0 ] && echo "$output" | grep -q "Total bash-heaviness findings: 0"; then
+  pass "non-bash fence literal title skipped → exit 0"
+else fail "expected rc=0 (non-bash fence), got rc=$rc: $output"; fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要

`bash-heaviness-check.sh` の standalone signal `inline-gh-create-title` に対するテストの分岐網羅性（mutation 耐性）を補強する。検出 regex `["'][^$"']` のうち single-quote 開始引用符の分岐が既存 TC で一度も実行されておらず、`["']`→`["]` の劣化 regression を検出できない盲点があった。

実装（`bash-heaviness-check.sh`）は変更しない。テスト追加のみ。

## 変更内容

- **TC-026**（single-quote positive）: single-quote literal `--title 'literal'` を standalone で flag（exit 1）。開始引用符 `["']` の `'` 分岐を pin（既存 TC-017/019/024 は全て double-quote）
- **TC-027**（single-quote `$` behavior）: single-quote 内 `$`（`--title '$pr_title'`）を not-flag（exit 0）。bash では literal だが `$` を変数 sentinel とみなす意図的 false-negative を single-quote パスで pin
- **TC-028**（非 bash フェンス negative）: 非 bash フェンス内の literal `--title "..."` を not-flag（exit 0）。TC-013 の title 特化版（AC-3「fenced code is data」トレーサビリティ）

## テスト

- `bash plugins/rite/hooks/tests/bash-heaviness-check.test.sh` → 全 28 TC pass
- mutation 検証: `["']`→`["]` の劣化を適用すると double-quote の TC-017/019/024 は pass のまま **TC-026 のみ FAIL** することを確認（盲点が塞がれたことを実証）

## 関連 Issue

Closes #1312

## チェックリスト

- [x] テスト追加（TC-026 / TC-027 / TC-028）
- [x] 全 28 TC pass
- [x] 実装挙動は不変（テストのみ・mutation 耐性向上が目的）
