### PR TITLE
test(tests): create-md-invocation-symmetry の TC-5b を awk 隣接検査へ強化

### DIFF
--- a/plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh
+++ b/plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh
@@ -261,15 +261,32 @@ else
   fail "TC-5 decompose-issues.sh link-sub-issue.sh integrity broken (canonical=$link_canonical, total=$link_total) — silent removal suspected"
 fi
 
-# TC-5b: the positional 4-arg contract is visible at the canonical callsite.
-# link-sub-issue.sh takes <owner> <repo> <parent> <child>; assert the callsite
-# passes "$owner" "$repo" "$parent_issue_number" "$sub_number" so an accidental
-# switch to a flag/JSON form (which the script does not accept) is caught.
-if grep -qE 'bash "\$LINK_SCRIPT"' "$DECOMPOSE_SH" \
-   && grep -qE '"\$owner" "\$repo" "\$parent_issue_number" "\$sub_number"' "$DECOMPOSE_SH"; then
-  pass "TC-5b link-sub-issue.sh canonical callsite passes positional 4 args (owner repo parent child)"
+# TC-5b: the positional 4-arg contract is visible AT the canonical callsite —
+# on the line immediately following `bash "$LINK_SCRIPT" \`. link-sub-issue.sh
+# takes <owner> <repo> <parent> <child>; pinning the 4-arg form *adjacent to* the
+# callsite (rather than two independent file-wide greps that only prove both
+# strings exist somewhere) catches an accidental switch to a flag/JSON form (which
+# the script does not accept) AND a relocation of the 4-arg away from the callsite.
+# Mirrors TC-7b (sentinel↔disambiguator adjacency) / TC-5c (recovery-line pin).
+# awk regex uses [$] for a literal `$` to avoid escape-sequence warnings (see the
+# TC-3 note above). `link_canonical` (callsite count) is reused from TC-5.
+tc5b_violations=$(awk '
+  prev_is_callsite {
+    if ($0 !~ /"[$]owner" "[$]repo" "[$]parent_issue_number" "[$]sub_number"/) {
+      print (NR-1) ": bash \"$LINK_SCRIPT\" not immediately followed by positional 4 args (next line " NR ": " $0 ")"
+    }
+    prev_is_callsite = 0
+  }
+  /bash "[$]LINK_SCRIPT"[[:space:]]*\\$/ { prev_is_callsite = 1 }
+' "$DECOMPOSE_SH" || true)
+if [ "$link_canonical" -ge 1 ] && [ -z "$tc5b_violations" ]; then
+  pass "TC-5b link-sub-issue.sh canonical callsite is immediately followed by positional 4 args (owner repo parent child) at $link_canonical callsite(s)"
+elif [ "$link_canonical" -lt 1 ]; then
+  fail "TC-5b no canonical 'bash \"\$LINK_SCRIPT\" \\' callsite found in $DECOMPOSE_SH (TC-5 should have caught this)"
 else
-  fail "TC-5b link-sub-issue.sh positional 4-arg form not found at the decompose callsite"
+  echo "  Callsite / 4-arg adjacency violations:"
+  printf '%s\n' "$tc5b_violations" | sed 's/^/    /'
+  fail "TC-5b positional 4-arg form not adjacent to the link-sub-issue.sh callsite (relocation or flag/JSON regression suspected)"
 fi
 
 # TC-5c: create.md no longer runs link-sub-issue.sh in its create flow (the


### PR DESCRIPTION
## 概要

`plugins/rite/hooks/tests/create-md-invocation-symmetry.test.sh` の TC-5b アサーションを、TC-7b / TC-5c と同型の awk 隣接検査へ強化した。従来の「2 つの独立した file-wide `grep -qE` の AND」は両文字列が同ファイルに存在することしか保証せず、コメントが主張する「同一 callsite に隣接」を強制できなかった。4-arg が将来 callsite から分離した場合に theoretical false negative の余地があったため、アサーションの精度をコメントの主張に一致させる。

## 関連 Issue

Closes #1215

## 変更内容

- TC-5b を file-wide grep-AND から awk 隣接検査へ置換。`bash "$LINK_SCRIPT" \`（行継続）callsite 行の**直後行**に positional 4-arg (`"$owner" "$repo" "$parent_issue_number" "$sub_number"`) があることを検証する
- awk regex は escape-sequence 警告回避のため `[$]` bracket expression を使用（既存 TC-3 の規約に準拠）
- callsite 数は TC-5 で算出済みの `link_canonical` を再利用（重複計算なし）
- pass/fail 出力形式を TC-7b に揃え、隣接違反行を列挙

## 検証

- 全 61 テストファイル（`hooks/tests/run-tests.sh`）pass、対象テスト単体も 25/25 pass、awk の stderr 警告なし
- negative case 検証（トートロジーでないことを確認）:
  - 4-arg を callsite から分離 → 違反検出 ✓（旧 grep-AND では pass していたケース）
  - flag 形式へ置換 → 違反検出 ✓
  - 現行の隣接実態（`decompose-issues.sh:237-238`）→ 違反なし ✓

## スコープ

- TC-5b のアサーションロジックのみ（Issue #1215 の非スコープ宣言を厳守）
- 対象 callsite の実態は不変。既存の pass は維持

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (test-only change; 全 61 テストファイル pass)
- [ ] Documentation updated (該当なし — test-only change)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
