### PR TITLE
chore(reviewers): reviewer の read-only bash -c probe block の deny メッセージを是正

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -43,6 +43,15 @@ Reviewer subagents **may** use the following read-only commands for evidence gat
 
 **Rationale**: The `[READ-ONLY RULE]` is not just a tool-level (`Edit`/`Write`) restriction — it is a **state-level** guarantee. A reviewer that runs `git checkout develop -- path/to/file` silently pollutes the parent session's index, which later surfaces as a "ghost diff" the parent session cannot attribute. Always compare blobs via `git show <ref>:<file>` or `git diff <ref> -- <file>` instead. 同様に、`git stash` は「undo すれば戻る」ように見えるが、stash entry の作成自体が parent session の working tree をクリアし、並列レビュアー間で race を起こす。`git add` / `git reset` も index を汚染し、後続の `/rite:pr:fix` が diff を誤認する根本原因になる。`git fetch --prune` は remote-tracking branch を削除するため、後続の `git diff origin/<branch>` が「unknown revision」で壊れる silent regression を引き起こす。
 
+### Shell-command wrappers are blocked — even for read-only probes
+
+`hooks/pre-tool-bash-guard.sh` は reviewer subagent からの **shell-command wrapper** (`eval`, `bash -c`, `sh -c`, `zsh -c`, `ksh -c`, `dash -c`, `fish -c`) を**中身に関係なく一律 block** する。これは「中身が read-only な挙動プローブなら許可してほしい」という直感に反するように見えるが、意図的な設計である。
+
+- **理由**: guard は Bash 組み込みの word-boundary マッチで state-mutating git を検出するが、quote の中身 (`bash -c '...'` の `...`) はこのマッチから opaque で、`bash -c 'git reset --hard'` のような state-mutating git を隠して bypass できてしまう。quote 内を信頼できる形で解析するのは fragile で新たな bypass 面を生むため、wrapper 自体を一律 block する方が安全側に倒せる。
+- **read-only プローブの代替**: wrapper を外す。コマンドを直接実行する / 複数コマンドは subshell `( cmd1; cmd2 )` でまとめる / スクリプト化して `bash <script.sh>` で実行する (上記 "Allowed Bash/Git commands" の `bash <test>` と同じ経路)。これらは block されない。
+
+> 補足: read-only な挙動プローブのために `bash -c` を使うと block されるが、`( ... )` / 直接実行 / `bash <script.sh>` で検証強度を落とさず代替できる (Issue #1322)。block 時の deny メッセージにもこの代替が表示される。
+
 ### Mutation experiments and verification (worktree-only)
 
 Reviewer が **mutation testing / verification experiment** (例: 「ある line を `return 1` から `exit 1` に変えたら test が失敗するか」「helper を inline 展開したら sibling test が落ちるか」) を実行する必要がある場合、**parent repo の working tree / branch を絶対に変更してはならない**。正規経路は以下の **worktree-only mutation pattern** に限定される。

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -145,6 +145,10 @@ CMD_CHECK="${COMMAND%%<<*}"
 BLOCKED_PATTERN=""
 BLOCKED_REASON=""
 BLOCKED_ALTERNATIVE=""
+# Sub-kind tag for the deny message. Stays empty for git-verb blocks (A)-(G);
+# the (Z) shell-wrapper sub-block sets it to "shell-wrapper" so the final deny
+# message can explain why a read-only wrapper probe is blocked (Issue #1322).
+BLOCKED_SUBKIND=""
 
 # Pattern 1: gh pr diff --stat
 case "$CMD_CHECK" in
@@ -315,6 +319,10 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     *" dash -c "*|\
     *" fish -c "*)
       BLOCKED_PATTERN="reviewer-state-mutating-git"
+      # 中身が read-only でも block するため、deny message 側で理由を明示する (Issue #1322)。
+      # pattern 名は既存テスト (assert_subagent_deny が reason に "reviewer-state-mutating-git"
+      # を要求) との互換のため変えず、subkind タグで message だけを分岐する。
+      BLOCKED_SUBKIND="shell-wrapper"
       ;;
   esac
 
@@ -534,6 +542,15 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   if [ -n "$BLOCKED_PATTERN" ]; then
     BLOCKED_REASON="Reviewer subagents must not mutate the working tree, index, or refs. State-changing git commands (checkout/reset/add/stash push/restore/commit/push/merge/rebase/cherry-pick/revert/tag -a -d -f/clean/gc/branch -D --delete/update-ref/symbolic-ref/am/apply/mv/notes/config/remote/bisect/filter-branch/replace/reflog expire/worktree remove/fetch --prune/--force/etc.) are forbidden inside reviewer contexts."
     BLOCKED_ALTERNATIVE="Use read-only alternatives: 'git show <ref>:<file>' to read a blob, 'git diff <ref> -- <file>' to compare, 'git worktree add <path> <ref>' to inspect a different ref in an isolated directory, 'git tag -l' / 'git stash list' / 'git reflog' / 'git branch --list' for display-only queries, or bare 'git fetch' (without --prune/--force) for ref sync. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the full list. If this block fires on a main session (not a reviewer subagent), check whether CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE env vars are accidentally set; recover with: unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE"
+    # (Z) shell-wrapper の場合は、wrapper 専用の理由・代替を前置する (Issue #1322)。
+    # 汎用 git message だけだと、git を含まない read-only probe (例: `bash -c 'echo x'`) が
+    # "State-changing git commands ... forbidden" と表示され、reviewer には over-broad で
+    # 不可解な block に見える。なぜ wrapper を一律 block するか / read-only probe をどう書き
+    # 直すかを先頭で説明する (既存 git ガイダンスは wrapper が git を包む場合に有効なので残す)。
+    if [ "$BLOCKED_SUBKIND" = "shell-wrapper" ]; then
+      BLOCKED_REASON="Shell-command wrappers (eval / bash -c / sh -c / zsh -c / ksh -c / dash -c / fish -c) are blocked in reviewer contexts because their quoted argument is opaque to this guard's word-boundary matching and can hide state-mutating git commands. They are therefore blocked unconditionally — even when the wrapped command is read-only. $BLOCKED_REASON"
+      BLOCKED_ALTERNATIVE="For a read-only probe, drop the wrapper: run the command directly, group multiple commands in a subshell '( cmd1; cmd2 )', or put them in a file and run 'bash <script.sh>'. $BLOCKED_ALTERNATIVE"
+    fi
   fi
 fi
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -864,6 +864,48 @@ assert_subagent_allow "subagent git -C log allowed (-C with read-only verb)" \
   "git -C /tmp log --oneline"
 
 # --------------------------------------------------------------------------
+# TC-057ad〜af: Issue #1322 — shell-wrapper の deny message に read-only probe 用の
+# 代替ガイダンス (subshell / 直接実行 / bash <script>) を付加する。
+# pattern 名 (reviewer-state-mutating-git) は既存テスト互換のため不変で、wrapper 専用の
+# 理由・代替が reason に出ることを pin する。「(Z) bash -c 一律 block は緩和しない」判断のため、
+# read-only git を包む wrapper も依然 deny されること、wrapper block が subagent 限定で
+# main session は非影響であることも併せて固定する。
+# --------------------------------------------------------------------------
+
+# Helper: subagent deny かつ reason に wrapper guidance が含まれることを確認
+assert_subagent_deny_wrapper_guidance() {
+  local label="$1"
+  local cmd="$2"
+  local rc=0
+  local output
+  output=$(run_guard_with_transcript "Bash" "$cmd" "$SUBAGENT_TRANSCRIPT") || rc=$?
+  local decision reason
+  decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+  if [ "$decision" = "deny" ] \
+    && [[ "$reason" == *"reviewer-state-mutating-git"* ]] \
+    && [[ "$reason" == *"Shell-command wrappers"* ]] \
+    && [[ "$reason" == *"subshell"* ]] \
+    && [[ "$reason" == *"bash <script.sh>"* ]]; then
+    pass "$label"
+  else
+    fail "$label — expected deny with shell-wrapper guidance, got decision=$decision reason=$reason"
+  fi
+}
+
+echo "TC-057ad: subagent + 'bash -c \"echo readonly-probe\"' (no git) → deny + wrapper guidance (Issue #1322)"
+assert_subagent_deny_wrapper_guidance "subagent non-git bash -c probe denied with wrapper guidance" \
+  'bash -c "echo readonly-probe"'
+
+echo "TC-057ae: subagent + 'bash -c \"git status\"' (read-only git wrapped) → deny + wrapper guidance (no relaxation)"
+assert_subagent_deny_wrapper_guidance "subagent read-only-git bash -c probe still denied (policy: no relaxation)" \
+  'bash -c "git status"'
+
+echo "TC-057af: main session + 'bash -c \"echo readonly-probe\"' → allow (wrapper block is subagent-scoped)"
+assert_main_allow "main session non-git bash -c allowed (wrapper block subagent-scoped)" \
+  'bash -c "echo readonly-probe"'
+
+# --------------------------------------------------------------------------
 # TC-058: git fetch (bare) allowed, --prune denied
 # --------------------------------------------------------------------------
 echo "TC-058a: subagent + 'git fetch origin' (bare) → allow"


### PR DESCRIPTION
## 概要

reviewer subagent の read-only な `bash -c` 挙動プローブが `pre-tool-bash-guard.sh` の (Z) shell-wrapper guard で一律 block される over-broad 問題を精査した。

**精査結論: 緩和しない。** (Z) の `bash -c` 一律 block は PR #997 / Issue #995 で実インシデント（reviewer が親セッションの working tree を破壊）への多層防御として意図的に追加された構造的防御であり、緩和すると quote 内パースという fragile な bypass 面を security hook に再導入する。reviewer は subshell `( ... )` / 直接コマンド / `bash <script>` で検証強度を落とさず代替でき、実害はほぼゼロ。

over-broad 体験の実害は **deny メッセージの乖離**にある — 中身が git でない read-only probe（例: `bash -c 'echo x'`）でも "State-changing git commands ... forbidden" と表示され、reviewer には不可解な block に見える。本 PR はこのメッセージを是正し、reviewer 向けガイダンスを強化する。

## 変更内容

- `plugins/rite/hooks/pre-tool-bash-guard.sh`: (Z) 発火時に `BLOCKED_SUBKIND="shell-wrapper"` を立て、deny メッセージに wrapper 専用の理由（中身に関係なく block する根拠）と read-only probe の代替（subshell `( )` / 直接コマンド / `bash <script>`）を前置。**パターン名・deny 判定ロジックは不変**（セキュリティ境界を一切緩めない）。
- `plugins/rite/agents/_reviewer-base.md`: shell-wrapper（`eval` / `bash -c` / `sh -c` 等）は read-only probe でも block される旨と代替手段・理由を明示する節を追加。
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`: TC-057ad/ae/af を追加。非 git の `bash -c` probe が wrapper 専用メッセージ付きで deny されること、read-only git を包む wrapper も依然 deny されること（緩和しない方針の pin）、main session は非影響であることを固定。

## 設計上の制約

`assert_subagent_deny`（test）が deny reason に `reviewer-state-mutating-git` を含むことを要求しているため、**パターン名は変えず** `BLOCKED_SUBKIND` フラグでメッセージのみを分岐した。これにより既存の TC-057t/u/v/aa を含む回帰テストは不変のまま通る。

## テスト

- `pre-tool-bash-guard.test.sh`: 165/165 pass（既存 + 新規 TC-057ad/ae/af）。
- 実機 smoke: subagent transcript で `bash -c 'echo hello'` → deny + wrapper 専用メッセージを確認。

## 関連 Issue

Closes #1322

## 補足（follow-up 候補・本 PR スコープ外）

- `docs/SPEC.md` の Pre-Tool Bash Guard "Blocked Patterns" 表は Pattern 1-3 のみ記載で、Pattern 4 (`reviewer-state-mutating-git`) / (Z) shell-wrapper が **PR #997 以来未記載**。本 PR の挙動とは独立した既存ギャップのため別途追跡を推奨。
