### PR TITLE
docs(archive): anti-pattern doc L57 の start.md ステップ 8.5 stale ref に廃止注記を追加

### DIFF
--- a/docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md
+++ b/docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md
@@ -54,7 +54,7 @@ resolution_issue: 1144
 | anti-pattern / correct-pattern 契約 | `cleanup.md` 冒頭 | sub-skill return = continuation trigger である旨を明示 |
 | Pre-check list Item 0-3 | `cleanup.md` | LLM の self-check で routing dispatcher + state check |
 | 🚨 Mandatory After Wiki Ingest Step 1 | `cleanup.md` Phase 4.W 末尾 | `cleanup_post_ingest` patch を即時実行 |
-| `workflow_incident` 検出 | `start.md` ステップ 8.5 (PR #1088 / #1136 で削除済) | post-hoc で Issue 自動登録（機構撤去済）|
+| `workflow_incident` 検出 | `start.md` ステップ 8.5 (#1088 で機構撤去 (実装: #1091)、start.md 自体も #1136 で削除済) | post-hoc で Issue 自動登録（機構撤去済） |
 
 ## 根本原因 evidence（Issue #621 S1 Decision Log）
 

--- a/docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md
+++ b/docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md
@@ -54,7 +54,7 @@ resolution_issue: 1144
 | anti-pattern / correct-pattern 契約 | `cleanup.md` 冒頭 | sub-skill return = continuation trigger である旨を明示 |
 | Pre-check list Item 0-3 | `cleanup.md` | LLM の self-check で routing dispatcher + state check |
 | 🚨 Mandatory After Wiki Ingest Step 1 | `cleanup.md` Phase 4.W 末尾 | `cleanup_post_ingest` patch を即時実行 |
-| `workflow_incident` 検出 | `start.md` ステップ 8.5 | post-hoc で Issue 自動登録 |
+| `workflow_incident` 検出 | `start.md` ステップ 8.5 (PR #1088 / #1136 で削除済) | post-hoc で Issue 自動登録（機構撤去済）|
 
 ## 根本原因 evidence（Issue #621 S1 Decision Log）
 


### PR DESCRIPTION
## 概要

`docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md` L57 の `start.md ステップ 8.5` 参照は、Issue #1136 / PR #1088 で削除済の `/rite:issue:start` へ向いている stale reference でした。`workflow_incident` 検出機構自体が撤去済のため、本行に inline の廃止注記を追加し、初見読者が現行 start.md を探して 404 になる経路を解消します。

## 関連 Issue

Closes #1152

### 検出された問題（別 Issue として追跡）

- #1324: docs/tests/rite-issue-create-e2e-smoke.test.md の削除済 start.md ステップ 8.5 参照に廃止注記を追加

## 変更内容

- `docs/anti-patterns/cleanup-wiki-ingest-turn-boundary.md` - 変更
  - L57 の defense-in-depth 表の `workflow_incident` 検出行に「(PR #1088 / #1136 で削除済)」「（機構撤去済）」の注記を追加

注記表現は `docs/migration-guides/v2-to-v3.md` / `plugins/rite/references/issue-create-with-projects.md` の既存 archive 注記と整合させています。

## チェックリスト

- [x] Issue の実装ステップ完了 (Issue #1152 チェックリスト更新済)
- [x] lint 実行（コマンド未検出のためスキップ。プラグイン内部チェックは既存 warning のみで非ブロッキング）
- [x] 廃止注記の根拠 (Issue #1136 / PR #1088) を本文に明記

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
