### PR TITLE
test(tests): flow-state.test.sh TC-H7 末尾に corrupt state_file の sandbox 隔離留意コメントを追加

### DIFF
--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -916,6 +916,10 @@ else
 fi
 [ "${_tch7_stderr:-/dev/null}" != "/dev/null" ] && rm -f "$_tch7_stderr"
 unset _tch7_stderr
+# ⚠️ sandbox 隔離の留意 (Issue #1174): TC-H7 は corrupt JSON を state_file に書き込んだまま終了する
+# (corrupt 状態の観測が目的のため cleanup しないのは意図的)。本 TC より後ろに TC を追加する場合は、
+# 残置された corrupt state_file を引き継がないよう必ず new_sandbox で独立 sandbox を取得すること
+# (直後の TC-23 は準拠済み)。
 
 # --- TC-23: jq stderr スニペットの control-char 中和 (Issue #1173) ---
 echo ""


### PR DESCRIPTION
## 概要

`flow-state.test.sh` の TC-H7 は corrupt JSON を state_file に書き込んだまま終了します（corrupt 状態の観測が目的のため cleanup しないのは意図的）。TC-H7 より後ろに TC を追加する際に corrupt state_file を引き継がないよう、`new_sandbox` での独立 sandbox 取得を必須とする留意コメントを TC-H7 ブロック末尾に追加します。

Issue 起票時は TC-H7 が最後の TC でしたが、現在は TC-23 (Issue #1173 / #1274) が後ろに追加済みであり（`new_sandbox` 取得済みで実害なし）、本留意点は既に実際の参照対象を持ちます。

## 関連 Issue

Closes #1174

## 変更内容

- `plugins/rite/hooks/tests/flow-state.test.sh` - 変更
  - TC-H7 ブロック末尾（TC-23 直前）に sandbox 隔離の留意コメント 4 行を追加（テスト挙動の変更なし）

## 検証

- `bash plugins/rite/hooks/tests/flow-state.test.sh` → 109 PASS / 0 FAIL（回帰なし）

## チェックリスト

- [x] Issue の実装ステップ完了 (Issue #1174 チェックリスト更新済)
- [x] テストスイート実行 (109 PASS / 0 FAIL)
- [x] lint 実行（コマンド未検出のためスキップ。プラグイン内部チェックは既存 warning のみで本変更による新規なし）

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした）
