### PR TITLE
refactor(hooks): jq stderr 診断スニペットの control-char 中和を全 hook へ横展開 (#1173 follow-up)

### DIFF
--- a/plugins/rite/hooks/_resolve-cross-session-guard.sh
+++ b/plugins/rite/hooks/_resolve-cross-session-guard.sh
@@ -44,6 +44,8 @@
 # Exit codes:
 #   0 — always (classification printed to stdout)
 set -euo pipefail
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 
 LEGACY_PATH="${1:-}"
 CURRENT_SID="${2:-}"
@@ -149,7 +151,7 @@ else
   # observability that was traded away when stdout pollution forced removal
   # of an earlier `cat "$_jq_err" >&2` block; details in
   # references/state-read-evolution.md.
-  [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" >&2
+  [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | neutralize_ctrl --keep-newline >&2
   printf 'corrupt:%d' "$jq_rc"
   exit 0
 fi

--- a/plugins/rite/hooks/_resolve-session-id-from-file.sh
+++ b/plugins/rite/hooks/_resolve-session-id-from-file.sh
@@ -45,6 +45,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # verified-review (PR #688 cycle 39 H-01) MEDIUM (silent-failure-hunter):
 # `_resolve-session-id.sh` の存在 check を upfront で実施する。
@@ -136,7 +138,7 @@ else
   _tr_rc=$?
   echo "WARNING: _resolve-session-id-from-file.sh: tr が IO/permission エラーで失敗しました (rc=$_tr_rc)" >&2
   if [ -n "$_tr_err" ] && [ -s "$_tr_err" ]; then
-    head -3 "$_tr_err" | sed 's/^/  /' >&2
+    head -3 "$_tr_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   echo "  対処: $sid_file の permission / inode 健全性を確認してください" >&2
   echo "  影響: graceful degradation で空文字復帰しますが、cross-session guard が空 SID で経路判定する可能性があります" >&2

--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -18,6 +18,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Resolve repository root
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$(pwd)" 2>/dev/null) || STATE_ROOT="$(pwd)"
@@ -64,7 +66,7 @@ if [ "$CLOSE_MODE" = false ]; then
       _isn_tag=""
       [ -z "$_isn_err" ] && _isn_tag=" stderr_capture=disabled"
       echo "[rite] WARNING: cleanup-work-memory: .rite-flow-state の .issue_number 取得失敗 (rc=$_isn_rc — FLOW_STATE may be corrupt${_isn_tag})" >&2
-      [ -n "$_isn_err" ] && [ -s "$_isn_err" ] && head -3 "$_isn_err" | sed 's/^/  /' >&2
+      [ -n "$_isn_err" ] && [ -s "$_isn_err" ] && head -3 "$_isn_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       ISSUE_NUMBER=""
     fi
     [ -n "$_isn_err" ] && rm -f "$_isn_err"
@@ -99,13 +101,13 @@ if [ "$CLOSE_MODE" = false ]; then
         else
           _mv_rc=$?
           echo "WARNING: .rite-flow-state の更新に失敗しました (mv rc=$_mv_rc)" >&2
-          [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | sed 's/^/  /' >&2
+          [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         fi
         [ -n "$_mv_err" ] && rm -f "$_mv_err"
       else
         _jq_rc=$?
         echo "WARNING: .rite-flow-state のリセットに失敗しました (jq rc=$_jq_rc — missing in PATH / locale / parse error を区別)" >&2
-        [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | sed 's/^/  /' >&2
+        [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       fi
       [ -n "$_jq_err" ] && rm -f "$_jq_err"
     else
@@ -157,7 +159,7 @@ if [ -d "$WM_DIR" ]; then
   _find_out=$(find "$WM_DIR" -name 'issue-*.md' -type f 2>"${_find_err:-/dev/null}" | wc -l | tr -d ' ') || _find_out=""
   if [ -n "$_find_err" ] && [ -s "$_find_err" ]; then
     echo "WARNING: cleanup-work-memory: find $WM_DIR で stderr を観測 (permission denied / IO error 等)。残存件数は信頼できません。" >&2
-    head -3 "$_find_err" | sed 's/^/  /' >&2
+    head -3 "$_find_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     remaining="unknown"
   else
     remaining="${_find_out:-0}"

--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # rite workflow - Control Character Neutralization (shared)
 # Provides the single source of truth for the "control chars → ?" diagnostic
-# neutralization convention shared by flow-state.sh (_emit_jq_err_snippet),
-# stop-loop-continuation.sh (unknown handoff prefix WARNING / JSON emit
-# fallback), and pre-tool-bash-guard.sh (deny fallback JSON — Issue #1278),
-# plus the detection-side counterpart contains_ctrl() for reject-purpose
-# validation (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh
+# neutralization convention shared by all hooks/ diagnostic snippet emission
+# sites (`head -3 "$err_file" | neutralize_ctrl --keep-newline | sed ... >&2`
+# — Issue #1183 rollout; the parity is pinned by
+# tests/diag-snippet-neutralize-parity.test.sh), by stop-loop-continuation.sh
+# (unknown handoff prefix WARNING / JSON emit fallback) and
+# pre-tool-bash-guard.sh (deny fallback JSON — Issue #1278), plus the
+# detection-side counterpart contains_ctrl() for reject-purpose validation
+# (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh
 # SOURCE_REF / TITLE — Issue #1276).
 #
 # WHY a shared helper (Issue #1274): the POSIX class [[:cntrl:]] on glibc

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -48,6 +48,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 PYTHON_SCRIPT="$SCRIPT_DIR/issue-comment-wm-update.py"
 
 # Resolve repository root for .rite-flow-state access
@@ -66,7 +68,7 @@ get_owner_repo() {
   if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
     if [ -n "$_err" ] && [ -s "$_err" ]; then
       echo "[rite] WARNING: issue-comment-wm-sync: gh repo view failed (rc=$_rc)" >&2
-      head -3 "$_err" | sed 's/^/  /' >&2
+      head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     _out=""
   fi
@@ -101,14 +103,14 @@ cache_comment_id() {
     else
       local _mv_rc=$?
       echo "[rite] WARNING: issue-comment-wm-sync: cache_comment_id mv failed (rc=$_mv_rc)" >&2
-      [ -n "$_cid_mv_err" ] && [ -s "$_cid_mv_err" ] && head -3 "$_cid_mv_err" | sed 's/^/  /' >&2
+      [ -n "$_cid_mv_err" ] && [ -s "$_cid_mv_err" ] && head -3 "$_cid_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       rm -f "$tmp"
     fi
     [ -n "$_cid_mv_err" ] && rm -f "$_cid_mv_err"
   else
     _jq_rc=$?
     echo "[rite] WARNING: issue-comment-wm-sync: cache_comment_id jq failed (rc=$_jq_rc — FLOW_STATE may be corrupt or cid='$cid' not numeric)" >&2
-    [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | sed 's/^/  /' >&2
+    [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     rm -f "$tmp"
   fi
   [ -n "$_jq_err" ] && rm -f "$_jq_err"
@@ -130,7 +132,7 @@ get_comment_id() {
     cached=$(jq -r '.wm_comment_id // empty' "$FLOW_STATE" 2>"${_err:-/dev/null}") || _rc=$?
     if [ "$_rc" -ne 0 ]; then
       echo "[rite] WARNING: issue-comment-wm-sync: cache 読み取り jq 失敗 (rc=$_rc — FLOW_STATE may be corrupt)" >&2
-      [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | sed 's/^/  /' >&2
+      [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       cached=""
     fi
     [ -n "$_err" ] && rm -f "$_err"
@@ -145,7 +147,7 @@ get_comment_id() {
         # 失敗を区別する。auth / rate limit エラーは WARNING で operator に通知。
         if [ -n "$_err" ] && [ -s "$_err" ] && grep -qiE 'rate limit|HTTP 401|HTTP 403|network' "$_err"; then
           echo "[rite] WARNING: issue-comment-wm-sync: cache 検証 gh api 失敗 (rc=$_rc, auth/rate/network 系)" >&2
-          head -3 "$_err" | sed 's/^/  /' >&2
+          head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         fi
         verify=""
       fi
@@ -164,7 +166,7 @@ get_comment_id() {
     --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | .id // empty' 2>"${_err:-/dev/null}") || _rc=$?
   if [ "$_rc" -ne 0 ]; then
     echo "[rite] WARNING: issue-comment-wm-sync: comment 一覧取得 gh api 失敗 (rc=$_rc — auth/rate/network 系の可能性)" >&2
-    [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | sed 's/^/  /' >&2
+    [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     comment_id=""
   fi
   [ -n "$_err" ] && rm -f "$_err"
@@ -342,7 +344,7 @@ INIT_EOF
   result=$(gh issue comment "$ISSUE" --body-file "$tmpfile" 2>"${_init_err:-/dev/null}") || _init_rc=$?
   if [ "$_init_rc" -ne 0 ]; then
     echo "[rite] WARNING: issue-comment-wm-sync: gh issue comment 作成失敗 (rc=$_init_rc)" >&2
-    [ -n "$_init_err" ] && [ -s "$_init_err" ] && head -3 "$_init_err" | sed 's/^/  /' >&2
+    [ -n "$_init_err" ] && [ -s "$_init_err" ] && head -3 "$_init_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     [ -n "$_init_err" ] && rm -f "$_init_err"
     exit 0
   fi
@@ -364,7 +366,7 @@ INIT_EOF
       _verify_tag=""
       [ -z "$_verify_err" ] && _verify_tag=" stderr_capture=disabled"
       echo "[rite] WARNING: issue-comment-wm-sync: validation gh api 失敗 (attempt=$attempt, rc=$_verify_rc${_verify_tag})" >&2
-      [ -n "$_verify_err" ] && [ -s "$_verify_err" ] && head -3 "$_verify_err" | sed 's/^/  /' >&2
+      [ -n "$_verify_err" ] && [ -s "$_verify_err" ] && head -3 "$_verify_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       created_id=""
     fi
     [ -n "$_verify_err" ] && rm -f "$_verify_err"
@@ -427,7 +429,7 @@ _cb_rc=0
 current_body=$(gh api "repos/${OWNER_REPO}/issues/comments/${COMMENT_ID}" --jq '.body // empty' 2>"${_cb_err:-/dev/null}") || _cb_rc=$?
 if [ "$_cb_rc" -ne 0 ]; then
   echo "[rite] WARNING: issue-comment-wm-sync: comment body 取得 gh api 失敗 (rc=$_cb_rc — auth/rate/network/404 系)" >&2
-  [ -n "$_cb_err" ] && [ -s "$_cb_err" ] && head -3 "$_cb_err" | sed 's/^/  /' >&2
+  [ -n "$_cb_err" ] && [ -s "$_cb_err" ] && head -3 "$_cb_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   current_body=""
 fi
 [ -n "$_cb_err" ] && rm -f "$_cb_err"
@@ -479,7 +481,7 @@ patch_status=0
 
 if [ "$patch_status" -ne 0 ]; then
   echo "[rite] WARNING: issue-comment-wm-sync: PATCH failed (rc=$patch_status, Backup: $backup_file)" >&2
-  [ -n "$patch_err" ] && [ -s "$patch_err" ] && head -3 "$patch_err" | sed 's/^/  /' >&2
+  [ -n "$patch_err" ] && [ -s "$patch_err" ] && head -3 "$patch_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   [ -n "$patch_err" ] && rm -f "$patch_err"
   echo "status=error; reason=patch_failed"
   exit 0

--- a/plugins/rite/hooks/notification.sh
+++ b/plugins/rite/hooks/notification.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 command -v jq >/dev/null 2>&1 || exit 0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Read CWD from stdin JSON (consistent with other hooks).
 # CWD is provided by the Claude Code runtime and is already an absolute path;
@@ -27,7 +29,7 @@ if CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>"${_cwd_jq_err:-/dev/null}"); t
 else
     _cwd_rc=$?
     echo "[rite] WARNING: notification: hook stdin jq parse failed (rc=$_cwd_rc) — notification dispatch skipped for this event" >&2
-    [ -n "${RITE_DEBUG:-}" ] && [ -n "$_cwd_jq_err" ] && [ -s "$_cwd_jq_err" ] && head -3 "$_cwd_jq_err" | sed 's/^/  /' >&2
+    [ -n "${RITE_DEBUG:-}" ] && [ -n "$_cwd_jq_err" ] && [ -s "$_cwd_jq_err" ] && head -3 "$_cwd_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     CWD=""
 fi
 [ -n "$_cwd_jq_err" ] && rm -f "$_cwd_jq_err"
@@ -85,7 +87,7 @@ _send_webhook() {
     else
         local _rc=$?
         echo "[rite] WARNING: notification($channel): curl failed (rc=$_rc) — webhook may be expired or unreachable" >&2
-        [ -n "$_curl_err" ] && [ -s "$_curl_err" ] && head -3 "$_curl_err" | sed 's/^/  /' >&2
+        [ -n "$_curl_err" ] && [ -s "$_curl_err" ] && head -3 "$_curl_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_curl_err" ] && rm -f "$_curl_err"
 }

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -11,6 +11,8 @@ export _RITE_HOOK_RUNNING_POSTCOMPACT=1
 # Hook version resolution preamble (must be before INPUT=$(cat) to preserve stdin)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
@@ -83,7 +85,7 @@ _flow_active_err=$(mktemp 2>/dev/null) || _flow_active_err=""
 FLOW_ACTIVE=$(jq -r '.active // false' "$FLOW_STATE" 2>"${_flow_active_err:-/dev/null}") || FLOW_ACTIVE="false"
 if [ -n "$_flow_active_err" ] && [ -s "$_flow_active_err" ]; then
   echo "[rite] WARNING: post-compact: jq parse of .active failed (FLOW_STATE may be corrupt)" >&2
-  head -3 "$_flow_active_err" | sed 's/^/  /' >&2
+  head -3 "$_flow_active_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
 fi
 [ -n "$_flow_active_err" ] && rm -f "$_flow_active_err"
 if [ "$FLOW_ACTIVE" != "true" ]; then
@@ -106,7 +108,7 @@ if [ "$_compact_val_rc" -ne 0 ]; then
   _compact_val_tag=""
   [ -z "$_compact_val_err" ] && _compact_val_tag=" stderr_capture=disabled"
   echo "[rite] WARNING: post-compact: jq parse of .compact_state failed (rc=$_compact_val_rc — COMPACT_STATE may be corrupt${_compact_val_tag})" >&2
-  [ -n "$_compact_val_err" ] && [ -s "$_compact_val_err" ] && head -3 "$_compact_val_err" | sed 's/^/  /' >&2
+  [ -n "$_compact_val_err" ] && [ -s "$_compact_val_err" ] && head -3 "$_compact_val_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
 fi
 [ -n "$_compact_val_err" ] && rm -f "$_compact_val_err"
 if [ "$COMPACT_VAL" != "recovering" ]; then
@@ -134,7 +136,7 @@ if [ -n "$_flow_data_err" ] && [ -s "$_flow_data_err" ]; then
   # concurrent writer race) を、上流 WARNING ではカバーできない経路として独立に expose する。
   # silent fall-through すると recovery が phase=unknown で再開する。
   echo "[rite] WARNING: post-compact: jq parse of flow-state composite fields failed (FLOW_STATE may be partially corrupt)" >&2
-  head -3 "$_flow_data_err" | sed 's/^/  /' >&2
+  head -3 "$_flow_data_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
 fi
 [ -n "$_flow_data_err" ] && rm -f "$_flow_data_err"
 
@@ -179,13 +181,13 @@ if acquire_wm_lock "$LOCKDIR"; then
       rm -f "$TMP_COMPACT"
       TMP_COMPACT=""
       echo "rite: post-compact: mv compact_state failed (rc=$_mv_rc)" >&2
-      [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | sed 's/^/  /' >&2
+      [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_mv_err" ] && rm -f "$_mv_err"
   else
     _jq_norm_rc=$?
     echo "rite: post-compact: jq normalize compact_state failed (rc=$_jq_norm_rc)" >&2
-    [ -n "$_jq_norm_err" ] && [ -s "$_jq_norm_err" ] && head -3 "$_jq_norm_err" | sed 's/^/  /' >&2
+    [ -n "$_jq_norm_err" ] && [ -s "$_jq_norm_err" ] && head -3 "$_jq_norm_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     rm -f "$TMP_COMPACT"
     TMP_COMPACT=""
   fi

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -13,6 +13,8 @@ export _RITE_HOOK_RUNNING_POSTTOOL=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Recursion guard
 [ -z "${RITE_WM_HOOK_ACTIVE:-}" ] || exit 0
@@ -149,7 +151,7 @@ if [ "$_pd_rc" -ne 0 ]; then
   _pd_tag=""
   [ -z "$_pd_err" ] && _pd_tag=" stderr_capture=disabled"
   echo "[rite] WARNING: post-tool-wm-sync: phase_detail 取得失敗 (rc=$_pd_rc${_pd_tag}) — phase 名に縮退" >&2
-  [ -n "$_pd_err" ] && [ -s "$_pd_err" ] && head -3 "$_pd_err" | sed 's/^/  /' >&2
+  [ -n "$_pd_err" ] && [ -s "$_pd_err" ] && head -3 "$_pd_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   _phase_detail=""
 fi
 [ -n "$_pd_err" ] && rm -f "$_pd_err"
@@ -179,7 +181,7 @@ if "$SCRIPT_DIR/issue-comment-wm-sync.sh" update \
 else
   _rc=$?
   echo "[rite] WARNING: post-tool-wm-sync: update-phase failed (rc=$_rc${_phase_sync_stderr_tag}) — last_synced_phase will NOT be advanced so next hook invocation retries" >&2
-  [ -n "$_phase_sync_err" ] && [ -s "$_phase_sync_err" ] && head -3 "$_phase_sync_err" | sed 's/^/  /' >&2
+  [ -n "$_phase_sync_err" ] && [ -s "$_phase_sync_err" ] && head -3 "$_phase_sync_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
 fi
 [ -n "$_phase_sync_err" ] && rm -f "$_phase_sync_err"
 
@@ -210,7 +212,7 @@ case "$_phase" in
     _diff_raw=$(git diff --name-status "origin/${_base_branch}...HEAD" 2>"${_git_diff_err:-/dev/null}") || _diff_raw=""
     if [ -n "$_git_diff_err" ] && [ -s "$_git_diff_err" ]; then
       echo "[rite] WARNING: post-tool-wm-sync: git diff failed — progress table may show stale or empty file list:" >&2
-      head -3 "$_git_diff_err" | sed 's/^/  /' >&2
+      head -3 "$_git_diff_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_git_diff_err" ] && rm -f "$_git_diff_err"
 
@@ -249,7 +251,7 @@ case "$_phase" in
     else
       _rc=$?
       echo "[rite] WARNING: post-tool-wm-sync: update-progress failed (rc=$_rc${_progress_sync_stderr_tag}) — last_synced_phase will NOT be advanced" >&2
-      [ -n "$_progress_sync_err" ] && [ -s "$_progress_sync_err" ] && head -3 "$_progress_sync_err" | sed 's/^/  /' >&2
+      [ -n "$_progress_sync_err" ] && [ -s "$_progress_sync_err" ] && head -3 "$_progress_sync_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       _phase_sync_ok=0
     fi
     [ -n "$_progress_sync_err" ] && rm -f "$_progress_sync_err"
@@ -266,7 +268,7 @@ case "$_phase" in
     else
       _rc=$?
       echo "[rite] WARNING: post-tool-wm-sync: update-plan-status failed (rc=$_rc${_plan_sync_stderr_tag}) — last_synced_phase will NOT be advanced" >&2
-      [ -n "$_plan_sync_err" ] && [ -s "$_plan_sync_err" ] && head -3 "$_plan_sync_err" | sed 's/^/  /' >&2
+      [ -n "$_plan_sync_err" ] && [ -s "$_plan_sync_err" ] && head -3 "$_plan_sync_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       _phase_sync_ok=0
     fi
     [ -n "$_plan_sync_err" ] && rm -f "$_plan_sync_err"
@@ -296,14 +298,14 @@ if [ "$_phase_sync_ok" = "1" ]; then
       _mv_rc=$?
       rm -f "$_tmp_fs"
       echo "rite: post-tool-wm-sync: mv last_synced_phase failed (rc=$_mv_rc)" >&2
-      [ -n "$_lp_mv_err" ] && [ -s "$_lp_mv_err" ] && head -3 "$_lp_mv_err" | sed 's/^/  /' >&2
+      [ -n "$_lp_mv_err" ] && [ -s "$_lp_mv_err" ] && head -3 "$_lp_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_lp_mv_err" ] && rm -f "$_lp_mv_err"
   else
     _last_phase_jq_rc=$?
     rm -f "$_tmp_fs"
     echo "rite: post-tool-wm-sync: WARNING: jq write of last_synced_phase failed (rc=$_last_phase_jq_rc) — next hook invocation will re-run all transformers" >&2
-    [ -n "$_last_phase_jq_err" ] && [ -s "$_last_phase_jq_err" ] && head -3 "$_last_phase_jq_err" | sed 's/^/  /' >&2
+    [ -n "$_last_phase_jq_err" ] && [ -s "$_last_phase_jq_err" ] && head -3 "$_last_phase_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$_last_phase_jq_err" ] && rm -f "$_last_phase_jq_err"
 fi

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -12,6 +12,8 @@ export _RITE_HOOK_RUNNING_PRECOMPACT=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -103,14 +105,14 @@ if acquire_wm_lock "$LOCKDIR"; then
         _mv_rc=$?
         rm -f "$TMP_FILE"
         echo "rite: pre-compact: mv flow-state updated_at failed (rc=$_mv_rc)" >&2
-        [ -n "$_hb_mv_err" ] && [ -s "$_hb_mv_err" ] && head -3 "$_hb_mv_err" | sed 's/^/  /' >&2
+        [ -n "$_hb_mv_err" ] && [ -s "$_hb_mv_err" ] && head -3 "$_hb_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       fi
       [ -n "$_hb_mv_err" ] && rm -f "$_hb_mv_err"
     else
       _heartbeat_rc=$?
       rm -f "$TMP_FILE"
       echo "rite: pre-compact: WARNING: heartbeat jq failed (rc=$_heartbeat_rc) — session-ownership staleness check may misclassify this session as stale" >&2
-      [ -n "$_heartbeat_err" ] && [ -s "$_heartbeat_err" ] && head -3 "$_heartbeat_err" | sed 's/^/  /' >&2
+      [ -n "$_heartbeat_err" ] && [ -s "$_heartbeat_err" ] && head -3 "$_heartbeat_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_heartbeat_err" ] && rm -f "$_heartbeat_err"
     TMP_FILE=""
@@ -126,7 +128,7 @@ if acquire_wm_lock "$LOCKDIR"; then
     ACTIVE_ISSUE=$(jq -r '.issue_number // "null"' "$FLOW_STATE" 2>"${_ai_err:-/dev/null}") || _ai_rc=$?
     if [ "$_ai_rc" -ne 0 ] || [ -z "$ACTIVE_ISSUE" ]; then
       [ -n "${RITE_DEBUG:-}" ] && echo "[rite] DEBUG: pre-compact: .issue_number jq 失敗 (rc=$_ai_rc) — branch name fallback へ降格" >&2
-      [ -n "${RITE_DEBUG:-}" ] && [ -n "$_ai_err" ] && [ -s "$_ai_err" ] && head -3 "$_ai_err" | sed 's/^/  /' >&2
+      [ -n "${RITE_DEBUG:-}" ] && [ -n "$_ai_err" ] && [ -s "$_ai_err" ] && head -3 "$_ai_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       ACTIVE_ISSUE="null"
     fi
     [ -n "$_ai_err" ] && rm -f "$_ai_err"
@@ -146,7 +148,7 @@ if acquire_wm_lock "$LOCKDIR"; then
     BRANCH=$(cd "$CWD" && git branch --show-current 2>"${_pc_br_err:-/dev/null}") || _pc_br_rc=$?
     if [ "$_pc_br_rc" -ne 0 ]; then
       echo "[rite] WARNING: pre-compact: git branch --show-current 失敗 (rc=$_pc_br_rc)" >&2
-      [ -n "$_pc_br_err" ] && [ -s "$_pc_br_err" ] && head -3 "$_pc_br_err" | sed 's/^/  /' >&2
+      [ -n "$_pc_br_err" ] && [ -s "$_pc_br_err" ] && head -3 "$_pc_br_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       BRANCH=""
     fi
     [ -n "$_pc_br_err" ] && rm -f "$_pc_br_err"
@@ -184,7 +186,7 @@ if acquire_wm_lock "$LOCKDIR"; then
       else
         _chmod_rc=$?
         echo "rite: pre-compact: chmod 600 $COMPACT_STATE failed (rc=$_chmod_rc)" >&2
-        [ -n "$_chmod_err" ] && [ -s "$_chmod_err" ] && head -3 "$_chmod_err" | sed 's/^/  /' >&2
+        [ -n "$_chmod_err" ] && [ -s "$_chmod_err" ] && head -3 "$_chmod_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       fi
       [ -n "$_chmod_err" ] && rm -f "$_chmod_err"
     else
@@ -192,7 +194,7 @@ if acquire_wm_lock "$LOCKDIR"; then
       rm -f "$TMP_COMPACT"
       TMP_COMPACT=""
       echo "rite: pre-compact: mv compact state failed (rc=$_mv_rc)" >&2
-      [ -n "$_cs_mv_err" ] && [ -s "$_cs_mv_err" ] && head -3 "$_cs_mv_err" | sed 's/^/  /' >&2
+      [ -n "$_cs_mv_err" ] && [ -s "$_cs_mv_err" ] && head -3 "$_cs_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_cs_mv_err" ] && rm -f "$_cs_mv_err"
   else
@@ -200,7 +202,7 @@ if acquire_wm_lock "$LOCKDIR"; then
     rm -f "$TMP_COMPACT"
     TMP_COMPACT=""
     echo "rite: pre-compact: failed to write compact state (jq rc=$_jq_compact_rc)" >&2
-    [ -n "$_jq_compact_err" ] && [ -s "$_jq_compact_err" ] && head -3 "$_jq_compact_err" | sed 's/^/  /' >&2
+    [ -n "$_jq_compact_err" ] && [ -s "$_jq_compact_err" ] && head -3 "$_jq_compact_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$_jq_compact_err" ] && rm -f "$_jq_compact_err"
 
@@ -217,7 +219,7 @@ if acquire_wm_lock "$LOCKDIR"; then
   else
     _flow_active_rc=$?
     echo "rite: pre-compact: WARNING: failed to parse .active from $FLOW_STATE (jq rc=$_flow_active_rc) — workflow snapshot will be skipped, recovery may lose context" >&2
-    [ -n "$_flow_active_err" ] && [ -s "$_flow_active_err" ] && head -3 "$_flow_active_err" | sed 's/^/  /' >&2
+    [ -n "$_flow_active_err" ] && [ -s "$_flow_active_err" ] && head -3 "$_flow_active_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     FLOW_ACTIVE="false"
   fi
   [ -n "$_flow_active_err" ] && rm -f "$_flow_active_err"
@@ -233,7 +235,7 @@ if acquire_wm_lock "$LOCKDIR"; then
     FLOW_DATA=$(jq -r '[.phase // "unknown", .pr_number // "null", .loop_count // 0, .next_action // ""] | join("\u001f")' "$FLOW_STATE" 2>"${_flow_data_snap_err:-/dev/null}") || FLOW_DATA=""
     if [ -n "$_flow_data_snap_err" ] && [ -s "$_flow_data_snap_err" ]; then
       echo "rite: pre-compact: WARNING: snapshot jq failed — post-compact recovery may resume with phase=unknown" >&2
-      head -3 "$_flow_data_snap_err" | sed 's/^/  /' >&2
+      head -3 "$_flow_data_snap_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_flow_data_snap_err" ] && rm -f "$_flow_data_snap_err"
     if [ -n "$FLOW_DATA" ]; then

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -42,6 +42,8 @@
 #   0: PR コメント投稿成功、または post_comment_mode=false の silent skip。
 #   1: gate 違反 / 操作失敗 (REVIEW_OUTPUT_FAILED emit 済)。引数エラー (--content-file 欠落等)。
 set -uo pipefail
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 
 SENTINEL='__RITE_TS_PLACEHOLDER_7f3a9b2c__'
 
@@ -215,7 +217,7 @@ if gh pr comment "$PR_NUMBER" --body-file "$tmpfile_patched" 2>"${gh_err:-/dev/n
 else
   gh_rc=$?
   echo "ERROR: PR コメント投稿に失敗しました (gh rc=$gh_rc)" >&2
-  [ -n "$gh_err" ] && [ -s "$gh_err" ] && { echo "  詳細 (gh stderr 先頭 5 行):" >&2; head -5 "$gh_err" | sed 's/^/  /' >&2; }
+  [ -n "$gh_err" ] && [ -s "$gh_err" ] && { echo "  詳細 (gh stderr 先頭 5 行):" >&2; head -5 "$gh_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2; }
   echo "  対処: gh auth status / network 接続 / PR #${PR_NUMBER} の権限を確認してください" >&2
   if [ "$JSON_SAVED" = "true" ]; then
     echo "ℹ️ ただし、レビュー結果はローカルファイルに保存済みです (ステップ 6.1.a)" >&2

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -41,6 +41,8 @@
 #   0: 常に (success / 非ブロッキング失敗どちらも)。caller は LOCAL_SAVE_FAILED / JSON_SAVED で判定。
 #   1: 引数エラー (--pr / --content-file 欠落、--content-file 不在)。
 set -uo pipefail
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 
 # --- Argument parsing ---
 PR_NUMBER=""
@@ -192,7 +194,7 @@ elif jq --arg ts "$iso_timestamp" '.timestamp = $ts' "$json_tmp" > "$json_ts_inj
   fi
 else
   echo "WARNING: jq による timestamp 注入に失敗しました (sentinel 置換不可)" >&2
-  [ -n "$jq_ts_err" ] && [ -s "$jq_ts_err" ] && head -3 "$jq_ts_err" | sed 's/^/  /' >&2
+  [ -n "$jq_ts_err" ] && [ -s "$jq_ts_err" ] && head -3 "$jq_ts_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  対処: --content-file で渡した JSON body ($CONTENT_FILE) が valid JSON で、.timestamp フィールド (sentinel __RITE_TS_PLACEHOLDER_7f3a9b2c__) を持つか確認してください" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=write_failure" >&2
   rm -f "$json_ts_injected"
@@ -209,7 +211,7 @@ fi
 jq_val_err_r=$(mktemp /tmp/rite-jq-val-err-r-XXXXXX 2>/dev/null) || jq_val_err_r=""
 if ! jq empty "$json_tmp" 2>"${jq_val_err_r:-/dev/null}"; then
   echo "WARNING: JSON 一時ファイルが syntactically invalid です (注入後に外部要因で破損した稀ケース。通常の literal substitute 漏れは upstream の write_failure で検出済)" >&2
-  [ -n "${jq_val_err_r:-}" ] && [ -s "$jq_val_err_r" ] && head -3 "$jq_val_err_r" | sed 's/^/  jq: /' >&2
+  [ -n "${jq_val_err_r:-}" ] && [ -s "$jq_val_err_r" ] && head -3 "$jq_val_err_r" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2
   echo "  内容 preview (先頭 5 行):" >&2
   head -5 "$json_tmp" 2>/dev/null | sed 's/^/  /' >&2
   echo "  対処: review-result-schema.md に従った正しい JSON が生成されているか確認してください" >&2

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -137,7 +137,7 @@ json_path="${REVIEW_RESULTS_DIR}/${PR_NUMBER}-${file_timestamp}.json"
 mkdir_err=$(mktemp /tmp/rite-review-p61a-mkdir-err-XXXXXX 2>/dev/null) || mkdir_err=""
 if ! mkdir -p "$REVIEW_RESULTS_DIR" 2>"${mkdir_err:-/dev/null}"; then
   echo "WARNING: .rite/review-results/ ディレクトリの作成に失敗しました。会話コンテキストのみで続行します。" >&2
-  [ -n "$mkdir_err" ] && [ -s "$mkdir_err" ] && head -5 "$mkdir_err" | sed 's/^/  /' >&2
+  [ -n "$mkdir_err" ] && [ -s "$mkdir_err" ] && head -5 "$mkdir_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  対処: 親ディレクトリの permission / disk space / read-only filesystem を確認してください" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=mkdir_failure" >&2
   [ -n "$mkdir_err" ] && rm -f "$mkdir_err"
@@ -154,7 +154,7 @@ fi
 
 if ! json_tmp=$(mktemp /tmp/rite-review-p61a-json-XXXXXX.json 2>"${mktemp_err:-/dev/null}"); then
   echo "WARNING: JSON 一時ファイルの作成に失敗しました" >&2
-  [ -n "$mktemp_err" ] && [ -s "$mktemp_err" ] && { echo "  詳細 (mktemp stderr):" >&2; head -5 "$mktemp_err" | sed 's/^/  /' >&2; }
+  [ -n "$mktemp_err" ] && [ -s "$mktemp_err" ] && { echo "  詳細 (mktemp stderr):" >&2; head -5 "$mktemp_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2; }
   echo "  対処: /tmp の容量 / permission / readonly filesystem を確認してください" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=mktemp_failure" >&2
   [ -n "$mktemp_err" ] && rm -f "$mktemp_err"
@@ -213,7 +213,7 @@ if ! jq empty "$json_tmp" 2>"${jq_val_err_r:-/dev/null}"; then
   echo "WARNING: JSON 一時ファイルが syntactically invalid です (注入後に外部要因で破損した稀ケース。通常の literal substitute 漏れは upstream の write_failure で検出済)" >&2
   [ -n "${jq_val_err_r:-}" ] && [ -s "$jq_val_err_r" ] && head -3 "$jq_val_err_r" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2
   echo "  内容 preview (先頭 5 行):" >&2
-  head -5 "$json_tmp" 2>/dev/null | sed 's/^/  /' >&2
+  head -5 "$json_tmp" 2>/dev/null | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  対処: review-result-schema.md に従った正しい JSON が生成されているか確認してください" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=json_invalid" >&2
   exit 0
@@ -310,7 +310,7 @@ else
   echo "WARNING: JSON ファイルの配置に失敗しました" >&2
   echo "  from: $json_tmp" >&2
   echo "  to:   $json_path" >&2
-  [ -n "$mv_err" ] && [ -s "$mv_err" ] && { echo "  詳細 (mv stderr 先頭 5 行):" >&2; head -5 "$mv_err" | sed 's/^/  /' >&2; }
+  [ -n "$mv_err" ] && [ -s "$mv_err" ] && { echo "  詳細 (mv stderr 先頭 5 行):" >&2; head -5 "$mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2; }
   echo "  対処: cross-filesystem / permission denied / read-only FS / path-too-long / TOCTOU のいずれかを確認してください" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=mv_failure" >&2
   [ -n "$mv_err" ] && rm -f "$mv_err"

--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -24,6 +24,8 @@
 # Exit codes: 0 = clean, 1 = drift detected, 2 = invocation error.
 
 set -uo pipefail
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 
 REPO_ROOT=""
 QUIET=0
@@ -477,7 +479,7 @@ check_pattern_6() {
     # rc != 0/1 (delegate invocation error / jq missing 等): silent に握りつぶさず log + stderr 内容を表示
     log "Pattern 6 delegate exited with unexpected code $rc; check delegate diagnostics:"
     if [ -s "$PATTERN6_STDERR" ]; then
-      head -5 "$PATTERN6_STDERR" | sed 's/^/    /' >&2
+      head -5 "$PATTERN6_STDERR" | neutralize_ctrl --keep-newline | sed 's/^/    /' >&2
     fi
   fi
   # trap が cleanup を保証するが、明示 reset で次回 invocation 時の stale 参照を防ぐ

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -66,6 +66,8 @@
 #   `==> Total ... findings: N` line (it is not a drift-count aggregator).
 #
 set -uo pipefail
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 
 # Signal-specific trap (canonical pattern from references/bash-trap-patterns.md):
 # - EXIT preserves original exit code via `rc=$?`
@@ -197,7 +199,7 @@ if [ "$VERIFY_NEGATION" -eq 1 ]; then
     echo "  stdout: $add_dry_out" >&2
     if [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ]; then
       echo "  stderr (先頭 3 行):" >&2
-      head -3 "$add_dry_err" | sed 's/^/    /' >&2
+      head -3 "$add_dry_err" | neutralize_ctrl --keep-newline | sed 's/^/    /' >&2
     fi
     echo "  対処: .gitignore の .rite/wiki/ 行直後 (gitignore-wiki-section-end anchor 直後) に" >&2
     echo "        !.rite/wiki/ と !.rite/wiki/** が配置されているか確認してください" >&2
@@ -280,7 +282,7 @@ fi
 #   2+ = git error
 if [ "$check_ignore_rc" -ge 2 ]; then
   echo "WARNING: gitignore-health-check: git check-ignore failed (rc=$check_ignore_rc) — skipping separate_branch verify" >&2
-  [ -n "$check_ignore_err" ] && [ -s "$check_ignore_err" ] && head -3 "$check_ignore_err" | sed 's/^/  /' >&2
+  [ -n "$check_ignore_err" ] && [ -s "$check_ignore_err" ] && head -3 "$check_ignore_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   # Report "unknown" (not "0") so lint aggregators don't mistake an invocation
   # failure for a clean run. exit 2 still signals invocation error to callers.
   echo "==> Total gitignore-health-check findings: unknown (verification failed)"
@@ -366,7 +368,7 @@ case "$branch_strategy" in
     else
       echo "==> gitignore-health-check: DRIFT DETECTED (same_branch): negation override for '.rite/wiki/' missing or broken" >&2
       echo "==> git add --dry-run $negation_probe returned rc=$add_dry_rc" >&2
-      [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ] && head -3 "$add_dry_err" | sed 's/^/  /' >&2
+      [ -n "$add_dry_err" ] && [ -s "$add_dry_err" ] && head -3 "$add_dry_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       echo "==> Hint: same_branch strategy requires '!.rite/wiki/' negation entry in .gitignore (see section 'DRIFT-CHECK ANCHOR: same_branch verification-first setup steps' in .gitignore for setup steps)." >&2
       findings=$((findings + 1))
     fi

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -238,7 +238,7 @@ worktree_commit_push() {
  local _first_path="$1"
  if ! git -C "$worktree" add -- "$@" 2>"${add_err:-/dev/null}"; then
  echo "ERROR: git add '$_first_path' failed in worktree '$worktree'" >&2
- [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | sed 's/^/ git: /' >&2
+ [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " hint: index lock / path error / permission denied のいずれかを確認してください" >&2
  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
  _wtgp_restore_caller_state
@@ -266,7 +266,7 @@ worktree_commit_push() {
  1) ;; # staged diff present, proceed
  *)
  echo "ERROR: git diff --cached failed in worktree '$worktree' (rc=$cached_rc)" >&2
- [ -n "$diff_err" ] && [ -s "$diff_err" ] && head -n 10 "$diff_err" | sed 's/^/ git: /' >&2
+ [ -n "$diff_err" ] && [ -s "$diff_err" ] && head -n 10 "$diff_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
  _wtgp_restore_caller_state
  return 3
@@ -276,7 +276,7 @@ worktree_commit_push() {
  # Step 3: commit
  if ! git -C "$worktree" commit --quiet -m "$commit_msg" 2>"${commit_err:-/dev/null}"; then
  echo "ERROR: git commit failed in worktree '$worktree'" >&2
- [ -n "$commit_err" ] && [ -s "$commit_err" ] && head -n 10 "$commit_err" | sed 's/^/ git: /' >&2
+ [ -n "$commit_err" ] && [ -s "$commit_err" ] && head -n 10 "$commit_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " hint: pre-commit hook / gpg sign / author config / permission のいずれかを確認" >&2
  rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
  _wtgp_restore_caller_state
@@ -298,7 +298,7 @@ worktree_commit_push() {
  else
  local head_rc=$?
  echo "WARNING: git -C '$worktree' rev-parse HEAD failed post-commit (rc=$head_rc)" >&2
- [ -n "$head_err" ] && [ -s "$head_err" ] && head -n 5 "$head_err" | sed 's/^/ git: /' >&2
+ [ -n "$head_err" ] && [ -s "$head_err" ] && head -n 5 "$head_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " head SHA will be reported as 'unknown' — the commit itself succeeded but the worktree may be corrupt" >&2
  head_sha="unknown"
  fi
@@ -312,7 +312,7 @@ worktree_commit_push() {
  if ! git -C "$worktree" push --quiet origin "$branch" 2>"${push_err:-/dev/null}"; then
  push_status="failed"
  echo "WARNING: git push origin '$branch' failed in worktree '$worktree' — commit is local only" >&2
- [ -n "$push_err" ] && [ -s "$push_err" ] && head -n 10 "$push_err" | sed 's/^/ git: /' >&2
+ [ -n "$push_err" ] && [ -s "$push_err" ] && head -n 10 "$push_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " manual recovery: git -C '$worktree' push origin '$branch'" >&2
  fi
 

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -77,6 +77,9 @@
 # * COMMIT_MSG has been checked for newline/CR injection
 # * BRANCH matches the expected wiki.branch_name
 
+# shellcheck source=../../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../control-char-neutralize.sh"
+
 # -----------------------------------------------------------------------
 # verify_worktree_branch: confirm a worktree's HEAD is on an expected branch.
 #
@@ -109,8 +112,6 @@
 # 0 worktree is on expected branch
 # 2 rev-parse failed (worktree corrupt / permission / git binary issue)
 # 3 worktree is on a different branch
-# shellcheck source=../../control-char-neutralize.sh
-source "$(dirname "${BASH_SOURCE[0]}")/../../control-char-neutralize.sh"
 verify_worktree_branch() {
  local worktree="$1"
  local expected_branch="$2"

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -109,6 +109,8 @@
 # 0 worktree is on expected branch
 # 2 rev-parse failed (worktree corrupt / permission / git binary issue)
 # 3 worktree is on a different branch
+# shellcheck source=../../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../control-char-neutralize.sh"
 verify_worktree_branch() {
  local worktree="$1"
  local expected_branch="$2"
@@ -145,7 +147,7 @@ verify_worktree_branch() {
  if [ "$wt_head_rc" -ne 0 ]; then
  echo "ERROR: git -C '$worktree' rev-parse --abbrev-ref HEAD が失敗しました (rc=$wt_head_rc)" >&2
  if [ -n "$rev_parse_err" ] && [ -s "$rev_parse_err" ]; then
- head -3 "$rev_parse_err" | sed 's/^/ git: /' >&2
+ head -3 "$rev_parse_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  fi
  echo " 原因候補: worktree corrupt (.git file 破損) / permission denied / git binary 異常" >&2
  echo " 対処: git worktree remove '$worktree' && bash plugins/rite/hooks/scripts/wiki-worktree-setup.sh" >&2

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -52,6 +52,8 @@
 #     subsequent branch deletion attempts.
 
 set -euo pipefail
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 
 export GIT_TERMINAL_PROMPT=0
 
@@ -152,7 +154,7 @@ else
   wt_rc=$?
   echo "WARNING: git worktree list --porcelain が失敗しました (rc=$wt_rc)" >&2
   if [ -n "$wt_list_err" ] && [ -s "$wt_list_err" ]; then
-    head -3 "$wt_list_err" | sed 's/^/  /' >&2
+    head -3 "$wt_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   errors=$((errors + 1))
 fi
@@ -170,7 +172,7 @@ if [ "$DRY_RUN" = "0" ]; then
     prune_rc=$?
     echo "WARNING: git worktree prune が失敗しました (rc=$prune_rc)" >&2
     if [ -n "$prune_err" ] && [ -s "$prune_err" ]; then
-      head -3 "$prune_err" | sed 's/^/  /' >&2
+      head -3 "$prune_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     errors=$((errors + 1))
   fi
@@ -202,7 +204,7 @@ else
   ref_rc=$?
   echo "WARNING: git for-each-ref refs/heads/ が失敗しました (rc=$ref_rc)" >&2
   if [ -n "$ref_err" ] && [ -s "$ref_err" ]; then
-    head -3 "$ref_err" | sed 's/^/  /' >&2
+    head -3 "$ref_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   errors=$((errors + 1))
 fi
@@ -253,7 +255,7 @@ else
   workdir_find_rc=$?
   echo "WARNING: find による orphan workdir 走査が失敗しました (rc=$workdir_find_rc, base=$workdir_tmp_base)" >&2
   if [ -n "$workdir_find_err" ] && [ -s "$workdir_find_err" ]; then
-    head -3 "$workdir_find_err" | sed 's/^/  /' >&2
+    head -3 "$workdir_find_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   errors=$((errors + 1))
 fi

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -112,6 +112,8 @@ while [ "$REPO_ROOT" != "/" ] && [ ! -f "$REPO_ROOT/rite-config.yml" ] && [ ! -d
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$SCRIPT_DIR/../control-char-neutralize.sh"
 # SCRIPT_DIR is .../hooks/scripts; plugin root (plugins/rite) is its grandparent (../..)
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
@@ -154,7 +156,7 @@ repo_view_err=$(mktemp /tmp/rite-board-drift-repo-err-XXXXXX) || repo_view_err="
 if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
   echo "ERROR: gh repo view failed" >&2
   if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
-    head -5 "$repo_view_err" | sed 's/^/  /' >&2
+    head -5 "$repo_view_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   echo "  対処: gh auth status / network 接続を確認してください" >&2
   exit 2
@@ -207,8 +209,8 @@ query($owner: String!, $repo: String!, $first: Int!) {
       | "\($i.number)\t\($st)\t\($i.title)"
     ' 2>"${jq_err:-/dev/null}"); then
   echo "ERROR: gh api graphql or jq pipeline failed while scanning CLOSED Issues" >&2
-  if [ -n "$gql_err" ] && [ -s "$gql_err" ]; then head -5 "$gql_err" | sed 's/^/  gh: /' >&2; fi
-  if [ -n "$jq_err" ] && [ -s "$jq_err" ]; then head -5 "$jq_err" | sed 's/^/  jq: /' >&2; fi
+  if [ -n "$gql_err" ] && [ -s "$gql_err" ]; then head -5 "$gql_err" | neutralize_ctrl --keep-newline | sed 's/^/  gh: /' >&2; fi
+  if [ -n "$jq_err" ] && [ -s "$jq_err" ]; then head -5 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2; fi
   echo "  対処: gh auth status / network 接続 / repository 権限を確認してください" >&2
   exit 2
 fi

--- a/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
+++ b/plugins/rite/hooks/scripts/settings-local-rite-hook-cleanup.sh
@@ -23,6 +23,8 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$SCRIPT_DIR/../control-char-neutralize.sh"
 PYTHON_SCRIPT="$SCRIPT_DIR/settings-local-rite-hook-cleanup.py"
 
 settings="${1:-}"
@@ -54,7 +56,7 @@ if python3 "$PYTHON_SCRIPT" < "$settings" > "$tmp" 2>/dev/null; then
     mv_rc=$?
     echo "NO_RITE_HOOKS"
     echo "[rite] WARNING: settings-local-rite-hook-cleanup: mv failed (rc=$mv_rc); legacy rite hooks left in place" >&2
-    [ -n "$mv_err" ] && [ -s "$mv_err" ] && head -3 "$mv_err" | sed 's/^/  /' >&2
+    [ -n "$mv_err" ] && [ -s "$mv_err" ] && head -3 "$mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$mv_err" ] && rm -f "$mv_err"
 else

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -37,6 +37,8 @@
 #   (parsed by lint.md Phase 3.8 to populate `wiki_growth_finding_count`).
 #
 set -uo pipefail
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 
 # Signal-specific trap (canonical signal-specific trap pattern from references/bash-trap-patterns.md):
 # - EXIT preserves the original exit code via `rc=$?`
@@ -198,7 +200,7 @@ if [ -n "$git_log_target" ]; then
   else
     git_log_rc=$?
     echo "WARNING: git log on '$git_log_target' failed (rc=$git_log_rc) — wiki-growth-check skipped" >&2
-    [ -n "$git_log_err" ] && [ -s "$git_log_err" ] && head -3 "$git_log_err" | sed 's/^/  /' >&2
+    [ -n "$git_log_err" ] && [ -s "$git_log_err" ] && head -3 "$git_log_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  対処: repository の整合性 (.git permission / corrupt object) を確認してください" >&2
     [ -n "$git_log_err" ] && rm -f "$git_log_err"
     git_log_err=""
@@ -273,7 +275,7 @@ jq_rc=$?
 
 if [ -z "$merged_count" ] || ! [[ "$merged_count" =~ ^[0-9]+$ ]]; then
   echo "WARNING: gh pr list の JSON 解析に失敗しました (jq rc=$jq_rc) — wiki-growth-check skipped" >&2
-  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  jq: /' >&2
+  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2
   echo "  raw stdout (先頭 200 文字): $(printf '%s' "$gh_json_out" | head -c 200)" >&2
   [ -n "$jq_err" ] && rm -f "$jq_err"
   echo "==> Total wiki-growth-check findings: 0"
@@ -330,7 +332,7 @@ check_pr_raw_correspondence() {
     --json number \
     --limit "$threshold" 2>"${gh_pr_err:-/dev/null}") || {
     echo "WARNING: wiki-growth-check: pr-raw-correspondence: gh pr list failed, skipping" >&2
-    [ -n "$gh_pr_err" ] && [ -s "$gh_pr_err" ] && head -3 "$gh_pr_err" | sed 's/^/  /' >&2
+    [ -n "$gh_pr_err" ] && [ -s "$gh_pr_err" ] && head -3 "$gh_pr_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     [ -n "$gh_pr_err" ] && rm -f "$gh_pr_err"
     return 0
   }
@@ -340,7 +342,7 @@ check_pr_raw_correspondence() {
   jq_pr_err=$(mktemp /tmp/rite-wiki-growth-jq-err-XXXXXX 2>/dev/null) || jq_pr_err=""
   recent_pr_numbers=$(printf '%s' "$recent_prs_json" | jq -r '.[].number' 2>"${jq_pr_err:-/dev/null}") || {
     echo "WARNING: wiki-growth-check: pr-raw-correspondence: jq parse failed, skipping" >&2
-    [ -n "$jq_pr_err" ] && [ -s "$jq_pr_err" ] && head -3 "$jq_pr_err" | sed 's/^/  /' >&2
+    [ -n "$jq_pr_err" ] && [ -s "$jq_pr_err" ] && head -3 "$jq_pr_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     [ -n "$jq_pr_err" ] && rm -f "$jq_pr_err"
     return 0
   }

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -255,7 +255,7 @@ if gh_json_out=$(gh pr list \
 else
   gh_rc=$?
   echo "WARNING: gh pr list failed (rc=$gh_rc) — wiki-growth-check skipped" >&2
-  [ -n "$gh_pr_list_err" ] && [ -s "$gh_pr_list_err" ] && head -5 "$gh_pr_list_err" | sed 's/^/  /' >&2
+  [ -n "$gh_pr_list_err" ] && [ -s "$gh_pr_list_err" ] && head -5 "$gh_pr_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  対処: gh auth status (auth error) / network 接続 / rate limit を確認してください" >&2
   [ -n "$gh_pr_list_err" ] && rm -f "$gh_pr_list_err"
   gh_pr_list_err=""

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -115,6 +115,8 @@ fi
 # for rationale — `$(dirname "$0")` after `cd` breaks under relative
 # invocation paths.
 _SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$_SCRIPT_DIR/../control-char-neutralize.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -237,7 +239,7 @@ if [[ -d ".rite/wiki/raw" ]]; then
  ' "$f" 2>"${fm_err:-/dev/null}" || true)
  if [[ -n "$fm_err" ]] && [[ -s "$fm_err" ]]; then
  echo "WARNING: frontmatter parse produced stderr for '$f' — treating as pending" >&2
- head -n 3 "$fm_err" | sed 's/^/ awk: /' >&2
+ head -n 3 "$fm_err" | neutralize_ctrl --keep-newline | sed 's/^/ awk: /' >&2
  : > "$fm_err" 2>/dev/null || true
  fi
  ingested_norm=$(printf '%s' "$ingested_val" | tr -d '"'"'" | tr '[:upper:]' '[:lower:]')
@@ -279,7 +281,7 @@ if [[ "$branch_strategy" == "same_branch" ]]; then
  _sb_dump() {
   local label="$1"
   if [ -n "$_sb_git_err" ] && [ -s "$_sb_git_err" ]; then
-   head -n 10 "$_sb_git_err" | sed 's/^/  git ('"$label"'): /' >&2
+   head -n 10 "$_sb_git_err" | neutralize_ctrl --keep-newline | sed 's/^/  git ('"$label"'): /' >&2
    : > "$_sb_git_err" 2>/dev/null || true
   fi
  }
@@ -674,7 +676,7 @@ fi
 dump_git_err() {
  local label="$1"
  if [[ -n "$git_err" ]] && [[ -s "$git_err" ]]; then
- head -n 10 "$git_err" | sed 's/^/ git ('"$label"'): /' >&2
+ head -n 10 "$git_err" | neutralize_ctrl --keep-newline | sed 's/^/ git ('"$label"'): /' >&2
  : > "$git_err" 2>/dev/null || true
  fi
 }

--- a/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
@@ -45,6 +45,8 @@
 # likewise omitted to preserve verbatim behavior; all variable refs are
 # `${var:-}`-guarded.
 
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 branch_strategy=""
 wiki_branch=""
 REPO_ROOT=""
@@ -186,7 +188,7 @@ case "$branch_strategy" in
     if log_content=$(LC_ALL=C git show "${wiki_branch}:.rite/wiki/log.md" 2>"${log_err:-/dev/null}"); then
       log_read_ok="true"
       # selective surface pattern: 成功時でも ambiguous ref hint 等の git stderr を surface する
-      [ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | sed 's/^/  WARNING(git hint): /' >&2
+      [ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | neutralize_ctrl --keep-newline | sed 's/^/  WARNING(git hint): /' >&2
     else
       rc=$?
       # legitimate absence 判別 (4 pattern を OR):
@@ -202,7 +204,7 @@ case "$branch_strategy" in
       elif [ -n "$log_err" ] && [ -s "$log_err" ]; then
         log_read_ok="io_error"
         echo "WARNING: .rite/wiki/log.md の git show に失敗しました (rc=$rc)" >&2
-        head -3 "$log_err" | sed 's/^/  /' >&2
+        head -3 "$log_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         _rite_log_read_impact_advice
         echo "  対処: wiki branch の integrity / 権限を確認してください" >&2
       else
@@ -215,7 +217,7 @@ case "$branch_strategy" in
   same_branch)
     if log_content=$(LC_ALL=C cat .rite/wiki/log.md 2>"${log_err:-/dev/null}"); then
       log_read_ok="true"
-      [ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | sed 's/^/  WARNING(cat hint): /' >&2
+      [ -n "$log_err" ] && [ -s "$log_err" ] && head -3 "$log_err" | neutralize_ctrl --keep-newline | sed 's/^/  WARNING(cat hint): /' >&2
     else
       rc=$?
       if [ -n "$log_err" ] && [ -s "$log_err" ] && grep -qE "No such file or directory|cannot open" "$log_err"; then
@@ -223,7 +225,7 @@ case "$branch_strategy" in
       elif [ -n "$log_err" ] && [ -s "$log_err" ]; then
         log_read_ok="io_error"
         echo "WARNING: .rite/wiki/log.md の cat に失敗しました (rc=$rc)" >&2
-        head -3 "$log_err" | sed 's/^/  /' >&2
+        head -3 "$log_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         _rite_log_read_impact_advice
         echo "  対処: .rite/wiki/log.md の存在 / 権限を確認してください" >&2
       else
@@ -259,7 +261,7 @@ if [ -n "$log_content" ]; then
   rc=$?
   if [ "$rc" -ne 0 ]; then
     echo "WARNING: ステップ 6.0 の awk/sort pipeline が失敗しました (rc=$rc)" >&2
-    [ -n "$awk_sort_err" ] && [ -s "$awk_sort_err" ] && head -3 "$awk_sort_err" | sed 's/^/  /' >&2
+    [ -n "$awk_sort_err" ] && [ -s "$awk_sort_err" ] && head -3 "$awk_sort_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  対処: awk / sort バイナリと /tmp の容量を確認してください" >&2
     _rite_log_read_impact_advice
     skipped_refs=""

--- a/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
@@ -45,6 +45,8 @@
 # the sort/awk pipelines exactly as the inline block did. `set -u` is likewise
 # omitted to preserve verbatim behavior; all variable refs are `${var:-}`-guarded.
 
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 branch_strategy=""
 wiki_branch=""
 REPO_ROOT=""
@@ -287,7 +289,7 @@ while IFS= read -r page; do
       # 真の IO error: all_source_refs_read_errors を increment (後段で io_error に畳み込み)
       all_source_refs_read_errors=$((all_source_refs_read_errors + 1))
       echo "WARNING: $page の sources[].ref 抽出に失敗 (rc=$page_read_cmd_rc, branch_strategy=$branch_strategy)" >&2
-      [ -n "$page_err" ] && [ -s "$page_err" ] && head -3 "$page_err" | sed 's/^/  /' >&2
+      [ -n "$page_err" ] && [ -s "$page_err" ] && head -3 "$page_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
   fi
   [ -n "$page_err" ] && rm -f "$page_err"
@@ -326,7 +328,7 @@ if [ -n "$all_source_refs" ]; then
   sort_rc=$?
   if [ "$sort_rc" -ne 0 ]; then
     echo "WARNING: ステップ 6.2 の all_source_refs 正規化 pipeline が失敗しました (rc=$sort_rc)" >&2
-    [ -n "$sort_err" ] && [ -s "$sort_err" ] && head -3 "$sort_err" | sed 's/^/  /' >&2
+    [ -n "$sort_err" ] && [ -s "$sort_err" ] && head -3 "$sort_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  対処: sort バイナリ / /tmp の容量 / 権限を確認してください" >&2
     echo "  影響: all_source_refs が部分出力で populate されると真の欠落判定が false positive になるため io_error に降格します" >&2
     all_source_refs_read_ok="io_error"

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -108,6 +108,8 @@ fi
 # for rationale — `$(dirname "$0")` after `cd` breaks under relative
 # invocation paths.
 _SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$_SCRIPT_DIR/../control-char-neutralize.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -227,7 +229,7 @@ set -e
 if [ "$lsf_rc" -ne 0 ]; then
  echo "ERROR: git -C '$worktree_path' ls-files --others が失敗しました (rc=$lsf_rc)" >&2
  if [ -n "$lsf_err" ] && [ -s "$lsf_err" ]; then
- head -3 "$lsf_err" | sed 's/^/ git: /' >&2
+ head -3 "$lsf_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  fi
  echo " 原因候補: broken worktree (.git file 破損) / permission denied / git binary 異常" >&2
  echo " 影響: untracked file 検出が skip されると pending change を誤って 'なし' と判定する経路があるため fail-fast" >&2

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -241,7 +241,7 @@ fi
 if ! git worktree add --quiet "$target_path" "$wiki_branch" 2>"${add_err:-/dev/null}"; then
   echo "ERROR: git worktree add '$target_path' '$wiki_branch' failed" >&2
   if [[ -n "$add_err" ]] && [[ -s "$add_err" ]]; then
-    head -n 10 "$add_err" | sed 's/^/  git: /' >&2
+    head -n 10 "$add_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
   fi
   echo "  hint: ensure the wiki branch is not already checked out elsewhere (git worktree list)" >&2
   exit 3

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -65,6 +65,8 @@ fi
 # symlinks to the script's physical location — both are supersets of
 # the sibling convention rather than drifts away from it.
 _SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$_SCRIPT_DIR/../control-char-neutralize.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -183,7 +185,7 @@ else
   wt_list_rc=$?
   echo "WARNING: git worktree list --porcelain が失敗しました (rc=$wt_list_rc)" >&2
   if [ -n "$wt_list_err" ] && [ -s "$wt_list_err" ]; then
-    head -3 "$wt_list_err" | sed 's/^/  git: /' >&2
+    head -3 "$wt_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
   fi
   echo "  原因候補: corrupt .git/worktrees/ / permission denied / git binary 異常" >&2
   echo "  影響: idempotency check が空結果として進み、後段の git worktree add で初めて顕在化する可能性" >&2
@@ -196,7 +198,7 @@ if [[ "$existing_prunable" == "true" ]]; then
   if ! git worktree prune 2>"${wt_list_err:-/dev/null}"; then
     echo "ERROR: git worktree prune に失敗しました" >&2
     if [ -n "$wt_list_err" ] && [ -s "$wt_list_err" ]; then
-      head -3 "$wt_list_err" | sed 's/^/  git: /' >&2
+      head -3 "$wt_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
     fi
     echo "  手動回復: git worktree prune を直接実行してから本 script を再実行してください" >&2
     exit 3

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -11,6 +11,8 @@ export _RITE_HOOK_RUNNING_SESSIONEND=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 # session-ownership.sh provides the ownership guard consumed below. Sourcing is
 # fail-open (2>/dev/null || true) so a missing or unparsable helper cannot block
 # session-end's main job: persisting / deactivating the flow state.
@@ -80,7 +82,7 @@ _br_rc=0
 BRANCH=$(cd "$CWD" && git branch --show-current 2>"${_br_err:-/dev/null}") || _br_rc=$?
 if [ "$_br_rc" -ne 0 ]; then
   echo "[rite] WARNING: session-end: git branch --show-current 失敗 (rc=$_br_rc — corrupt .git / permission denied / git unavailable の可能性)" >&2
-  [ -n "$_br_err" ] && [ -s "$_br_err" ] && head -3 "$_br_err" | sed 's/^/  /' >&2
+  [ -n "$_br_err" ] && [ -s "$_br_err" ] && head -3 "$_br_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   BRANCH=""
 fi
 [ -n "$_br_err" ] && rm -f "$_br_err"
@@ -122,14 +124,14 @@ if [ -f "$STATE_FILE" ]; then
     _state_phase=$(jq -r '.phase // empty' "$STATE_FILE" 2>"${_lifecycle_phase_err:-/dev/null}") || _state_phase=""
     if [ -n "$_lifecycle_phase_err" ] && [ -s "$_lifecycle_phase_err" ]; then
         echo "rite: session-end: WARNING: jq parse of .phase failed (STATE_FILE may be corrupt) — lifecycle WARN suppressed" >&2
-        head -3 "$_lifecycle_phase_err" | sed 's/^/  /' >&2
+        head -3 "$_lifecycle_phase_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_lifecycle_phase_err" ] && rm -f "$_lifecycle_phase_err"
     _lifecycle_active_err=$(mktemp 2>/dev/null) || _lifecycle_active_err=""
     _state_active=$(jq -r '.active // false' "$STATE_FILE" 2>"${_lifecycle_active_err:-/dev/null}") || _state_active="false"
     if [ -n "$_lifecycle_active_err" ] && [ -s "$_lifecycle_active_err" ]; then
         echo "rite: session-end: WARNING: jq parse of .active failed (STATE_FILE may be corrupt)" >&2
-        head -3 "$_lifecycle_active_err" | sed 's/^/  /' >&2
+        head -3 "$_lifecycle_active_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_lifecycle_active_err" ] && rm -f "$_lifecycle_active_err"
     _lifecycle_unfinished_kind=""
@@ -197,7 +199,7 @@ WARN_MSG
             _log_flow_diag "session_end_mv_failed rc=$_mv_rc state=$STATE_FILE"
           fi
           echo "rite: session-end: mv deactivation state failed (rc=$_mv_rc)" >&2
-          [ -n "$_deact_mv_err" ] && [ -s "$_deact_mv_err" ] && head -3 "$_deact_mv_err" | sed 's/^/  /' >&2
+          [ -n "$_deact_mv_err" ] && [ -s "$_deact_mv_err" ] && head -3 "$_deact_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         fi
         [ -n "$_deact_mv_err" ] && rm -f "$_deact_mv_err"
     else
@@ -208,7 +210,7 @@ WARN_MSG
         # state_file path を WARNING に含めることで、Issue 番号が解決できない経路 (detached HEAD /
         # non-issue branch / git 未初期化) でも debug 情報を残せる。
         echo "rite: session-end: WARNING: failed to deactivate state file (jq rc=$_deact_jq_rc): $STATE_FILE${ISSUE_NUMBER:+ (Issue #$ISSUE_NUMBER)}" >&2
-        [ -n "$_deact_jq_err" ] && [ -s "$_deact_jq_err" ] && head -3 "$_deact_jq_err" | sed 's/^/  /' >&2
+        [ -n "$_deact_jq_err" ] && [ -s "$_deact_jq_err" ] && head -3 "$_deact_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         rm -f "$TMP_FILE"
     fi
     [ -n "$_deact_jq_err" ] && rm -f "$_deact_jq_err"

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -35,6 +35,8 @@
 #   under RITE_DEBUG would let a corrupt hook payload silently grant ownership.
 #   The stderr snippet stays behind RITE_DEBUG to keep the WARNING one line on
 #   the hot path.
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 extract_session_id() {
   local hook_json="$1"
   local sid jq_err
@@ -47,7 +49,7 @@ extract_session_id() {
   else
     local _jq_rc=$?
     echo "[rite] WARNING: extract_session_id: jq parse failed on hook payload (rc=$_jq_rc, returning empty — ownership check falls back to backward-compat path)" >&2
-    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     sid=""
   fi
   [ -n "$jq_err" ] && rm -f "$jq_err"
@@ -74,7 +76,7 @@ get_state_session_id() {
   else
     local _jq_rc=$?
     echo "[rite] WARNING: get_state_session_id: jq parse failed on $state_file (rc=$_jq_rc, returning empty — may classify a corrupt state file as legacy)" >&2
-    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     sid=""
   fi
   [ -n "$jq_err" ] && rm -f "$jq_err"
@@ -184,7 +186,7 @@ check_session_ownership() {
   else
     local _jq_rc=$?
     echo "[rite] WARNING: check_session_ownership: jq parse failed on $state_file (rc=$_jq_rc, treating as stale — may overwrite another active session)" >&2
-    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+    [ -n "${RITE_DEBUG:-}" ] && [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     updated_at=""
   fi
   [ -n "$jq_err" ] && rm -f "$jq_err"

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -26,6 +26,9 @@
 # to short-circuit ownership checks (e.g., when reading a path that has just
 # been resolved by `_resolve-flow-state-path.sh`).
 
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
+
 # Extract session_id from hook JSON payload
 # Args: $1 = hook JSON string (from stdin of the hook)
 # Output: session_id string, or empty string if not found
@@ -35,8 +38,6 @@
 #   under RITE_DEBUG would let a corrupt hook payload silently grant ownership.
 #   The stderr snippet stays behind RITE_DEBUG to keep the WARNING one line on
 #   the hot path.
-# shellcheck source=control-char-neutralize.sh
-source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 extract_session_id() {
   local hook_json="$1"
   local sid jq_err

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -17,6 +17,8 @@ fi
 
 # Source session ownership helper for session_id extraction and ownership checks
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -91,7 +93,7 @@ _rite_read_yaml_key() {
   _val=$(set -o pipefail; awk -v k="${_key}:" 'index($0, k) == 1 {print $2}' "$_file" 2>"${_err:-/dev/null}" | tr -d '[:space:]"') || _rc=$?
   if [ "$_rc" -ne 0 ]; then
     echo "[rite] WARNING: session-start: ${_label} 読み取り失敗 (rc=$_rc) — ${_file}" >&2
-    [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | sed 's/^/  /' >&2
+    [ -n "$_err" ] && [ -s "$_err" ] && head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$_err" ] && rm -f "$_err"
   printf '%s' "$_val"
@@ -207,7 +209,7 @@ if [ "$SOURCE" = "startup" ]; then
             _mv_rc=$?
             rm -f "$_repair_tmp" 2>/dev/null
             echo "rite: session-start: mv settings.local.json repair failed (rc=$_mv_rc)" >&2
-            [ -n "$_settings_mv_err" ] && [ -s "$_settings_mv_err" ] && head -3 "$_settings_mv_err" | sed 's/^/  /' >&2
+            [ -n "$_settings_mv_err" ] && [ -s "$_settings_mv_err" ] && head -3 "$_settings_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
           fi
           [ -n "$_settings_mv_err" ] && rm -f "$_settings_mv_err"
         else
@@ -221,7 +223,7 @@ if [ "$SOURCE" = "startup" ]; then
               # Non-empty stderr means python3 itself failed (missing/unreadable cleanup
               # script, import error) — surface its diagnostic but NOT the JSON hint, which
               # would misdirect: the fault is not the settings.local.json content (Issue #1241).
-              head -3 "$_py_err" | sed 's/^/  /' >&2
+              head -3 "$_py_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
             elif [ "$_py_rc" -eq 2 ]; then
               # The cleanup script ran, returned 2, and wrote nothing to stderr → invalid
               # JSON (its only rc=2 path). This is the one case where the JSON hint is correct.
@@ -324,7 +326,7 @@ if [ -n "$_active_err" ] && [ -s "$_active_err" ]; then
   # silent fallback to "inactive" だと corrupt JSON が見えず post-compact recovery が消失する
   # 経路を operator が triage できない。stderr を expose する。
   echo "rite: session-start: WARNING: jq parse of .active failed (STATE_FILE may be corrupt)" >&2
-  head -3 "$_active_err" | sed 's/^/  /' >&2
+  head -3 "$_active_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
 fi
 [ -n "$_active_err" ] && rm -f "$_active_err"
 if [ "$ACTIVE" != "true" ]; then
@@ -361,7 +363,7 @@ _reset_active_state() {
     "$STATE_FILE" 2>"${_reset_jq_err:-/dev/null}") || _composite=$'\t\t'
   if [ -n "$_reset_jq_err" ] && [ -s "$_reset_jq_err" ]; then
     echo "rite: session-start: WARNING: _reset_active_state jq read failed (STATE_FILE may be corrupt)" >&2
-    head -3 "$_reset_jq_err" | sed 's/^/  /' >&2
+    head -3 "$_reset_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$_reset_jq_err" ] && rm -f "$_reset_jq_err"
   IFS=$'\t' read -r _phase _issue _branch <<< "$_composite"
@@ -399,13 +401,13 @@ _reset_active_state() {
       _mv_rc=$?
       rm -f "$_tmp" 2>/dev/null
       echo "rite: session-start: mv defensive reset failed (rc=$_mv_rc)" >&2
-      [ -n "$_reset_mv_err" ] && [ -s "$_reset_mv_err" ] && head -3 "$_reset_mv_err" | sed 's/^/  /' >&2
+      [ -n "$_reset_mv_err" ] && [ -s "$_reset_mv_err" ] && head -3 "$_reset_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     [ -n "$_reset_mv_err" ] && rm -f "$_reset_mv_err"
   else
     _reset_jq_rc=$?
     echo "rite: session-start: jq defensive reset failed (rc=$_reset_jq_rc; STATE_FILE may be corrupt)" >&2
-    [ -n "$_reset_jq_err" ] && [ -s "$_reset_jq_err" ] && head -3 "$_reset_jq_err" | sed 's/^/  /' >&2
+    [ -n "$_reset_jq_err" ] && [ -s "$_reset_jq_err" ] && head -3 "$_reset_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     rm -f "$_tmp" 2>/dev/null
   fi
   [ -n "$_reset_jq_err" ] && rm -f "$_reset_jq_err"
@@ -461,7 +463,7 @@ _tsv_output=$(jq -r '[
 ] | join("\u001f")' "$STATE_FILE" 2>"${_tsv_err:-/dev/null}") || _tsv_rc=$?
 if [ "$_tsv_rc" -ne 0 ]; then
   echo "rite: Warning - state file contains invalid JSON. Use /rite:resume to recover." >&2
-  [ -n "$_tsv_err" ] && [ -s "$_tsv_err" ] && head -3 "$_tsv_err" | sed 's/^/  /' >&2
+  [ -n "$_tsv_err" ] && [ -s "$_tsv_err" ] && head -3 "$_tsv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   [ -n "$_tsv_err" ] && rm -f "$_tsv_err"
   exit 0
 fi

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Tests for Issue #1183: jq / コマンド stderr 診断スニペット emission site の
+# control-char 中和の横展開 parity を静的に pin する。
+#
+# Purpose:
+#   flow-state.sh (#1173/#1181) で導入された「診断スニペットは
+#   neutralize_ctrl を経由して emit する」規約を、hooks/ 配下の全
+#   `head -3` emission site に対称適用したことを保証する
+#   (Wiki 経験則 Asymmetric Fix Transcription — 対称位置への伝播漏れ防止)。
+#   将来 hook に新しい `head -3 ... >&2` 診断 site が中和なしで追加された
+#   場合も TC-1 が検出する。
+#
+# Test cases:
+#   TC-1: hooks/ 配下 (tests/ 除く) に neutralize_ctrl を経由しない
+#         `head -3` emission site が存在しない (コメント行は除外)
+#   TC-2: neutralize_ctrl を call する全 hook ファイルが
+#         control-char-neutralize.sh を source している
+#         (定義元 control-char-neutralize.sh 自身は除外)
+#
+# Usage: bash plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+HOOKS_DIR="$PLUGIN_ROOT/hooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+  echo "ERROR: $HOOKS_DIR not found" >&2
+  exit 1
+fi
+
+echo "=== TC-1: head -3 emission site は全て neutralize_ctrl を経由 ==="
+# 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
+violations=$(grep -rn 'head -3' "$HOOKS_DIR" --include='*.sh' \
+  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v 'neutralize_ctrl' \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+  || true)
+assert "TC-1: un-neutralized head -3 emission sites" "" "$violations"
+if [ -n "$violations" ]; then
+  echo "  検出された未中和 site (head -3 の直後に '| neutralize_ctrl --keep-newline' を挿入すること):"
+  printf '%s\n' "$violations" | sed 's/^/    /'
+fi
+
+echo ""
+echo "=== TC-2: neutralize_ctrl の caller は helper を source 済み ==="
+# `neutralize_ctrl` を実行コードとして含むファイル一覧 (コメント行のみの言及は除外)
+caller_files=$(grep -rl 'neutralize_ctrl' "$HOOKS_DIR" --include='*.sh' \
+  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v '/control-char-neutralize.sh$' \
+  || true)
+checked=0
+for f in $caller_files; do
+  # コメント行を除いた実 call site があるファイルのみ検査
+  if ! grep -vE '^[[:space:]]*#' "$f" | grep -q 'neutralize_ctrl\|contains_ctrl'; then
+    continue
+  fi
+  checked=$((checked + 1))
+  # source 行は `source "$SCRIPT_DIR/..."` と `source "$(dirname "${BASH_SOURCE[0]}")/..."`
+  # の両形式 (path 内に入れ子クォートあり) を許容する
+  assert_grep "TC-2: $(basename "$f") sources control-char-neutralize.sh" \
+    "$f" 'source ".*control-char-neutralize\.sh"'
+done
+# sweep 自体が空回りしていないことを pin (rollout 対象は 24 ファイル以上)
+if [ "$checked" -ge 24 ]; then
+  pass "TC-2: sweep coverage ($checked caller files checked)"
+else
+  fail "TC-2: sweep coverage too small ($checked files — rollout 対象が grep から漏れている可能性)"
+fi
+
+if ! print_summary "$(basename "$0")" \
+  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、head -3 の直後に '| neutralize_ctrl --keep-newline' を挿入すること (Issue #1183)"; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -7,12 +7,15 @@
 #   neutralize_ctrl を経由して emit する」規約を、hooks/ 配下の全
 #   `head -3` emission site に対称適用したことを保証する
 #   (Wiki 経験則 Asymmetric Fix Transcription — 対称位置への伝播漏れ防止)。
-#   将来 hook に新しい `head -3 ... >&2` 診断 site が中和なしで追加された
+#   sweep は `head -3` 限定ではなく `head -N` (任意行数) を対象とする —
+#   PR #1328 cycle 1 で head -5 変種の兄弟イディオムが同一ファイル内に
+#   未中和で残存し literal `head -3` sweep では検出できないことが実証された。
+#   将来 hook に新しい `head -N ... >&2` 診断 site が中和なしで追加された
 #   場合も TC-1 が検出する。
 #
 # Test cases:
 #   TC-1: hooks/ 配下 (tests/ 除く) に neutralize_ctrl を経由しない
-#         `head -3` emission site が存在しない (コメント行は除外)
+#         `head -N` 行指向 emission site が存在しない (コメント行は除外)
 #   TC-2: neutralize_ctrl を call する全 hook ファイルが
 #         control-char-neutralize.sh を source している
 #         (定義元 control-char-neutralize.sh 自身は除外)
@@ -30,16 +33,19 @@ if [ ! -d "$HOOKS_DIR" ]; then
   exit 1
 fi
 
-echo "=== TC-1: head -3 emission site は全て neutralize_ctrl を経由 ==="
+echo "=== TC-1: head -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
-violations=$(grep -rn 'head -3' "$HOOKS_DIR" --include='*.sh' \
+# `head -[0-9]+` (行指向 snippet) を対象とする。`head -c` (byte 指向 inline 埋め込み) は
+# 1 行 WARNING への embed で別イディオム (default モード中和や iconv sanitize を併用) のため対象外
+violations=$(grep -rnE 'head -[0-9]+ ' "$HOOKS_DIR" --include='*.sh' \
+  | grep '>&2' \
   | grep -v "$HOOKS_DIR/tests/" \
   | grep -v 'neutralize_ctrl' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   || true)
-assert "TC-1: un-neutralized head -3 emission sites" "" "$violations"
+assert "TC-1: un-neutralized head -N emission sites" "" "$violations"
 if [ -n "$violations" ]; then
-  echo "  検出された未中和 site (head -3 の直後に '| neutralize_ctrl --keep-newline' を挿入すること):"
+  echo "  検出された未中和 site (head -N の直後に '| neutralize_ctrl --keep-newline' を挿入すること):"
   printf '%s\n' "$violations" | sed 's/^/    /'
 fi
 

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -7,10 +7,11 @@
 #   neutralize_ctrl を経由して emit する」規約を、hooks/ 配下の全
 #   `head -3` emission site に対称適用したことを保証する
 #   (Wiki 経験則 Asymmetric Fix Transcription — 対称位置への伝播漏れ防止)。
-#   sweep は `head -3` 限定ではなく `head -N` (任意行数) を対象とする —
-#   PR #1328 cycle 1 で head -5 変種の兄弟イディオムが同一ファイル内に
-#   未中和で残存し literal `head -3` sweep では検出できないことが実証された。
-#   将来 hook に新しい `head -N ... >&2` 診断 site が中和なしで追加された
+#   sweep は `head -3` 限定ではなく `head -N` / `head -n N` (任意行数・両綴り)
+#   を対象とする — literal パターン限定の sweep は数値違い (head -5) や
+#   綴り違い (head -n 10) の同型イディオムを構造的に見逃すことが
+#   実証されている (Asymmetric Fix Transcription の変種)。
+#   将来 hook に新しい行指向 head 診断 site が中和なしで追加された
 #   場合も TC-1 が検出する。
 #
 # Test cases:
@@ -35,11 +36,13 @@ fi
 
 echo "=== TC-1: head -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
-# `head -[0-9]+` (行指向 snippet) を対象とする。`head -c` (byte 指向 inline 埋め込み) は
-# 1 行 WARNING への embed で行構造が異なる別イディオムのため本 sweep の対象外。
-# 注意: head -c site は現状中和未適用 (Issue #1183 の対象は行指向 head -N snippet のみ)。
-# 横展開する場合は別 Issue で扱う
-violations=$(grep -rnE 'head -[0-9]+ ' "$HOOKS_DIR" --include='*.sh' \
+# `head -[0-9]+` / `head -n [0-9]+` (行指向 snippet、両綴り) を対象とする。
+# `head -c` (byte 指向 inline 埋め込み) は 1 行 WARNING への embed で行構造が異なる
+# 別イディオムのため本 sweep の対象外。
+# 注意: head -c site は現状中和未適用 (Issue #1183 の対象は行指向 head snippet のみ)。
+# 横展開する場合は別 Issue で扱う。同様に、`>&2` が log() 等の関数内部に隠れて
+# 同一行に現れない emission 経路も本 sweep の検出対象外 (別 Issue の横展開対象候補)
+violations=$(grep -rnE 'head (-[0-9]+|-n +[0-9]+) ' "$HOOKS_DIR" --include='*.sh' \
   | grep '>&2' \
   | grep -v "$HOOKS_DIR/tests/" \
   | grep -v 'neutralize_ctrl' \
@@ -61,8 +64,8 @@ caller_files=$(grep -rlE 'neutralize_ctrl|contains_ctrl' "$HOOKS_DIR" --include=
   || true)
 checked=0
 for f in $caller_files; do
-  # コメント行を除いた実 call site があるファイルのみ検査
-  if ! grep -vE '^[[:space:]]*#' "$f" | grep -q 'neutralize_ctrl\|contains_ctrl'; then
+  # コメント行を除いた実 call site があるファイルのみ検査 (収集側 grep -rlE と書式統一)
+  if ! grep -vE '^[[:space:]]*#' "$f" | grep -qE 'neutralize_ctrl|contains_ctrl'; then
     continue
   fi
   checked=$((checked + 1))

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -36,7 +36,9 @@ fi
 echo "=== TC-1: head -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
 # `head -[0-9]+` (行指向 snippet) を対象とする。`head -c` (byte 指向 inline 埋め込み) は
-# 1 行 WARNING への embed で別イディオム (default モード中和や iconv sanitize を併用) のため対象外
+# 1 行 WARNING への embed で行構造が異なる別イディオムのため本 sweep の対象外。
+# 注意: head -c site は現状中和未適用 (Issue #1183 の対象は行指向 head -N snippet のみ)。
+# 横展開する場合は別 Issue で扱う
 violations=$(grep -rnE 'head -[0-9]+ ' "$HOOKS_DIR" --include='*.sh' \
   | grep '>&2' \
   | grep -v "$HOOKS_DIR/tests/" \
@@ -51,8 +53,9 @@ fi
 
 echo ""
 echo "=== TC-2: neutralize_ctrl の caller は helper を source 済み ==="
-# `neutralize_ctrl` を実行コードとして含むファイル一覧 (コメント行のみの言及は除外)
-caller_files=$(grep -rl 'neutralize_ctrl' "$HOOKS_DIR" --include='*.sh' \
+# `neutralize_ctrl` / `contains_ctrl` を実行コードとして含むファイル一覧 (コメント行のみの言及は除外)
+# 収集側も両関数対応にする — contains_ctrl のみを使う hook が将来追加された場合の検査漏れ防止
+caller_files=$(grep -rlE 'neutralize_ctrl|contains_ctrl' "$HOOKS_DIR" --include='*.sh' \
   | grep -v "$HOOKS_DIR/tests/" \
   | grep -v '/control-char-neutralize.sh$' \
   || true)
@@ -76,6 +79,6 @@ else
 fi
 
 if ! print_summary "$(basename "$0")" \
-  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、head -3 の直後に '| neutralize_ctrl --keep-newline' を挿入すること (Issue #1183)"; then
+  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、head -N の直後に '| neutralize_ctrl --keep-newline' を挿入すること (Issue #1183)"; then
   exit 1
 fi

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -252,7 +252,7 @@ if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   else
     _sed_rc=$?
     echo "ERROR: sed による rite-config.yml wiki セクション抽出が失敗 (rc=$_sed_rc)" >&2
-    [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | sed 's/^/  /' >&2
+    [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  safe-default: config parse 失敗のため staging を中止します (silent policy-violation 防止)" >&2
     [ -n "$_yaml_err" ] && rm -f "$_yaml_err"
     exit 2
@@ -267,7 +267,7 @@ if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
     else
       _awk_rc=$?
       echo "ERROR: awk による wiki.enabled 行抽出が失敗 (rc=$_awk_rc)" >&2
-      [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | sed 's/^/  /' >&2
+      [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       echo "  safe-default: awk parse 失敗のため staging を中止します (silent policy-violation 防止)" >&2
       [ -n "$_yaml_err" ] && rm -f "$_yaml_err"
       exit 2

--- a/plugins/rite/hooks/wiki-query-inject.sh
+++ b/plugins/rite/hooks/wiki-query-inject.sh
@@ -44,6 +44,8 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Resolve project root (git root anchored). Matches session-start.sh /
 # _resolve-schema-version.sh / notification.sh convention. `$PWD`-based
@@ -174,7 +176,7 @@ if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   else
     _sed_rc=$?
     echo "WARNING: failed to read wiki section from rite-config.yml (sed rc=$_sed_rc)" >&2
-    [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | sed 's/^/  /' >&2
+    [ -n "$_yaml_err" ] && [ -s "$_yaml_err" ] && head -3 "$_yaml_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  lenient fallback: treating wiki as disabled and exiting silently" >&2
     exit 0
   fi
@@ -230,7 +232,7 @@ else
   _awk_rc=$?
   if [ "$_awk_rc" -ne 1 ]; then
     echo "WARNING: awk failed unexpectedly while detecting wiki.enabled line (rc=$_awk_rc)" >&2
-    [ -n "$_awk_err" ] && [ -s "$_awk_err" ] && head -3 "$_awk_err" | sed 's/^/  /' >&2
+    [ -n "$_awk_err" ] && [ -s "$_awk_err" ] && head -3 "$_awk_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "  lenient fallback: treating wiki.enabled as absent" >&2
   fi
   # rc == 1 is the intentional "not found" path — no warning.
@@ -297,7 +299,7 @@ if [[ "$branch_strategy" == "separate_branch" ]]; then
   else
     _index_rc=$?
     echo "WARNING: cannot read index.md from ref '$ref' (git show rc=$_index_rc)" >&2
-    [ -n "$_index_err" ] && [ -s "$_index_err" ] && head -3 "$_index_err" | sed 's/^/  /' >&2
+    [ -n "$_index_err" ] && [ -s "$_index_err" ] && head -3 "$_index_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     exit 0
   fi
 else
@@ -474,7 +476,7 @@ while IFS=$'\x1f' read -r score title path domain summary updated confidence; do
       else
         _git_show_rc=$?
         echo "WARNING: cannot read ${path} from ref '${ref}' — index.md may be stale (git show rc=${_git_show_rc})" >&2
-        [ -n "$_git_show_err" ] && [ -s "$_git_show_err" ] && head -3 "$_git_show_err" | sed 's/^/  /' >&2
+        [ -n "$_git_show_err" ] && [ -s "$_git_show_err" ] && head -3 "$_git_show_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         page_body=""
       fi
     else

--- a/plugins/rite/hooks/work-memory-lock.sh
+++ b/plugins/rite/hooks/work-memory-lock.sh
@@ -12,9 +12,10 @@
 #   0: Lock acquired
 #   1: Lock acquisition failed (timeout or stale removal failed)
 
-# Stale lock threshold in seconds (default: 120s for compact, 300s for issue)
 # shellcheck source=control-char-neutralize.sh
 source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
+
+# Stale lock threshold in seconds (default: 120s for compact, 300s for issue)
 WM_LOCK_STALE_THRESHOLD="${WM_LOCK_STALE_THRESHOLD:-120}"
 
 acquire_wm_lock() {

--- a/plugins/rite/hooks/work-memory-lock.sh
+++ b/plugins/rite/hooks/work-memory-lock.sh
@@ -13,6 +13,8 @@
 #   1: Lock acquisition failed (timeout or stale removal failed)
 
 # Stale lock threshold in seconds (default: 120s for compact, 300s for issue)
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 WM_LOCK_STALE_THRESHOLD="${WM_LOCK_STALE_THRESHOLD:-120}"
 
 acquire_wm_lock() {
@@ -39,7 +41,7 @@ acquire_wm_lock() {
         lock_mtime=$(stat -c %Y "$lockdir" 2>"${stat_err:-/dev/null}" || stat -f %m "$lockdir" 2>"${stat_err:-/dev/null}")
         if [ -z "$lock_mtime" ] || [ "$lock_mtime" = "0" ]; then
           echo "[rite] WARNING: acquire_wm_lock: stat failed on $lockdir — staleness undetectable, treating as fresh lock" >&2
-          [ -n "$stat_err" ] && [ -s "$stat_err" ] && head -3 "$stat_err" | sed 's/^/  /' >&2
+          [ -n "$stat_err" ] && [ -s "$stat_err" ] && head -3 "$stat_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
           [ -n "$stat_err" ] && rm -f "$stat_err"
           return 1
         fi

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -59,6 +59,8 @@
 # Source lock helper at file load time (not inside the function)
 # This avoids re-sourcing on every function call and prevents BASH_SOURCE issues.
 source "$(dirname "${BASH_SOURCE[0]}")/work-memory-lock.sh"
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 
 # verified-review F-04 MEDIUM: flow-state.sh 呼び出し boilerplate を helper 関数に抽出。
 # 旧実装は (a) helper executable check と (b) `if cmd; then :; else rc=$?; ...; return 2; fi` 形式の
@@ -313,7 +315,7 @@ update_local_work_memory() {
   fi
   local _mv_rc=$?
   echo "rite: ${WM_SOURCE}: mv failed (rc=$_mv_rc): $tmp_wm -> $local_wm" >&2
-  [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | sed 's/^/  /' >&2
+  [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   [ -n "$_mv_err" ] && rm -f "$_mv_err"
   rm -f "$tmp_wm"
   return 2


### PR DESCRIPTION
## 概要

PR #1181 (Issue #1173) で flow-state.sh に導入した「診断スニペットの control-char 中和」を、同型の `head -3 "$err_file" | sed 's/^/  /' >&2` イディオムを持つ全 hook（25 ファイル / 88 emission site）へ横展開する。corrupt state file / API レスポンス断片経由で生の制御バイト（ANSI escape / C1 8-bit CSI 等）が operator terminal に到達する経路を全 hook で遮断する。

Closes #1183

## 変更内容

### 方針（AC-2）

新規 helper ファイルは追加せず、#1274 の既存共通 helper `control-char-neutralize.sh` を各 hook が source し、emission site に inline で `| neutralize_ctrl --keep-newline` を挿入する。flow-state.sh / wiki-ingest-trigger.sh が既に採用しているパターンの横展開であり、prefix（`'  '` / `'  jq: '` / `' git: '` 等）や guard 条件がサイトごとに異なるため、汎用関数化より既存構造の保持を優先した。

### 変更ファイル

- `hooks/` 直下 16 ファイル: post-tool-wm-sync / pre-compact / session-end / session-start / post-compact / cleanup-work-memory / wiki-query-inject / issue-comment-wm-sync / notification / review-result-save / session-ownership / work-memory-lock / work-memory-update / _resolve-session-id-from-file / _resolve-cross-session-guard / wiki-ingest-trigger
- `hooks/scripts/` 8 ファイル: wiki-lint-source-refs / settings-local-rite-hook-cleanup / wiki-worktree-setup / wiki-growth-check / wiki-lint-skipped-refs / gitignore-health-check / wiki-worktree-commit / pr-cycle-cleanup
- `hooks/scripts/lib/worktree-git.sh`
- `hooks/control-char-neutralize.sh`: ヘッダーの共有規約の記述を実態（全 hook 横展開）に更新
- `hooks/tests/diag-snippet-neutralize-parity.test.sh`（新規）: 静的 parity テスト

### テスト（AC-3）

- 新規 `diag-snippet-neutralize-parity.test.sh`:
  - TC-1: hooks/ 配下に neutralize_ctrl を経由しない `head -3` emission site が存在しないことを pin（将来の未中和サイト追加も検出）
  - TC-2: neutralize_ctrl の全 caller（28 ファイル）が helper を source していることを pin + sweep coverage 下限ガード
- 既存テストスイート: 62/62 pass（変換後）

## 受入基準

- [x] AC-1: 対象 hook の jq / コマンド stderr 診断スニペット emission site に control-char 中和が適用されている（grep で未対策サイト残存ゼロを確認）
- [x] AC-2: helper 集約方針が一貫している（既存共通 helper `control-char-neutralize.sh` の source + inline 挿入で統一、新規ファイル追加なし）
- [x] AC-3: 既存テストが全て pass し、中和を pin する代表テストが追加されている

## チェックリスト

- [x] テスト追加（diag-snippet-neutralize-parity.test.sh）
- [x] 既存テスト全 pass（62/62）
- [x] bash -n 構文チェック全 pass
- [x] ドキュメント影響調査（SPEC.md 等に陳腐化なし、helper ヘッダーのみ更新）

## 備考

- lint: コマンド未設定のためスキップ。プラグイン固有チェック（drift / bang-backtick / comment-journal 等）は今回の変更ファイルへの新規指摘なし
- Out of Scope（Issue 通り）: WARNING 行の caller 供給文字列の中和は #1173 と同方針でスコープ外
