### PR TITLE
refactor(hooks): review-comment-post.sh の awk sentinel 置換 / iso_timestamp gate を防御的にハードニング

### DIFF
--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3045,7 +3045,7 @@ Output the review results via two independent paths. Use `mktemp` + `--body-file
 - `p61b_post_comment_mode_invalid`: `--post-comment-mode` が `true`/`false` 以外 (Issue #510 対応、caller branch selection ミスの machine-enforced 遮断、`p61c_post_comment_mode_invalid` と対称)
 - `p61b_pr_number_invalid`: `--pr` が literal substitute されていない / 数値以外 (`p61c_pr_number_invalid` と対称)
 - `json_saved_from_p61a_unset`: `--json-saved` が `true`/`false` 以外 (ステップ 6.1.a の `[CONTEXT] JSON_SAVED=` 読取漏れ)
-- `iso_timestamp_from_p61a_unset`: `--iso-timestamp` が sentinel 残留 / 空文字 / placeholder 形式 (ステップ 6.1.a の `[CONTEXT] ISO_TIMESTAMP=` 読取漏れ)
+- `iso_timestamp_from_p61a_unset`: `--iso-timestamp` が ISO 8601 形状でない (sentinel 残留 / 空文字 / placeholder 形式 / 非 ISO 形状を allowlist で一括 reject — ステップ 6.1.a の `[CONTEXT] ISO_TIMESTAMP=` 読取漏れ、Issue #1200)
 - `tmpfile_write_failure`: PR コメント本文の中間 tmpfile (mktemp) 失敗、または `--content-file` 不在
 - `raw_json_timestamp_injection_failed`: Raw JSON セクション内 sentinel の awk 置換 / post-condition (Raw JSON 内残留なし / Markdown 不変) が失敗
 - `gh_comment_post_failure`: `gh pr comment` 投稿が exit != 0 で失敗 (network / auth / rate-limit / permission、rc>=128 時は signal 番号併記)

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3045,7 +3045,7 @@ Output the review results via two independent paths. Use `mktemp` + `--body-file
 - `p61b_post_comment_mode_invalid`: `--post-comment-mode` が `true`/`false` 以外 (Issue #510 対応、caller branch selection ミスの machine-enforced 遮断、`p61c_post_comment_mode_invalid` と対称)
 - `p61b_pr_number_invalid`: `--pr` が literal substitute されていない / 数値以外 (`p61c_pr_number_invalid` と対称)
 - `json_saved_from_p61a_unset`: `--json-saved` が `true`/`false` 以外 (ステップ 6.1.a の `[CONTEXT] JSON_SAVED=` 読取漏れ)
-- `iso_timestamp_from_p61a_unset`: `--iso-timestamp` が ISO 8601 形状でない (sentinel 残留 / 空文字 / placeholder 形式 / 非 ISO 形状を allowlist で一括 reject — ステップ 6.1.a の `[CONTEXT] ISO_TIMESTAMP=` 読取漏れ、Issue #1200)
+- `iso_timestamp_from_p61a_unset`: `--iso-timestamp` が ISO 8601 形状でない (sentinel 残留 / 空文字 / placeholder 形式 / 非 ISO 形状を allowlist で一括 reject — ステップ 6.1.a の `[CONTEXT] ISO_TIMESTAMP=` 読取漏れ、Issue #1200)。ステップ 6.1.a の早期失敗 degraded 値 `unknown` も reject される (期待動作 — 再投入では解決せず、6.1.a の `LOCAL_SAVE_FAILED` reason の解消が必要。helper が専用診断を表示する)
 - `tmpfile_write_failure`: PR コメント本文の中間 tmpfile (mktemp) 失敗、または `--content-file` 不在
 - `raw_json_timestamp_injection_failed`: Raw JSON セクション内 sentinel の awk 置換 / post-condition (Raw JSON 内残留なし / Markdown 不変) が失敗
 - `gh_comment_post_failure`: `gh pr comment` 投稿が exit != 0 で失敗 (network / auth / rate-limit / permission、rc>=128 時は signal 番号併記)

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -121,6 +121,15 @@ fi
 # bash 組込み `[[ =~ ]]` を使う: `printf | grep -qE` は行単位マッチのため複数行値の
 # いずれか 1 行が ISO 形状なら gate を通過する bypass 穴がある。`[[ =~ ]]` の `^`/`$` は
 # 文字列全体に anchor され、改行を含む値を構造的に reject する (hooks/ の支配的 gate パターンとも整合)。
+# `unknown` は ステップ 6.1.a の EXIT trap が timestamp 算出前の早期失敗時に emit する正規の
+# degraded 値 (review-result-save.sh の `${iso_timestamp:-unknown}`)。読取漏れではないため、
+# 「emit 値を渡せ」という誤診断で caller を同一値の再投入ループに誘導しないよう専用診断で reject する。
+if [ "$ISO_TIMESTAMP" = "unknown" ]; then
+  echo "ERROR: review-comment-post: iso_timestamp が degraded 値 'unknown' です (ステップ 6.1.a が timestamp 算出前に失敗)" >&2
+  echo "  --iso-timestamp の再投入では解決しません。ステップ 6.1.a の [CONTEXT] LOCAL_SAVE_FAILED=1; reason=... を確認し、原因 (date 失敗 / 書込失敗等) を解消してから review をやり直してください" >&2
+  echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset" >&2
+  exit 1
+fi
 _iso8601_re='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2}|Z)$'
 if ! [[ "$ISO_TIMESTAMP" =~ $_iso8601_re ]]; then
   echo "ERROR: review-comment-post: iso_timestamp が ISO 8601 形状ではありません (値: '$ISO_TIMESTAMP')" >&2
@@ -148,7 +157,7 @@ tmpfile_patched=$(mktemp /tmp/rite-review-p61b-comment-patched-XXXXXX.md) || {
 
 # Raw JSON section 内 (`### 📄 Raw JSON` 見出し後の ```json fence 内) の sentinel のみを
 # $ISO_TIMESTAMP に置換する (Markdown 本文の literal sentinel には触れない scope 限定置換)。
-# State machine: 全行を buffer し END block で最後の heading 以降の fence 内のみ gsub する
+# State machine: 全行を buffer し END block で最後の heading 以降の fence 内のみリテラル置換する
 # (finding 列に literal `### 📄 Raw JSON` が含まれる反例に備え fix.md Priority 3 と同じ「last」方式)。
 awk -v ts="$ISO_TIMESTAMP" -v sentinel="$SENTINEL" '
   { lines[NR] = $0 }

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -111,17 +111,19 @@ if [ -z "$CONTENT_FILE" ] || [ ! -f "$CONTENT_FILE" ]; then
   exit 1
 fi
 
-# iso_timestamp sentinel fail-fast gate。
-# substitute 漏れ時 sentinel が Raw JSON に残留し、fix.md Priority 3 が sentinel 付き timestamp で
-# findings を解釈する silent regression を持つため機械的に強制。
-case "$ISO_TIMESTAMP" in
-  "{"*|*"}"|""|"$SENTINEL")
-    echo "ERROR: review-comment-post: iso_timestamp が literal substitute されていません (値: '$ISO_TIMESTAMP')" >&2
-    echo "  caller は ステップ 6.1.a の [CONTEXT] ISO_TIMESTAMP=... emit 値を --iso-timestamp に渡す必要があります (例: 2026-04-11T12:34:56+09:00)" >&2
-    echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset" >&2
-    exit 1
-    ;;
-esac
+# iso_timestamp fail-fast gate (ISO 8601 allowlist — Issue #1200)。
+# 旧 denylist (`{`-prefix / `}`-suffix / 空 / sentinel 完全一致のみ reject) は placeholder 残留の
+# 典型形しか弾けず、`&`/`\` 等の awk replacement metacharacter や任意の不正値を素通ししていた。
+# ISO 8601 形状 (`YYYY-MM-DDTHH:MM:SS` + `±HH:MM` または `Z`) の allowlist 検証に置換し、
+# sentinel 残留 / 空文字 / placeholder 形式 / 非 ISO 形状をすべて同一 reason で reject する
+# (substitute 漏れ時 sentinel が Raw JSON に残留し、fix.md Priority 3 が sentinel 付き timestamp で
+# findings を解釈する silent regression を防ぐ機械的強制)。
+if ! printf '%s' "$ISO_TIMESTAMP" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2}|Z)$'; then
+  echo "ERROR: review-comment-post: iso_timestamp が ISO 8601 形状ではありません (値: '$ISO_TIMESTAMP')" >&2
+  echo "  caller は ステップ 6.1.a の [CONTEXT] ISO_TIMESTAMP=... emit 値を --iso-timestamp に渡す必要があります (例: 2026-04-11T12:34:56+09:00)" >&2
+  echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset" >&2
+  exit 1
+fi
 
 # --- trap 保護 ---
 tmpfile_patched=""
@@ -154,7 +156,18 @@ awk -v ts="$ISO_TIMESTAMP" '
       if (past && lines[i] ~ /^```json$/) { in_fence = 1; print lines[i]; continue }
       if (past && in_fence && lines[i] ~ /^```$/) { in_fence = 0; print lines[i]; continue }
       if (in_fence) {
-        gsub(/"__RITE_TS_PLACEHOLDER_7f3a9b2c__"/, "\"" ts "\"", lines[i])
+        # index()/substr() ベースのリテラル置換 (Issue #1200)。gsub の replacement に ts を
+        # 直接埋め込むと `&` (マッチ全体に展開) / `\` (エスケープ) が metacharacter として
+        # 解釈され置換結果が壊れる。index/substr は needle / replacement とも純リテラル扱い。
+        needle = "\"__RITE_TS_PLACEHOLDER_7f3a9b2c__\""
+        repl = "\"" ts "\""
+        line = lines[i]
+        out = ""
+        while ((pos = index(line, needle)) > 0) {
+          out = out substr(line, 1, pos - 1) repl
+          line = substr(line, pos + length(needle))
+        }
+        lines[i] = out line
       }
       print lines[i]
     }

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -118,7 +118,11 @@ fi
 # sentinel 残留 / 空文字 / placeholder 形式 / 非 ISO 形状をすべて同一 reason で reject する
 # (substitute 漏れ時 sentinel が Raw JSON に残留し、fix.md Priority 3 が sentinel 付き timestamp で
 # findings を解釈する silent regression を防ぐ機械的強制)。
-if ! printf '%s' "$ISO_TIMESTAMP" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2}|Z)$'; then
+# bash 組込み `[[ =~ ]]` を使う: `printf | grep -qE` は行単位マッチのため複数行値の
+# いずれか 1 行が ISO 形状なら gate を通過する bypass 穴がある。`[[ =~ ]]` の `^`/`$` は
+# 文字列全体に anchor され、改行を含む値を構造的に reject する (hooks/ の支配的 gate パターンとも整合)。
+_iso8601_re='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2}|Z)$'
+if ! [[ "$ISO_TIMESTAMP" =~ $_iso8601_re ]]; then
   echo "ERROR: review-comment-post: iso_timestamp が ISO 8601 形状ではありません (値: '$ISO_TIMESTAMP')" >&2
   echo "  caller は ステップ 6.1.a の [CONTEXT] ISO_TIMESTAMP=... emit 値を --iso-timestamp に渡す必要があります (例: 2026-04-11T12:34:56+09:00)" >&2
   echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset" >&2
@@ -146,7 +150,7 @@ tmpfile_patched=$(mktemp /tmp/rite-review-p61b-comment-patched-XXXXXX.md) || {
 # $ISO_TIMESTAMP に置換する (Markdown 本文の literal sentinel には触れない scope 限定置換)。
 # State machine: 全行を buffer し END block で最後の heading 以降の fence 内のみ gsub する
 # (finding 列に literal `### 📄 Raw JSON` が含まれる反例に備え fix.md Priority 3 と同じ「last」方式)。
-awk -v ts="$ISO_TIMESTAMP" '
+awk -v ts="$ISO_TIMESTAMP" -v sentinel="$SENTINEL" '
   { lines[NR] = $0 }
   /^### 📄 Raw JSON/ { last_heading = NR }
   END {
@@ -159,7 +163,9 @@ awk -v ts="$ISO_TIMESTAMP" '
         # index()/substr() ベースのリテラル置換 (Issue #1200)。gsub の replacement に ts を
         # 直接埋め込むと `&` (マッチ全体に展開) / `\` (エスケープ) が metacharacter として
         # 解釈され置換結果が壊れる。index/substr は needle / replacement とも純リテラル扱い。
-        needle = "\"__RITE_TS_PLACEHOLDER_7f3a9b2c__\""
+        # needle は SENTINEL 変数を -v で受け取り literal 重複を解消 (値は backslash を含まないため
+        # -v の escape 解釈は安全)。
+        needle = "\"" sentinel "\""
         repl = "\"" ts "\""
         line = lines[i]
         out = ""

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -163,8 +163,8 @@ awk -v ts="$ISO_TIMESTAMP" -v sentinel="$SENTINEL" '
         # index()/substr() ベースのリテラル置換 (Issue #1200)。gsub の replacement に ts を
         # 直接埋め込むと `&` (マッチ全体に展開) / `\` (エスケープ) が metacharacter として
         # 解釈され置換結果が壊れる。index/substr は needle / replacement とも純リテラル扱い。
-        # needle は SENTINEL 変数を -v で受け取り literal 重複を解消 (値は backslash を含まないため
-        # -v の escape 解釈は安全)。
+        # needle は SENTINEL 変数を -v で受け取る (値は backslash を含まないため -v の
+        # escape 解釈は安全)。post-condition 側の awk は regex literal のため別管理。
         needle = "\"" sentinel "\""
         repl = "\"" ts "\""
         line = lines[i]

--- a/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
+++ b/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
@@ -15,7 +15,8 @@
 #        file_timestamp 整合性 (unknown ∧ local_save_failed≠1 遮断) / local_save_failed 値検証 /
 #        ケース 1 (INFO, exit 0) vs ケース 2 (p61c_persistence_unrecoverable, exit 2 hard-fail)
 #   TC-2 review-comment-post.sh — post_comment_mode gate (false silent skip は gh 不実行まで検証) /
-#        pr_number / json_saved / content-file / iso_timestamp の各 gate /
+#        pr_number / json_saved / content-file / iso_timestamp の各 gate
+#        (iso_timestamp は ISO 8601 allowlist — 非 ISO 形状 / awk metachar 注入形も reject、Issue #1200) /
 #        stub gh での happy path (Raw JSON 内 sentinel 置換 + Markdown 本文 sentinel 保存) /
 #        gh 失敗時の gh_comment_post_failure emit
 #   TC-3 review-result-save.sh — D-04 非ブロッキング契約 (gate 失敗でも exit 0 + EXIT trap が
@@ -211,6 +212,14 @@ assert_grep "TC-2.6b reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_O
 run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "$SENTINEL" --content-file "$DUMMY_CONTENT"
 assert "TC-2.6c iso_timestamp が sentinel そのもの: exit 1" "1" "$RC"
 assert_grep "TC-2.6c reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
+# TC-2.6d ISO 8601 allowlist (Issue #1200): 非 ISO 形状は旧 denylist 通過形でも reject
+run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "not-a-timestamp" --content-file "$DUMMY_CONTENT"
+assert "TC-2.6d iso_timestamp 非 ISO 形状: exit 1" "1" "$RC"
+assert_grep "TC-2.6d reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
+# TC-2.6e awk replacement metachar 注入形 (`&` / `\`) も allowlist が reject (gsub metachar 防御の第一層)
+run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp '2026-01-02T03:04:05+09:00&\evil' --content-file "$DUMMY_CONTENT"
+assert "TC-2.6e iso_timestamp metachar 注入形: exit 1" "1" "$RC"
+assert_grep "TC-2.6e reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
 
 # TC-2.7 happy path: 全 gate 通過 + Raw JSON 内 sentinel のみ scope 限定置換
 POST_CONTENT="$TMP_ROOT/post-content.md"

--- a/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
+++ b/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
@@ -220,7 +220,7 @@ assert_grep "TC-2.6d reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_O
 run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp '2026-01-02T03:04:05+09:00&\evil' --content-file "$DUMMY_CONTENT"
 assert "TC-2.6e iso_timestamp metachar 注入形: exit 1" "1" "$RC"
 assert_grep "TC-2.6e reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
-# TC-2.6f 複数行値 bypass 防止 (cycle 1 fix): grep 行単位マッチでは 2 行目の valid ISO で素通りしていた
+# TC-2.6f 複数行値 bypass 防止: grep -qE は行単位マッチのため 2 行目の valid ISO で素通りする (=~ の文字列全体 anchor を検証)
 run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "$(printf 'garbage\n2026-01-02T03:04:05Z')" --content-file "$DUMMY_CONTENT"
 assert "TC-2.6f iso_timestamp 複数行値: exit 1" "1" "$RC"
 assert_grep "TC-2.6f reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'

--- a/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
+++ b/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
@@ -224,6 +224,12 @@ assert_grep "TC-2.6e reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_O
 run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "$(printf 'garbage\n2026-01-02T03:04:05Z')" --content-file "$DUMMY_CONTENT"
 assert "TC-2.6f iso_timestamp 複数行値: exit 1" "1" "$RC"
 assert_grep "TC-2.6f reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
+# TC-2.6g degraded 値 `unknown` (6.1.a EXIT trap の正規 emit) は専用診断で reject — 「emit 値を渡せ」の誤診断で再投入ループに誘導しない
+run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "unknown" --content-file "$DUMMY_CONTENT"
+assert "TC-2.6g iso_timestamp=unknown: exit 1" "1" "$RC"
+assert_grep "TC-2.6g reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
+assert_grep "TC-2.6g 専用診断 (degraded 値) を表示" "$ERR" "degraded 値 'unknown'"
+assert_grep "TC-2.6g 再投入では解決しない旨を案内" "$ERR" '再投入では解決しません'
 
 # TC-2.7 happy path: 全 gate 通過 + Raw JSON 内 sentinel のみ scope 限定置換
 POST_CONTENT="$TMP_ROOT/post-content.md"

--- a/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
+++ b/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
@@ -220,6 +220,10 @@ assert_grep "TC-2.6d reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_O
 run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp '2026-01-02T03:04:05+09:00&\evil' --content-file "$DUMMY_CONTENT"
 assert "TC-2.6e iso_timestamp metachar 注入形: exit 1" "1" "$RC"
 assert_grep "TC-2.6e reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
+# TC-2.6f 複数行値 bypass 防止 (cycle 1 fix): grep 行単位マッチでは 2 行目の valid ISO で素通りしていた
+run_post --pr 123 --post-comment-mode true --json-saved true --iso-timestamp "$(printf 'garbage\n2026-01-02T03:04:05Z')" --content-file "$DUMMY_CONTENT"
+assert "TC-2.6f iso_timestamp 複数行値: exit 1" "1" "$RC"
+assert_grep "TC-2.6f reason=iso_timestamp_from_p61a_unset emit" "$ERR" 'REVIEW_OUTPUT_FAILED=1; reason=iso_timestamp_from_p61a_unset'
 
 # TC-2.7 happy path: 全 gate 通過 + Raw JSON 内 sentinel のみ scope 限定置換
 POST_CONTENT="$TMP_ROOT/post-content.md"


### PR DESCRIPTION
## 概要

PR #1198 のレビューで security reviewer が推奨した `review-comment-post.sh` の防御強化 2 点を実装する（Hypothetical 例外カテゴリ — 現状の実 source は `date` 由来で実害なし、将来の caller 変更に備えた防御層）。

Closes #1200

## 変更内容

1. **awk sentinel 置換のリテラル化**: `gsub(/.../, "\"" ts "\"", ...)` は replacement に `ts` を直接埋め込むため `&`（マッチ全体に展開）/ `\`（エスケープ）が metacharacter として解釈され置換結果が壊れる。`index()`/`substr()` ベースのリテラル置換ループに変更し、needle / replacement とも純リテラル扱いにした。
2. **iso_timestamp gate の denylist → allowlist 化**: 旧 gate は `{`-prefix / `}`-suffix / 空 / sentinel 完全一致のみ reject する denylist。ISO 8601 形状（`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2}|Z)$`）の allowlist 検証に置換し、非 ISO 形状・metachar 注入形を一括 reject する。reason は既存 `iso_timestamp_from_p61a_unset` を維持（emit enumeration 不変、既存テスト TC-2.6a-c 互換）。
3. **横断調査の結論**: 変数 replacement を持つ gsub は本サイトのみ。fix.md Priority 3 の同型 awk は抽出のみで置換を行わず、他の hook の gsub は静的パターンのため横断対応不要（Issue 本文の調査推奨に対する回答）。
4. **ドキュメント同期**: review.md の reason 記述を allowlist 仕様に更新。

## テスト

- TC-2.6d（非 ISO 形状 reject）/ TC-2.6e（`&`/`\` metachar 注入形 reject）を `review-helpers-gate-behavior.test.sh` に追加
- 既存 TC-2.6a-c（placeholder / 空文字 / sentinel reject）・TC-2.7（happy path: sentinel 置換 + Markdown 本文保存）は変更なしで pass — allowlist 化が後方互換であることを pin
- 全テストスイート 62/62 pass

## チェックリスト

- [x] テスト追加（TC-2.6d/e）
- [x] 既存テスト全 pass（62/62）
- [x] bash -n 構文チェック pass
- [x] ドキュメント影響調査（review.md reason 記述を更新、他に陳腐化なし）

## 備考

- lint: コマンド未設定のためスキップ。プラグイン固有チェックは変更ファイルへの新規指摘なし
