### PR TITLE
refactor(hooks): head -c / 関数内 >&2 / cat 系の未中和診断 emission へ control-char 中和を横展開 (#1183 follow-up)

### DIFF
--- a/plugins/rite/hooks/issue-body-safe-update.sh
+++ b/plugins/rite/hooks/issue-body-safe-update.sh
@@ -34,6 +34,9 @@
 #   1: Argument error
 set -euo pipefail
 
+# shellcheck source=control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
+
 # Persistent body-update failures must not vanish silently. The safety guards
 # (empty write / <50% shrinkage / gh edit failure / diff IO error) all exit 0 so
 # the caller's workflow continues, but the caller cannot detect a "guard tripped"
@@ -119,7 +122,7 @@ case "$MODE" in
       :
     else
       rc=$?
-      err_snippet=$(head -c 500 "$tmpfile_err" 2>/dev/null | tr -d '\r' || echo "")
+      err_snippet=$(head -c 500 "$tmpfile_err" 2>/dev/null | tr -d '\r' | tr '\n' ' ' | neutralize_ctrl --c0-only || echo "")
       echo "${err_level}: gh issue view 失敗 (rc=$rc): ${err_snippet}" >&2
       echo "fetch_failure_reason=gh_view_failed"
       _emit_body_update_incident "issue_body_fetch_failed" "gh_view_failed" "$rc" "$err_snippet"
@@ -221,7 +224,7 @@ case "$MODE" in
       :
     else
       rc=$?
-      err_snippet=$(head -c 500 "${apply_err:-/dev/null}" 2>/dev/null | tr -d '\r' || echo "")
+      err_snippet=$(head -c 500 "${apply_err:-/dev/null}" 2>/dev/null | tr -d '\r' | tr '\n' ' ' | neutralize_ctrl --c0-only || echo "")
       echo "${err_level}: gh issue edit 失敗 (rc=$rc): ${err_snippet}" >&2
       echo "apply_failure_reason=gh_edit_failed"
       _emit_body_update_incident "issue_body_fetch_failed" "gh_edit_failed" "$rc" "$err_snippet"

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -46,7 +46,7 @@ FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>"$
 # any new resolver prefix (INFO:/DIAG:/...) would silently drop without the counter.
 if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
   if [ -n "${RITE_DEBUG:-}" ]; then
-    cat "$_resolve_err" >&2
+    neutralize_ctrl --keep-newline < "$_resolve_err" >&2
   else
     # `grep -c ''` agrees with the filter `grep -c` below regardless of trailing
     # newline; `wc -l` would undercount and let `_dropped` go negative.
@@ -274,8 +274,8 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       :
     else
       pr_rc=$?
-      pr_view_err_oneline=$(head -c 200 "${pr_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
-      pr_cd_err_oneline=$(head -c 200 "${_pr_cd_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+      pr_view_err_oneline=$(head -c 200 "${pr_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+      pr_cd_err_oneline=$(head -c 200 "${_pr_cd_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
       if [ -n "$pr_cd_err_oneline" ]; then
         echo "[rite] WARNING: post-compact: Issue #$ISSUE — cd STATE_ROOT failed inside gh pr view subshell (rc=$pr_rc, stderr=$pr_cd_err_oneline); TOCTOU race between -d check and cd (state_root_toctou_race)" >&2
       else
@@ -305,7 +305,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
         :
       else
         repo_rc=$?
-        repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+        repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
         REPO_INFO=""
       fi
       # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
@@ -328,13 +328,13 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       awk_parse_failed=0
       if [ "$awk_pe_rc" -ne 0 ] || { [ -n "${awk_pe_err:-}" ] && [ -s "$awk_pe_err" ]; }; then
         awk_pe_oneline=""
-        [ -n "${awk_pe_err:-}" ] && [ -s "$awk_pe_err" ] && awk_pe_oneline=$(head -c 200 "$awk_pe_err" | tr '\n' ' ')
+        [ -n "${awk_pe_err:-}" ] && [ -s "$awk_pe_err" ] && awk_pe_oneline=$(head -c 200 "$awk_pe_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
         echo "[rite] WARNING: post-compact: awk parse of projects.enabled failed (rc=$awk_pe_rc, stderr=$awk_pe_oneline)" >&2
         awk_parse_failed=1
       fi
       if [ "$awk_pn_rc" -ne 0 ] || { [ -n "${awk_pn_err:-}" ] && [ -s "$awk_pn_err" ]; }; then
         awk_pn_oneline=""
-        [ -n "${awk_pn_err:-}" ] && [ -s "$awk_pn_err" ] && awk_pn_oneline=$(head -c 200 "$awk_pn_err" | tr '\n' ' ')
+        [ -n "${awk_pn_err:-}" ] && [ -s "$awk_pn_err" ] && awk_pn_oneline=$(head -c 200 "$awk_pn_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
         echo "[rite] WARNING: post-compact: awk parse of projects.project_number failed (rc=$awk_pn_rc, stderr=$awk_pn_oneline)" >&2
         awk_parse_failed=1
       fi
@@ -358,8 +358,8 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
         _owner_repo_ok=0
         jq_owner_err_oneline=""
         jq_name_err_oneline=""
-        [ -n "${jq_owner_err:-}" ] && [ -s "$jq_owner_err" ] && jq_owner_err_oneline=$(head -c 200 "$jq_owner_err" | tr '\n' ' ')
-        [ -n "${jq_name_err:-}" ] && [ -s "$jq_name_err" ] && jq_name_err_oneline=$(head -c 200 "$jq_name_err" | tr '\n' ' ')
+        [ -n "${jq_owner_err:-}" ] && [ -s "$jq_owner_err" ] && jq_owner_err_oneline=$(head -c 200 "$jq_owner_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
+        [ -n "${jq_name_err:-}" ] && [ -s "$jq_name_err" ] && jq_name_err_oneline=$(head -c 200 "$jq_name_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
         if [ -z "$REPO_INFO" ]; then
           echo "[rite] WARNING: post-compact: Issue #$ISSUE — gh repo view failed (rc=${repo_rc:-NA}, stderr=${repo_err_oneline:-NA}); PR Status reconciliation could not run (post_compact_gh_repo_view_failed)" >&2
         else
@@ -396,8 +396,8 @@ query($owner: String!, $repo: String!, $number: Int!) {
           :
         else
           gql_rc=$?
-          gql_err_oneline=$(head -c 200 "${gql_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
-          jq_err_oneline=$(head -c 200 "${jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+          gql_err_oneline=$(head -c 200 "${gql_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+          jq_err_oneline=$(head -c 200 "${jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
           echo "[rite] WARNING: post-compact: Issue #$ISSUE — gh api graphql failed (rc=$gql_rc, gh_stderr=$gql_err_oneline, jq_stderr=$jq_err_oneline); PR Status reconciliation could not run (post_compact_gh_api_failed)" >&2
           CURRENT_STATUS=""
         fi
@@ -424,7 +424,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
             --argjson auto_add false --argjson non_blocking true \
             '{issue_number:$issue, owner:$owner, repo:$repo, project_number:$project_number, status_name:$status, auto_add:$auto_add, non_blocking:$non_blocking}' 2>"${reconcile_jq_err:-/dev/null}") || JQ_PAYLOAD_RC=$?
           if [ "$JQ_PAYLOAD_RC" -ne 0 ] || [ -z "$JQ_PAYLOAD" ]; then
-            jq_err_oneline=$(head -c 200 "${reconcile_jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+            jq_err_oneline=$(head -c 200 "${reconcile_jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
             echo "[rite] ❌ post-compact reconciliation jq payload build failed (rc=$JQ_PAYLOAD_RC, jq_stderr=$jq_err_oneline, post_compact_jq_payload_build_failed)" >&2
           else
             RECONCILE_RESULT=$(cd "$STATE_ROOT" && bash "$PLUGIN_ROOT_PC/scripts/projects-status-update.sh" "$JQ_PAYLOAD" 2>"${reconcile_err:-/dev/null}") || RECONCILE_RC=$?
@@ -432,14 +432,14 @@ query($owner: String!, $repo: String!, $number: Int!) {
             if [ "$RECONCILE_STATUS" = "updated" ]; then
               echo "[rite] ✅ post-compact reconciliation succeeded: Issue #$ISSUE Status → In Review" >&2
             else
-              reconcile_err_oneline=$(head -c 200 "${reconcile_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+              reconcile_err_oneline=$(head -c 200 "${reconcile_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
               # RECONCILE_STATUS が空で RECONCILE_RESULT が非空なら、reconcile script は応答したが
               # result field を抽出できなかった (= JSON shape drift)。これは reconcile 自体の失敗とは
               # 別の triage が必要なので、empty/non-empty で区別する。
               if [ -z "$RECONCILE_STATUS" ] && [ -n "$RECONCILE_RESULT" ]; then
                 parse_err_snippet=""
-                [ -n "$reconcile_parse_err" ] && [ -s "$reconcile_parse_err" ] && parse_err_snippet=$(head -c 200 "$reconcile_parse_err" 2>/dev/null | tr '\n' ' ')
-                echo "[rite] ❌ post-compact reconciliation result parse failed (jq err=$parse_err_snippet, stdout snippet=$(printf '%s' "$RECONCILE_RESULT" | head -c 200))" >&2
+                [ -n "$reconcile_parse_err" ] && [ -s "$reconcile_parse_err" ] && parse_err_snippet=$(head -c 200 "$reconcile_parse_err" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+                echo "[rite] ❌ post-compact reconciliation result parse failed (jq err=$parse_err_snippet, stdout snippet=$(printf '%s' "$RECONCILE_RESULT" | head -c 200 | tr '\n' ' ' | neutralize_ctrl --c0-only))" >&2
                 RECONCILE_STATUS="parse_failed"
               else
                 RECONCILE_STATUS="${RECONCILE_STATUS:-failed}"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -98,7 +98,7 @@ _jq_input_err=$(mktemp 2>/dev/null) || _jq_input_err=""
 JQ_OUT=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>"${_jq_input_err:-/dev/null}") || JQ_OUT=$'\t\t'
 if [ -n "${RITE_DEBUG:-}" ] && [ -n "$_jq_input_err" ] && [ -s "$_jq_input_err" ]; then
   printf '[%s] pre-tool-bash-guard: jq input parse stderr: %s\n' \
-    "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$(head -c 200 "$_jq_input_err" | tr '\n' ' ')" \
+    "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$(head -c 200 "$_jq_input_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" \
     >> "${STATE_ROOT:-/tmp}/.rite-flow-debug.log" 2>/dev/null || true
 fi
 [ -n "$_jq_input_err" ] && rm -f "$_jq_input_err"

--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -259,7 +259,7 @@ check_pattern_2() {
   if [ "$awk_table_rc" -ne 0 ]; then
     log "  [P2] Pattern 2 skipped on $file: table-side awk rc=$awk_table_rc"
     if [ -n "$AWK_TABLE_ERR" ] && [ -s "$AWK_TABLE_ERR" ]; then
-      log "    awk stderr: $(head -1 "$AWK_TABLE_ERR")"
+      log "    awk stderr: $(head -1 "$AWK_TABLE_ERR" | tr -d '\n' | neutralize_ctrl --c0-only)"
     fi
     out "[drift-check-skip][P2] ${file}: awk_rc=${awk_table_rc} (table)"
     rm -f "$AWK_TABLE_OUT" "${AWK_TABLE_ERR:-}"
@@ -297,7 +297,7 @@ check_pattern_2() {
   if [ "$awk_emit_rc" -ne 0 ]; then
     log "  [P2] Pattern 2 skipped on $file: emit-side awk rc=$awk_emit_rc"
     if [ -n "$AWK_EMIT_ERR" ] && [ -s "$AWK_EMIT_ERR" ]; then
-      log "    awk stderr: $(head -1 "$AWK_EMIT_ERR")"
+      log "    awk stderr: $(head -1 "$AWK_EMIT_ERR" | tr -d '\n' | neutralize_ctrl --c0-only)"
     fi
     out "[drift-check-skip][P2] ${file}: awk_rc=${awk_emit_rc} (emit)"
     rm -f "$AWK_EMIT_OUT" "${AWK_EMIT_ERR:-}"

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -244,7 +244,7 @@ if [ -n "$DRIFT_TSV" ]; then
         RECONCILE_FAILURES=$((RECONCILE_FAILURES + 1))
         reconcile_suffix=" -> reconcile FAILED ($reconcile_result)"
         if [ "$QUIET" != "true" ] && [ -n "$reconcile_err" ] && [ -s "$reconcile_err" ]; then
-          echo "projects-board-drift: reconcile failed for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ')" >&2
+          echo "projects-board-drift: reconcile failed for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
         fi
       fi
       [ -n "$reconcile_err" ] && rm -f "$reconcile_err"; reconcile_err=""

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -276,7 +276,7 @@ jq_rc=$?
 if [ -z "$merged_count" ] || ! [[ "$merged_count" =~ ^[0-9]+$ ]]; then
   echo "WARNING: gh pr list の JSON 解析に失敗しました (jq rc=$jq_rc) — wiki-growth-check skipped" >&2
   [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2
-  echo "  raw stdout (先頭 200 文字): $(printf '%s' "$gh_json_out" | head -c 200)" >&2
+  echo "  raw stdout (先頭 200 文字): $(printf '%s' "$gh_json_out" | head -c 200 | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
   [ -n "$jq_err" ] && rm -f "$jq_err"
   echo "==> Total wiki-growth-check findings: 0"
   exit 0

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -698,7 +698,7 @@ surface_git_warnings() {
  local label="$1"
  if [[ -n "$git_err" ]] && [[ -s "$git_err" ]]; then
  local warnings
- warnings=$(head -n 10 "$git_err" | grep -iE '^(warning|hint|error):' || true)
+ warnings=$(head -n 10 "$git_err" | grep -iE '^(warning|hint|error):' | neutralize_ctrl --keep-newline || true)
  if [[ -n "$warnings" ]]; then
  printf '%s\n' "$warnings" | sed 's/^/ git ('"$label"'): /' >&2
  fi

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -50,7 +50,7 @@ if [ -n "$_resolve_err" ] && [ -s "$_resolve_err" ]; then
   # adds (INFO:/DIAG:/Notice:/...) would be silently dropped without the counter.
   # RITE_DEBUG bypasses filtering entirely for triage.
   if [ -n "${RITE_DEBUG:-}" ]; then
-    cat "$_resolve_err" >&2
+    neutralize_ctrl --keep-newline < "$_resolve_err" >&2
   else
     # Use `grep -c ''` (matches every line, ignores trailing-newline differences)
     # so the total agrees with the filter `grep -c` below. `wc -l` undercounts

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -20,6 +20,13 @@
 #   TC-2: neutralize_ctrl を call する全 hook ファイルが
 #         control-char-neutralize.sh を source している
 #         (定義元 control-char-neutralize.sh 自身は除外)
+#   TC-3: `head -c N` byte 指向 inline 埋め込み (1 行 WARNING への embed) も
+#         neutralize_ctrl を経由する (Issue #1329 — #1183 follow-up 横展開)
+#   TC-4: `cat "$file" >&2` 形式の full-file 直接 emission も neutralize_ctrl
+#         を経由する (Issue #1329)
+#   TC-5: `>&2` が log() / surface_git_warnings() 等の関数内部に隠れる emission
+#         経路は静的 sweep で構造的に検出不能のため、既知 site を個別に pin する
+#         (Issue #1329)
 #
 # Usage: bash plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
 set -euo pipefail
@@ -38,10 +45,10 @@ echo "=== TC-1: head -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
 # `head -[0-9]+` / `head -n [0-9]+` (行指向 snippet、両綴り) を対象とする。
 # `head -c` (byte 指向 inline 埋め込み) は 1 行 WARNING への embed で行構造が異なる
-# 別イディオムのため本 sweep の対象外。
-# 注意: head -c site は現状中和未適用 (Issue #1183 の対象は行指向 head snippet のみ)。
-# 横展開する場合は別 Issue で扱う。同様に、`>&2` が log() 等の関数内部に隠れて
-# 同一行に現れない emission 経路も本 sweep の検出対象外 (別 Issue の横展開対象候補)
+# 別イディオムのため本 sweep の対象外 — TC-3 が同一行 `>&2` 条件で別途 sweep する
+# (Issue #1329 で中和を横展開済み)。`>&2` が log() 等の関数内部に隠れて同一行に
+# 現れない emission 経路は静的 sweep で構造的に検出できないため、TC-5 が既知 site を
+# 個別に pin する (Issue #1329)
 violations=$(grep -rnE 'head (-[0-9]+|-n +[0-9]+) ' "$HOOKS_DIR" --include='*.sh' \
   | grep '>&2' \
   | grep -v "$HOOKS_DIR/tests/" \
@@ -80,6 +87,54 @@ if [ "$checked" -ge 24 ]; then
 else
   fail "TC-2: sweep coverage too small ($checked files — rollout 対象が grep から漏れている可能性)"
 fi
+
+echo ""
+echo "=== TC-3: head -c byte 指向 embed site は全て neutralize_ctrl を経由 ==="
+# `head -c N` snippet の大半は `var=$(... | head -c 200 ...)` の代入行で、emission の
+# `>&2` は後続 echo 行に分離している — `>&2` 同一行条件では構造的に検出できない
+# (Issue #1329 mutation 検証で実証)。そのため head -c 全行を sweep し、非 emission の
+# 既知 site のみ明示 allowlist で除外する fail-closed 設計とする。新規の head -c が
+# 非 emission 用途なら本 allowlist に追記すること。
+violations_c=$(grep -rnE 'head -c [0-9]+' "$HOOKS_DIR" --include='*.sh' \
+  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v 'neutralize_ctrl' \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+  | grep -v 'work-memory-lock.sh:.*lock_pid=' \
+  || true)
+assert "TC-3: un-neutralized head -c emission sites" "" "$violations_c"
+if [ -n "$violations_c" ]; then
+  echo "  検出された未中和 site (head -c の直後に '| tr '\\''\\n'\\'' '\\'' '\\'' | neutralize_ctrl --c0-only' を挿入すること):"
+  printf '%s\n' "$violations_c" | sed 's/^/    /'
+fi
+
+echo ""
+echo "=== TC-4: cat full-file 直接 emission site は全て neutralize_ctrl を経由 ==="
+# `cat "$file" >&2` 形式の full-file stderr 直接 emission (RITE_DEBUG triage 経路等)
+# を sweep する (Issue #1329)。中和版は `neutralize_ctrl --keep-newline < "$file" >&2`。
+violations_cat=$(grep -rnE 'cat "[^"]+" *>&2' "$HOOKS_DIR" --include='*.sh' \
+  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v 'neutralize_ctrl' \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+  || true)
+assert "TC-4: un-neutralized cat full-file emission sites" "" "$violations_cat"
+if [ -n "$violations_cat" ]; then
+  echo "  検出された未中和 site ('neutralize_ctrl --keep-newline < \"\$file\" >&2' へ置換すること):"
+  printf '%s\n' "$violations_cat" | sed 's/^/    /'
+fi
+
+echo ""
+echo "=== TC-5: 関数内 >&2 経由の既知 emission site は個別 pin ==="
+# log() / surface_git_warnings() 内部の >&2 は同一行 sweep で構造的に検出できない。
+# Issue #1329 で中和を適用した既知 site が回帰しないことを行単位で pin する。
+assert_grep "TC-5: distributed-fix-drift-check.sh table-side awk stderr log" \
+  "$HOOKS_DIR/scripts/distributed-fix-drift-check.sh" \
+  'head -1 "\$AWK_TABLE_ERR" \| tr -d .\\n. \| neutralize_ctrl --c0-only'
+assert_grep "TC-5: distributed-fix-drift-check.sh emit-side awk stderr log" \
+  "$HOOKS_DIR/scripts/distributed-fix-drift-check.sh" \
+  'head -1 "\$AWK_EMIT_ERR" \| tr -d .\\n. \| neutralize_ctrl --c0-only'
+assert_grep "TC-5: wiki-ingest-commit.sh surface_git_warnings" \
+  "$HOOKS_DIR/scripts/wiki-ingest-commit.sh" \
+  'grep -iE .\^\(warning\|hint\|error\):. \| neutralize_ctrl --keep-newline'
 
 if ! print_summary "$(basename "$0")" \
   "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、head -N の直後に '| neutralize_ctrl --keep-newline' を挿入すること (Issue #1183)"; then

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -45,10 +45,10 @@ echo "=== TC-1: head -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
 # `head -[0-9]+` / `head -n [0-9]+` (行指向 snippet、両綴り) を対象とする。
 # `head -c` (byte 指向 inline 埋め込み) は 1 行 WARNING への embed で行構造が異なる
-# 別イディオムのため本 sweep の対象外 — TC-3 が同一行 `>&2` 条件で別途 sweep する
-# (Issue #1329 で中和を横展開済み)。`>&2` が log() 等の関数内部に隠れて同一行に
-# 現れない emission 経路は静的 sweep で構造的に検出できないため、TC-5 が既知 site を
-# 個別に pin する (Issue #1329)
+# 別イディオムのため本 sweep の対象外 — TC-3 が head -c 全行を fail-closed sweep する
+# (非 emission site は明示 allowlist で除外、Issue #1329 で中和を横展開済み)。
+# `>&2` が log() 等の関数内部に隠れて同一行に現れない emission 経路は静的 sweep で
+# 構造的に検出できないため、TC-5 が既知 site を個別に pin する (Issue #1329)
 violations=$(grep -rnE 'head (-[0-9]+|-n +[0-9]+) ' "$HOOKS_DIR" --include='*.sh' \
   | grep '>&2' \
   | grep -v "$HOOKS_DIR/tests/" \

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -668,10 +668,10 @@ if grep -qE '_resolve_err_dropped|resolver stderr lines filtered' "$SESSION_END_
 else
   fail "TC-024 resolver stderr filter / drop counter wiring absent"
 fi
-if grep -qE 'if \[ -n "\$\{RITE_DEBUG:-\}" \].*then.*cat "\$_resolve_err"' "$SESSION_END_SCRIPT" \
+if grep -qE 'if \[ -n "\$\{RITE_DEBUG:-\}" \].*then.*neutralize_ctrl --keep-newline < "\$_resolve_err"' "$SESSION_END_SCRIPT" \
   || awk '
       /if \[ -n "\$\{RITE_DEBUG:-\}" \]; then/ { matched=1 }
-      matched && /cat "\$_resolve_err"/ { found=1; exit }
+      matched && /neutralize_ctrl --keep-newline < "\$_resolve_err"/ { found=1; exit }
       END { exit !found }
     ' "$SESSION_END_SCRIPT"; then
   pass "TC-025 RITE_DEBUG bypass branch anchored to resolver stderr handler"


### PR DESCRIPTION
## 概要

PR #1328 (Issue #1183) の行指向 `head -N` snippet 中和横展開で構造的に対象外だった 3 カテゴリの未中和診断 emission site に、`control-char-neutralize.sh` の適切なモードで中和を横展開する。脅威モデルは #1173/#1183 と同一: corrupt state file / gh・git・jq stderr 断片由来の制御バイト (特に CSI 0x9b / ESC 0x1b) が operator terminal を駆動する経路の遮断。

Closes #1329

## 変更内容

### カテゴリ 1: `head -c N` byte 指向 inline 埋め込み (17 site)

1 行 WARNING への `$(... | head -c N)` embed に `tr '\n' ' '` 先行 + `neutralize_ctrl --c0-only` を適用 (UTF-8 本文保持、security reviewer 推奨モード):

- `hooks/post-compact.sh` — 13 site (277-442)
- `hooks/issue-body-safe-update.sh` — 2 site (122/224、helper の source 追加を含む)
- `hooks/pre-tool-bash-guard.sh` — 1 site (101)
- `hooks/scripts/projects-board-drift-check.sh` / `hooks/scripts/wiki-growth-check.sh` — 各 1 site

### カテゴリ 2: `>&2` が関数内部に隠れる経路 (3 site)

- `hooks/scripts/distributed-fix-drift-check.sh` — `log()` 内 `head -1` embed 2 site に `tr -d '\n'` + `--c0-only` (command substitution の末尾改行除去より先に中和すると改行が `?` 化するため `tr -d '\n'` を先行)
- `hooks/scripts/wiki-ingest-commit.sh` — `surface_git_warnings()` の warnings 取得 pipeline に `--keep-newline` (行構造保持)

### カテゴリ 3: `cat` full-file 直接 emission (2 site)

- `hooks/session-end.sh:53` / `hooks/post-compact.sh:49` — `RITE_DEBUG` triage 経路の `cat "$_resolve_err" >&2` を `neutralize_ctrl --keep-newline < "$_resolve_err" >&2` へ置換

### テスト (AC-2: 回帰 pin)

`tests/diag-snippet-neutralize-parity.test.sh` に 3 検査を追加し、docstring の「別 Issue 送り」注記を解消:

- **TC-3**: `head -c` 全行 sweep + 非 emission 既知 site (work-memory-lock.sh lock pid 読み取り) の明示 allowlist。`>&2` 同一行条件では代入行 idiom (`var=$(... head -c ...)`) を構造的に検出できないことを mutation 注入で実証した上で fail-closed 設計を採用
- **TC-4**: `cat "$file" >&2` 形式の full-file 直接 emission sweep (mutation 検証済み)
- **TC-5**: 静的 sweep 不能な関数内 `>&2` 経路の既知 3 site を行単位 pin

`tests/session-end.test.sh` TC-025 は旧 `cat` literal を pin していたため中和版に追随更新。

## 受入条件

- [x] AC-1: 3 カテゴリの emission site に適切なモードの中和が適用されている
- [x] AC-2: parity テストの sweep を拡張し新カテゴリ検査 (TC-3/TC-4/TC-5) で回帰を pin
- [x] AC-3: 既存テストが全て pass する (hooks/tests 62/62)

## テスト結果

- `diag-snippet-neutralize-parity.test.sh`: 39 PASS / 0 FAIL (TC-3/TC-4 は mutation 注入で non-vacuous を検証)
- `run-tests.sh`: 62/62 passed

## 関連 Issue

Closes #1329

- 元 PR: #1328 / 元 Issue: #1183 / 設計元: #1274 (`control-char-neutralize.sh` のモード定義)
