### PR TITLE
refactor(hooks): review-comment-post.sh の post-condition awk sentinel を変数参照に統一 (from #1330)

### DIFF
--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -173,7 +173,8 @@ awk -v ts="$ISO_TIMESTAMP" -v sentinel="$SENTINEL" '
         # 直接埋め込むと `&` (マッチ全体に展開) / `\` (エスケープ) が metacharacter として
         # 解釈され置換結果が壊れる。index/substr は needle / replacement とも純リテラル扱い。
         # needle は SENTINEL 変数を -v で受け取る (値は backslash を含まないため -v の
-        # escape 解釈は安全)。post-condition 側の awk は regex literal のため別管理。
+        # escape 解釈は安全)。post-condition (a) 側の awk も同じ -v sentinel +
+        # index() 検査で統一されている (参照経路の対称性)。
         needle = "\"" sentinel "\""
         repl = "\"" ts "\""
         line = lines[i]
@@ -196,16 +197,20 @@ if [ "$awk_rc" -ne 0 ]; then
 fi
 
 # Post-condition (a): Raw JSON section 内に sentinel が残留していないこと。
-remaining_in_raw_json=$(awk '
+# needle は置換側 awk と同じく SENTINEL 変数を -v で受け取り index() でリテラル検査する
+# (置換側と検証側の sentinel 参照を変数経由に統一 — 片側だけ literal だと SENTINEL 値の
+# 変更時に検証側が旧 literal を検索して空振り pass する silent drift の余地が生じる)。
+remaining_in_raw_json=$(awk -v sentinel="$SENTINEL" '
   { lines[NR] = $0 }
   /^### 📄 Raw JSON/ { last_heading = NR }
   END {
     in_fence = 0
+    needle = "\"" sentinel "\""
     for (i = 1; i <= NR; i++) {
       if (i == last_heading) { past = 1; continue }
       if (past && lines[i] ~ /^```json$/) { in_fence = 1; continue }
       if (past && in_fence && lines[i] ~ /^```$/) { in_fence = 0; continue }
-      if (in_fence && lines[i] ~ /"__RITE_TS_PLACEHOLDER_7f3a9b2c__"/) { print lines[i] }
+      if (in_fence && index(lines[i], needle) > 0) { print lines[i] }
     }
   }
 ' "$tmpfile_patched")


### PR DESCRIPTION
## 概要

`review-comment-post.sh` の post-condition (a) (Raw JSON 内 sentinel 残留検知) の awk が sentinel を regex literal でハードコードしていた。PR #1330 で置換側 awk は `-v sentinel="$SENTINEL"` にパラメータ化されたため、参照経路が置換側 (変数) と検証側 (literal) で非対称になっており、将来 `SENTINEL` 値を変更した場合に検証側が旧 literal を検索して空振り pass する silent drift の余地があった。

Closes #1331

## 変更内容

- post-condition (a) の awk に `-v sentinel="$SENTINEL"` を渡し、regex literal 検査 (`lines[i] ~ /"__RITE_TS_PLACEHOLDER_7f3a9b2c__"/`) を `index(lines[i], needle)` ベースのリテラル検査に統一 (needle は置換側と同じ `"\"" sentinel "\""` 構築)
- 置換側 awk コメントの「post-condition 側の awk は regex literal のため別管理」注記を、参照経路の対称性を述べる記述に更新
- これにより SENTINEL literal の残存は変数定義 (1 箇所) と docstring のみになった

## 受入条件

- [x] AC-1: post-condition (a) の sentinel 参照が `$SENTINEL` 変数経由に統一されている
- [x] AC-2: 既存テスト (review-helpers-gate-behavior.test.sh) が全て pass する (97/97)

## 関連 Issue

Closes #1331

- 元 PR: #1330 (Issue #1200) — review cycle 2/4 で code-quality + error-handling が独立に推奨
