### PR TITLE
docs: simplification-charter.md の create.md ステップ 5.3-5.4 stale 参照を更新 (from #1332)

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/simplification-charter.md
+++ b/plugins/rite/skills/rite-workflow/references/simplification-charter.md
@@ -71,7 +71,7 @@ rite workflow 自体および rite workflow が生成する成果物（commit me
 - `plugins/rite/scripts/` 配下の .sh（実装契約として必要）
 - `plugins/rite/hooks/` の hook 自体（runtime に効く）
 - decision tree 系の reference（`complexity-gate.md` / `slug-generation.md` 等）
-- bash literal そのもの（`commands/issue/create.md` ステップ 5.3-5.4 の Decompose Path bash literal 等）
+- bash literal そのもの（`commands/issue/create.md` ステップ「5.3 + 5.4 + 5.5 Step 1」の Decompose Path が呼ぶ `scripts/decompose-issues.sh` 等 — bash 実体は helper へ委譲済みで、command 側に残る呼び出し block も実装契約として現状維持）
 
 ただし、これら適用範囲外のファイル**内でも上記『禁止パターン』は適用される** (`Issue #` 本文引用 / cycle # 記録 / 散文対称化契約 / `🚨` 濫用 等)。「適用範囲外」とは「ファイル丸ごと削除しない」の意味であり、ファイル内の歴史記述ノイズの整理は対象。
 


### PR DESCRIPTION
## 概要

`simplification-charter.md` の「適用範囲外」リストにある「`commands/issue/create.md` ステップ 5.3-5.4 の Decompose Path bash literal」という記述が、PR #1205 の helper 委譲後の実態（見出しは「5.3 + 5.4 + 5.5 Step 1」に統合、bash 実体は `scripts/decompose-issues.sh` へ移管）と乖離していたため、実態に追随させる。Issue #1207 と同一クラスの委譲後 cross-ref drift の解消。

Closes #1333

## 変更内容

- 参照を現行見出し「5.3 + 5.4 + 5.5 Step 1」と `scripts/decompose-issues.sh` への委譲実態を反映する記述へ更新（command 側に残る呼び出し block も実装契約として現状維持である旨を明記）

## 受入条件

- [x] AC-1: simplification-charter.md L74 の参照が実態と一致している
- [x] AC-2: 同型の stale 参照（「ステップ 5.3-5.4」表記）が他に残存しないことを grep で確認（plugins/rite/ + docs/ 全域で 0 件）

## 関連 Issue

Closes #1333

- 元 PR: #1332 (Issue #1207) — review cycle 1/4/5 で tech-writer / code-quality が独立に検出
