### PR TITLE
docs(tests): bash-trap-patterns.md の canonical 確立先記述に 6.0/6.2 helper 委譲注記を追加 (from #1334)

### DIFF
--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -234,7 +234,8 @@ esac
 ### 参照実装
 
 canonical 確立先は `plugins/rite/commands/wiki/lint.md` (ステップ 6.0 / 6.2 / 8.2 / 8.3 の dispatch
-構造 case 文)。**Scope**: dispatch 構造の case 文 (placeholder substitute validation gate /
+構造 case 文。うち 6.0 / 6.2 の case 文実体は `hooks/scripts/wiki-lint-skipped-refs.sh` /
+`wiki-lint-source-refs.sh` へ移設済みで helper 内にある — lint.md 側の注記と同一の委譲実態)。**Scope**: dispatch 構造の case 文 (placeholder substitute validation gate /
 strategy dispatch / rc dispatch) を対象とし、他 case arm 内にネストした dispatch case も含む。
 while loop の inner case (per-iteration 状態判定) は scope 外。新規 case 追加時は本 pattern を
 採用すること。ステップ番号 + case label の semantic anchor 形式で参照する (line 番号参照は drift する


### PR DESCRIPTION
## 概要

`bash-trap-patterns.md` の「参照実装」セクションが「canonical 確立先は lint.md (ステップ 6.0 / 6.2 / 8.2 / 8.3 の dispatch 構造 case 文)」と記述していたが、6.0 / 6.2 の case 文実体は `hooks/scripts/wiki-lint-skipped-refs.sh` / `wiki-lint-source-refs.sh` へ移設済み（lint.md 自身は「うち 6.0 / 6.2 は helper 内」と注記済み）。#1212 で是正したのと同種の委譲後 stale canonical 参照を解消する。

Closes #1335

## 変更内容

- canonical 確立先記述に「うち 6.0 / 6.2 の case 文実体は `hooks/scripts/wiki-lint-skipped-refs.sh` / `wiki-lint-source-refs.sh` へ移設済みで helper 内にある」の注記を追記（lint.md 側の既存注記と同一の委譲実態を表現）

## 受入条件

- [x] AC-1: bash-trap-patterns.md の記述が実態 (helper 委譲) と一致している — lint.md 側注記「うち 6.0 / 6.2 は helper 内で実行」と整合

## 関連 Issue

Closes #1335

- 元 PR: #1334 (Issue #1212) — review で code-quality reviewer が横断検証中に検出
