### PR TITLE
docs(tests): diag-snippet-neutralize-parity.test.sh の print_summary ガイダンスを 4 検査カテゴリ対応へ更新 (refs #1338)

### DIFF
--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -137,6 +137,10 @@ assert_grep "TC-5: wiki-ingest-commit.sh surface_git_warnings" \
   'grep -iE .\^\(warning\|hint\|error\):. \| neutralize_ctrl --keep-newline'
 
 if ! print_summary "$(basename "$0")" \
-  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、head -N の直後に '| neutralize_ctrl --keep-newline' を挿入すること (Issue #1183)"; then
+  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、emission site の構造に応じて中和を挿入すること (Issue #1183/#1329): \
+TC-1 (head -N 行指向) は直後に '| neutralize_ctrl --keep-newline'; \
+TC-3 (head -c byte 指向 embed) は '| tr '\\''\\n'\\'' '\\'' '\\'' | neutralize_ctrl --c0-only'; \
+TC-4 (cat full-file 直接 emission) は 'neutralize_ctrl --keep-newline < \"\$file\" >&2' へ置換; \
+TC-5 (log()/surface_git_warnings() 等の関数内 >&2) は静的 sweep で検出不能のため中和適用後に本テストへ個別 pin を追記すること"; then
   exit 1
 fi


### PR DESCRIPTION
## 概要

`diag-snippet-neutralize-parity.test.sh` 末尾 `print_summary` の drift_hint が TC-1 (head -N) 向け recipe のみに言及していたのを、PR #1337 で追加された TC-3/TC-4/TC-5 を含む 4 検査カテゴリの中和イディオムに言及する形へ更新する。

## 変更内容

- `print_summary` の第 2 引数 (drift_hint) を以下の 4 カテゴリ対応へ拡張:
  - TC-1 (head -N 行指向): 直後に `| neutralize_ctrl --keep-newline`
  - TC-3 (head -c byte 指向 embed): `| tr '\n' ' ' | neutralize_ctrl --c0-only`
  - TC-4 (cat full-file 直接 emission): `neutralize_ctrl --keep-newline < "$file" >&2` へ置換
  - TC-5 (関数内 >&2): 静的 sweep 不能のため中和後に本テストへ個別 pin を追記
- 各 TC 失敗時の inline メッセージ文言と整合させた

## Acceptance Criteria

- [x] print_summary のガイダンス文言が TC-1/TC-3/TC-4/TC-5 の 4 検査カテゴリと対応する recipe に言及している
- [x] 既存テストが全て pass する (PASS: 39 / FAIL: 0)

## 関連

- 元 PR: #1337 / 元 Issue: #1329, #1338

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)