### PR TITLE
docs(tests): bash-trap-patterns.md「採用 site」節に 6.0/6.2 helper 委譲注記を追加 (refs #1344)

### DIFF
--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -142,6 +142,10 @@ _rite_<scope>_<phase>_cleanup() {
 #### 採用 site (canonical 参照実装)
 
 - `plugins/rite/commands/wiki/lint.md` ステップ 2.2 / 6.0 / 6.2 / 8.3
+  - うち **ステップ 6.0 / 6.2** の trap/cleanup 関数実体は `hooks/scripts/wiki-lint-skipped-refs.sh` /
+    `wiki-lint-source-refs.sh` へ移設済みで、lint.md 側の bash block は helper を呼び出すだけ (本ファイル
+    「参照実装」節 L236 周辺の委譲注記と同一の実態)。lint.md 内に inline で残る trap/cleanup は
+    **ステップ 2.2 / 8.3** の 2 site (`_cleanup` 定義 + 4 行 trap が lint.md 本文に存在)。
 - `plugins/rite/commands/wiki/ingest.md` ステップ 2.2 / 2.3 / 5.2
 
 #### 命名規約

--- a/plugins/rite/commands/pr/references/bash-trap-patterns.md
+++ b/plugins/rite/commands/pr/references/bash-trap-patterns.md
@@ -144,7 +144,7 @@ _rite_<scope>_<phase>_cleanup() {
 - `plugins/rite/commands/wiki/lint.md` ステップ 2.2 / 6.0 / 6.2 / 8.3
   - うち **ステップ 6.0 / 6.2** の trap/cleanup 関数実体は `hooks/scripts/wiki-lint-skipped-refs.sh` /
     `wiki-lint-source-refs.sh` へ移設済みで、lint.md 側の bash block は helper を呼び出すだけ (本ファイル
-    「参照実装」節 L236 周辺の委譲注記と同一の実態)。lint.md 内に inline で残る trap/cleanup は
+    「Case Statement Indent Convention」節の「参照実装」サブ節の委譲注記と同一の実態)。lint.md 内に inline で残る trap/cleanup は
     **ステップ 2.2 / 8.3** の 2 site (`_cleanup` 定義 + 4 行 trap が lint.md 本文に存在)。
 - `plugins/rite/commands/wiki/ingest.md` ステップ 2.2 / 2.3 / 5.2
 


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/references/bash-trap-patterns.md` の「#### 採用 site (canonical 参照実装)」節に、`wiki/lint.md` ステップ 6.0 / 6.2 の trap/cleanup 関数実体が helper (`wiki-lint-skipped-refs.sh` / `wiki-lint-source-refs.sh`) へ移設済みである委譲注記を追加した。L236 周辺「参照実装」節の既存注記と同型。

## 変更内容

- 「採用 site」節の `wiki/lint.md ステップ 2.2 / 6.0 / 6.2 / 8.3` 列挙に sub-bullet を追加:
  - ステップ 6.0 / 6.2 の trap/cleanup 関数実体は helper へ移設済み
  - lint.md 内に inline で残る trap/cleanup は ステップ 2.2 / 8.3 の 2 site であることを明示

## 検証

- AC-1: 「採用 site」節の 6.0 / 6.2 記述が helper 委譲の実態と一致（helper に `_cleanup`+4 行 trap 実体、lint.md に inline `_rite_wiki_lint_*_cleanup` 定義なしを確認）
- AC-2: 同型 stale 参照が同ファイル内に残存しないことを grep で確認（L156 は命名規約例、L240-241 は既存の正しい注記）

Closes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)