### PR TITLE
docs(tests): pr-cycle-cleanup.test.sh 先頭 TC マップ docblock に T-14/T-15→#1340 を追記 (refs #1350)

### DIFF
--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -18,6 +18,12 @@
 #                  mutation-worktree parent) — extends the symmetry to the
 #                  mutation-worktree reap added in #1340
 #
+# Step 4 mutation worktree reaping (Issue #1340) — path-based sweep of orphan
+# detached `rite-review-mutation-*` worktrees that the Step 1 branch sweep cannot
+# catch (they have no named branch):
+#   T-14 → Step 4: aged orphan mutation worktree reaped (mutation_worktrees=1)
+#   T-15 → Step 4: age guard protects a fresh mutation worktree (in-flight safety)
+#
 # Each test creates an isolated temp git repository, simulates branch /
 # worktree creation, runs the cleanup script, and asserts the result.
 


### PR DESCRIPTION
## 概要

`pr-cycle-cleanup.test.sh` 先頭の test-case マップ docblock に **T-14 / T-15 → #1340** の 2 行を追記し、自己文書化の一貫性を回復する。

Closes #1350

## 背景

PR #1348 (Issue #1340) のレビューで test reviewer が検出 (actionable LOW / nit)。先頭マップは「どの AC をどの TC が担うか」のインデックスとして機能しているが、PR #1348 で追加した T-14 (Step 4 mutation worktree reaping) / T-15 (age guard) への言及が欠けていた。各テストの inline コメントは詳細だが、先頭マップだけが drift していた。

## 変更内容

- `plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh`
  - per-item failure-branch coverage セクション (T-16 まで) の後に、`Step 4 mutation worktree reaping (Issue #1340)` の専用セクションを追加
  - `T-14 → Step 4: aged orphan mutation worktree reaped (mutation_worktrees=1)`
  - `T-15 → Step 4: age guard protects a fresh mutation worktree (in-flight safety)`

docs のみの変更でテストロジックには手を加えていない。

## 検証

```
=== Summary ===
  PASS: 18
  FAIL: 0
  SKIP: 0
```

全 18 テスト PASS（変更前後で不変）。

## 関連
- 元 PR: #1348 / 元 Issue: #1340
