### PR TITLE
refactor(hooks): pr-cycle-cleanup.sh Step 3/4 の here-string 走査を find -print0 へ移行し改行名安全化 (refs #1351)

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -257,7 +257,13 @@ workdir_tmp_base="${workdir_tmp_base%/}"  # strip trailing slash
 # の `read -r -d ''` で、ディレクトリ名に改行を含む病的ケースでも 1 エントリを分割せず読む。
 workdir_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-err-XXXXXX 2>/dev/null) || workdir_find_err=""
 workdir_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-out-XXXXXX 2>/dev/null) || workdir_find_out=""
-if find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "${workdir_find_out:-/dev/null}" 2>"${workdir_find_err:-/dev/null}"; then
+# find 出力先 mktemp が失敗すると `> /dev/null` fallback で find 成功 (rc=0) でも reap 対象を
+# 空読みで silent 取りこぼす。本ファイルの「失敗を errors に加算して silent 化しない」方針と
+# 対称化するため WARNING + errors++ で surface する (age ガードにより次回正常実行で回収される)。
+if [ -z "$workdir_find_out" ]; then
+  echo "WARNING: orphan workdir 走査の出力先 mktemp に失敗しました。今回の回収をスキップします (次回 age 超過で回収)" >&2
+  errors=$((errors + 1))
+elif find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "$workdir_find_out" 2>"${workdir_find_err:-/dev/null}"; then
   while IFS= read -r -d '' orphan_workdir; do
     [ -z "$orphan_workdir" ] && continue
     if [ "$DRY_RUN" = "1" ]; then
@@ -310,7 +316,11 @@ mutation_tmp_base="${mutation_tmp_base%/}"  # strip trailing slash
 # する (command substitution は NUL を除去するため使えない、refs #1351)。
 mutation_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-err-XXXXXX 2>/dev/null) || mutation_find_err=""
 mutation_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-out-XXXXXX 2>/dev/null) || mutation_find_out=""
-if find "$mutation_tmp_base" -maxdepth 1 -type d -name 'rite-review-mutation-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "${mutation_find_out:-/dev/null}" 2>"${mutation_find_err:-/dev/null}"; then
+# Step 3 と同型: 出力先 mktemp 失敗時の silent 取りこぼしを WARNING + errors++ で surface する。
+if [ -z "$mutation_find_out" ]; then
+  echo "WARNING: orphan mutation worktree 走査の出力先 mktemp に失敗しました。今回の回収をスキップします (次回 age 超過で回収)" >&2
+  errors=$((errors + 1))
+elif find "$mutation_tmp_base" -maxdepth 1 -type d -name 'rite-review-mutation-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "$mutation_find_out" 2>"${mutation_find_err:-/dev/null}"; then
   mutation_reaped_any=0
   while IFS= read -r -d '' orphan_wt; do
     [ -z "$orphan_wt" ] && continue

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -109,8 +109,14 @@ prune_err=""
 ref_err=""
 workdir_find_err=""
 mutation_find_err=""
+# Step 3/4 の find -print0 出力を保持する NUL-delimited 一時ファイル (refs #1351)。
+# command substitution は NUL バイトを除去するため list を変数に持てない。find rc 捕捉を
+# 保ちつつ改行安全に読むには、出力を一時ファイルに退避して `read -r -d ''` で読む。
+workdir_find_out=""
+mutation_find_out=""
 _rite_pr_cycle_cleanup() {
-  rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}" "${workdir_find_err:-}" "${mutation_find_err:-}"
+  rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}" "${workdir_find_err:-}" "${mutation_find_err:-}" \
+        "${workdir_find_out:-}" "${mutation_find_out:-}"
 }
 trap 'rc=$?; _rite_pr_cycle_cleanup; exit $rc' EXIT
 trap '_rite_pr_cycle_cleanup; exit 130' INT
@@ -240,16 +246,19 @@ fi
 readonly WORKDIR_REAP_AGE_MINUTES=1440  # 24h
 workdir_tmp_base="${TMPDIR:-/tmp}"
 workdir_tmp_base="${workdir_tmp_base%/}"  # strip trailing slash
-# find は process substitution `< <(find ...)` ではなく command substitution + here-string で
-# 呼ぶ。process substitution は subshell の exit code がシェルに伝播しないため、$TMPDIR 不在 /
+# find は process substitution `< <(find ...)` ではなく、出力を一時ファイルに退避して呼ぶ。
+# process substitution は subshell の exit code がシェルに伝播しないため、$TMPDIR 不在 /
 # 権限なし / IO エラーで find が wholesale 失敗しても空ループ → 無言 no-op になり、本ファイルが
 # Step 1/2 (wt_list / prune / ref) で確立した「失敗を silent に握り潰さず errors カウンタに加算する」
-# 方針 (上記 prune block 参照) と非対称になる。command substitution で rc を捕捉し、失敗時は
-# WARNING + errors++ で sibling と対称化する。空 stdout 時の here-string は単一空行を生むが、
-# ループ先頭の `[ -z ]` ガードが branch-loop と同様に skip する。
+# 方針 (上記 prune block 参照) と非対称になる。`if find ... -print0 > "$out"; then` 形式なら
+# find が if の直接コマンドのため rc を捕捉でき、失敗時は WARNING + errors++ で sibling と対称化
+# できる。出力の保持に command substitution を使わない理由は、bash の `$(...)` が NUL バイトを
+# 除去してしまい -print0 の区切りが失われるため (refs #1351)。代わりに一時ファイル + NUL 区切り
+# の `read -r -d ''` で、ディレクトリ名に改行を含む病的ケースでも 1 エントリを分割せず読む。
 workdir_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-err-XXXXXX 2>/dev/null) || workdir_find_err=""
-if workdir_list=$(find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>"${workdir_find_err:-/dev/null}"); then
-  while IFS= read -r orphan_workdir; do
+workdir_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-out-XXXXXX 2>/dev/null) || workdir_find_out=""
+if find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-create-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "${workdir_find_out:-/dev/null}" 2>"${workdir_find_err:-/dev/null}"; then
+  while IFS= read -r -d '' orphan_workdir; do
     [ -z "$orphan_workdir" ] && continue
     if [ "$DRY_RUN" = "1" ]; then
       echo "[dry-run] would reap orphan workdir: $orphan_workdir"
@@ -261,7 +270,7 @@ if workdir_list=$(find "$workdir_tmp_base" -maxdepth 1 -type d -name 'rite-pr-cr
         errors=$((errors + 1))
       fi
     fi
-  done <<< "$workdir_list"
+  done < "${workdir_find_out:-/dev/null}"
 else
   workdir_find_rc=$?
   echo "WARNING: find による orphan workdir 走査が失敗しました (rc=$workdir_find_rc, base=$workdir_tmp_base)" >&2
@@ -297,10 +306,13 @@ fi
 # -----------------------------------------------------------------------
 mutation_tmp_base="${TMPDIR:-/tmp}"
 mutation_tmp_base="${mutation_tmp_base%/}"  # strip trailing slash
+# Step 3 と同型: find -print0 を一時ファイルに退避して rc 捕捉と改行安全な NUL 区切り読みを両立
+# する (command substitution は NUL を除去するため使えない、refs #1351)。
 mutation_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-err-XXXXXX 2>/dev/null) || mutation_find_err=""
-if mutation_list=$(find "$mutation_tmp_base" -maxdepth 1 -type d -name 'rite-review-mutation-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>"${mutation_find_err:-/dev/null}"); then
+mutation_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-out-XXXXXX 2>/dev/null) || mutation_find_out=""
+if find "$mutation_tmp_base" -maxdepth 1 -type d -name 'rite-review-mutation-*' -mmin +"$WORKDIR_REAP_AGE_MINUTES" -print0 > "${mutation_find_out:-/dev/null}" 2>"${mutation_find_err:-/dev/null}"; then
   mutation_reaped_any=0
-  while IFS= read -r orphan_wt; do
+  while IFS= read -r -d '' orphan_wt; do
     [ -z "$orphan_wt" ] && continue
     if [ "$DRY_RUN" = "1" ]; then
       echo "[dry-run] would reap orphan mutation worktree: $orphan_wt"
@@ -314,7 +326,7 @@ if mutation_list=$(find "$mutation_tmp_base" -maxdepth 1 -type d -name 'rite-rev
         errors=$((errors + 1))
       fi
     fi
-  done <<< "$mutation_list"
+  done < "${mutation_find_out:-/dev/null}"
   # rm -rf fallback で残った stale worktree メタデータを掃除する (remove --force 経路では不要だが冪等)
   if [ "$DRY_RUN" = "0" ] && [ "$mutation_reaped_any" = "1" ]; then
     git worktree prune 2>/dev/null || true

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -683,20 +683,34 @@ fi
 # -----------------------------------------------------------------------
 echo "T-17: Step 3 改行入り名の workdir が単一エントリで回収される (refs #1351)"
 rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
-t17_nl_name="rite-pr-create-nl$(printf '\n')evil"
-mkdir -p "$WORKDIR_SCAN_TMP/$t17_nl_name"
-touch -t 202001010000 "$WORKDIR_SCAN_TMP/$t17_nl_name"
-TEST_REPO=$(make_temp_repo)
-t17_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
-if [ ! -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] \
-   && echo "$t17_output" | grep -q 'status=cleaned' \
-   && echo "$t17_output" | grep -q 'workdirs=1'; then
-  pass "T-17: 改行入り名の workdir が単一エントリとして回収され workdirs=1"
-else
-  fail "T-17: dir=$([ -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] && echo present || echo gone) を期待 gone / workdirs=1。Output: $t17_output"
+# ANSI-C quoting ($'\n') で **literal 改行** を埋め込む。`$(printf '\n')` は command
+# substitution の末尾改行ストリップで改行が消え、テストが病的入力を生成しない false
+# positive (旧実装でも PASS) になるため使わない。
+t17_nl_name="rite-pr-create-nl"$'\n'"evil"
+# 前提条件 self-check: フィクスチャ名が本当に改行を含むことを固定する。将来 $'\n' が
+# 誤って書き換えられても、この guard が「病的入力を生成していない」状態を即座に検出する。
+# 注: `case ... in *"$(printf '\n')"*` は command substitution の改行ストリップで pattern が
+# 空になり常時マッチする欠陥があるため使わない。tr+wc で改行バイト数を直接数える。
+t17_nl_count=$(printf '%s' "$t17_nl_name" | tr -dc '\n' | wc -c | tr -d '[:space:]')
+if [ "$t17_nl_count" -lt 1 ]; then
+  fail "T-17: フィクスチャ名に改行が含まれていません (テスト前提崩壊、nl_count=$t17_nl_count)"
+  t17_nl_name=""
 fi
-rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
-cleanup_temp_repo "$TEST_REPO"
+if [ -n "$t17_nl_name" ]; then
+  mkdir -p "$WORKDIR_SCAN_TMP/$t17_nl_name"
+  touch -t 202001010000 "$WORKDIR_SCAN_TMP/$t17_nl_name"
+  TEST_REPO=$(make_temp_repo)
+  t17_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+  if [ ! -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] \
+     && echo "$t17_output" | grep -q 'status=cleaned' \
+     && echo "$t17_output" | grep -q 'workdirs=1'; then
+    pass "T-17: 改行入り名の workdir が単一エントリとして回収され workdirs=1"
+  else
+    fail "T-17: dir=$([ -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] && echo present || echo gone) を期待 gone / workdirs=1。Output: $t17_output"
+  fi
+  rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+  cleanup_temp_repo "$TEST_REPO"
+fi
 
 # -----------------------------------------------------------------------
 # Summary

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -670,6 +670,35 @@ else
 fi
 
 # -----------------------------------------------------------------------
+# T-17: Step 3 newline-in-name workdir is reaped as a single entry (refs #1351)
+# Given: an aged `rite-pr-create-*` workdir whose directory name contains an
+#        embedded newline (the pathological case the find -print0 migration targets)
+# When: cleanup runs
+# Then: the workdir is reaped (status=cleaned, workdirs=1) and the directory is gone.
+# Regression intent: under the prior `find | while IFS= read -r` + here-string code,
+# the newline split the single path into two non-existent partial paths, so `rm -rf`
+# no-op'd on both (rm -f ignores missing) — the real dir survived while workdirs was
+# miscounted. The `find -print0` + `read -r -d ''` migration reads the whole path as
+# one NUL-delimited entry, so the real dir is removed and counted once.
+# -----------------------------------------------------------------------
+echo "T-17: Step 3 改行入り名の workdir が単一エントリで回収される (refs #1351)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+t17_nl_name="rite-pr-create-nl$(printf '\n')evil"
+mkdir -p "$WORKDIR_SCAN_TMP/$t17_nl_name"
+touch -t 202001010000 "$WORKDIR_SCAN_TMP/$t17_nl_name"
+TEST_REPO=$(make_temp_repo)
+t17_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ ! -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] \
+   && echo "$t17_output" | grep -q 'status=cleaned' \
+   && echo "$t17_output" | grep -q 'workdirs=1'; then
+  pass "T-17: 改行入り名の workdir が単一エントリとして回収され workdirs=1"
+else
+  fail "T-17: dir=$([ -d "$WORKDIR_SCAN_TMP/$t17_nl_name" ] && echo present || echo gone) を期待 gone / workdirs=1。Output: $t17_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-pr-create-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 echo


### PR DESCRIPTION
## 概要

`pr-cycle-cleanup.sh` の Step 3 (workdir reap) / Step 4 (mutation worktree reap) の find 走査を `find | while IFS= read -r` + here-string から **`find -print0` + 一時ファイル + `read -r -d ''`** へ移行し、改行名安全化する。

Closes #1351

## 背景

PR #1348 (Issue #1340) のレビューで security reviewer が検出 (actionable LOW)。旧実装はディレクトリ名に改行を含む病的ケースで 1 エントリが複数行に分割され、存在しない部分パスへの `git worktree remove` / `rm -rf` 空振り → real dir 残存・カウンタ誤計上を招きうる。`mktemp -d -t` 生成名に改行は混入せず攻撃には local write 権限が必要なためリスクは LOW だが、Step 3/4 が同一前提を共有するため一括対応。

## 実装上の判断

**bash の command substitution `$(...)` は NUL バイトを除去する**ため、`-print0` 出力を変数に保持できない。一方、現行設計は find の rc 捕捉（silent-failure 防止）のため command substitution を採用していた。両立のため、**find 出力を一時ファイルに退避**（`if find ... -print0 > "$out"; then` で find が if の直接コマンドとなり rc 捕捉を維持）し、`read -r -d ''` で NUL 区切り読みする方式を採用した。process substitution は rc が伝播しないため不採用（既存コメントの理由と整合）。

## 変更内容

- `plugins/rite/hooks/scripts/pr-cycle-cleanup.sh`
  - Step 3/4 を `find -print0` + 一時ファイル + `read -r -d ''` へ移行
  - 出力用一時ファイル変数 (`workdir_find_out` / `mutation_find_out`) を既存の先行宣言 + 集約 cleanup trap に追加（orphan race window 排除）
  - 各ステップのコメントを新方式に合わせて更新
- `plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh`
  - **T-17 追加**: 改行入り名の workdir が単一エントリで回収され `workdirs=1` となることを pin。旧 here-string 実装では dir 残存 + `workdirs=2` で fail する回帰検出テスト

## 検証

```
=== Summary ===
  PASS: 19
  FAIL: 0
  SKIP: 0
```

T-17 を含む全 19 テスト PASS。既存ケース (T-06〜T-16) も挙動保存。

## 関連
- 元 PR: #1348 / 元 Issue: #1340 / 後続: #1352 (Step 3/4 ヘルパー化 — 本 PR の -print0 パターンを取り込む)
