### PR TITLE
fix(hooks): pr-cycle-cleanup.sh の WARNING/dry-run ヘッダ行を neutralize_ctrl 経由に統一

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -150,14 +150,16 @@ if wt_list=$(git worktree list --porcelain 2>"${wt_list_err:-/dev/null}"); then
         fi
         if [[ "$branch_name" =~ $PATTERN ]]; then
           if [ "$DRY_RUN" = "1" ]; then
-            echo "[dry-run] would remove worktree: $current_path (branch=$branch_name)"
+            safe_path=$(printf '%s' "$current_path" | neutralize_ctrl)
+            safe_branch=$(printf '%s' "$branch_name" | neutralize_ctrl)
+            echo "[dry-run] would remove worktree: $safe_path (branch=$safe_branch)"
           else
             # 失敗時は git の stderr を診断として surface する (refs #1352、従来は
             # `2>/dev/null` で失敗理由 — lock / 権限 / submodule 等 — が落ちていた)。
             if wt_rm_err=$(git worktree remove --force "$current_path" 2>&1); then
               worktrees_removed=$((worktrees_removed + 1))
             else
-              echo "WARNING: failed to remove worktree '$current_path'" >&2
+              echo "WARNING: failed to remove worktree '$(printf '%s' "$current_path" | neutralize_ctrl)'" >&2
               if [ -n "$wt_rm_err" ]; then
                 head -3 <<< "$wt_rm_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
               fi
@@ -211,12 +213,12 @@ if branches=$(git for-each-ref --format='%(refname:short)' refs/heads/ 2>"${ref_
     [ -z "$br" ] && continue
     if [[ "$br" =~ $PATTERN ]]; then
       if [ "$DRY_RUN" = "1" ]; then
-        echo "[dry-run] would delete branch: $br"
+        echo "[dry-run] would delete branch: $(printf '%s' "$br" | neutralize_ctrl)"
       else
         if git branch -D "$br" >/dev/null 2>&1; then
           branches_deleted=$((branches_deleted + 1))
         else
-          echo "WARNING: failed to delete branch '$br'" >&2
+          echo "WARNING: failed to delete branch '$(printf '%s' "$br" | neutralize_ctrl)'" >&2
           errors=$((errors + 1))
         fi
       fi
@@ -284,7 +286,7 @@ reap_orphan_dirs() {
     while IFS= read -r -d '' orphan; do
       [ -z "$orphan" ] && continue
       if [ "$DRY_RUN" = "1" ]; then
-        echo "[dry-run] would reap ${label}: $orphan"
+        echo "[dry-run] would reap ${label}: $(printf '%s' "$orphan" | neutralize_ctrl)"
       else
         "$reaper_fn" "$orphan"
       fi
@@ -307,7 +309,7 @@ _reap_workdir() {
     workdirs_reaped=$((workdirs_reaped + 1))
     return 0
   fi
-  echo "WARNING: failed to reap orphan workdir '$orphan'" >&2
+  echo "WARNING: failed to reap orphan workdir '$(printf '%s' "$orphan" | neutralize_ctrl)'" >&2
   if [ -n "$rm_err" ]; then
     head -3 <<< "$rm_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
@@ -330,7 +332,7 @@ _reap_mutation_worktree() {
     mutation_reaped_any=1
     return 0
   fi
-  echo "WARNING: failed to reap orphan mutation worktree '$orphan'" >&2
+  echo "WARNING: failed to reap orphan mutation worktree '$(printf '%s' "$orphan" | neutralize_ctrl)'" >&2
   if [ -n "$wt_err" ]; then
     echo "  git worktree remove --force:" >&2
     head -2 <<< "$wt_err" | neutralize_ctrl --keep-newline | sed 's/^/    /' >&2


### PR DESCRIPTION
## 概要

`pr-cycle-cleanup.sh` の WARNING / dry-run **ヘッダ行**が、attacker-controllable な per-item 名 (`$current_path` / `$br` / `$orphan`) を `neutralize_ctrl` を通さず生で stderr に echo していた。stderr の body (失敗理由 snippet) は無害化済みだが、ヘッダの name/path は素通しのため、`rite-pr-create-<ESC>[2J...` のような名前でターミナル制御 sequence が surface しうる非対称があった。本 PR でヘッダ/body 間の無害化方式を揃え、この非対称を解消する。

## 変更内容

helper の文書化済み規約 `printf '%s' "$value" | neutralize_ctrl`（1 行埋め込み用・改行も `?` 化）で 7 箇所のヘッダ行を無害化:

- **Step 1**: dry-run worktree / WARNING worktree (`$current_path`, `$branch_name`)
- **Step 2**: dry-run branch / WARNING branch (`$br`)
- **reaper**: dry-run reap / orphan workdir / mutation worktree (`$orphan`)

`$base` / `$PATTERN` / `${label}` は固定の設定値であり per-item 攻撃面ではないため対象外とした。新しい抽象 (wrapper / helper) は追加せず、body と同じ `neutralize_ctrl` を直接利用している。

## 検証

- `bash -n` 構文チェック OK
- `pr-cycle-cleanup.test.sh` 全 19 ケース PASS（リグレッションなし）
- ESC (0x1b) / C1 CSI (0x9b) を含む名前がヘッダ出力で `?` 化されることを手動確認

## 関連 Issue

Closes #1358

- 元 PR: #1357 / 元 Issue: #1352 / 系統: #1340
