### PR TITLE
feat(hooks): Issue claim 機構 issue-claim.sh の追加 (refs #1363)

### DIFF
--- a/docs/designs/multi-session-worktree.md
+++ b/docs/designs/multi-session-worktree.md
@@ -185,6 +185,19 @@ multi_session:
 - 他セッションの live claim 検出時は**常に AskUserQuestion**（無人での奪取はしない）。
 - **既知の限界**: phase 遷移なしで 2h を超える implement 中は stale 誤判定しうる → 自動奪取は reap（§8）のみ、かつ clean worktree 条件付き。
 
+#### S3 確定 CLI 契約（S6/S7/S9 配線仕様 — Issue #1363 で確定）
+
+`bash hooks/issue-claim.sh {claim|release|check} --issue N [--worktree PATH] [--session UUID]`
+
+| サブコマンド | stdout | exit code | 挙動 |
+|---|---|---|---|
+| `claim` | `claimed` / `own` / `other` | `0`（claimed/own/stale-steal）/ `10`（other=live）/ `1`（usage/env エラー） | free→noclobber 取得 / own→冪等 refresh / stale→flock 奪取 / **other(live)→取得せず rc 10**（呼び出し側が AskUserQuestion） |
+| `release` | `released` / `skipped` | `0`（冪等。不在でも `released`）/ `1` | 自セッションの claim のみ削除。他セッション保持時は `skipped`（触らない） |
+| `check` | `own` / `free` / `other` / `stale` | `0` | 読み取りのみ。corrupt/空 holder は `stale`（再取得可能） |
+
+- **session_id 解決**: `_resolve-session-id-from-file.sh`（`.rite-session-id` ファイル優先）→ env（`CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID`）の順で、`flow-state.sh` の解決順と**一致**させる（claim の session_id が holder の per-session flow-state ファイル名と一致することが liveness 判定の前提）。テスト・明示制御は `--session` override。
+- **配線挿入点**: pr:open Step 1.6 = `claim`（rc 10 → AskUserQuestion / rc 0 → 続行、`--worktree {path}` で worktree path も記録）。cleanup Step 11-12 = `release`。sprint execute/team-execute = `check`（`other` のみスキップ、`stale` はスキップせず pr:open の claim に委ねる）。
+
 ### §8 セッション worktree の遅延 reap（pr-cycle-cleanup.sh Step 5 追加）
 
 責務分担: **正常系は cleanup.md が即時削除**、reap は**異常終了の残骸回収のみ**。

--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# rite workflow - Issue Claim mechanism (multi-session design §7)
+#
+# Prevents two sessions from starting work on the SAME Issue concurrently
+# ("double-commit"). Always active regardless of `multi_session.enabled`
+# (Decision D-3): multiple sessions in one checkout are already supported via
+# per-session flow-state, so the double-commit risk exists independent of the
+# worktree feature. Silent when there is no conflict → backward-compatible.
+#
+# Subcommands:
+#   claim   --issue N [--worktree PATH] [--session UUID]   acquire the claim
+#   release --issue N [--session UUID]                      release own claim
+#   check   --issue N [--session UUID]                      classify: own|free|other|stale
+#
+# Data contract (`<shared-root>/.rite/state/issue-claims/issue-{N}.json`):
+#   {"schema_version":1,"issue_number":N,"session_id":"...","worktree":"<abs|''>","claimed_at":"ISO8601Z"}
+#   `.rite/state/` is already gitignored, so no new .gitignore entry is needed.
+#
+# Liveness (NO new heartbeat — reuses flow-state `updated_at`): a claim is LIVE
+# when the holder's per-session flow-state has `active=true` AND `updated_at`
+# within 7200s (2h). The 2h threshold + `parse_iso8601_to_epoch` are sourced
+# from `session-ownership.sh` (single source of truth). `flow-state.sh set`
+# refreshes `updated_at` on every phase transition, so that IS the heartbeat.
+#
+# Atomicity: a FREE issue is claimed via `noclobber` (`set -C`) file creation —
+# only one of N racing processes wins the create. The stale-steal and own-refresh
+# paths serialize through an flock on `issue-claims/.lock` (same shape as
+# `flow-state.sh` `_atomic_write`). A LIVE other-session claim is NEVER stolen
+# unattended (AC-5) — `claim` returns rc=10 so the caller (pr:open Step 1.6)
+# raises an AskUserQuestion.
+#
+# KNOWN LIMITATION: an `implement` phase that runs >2h without any phase
+# transition can be misclassified as stale (its flow-state `updated_at` ages
+# out). The claim's stale-steal only overwrites the lock record; the physical
+# session worktree is only auto-removed by the §8 reap, and only when clean.
+#
+# Exit codes:
+#   0   success (claim acquired / refreshed / released / check printed)
+#   1   usage / argument / environment error (cannot resolve session_id, etc.)
+#   10  claim refused — another LIVE session holds the claim (caller: AskUserQuestion)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=state-path-resolve.sh
+source "$SCRIPT_DIR/state-path-resolve.sh"
+# shellcheck source=control-char-neutralize.sh
+source "$SCRIPT_DIR/control-char-neutralize.sh"
+# shellcheck source=session-ownership.sh  (parse_iso8601_to_epoch + 2h threshold)
+source "$SCRIPT_DIR/session-ownership.sh"
+
+export GIT_TERMINAL_PROMPT=0
+
+# Stale threshold (seconds). Mirrors session-ownership.sh check_session_ownership
+# (2h). Kept as a named constant so the parity with that file is explicit.
+CLAIM_STALE_SECONDS=7200
+
+# Shared state root (main checkout under multi-session — state-path-resolve.sh is
+# worktree-aware). Callers may pre-resolve and pass RITE_STATE_ROOT.
+if [ -n "${RITE_STATE_ROOT:-}" ] && [ -d "$RITE_STATE_ROOT" ]; then
+  STATE_ROOT="$RITE_STATE_ROOT"
+else
+  STATE_ROOT=$(resolve_state_root)
+fi
+CLAIMS_DIR="$STATE_ROOT/.rite/state/issue-claims"
+CLAIMS_LOCK="$CLAIMS_DIR/.lock"
+
+# Resolve the CURRENT session_id. Reuses the canonical helpers:
+#   - `_resolve-session-id-from-file.sh` reads + UUID-validates `.rite-session-id`
+#   - `_resolve-session-id.sh` UUID-validates a runtime env candidate
+# Returns empty when no valid session_id can be resolved (caller decides).
+_resolve_current_session_id() {
+  local override="${1:-}" sid=""
+  if [ -n "$override" ]; then
+    sid=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$override" 2>/dev/null) || sid=""
+    printf '%s' "$sid"
+    return 0
+  fi
+  sid=$(bash "$SCRIPT_DIR/_resolve-session-id-from-file.sh" "$STATE_ROOT" 2>/dev/null) || sid=""
+  if [ -z "$sid" ]; then
+    local cand
+    for cand in "${CLAUDE_CODE_SESSION_ID:-}" "${CLAUDE_SESSION_ID:-}"; do
+      [ -n "$cand" ] || continue
+      sid=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$cand" 2>/dev/null) || sid=""
+      [ -n "$sid" ] && break
+    done
+  fi
+  printf '%s' "$sid"
+}
+
+# Is the holding session live? claim is LIVE when the holder's flow-state has
+# active=true AND updated_at within CLAIM_STALE_SECONDS. Reads the holder's
+# per-session state via flow-state.sh (passing the shared STATE_ROOT). rc 0=live.
+_holder_is_live() {
+  local holder="$1"
+  [ -n "$holder" ] || return 1
+  local active updated epoch now
+  active=$(RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" \
+            get --session "$holder" --field active --default "false" 2>/dev/null) || active="false"
+  [ "$active" = "true" ] || return 1
+  updated=$(RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" \
+            get --session "$holder" --field updated_at --default "" 2>/dev/null) || updated=""
+  [ -n "$updated" ] || return 1
+  epoch=$(parse_iso8601_to_epoch "$updated")
+  [ "$epoch" -gt 0 ] || return 1
+  now=$(date +%s)
+  [ $((now - epoch)) -le "$CLAIM_STALE_SECONDS" ]
+}
+
+# Read the holder session_id from a claim file ('' on missing/corrupt).
+_claim_holder() {
+  local file="$1"
+  [ -f "$file" ] || { printf ''; return 0; }
+  jq -r '.session_id // ""' "$file" 2>/dev/null || printf ''
+}
+
+# Classify a claim: own | free | other | stale. $1=claim file, $2=current sid.
+_classify() {
+  local file="$1" current="$2" holder
+  [ -f "$file" ] || { printf 'free'; return 0; }
+  holder=$(_claim_holder "$file")
+  # Empty/corrupt holder → reclaimable (treat as stale).
+  [ -n "$holder" ] || { printf 'stale'; return 0; }
+  if [ -n "$current" ] && [ "$holder" = "$current" ]; then printf 'own'; return 0; fi
+  if _holder_is_live "$holder"; then printf 'other'; else printf 'stale'; fi
+}
+
+# Build the claim JSON for the current session.
+_build_json() {
+  local issue="$1" sid="$2" worktree="$3" now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  jq -nc --argjson sv 1 --argjson issue "$issue" --arg sid "$sid" \
+         --arg wt "$worktree" --arg ts "$now" \
+    '{schema_version:$sv, issue_number:$issue, session_id:$sid, worktree:$wt, claimed_at:$ts}'
+}
+
+# Atomic write of the claim file under the issue-claims flock (own-refresh /
+# stale-steal). Degrades to a plain atomic mv when flock is unavailable
+# (minimal containers / macOS without util-linux) — matches the wiki helpers.
+_atomic_claim_write() {
+  local file="$1" json="$2" tmp rc=0
+  tmp=$(mktemp "${file}.XXXXXX" 2>/dev/null) || return 1
+  printf '%s\n' "$json" > "$tmp" || { rm -f "$tmp"; return 1; }
+  if command -v flock >/dev/null 2>&1; then
+    if ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
+      ( exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1; mv -f "$tmp" "$file" ) || rc=$?
+    else
+      mv -f "$tmp" "$file" || rc=$?
+    fi
+  else
+    mv -f "$tmp" "$file" || rc=$?
+  fi
+  [ "$rc" -eq 0 ] || rm -f "$tmp" 2>/dev/null || true
+  return "$rc"
+}
+
+_validate_issue() {
+  case "$1" in
+    ''|*[!0-9]*) echo "ERROR: --issue must be a positive integer (got: '${1:-}')" >&2; return 1 ;;
+  esac
+  [ "$1" -gt 0 ] || { echo "ERROR: --issue must be > 0" >&2; return 1; }
+  return 0
+}
+
+cmd_claim() {
+  local issue="" worktree="" session=""
+  while [ $# -gt 0 ]; do case "$1" in
+    --issue) issue="$2"; shift 2 ;;
+    --worktree) worktree="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
+  esac; done
+  _validate_issue "$issue" || return 1
+  local sid; sid=$(_resolve_current_session_id "$session")
+  [ -n "$sid" ] || { echo "ERROR: issue-claim.sh claim: cannot resolve session_id" >&2; return 1; }
+  mkdir -p "$CLAIMS_DIR" 2>/dev/null || { echo "ERROR: cannot create $CLAIMS_DIR" >&2; return 1; }
+  local file="$CLAIMS_DIR/issue-${issue}.json" json
+  json=$(_build_json "$issue" "$sid" "$worktree") || { echo "ERROR: failed to build claim JSON" >&2; return 1; }
+
+  # Fast path: claim a FREE issue via noclobber. Only one racing process wins.
+  if ( set -C; printf '%s\n' "$json" > "$file" ) 2>/dev/null; then
+    echo "claimed"
+    return 0
+  fi
+
+  # File already exists — classify and act.
+  local state; state=$(_classify "$file" "$sid")
+  case "$state" in
+    own)
+      _atomic_claim_write "$file" "$json" || { echo "ERROR: failed to refresh own claim" >&2; return 1; }
+      echo "own"
+      return 0
+      ;;
+    stale)
+      local prev; prev=$(_claim_holder "$file")
+      _atomic_claim_write "$file" "$json" || { echo "ERROR: failed to steal stale claim" >&2; return 1; }
+      echo "[issue-claim] stole stale claim for issue #${issue} (previous holder: ${prev:-<corrupt>})" >&2
+      echo "claimed"
+      return 0
+      ;;
+    other)
+      local holder; holder=$(_claim_holder "$file")
+      echo "[issue-claim] issue #${issue} is claimed by another LIVE session (${holder}); not stealing unattended" >&2
+      echo "other"
+      return 10
+      ;;
+  esac
+}
+
+cmd_release() {
+  local issue="" session=""
+  while [ $# -gt 0 ]; do case "$1" in
+    --issue) issue="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
+  esac; done
+  _validate_issue "$issue" || return 1
+  local sid; sid=$(_resolve_current_session_id "$session")
+  [ -n "$sid" ] || { echo "ERROR: issue-claim.sh release: cannot resolve session_id" >&2; return 1; }
+  local file="$CLAIMS_DIR/issue-${issue}.json"
+  # Idempotent: releasing an absent claim is a success (AC-4).
+  [ -f "$file" ] || { echo "released"; return 0; }
+  local holder; holder=$(_claim_holder "$file")
+  if [ "$holder" != "$sid" ]; then
+    # Only the owner releases its own claim — never touch another session's (AC-3).
+    echo "[issue-claim] release: issue #${issue} is held by another session (${holder:-<corrupt>}); leaving it intact" >&2
+    echo "skipped"
+    return 0
+  fi
+  if command -v flock >/dev/null 2>&1 && ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
+    ( exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1; rm -f "$file" ) || { echo "ERROR: failed to remove claim" >&2; return 1; }
+  else
+    rm -f "$file" || { echo "ERROR: failed to remove claim" >&2; return 1; }
+  fi
+  echo "released"
+  return 0
+}
+
+cmd_check() {
+  local issue="" session=""
+  while [ $# -gt 0 ]; do case "$1" in
+    --issue) issue="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
+  esac; done
+  _validate_issue "$issue" || return 1
+  local sid; sid=$(_resolve_current_session_id "$session")
+  local file="$CLAIMS_DIR/issue-${issue}.json"
+  _classify "$file" "$sid"
+  echo ""
+  return 0
+}
+
+case "${1:-}" in
+  claim)   shift; cmd_claim "$@" ;;
+  release) shift; cmd_release "$@" ;;
+  check)   shift; cmd_check "$@" ;;
+  *)
+    cat >&2 <<EOF
+Usage: $0 {claim|release|check} --issue N [--worktree PATH] [--session UUID]
+  claim   --issue N [--worktree PATH] [--session UUID]   acquire (rc 10 if held by live session)
+  release --issue N [--session UUID]                      release own claim (idempotent)
+  check   --issue N [--session UUID]                      print: own|free|other|stale
+EOF
+    exit 1
+    ;;
+esac

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Tests for issue-claim.sh (Issue #1363 / S3, multi-session design §7).
+#
+# Covers:
+#   AC-1: concurrent claim → exactly one process succeeds (noclobber atomicity)
+#   AC-2: own | other | stale classification (live / active=false / >2h)
+#   AC-3: release removes only the OWN claim; another session's is untouched
+#   AC-4: release on an absent claim is idempotent (success)
+#   plus: free check, stale-steal, corrupt-claim → stale, live-other refusal (rc 10)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+IC="$SCRIPT_DIR/../issue-claim.sh"
+FS="$SCRIPT_DIR/../flow-state.sh"
+
+SID_A="aaaaaaaa-1111-2222-3333-444444444444"
+SID_B="bbbbbbbb-5555-6666-7777-888888888888"
+
+cleanup_dirs=()
+cleanup() { local d; for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+ROOT=$(make_sandbox --branch develop)
+cleanup_dirs+=("$ROOT")
+export RITE_STATE_ROOT="$ROOT"
+
+# Helper: set an active flow-state for a session (makes its claim "live").
+mk_active() { bash "$FS" set --session "$1" --phase implement --issue "$2" --branch x --next n >/dev/null 2>&1; }
+claim()   { bash "$IC" claim   --session "$1" --issue "$2" ${3:+--worktree "$3"} 2>/dev/null; }
+check()   { bash "$IC" check   --session "$1" --issue "$2" 2>/dev/null; }
+release() { bash "$IC" release --session "$1" --issue "$2" 2>/dev/null; }
+
+# === AC-2 / free / own / other / stale ===
+echo "=== TC-1: check on free issue → free ==="
+assert "TC-1 free" "free" "$(check "$SID_A" 700)"
+
+echo "=== TC-2: claim → claimed; check → own ==="
+mk_active "$SID_A" 700
+assert "TC-2 claimed" "claimed" "$(claim "$SID_A" 700)"
+assert "TC-2 own" "own" "$(check "$SID_A" 700)"
+
+echo "=== TC-3 (AC-2): other session sees live claim as 'other' ==="
+assert "TC-3 other" "other" "$(check "$SID_B" 700)"
+
+echo "=== TC-4 (AC-5): claim by other live session refused (rc 10, prints 'other') ==="
+rc=0; out=$(bash "$IC" claim --session "$SID_B" --issue 700 2>/dev/null) || rc=$?
+assert "TC-4 prints other" "other" "$out"
+assert "TC-4 rc 10" "10" "$rc"
+
+echo "=== TC-5 (AC-3): other session's release does NOT touch the claim ==="
+assert "TC-5 release skipped" "skipped" "$(release "$SID_B" 700)"
+assert "TC-5 holder still A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-700.json")"
+
+echo "=== TC-6 (AC-2): active=false holder → stale; stale-steal succeeds ==="
+bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+assert "TC-6 stale (inactive)" "stale" "$(check "$SID_B" 700)"
+assert "TC-6 steal → claimed" "claimed" "$(claim "$SID_B" 700)"
+assert "TC-6 holder now B" "$SID_B" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-700.json")"
+
+echo "=== TC-7 (AC-2): holder updated_at > 2h → stale ==="
+mk_active "$SID_A" 701
+claim "$SID_A" 701 >/dev/null
+PAST=$(date -u -d '3 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-3H +"%Y-%m-%dT%H:%M:%SZ")
+tmp=$(mktemp); jq --arg t "$PAST" '.updated_at=$t' "$ROOT/.rite/sessions/$SID_A.flow-state" > "$tmp" && mv "$tmp" "$ROOT/.rite/sessions/$SID_A.flow-state"
+assert "TC-7 stale (2h aged)" "stale" "$(check "$SID_B" 701)"
+
+echo "=== TC-8 (AC-4): release on absent claim is idempotent ==="
+assert "TC-8 release absent → released" "released" "$(release "$SID_A" 9999)"
+
+echo "=== TC-9: own-claim refresh stores worktree path; release removes it ==="
+mk_active "$SID_A" 702
+claim "$SID_A" 702 "/abs/wt/issue-702" >/dev/null
+assert "TC-9 worktree recorded" "/abs/wt/issue-702" "$(jq -r .worktree "$ROOT/.rite/state/issue-claims/issue-702.json")"
+assert "TC-9 release own" "released" "$(release "$SID_A" 702)"
+assert "TC-9 check free after release" "free" "$(check "$SID_A" 702)"
+
+echo "=== TC-10: corrupt claim file → stale (reclaimable) ==="
+mkdir -p "$ROOT/.rite/state/issue-claims"
+printf 'not-json{' > "$ROOT/.rite/state/issue-claims/issue-703.json"
+assert "TC-10 corrupt → stale" "stale" "$(check "$SID_A" 703)"
+
+echo "=== TC-11 (AC-1): 5 concurrent claims → exactly one 'claimed' ==="
+for i in 1 2 3 4 5; do mk_active "0000000$i-1111-2222-3333-444444444444" 900; done
+rm -f "$ROOT"/claimout.* 2>/dev/null || true
+for i in 1 2 3 4 5; do
+  ( bash "$IC" claim --session "0000000$i-1111-2222-3333-444444444444" --issue 900 > "$ROOT/claimout.$i" 2>/dev/null ) &
+done
+wait
+_claimed=0
+for i in 1 2 3 4 5; do [ "$(cat "$ROOT/claimout.$i" 2>/dev/null)" = "claimed" ] && _claimed=$((_claimed+1)); done
+assert "TC-11 exactly one claimed" "1" "$_claimed"
+
+echo "=== TC-12: invalid --issue rejected (rc 1) ==="
+rc=0; bash "$IC" claim --session "$SID_A" --issue abc >/dev/null 2>&1 || rc=$?; assert "TC-12 non-numeric rc 1" "1" "$rc"
+rc=0; bash "$IC" check --session "$SID_A" --issue 0 >/dev/null 2>&1 || rc=$?; assert "TC-12 zero rc 1" "1" "$rc"
+
+print_summary "$(basename "$0")" \
+  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity."


### PR DESCRIPTION
## 概要

Closes #1363 — マルチセッション対応（親 #1360）の **S3: Issue claim 機構**。同一 Issue への二重着手を防止する。`multi_session.enabled` に依らず**常時有効**（Decision D-3）。設計 §7。

## 変更点

- **`hooks/issue-claim.sh`** 新規（`claim` / `release` / `check`）
  - **claim**: free→`noclobber`(set -C) 取得 / own→冪等 refresh / stale→flock 奪取 / **other(live)→取得せず rc 10**（呼び出し側が AskUserQuestion）
  - **release**: 自セッションの claim のみ削除（他セッションは触らない）、不在でも冪等成功
  - **check**: `own | free | other | stale`（corrupt/空 holder は `stale`）
  - **liveness**: holder の flow-state `active=true` ∧ `updated_at` 2h 以内。`session-ownership.sh` の 7200s 閾値 + `parse_iso8601_to_epoch` を source 再利用（新 heartbeat を作らない）
  - session_id 解決は flow-state と**同一順**（`_resolve-session-id-from-file.sh` → env）で claim の sid が holder の per-session state ファイル名と一致することを保証
- **`hooks/tests/issue-claim.test.sh`** 新規（20 assertions）
- 設計 §7 に **S3 確定 CLI 契約**（rc / 分類値 / 配線挿入点）を追記（S6/S7/S9 が参照）

## AC

- [x] AC-1: 2（5）プロセス同時 claim で必ず一方のみ成功（noclobber 原子性テスト TC-11）
- [x] AC-2: own / other(live) / stale(active=false, 2h超) 分類（TC-2/3/6/7）
- [x] AC-3: release は自セッションの claim のみ削除、他は触らない（TC-5）
- [x] AC-4: claim 不在で release しても成功扱い（冪等、TC-8）

## DoD

- [x] 全 AC 達成 + テスト追加（hook テスト全 pass: **65/65**）
- [x] S6/S7/S9 が参照する配線仕様を設計 §7 に確定記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)