### PR TITLE
feat(hooks): セッション worktree の遅延 reap（pr-cycle-cleanup Step 5）(refs #1364)

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -108,6 +108,7 @@ worktrees_removed=0
 branches_deleted=0
 workdirs_reaped=0
 mutation_worktrees_reaped=0
+session_worktrees_reaped=0
 errors=0
 
 # trap + cleanup パターン (canonical: references/bash-trap-patterns.md#signal-specific-trap-template)
@@ -400,16 +401,113 @@ if [ "$DRY_RUN" = "0" ] && [ "$mutation_reaped_any" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------
+# Step 5: Lazy reap of orphaned SESSION worktrees (multi-session design §8).
+# 責務分担: 正常系の即時削除は cleanup.md (S7) の責務、本 reap は **異常終了の
+# 残骸回収のみ**。`.rite/worktrees/issue-{N}` (multi_session.worktree_base 配下)
+# を `git worktree list` から列挙し、**3 ゲート全通過時のみ** reap する:
+#   1. ディレクトリ名が `^issue-[0-9]+$` に完全一致 (strict regex doctrine。
+#      parallel/team-execute の `.worktrees/` 名前空間や `.rite/wiki-worktree`
+#      とは交差しない)
+#   2. claim liveness (S3) が live でない (issue-claim.sh check が stale、または
+#      claim 不在 free のとき mtime > 24h の age guard を再利用)
+#   3. `git -C <wt> status --porcelain` が空 (dirty worktree は絶対に auto-reap
+#      しない — WARNING + 手動コマンド提示で skip)
+# 処理は Step 1/4 と同型: `git worktree remove --force` → fallback `rm -rf` →
+# ループ後 `git worktree prune` + 対応 claim ファイル削除。**branch は削除しない**
+# (push 済み / 未 push 作業の保全。branch 掃除は正常系 cleanup.md の責務のまま)。
+# -----------------------------------------------------------------------
+session_wt_base=""
+if [ -f "$repo_root/rite-config.yml" ]; then
+  _ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' "$repo_root/rite-config.yml" 2>/dev/null) || _ms_section=""
+  session_wt_base=$(printf '%s\n' "$_ms_section" | awk '/^[[:space:]]+worktree_base:/ {print; exit}' \
+    | sed 's/[[:space:]]#.*//' | sed 's/.*worktree_base:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+fi
+[ -n "$session_wt_base" ] || session_wt_base=".rite/worktrees"
+session_wt_root="$repo_root/$session_wt_base"
+
+if [ -d "$session_wt_root" ]; then
+  while IFS= read -r _wt_line; do
+    case "$_wt_line" in
+      "worktree "*) wt_path="${_wt_line#worktree }" ;;
+      *) continue ;;
+    esac
+    # Must be a DIRECT child of the session worktree base.
+    [ "$(dirname "$wt_path")" = "$session_wt_root" ] || continue
+    [ -d "$wt_path" ] || continue
+    wt_base=$(basename "$wt_path")
+    # Gate 1: strict `^issue-[0-9]+$` (excludes .rite/wiki-worktree, .worktrees/*).
+    [[ "$wt_base" =~ ^issue-[0-9]+$ ]] || continue
+    issue_num="${wt_base#issue-}"
+
+    # Gate 3: dirty worktree is NEVER auto-reaped. An indeterminate status
+    # (rc != 0) is treated conservatively as "do not reap" to avoid data loss.
+    _st_out=$(git -C "$wt_path" status --porcelain 2>/dev/null)
+    _st_rc=$?
+    if [ "$_st_rc" -ne 0 ]; then
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' の status を判定できません (rc=$_st_rc) — 安全側で reap をスキップします" >&2
+      continue
+    fi
+    if [ -n "$_st_out" ]; then
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は未コミット変更があるため auto-reap をスキップします。" >&2
+      echo "  手動確認: git -C '$wt_path' status / 不要なら git worktree remove '$wt_path'" >&2
+      continue
+    fi
+
+    # Gate 2: claim liveness. issue-claim.sh resolves its own session_id.
+    claim_state=$(bash "$SCRIPT_DIR/../issue-claim.sh" check --issue "$issue_num" 2>/dev/null) || claim_state=""
+    case "$claim_state" in
+      other|own)
+        # A live session holds the claim — leave the worktree intact.
+        continue
+        ;;
+      stale)
+        : # holder is not live → reapable
+        ;;
+      free|"")
+        # No claim recorded → conservative mtime age guard (24h) so an in-flight
+        # worktree that simply has not written a claim yet is not reaped.
+        if [ -z "$(find "$wt_path" -maxdepth 0 -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)" ]; then
+          continue
+        fi
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "[pr-cycle-cleanup] would reap session worktree: $wt_path (claim=${claim_state:-none})"
+      continue
+    fi
+
+    # Reap: remove --force first (drops worktree metadata + dir atomically),
+    # rm -rf fallback for dirs whose registration was already lost. The branch
+    # is intentionally preserved.
+    if git worktree remove --force "$wt_path" 2>/dev/null || rm -rf "$wt_path" 2>/dev/null; then
+      session_worktrees_reaped=$((session_worktrees_reaped + 1))
+      rm -f "$repo_root/.rite/state/issue-claims/issue-${issue_num}.json" 2>/dev/null || true
+    else
+      echo "WARNING: failed to reap session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)'" >&2
+      errors=$((errors + 1))
+    fi
+  done < <(git worktree list --porcelain 2>/dev/null)
+
+  if [ "$DRY_RUN" = "0" ] && [ "$session_worktrees_reaped" -gt 0 ]; then
+    git worktree prune 2>/dev/null || true
+  fi
+fi
+
+# -----------------------------------------------------------------------
 # Status line
 # -----------------------------------------------------------------------
 if [ "$DRY_RUN" = "1" ]; then
   echo "[pr-cycle-cleanup] status=dry-run; pattern=$PATTERN"
 elif [ "$errors" -gt 0 ]; then
-  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; errors=$errors"
-elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ]; then
-  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0"
+  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; errors=$errors"
+elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ]; then
+  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0"
 else
-  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped"
+  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped"
 fi
 
 exit 0

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -275,6 +275,18 @@ fi
 # quiet session starts (only v3 files → verbose-gated skip) stay silent.
 RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" migrate >/dev/null || true
 
+# --- Best-effort lazy reap of orphaned session worktrees (multi-session §8) ---
+# Only when the session starts at the main checkout root (CWD == shared root):
+# sessions start at the repo root (D-1), so a worktree-rooted CWD means we are
+# inside a linked worktree and must NOT drive the reap (cannot remove a worktree
+# you are standing in — though the reap's own gates already protect live/dirty
+# trees). pr-cycle-cleanup.sh resolves repo_root to the main checkout and reaps
+# only stale + clean `.rite/worktrees/issue-{N}` trees. Fully non-blocking:
+# stdout discarded, `|| true` keeps a slow/failed GC from blocking session start.
+if [ "$CWD" = "$STATE_ROOT" ]; then
+  ( cd "$CWD" && bash "$SCRIPT_DIR/scripts/pr-cycle-cleanup.sh" ) >/dev/null 2>&1 || true
+fi
+
 # Resolve active flow-state file path (Issue #680).
 # `_resolve-flow-state-path.sh` returns the per-session file
 # (`.rite/sessions/<sid>.flow-state`) when schema_version=2 and a valid

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Tests for pr-cycle-cleanup.sh Step 5 — session worktree lazy reap
+# (Issue #1364 / S4, multi-session design §8).
+#
+#   AC-1: a worktree whose claim is LIVE is NOT reaped.
+#   AC-2: a worktree whose claim is STALE and clean IS reaped, claim file deleted.
+#   AC-3: a DIRTY worktree is NOT reaped (claim stale) — WARNING + manual hint.
+#   AC-4: after reap the corresponding branch still exists.
+#   AC-5: `.rite/wiki-worktree` and non-issue dirs are NOT matched (regression).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+PCC="$SCRIPT_DIR/../scripts/pr-cycle-cleanup.sh"
+FS="$SCRIPT_DIR/../flow-state.sh"
+IC="$SCRIPT_DIR/../issue-claim.sh"
+GIT="git -c user.email=t@test.local -c user.name=test -c commit.gpgsign=false"
+
+cleanup_dirs=()
+cleanup() { local d; for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+# SID_A = the "working" session that holds the claim; SID_B = the (different)
+# session that triggers the reap (a new session-start / another session's
+# cleanup). session↔worktree is not 1:1 so the reaping session is never the
+# holder in practice.
+SID_A="aaaaaaaa-1111-2222-3333-444444444444"
+SID_B="bbbbbbbb-5555-6666-7777-888888888888"
+
+# Build a main checkout with multi_session config + a session worktree for issue N.
+# Echoes the main repo path. The holder session ($SID_A) gets an active flow-state
+# and the claim; `.rite-session-id` is SID_B (the reaping session).
+make_repo() {
+  local n="$1" root
+  root=$(make_sandbox --branch develop)
+  printf 'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n' > "$root/rite-config.yml"
+  printf '%s' "$SID_B" > "$root/.rite-session-id"
+  ( cd "$root" && $GIT worktree add -q -b "feat/issue-$n" ".rite/worktrees/issue-$n" >/dev/null 2>&1 )
+  RITE_STATE_ROOT="$root" bash "$FS" set --session "$SID_A" --phase implement --issue "$n" --branch "feat/issue-$n" --next n >/dev/null 2>&1
+  RITE_STATE_ROOT="$root" bash "$IC" claim --issue "$n" --session "$SID_A" --worktree "$root/.rite/worktrees/issue-$n" >/dev/null 2>&1
+  printf '%s' "$root"
+}
+
+run_pcc() { ( cd "$1" && bash "$PCC" 2>"$1/pcc.err"; echo "rc=$?" ) ; }
+
+echo "=== TC-1 (AC-1): live claim → worktree NOT reaped ==="
+R=$(make_repo 50); cleanup_dirs+=("$R")
+# Holder SID_A is active → from the reaping session (SID_B) the claim is "other" (live).
+run_pcc "$R" >/dev/null
+assert "TC-1 live worktree survives" "1" "$( [ -d "$R/.rite/worktrees/issue-50" ] && echo 1 || echo 0 )"
+assert "TC-1 claim file survives" "1" "$( [ -f "$R/.rite/state/issue-claims/issue-50.json" ] && echo 1 || echo 0 )"
+
+echo "=== TC-2 (AC-2): stale claim + clean → reaped, claim deleted ==="
+R=$(make_repo 51); cleanup_dirs+=("$R")
+# make holder (SID_A) stale (inactive) → from SID_B the claim is "stale"
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "TC-2 stale worktree reaped" "0" "$( [ -d "$R/.rite/worktrees/issue-51" ] && echo 1 || echo 0 )"
+assert "TC-2 claim file deleted" "0" "$( [ -f "$R/.rite/state/issue-claims/issue-51.json" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "TC-2 status reports session_worktrees=1" ;; *) fail "TC-2 status: $out" ;; esac
+
+echo "=== TC-4 (AC-4): branch preserved after reap ==="
+assert "TC-4 branch feat/issue-51 still exists" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-51 >/dev/null 2>&1; echo $? )"
+
+echo "=== TC-3 (AC-3): dirty worktree (stale claim) → NOT reaped + WARNING ==="
+R=$(make_repo 52); cleanup_dirs+=("$R")
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+echo "uncommitted" > "$R/.rite/worktrees/issue-52/dirty.txt"   # untracked → dirty porcelain
+run_pcc "$R" >/dev/null
+assert "TC-3 dirty worktree survives" "1" "$( [ -d "$R/.rite/worktrees/issue-52" ] && echo 1 || echo 0 )"
+assert_grep "TC-3 WARNING emitted for dirty" "$R/pcc.err" "未コミット変更があるため auto-reap をスキップ"
+
+echo "=== TC-5 (AC-5): .rite/wiki-worktree + non-issue dirs NOT matched ==="
+R=$(make_repo 53); cleanup_dirs+=("$R")
+# A wiki-worktree-shaped registered worktree must be excluded by the strict regex.
+( cd "$R" && $GIT worktree add -q -b wiki ".rite/wiki-worktree" >/dev/null 2>&1 )
+# holder SID_A made stale so issue-53 WOULD be reaped (proves the loop runs)
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+run_pcc "$R" >/dev/null
+assert "TC-5 issue-53 reaped (loop active)" "0" "$( [ -d "$R/.rite/worktrees/issue-53" ] && echo 1 || echo 0 )"
+assert "TC-5 .rite/wiki-worktree untouched" "1" "$( [ -d "$R/.rite/wiki-worktree" ] && echo 1 || echo 0 )"
+
+echo "=== TC-6: session-start.sh best-effort wiring reaps a stale worktree ==="
+R=$(make_repo 54); cleanup_dirs+=("$R")
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+SS="$SCRIPT_DIR/../session-start.sh"
+printf '{"session_id":"%s","cwd":"%s","hook_event_name":"SessionStart","source":"startup"}' "$SID_B" "$R" \
+  | bash "$SS" >/dev/null 2>&1 || true
+assert "TC-6 session-start reaped stale worktree" "0" "$( [ -d "$R/.rite/worktrees/issue-54" ] && echo 1 || echo 0 )"
+
+print_summary "$(basename "$0")" \
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."


### PR DESCRIPTION
## 概要

Closes #1364 — マルチセッション対応（親 #1360）の **S4: セッション worktree 遅延 reap**。異常終了で残骸化した `.rite/worktrees/issue-{N}` を安全に回収する。正常系の即時削除は cleanup（S7）の責務。設計 §8。

## 変更点

- **`pr-cycle-cleanup.sh` Step 5**: `git worktree list` から `{worktree_base}` 配下を列挙し**3 ゲート全通過時のみ** reap:
  1. ディレクトリ名 `^issue-[0-9]+$` 完全一致（strict regex — `.worktrees/`・`.rite/wiki-worktree` と非交差）
  2. claim liveness（`issue-claim.sh check`）が **live でない**（claim 不在は mtime > 24h age guard 再利用）
  3. `git -C <wt> status --porcelain` が空（**dirty は絶対 auto-reap せず** WARNING + skip。status 判定不能時も安全側 skip）

  処理は既存 reap と同型（`remove --force` → `rm -rf` fallback → `prune` + claim 削除）。**branch は削除しない**。status line に `session_worktrees=N` 追加。
- **`session-start.sh`**: main checkout 起動時（`CWD == STATE_ROOT`）に best-effort 呼び出し（`|| true`）。

## AC

- [x] AC-1: live claim を持つ worktree は reap されない（TC-1）
- [x] AC-2: claim stale + clean な worktree が reap され claim ファイルも削除（TC-2）
- [x] AC-3: dirty worktree は claim stale でも reap されず WARNING + 手動コマンド（TC-3）
- [x] AC-4: reap 後も対応 branch が残存（TC-4）
- [x] AC-5: `pr-{N}-cycle{X}` / `.worktrees/` / `.rite/wiki-worktree` の既存 reap 対象・除外が不変（TC-5 + 既存 16 TC 全 pass）

## DoD

- [x] 全 AC 達成 + pr-cycle-cleanup-session-reap.test.sh（11 assertions、session-start 配線含む）+ 既存テスト全 pass（**68/68**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)