### PR TITLE
feat(sprint): 他セッション claim 中 Issue のスキップ判定 (refs #1369)

### DIFF
--- a/plugins/rite/commands/sprint/execute.md
+++ b/plugins/rite/commands/sprint/execute.md
@@ -252,6 +252,19 @@ For each Issue, check for dependencies:
 
 Build a simple dependency graph. If Issue A depends on Issue B, ensure B appears before A in the execution order. If circular dependencies exist, warn and use the priority-based order.
 
+### 2.3.5 Claim フィルタ（他セッション live claim の除外）
+
+multi_session 環境で他セッションが既に着手中の Issue を二重実行しないよう、各 Issue を `issue-claim.sh check` で確認し、`other`（他の live セッションが claim 中）のものを実行対象から除外する。`stale` の Issue は除外しない（pr:open 側の claim 取得 + AskUserQuestion に委ねる）。claim が 1 件もなければ全 Issue が対象のまま = 現行と完全一致:
+
+```bash
+for n in {sorted_issue_numbers}; do
+  st=$(bash {plugin_root}/hooks/issue-claim.sh check --issue "$n" 2>/dev/null) || st=""
+  [ "$st" = "other" ] && echo "[CONTEXT] SPRINT_SKIP_CLAIM=$n"
+done
+```
+
+`[CONTEXT] SPRINT_SKIP_CLAIM=` marker に挙がった Issue を実行対象から除外し、2.4 実行計画表に「スキップ（他セッション作業中）」行として**明示する（無音にしない）**。
+
 ### 2.4 Display Execution Plan
 
 ```
@@ -264,6 +277,13 @@ Build a simple dependency graph. If Issue A depends on Issue B, ensure B appears
 | 3 | #{number} {title} | {priority} | {complexity} | - |
 
 合計: {count} 件の Issue を実行予定
+```
+
+`SPRINT_SKIP_CLAIM` で除外した Issue がある場合は、計画表の下にスキップ一覧を付記する:
+
+```
+スキップ（他セッション作業中）:
+- #{number} {title}
 ```
 
 ### 2.5 User Confirmation
@@ -324,6 +344,12 @@ Priority: {priority} | Complexity: {complexity}
 ```
 
 #### 3.1.2 Execute Issue
+
+> **Claim 再チェック（TOCTOU 窓対策）**: Phase 2.3.5 のフィルタから本ループの実行までに別セッションが claim する窓があるため、pr:open invoke の直前に再確認する。`other`（他 live セッションが claim 中）なら本 Issue を `skipped`（理由: 他セッション作業中）として Phase 3.1.3 に記録し、次の Issue へ進む。最終ガードは pr:open Step 2.2-W の branch 衝突検出:
+> ```bash
+> st=$(bash {plugin_root}/hooks/issue-claim.sh check --issue {issue_number} 2>/dev/null) || st=""
+> [ "$st" = "other" ] && echo "[CONTEXT] SPRINT_SKIP_CLAIM_TOCTOU={issue_number}"
+> ```
 
 Invoke the new per-Issue flow as 3 sequential Skill tool calls:
 

--- a/plugins/rite/commands/sprint/team-execute.md
+++ b/plugins/rite/commands/sprint/team-execute.md
@@ -125,6 +125,19 @@ Same as execute.md Phase 2.2.
 
 Same as execute.md Phase 2.3. Additionally, identify which Issues can run in parallel (no mutual dependencies) and which must run sequentially (dependency chain).
 
+### 2.3.5 Claim フィルタ（他セッション live claim の除外）
+
+[execute.md](./execute.md) Phase 2.3.5 と同様に、各 Issue を `issue-claim.sh check` で確認し `other`（他の live セッションが claim 中）の Issue を**バッチ割当の前に除外**する。`stale` は除外しない。除外した Issue は 2.5 実行計画表に「スキップ（他セッション作業中）」として明示する:
+
+```bash
+for n in {sorted_issue_numbers}; do
+  st=$(bash {plugin_root}/hooks/issue-claim.sh check --issue "$n" 2>/dev/null) || st=""
+  [ "$st" = "other" ] && echo "[CONTEXT] SPRINT_SKIP_CLAIM=$n"
+done
+```
+
+`SPRINT_SKIP_CLAIM` の Issue は 2.4 Parallel Batch Planning のバッチ割当対象から外す。
+
 ### 2.4 Parallel Batch Planning
 
 Group Issues into parallel batches based on:
@@ -240,6 +253,12 @@ Batch {current} の Issue:
 #### 3.1.2 Create Worktrees and Branches
 
 For each Issue in the current batch:
+
+> **Claim 再チェック（TOCTOU 窓対策）**: Phase 2.3.5 のフィルタからバッチ実行までに別セッションが claim する窓があるため、worktree / branch 作成の直前に再確認する。`other`（他 live セッションが claim 中）なら本 Issue をバッチからスキップし `skipped`（理由: 他セッション作業中）として Phase 3.1.8 に記録する（既存の branch-already-exists エラーハンドリングの手前での早期 skip）。最終ガードは pr:open Step 2.2-W の branch 衝突検出:
+> ```bash
+> st=$(bash {plugin_root}/hooks/issue-claim.sh check --issue {issue_number} 2>/dev/null) || st=""
+> [ "$st" = "other" ] && echo "[CONTEXT] SPRINT_SKIP_CLAIM_TOCTOU={issue_number}"
+> ```
 
 **Step 1**: Generate branch name (same as [pr/open.md](../pr/open.md) ステップ 2):
 


### PR DESCRIPTION
## 概要

Closes #1369 — マルチセッション対応（親 #1360）の **S9: sprint claim スキップ**。`/rite:sprint:execute` / `team-execute` が他セッション live claim 中の Issue をスキップして衝突を防止する。設計 §10。

## 変更点

- **`execute.md`**:
  - **2.3.5 Claim フィルタ**（Todo フィルタ直後）: `issue-claim.sh check` で `other`（他 live セッションが claim 中）の Issue を除外。`stale` はスキップしない。実行計画表に「スキップ（他セッション作業中）」行として**明示**。
  - **3.1.2 TOCTOU 再チェック**: pr:open invoke 直前に再確認、`other` なら `skipped` 記録。
- **`team-execute.md`**:
  - **2.3.5 Claim フィルタ**（execute.md と同様、バッチ割当の前に除外）。
  - **3.1.2 TOCTOU 再チェック**: worktree/branch 作成の直前に再確認、`other` なら早期 skip。
- 各挿入点は 5 行程度の判定スニペット。最終ガードは pr:open Step 2.2-W の branch 衝突検出。

## AC

- [x] AC-1: 別セッション live claim 中の Issue が execute の実行対象から除外され、計画表に理由付きで表示（2.3.5）
- [x] AC-2: team-execute のバッチ割当でも同様に除外（2.3.5）
- [x] AC-3: stale claim の Issue は実行対象に残る（check が stale → 非スキップ。実機検証: issue 5=other のみ skip、free/stale は残る）
- [x] AC-4: claim が 1 件もない場合の動作が現行と完全一致（SPRINT_SKIP_CLAIM が空 → 全 Issue 対象）

## 検証

- Claim フィルタ block を実機検証（live claim の issue 5 のみ `SPRINT_SKIP_CLAIM=5`、free の 8/9 は残る）。
- hook スイート **68/68 pass**。(.md のみのため CI hook-test 対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)