### PR TITLE
test(hooks): compact-state legacy fallback 経路の回帰テストを追加

### DIFF
--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -555,7 +555,8 @@ elif [ -f "$TC_DIR/.rite-compact-state" ]; then
 else
   pass "TC-LEGACY-FALLBACK: legacy .rite-compact-state removed via fallback cleanup path"
 fi
-rm -f "$lf_err"
+# $lf_err lives under $TEST_DIR and is reclaimed by the file-level `trap cleanup EXIT`,
+# matching the other stderr-tempfile sites in this file (no per-TC rm).
 
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -533,5 +533,27 @@ else
   fail "TC-COMPACT-STATE-CORRUPT: expected WARNING with rc on corrupt compact-state; got: $STDERR_OUT"
 fi
 
+# --- TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state cleaned up ---
+# When the session id cannot be resolved (no .rite-session-id file AND no
+# CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID env), flow-state.sh path exits non-zero,
+# FLOW_STATE="", and post-compact.sh falls back to the legacy shared
+# "$STATE_ROOT/.rite-compact-state". With no flow-state file the "no flow state →
+# clean up and exit" branch removes that legacy file. Seeding it and asserting removal
+# pins that the fallback targets the legacy path: a per-session COMPACT_STATE would
+# leave this seeded file untouched. env -u strips any ambient session id so the
+# fallback is deterministic (fixture-based TCs write .rite-session-id, which wins).
+echo "TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state cleaned up"
+TC_DIR=$(setup_test "tc-legacy-fallback")
+printf '%s\n' '{"compact_state": "recovering", "compact_state_set_at": "2026-03-14T12:00:00Z", "active_issue": 55}' > "$TC_DIR/.rite-compact-state"
+lf_rc=0
+echo '{"cwd": "'"$TC_DIR"'", "source": "auto"}' | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" >/dev/null 2>&1 || lf_rc=$?
+if [ "$lf_rc" -ne 0 ]; then
+  fail "TC-LEGACY-FALLBACK: hook should exit 0 (got rc=$lf_rc)"
+elif [ -f "$TC_DIR/.rite-compact-state" ]; then
+  fail "TC-LEGACY-FALLBACK: legacy .rite-compact-state should be cleaned up when session id is unresolvable"
+else
+  pass "TC-LEGACY-FALLBACK: legacy .rite-compact-state removed via fallback cleanup path"
+fi
+
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -546,14 +546,16 @@ echo "TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state cleane
 TC_DIR=$(setup_test "tc-legacy-fallback")
 printf '%s\n' '{"compact_state": "recovering", "compact_state_set_at": "2026-03-14T12:00:00Z", "active_issue": 55}' > "$TC_DIR/.rite-compact-state"
 lf_rc=0
-echo '{"cwd": "'"$TC_DIR"'", "source": "auto"}' | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" >/dev/null 2>&1 || lf_rc=$?
+lf_err=$(mktemp "$TEST_DIR/stderr.XXXXXX")
+echo '{"cwd": "'"$TC_DIR"'", "source": "auto"}' | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" >/dev/null 2>"$lf_err" || lf_rc=$?
 if [ "$lf_rc" -ne 0 ]; then
-  fail "TC-LEGACY-FALLBACK: hook should exit 0 (got rc=$lf_rc)"
+  fail "TC-LEGACY-FALLBACK: hook should exit 0 (got rc=$lf_rc); stderr: $(cat "$lf_err")"
 elif [ -f "$TC_DIR/.rite-compact-state" ]; then
   fail "TC-LEGACY-FALLBACK: legacy .rite-compact-state should be cleaned up when session id is unresolvable"
 else
   pass "TC-LEGACY-FALLBACK: legacy .rite-compact-state removed via fallback cleanup path"
 fi
+rm -f "$lf_err"
 
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -838,14 +838,15 @@ lf_stderr="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
 lf_rc=0
 echo "{\"cwd\": \"$dirlf\"}" | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" 2>"$lf_stderr" || lf_rc=$?
 LAST_STDERR_FILE="$lf_stderr"
+cs_state=$(jq -r '.compact_state' "$dirlf/.rite-compact-state" 2>/dev/null)
 if [ "$lf_rc" -ne 0 ]; then
   fail "Hook should exit 0 on legacy fallback (got rc=$lf_rc)"
 elif [ ! -f "$dirlf/.rite-compact-state" ]; then
   fail "legacy .rite-compact-state should be written when session id is unresolvable"
 elif [ -e "$dirlf/.rite/sessions" ]; then
   fail "per-session .rite/sessions must not be created on the legacy fallback path"
-elif [ "$(jq -r '.compact_state' "$dirlf/.rite-compact-state" 2>/dev/null)" != "recovering" ]; then
-  fail "legacy compact_state should be 'recovering', got '$(jq -r '.compact_state' "$dirlf/.rite-compact-state" 2>/dev/null)'"
+elif [ "$cs_state" != "recovering" ]; then
+  fail "legacy compact_state should be 'recovering', got '$cs_state'"
 elif ! grep -q 'flow-state.sh path resolution failed' "$lf_stderr"; then
   fail "expected resolver-failure WARNING on stderr"
 else

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -821,6 +821,38 @@ if [ "$ac1_ok" = true ]; then
 fi
 echo ""
 
+# --- TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state written ---
+# Complement of AC-1 (per-session isolation): when the session id cannot be resolved
+# (no .rite-session-id file AND no CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID env),
+# flow-state.sh path exits non-zero, FLOW_STATE="", and pre-compact.sh falls back to
+# the legacy shared "$STATE_ROOT/.rite-compact-state". This pins the "preserving
+# pre-per-session behavior" claim in the COMPACT_STATE derivation: the compact-state
+# write is NOT guarded by [ -f "$FLOW_STATE" ], so the legacy path is actually written
+# with compact_state=recovering. env -u strips any ambient session id so the fallback
+# is reproduced regardless of the test runner's environment (.rite-session-id always
+# wins over env, so existing fixture-based TCs are unaffected).
+echo "TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state written (recovering)"
+dirlf="$TEST_DIR/tc-legacy-fallback"
+mkdir -p "$dirlf"
+lf_stderr="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+lf_rc=0
+echo "{\"cwd\": \"$dirlf\"}" | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" 2>"$lf_stderr" || lf_rc=$?
+LAST_STDERR_FILE="$lf_stderr"
+if [ "$lf_rc" -ne 0 ]; then
+  fail "Hook should exit 0 on legacy fallback (got rc=$lf_rc)"
+elif [ ! -f "$dirlf/.rite-compact-state" ]; then
+  fail "legacy .rite-compact-state should be written when session id is unresolvable"
+elif [ -e "$dirlf/.rite/sessions" ]; then
+  fail "per-session .rite/sessions must not be created on the legacy fallback path"
+elif [ "$(jq -r '.compact_state' "$dirlf/.rite-compact-state" 2>/dev/null)" != "recovering" ]; then
+  fail "legacy compact_state should be 'recovering', got '$(jq -r '.compact_state' "$dirlf/.rite-compact-state" 2>/dev/null)'"
+elif ! grep -q 'flow-state.sh path resolution failed' "$lf_stderr"; then
+  fail "expected resolver-failure WARNING on stderr"
+else
+  pass "sid unresolvable → legacy .rite-compact-state written with compact_state=recovering + resolver WARNING"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/preflight-check.test.sh
+++ b/plugins/rite/hooks/tests/preflight-check.test.sh
@@ -293,6 +293,40 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state read (block)
+# --------------------------------------------------------------------------
+# When the session id cannot be resolved (no .rite-session-id file AND no
+# CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID env), flow-state.sh path exits non-zero,
+# FLOW_STATE="", and preflight-check.sh falls back to reading the legacy shared
+# "$STATE_ROOT/.rite-compact-state". Seeding it with compact_state=recovering and
+# asserting a non-resume command is blocked pins that the gate reads the legacy path
+# on the fallback. env -u strips any ambient session id for determinism (fixture-based
+# TCs write .rite-session-id, which wins over env, so they are unaffected).
+echo "TC-LEGACY-FALLBACK: sid unresolvable → legacy .rite-compact-state read → block"
+dirlf="$TEST_DIR/tc-legacy-fallback"
+mkdir -p "$dirlf"
+printf '%s\n' '{"compact_state": "recovering", "active_issue": 77, "compact_state_set_at": "2026-01-01T00:00:00Z"}' > "$dirlf/.rite-compact-state"
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+lf_out=$(env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" --command-id "/rite:pr:open" --cwd "$dirlf" 2>"$LAST_STDERR_FILE") && lf_rc=0 || lf_rc=$?
+if [ "$lf_rc" -eq 1 ] && printf '%s' "$lf_out" | grep -q "#77"; then
+  pass "sid unresolvable + legacy recovering → non-resume command blocked (legacy path read)"
+else
+  fail "Expected exit 1 with Issue #77 reading legacy path, got exit $lf_rc: $lf_out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-LEGACY-FALLBACK-RESUME: sid unresolvable + legacy recovering + /rite:resume → allow
+# --------------------------------------------------------------------------
+echo "TC-LEGACY-FALLBACK-RESUME: sid unresolvable + legacy recovering + /rite:resume → exit 0"
+if env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" --command-id "/rite:resume" --cwd "$dirlf" >/dev/null 2>&1; then
+  pass "/rite:resume allowed even on legacy fallback block"
+else
+  fail "/rite:resume should be allowed regardless of legacy compact state"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/preflight-check.test.sh
+++ b/plugins/rite/hooks/tests/preflight-check.test.sh
@@ -318,6 +318,12 @@ echo ""
 # --------------------------------------------------------------------------
 # TC-LEGACY-FALLBACK-RESUME: sid unresolvable + legacy recovering + /rite:resume → allow
 # --------------------------------------------------------------------------
+# Note: /rite:resume is allowed regardless of compact-state (even when the file is
+# absent — preflight-check.sh exits 0 for /rite:resume at the no-file and resume gates
+# alike), so this case ALONE does not discriminate the legacy fallback read. Its value
+# is as the complement to the preceding block TC: together they pin that under the
+# legacy fallback a recovering state blocks non-resume commands while /rite:resume stays
+# exempt. Reuses $dirlf and its seeded legacy .rite-compact-state from that block.
 echo "TC-LEGACY-FALLBACK-RESUME: sid unresolvable + legacy recovering + /rite:resume → exit 0"
 if env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$HOOK" --command-id "/rite:resume" --cwd "$dirlf" >/dev/null 2>&1; then
   pass "/rite:resume allowed even on legacy fallback block"


### PR DESCRIPTION
## 概要

compact-state の per-session 化 (#1371) で導入された legacy fallback 分岐 — `flow-state.sh path` が session id を解決できず `FLOW_STATE` が空のとき `$STATE_ROOT/.rite-compact-state` を read/write する経路 — を直接 exercise する回帰テストを追加する。実装コメントが主張する「preserving pre-per-session behavior」を pin し、将来の per-session 化リファクタが fallback 経路を壊しても検出できるようにする。

PR #1381 のレビュー（test-reviewer）で検出された follow-up 推奨に対応する。

## 関連 Issue

Closes #1382

## 変更内容

`.rite-session-id` 不在 + `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` 両 env 不在で resolver を ERROR exit させ `FLOW_STATE=""` を決定的に再現する TC を 3 つの hook テストへ追加した（各起動を `env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID` で包み、ambient な session id に依存せず fallback を再現）。

- **`pre-compact.test.sh`**: sid 解決不能時に legacy `.rite-compact-state` が `compact_state=recovering` で**書き込まれる**ことを assert（write 経路。既存 AC-1「per-session 分離」テストの補集合 = 共有パスへ書かれることを pin）。per-session `.rite/sessions/` が作られないこと・resolver-failure WARNING も検証。
- **`post-compact.test.sh`**: seed した legacy `.rite-compact-state` が「no flow state → cleanup」分岐で**削除される**ことを assert（read+cleanup 経路。per-session パスなら seed が残るため、fallback がレガシーパスを対象にした証跡になる）。
- **`preflight-check.test.sh`**: legacy `.rite-compact-state`(recovering) を**読んで**非 resume コマンドを exit 1 でブロック、かつ `/rite:resume` は許可されることを assert（read+block 経路）。

hook 本体（`*.sh`）は無変更。テスト追加のみ（3 files, +88 行）。

## 検証

- `pre-compact.test.sh`: 32 passed / 0 failed（+1）
- `post-compact.test.sh`: 32 passed / 0 failed（+1）
- `preflight-check.test.sh`: 16 passed / 0 failed（+2）
- `run-tests.sh`（全 hook スイート）: **68/68 passed**

新規 TC は `CLAUDE_CODE_SESSION_ID` がセットされた環境でも green（`env -u` が effく）ことを確認済み = trivially-passing ではなく実際に fallback 経路を pin している。

## チェックリスト

- [x] プロジェクト規約に従っている
- [x] テストが通る（上記「検証」参照）
- [ ] ドキュメント更新（test-only のため対象外）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
