### PR TITLE
refactor(hooks): session_id validation 契約の SoT を明文化

### DIFF
--- a/plugins/rite/hooks/_resolve-session-id.sh
+++ b/plugins/rite/hooks/_resolve-session-id.sh
@@ -5,6 +5,13 @@
 # hyphens at fixed positions). Returns 0 with the validated UUID on stdout
 # when input matches; returns 1 with empty stdout when invalid.
 #
+# Contract (SoT: references/session-id-validation-contract.md): this is the Layer 2
+# format/identity validator. It answers "is this a canonical UUID?" so a caller can
+# choose between the per-session state file and the legacy single-file fallback (see
+# _resolve-session-id-from-file.sh). It is intentionally distinct from flow-state.sh's
+# Layer 1 `_validate_session_id` (security-boundary, format-agnostic). Do NOT unify the
+# two: flow-state.sh's path must keep accepting non-UUID opaque sids.
+#
 # Usage:
 #   bash plugins/rite/hooks/_resolve-session-id.sh "$candidate_uuid"
 #   if validated_sid=$(bash _resolve-session-id.sh "$raw"); then

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -54,7 +54,7 @@ _phase_migrate() {
 # route this through `_resolve-session-id.sh` (strict RFC 4122 / Layer 2) or add UUID-shape
 # checks here: hook tests pass non-UUID sids directly to flow-state.sh and would silently
 # go vacuous if this validator were tightened. The acceptance side is pinned by
-# flow-state.test.sh TC-21.
+# flow-state.test.sh TC-24.
 _validate_session_id() {
   # `origin` (引数 2) は session_id の出所 (override / SESSION_ID_FILE / env var) を識別する
   # エラーメッセージ用ラベル。bash builtin `source` の shadow を避けるため `origin` を採用。

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -47,6 +47,14 @@ _phase_migrate() {
 # rejection prevents attackers from injecting fake "WARNING:" lines into stderr by setting
 # env var to e.g. $'innocent\nWARNING: fake injected'. Path-traversal rejection prevents
 # CLAUDE_CODE_SESSION_ID="../../tmp/owned" from writing state files outside .rite/sessions/.
+#
+# Contract (SoT: references/session-id-validation-contract.md): this is the Layer 1
+# security-boundary validator and is **format-agnostic by design** — it does NOT enforce
+# UUID form. Non-UUID opaque sids (e.g. `session-aaaa-1371`) MUST keep passing. Do NOT
+# route this through `_resolve-session-id.sh` (strict RFC 4122 / Layer 2) or add UUID-shape
+# checks here: hook tests pass non-UUID sids directly to flow-state.sh and would silently
+# go vacuous if this validator were tightened. The acceptance side is pinned by
+# flow-state.test.sh TC-21.
 _validate_session_id() {
   # `origin` (引数 2) は session_id の出所 (override / SESSION_ID_FILE / env var) を識別する
   # エラーメッセージ用ラベル。bash builtin `source` の shadow を避けるため `origin` を採用。

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1004,6 +1004,64 @@ result=$(new_sandbox); d2="${result%|*}"; sid2="${result#*|}"
 state_file2="$d2/.rite/sessions/${sid2}.flow-state"
 assert "no worktree key when --worktree never passed" "false" "$(jq 'has("worktree")' "$state_file2")"
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker + Issue #1170 consume-handoff corrupt-read WARNING + Issue #1173 jq stderr snippet control-char neutralization + Issue #1274 C1 8-bit coverage via shared neutralize_ctrl + Issue #1362 --worktree merge-preserve field"; then
+# --- TC-24: non-UUID opaque session_id is ACCEPTED (Layer 1 format-agnostic contract) ---
+# Why (Issue #1383): `_validate_session_id` is the Layer 1 security-boundary validator and is
+# format-agnostic BY DESIGN — it rejects path-traversal / control chars (pinned by TC-18/TC-19)
+# but MUST keep ACCEPTING non-UUID opaque sids. pre-compact.test.sh TC-1371-AC1 sets
+# CLAUDE_CODE_SESSION_ID="session-aaaa-1371" and relies on `flow-state.sh path` resolving it to a
+# per-session file. If this were ever routed through `_resolve-session-id.sh` (strict RFC 4122 /
+# Layer 2), such sids would degrade to legacy fallback and the dependent tests would go SILENTLY
+# vacuous. These positive assertions convert that silent-vacuous risk into a loud failure.
+# SoT: references/session-id-validation-contract.md.
+echo ""
+echo "=== TC-24: non-UUID opaque session_id accepted (format-agnostic Layer 1 contract pin) ==="
+opaque="session-aaaa-1371"
+
+# TC-24.1: env-var (CLAUDE_CODE_SESSION_ID) — the exact at-risk path from pre-compact.test.sh
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$opaque" \
+  bash "$HOOK" set --phase implement --issue 1383 --branch "refactor/issue-1383" --pr 0 --next "n") 2>&1 || true )
+state_file="$d/.rite/sessions/${opaque}.flow-state"
+if [ -f "$state_file" ]; then
+  pass "TC-24.1: set accepts non-UUID env sid → .rite/sessions/${opaque}.flow-state"
+else
+  fail "TC-24.1: non-UUID env sid rejected/degraded (no per-session file). stderr: '$err'"
+fi
+got=$(cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$opaque" bash "$HOOK" get --field phase --default "MISS")
+assert "TC-24.1b: phase round-trips under non-UUID sid" "implement" "$got"
+
+# TC-24.2: `path` resolves the non-UUID sid to the per-session file (not a legacy fallback path)
+got_path=$( (cd "$d" && env -u CLAUDE_SESSION_ID CLAUDE_CODE_SESSION_ID="$opaque" bash "$HOOK" path) 2>/dev/null || true )
+case "$got_path" in
+  */.rite/sessions/"${opaque}".flow-state)
+    pass "TC-24.2: path resolves non-UUID sid to per-session file (no Layer 2 strict downgrade)" ;;
+  *)
+    fail "TC-24.2: path did not resolve to per-session file for non-UUID sid: '$got_path'" ;;
+esac
+
+# TC-24.3: SESSION_ID_FILE (.rite-session-id) content path also accepts non-UUID
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+printf '%s\n' "$opaque" > "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID \
+  bash "$HOOK" set --phase plan --issue 1383 --branch "b" --pr 0 --next "n") 2>&1 || true )
+if [ -f "$d/.rite/sessions/${opaque}.flow-state" ]; then
+  pass "TC-24.3: SESSION_ID_FILE non-UUID content accepted → per-session file"
+else
+  fail "TC-24.3: SESSION_ID_FILE non-UUID content rejected/degraded. stderr: '$err'"
+fi
+
+# TC-24.4: --session override path also accepts non-UUID (4-source symmetry with TC-18/TC-19)
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+rm -f "$d/.rite-session-id"
+err=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID \
+  bash "$HOOK" set --session "$opaque" --phase review --issue 1383 --branch "b" --pr 0 --next "n") 2>&1 || true )
+if [ -f "$d/.rite/sessions/${opaque}.flow-state" ]; then
+  pass "TC-24.4: --session override non-UUID accepted → per-session file"
+else
+  fail "TC-24.4: --session override non-UUID rejected/degraded. stderr: '$err'"
+fi
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + Issue #1142 silent-failure fixes + security/observability hardening + Issue #1168 handoff marker + Issue #1170 consume-handoff corrupt-read WARNING + Issue #1173 jq stderr snippet control-char neutralization + Issue #1274 C1 8-bit coverage via shared neutralize_ctrl + Issue #1362 --worktree merge-preserve field + Issue #1383 non-UUID acceptance (Layer 1 format-agnostic contract pin)"; then
   exit 1
 fi

--- a/plugins/rite/references/session-id-validation-contract.md
+++ b/plugins/rite/references/session-id-validation-contract.md
@@ -55,9 +55,9 @@
 2. **2 つの validator を統一（DRY 化）してはならない。** 上記のとおり別レイヤー・別関心事であり、
    統一は safe-path-construction を UUID-shape に結合させ silent-vacuous リスクを再導入する。
 
-3. **正の契約は executable test で pin する。** `flow-state.test.sh` の TC-21 が、非 UUID opaque
+3. **正の契約は executable test で pin する。** `flow-state.test.sh` の TC-24 が、非 UUID opaque
    sid が `flow-state.sh` の `path` / `set` / `get` を round-trip することを assert する。将来 Layer 1
-   を strict 化すると TC-21 が loud に落ち、silent-vacuous リスクを **CI 失敗に変換**する。
+   を strict 化すると TC-24 が loud に落ち、silent-vacuous リスクを **CI 失敗に変換**する。
 
 ## Layer 1（緩い契約）に依存するテスト
 
@@ -66,7 +66,7 @@
 - `pre-compact.test.sh` — `session-aaaa-1371` / `session-bbbb-1371`（TC-1371-AC1、Issue 名指しの代表例）
 - `pre-compact.test.sh` / `post-compact.test.sh` / `preflight-check.test.sh` / `session-start.test.sh` —
   test helper の default sid `test-sid-<dir>`（非 UUID 形）
-- `flow-state.test.sh` — TC-21（本契約を pin する正のテスト）
+- `flow-state.test.sh` — TC-24（本契約を pin する正のテスト）
 
 > 将来これらを UUID sid へ移行する場合は、本一覧を更新し、Layer 1 契約を format-agnostic に
 > 保つ必要が依然あるかを再評価すること。

--- a/plugins/rite/references/session-id-validation-contract.md
+++ b/plugins/rite/references/session-id-validation-contract.md
@@ -17,7 +17,7 @@
 | 検証内容 | path-traversal (`..` / `/`) と制御文字 (C0 / DEL / C1 8-bit) のみ拒否。**形式は問わない** | 厳格 RFC 4122（`8-4-4-4-12` hex、case-lenient、lowercase 正規化） |
 | 通すもの | 任意の opaque token（例: `session-aaaa-1371`） | canonical UUID のみ |
 | 関心事 | session_id が**ファイルパス構築・ログ出力に流れる chokepoint** を安全に保つこと（path-traversal / log-injection 遮断） | 候補文字列が **canonical UUID かどうか**を判定し、per-session state file と legacy 単一ファイル fallback を切り分けること |
-| 適用経路 | `flow-state.sh` の `_resolve_session_id`（override / `.rite-session-id` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` の 4 source）→ `path` / `set` / `get` 各サブコマンド | `_resolve-session-id-from-file.sh`（file 読込 → strict 検証 → 失敗時 legacy fallback）経由で各 reader hook（`session-start.sh` / `issue-claim.sh` / `work-memory-update.sh` 等）/ cross-session guard |
+| 適用経路 | `flow-state.sh` の `_resolve_session_id`（override / `.rite-session-id` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` の 4 source）→ `path` / `set` / `get` 各サブコマンド | `_resolve-session-id-from-file.sh`（file 読込 → strict 検証 → 失敗時 legacy fallback）経由で `issue-claim.sh` / `scripts/wiki-ingest-lock.sh`、および cross-session guard（`_resolve-cross-session-guard.sh` が `_resolve-session-id.sh` を直接呼び legacy sid を UUID 検証） |
 
 ## なぜ乖離しているか（drift ではなく意図的）
 
@@ -29,7 +29,7 @@
 
 - **Layer 2** は、ある文字列が「本物の session id か、ゴミか」を判定して per-session state file を
   選ぶか legacy 単一ファイルへ fallback するかを決める箇所で使う
-  (`_resolve-session-id-from-file.sh` → 各 reader hook 等)。ここでの厳格さこそが、その判定を
+  (`_resolve-session-id-from-file.sh` → `issue-claim.sh` / `scripts/wiki-ingest-lock.sh`)。ここでの厳格さこそが、その判定を
   decidable にしている。検証失敗時は空文字を返し、caller は「session 不在」相当として legacy 経路へ
   降格する。
 

--- a/plugins/rite/references/session-id-validation-contract.md
+++ b/plugins/rite/references/session-id-validation-contract.md
@@ -1,0 +1,80 @@
+# Session ID Validation Contract (SoT)
+
+> rite workflow には session_id を検証する validator が **2 つ** 存在し、それぞれ
+> **異なる契約**を持つ。本ドキュメントは、その責務分担と「両者を乖離させたまま維持する」
+> 契約の Source of Truth (SoT) である。判定ロジックそのものの SoT は各実装ファイルだが、
+> **なぜ 2 つに分かれているか / 統一してはいけない理由**の SoT は本書とする。
+>
+> **背景 Issue**: #1383（PR #1381 test-reviewer follow-up）。
+
+---
+
+## 2 つの validator、2 つの関心事
+
+| | Layer 1: security boundary | Layer 2: format / identity |
+|---|---|---|
+| 実装 | `flow-state.sh` の `_validate_session_id` | `_resolve-session-id.sh` |
+| 検証内容 | path-traversal (`..` / `/`) と制御文字 (C0 / DEL / C1 8-bit) のみ拒否。**形式は問わない** | 厳格 RFC 4122（`8-4-4-4-12` hex、case-lenient、lowercase 正規化） |
+| 通すもの | 任意の opaque token（例: `session-aaaa-1371`） | canonical UUID のみ |
+| 関心事 | session_id が**ファイルパス構築・ログ出力に流れる chokepoint** を安全に保つこと（path-traversal / log-injection 遮断） | 候補文字列が **canonical UUID かどうか**を判定し、per-session state file と legacy 単一ファイル fallback を切り分けること |
+| 適用経路 | `flow-state.sh` の `_resolve_session_id`（override / `.rite-session-id` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` の 4 source）→ `path` / `set` / `get` 各サブコマンド | `_resolve-session-id-from-file.sh`（file 読込 → strict 検証 → 失敗時 legacy fallback）経由で `state-read.sh` / cross-session guard / resume restore |
+
+## なぜ乖離しているか（drift ではなく意図的）
+
+- **Layer 1** は session_id が「filesystem path の一部」または「stderr のログ行」になる単一の
+  chokepoint を守る。その唯一の仕事はその操作を**安全**にすること（`.rite/sessions/{sid}.flow-state`
+  の外へ書き込ませない、偽の `WARNING:` 行を注入させない）。UUID 形式を**あえて強制しない**ことで、
+  - hook test / tooling が可読な opaque sid を使える
+  - UUID 形ではない非 Code クライアント由来 / 将来の runtime 識別子でも動作する
+
+- **Layer 2** は、ある文字列が「本物の session id か、ゴミか」を判定して per-session state file を
+  選ぶか legacy 単一ファイルへ fallback するかを決める箇所で使う
+  (`_resolve-session-id-from-file.sh` → `state-read.sh` 等)。ここでの厳格さこそが、その判定を
+  decidable にしている。検証失敗時は空文字を返し、caller は「session 不在」相当として legacy 経路へ
+  降格する。
+
+両者は**異なるレイヤー**（安全な path 構築 vs 同一性 / 形式判定）で、**異なる問い**に答える。
+見た目が似た「session_id validator」だからといって統一すると、安全な path 構築が UUID 形に
+結合し、下記の silent-vacuous リスクを再導入する。
+
+## 契約（SoT）
+
+1. **`flow-state.sh` の path validation は format-agnostic を維持する MUST。**
+   `flow-state.sh` の `_resolve_session_id` を `_resolve-session-id.sh`（strict UUID）経由に
+   切り替えたり、Layer 1 validator に UUID 形式チェックを追加してはならない。
+
+   - **理由**: 複数の hook test が非 UUID opaque sid を `flow-state.sh` に直接渡し、その受理に
+     依存している。代表例として `pre-compact.test.sh` の TC-1371-AC1 は
+     `CLAUDE_CODE_SESSION_ID="session-aaaa-1371"` / `"session-bbbb-1371"` を設定し、
+     `pre-compact.sh` 内の `flow-state.sh path`（Layer 1 経由）が
+     `.rite/sessions/session-aaaa-1371.compact-state` 等へ解決することを期待する。
+     もし Layer 1 が strict UUID 検証を採用すると、これらの sid は解決に失敗 / legacy 経路へ
+     降格し、test は **loud に失敗するのではなく silent に vacuous 化**する（意図した per-session
+     経路ではなく legacy 単一ファイル経路を検証してしまう）。
+
+2. **2 つの validator を統一（DRY 化）してはならない。** 上記のとおり別レイヤー・別関心事であり、
+   統一は safe-path-construction を UUID-shape に結合させ silent-vacuous リスクを再導入する。
+
+3. **正の契約は executable test で pin する。** `flow-state.test.sh` の TC-21 が、非 UUID opaque
+   sid が `flow-state.sh` の `path` / `set` / `get` を round-trip することを assert する。将来 Layer 1
+   を strict 化すると TC-21 が loud に落ち、silent-vacuous リスクを **CI 失敗に変換**する。
+
+## Layer 1（緩い契約）に依存するテスト
+
+以下のテストは非 UUID sid を使い、`flow-state.sh` がそれを受理することに依存する:
+
+- `pre-compact.test.sh` — `session-aaaa-1371` / `session-bbbb-1371`（TC-1371-AC1、Issue 名指しの代表例）
+- `pre-compact.test.sh` / `post-compact.test.sh` / `preflight-check.test.sh` / `session-start.test.sh` —
+  test helper の default sid `test-sid-<dir>`（非 UUID 形）
+- `flow-state.test.sh` — TC-21（本契約を pin する正のテスト）
+
+> 将来これらを UUID sid へ移行する場合は、本一覧を更新し、Layer 1 契約を format-agnostic に
+> 保つ必要が依然あるかを再評価すること。
+
+## 関連
+
+- `flow-state.sh` `_validate_session_id` — Layer 1 validator（判定ロジック自体の SoT）
+- `_resolve-session-id.sh` — Layer 2 validator（strict RFC 4122）
+- `_resolve-session-id-from-file.sh` — Layer 2 consumer（file 読込 → strict 検証 → legacy fallback）
+- [state-read.sh Evolution History](./state-read-evolution.md) — helper 集約の経緯（cycle 34 F-01 で UUID validation を DRY 化）
+- [multi-session-state.md](../../../docs/designs/multi-session-state.md) — per-session state file 構造

--- a/plugins/rite/references/session-id-validation-contract.md
+++ b/plugins/rite/references/session-id-validation-contract.md
@@ -17,7 +17,7 @@
 | 検証内容 | path-traversal (`..` / `/`) と制御文字 (C0 / DEL / C1 8-bit) のみ拒否。**形式は問わない** | 厳格 RFC 4122（`8-4-4-4-12` hex、case-lenient、lowercase 正規化） |
 | 通すもの | 任意の opaque token（例: `session-aaaa-1371`） | canonical UUID のみ |
 | 関心事 | session_id が**ファイルパス構築・ログ出力に流れる chokepoint** を安全に保つこと（path-traversal / log-injection 遮断） | 候補文字列が **canonical UUID かどうか**を判定し、per-session state file と legacy 単一ファイル fallback を切り分けること |
-| 適用経路 | `flow-state.sh` の `_resolve_session_id`（override / `.rite-session-id` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` の 4 source）→ `path` / `set` / `get` 各サブコマンド | `_resolve-session-id-from-file.sh`（file 読込 → strict 検証 → 失敗時 legacy fallback）経由で `state-read.sh` / cross-session guard / resume restore |
+| 適用経路 | `flow-state.sh` の `_resolve_session_id`（override / `.rite-session-id` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` の 4 source）→ `path` / `set` / `get` 各サブコマンド | `_resolve-session-id-from-file.sh`（file 読込 → strict 検証 → 失敗時 legacy fallback）経由で各 reader hook（`session-start.sh` / `issue-claim.sh` / `work-memory-update.sh` 等）/ cross-session guard |
 
 ## なぜ乖離しているか（drift ではなく意図的）
 
@@ -29,7 +29,7 @@
 
 - **Layer 2** は、ある文字列が「本物の session id か、ゴミか」を判定して per-session state file を
   選ぶか legacy 単一ファイルへ fallback するかを決める箇所で使う
-  (`_resolve-session-id-from-file.sh` → `state-read.sh` 等)。ここでの厳格さこそが、その判定を
+  (`_resolve-session-id-from-file.sh` → 各 reader hook 等)。ここでの厳格さこそが、その判定を
   decidable にしている。検証失敗時は空文字を返し、caller は「session 不在」相当として legacy 経路へ
   降格する。
 

--- a/plugins/rite/references/state-read-evolution.md
+++ b/plugins/rite/references/state-read-evolution.md
@@ -70,6 +70,11 @@ helper を追加する際は `_validate-helpers.sh` 内 `DEFAULT_HELPERS` への
 | `_validate-state-root.sh` | STATE_ROOT path traversal + shell metacharacter + control character 検証 | post-cycle-44 re-review (M-1) |
 | `state-path-resolve.sh` (参考: base resolver) | STATE_ROOT 解決の入口 (集約ではないが `DEFAULT_HELPERS` には登録) | (該当なし — base resolver) |
 
+> **Layer 区別 (Issue #1383)**: `_resolve-session-id.sh` は **strict RFC 4122 (Layer 2)** validator。
+> `flow-state.sh` の `_validate_session_id`（path-traversal / 制御文字のみ拒否する **format-agnostic** な
+> Layer 1 validator）とは別契約であり、**統一してはならない**。両者の責務分担と乖離を維持する理由の SoT は
+> [session-id-validation-contract.md](./session-id-validation-contract.md) を参照。
+
 ---
 
 ## Cycle 別の主要な修正


### PR DESCRIPTION
## 概要

session_id を検証する 2 つの helper の validation 契約が乖離していた点を Source of Truth (SoT) として明文化し、将来の安易な統一による hook test の silent-vacuous 化リスクを解消する。

- **Layer 1** (`flow-state.sh` の `_validate_session_id`): セキュリティ境界バリデータ。path-traversal / 制御文字のみ拒否し、**UUID 形式は強制しない**（format-agnostic by design）
- **Layer 2** (`_resolve-session-id.sh`): 厳格 RFC 4122 バリデータ。canonical UUID 判定で per-session ファイルと legacy fallback を切り分ける

両者は別レイヤー・別関心事であり、統一すると非 UUID opaque sid（`session-aaaa-1371` 等）を直接 `flow-state.sh` に渡す hook test が legacy fallback へ降格し、silent に vacuous 化する。

## Related Issue

Closes #1383

## 変更内容

- `references/session-id-validation-contract.md`（**新規**）: 2 レイヤーの責務・乖離を維持する理由・「flow-state.sh の path validation に UUID 強制を追加してはならない」契約・依存テスト一覧を明文化した SoT 文書
- `flow-state.sh` / `_resolve-session-id.sh`: 各バリデータの comment に SoT への cross-ref と layering 区別を追記（**判定ロジックは不変**）
- `state-read-evolution.md`: `_resolve-session-id.sh` 行に SoT 相互参照を追加
- `flow-state.test.sh`: 非 UUID opaque sid の **acceptance** を pin する positive test（TC-24, env-var / SESSION_ID_FILE / `--session` override / `path` の 4 経路）を追加。将来 Layer 1 が strict 化されたら silent-vacuous ではなく **loud に失敗**する

## 検証

- `flow-state.test.sh`: **119 PASS / 0 FAIL**（新規 TC-24 含む）
- 非 vacuity 実証: 同じ `session-aaaa-1371` を Layer 2 に渡すと rc=1（拒否）、`flow-state.sh` は受理 → 統一すれば TC-24 が loud に落ちることを確認
- `pre-compact.test.sh`（TC-1371-AC1 含む）/ `_resolve-session-id.test.sh`: 回帰なし
- プラグイン固有 drift チェック群: 新規 drift **0 件**（develop baseline と同数）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass（flow-state.test.sh 119 PASS）
- [x] Documentation updated（新規 SoT doc + 両ソース cross-ref）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
