### PR TITLE
fix(init): .gitignore 生成に .rite/sessions/ を追加

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -933,7 +933,7 @@ Add `.rite-work-memory/` and `.rite-compact-state*` to `.gitignore` if not alrea
 
 ```bash
 # Check and add entries if missing
-for entry in ".rite-work-memory/" ".rite-compact-state" ".rite-compact-state.lockdir/" ".rite-compact-state.tmp.*" ".rite-initialized-version" ".rite-settings-hooks-cleaned" ".rite/worktrees/"; do
+for entry in ".rite-work-memory/" ".rite-compact-state" ".rite-compact-state.lockdir/" ".rite-compact-state.tmp.*" ".rite-initialized-version" ".rite-settings-hooks-cleaned" ".rite/sessions/" ".rite/worktrees/"; do
   if ! grep -qF "$entry" .gitignore 2>/dev/null; then
     echo "$entry" >> .gitignore
   fi


### PR DESCRIPTION
## 概要

`/rite:init` の `.gitignore` 生成ループに `.rite/sessions/` を追加し、消費プロジェクトの初期化時に per-session 状態ファイルが追跡（tracking-leak）されないようにする。

## 背景

`plugins/rite/commands/init.md` の gitignore 生成ループは `.rite-compact-state*` と `.rite/worktrees/` を含むが、per-session 状態ファイルを覆う `.rite/sessions/` を列挙していなかった。

per-session 状態ファイル:
- `.rite/sessions/{sid}.flow-state`
- `.rite/sessions/{sid}.compact-state`

本リポジトリ自身の `.gitignore` は既に `.rite/sessions/` をカバーしているためドッグフーディングには影響しないが、消費プロジェクトで初期化したときに上記ファイルが gitignore されず追跡されてしまう懸念があった。

## 変更内容

- `plugins/rite/commands/init.md` の gitignore 生成ループの entry 列挙に `.rite/sessions/` を追加（`.rite/worktrees/` の直前に配置し `.rite/` 系をグループ化）

## 関連 Issue

Closes #1384

検出元: PR #1381 review（prompt-engineer / code-quality の follow-up 推奨）

## チェックリスト

- [x] 受入基準を満たす（init 時に per-session 状態ファイルが gitignore される）
- [x] 内部整合性確認（gitignore-health-check は multi_session の `.rite/worktrees/` ドリフト検出専用でスコープ外）
- [ ] レビュー（/rite:pr:iterate で実施予定）
