### PR TITLE
fix: gitignore-health-check に .rite/sessions/ の検証を追加

### DIFF
--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -218,6 +218,32 @@ if [ ! -f "$config_file" ]; then
   exit 0
 fi
 
+# --- Always-on: verify .rite/sessions/ is ignored (per-session state leak guard) ---
+# Unlike the .rite/worktrees/ block below, this is NOT gated on multi_session.enabled:
+# `.rite/sessions/{session_id}.flow-state` (per-session flow/compact state, #1381/#1384)
+# is written on EVERY rite session regardless of multi_session, so the leak surface is
+# always present. Placed BEFORE the wiki early-exits so a wiki.enabled=false config is
+# still verified. Non-blocking & always-on: drift → WARNING + exit 1; healthy → fall
+# through. Mirrors the separate_branch Layer-1 probe: a static `git check-ignore -v` (no
+# file created) asks git whether a session state path is ignored. If not, per-session
+# state files (.rite/sessions/{session_id}.flow-state) would leak into dev-branch diffs.
+sessions_probe=".rite/sessions/.rite-lint-probe"
+sessions_ci_out=""
+sessions_ci_rc=0
+if sessions_ci_out=$(git check-ignore -v "$sessions_probe" 2>/dev/null); then sessions_ci_rc=0; else sessions_ci_rc=$?; fi
+if [ "$sessions_ci_rc" -eq 0 ] && printf '%s' "$sessions_ci_out" | grep -qE ':\.rite/sessions/'; then
+  log_info "gitignore-health-check: sessions layer healthy — .rite/sessions/ ignored (${sessions_ci_out})"
+elif [ "$sessions_ci_rc" -ge 2 ]; then
+  echo "WARNING: gitignore-health-check: git check-ignore failed (rc=$sessions_ci_rc) for .rite/sessions/ verify — skipping sessions check" >&2
+else
+  echo "==> gitignore-health-check: DRIFT DETECTED (sessions): '.rite/sessions/' rule missing from .gitignore" >&2
+  echo "==> per-session state files (.rite/sessions/{session_id}.flow-state) would leak into dev-branch diffs." >&2
+  echo "==> Hint: add '.rite/sessions/' to .gitignore (init.md gitignore generation adds it; see #1384/#1389)." >&2
+  echo "WARNING: gitignore-health-check: .rite/sessions/ rule missing" >&2
+  echo "==> Total gitignore-health-check findings: 1"
+  exit 1
+fi
+
 # --- Multi-session: verify .rite/worktrees/ is ignored when enabled (design §2) ---
 # Independent of wiki settings — placed BEFORE the wiki early-exits so a
 # wiki.enabled=false + multi_session.enabled=true config is still verified.

--- a/plugins/rite/hooks/tests/gitignore-health-check-multi-session.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-health-check-multi-session.test.sh
@@ -39,8 +39,11 @@ WIKI_OK=$'wiki:\n  enabled: true\n  branch_strategy: separate_branch\n'
 WIKI_OFF=$'wiki:\n  enabled: false\n'
 MS_ON=$'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n'
 MS_OFF=$'multi_session:\n  enabled: false\n'
-GI_WIKI=$'.rite/wiki/\n'
-GI_WIKI_WT=$'.rite/wiki/\n.rite/worktrees/\n'
+# All fixtures include `.rite/sessions/` so the always-on sessions check (added for
+# Issue #1389) passes and these cases test the `.rite/worktrees/` behavior in isolation.
+# The dedicated sessions drift behavior lives in gitignore-health-check-sessions.test.sh.
+GI_WIKI=$'.rite/wiki/\n.rite/sessions/\n'
+GI_WIKI_WT=$'.rite/wiki/\n.rite/worktrees/\n.rite/sessions/\n'
 
 echo "=== TC-1: ms enabled + worktrees NOT ignored → drift (exit 1) ==="
 run_case "${WIKI_OK}${MS_ON}" "$GI_WIKI"
@@ -59,11 +62,11 @@ run_case "${WIKI_OK}${MS_OFF}" "$GI_WIKI"
 assert "TC-3 exit 0" "0" "$RUN_RC"
 
 echo "=== TC-4: wiki disabled + ms enabled + worktrees NOT ignored → still drift (exit 1) ==="
-run_case "${WIKI_OFF}${MS_ON}" $'# no rules\n'
+run_case "${WIKI_OFF}${MS_ON}" $'# no rules\n.rite/sessions/\n'
 assert "TC-4 exit 1 (check not gated on wiki.enabled)" "1" "$RUN_RC"
 
 echo "=== TC-5: wiki disabled + ms enabled + worktrees ignored → healthy (exit 0) ==="
-run_case "${WIKI_OFF}${MS_ON}" $'.rite/worktrees/\n'
+run_case "${WIKI_OFF}${MS_ON}" $'.rite/worktrees/\n.rite/sessions/\n'
 assert "TC-5 exit 0" "0" "$RUN_RC"
 
 print_summary "$(basename "$0")" \

--- a/plugins/rite/hooks/tests/gitignore-health-check-sessions.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-health-check-sessions.test.sh
@@ -57,8 +57,10 @@ run_case "${WIKI_OK}${MS_OFF}" "$GI_WIKI_SESS"
 assert "TC-2 exit 0" "0" "$RUN_RC"
 
 echo "=== TC-3: ms enabled + worktrees ignored + sessions NOT ignored → sessions drift (exit 1) ==="
-# Proves the sessions check is independent of (and fires before) the worktrees check:
-# worktrees is healthy here, yet the missing sessions rule still drifts.
+# Proves the sessions check is INDEPENDENT of the worktrees check: worktrees is healthy
+# here (ignored), yet the missing sessions rule still drifts. This does NOT exercise
+# ordering — both checks could run in either order and worktrees would still pass. The
+# strict "sessions fires before worktrees" ordering is proven separately by TC-6.
 run_case "${WIKI_OK}${MS_ON}" $'.rite/wiki/\n.rite/worktrees/\n'
 assert "TC-3 exit 1" "1" "$RUN_RC"
 case "$RUN_OUT" in
@@ -74,6 +76,19 @@ assert "TC-4 exit 1 (check not gated on wiki.enabled)" "1" "$RUN_RC"
 echo "=== TC-5: wiki disabled + sessions ignored → healthy (exit 0) ==="
 run_case "${WIKI_OFF}${MS_OFF}" $'.rite/sessions/\n'
 assert "TC-5 exit 0" "0" "$RUN_RC"
+
+echo "=== TC-6: ms enabled + BOTH sessions and worktrees NOT ignored → sessions fires first ==="
+# Genuine ordering proof: when BOTH the sessions rule AND the worktrees rule are missing
+# (and multi_session is enabled so the worktrees check is active), the script must emit
+# the sessions drift — NOT the multi_session/worktrees drift — because the sessions block
+# runs before, and exits at, the worktrees block. If a future change moves the sessions
+# block after the worktrees block, this case would emit "(multi_session)" instead and fail.
+run_case "${WIKI_OK}${MS_ON}" "$GI_WIKI"
+assert "TC-6 exit 1" "1" "$RUN_RC"
+case "$RUN_OUT" in
+  *"DRIFT DETECTED (sessions)"*) pass "TC-6 sessions drift fires before worktrees" ;;
+  *) fail "TC-6 expected sessions drift first, got: $RUN_OUT" ;;
+esac
 
 print_summary "$(basename "$0")" \
   "Drift hint: gitignore-health-check.sh always-on .rite/sessions/ check (Issue #1389) — runs before the wiki early-exits and is NOT gated on multi_session.enabled."

--- a/plugins/rite/hooks/tests/gitignore-health-check-sessions.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-health-check-sessions.test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Tests for gitignore-health-check.sh always-on .rite/sessions/ check (Issue #1389).
+#
+# Verifies the non-blocking, ALWAYS-ON `.rite/sessions/` ignore check folded into
+# gitignore-health-check.sh. Unlike the `.rite/worktrees/` check (gated on
+# multi_session.enabled), per-session state files (.rite/sessions/{session_id}.flow-state,
+# #1381/#1384) are written on every rite session, so this check is NOT gated:
+#   - .rite/sessions/ NOT ignored                       → drift (exit 1)
+#   - .rite/sessions/ ignored                            → healthy (exit 0)
+#   - multi_session.enabled=false + sessions NOT ignored → still drift (NOT gated on multi_session)
+#   - wiki.enabled=false + sessions NOT ignored          → still drift (runs BEFORE wiki early-exits)
+#   - sessions check fires before the .rite/worktrees/ check (independent leak surface)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+GHC="$SCRIPT_DIR/../scripts/gitignore-health-check.sh"
+
+cleanup_dirs=()
+# `return 0` so an empty array (loop body `[ -n "" ]` → rc 1) does not become the
+# script exit code via the EXIT trap (bash propagates the trap's last rc).
+cleanup() { local d; for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+# Build a sandbox repo with a given rite-config.yml + .gitignore, run the check,
+# and publish the result via globals RUN_RC / RUN_OUT. Called WITHOUT command
+# substitution so `cleanup_dirs+=` lands in the parent shell (a `$(run_case ...)`
+# wrapper would lose the push in the subshell and leak sandboxes).
+run_case() {
+  local config="$1" gitignore="$2" d
+  d=$(make_sandbox)
+  cleanup_dirs+=("$d")
+  printf '%s' "$config" > "$d/rite-config.yml"
+  printf '%s' "$gitignore" > "$d/.gitignore"
+  RUN_RC=0
+  RUN_OUT=$(cd "$d" && bash "$GHC" --quiet 2>&1) || RUN_RC=$?
+}
+
+WIKI_OK=$'wiki:\n  enabled: true\n  branch_strategy: separate_branch\n'
+WIKI_OFF=$'wiki:\n  enabled: false\n'
+MS_ON=$'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n'
+MS_OFF=$'multi_session:\n  enabled: false\n'
+GI_WIKI=$'.rite/wiki/\n'
+GI_WIKI_SESS=$'.rite/wiki/\n.rite/sessions/\n'
+
+echo "=== TC-1: sessions NOT ignored (ms off) → drift (exit 1) ==="
+run_case "${WIKI_OK}${MS_OFF}" "$GI_WIKI"
+assert "TC-1 exit 1" "1" "$RUN_RC"
+case "$RUN_OUT" in
+  *"DRIFT DETECTED (sessions)"*) pass "TC-1 sessions drift message emitted" ;;
+  *) fail "TC-1 sessions drift message missing: $RUN_OUT" ;;
+esac
+
+echo "=== TC-2: sessions ignored (ms off) → healthy (exit 0) ==="
+run_case "${WIKI_OK}${MS_OFF}" "$GI_WIKI_SESS"
+assert "TC-2 exit 0" "0" "$RUN_RC"
+
+echo "=== TC-3: ms enabled + worktrees ignored + sessions NOT ignored → sessions drift (exit 1) ==="
+# Proves the sessions check is independent of (and fires before) the worktrees check:
+# worktrees is healthy here, yet the missing sessions rule still drifts.
+run_case "${WIKI_OK}${MS_ON}" $'.rite/wiki/\n.rite/worktrees/\n'
+assert "TC-3 exit 1" "1" "$RUN_RC"
+case "$RUN_OUT" in
+  *"DRIFT DETECTED (sessions)"*) pass "TC-3 sessions drift (not worktrees) emitted" ;;
+  *) fail "TC-3 sessions drift message missing: $RUN_OUT" ;;
+esac
+
+echo "=== TC-4: wiki disabled + sessions NOT ignored → still drift (exit 1) ==="
+# Proves the check runs BEFORE the wiki early-exits (not gated on wiki.enabled).
+run_case "${WIKI_OFF}${MS_OFF}" $'# no rules\n'
+assert "TC-4 exit 1 (check not gated on wiki.enabled)" "1" "$RUN_RC"
+
+echo "=== TC-5: wiki disabled + sessions ignored → healthy (exit 0) ==="
+run_case "${WIKI_OFF}${MS_OFF}" $'.rite/sessions/\n'
+assert "TC-5 exit 0" "0" "$RUN_RC"
+
+print_summary "$(basename "$0")" \
+  "Drift hint: gitignore-health-check.sh always-on .rite/sessions/ check (Issue #1389) — runs before the wiki early-exits and is NOT gated on multi_session.enabled."


### PR DESCRIPTION
## 概要

`gitignore-health-check.sh` に `.rite/sessions/` の ignore 状態検証を追加した。`.rite/worktrees/`（multi_session gate 付き）と同等の last-line-of-defense を `.rite/sessions/` にも設ける。

## 背景

PR #1388（Issue #1384）のレビューで検出されたスコープ外の推奨事項。health check は `multi_session.enabled=true` 時に `.rite/worktrees/` のみを検証しており、multi_session に依存せず常時生成される `.rite/sessions/`（per-session 状態ファイル）には対応する検査行が無かった。将来の `.gitignore` cleanup PR が `.rite/sessions/` 行を削除しても `/rite:lint` が検知できない drift 面が残っていた。

## 変更点

- **`gitignore-health-check.sh`**: config 存在チェック直後・wiki early-exit より前に、always-on の `.rite/sessions/` drift 検査ブロックを追加。`git check-ignore -v` の静的プローブで ignore 状態を判定し、drift → WARNING + exit 1、healthy → fall through。`.rite/worktrees/` ブロックとは異なり **`multi_session.enabled` ゲートを持たない**（per-session 状態は毎セッション生成されるため）。
- **`gitignore-health-check-multi-session.test.sh`**: 全 fixture に `.rite/sessions/` を追加し、always-on の sessions チェックを通過させて worktrees 挙動を隔離してテスト。
- **`gitignore-health-check-sessions.test.sh`（新規）**: always-on / multi_session 非依存 / wiki early-exit より前に実行されること / worktrees チェックと独立であることを検証する専用テスト（5 ケース 7 アサーション）。

## 設計上の留意点

`.rite/sessions/` は multi_session に依存せず常時生成されるため、`.rite/worktrees/` の multi_session gate とは判定条件が異なる（Issue #1389 の指摘どおり）。本 PR では sessions チェックを worktrees チェックの**前**に配置し、ゲートなしで常時実行する。

## テスト

- 新規 sessions test: PASS 7 / FAIL 0
- 既存 multi-session test（回帰）: PASS 6 / FAIL 0
- 実リポジトリ実行: `==> Total gitignore-health-check findings: 0`（sessions layer healthy）

Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)