### PR TITLE
refactor(cleanup): hooks/scripts の説明的番号参照を Why 散文化 (refs #1397)

### DIFF
--- a/plugins/rite/hooks/_resolve-session-id-from-file.sh
+++ b/plugins/rite/hooks/_resolve-session-id-from-file.sh
@@ -48,7 +48,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=control-char-neutralize.sh
 source "$SCRIPT_DIR/control-char-neutralize.sh"
 
-# verified-review (PR #688 cycle 39 H-01) MEDIUM (silent-failure-hunter):
+# verified-review MEDIUM (silent-failure-hunter):
 # `_resolve-session-id.sh` の存在 check を upfront で実施する。
 # 旧実装 (cycle 39 helper check 追加前) は本ファイル末尾の `_resolve-session-id.sh` invocation
 # (`if validated=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$raw" 2>/dev/null); then ...`) で
@@ -106,7 +106,7 @@ fi
 # stderr を tempfile に退避し、IO error は WARNING を emit してから空文字復帰する (caller の
 # graceful degradation 動作は維持しつつ、observability を確保)。
 # cycle 43 F-08 (MEDIUM) 対応: mktemp 失敗 WARNING 統一 + chmod 600 + canonical 4 行 trap。
-# verified-review (PR #688 cycle 14) F-03 (MEDIUM) 対応:
+# verified-review F-03 (MEDIUM) 対応:
 # 旧コメントに含まれていた hardcoded 行番号 (state-read.sh:267 / _resolve-cross-session-guard.sh:93 /
 # flow-state-update.sh:282,422 / resume-active-flag-restore.sh:180) は本 PR で導入した「DRIFT-CHECK
 # ANCHOR は semantic name 参照、line 番号禁止」doctrine (cycle 38 F-04 / cycle 40) に違反する。
@@ -126,7 +126,7 @@ trap '_rite_resolve_sid_cleanup; exit 143' TERM
 trap '_rite_resolve_sid_cleanup; exit 129' HUP
 
 # F-02 (MEDIUM) consolidation: 共通 helper `_mktemp-stderr-guard.sh` 経由で
-# Stderr emit + chmod 600 + path return を集約 (PR #688 cycle 9 F-02)。
+# Stderr emit + chmod 600 + path return を集約。
 # chmod 600 (cycle 41 F-14 と対称化、multi-user 環境で session_id leak 防止) は helper 内に内蔵済。
 _tr_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "_resolve-session-id-from-file" "resolve-sid-tr-err" \

--- a/plugins/rite/hooks/_resolve-session-id.sh
+++ b/plugins/rite/hooks/_resolve-session-id.sh
@@ -20,7 +20,7 @@
 #     # validation failed; treat as missing/invalid
 #   fi
 #
-# Why this exists (PR #688 cycle 34 fix F-01 CRITICAL):
+# Why this exists:
 #   The same UUID regex literal `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
 #   was duplicated across 5 sites (state-read.sh:85, flow-state-update.sh:70/77/83,
 #   resume-active-flag-restore.sh:87). DRY-ifying eliminates the drift risk where

--- a/plugins/rite/hooks/_validate-helpers.sh
+++ b/plugins/rite/hooks/_validate-helpers.sh
@@ -42,7 +42,7 @@
 #   bash が exit 127 を silent suppression する経路が散在する。本 helper で upfront
 #   fail-fast 検査することで Issue #687 同型の deploy regression を構造的に塞ぐ。
 #
-# DEFAULT_HELPERS scope (PR #688 cycle 13 F-01):
+# DEFAULT_HELPERS scope:
 #   state-read.sh と flow-state-update.sh が依存する core helper set。両 caller は
 #   `bash <missing>` invocation 経路でこれらを direct/transitive に依存する。
 #   resume-active-flag-restore.sh は別 scope (resume layer の独自依存) のため、

--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -120,7 +120,7 @@ if [ "$CLOSE_MODE" = false ]; then
   # Legacy shared path removal is retained for pre-#1371 migration residue.
   rm -f "$STATE_ROOT/.rite-compact-state" 2>/dev/null || true
   rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory" >&2
-  # Per-session compact-state (Issue #1371): derive from the resolved flow-state
+  # Per-session compact-state: derive from the resolved flow-state
   # path so full cleanup also reaps the current session's snapshot.
   _cwm_flow_state=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>/dev/null) || _cwm_flow_state=""
   if [ -n "$_cwm_flow_state" ]; then

--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -11,7 +11,7 @@
 # (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh
 # SOURCE_REF / TITLE — Issue #1276).
 #
-# WHY a shared helper (Issue #1274): the POSIX class [[:cntrl:]] on glibc
+# WHY a shared helper: the POSIX class [[:cntrl:]] on glibc
 # (C and UTF-8 locales, byte-wise verified) does NOT classify C1 8-bit control
 # bytes (0x80-0x9f, notably the CSI introducer 0x9b) as cntrl, so the previous
 # per-site `s/[[:cntrl:]]/?/g` / `${var//[[:cntrl:]]/?}` idioms let 0x9b through
@@ -38,7 +38,7 @@
 #   - stdin → stdout byte filter; LC_ALL=C tr なので NUL を含む任意バイト列を扱える
 #   - default: C0 + DEL + C1 をすべて `?` へ (改行含む — 旧 `${var//[[:cntrl:]]/?}` と同じ 1 行化挙動)
 #   - --keep-newline: \n (0x0a) のみ素通し (旧 `sed 's/[[:cntrl:]]/?/g'` の行指向挙動と同じ)
-#   - --c0-only: C0 (0x00-0x1f) + DEL (0x7f) のみ `?` へ、0x80 以上は素通し (Issue #1275)。
+#   - --c0-only: C0 (0x00-0x1f) + DEL (0x7f) のみ `?` へ、0x80 以上は素通し。
 #     RFC 8259 が JSON 文字列リテラル内で生バイトを禁じるのは C0 のみで、0x80-0x9f を
 #     バイト単位で潰す default は UTF-8 継続バイト (例: 日本語) を巻き込んで本文を破壊する。
 #     モデル/consumer が読む実テキストを保持したまま invalid-JSON バイトだけを除去する
@@ -59,7 +59,7 @@ neutralize_ctrl() {
   fi
 }
 
-# Detection-side counterpart (Issue #1276): reject-purpose call sites
+# Detection-side counterpart: reject-purpose call sites
 # (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh SOURCE_REF /
 # TITLE) previously used bash `=~ [[:cntrl:]]`, which on glibc misses the same
 # C1 8-bit range the neutralize side closes — letting e.g. 0x9b slip through
@@ -74,7 +74,7 @@ neutralize_ctrl() {
 #     unreachable here (the stdin-filter neutralize_ctrl still covers it)
 #   - byte-wise under LC_ALL=C: UTF-8 continuation bytes overlapping 0x80-0x9f
 #     (e.g. most Japanese characters) are detected as control bytes — accepted
-#     (Issue #1276 設計判断): all call sites are ASCII-identifier / ASCII-title
+#    : all call sites are ASCII-identifier / ASCII-title
 #     fields. 日本語 TITLE が必要になったら UTF-8 セーフモードを別途追加する
 #   - implementation reuses the exact neutralize_ctrl default tr range and
 #     compares byte counts before/after deletion. grep は使わない — grep 実装に

--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -74,7 +74,7 @@ neutralize_ctrl() {
 #     unreachable here (the stdin-filter neutralize_ctrl still covers it)
 #   - byte-wise under LC_ALL=C: UTF-8 continuation bytes overlapping 0x80-0x9f
 #     (e.g. most Japanese characters) are detected as control bytes — accepted
-#    : all call sites are ASCII-identifier / ASCII-title
+#     設計判断: all call sites are ASCII-identifier / ASCII-title
 #     fields. 日本語 TITLE が必要になったら UTF-8 セーフモードを別途追加する
 #   - implementation reuses the exact neutralize_ctrl default tr range and
 #     compares byte counts before/after deletion. grep は使わない — grep 実装に

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -67,7 +67,7 @@ _validate_session_id() {
   esac
   # contains_ctrl (control-char-neutralize.sh) は C0 + DEL + C1 8-bit (0x80-0x9f)
   # をバイト単位で検出する。旧 `=~ [[:cntrl:]]` は glibc が C1 を cntrl と分類しない
-  # ため 0x9b (8-bit CSI) 入り session_id を素通ししていた (Issue #1276)。
+  # ため 0x9b (8-bit CSI) 入り session_id を素通ししていた。
   if contains_ctrl "$sid"; then
     echo "ERROR: invalid session_id from $origin: contains control characters (newline / tab / C1 8-bit bytes / etc.)" >&2
     return 1
@@ -91,7 +91,7 @@ _resolve_session_id() {
   fi
   # Claude Code runtime exposes CLAUDE_CODE_SESSION_ID; older / non-Code clients used
   # CLAUDE_SESSION_ID. Accept both so cmd_get / cmd_set --if-exists do not silently
-  # degrade when `.rite-session-id` is absent but the runtime env IS set (Issue #1142).
+  # degrade when `.rite-session-id` is absent but the runtime env IS set.
   # 両 env-var 経路にも _validate_session_id を適用し、無検証で _state_path に渡る
   # path-traversal / log-injection 経路を遮断する。
   if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
@@ -145,7 +145,7 @@ _atomic_write() {
 # Emit up to 3 lines of a jq stderr capture ($1 = error file) to stderr, 2-space
 # indented, with control characters neutralized to '?' via the shared
 # neutralize_ctrl helper (control-char-neutralize.sh) — covers C0 + DEL + C1
-# 0x80-0x9f, which the former inline `s/[[:cntrl:]]/?/g` missed (Issue #1274).
+# 0x80-0x9f, which the former inline `s/[[:cntrl:]]/?/g` missed.
 # Shared with the stop-loop-continuation.sh unknown-prefix WARNING so the
 # neutralization convention lives in one place: a corrupt state file fragment can
 # carry ANSI escape / control bytes that, echoed raw, would let the corrupt
@@ -186,7 +186,7 @@ cmd_set() {
   path=$(_state_path "$sid")
   if [ $if_exists -eq 1 ] && [ ! -f "$path" ]; then
     # `.rite-session-id` exists ⇒ a session-start hook ran and the caller expects an
-    # active session. Resolved path missing means stale/drifted session_id (Issue #1142)
+    # active session. Resolved path missing means stale/drifted session_id
     # — emit a WARNING so the silent skip is observable. Truly first-time sessions (no
     # `.rite-session-id`) stay silent to preserve the graceful no-op contract that
     # `commands/wiki/ingest.md` / `commands/pr/ready.md` 等の `--if-exists` caller が depend on
@@ -204,7 +204,7 @@ cmd_set() {
   # 既存値が無い場合は空文字 → null として書き込み、wm-sync 側の `// "" | tostring` で
   # 空文字に縮退する (空 vs 非空 を別値として扱う wm-sync の diff guard と整合)。
   #
-  # Single composite jq read (PR #1089 H3): 6 つの独立 jq 呼び出しの silent fallback chain
+  # Single composite jq read: 6 つの独立 jq 呼び出しの silent fallback chain
   # では既存 state が corrupt JSON でも全フィールドが default に縮退して silent overwrite
   # される。1 回の composite jq + stderr capture に集約し、jq 失敗時に WARNING を stderr emit
   # して operator が corrupt overwrite を検出できるようにする。Unit separator () で field
@@ -252,9 +252,9 @@ cmd_set() {
   # handoff には 3 種類の値が入る:
   #   - 継続 handoff "/rite:pr:..." : 継続 sentinel (review:fix-needed / fix:pushed) を出す sub-skill が渡す。
   #   - 終了 handoff "FINALIZE:{result}:{pr}" : 終了 sentinel (mergeable / replied-only / cancelled) を
-  #     出す sub-skill が渡す (Issue #1176)。
+  #     出す sub-skill が渡す。
   #   - チェーン handoff "WIKICHAIN:{caller}:{pr}" : cleanup.md ステップ 9 が wiki:ingest invoke 直前に
-  #     渡す (Issue #1245)。チェーン完走時はステップ 12 の set (--handoff なし) が default-clear する。
+  #     渡す。チェーン完走時はステップ 12 の set (--handoff なし) が default-clear する。
   #   `flow-state.sh` 自体は任意文字列を verbatim 格納するため
   #   機構変更は不要 — prefix 分岐は Stop hook (stop-loop-continuation.sh) 側の reason 生成で行う。
   # Stop hook が `consume-handoff` で読み取り + 削除し、prefix で reason を分岐して block する
@@ -350,7 +350,7 @@ cmd_deactivate() {
 }
 
 # consume-handoff: review↔fix loop / cleanup wiki チェーンの one-shot 継続マーカーを
-# **読み取り + 削除** する (Issue #1168 / #1245)。
+# **読み取り + 削除** する。
 # Stop hook (stop-loop-continuation.sh) が turn 終了時に呼ぶ。`handoff` が非空ならその値を stdout に
 # 出力し、同じ呼び出しで file から削除 (atomic) する。これにより:
 #   - handoff 非空 → 値を出力 → hook が block + 再注入。削除済みなので次に LLM が何もせず止まれば
@@ -420,7 +420,7 @@ _migrate_file() {
   local now updated; now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   # v3 schema: drop legacy `previous_phase` (replaced by step name discrimination in v3) and
   # normalize legacy `branch_name` → `branch`. `last_synced_phase` is preserved because
-  # post-tool-wm-sync.sh continues to use it as a runtime-only diff guard field (PR #1089 H1);
+  # post-tool-wm-sync.sh continues to use it as a runtime-only diff guard field;
   # dropping it during migrate would cause one round of unnecessary GitHub API spam right after
   # migration.
   updated=$(jq --argjson s "$SCHEMA_VERSION_V3" --arg p "$np" --arg ts "$now" \
@@ -485,7 +485,7 @@ Usage: $0 {set|get|deactivate|consume-handoff|migrate|path} [options]
   get --field <F> [--default V] [--session UUID]
       | --jq-filter <FILTER> [--default V] [--session UUID]
   deactivate [--next T] [--session UUID]
-  consume-handoff [--session UUID]   # print + clear the one-shot handoff marker (Issue #1168 / #1245)
+  consume-handoff [--session UUID]   # print + clear the one-shot handoff marker
   migrate [--dry-run] [--verbose]
   path [--session UUID]
 Phase enum (v3): $PHASE_ENUM_V3

--- a/plugins/rite/hooks/notification.sh
+++ b/plugins/rite/hooks/notification.sh
@@ -40,7 +40,7 @@ fi
 # Resolve project root (git root anchored). Matches session-start.sh /
 # _resolve-schema-version.sh / post-tool-wm-sync.sh convention; `$CWD` based
 # lookup would silently miss rite-config.yml when Claude Code is launched from
-# a subdirectory (Issue #976).
+# a subdirectory.
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
 CONFIG_FILE="$STATE_ROOT/rite-config.yml"

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -65,7 +65,7 @@ fi
 [ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 # Derive the per-session compact-state path from the resolved flow-state path
-# (Issue #1371): must mirror pre-compact.sh so the snapshot written by PreCompact
+#: must mirror pre-compact.sh so the snapshot written by PreCompact
 # is the one consumed and normalized here. Falls back to the legacy shared path
 # only when the session id is unresolvable.
 if [ -n "$FLOW_STATE" ]; then

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -65,7 +65,7 @@ fi
 [ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 # Derive the per-session compact-state path from the resolved flow-state path
-#: must mirror pre-compact.sh so the snapshot written by PreCompact
+# It must mirror pre-compact.sh so the snapshot written by PreCompact
 # is the one consumed and normalized here. Falls back to the legacy shared path
 # only when the session id is unresolvable.
 if [ -n "$FLOW_STATE" ]; then

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # rite workflow - PostToolUse Work Memory Sync Hook
 # Auto-creates local work memory when missing during an active workflow.
-# Also auto-syncs Issue comment work memory when phase changes (Issue #167).
+# Also auto-syncs Issue comment work memory when phase changes.
 # Fires after every Bash tool use; quick-exits in most cases.
 set -euo pipefail
 
@@ -56,9 +56,9 @@ _flow_data=$(jq -r '[(.active // false | tostring), (.issue_number // "" | tostr
 IFS=$'\x1f' read -r _active issue_number _phase _last_synced_phase <<< "$_flow_data"
 [ "$_active" = "true" ] || exit 0
 [ -n "$issue_number" ] || exit 0
-# Session ownership check (#173): skip sync for other session's state.
+# Session ownership check: skip sync for other session's state.
 #
-# Note (Issue #681 F-04): under schema_version=2 with a per-session $FLOW_STATE,
+# Note: under schema_version=2 with a per-session $FLOW_STATE,
 # `check_session_ownership` returns "own" via its schema-2 fast-path without
 # invoking jq, so the failure path is structurally absent and the
 # `|| _ownership="own"` defensive default is dead code in that branch. The
@@ -67,7 +67,7 @@ IFS=$'\x1f' read -r _active issue_number _phase _last_synced_phase <<< "$_flow_d
 # environmental issues (jq error, IO error). Keep both branches.
 _ownership=$(check_session_ownership "$INPUT" "$FLOW_STATE") || _ownership="own"
 [ "$_ownership" != "other" ] || exit 0
-# Defense-in-depth: don't recreate WM for completed workflows (#776)
+# Defense-in-depth: don't recreate WM for completed workflows
 [ "$_phase" != "completed" ] || exit 0
 [ "$_phase" != "cleanup" ] || exit 0
 
@@ -128,7 +128,7 @@ if [ ! -f "$LOCAL_WM" ]; then
   exit 0
 fi
 
-# === Phase diff detection & Issue comment auto-sync (Issue #167) ===
+# === Phase diff detection & Issue comment auto-sync ===
 # Scope: phase changes only. next_action and loop_count changes are
 # handled by explicit calls in command files (Phase 2 follow-up).
 [ -n "$_phase" ] || exit 0

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -28,7 +28,7 @@ fi
 # SCRIPT_DIR already set in preamble block above
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
-# Resolve active flow-state file path (Issue #680).
+# Resolve active flow-state file path.
 # Returns the per-session file when schema_version=2 with a valid SID; otherwise legacy.
 #
 # Issue #749: stderr pass-through for diagnostic visibility, via canonical helper
@@ -54,7 +54,7 @@ fi
 [ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 # Derive the per-session compact-state path from the resolved flow-state path
-# (Issue #1371): .rite/sessions/{sid}.flow-state → .rite/sessions/{sid}.compact-state.
+#: .rite/sessions/{sid}.flow-state → .rite/sessions/{sid}.compact-state.
 # This makes each session's compact snapshot independent, removing the
 # last-writer-wins race on the previously shared single file. Falls back to the
 # legacy shared path only when the session id is unresolvable, preserving
@@ -82,7 +82,7 @@ source "$SCRIPT_DIR/work-memory-update.sh"
 
 trap cleanup EXIT TERM INT
 
-# Session ownership check (#173): skip state updates for other session's state.
+# Session ownership check: skip state updates for other session's state.
 # Must run before lock to avoid holding the lock while doing nothing.
 if [ -f "$FLOW_STATE" ]; then
   # Pass-through helper stderr so corrupt-state WARNINGs reach triage; the
@@ -168,8 +168,8 @@ if acquire_wm_lock "$LOCKDIR"; then
     fi
   fi
 
-  # Write compact state — always set to "recovering" regardless of current state (#854, #133)
-  # The previous "skip if resuming" guard (#851) was insufficient: when
+  # Write compact state — always set to "recovering" regardless of current state
+  # The previous "skip if resuming" guard was insufficient: when
   # post-compact-guard transitioned blocked→resuming on first denial, a second
   # compact would see "resuming" and skip, leaving all guards permissive.
   # Now PostCompact hook handles auto-recovery (recovering→normal), and pre-compact
@@ -288,7 +288,7 @@ if acquire_wm_lock "$LOCKDIR"; then
   release_wm_lock "$LOCKDIR"
 fi
 
-# Output advisory message only when workflow is active (#842, #776)
+# Output advisory message only when workflow is active
 # FLOW_ACTIVE is set inside the lock block; defaults to "false" if lock was not acquired.
 if [ "${FLOW_ACTIVE:-false}" = "true" ]; then
   # Provide defaults: PHASE may be unset when ACTIVE_ISSUE is null (line 96 guard)
@@ -298,7 +298,7 @@ if [ "${FLOW_ACTIVE:-false}" = "true" ]; then
   # stderr: displayed directly to user's terminal (guaranteed visibility)
   echo "[rite] ⚠️ compact detected (Issue #${_ISSUE}, Phase: ${_PHASE}). Auto-recovery will proceed via PostCompact." >&2
 
-  # stdout: fed to model as hook output (#887, #889)
+  # stdout: fed to model as hook output
   # Minimal message to reduce post-compaction token overhead.
   # System prompt alone is ~200K tokens; every token saved here helps stay under API limit.
   # PostCompact hook will restore full context after compaction completes.

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -54,7 +54,7 @@ fi
 [ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 # Derive the per-session compact-state path from the resolved flow-state path
-#: .rite/sessions/{sid}.flow-state → .rite/sessions/{sid}.compact-state.
+# .rite/sessions/{sid}.flow-state → .rite/sessions/{sid}.compact-state.
 # This makes each session's compact snapshot independent, removing the
 # last-writer-wins race on the previously shared single file. Falls back to the
 # legacy shared path only when the session id is unresolvable, preserving

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -32,7 +32,7 @@ source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
 # だけで、guard を付ける利点がない。
 source "$SCRIPT_DIR/control-char-neutralize.sh"
 
-# Deny フォールバック JSON 用の reason エスケープ (Issue #1278)。適用順序が契約:
+# Deny フォールバック JSON 用の reason エスケープ。適用順序が契約:
 # backslash → double-quote → 改行 \n 化 → neutralize_ctrl --c0-only (残存 C0+DEL を ? 化)。
 # backslash エスケープが先頭でないと、後続が生成する \" / \n の backslash を二重に
 # エスケープしてしまう。--c0-only なのは byte 単位の C1 置換が UTF-8 マルチバイト本文を
@@ -147,7 +147,7 @@ BLOCKED_REASON=""
 BLOCKED_ALTERNATIVE=""
 # Sub-kind tag for the deny message. Stays empty for git-verb blocks (A)-(G);
 # the (Z) shell-wrapper sub-block sets it to "shell-wrapper" so the final deny
-# message can explain why a read-only wrapper probe is blocked (Issue #1322).
+# message can explain why a read-only wrapper probe is blocked.
 BLOCKED_SUBKIND=""
 
 # Pattern 1: gh pr diff --stat
@@ -319,7 +319,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     *" dash -c "*|\
     *" fish -c "*)
       BLOCKED_PATTERN="reviewer-state-mutating-git"
-      # 中身が read-only でも block するため、deny message 側で理由を明示する (Issue #1322)。
+      # 中身が read-only でも block するため、deny message 側で理由を明示する。
       # pattern 名は既存テスト (assert_subagent_deny が reason に "reviewer-state-mutating-git"
       # を要求) との互換のため変えず、subkind タグで message だけを分岐する。
       BLOCKED_SUBKIND="shell-wrapper"
@@ -542,7 +542,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   if [ -n "$BLOCKED_PATTERN" ]; then
     BLOCKED_REASON="Reviewer subagents must not mutate the working tree, index, or refs. State-changing git commands (checkout/reset/add/stash push/restore/commit/push/merge/rebase/cherry-pick/revert/tag -a -d -f/clean/gc/branch -D --delete/update-ref/symbolic-ref/am/apply/mv/notes/config/remote/bisect/filter-branch/replace/reflog expire/worktree remove/fetch --prune/--force/etc.) are forbidden inside reviewer contexts."
     BLOCKED_ALTERNATIVE="Use read-only alternatives: 'git show <ref>:<file>' to read a blob, 'git diff <ref> -- <file>' to compare, 'git worktree add <path> <ref>' to inspect a different ref in an isolated directory, 'git tag -l' / 'git stash list' / 'git reflog' / 'git branch --list' for display-only queries, or bare 'git fetch' (without --prune/--force) for ref sync. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the full list. If this block fires on a main session (not a reviewer subagent), check whether CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE env vars are accidentally set; recover with: unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE"
-    # (Z) shell-wrapper の場合は、wrapper 専用の理由・代替を前置する (Issue #1322)。
+    # (Z) shell-wrapper の場合は、wrapper 専用の理由・代替を前置する。
     # 汎用 git message だけだと、git を含まない read-only probe (例: `bash -c 'echo x'`) が
     # "State-changing git commands ... forbidden" と表示され、reviewer には over-broad で
     # 不可解な block に見える。なぜ wrapper を一律 block するか / read-only probe をどう書き

--- a/plugins/rite/hooks/preflight-check.sh
+++ b/plugins/rite/hooks/preflight-check.sh
@@ -35,7 +35,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
 
-# Resolve the per-session compact-state path (Issue #1371). pre-compact.sh writes
+# Resolve the per-session compact-state path. pre-compact.sh writes
 # the "recovering" marker to .rite/sessions/{sid}.compact-state; this gate MUST read
 # the same per-session path or the compact block would never trigger after the
 # per-session migration. Falls back to the legacy shared path only when the session

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -5,7 +5,7 @@
 # review.md ステップ 6.1.b の PR コメント投稿処理 (post_comment_mode gate + 複数 case gate +
 # scope 限定 awk sentinel 置換 + 2 つの post-condition + atomic mv + gh pr comment + signal 検出)
 # を担う。本文側の巨大 inline bash を helper に切り出すことで、単一 Bash invocation での malform
-# 無言停止を回避する (Issue #1193 #4、背景は PR 説明参照)。PR コメント本文 (Markdown + Raw JSON
+# 無言停止を回避する。PR コメント本文 (Markdown + Raw JSON
 # section) は caller が Write tool で tmpfile に書き出し `--content-file` で渡す (heredoc malform 源を撤廃)。
 #
 # Usage:
@@ -25,7 +25,7 @@
 #     3. 本 helper を実行する。
 #
 # 契約 (review.md ステップ 6.1.b と verbatim 一致):
-#   - post_comment_mode machine-enforced gate (Issue #510): true→続行 / false→exit 0 silent skip
+#   - post_comment_mode machine-enforced gate: true→続行 / false→exit 0 silent skip
 #     (gh pr comment を絶対に実行しない) / その他→ERROR + [review:error] + exit 1。
 #   - ブロッキング: 失敗は `[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=...` を emit し exit 1
 #     (ステップ 6.1.a の非ブロッキング契約とは対照的)。reason 語彙:
@@ -56,7 +56,7 @@ CONTENT_FILE=""
 
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
+# 陥る。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pr)                PR_NUMBER="${2:-}"; shift; shift ;;
@@ -68,7 +68,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# post_comment_mode machine-enforced gate (Issue #510)。
+# post_comment_mode machine-enforced gate。
 # true→続行 / false→silent skip (gh pr comment 遮断、データ破壊なし) / その他→fail-fast。
 case "$POST_COMMENT_MODE" in
   true) ;;
@@ -169,7 +169,7 @@ awk -v ts="$ISO_TIMESTAMP" -v sentinel="$SENTINEL" '
       if (past && lines[i] ~ /^```json$/) { in_fence = 1; print lines[i]; continue }
       if (past && in_fence && lines[i] ~ /^```$/) { in_fence = 0; print lines[i]; continue }
       if (in_fence) {
-        # index()/substr() ベースのリテラル置換 (Issue #1200)。gsub の replacement に ts を
+        # index()/substr() ベースのリテラル置換。gsub の replacement に ts を
         # 直接埋め込むと `&` (マッチ全体に展開) / `\` (エスケープ) が metacharacter として
         # 解釈され置換結果が壊れる。index/substr は needle / replacement とも純リテラル扱い。
         # needle は SENTINEL 変数を -v で受け取る (値は backslash を含まないため -v の

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -4,7 +4,7 @@
 #
 # review.md ステップ 6.1.a のローカル JSON 保存処理 (timestamp 注入 / 多段 jq validation /
 # 同秒衝突回避 / atomic mv) を担う。本文側の巨大 inline bash を helper に切り出すことで、単一 Bash
-# invocation での malform 無言停止を回避する (Issue #1193 #3、背景は PR 説明参照)。JSON body は
+# invocation での malform 無言停止を回避する。JSON body は
 # caller が Write tool で tmpfile に書き出し `--content-file` で渡す (heredoc malform 源を撤廃)。
 #
 # Usage:
@@ -51,7 +51,7 @@ REVIEW_RESULTS_DIR=".rite/review-results"
 
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
+# 陥る。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pr)           PR_NUMBER="${2:-}"; shift; shift ;;
@@ -230,7 +230,7 @@ if ! jq -e '
   exit 0
 fi
 
-# NOTE (Issue #1193 #3 委譲時に発見・修正した precedence バグ):
+# NOTE:
 #   review.md ステップ 6.1.a の原実装は `[.findings[].id] | unique | length == (.findings | length)`
 #   と書いており、jq では `length == (.findings | length)` の `.findings` がパイプ後の配列
 #   (unique 結果) に対して評価され "Cannot index array with string findings" でエラーになる。
@@ -261,7 +261,7 @@ if [ "$_schema_ver" = "1.1.0" ] && ! jq -e '
   )
   ' "$json_tmp" >/dev/null 2>&1; then
   echo "WARNING: JSON の findings[].scope が enum 違反 (期待: current-pr / follow-up / nit-noted)" >&2
-  echo "  対処: reviewer が schema 1.1.0 の scope 列を正しく出力しているか確認 (Issue #1018 M2)" >&2
+  echo "  対処: reviewer が schema 1.1.0 の scope 列を正しく出力しているか確認" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=scope_enum_violation" >&2
   exit 0
 fi

--- a/plugins/rite/hooks/review-skip-notification.sh
+++ b/plugins/rite/hooks/review-skip-notification.sh
@@ -16,7 +16,7 @@
 #     --local-save-failed <0|1|"">
 #
 #   caller (review.md ステップ 6.1.c) は以下を会話コンテキストから読み取り literal substitute する:
-#     - --post-comment-mode: ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE= の値 (Issue #510)
+#     - --post-comment-mode: ステップ 1.0 の [CONTEXT] POST_COMMENT_MODE= の値
 #     - --pr: 正規化済 pr_number
 #     - --file-timestamp: ステップ 6.1.a の [CONTEXT] FILE_TIMESTAMP= の値 (成功時 YYYYMMDDHHMMSS、失敗時 "unknown")
 #     - --local-save-failed: ステップ 6.1.a の [CONTEXT] LOCAL_SAVE_FAILED= の値 ("1" または未 emit=空文字)。
@@ -24,7 +24,7 @@
 #
 # 契約 (review.md ステップ 6.1.c と verbatim 一致):
 #   - 実行条件: post_comment_mode=false の経路専用 (true 経路は 6.1.b の成功/失敗ログで完結する)。
-#   - post_comment_mode machine-enforced gate (Issue #510、6.1.b と対称): false→続行 /
+#   - post_comment_mode machine-enforced gate: false→続行 /
 #     true→ERROR + [review:error] + exit 1 / その他→ERROR + [review:error] + exit 1。
 #   - 「1 変数 1 gate」原則で fail-fast の局所性を最大化 (post_comment_mode gate 通過後に
 #     pr_number / file_timestamp / local_save_failed を順に検証)。reason 語彙:
@@ -52,7 +52,7 @@ LOCAL_SAVE_FAILED=""
 
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224、review-comment-post.sh と対称)。1 回目の shift で $# を確実に 0 にし、
+# 陥る。1 回目の shift で $# を確実に 0 にし、
 # 2 回目は no-op で安全に抜ける。
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -64,7 +64,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# post_comment_mode machine-enforced gate (Issue #510 対応、6.1.b と対称)。
+# post_comment_mode machine-enforced gate。
 # 6.1.c は post_comment_mode=false 経路専用。true 経路で誤呼出された場合、本来 6.1.b で
 # 成功/失敗ログが完結すべきところ skip notification を出すと観測値が混線する。caller の
 # branch selection ミスを fail-fast 遮断する。

--- a/plugins/rite/hooks/scripts/bash-heaviness-check.sh
+++ b/plugins/rite/hooks/scripts/bash-heaviness-check.sh
@@ -7,7 +7,7 @@
 # documented in skills/rite-workflow/references/coding-principles.md (added by
 # PR #1193), which prose-only enforcement cannot prevent from drifting.
 #
-# Why a separate hook (Issue #1197 / #1193 提案 c):
+# Why a separate hook:
 #   Issue #1193 observed that large operational bash blocks in command bodies
 #   (python inline / nested $() / multiple heredocs / long line counts) caused
 #   Claude's tool-call parsing to malform and silently end the turn with no
@@ -34,7 +34,7 @@
 # the literal content inside a heredoc, so a template heredoc that happens to
 # contain `$(...)` or `python3 -c` example text does not produce a finding.
 #
-# Standalone detection (Issue #1307 — separate from the >= 2 score model):
+# Standalone detection (separate from the >= 2 score model):
 #   inline-gh-create-title — a real shell line that runs `gh {pr,issue} create`
 #     with a LITERAL `--title "..."` / `--title '...'` (the first char inside the
 #     quote is neither `$` nor the closing quote). `--title "$var"` is sanctioned
@@ -44,7 +44,7 @@
 #     in references/gh-cli-commands.md), so the literal-title check stays armed across
 #     continuation lines until the logical line ends. Unlike the four heaviness
 #     signals, a single inline special-char/long title is itself a dominant
-#     malformed-tool-call trigger (#1307), so it is flagged on its own — it does not
+#     malformed-tool-call trigger, so it is flagged on its own — it does not
 #     need a second signal. The canonical fix is to write the title via the Write
 #     tool to a file and read it into a variable
 #     (`pr_title=$(cat title.txt)` → `--title "$pr_title"`), or pass it through a
@@ -191,7 +191,7 @@ BEGIN { in_block = 0 }
   if (line ~ /drift-check-ignore/) exempt = 1
   if (line ~ /python3?[[:space:]]+.*(-c([[:space:]]|=|$)|<<)/) has_python = 1
   if (line ~ /\$\([^)]*\$\(/) nested = 1
-  # Standalone trigger (#1307): inline `gh {pr,issue} create` with a LITERAL
+  # Standalone trigger: inline `gh {pr,issue} create` with a LITERAL
   # --title. `--title "$var"` (first char after the quote is `$`) and an empty
   # `--title ""` / `--title ''` (first char after the quote is the closing quote)
   # are both allowed — the bracket expression `[^$"']` excludes `$` and both quote
@@ -222,9 +222,9 @@ BEGIN { in_block = 0 }
 END { if (in_block == 1) evaluate() }
 function evaluate(   score, parts) {
   if (exempt == 1) return
-  # Standalone finding (#1307): independent of the >= 2 heaviness score.
+  # Standalone finding: independent of the >= 2 heaviness score.
   if (gh_title_inline == 1) {
-    printf "[bash-heaviness] %s:%d: inline-gh-create-title — literal --title in gh {pr,issue} create; delegate the title to a file (Write tool) or a variable to avoid malformed tool-call (refs #1307)\n", fname, gh_title_line
+    printf "[bash-heaviness] %s:%d: inline-gh-create-title — literal --title in gh {pr,issue} create; delegate the title to a file (Write tool) or a variable to avoid malformed tool-call\n", fname, gh_title_line
   }
   score = 0; parts = ""
   if (has_python == 1)            { score++; parts = parts (parts == "" ? "" : ", ") "python-inline" }

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -5,7 +5,7 @@
 # rule added in PR #564 that prevents wiki-ingest-trigger.sh temporary writes from
 # silently leaking into the develop branch PR diff. If a future `.gitignore`
 # cleanup PR inadvertently removes this rule, the regression must be detected
-# immediately (Issue #567).
+# immediately.
 #
 # Detection strategy (strategy-aware, per `.gitignore` header L101-113 spec):
 #

--- a/plugins/rite/hooks/scripts/lib/wiki-config.sh
+++ b/plugins/rite/hooks/scripts/lib/wiki-config.sh
@@ -7,7 +7,7 @@
 # wiki-ingest-commit.sh can share a single definition instead of keeping
 # three character-exact copies in sync manually.
 #
-# Design rationale (Issue #549): previous commits (PR #548 cycle 4 review
+# Design rationale: previous commits (PR #548 cycle 4 review
 # F-05 / F-06) identified that parse_wiki_scalar had drifted across the
 # three sibling scripts, creating a transcription-failure class of bugs
 # every time the `wiki.branch_name` parsing contract changed. Extracting a

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -6,7 +6,7 @@
 # - wiki-worktree-commit.sh (pages/index/log commits on wiki branch)
 # - wiki-ingest-commit.sh (worktree fast path for raw-source ingest)
 #
-# Design rationale (Issue #549): PR #548 cycle 4 F-06 identified that the
+# Design rationale: PR #548 cycle 4 F-06 identified that the
 # add/commit/push block + error handling (stderr tempfile -> head -n 10
 # -> sed prefix) was structurally identical across the two scripts. A
 # shared helper removes that drift vector. PR #550 review further

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -46,7 +46,7 @@ AUTO_RECOVER="true"
 
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
+# 陥る。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
 # (--original-branch 欠落はループ後の必須チェックが exit 2 で検出)。
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -197,7 +197,7 @@ fi
 
 # --- JSON summary ---
 # `drift_detail` / `drift_type` は他 hook script 由来の長文メッセージを内包する可能性があるため、
-# printf で JSON value に直接埋め込むのではなく jq で escape する (Issue #999 LOW follow-up)。
+# printf で JSON value に直接埋め込むのではなく jq で escape する。
 # `recovered` は "true"/"false" 文字列を JSON boolean に変換する。
 jq -nc --arg t "$drift_type" --arg d "$drift_detail" --arg r "$recovered" \
   '{drift: true, type: $t, detail: $d, recovered: ($r == "true")}'

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -36,8 +36,7 @@
 # Variation history:
 #   - `cycle{N}`: orchestrator-created (`/rite:pr:review` cycle worktrees)
 #   - `test` / `experiment` / `mutation` / `verify` / `check` / `sandbox`:
-#     reviewer-subagent verification experiments. Observed in Issue #995
-#    .
+#     reviewer-subagent verification experiments (observed in practice).
 #     The reviewer's READ-ONLY contract is enforced primarily by
 #     `pre-tool-bash-guard.sh` Pattern 4 (PreToolUse hook block), and these
 #     names should normally never be created. This regex serves as the

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -4,12 +4,12 @@
 # Responsibility: remove residual `pr-{N}-cycle{X}` worktrees and branches
 # that leak after reviewer subagent `git worktree add` invocations, plus
 # `pr-{N}-{test,experiment,mutation,verify,check,sandbox}` variations that
-# reviewers create for verification experiments (Issue #995). The reviewer's
+# reviewers create for verification experiments. The reviewer's
 # READ-ONLY contract forbids `git worktree remove` / `git branch -D`, so
 # cleanup MUST run from the orchestrator side.
 #
 # Additionally, reaps orphaned `rite-pr-create-*` workdirs left in
-# `${TMPDIR:-/tmp}` by pr/create.md Phase 3.4 (Issue #1311). Its 3-step protocol
+# `${TMPDIR:-/tmp}` by pr/create.md Phase 3.4. Its 3-step protocol
 # (mktemp -d -> Write tool -> gh pr create) spans separate processes, so a
 # malformed tool-call between workdir allocation and `gh pr create` leaves an
 # empty (or partially written) workdir behind. create.md's own signal-specific
@@ -18,7 +18,7 @@
 # an in-flight workdir held by a paused concurrent session.
 #
 # Also reaps orphaned `rite-review-mutation-*` detached worktrees left in
-# `${TMPDIR:-/tmp}` by reviewer subagents (Issue #1340). `_reviewer-base.md`'s
+# `${TMPDIR:-/tmp}` by reviewer subagents. `_reviewer-base.md`'s
 # worktree-only mutation pattern (`mktemp -d -t rite-review-mutation-XXXXXX`
 # + `git worktree add --detach`) lets reviewers run verification experiments
 # without mutating the parent working tree, but the reviewer's READ-ONLY
@@ -37,7 +37,7 @@
 #   - `cycle{N}`: orchestrator-created (`/rite:pr:review` cycle worktrees)
 #   - `test` / `experiment` / `mutation` / `verify` / `check` / `sandbox`:
 #     reviewer-subagent verification experiments. Observed in Issue #995
-#     (PR #994 cycle 3 review where a reviewer created `pr-994-test`).
+#    .
 #     The reviewer's READ-ONLY contract is enforced primarily by
 #     `pre-tool-bash-guard.sh` Pattern 4 (PreToolUse hook block), and these
 #     names should normally never be created. This regex serves as the
@@ -119,7 +119,7 @@ prune_err=""
 ref_err=""
 workdir_find_err=""
 mutation_find_err=""
-# Step 3/4 の find -print0 出力を保持する NUL-delimited 一時ファイル (refs #1351)。
+# Step 3/4 の find -print0 出力を保持する NUL-delimited 一時ファイル。
 # command substitution は NUL バイトを除去するため list を変数に持てない。find rc 捕捉を
 # 保ちつつ改行安全に読むには、出力を一時ファイルに退避して `read -r -d ''` で読む。
 workdir_find_out=""
@@ -244,7 +244,7 @@ else
 fi
 
 # -----------------------------------------------------------------------
-# Step 3: Reap orphaned `rite-pr-create-*` workdirs (refs #1311).
+# Step 3: Reap orphaned `rite-pr-create-*` workdirs.
 # pr/create.md Phase 3.4 の 3 段プロトコル (A: mktemp -d -> B: Write tool ->
 # C: gh pr create) は workdir を別プロセスに跨がせるため、(A) 確保後・(C) 到達前の
 # malformed tool-call 無言終了 (Cause A) で `${TMPDIR:-/tmp}/rite-pr-create-*` が
@@ -263,18 +263,18 @@ fi
 readonly WORKDIR_REAP_AGE_MINUTES=1440  # 24h
 
 # ---------------------------------------------------------------------------
-# reap_orphan_dirs (refs #1352): Step 3 (workdir) / Step 4 (mutation worktree) で
+# reap_orphan_dirs: Step 3 (workdir) / Step 4 (mutation worktree) で
 # 同型だった orphan ディレクトリ走査を 1 箇所に集約する。両 Step は「tmp_base 正規化 →
 # err/out mktemp → mktemp 失敗ガード → find rc 捕捉 → NUL 区切り (-print0) ループ →
 # find wholesale 失敗時の err surface」という subtle な不変条件群を共有しており、過去に
-# per-item 失敗分岐 (#1349) と find 出力先 mktemp 失敗 surface (#1351) を両 Step へ二重
+# per-item 失敗分岐 と find 出力先 mktemp 失敗 surface を両 Step へ二重
 # 修正する copy-paste drift が実際に発生した。本ヘルパーで不変条件を集約し drift を防ぐ。
 #
 # find は process substitution `< <(find ...)` ではなく出力を一時ファイルに退避して呼ぶ。
 # process substitution は subshell の exit code が伝播せず find wholesale 失敗が無言 no-op
 # になるため。`if find ... -print0 > "$out"; then` 形式なら find が if の直接コマンドで rc を
 # 捕捉でき、失敗を WARNING + errors++ で surface できる。出力保持に command substitution を
-# 使わないのは bash の `$(...)` が NUL バイトを除去して -print0 区切りが失われるため (#1351)。
+# 使わないのは bash の `$(...)` が NUL バイトを除去して -print0 区切りが失われるため。
 #
 # Args: $1 label (WARNING 用) / $2 base / $3 name_pattern / $4 reaper_fn /
 #       $5 find_out (mktemp 済み、空=失敗) / $6 find_err (mktemp 済み、stderr 退避用)
@@ -312,7 +312,7 @@ reap_orphan_dirs() {
 }
 
 # Step 3 reaper: orphan workdir を rm -rf で回収。失敗時は rm の stderr を診断として surface
-# する (refs #1352、従来は `2>/dev/null` で失敗理由が落ちていた)。
+# する。
 _reap_workdir() {
   local orphan="$1" rm_err=""
   if rm_err=$(rm -rf "$orphan" 2>&1); then
@@ -328,7 +328,7 @@ _reap_workdir() {
 }
 
 # Step 4 reaper: mutation worktree を `git worktree remove --force` 第一手・`rm -rf` fallback で
-# 回収。両手の失敗理由 (stderr) を surface する (refs #1352、Step 1/4 の診断性向上)。
+# 回収。両手の失敗理由 (stderr) を surface する。
 # 成功時に mutation_reaped_any=1 を立て、呼び出し側の post-loop prune を起動する。
 _reap_mutation_worktree() {
   local orphan="$1" wt_err="" rm_err=""
@@ -363,7 +363,7 @@ reap_orphan_dirs "orphan workdir" "$workdir_tmp_base" 'rite-pr-create-*' \
   _reap_workdir "$workdir_find_out" "$workdir_find_err"
 
 # -----------------------------------------------------------------------
-# Step 4: Reap orphaned `rite-review-mutation-*` worktrees (refs #1340).
+# Step 4: Reap orphaned `rite-review-mutation-*` worktrees.
 # reviewer subagent の mutation/verification 検証は `_reviewer-base.md` の
 # worktree-only mutation pattern (`mktemp -d -t rite-review-mutation-XXXXXX`
 # + `git worktree add --detach`) に従って detached worktree を作るが、reviewer は

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# rite workflow - Projects Board "Done" Drift Check (Issue #1305)
+# rite workflow - Projects Board "Done" Drift Check
 #
 # Reconciliation drift-guard for the "CLOSED+COMPLETED but board != Done" gap.
 # A Done transition is only wired into /rite:pr:cleanup and /rite:issue:close, but
@@ -69,7 +69,7 @@ while [ $# -gt 0 ]; do
     --quiet)     QUIET=true; shift ;;
     -h|--help)
       cat <<'USAGE_EOF'
-projects-board-drift-check.sh - Projects Board "Done" Drift Check (Issue #1305)
+projects-board-drift-check.sh - Projects Board "Done" Drift Check
 
 Scans recently-updated CLOSED Issues and reports the ones whose closure reason is
 COMPLETED yet whose GitHub Projects board Status is not "Done" — the symptom of a

--- a/plugins/rite/hooks/scripts/wiki-branch-init.sh
+++ b/plugins/rite/hooks/scripts/wiki-branch-init.sh
@@ -49,7 +49,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# --- Leading-dash fail-fast gate (Issue #1290) ---
+# --- Leading-dash fail-fast gate ---
 # wiki_branch は rite-config.yml の wiki.branch_name 由来 (開発者管理) だが、leading-`-` の
 # 値は `git push -u origin` で refspec ではなく option として解釈される (例: `--force`; 実測)。
 # `git checkout --orphan` 側は git 自身の branch name validation で fail するため実害はないが、

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -24,7 +24,7 @@
 #   --repo-root DIR        Repository root (default: git rev-parse --show-toplevel)
 #   --quiet                Suppress informational output (still emits findings line)
 #   --threshold N          Override growth-stall threshold from rite-config.yml
-#   --pr-raw-threshold N   Override PR↔raw correspondence threshold (Issue #536)
+#   --pr-raw-threshold N   Override PR↔raw correspondence threshold
 #   -h, --help             Show this help
 #
 # Exit codes (drift-check と同一の非ブロッキング契約):
@@ -70,7 +70,7 @@ Options:
   --threshold N            Override growth-stall threshold (default: read from
                            rite-config.yml, fallback 5)
   --pr-raw-threshold N     Override PR↔raw correspondence threshold (default:
-                           read from rite-config.yml, fallback 3) (Issue #536)
+                           read from rite-config.yml, fallback 3)
   -h, --help               Show this help
 
 Exit codes:
@@ -294,7 +294,7 @@ else
   log_info "wiki-growth-check: growth-stall: healthy ($merged_count merged PRs since last '$wiki_branch' commit, threshold: $threshold)"
 fi
 
-# --- PR ↔ raw source correspondence check (Issue #536) ---
+# --- PR ↔ raw source correspondence check ---
 # For each of the last N merged PRs, check whether at least one raw source
 # file exists on the wiki branch with a matching `pr-{number}` in its name.
 # This detects regressions where PRs are merged but Phase X.X.W never fires,
@@ -394,7 +394,7 @@ if ! check_pr_raw_correspondence; then
   findings=$((findings + 1))
 fi
 
-# --- Comprehensive health check: raw count, page count, pending count, page stall (Issue #538) ---
+# --- Comprehensive health check: raw count, page count, pending count, page stall ---
 # DRY: git ls-tree for .rite/wiki/raw/ is called once in check_page_stall and
 # passed to helper functions to avoid 3x duplication of the same git ls-tree call.
 

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -169,7 +169,7 @@ if [[ ! -f "rite-config.yml" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# Shared lib (Issue #549): parse_wiki_scalar / validate_wiki_branch_name /
+# Shared lib: parse_wiki_scalar / validate_wiki_branch_name /
 # worktree_commit_push. Extracted to lib/ so wiki-worktree-setup.sh /
 # wiki-worktree-commit.sh / wiki-ingest-commit.sh share a single source
 # of truth for the `wiki.branch_name` parsing contract and the worktree-
@@ -314,7 +314,7 @@ if [[ "$branch_strategy" == "same_branch" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# separate_branch strategy — Worktree fast path (Issue #547 / cycle 2 fix).
+# separate_branch strategy — Worktree fast path.
 #
 # When `.rite/wiki-worktree/` exists and is checked out to wiki_branch,
 # the legacy `git checkout wiki` path below would FAIL with

--- a/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
@@ -6,7 +6,7 @@
 # `cat` for same_branch), extract `ingest:skip` records, dedup, and emit the
 # set inside a marker block alongside a 4-value log_read_ok enum.
 #
-# Why a helper (Issue #1196 / #1193 MEDIUM #14):
+# Why a helper:
 #   The inline implementation in lint.md ステップ 6.0 was a ~165-line bash
 #   block. Delegating it removes a malform / drift source while keeping the
 #   cross-Bash-tool-boundary state-transfer contract verbatim.
@@ -15,7 +15,7 @@
 #   marker-delimited block).
 #
 # Symmetry note: this is the step 6.0 counterpart to step 6.2's
-# `wiki-lint-source-refs.sh` (Issue #1195 #10). Both share the marker block +
+# `wiki-lint-source-refs.sh`. Both share the marker block +
 # io_error enum shape and the legitimate-absence stderr pattern matching;
 # keep them aligned.
 #

--- a/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
@@ -7,7 +7,7 @@
 # same_branch), extract frontmatter `sources[].ref` entries, dedup, and emit
 # the set inside a marker block alongside a 3-value read_ok enum.
 #
-# Why a helper (Issue #1195 #10 / #1193 Where #10):
+# Why a helper:
 #   The inline implementation in lint.md was a ~240-line HIGH-weight bash
 #   block. Delegating it removes a heredoc-malform / drift source while
 #   keeping the cross-Bash-tool-boundary state-transfer contract verbatim.
@@ -16,7 +16,7 @@
 #   key=value stdout).
 #
 # Symmetry note: this is the step 6.2 counterpart to step 6.0's
-# `wiki-lint-skipped-refs.sh` (Issue #1195 #14, delegated in Issue #1196).
+# `wiki-lint-skipped-refs.sh`.
 # Both share the marker block + io_error enum shape; keep them aligned.
 #
 # Inputs:

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -8,7 +8,7 @@
 # `.rite/wiki/pages/**`, index.md updates, and log.md appendices
 # directly into the worktree tree.
 #
-# Design rationale (Issue #547): this script replaces the Block A/B
+# Design rationale: this script replaces the Block A/B
 # shell contract in ingest.md. Because the worktree lives at a stable
 # path alongside the dev-branch tree, there is no need for:
 # - `git stash push -u` (dev-branch work is untouched)
@@ -156,7 +156,7 @@ if [[ ! -f "rite-config.yml" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# Shared lib (Issue #549): parser/validator + worktree add/commit/push helper.
+# Shared lib: parser/validator + worktree add/commit/push helper.
 # -----------------------------------------------------------------------
 # shellcheck source=lib/wiki-config.sh
 source "$_SCRIPT_DIR/lib/wiki-config.sh"

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -5,7 +5,7 @@
 # checked out to the configured `wiki.branch_name`. Idempotent — running
 # this script repeatedly is safe and cheap.
 #
-# Design rationale (Issue #547): the legacy Block A/B pattern in
+# Design rationale: the legacy Block A/B pattern in
 # commands/wiki/ingest.md relied on `git stash + git checkout wiki` on
 # the current working tree, which loses access to the dev-branch
 # `plugins/rite/templates/wiki/page-template.md` during the LLM

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -97,7 +97,7 @@ fi
 
 # Deactivate flow state if it exists
 if [ -f "$STATE_FILE" ]; then
-    # Session ownership check (#173): only deactivate own/legacy/stale state.
+    # Session ownership check: only deactivate own/legacy/stale state.
     # Other session's fresh state (within 2h) must not be modified.
     # See pre-compact.sh: caller-side `2>/dev/null` would mute the corrupt-
     # state WARNING that exists to flag state-overwrite risk against another
@@ -215,7 +215,7 @@ WARN_MSG
     fi
     [ -n "$_deact_jq_err" ] && rm -f "$_deact_jq_err"
 
-    # AC-10 (Issue #680): clean up per-session flow-state file on session end.
+    # AC-10: clean up per-session flow-state file on session end.
     # Note: this block also runs after the jq deactivation `else` arm above —
     # i.e. when the .active=false update failed. The per-session file is unique
     # to this session, so even a corrupt one has no value post-termination, and

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -15,7 +15,7 @@
 #   ownership=$(check_session_ownership "$INPUT" "$STATE_FILE")
 #   # ownership: "own" | "legacy" | "other" | "stale"
 #
-# Role transition (Issue #681): With schema_version=2 (per-session files),
+# Role transition: With schema_version=2 (per-session files),
 # session ownership is structurally guaranteed by the session_id encoded in
 # the filename — the resolver (`_resolve-flow-state-path.sh`) only returns
 # a per-session path that matches the current session. `check_session_ownership`
@@ -89,7 +89,7 @@ get_state_session_id() {
 # Returns: 0 (true) if path matches `*/.rite/sessions/*.flow-state`, 1 otherwise.
 # Exit code: 0 or 1 (boolean — usable in `if is_per_session_state_file ...`)
 #
-# Why this exists (Issue #681): With schema_version=2 the resolver
+# Why this exists: With schema_version=2 the resolver
 # (`_resolve-flow-state-path.sh`) only returns a per-session path whose session_id
 # segment matches the current session, so the file is structurally owned by
 # this session and the 4-state legacy classification is unnecessary. Callers
@@ -123,7 +123,7 @@ is_per_session_state_file() {
 #
 # Issue #681: the per-session fast-path replaces the schema-2 portion of the
 # legacy 4-state classification with a structural check. The remaining branches
-# preserve schema-1 behavior unchanged so lifecycle hooks (#680) and pre-compact
+# preserve schema-1 behavior unchanged so lifecycle hooks and pre-compact
 # that depend on "legacy"/"other"/"stale" outputs continue to work.
 check_session_ownership() {
   local hook_json="$1"

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -27,7 +27,7 @@ source "$SCRIPT_DIR/control-char-neutralize.sh"
 # cat failure does not abort under set -e; || guard is defensive
 INPUT=$(cat) || INPUT=""
 
-# Plugin dual-load collision guard (#591)
+# Plugin dual-load collision guard
 # Only warn when this script is running from a local plugin-dir (not from
 # the marketplace cache). Normal marketplace users should have it enabled.
 # SCRIPT_DIR already set in preamble block above (replaces SCRIPT_PATH)
@@ -62,7 +62,7 @@ if [ -d "$_plugin_root/hooks" ]; then
   printf '%s' "$_plugin_root" > "$STATE_ROOT/.rite-plugin-root" 2>/dev/null || true
 fi
 
-# Save session_id to .rite-session-id for flow-state.sh auto-read (#216)
+# Save session_id to .rite-session-id for flow-state.sh auto-read
 if [ -n "$SESSION_ID" ]; then
   (umask 077; printf '%s' "$SESSION_ID" > "$STATE_ROOT/.rite-session-id") 2>/dev/null || {
     [ -n "${RITE_DEBUG:-}" ] && echo "[rite] WARNING: Failed to write .rite-session-id" >&2
@@ -70,7 +70,7 @@ if [ -n "$SESSION_ID" ]; then
   }
 fi
 
-# Helper: remove stale compact-state when no active flow (#756, #1371)
+# Helper: remove stale compact-state when no active flow
 # Called on startup when the flow-state is absent or inactive, to prevent stale
 # "recovering" state from persisting across sessions.
 #
@@ -205,7 +205,7 @@ if [ "$SOURCE" = "startup" ]; then
         # python3 must run in a set -e-exempt context (an if-condition) so a non-zero
         # exit (rc=1 no-op / rc=2 invalid JSON / missing script) does NOT abort the
         # whole hook before the rc branches below run. A bare statement here would trip
-        # `set -euo pipefail` and turn the entire else branch into dead code (Issue #1241).
+        # `set -euo pipefail` and turn the entire else branch into dead code.
         if python3 "$SCRIPT_DIR/scripts/settings-local-rite-hook-cleanup.py" \
           < "$_settings_local" > "$_repair_tmp" 2>"${_py_err:-/dev/null}"; then
           _py_rc=0
@@ -237,7 +237,7 @@ if [ "$SOURCE" = "startup" ]; then
             if [ -n "$_py_err" ] && [ -s "$_py_err" ]; then
               # Non-empty stderr means python3 itself failed (missing/unreadable cleanup
               # script, import error) — surface its diagnostic but NOT the JSON hint, which
-              # would misdirect: the fault is not the settings.local.json content (Issue #1241).
+              # would misdirect: the fault is not the settings.local.json content.
               head -3 "$_py_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
             elif [ "$_py_rc" -eq 2 ]; then
               # The cleanup script ran, returned 2, and wrote nothing to stderr → invalid
@@ -302,7 +302,7 @@ if [ "$CWD" = "$STATE_ROOT" ]; then
   ( cd "$CWD" && bash "$SCRIPT_DIR/scripts/pr-cycle-cleanup.sh" ) >/dev/null 2>&1 || true
 fi
 
-# Resolve active flow-state file path (Issue #680).
+# Resolve active flow-state file path.
 # `_resolve-flow-state-path.sh` returns the per-session file
 # (`.rite/sessions/<sid>.flow-state`) when schema_version=2 and a valid
 # session_id is present, otherwise the legacy `.rite-flow-state`. The
@@ -342,7 +342,7 @@ fi
 [ -n "$_resolve_err" ] && rm -f "$_resolve_err"
 
 if [ -z "$STATE_FILE" ] || [ ! -f "$STATE_FILE" ]; then
-  # Clean stale compact state on startup/clear when no flow state exists (#756, #800)
+  # Clean stale compact state on startup/clear when no flow state exists
   _cleanup_stale_compact
   exit 0
 fi
@@ -361,7 +361,7 @@ if [ "$ACTIVE" != "true" ]; then
   exit 0
 fi
 
-# --- Defensive reset helper (#558, #761, #173, #206) ---
+# --- Defensive reset helper ---
 # Shared by startup and clear blocks. Resets active=false on phase != completed.
 #
 # When the state is owned by another active session (check_session_ownership
@@ -372,7 +372,7 @@ fi
 # For "own" / "legacy" / "stale" / fail-safe paths, proceed with reset
 # (crash-recovery and backward-compat take priority over multi-instance protection).
 #
-# Regression note (#558): a prior commit moved the check_session_ownership call
+# Regression note: a prior commit moved the check_session_ownership call
 # inside an RITE_DEBUG block as a "performance" optimization, silently disabling
 # multi-instance protection in normal runs. DO NOT re-enclose check_session_ownership
 # in conditional gates — it must run on every reset path so the "other" branch can fire.
@@ -395,7 +395,7 @@ _reset_active_state() {
   [ -n "$_reset_jq_err" ] && rm -f "$_reset_jq_err"
   IFS=$'\t' read -r _phase _issue _branch <<< "$_composite"
 
-  # Session ownership check runs on the normal execution path (#558), not just RITE_DEBUG.
+  # Session ownership check runs on the normal execution path, not just RITE_DEBUG.
   # Fail-safe: if the helper isn't sourced or returns non-zero, treat as "unknown"
   # and proceed with reset — crash-recovery takes priority over multi-instance protection.
   if command -v check_session_ownership >/dev/null 2>&1; then
@@ -439,7 +439,7 @@ _reset_active_state() {
   fi
   [ -n "$_reset_jq_err" ] && rm -f "$_reset_jq_err"
   _cleanup_stale_compact
-  # Silent reset for completed workflows (#772): no message, no /rite:resume suggestion
+  # Silent reset for completed workflows: no message, no /rite:resume suggestion
   if [ "$_phase" = "completed" ]; then
     exit 0
   fi
@@ -449,12 +449,12 @@ _reset_active_state() {
   exit 0
 }
 
-# --- Defensive reset on new session startup (#761, #173) ---
+# --- Defensive reset on new session startup ---
 if [ "$SOURCE" = "startup" ]; then
   _reset_active_state
 fi
 
-# --- Defensive reset on /clear (#781, #133, #173) ---
+# --- Defensive reset on /clear ---
 if [ "$SOURCE" = "clear" ]; then
   _reset_active_state
 fi
@@ -515,7 +515,7 @@ If the user provides a different instruction, respect it but mention the pending
 Use \`bash {plugin_root}/hooks/flow-state.sh get --field <field>\` for full state details.
 EOF
 
-# --- Session ID notification (#173, #221) ---
+# --- Session ID notification ---
 # session_id is now auto-read from .rite-session-id by flow-state.sh.
 # stdout output removed to prevent Claude from fabricating inconsistent values
 # via the {session_id} placeholder. See Issue #221.

--- a/plugins/rite/hooks/stop-loop-continuation.sh
+++ b/plugins/rite/hooks/stop-loop-continuation.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# rite workflow - Stop Hook: review↔fix loop continuation + terminal finalize (Issue #1168 / #1176)
-#                 + cleanup → wiki:ingest → wiki:lint チェーン継続保証 (Issue #1245)
+# rite workflow - Stop Hook: review↔fix loop continuation + terminal finalize
+#                 + cleanup → wiki:ingest → wiki:lint チェーン継続保証
 #
 # Guarantees that /rite:pr:iterate の review↔fix ループが、LLM が継続/終了 sentinel を
 # 出した直後に turn を終了してしまっても、構造的な層で差し戻すことを保証する。
 #   - 継続 sentinel ([review:fix-needed:N] / [fix:pushed] / [fix:pushed-wm-stale]) → 次ループへ自動継続
 #   - 終了 sentinel ([review:mergeable] / [fix:replied-only] / [fix:cancelled-by-user]) → 完了通知を強制
 # 同じ one-shot handoff 機構で /rite:pr:cleanup の wiki チェーン (cleanup → wiki:ingest →
-# wiki:lint --auto) の未完走も差し戻す (Issue #1245):
+# wiki:lint --auto) の未完走も差し戻す:
 #   - ネスト最深部の [lint:returned-to-caller:auto] / [ingest:returned-to-caller] 直後に
 #     turn が閉じても、cleanup ステップ 10-12 までの継続を 1 回だけ強制する
 #
@@ -15,9 +15,9 @@
 #   - 継続 sentinel を出す sub-skill (review.md Step 8.0 / fix.md Step 5.1) が
 #     flow-state に継続 handoff (例 "/rite:pr:fix 99") をセットする。
 #   - 終了 sentinel を出す sub-skill (review.md Step 8.0 / fix.md Step 5.1 / Step 1.4 cancel) が
-#     flow-state に終了 handoff (例 "FINALIZE:review:mergeable:99") をセットする (Issue #1176)。
+#     flow-state に終了 handoff (例 "FINALIZE:review:mergeable:99") をセットする。
 #   - cleanup.md ステップ 9 が wiki:ingest invoke 直前にチェーン handoff
-#     (例 "WIKICHAIN:cleanup:99") をセットする (Issue #1245)。チェーンがステップ 12 まで
+#     (例 "WIKICHAIN:cleanup:99") をセットする。チェーンがステップ 12 まで
 #     完走した場合はステップ 12 末尾の flow-state.sh set (--handoff なし) が default-clear する。
 #   - 本 hook は turn 終了時に flow-state.sh consume-handoff で handoff を
 #     **読み取り + 削除** する (one-shot)。非空なら decision:block で停止を差し戻す。
@@ -77,11 +77,11 @@ fi
 # handoff 不在 → 継続待ちでも終了通知待ちでもない → 停止許可。
 [ -n "$HANDOFF" ] || exit 0
 
-# handoff pending: 停止を差し戻す。handoff の prefix で reason を分岐する (Issue #1176 / #1245)。
+# handoff pending: 停止を差し戻す。handoff の prefix で reason を分岐する。
 # block 可否は「handoff 非空」の軸のみで決まり、prefix は reason 文面の選択にのみ影響する。
 #   FINALIZE:{result}:{pr}  = 終了 sentinel 到達 → /rite:pr:iterate ステップ5 完了通知を強制
-#   WIKICHAIN:{caller}:{pr} = cleanup チェーン未完走 → 残り step の継続を強制 (Issue #1245)
-#   /rite:...               = 継続 sentinel 到達 → 次ループコマンドを再注入 (Issue #1168)
+#   WIKICHAIN:{caller}:{pr} = cleanup チェーン未完走 → 残り step の継続を強制
+#   /rite:...               = 継続 sentinel 到達 → 次ループコマンドを再注入
 #   それ以外                 = 未知 prefix。silent に既定動作へ吸収せず WARNING で可視化した上で
 #                             verbatim 再注入する (prefix 名前空間拡張時の分岐漏れ検出 / PR #1177 教訓)
 case "$HANDOFF" in
@@ -93,14 +93,14 @@ handoff は consume 済みのため、完了通知を出力した後に再度停
     ;;
   WIKICHAIN:*)
     _pr="${HANDOFF##*:}"
-    _reason="rite の cleanup → wiki:ingest → wiki:lint チェーン (PR #${_pr}) がまだ完走していません。停止せず、未実行の step を順に継続してください: wiki:ingest の残り step (lint 結果 parse → 完了レポート + [ingest:returned-to-caller]) → /rite:pr:cleanup ステップ 10 (関連 Issue close) → ステップ 11 (作業メモリ最終化 + ローカルファイル削除) → ステップ 12 (完了報告 + flow-state terminal)。wiki:ingest / wiki:lint の成否に関わらず cleanup ステップ 10 以降へ進むのが契約です (Issue #1245)。
+    _reason="rite の cleanup → wiki:ingest → wiki:lint チェーン (PR #${_pr}) がまだ完走していません。停止せず、未実行の step を順に継続してください: wiki:ingest の残り step (lint 結果 parse → 完了レポート + [ingest:returned-to-caller]) → /rite:pr:cleanup ステップ 10 (関連 Issue close) → ステップ 11 (作業メモリ最終化 + ローカルファイル削除) → ステップ 12 (完了報告 + flow-state terminal)。wiki:ingest / wiki:lint の成否に関わらず cleanup ステップ 10 以降へ進むのが契約です。
 
 handoff は consume 済みのため、進捗なく再度停止した場合は次回は停止が許可されます (無限 block しません)。"
     ;;
   /rite:*)
     _reason="rite の review↔fix ループ (/rite:pr:iterate) が継続中です。停止せず、次を実行してください: ${HANDOFF}
 
-このループは [review:mergeable] / [fix:replied-only] / [fix:cancelled-by-user] のいずれかに到達するか、ユーザーが Ctrl+C で中断するまで継続します (Issue #1136 / #1168)。handoff は consume 済みのため、進捗なく再度停止した場合は次回は停止が許可されます。"
+このループは [review:mergeable] / [fix:replied-only] / [fix:cancelled-by-user] のいずれかに到達するか、ユーザーが Ctrl+C で中断するまで継続します。handoff は consume 済みのため、進捗なく再度停止した場合は次回は停止が許可されます。"
     ;;
   *)
     # 未知 prefix: 新 prefix 追加時の case 分岐漏れを silent 吸収しない (fail-loud)。block 自体は
@@ -120,7 +120,7 @@ esac
 # decision:block を JSON で emit。jq 失敗時は literal JSON にフォールバックして継続意図を保つ
 # (pre-tool-bash-guard.sh の fail-closed フォールバックと同様の堅牢化)。
 # 手動エスケープは \ / " / 改行のみのため、HANDOFF 由来の C0 生バイト (raw ESC 等) が残ると
-# RFC 8259 違反の invalid JSON になる — neutralize_ctrl --c0-only で ? 化する (Issue #1275)。
+# RFC 8259 違反の invalid JSON になる — neutralize_ctrl --c0-only で ? 化する。
 # default モードを使わないのは、バイト単位の C1 置換が _reason の UTF-8 日本語 (モデルへの
 # 継続指示文) を破壊するため。C1 素通しが jq プライマリ経路と対称なのは valid UTF-8 の
 # C1 (0xc2 0x9b 等) のみで、raw 8-bit 単独の C1 バイト (0x9b 等) は jq が U+FFFD に

--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Static + offline tests for Issue #1305: projects-board-drift-check.sh
+# Static + offline tests for projects-board-drift-check.sh
 #
 # Verifies:
 #   T-1: script exists and is executable
@@ -54,7 +54,7 @@ assert_absent() {
   fi
 }
 
-echo "=== T: projects-board-drift-check.sh (Issue #1305) ==="
+echo "=== T: projects-board-drift-check.sh ==="
 
 echo ""
 echo "[T-1] Script exists and is executable"
@@ -118,7 +118,7 @@ assert_file_contains "$DRIFT_SH" '\-\-dry-run\)' "case clause handles --dry-run 
 assert_file_contains "$DRIFT_SH" '\-\-reconcile\)' "case clause handles --reconcile flag"
 assert_file_contains "$DRIFT_SH" '\-\-limit\)' "case clause handles --limit flag"
 assert_file_contains "$DRIFT_SH" '\-\-quiet\)' "case clause handles --quiet flag"
-assert_file_contains "$DRIFT_SH" 'Issue #1305' "header references Issue #1305"
+assert_file_contains "$DRIFT_SH" 'Reconciliation drift-guard' "header documents drift-guard purpose"
 # Detection: anchor asserts to the load-bearing jq predicates (with quotes), NOT to the header
 # comments (which spell COMPLETED/Done without the jq quoting), so deleting the detection logic
 # actually fails the suite. The quoted `stateReason == "COMPLETED"` predicate also pins the AC-2

--- a/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Static tests for Issue #1003 AC-9: watchdog-status-mismatch.sh
+# Static tests for watchdog-status-mismatch.sh
 #
 # Verifies:
 #   T-9a: script exists and is executable
@@ -46,7 +46,7 @@ assert_file_contains() {
   fi
 }
 
-echo "=== T-9: watchdog-status-mismatch.sh (Issue #1003 AC-9) ==="
+echo "=== T-9: watchdog-status-mismatch.sh ==="
 
 echo ""
 echo "[T-9a] Script exists and is executable"
@@ -110,9 +110,9 @@ assert_file_contains "$WATCHDOG_SH" '\-\-limit\)' \
   "Script case clause handles --limit flag"
 assert_file_contains "$WATCHDOG_SH" '\-\-quiet\)' \
   "Script case clause handles --quiet flag"
-# Issue #1003 AC-9 marker
-assert_file_contains "$WATCHDOG_SH" 'Issue #1003 AC-9' \
-  "Script header references Issue #1003 AC-9"
+# header purpose marker
+assert_file_contains "$WATCHDOG_SH" 'Status Mismatch Watchdog' \
+  "header documents watchdog purpose"
 # Detection logic: isDraft=false && Status="In Progress"
 assert_file_contains "$WATCHDOG_SH" 'isDraft' \
   "Script checks PR isDraft"

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -128,7 +128,7 @@ fi
 # 0x00-0x08 / 0x0B / 0x0C / 0x0E-0x1F / 0x7F as bypass vectors.
 # contains_ctrl (control-char-neutralize.sh) は C0 + DEL に加え C1 8-bit
 # (0x80-0x9f) もバイト単位で検出する — 旧 `=~ [[:cntrl:]]` は glibc が C1 を
-# cntrl と分類しないため 0x9b (8-bit CSI) を素通ししていた (Issue #1276)。
+# cntrl と分類しないため 0x9b (8-bit CSI) を素通ししていた。
 if contains_ctrl "$SOURCE_REF"; then
   echo "ERROR: --source-ref must not contain control characters (newlines, tabs, or other C0/DEL/C1 control bytes)" >&2
   echo "  reason: control characters can break YAML frontmatter (early --- close, key injection, escape sequences)" >&2
@@ -158,7 +158,7 @@ fi
 # in adjacent YAML keys, so an asymmetric guard would leak the same injection
 # class through whichever side is unprotected. Byte-wise C1 detection also
 # rejects multibyte (e.g. Japanese) titles via their 0x80-0x9f continuation
-# bytes — accepted: all in-repo callers pass ASCII-fixed titles (Issue #1276).
+# bytes — accepted: all in-repo callers pass ASCII-fixed titles.
 if [[ -n "$TITLE" ]]; then
   if contains_ctrl "$TITLE"; then
     echo "ERROR: --title must not contain control characters (newlines, tabs, or other C0/DEL/C1 control bytes)" >&2

--- a/plugins/rite/hooks/wiki-query-inject.sh
+++ b/plugins/rite/hooks/wiki-query-inject.sh
@@ -153,7 +153,7 @@ esac
 # Same YAML parse pattern as wiki-ingest-trigger.sh (F-23 compliant):
 # awk + section range + inline-comment strip + quote strip.
 #
-# Default policy (#483): Wiki is opt-out. When `wiki:` section is absent
+# Default policy: Wiki is opt-out. When `wiki:` section is absent
 # or `wiki.enabled` key is not specified, treat as enabled. The downstream
 # index.md fetch step exits silently with empty stdout when Wiki is not
 # initialized, so opt-out remains non-blocking for fresh repositories.
@@ -182,7 +182,7 @@ if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   fi
 fi
 
-# Note (#483): wiki_section may legitimately be empty when:
+# Note: wiki_section may legitimately be empty when:
 #   1. rite-config.yml does not exist
 #   2. rite-config.yml has no `wiki:` section
 # In both cases, opt-out policy treats wiki as enabled. The downstream

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -67,7 +67,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 # fail-fast capture を 3 箇所 (line 96-110 / 175-186 / 187-193) で完全に同一構造で複製していた。
 # 共通 helper に集約することで spec 変更を 1 箇所で完結させる。
 #
-# verified-review (PR #688 cycle 14) F-05 (MEDIUM) 対応: 旧コメントは
+# verified-review F-05 (MEDIUM) 対応: 旧コメントは
 # 「resume-active-flag-restore.sh にも 2 site 存在し計 5 site の boilerplate 重複を集約する
 # (writer/reader/resume 3 layer DRY 化)」と主張していたが、resume layer の 2 site
 # (resume-active-flag-restore.sh の curr_phase / curr_next 抽出ブロック) は **本 PR では consolidate
@@ -264,10 +264,10 @@ update_local_work_memory() {
   _branch_san=$(_sanitize_yaml_value "$branch")
   _last_commit_san=$(_sanitize_yaml_value "$last_commit")
 
-  # verified-review (PR #688 cycle 15) F-04 (MEDIUM) 対応 + post-review F-01 (MEDIUM) DRY 化:
+  # verified-review F-04 (MEDIUM) 対応 + post-review F-01 (MEDIUM) DRY 化:
   # pr_num / loop_cnt は flow-state.sh 経由で flow-state JSON から取得されるが、jq -r は raw string を
   # 返すため、tampered/corrupt な flow-state file (例: `{"pr_number": "123\nmalicious: injection"}`) で
-  # 改行込みの値が返ると YAML frontmatter parse が破壊される (Issue #687 同型の writer/reader 対称化破綻)。
+  # 改行込みの値が返ると YAML frontmatter parse が破壊される。
   # 数値型 validation を _validate_numeric_yaml_value() helper に集約し、新規数値フィールド追加時の
   # 片肺更新リスクを構造的に解消した (本 PR review F-01)。
   local _pr_num_san _loop_cnt_san

--- a/plugins/rite/scripts/backfill-sub-issues.sh
+++ b/plugins/rite/scripts/backfill-sub-issues.sh
@@ -91,7 +91,7 @@ api_error_count=0
 #
 # stderr suppression (`2>/dev/null`) は使用せず、エラー出力を一時ファイルに捕捉して
 # 呼び出し元に warning + 詳細メッセージを surface する。これにより MUST「silent skip 禁止」
-# (Issue #514) と CLAUDE.md feedback `feedback_e2e_no_stop_before_review` の精神を遵守する。
+# と CLAUDE.md feedback `feedback_e2e_no_stop_before_review` の精神を遵守する。
 extract_parent_number() {
   local child_num="$1"
   local body err_file
@@ -198,7 +198,7 @@ for child in "${TARGET_CHILDREN[@]}"; do
       failed_count=$((failed_count + 1))
       ;;
     *)
-      # 未知 status を silent 通過させない (Issue #514 MUST NOT)
+      # 未知 status を silent 通過させない
       # JSON parse 失敗や link-sub-issue.sh の将来拡張で空文字/未知値が
       # 返った場合、サイレントロスを起こさず failed として計上する。
       echo "❌ #$child: unexpected link status '$status' (msg: $message)" >&2

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -63,7 +63,7 @@ add_warning() {
   WARNINGS_ARR+=("$1")
 }
 
-# add_warning_with_stderr (#669): Projects registration failures must NOT be silent.
+# add_warning_with_stderr: Projects registration failures must NOT be silent.
 # Caller contract: only invoke for failures within the Projects registration phase
 # (after PROJECTS_ENABLED=true gate at L171). Do NOT use for the enabled=false skip
 # path or for informational Iteration-not-configured cases — those use add_warning.
@@ -78,7 +78,7 @@ if ! [[ "$RETRY_DELAY" =~ ^[0-9]+$ ]]; then
   RETRY_DELAY=1
 fi
 
-# retry_with_backoff (#669): exponential backoff retry for transient API failures.
+# retry_with_backoff: exponential backoff retry for transient API failures.
 # Usage: result=$(retry_with_backoff <max_attempts> <stderr_file> <command...>)
 # Sleeps RETRY_DELAY * 2^(n-1) seconds between attempts (1s, 2s, 4s for default delay).
 # Set RETRY_DELAY=0 in tests to skip sleep entirely.
@@ -133,7 +133,7 @@ output_result() {
 # JSON は positional arg ($1, canonical) または stdin (引数なし時) で受け取る。
 # stdin 対応は既存の positional-JSON 契約を温存したまま additive に追加したもので、
 # 新しい caller は `jq -n ... | bash create-issue-with-projects.sh` と書くことで
-# `$(bash ... "$(jq -n ...)")` の入れ子 $() を 1 段に削減できる (Issue #1193 #5)。
+# `$(bash ... "$(jq -n ...)")` の入れ子 $() を 1 段に削減できる。
 if [ $# -ge 1 ]; then
   INPUT_JSON="$1"
 else
@@ -206,7 +206,7 @@ ISSUE_URL=$(gh "${GH_ARGS[@]}" 2>"$GH_ERR_FILE") || {
   exit 1
 }
 
-# SIGPIPE 防止 (#398): printf | grep パターンを here-string に置換。
+# SIGPIPE 防止: printf | grep パターンを here-string に置換。
 # ISSUE_URL は短い文字列だが、pipefail 下での一貫性のため統一。
 ISSUE_NUMBER=$(grep -oE '[0-9]+$' <<< "$ISSUE_URL" || true)
 

--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -5,7 +5,7 @@
 # caller can append a Sub-Issues section.
 #
 # Extracted from `commands/issue/create.md` ステップ 5.3+5.4+5.5 Step 1
-# (refs #1193 / #1195 item #9). The old inline block expanded a
+#. The old inline block expanded a
 # `{REPEAT_FOR_EACH_SUB_ISSUE}` placeholder and embedded each body via heredoc;
 # both were heredoc/placeholder malform sources. This helper takes a spec JSON
 # whose `body_file` fields point at raw files the caller wrote with the Write
@@ -60,7 +60,7 @@ ISSUE_BODY_SCRIPT="$SCRIPT_DIR/../hooks/issue-body-safe-update.sh"
 # --- Argument parsing ---
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
+# 陥る。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける
 # (--spec 欠落はループ後の必須チェックが exit 2 で検出)。
 SPEC=""
 while [ $# -gt 0 ]; do
@@ -107,9 +107,9 @@ spec_get() { printf '%s' "$SPEC_JSON" | jq -r "$1"; }
 # caller's apply step. ---
 workdir=$(spec_get '.workdir // empty')
 # Per-iteration helper stderr is captured to this scratch file so it is never
-# merged into the helper's stdout JSON (Issue #1206): create-issue-with-projects.sh
+# merged into the helper's stdout JSON: create-issue-with-projects.sh
 # emits `ERROR: ...` on stderr while still printing valid JSON on stdout with
-# exit 0 on partial-Projects failures (Issue #669). A `2>&1` capture would splice
+# exit 0 on partial-Projects failures. A `2>&1` capture would splice
 # that ERROR ahead of the JSON and break the downstream `jq -r .issue_number`,
 # silently miscounting an actually-created Sub-Issue as failed (#514 contract break).
 helper_err_file=$(mktemp "${TMPDIR:-/tmp}/rite-decompose-helper-err.XXXXXX") \
@@ -200,7 +200,7 @@ while IFS= read -r sub_json; do
     echo "WARNING: Sub-Issue '$sub_title' body が空、skip" >&2
     failed_count=$((failed_count + 1))
   else
-    # stderr を helper_err_file へ分離する (Issue #1206)。`2>&1` だと partial-Projects
+    # stderr を helper_err_file へ分離する。`2>&1` だと partial-Projects
     # 失敗時の stderr ERROR が stdout JSON 前方へ混入し、直後の jq parse が壊れて
     # 実際には作成された Sub-Issue を failed_count に誤カウントする (silent data loss)。
     sub_result=$(bash "$CREATE_SCRIPT" "$(build_payload "$sub_title" "$sub_body_file" "$sub_labels_json" "$sub_complexity")" 2>"$helper_err_file")
@@ -216,7 +216,7 @@ while IFS= read -r sub_json; do
         failed_count=$((failed_count + 1))
       else
         # 成功時でも create-issue-with-projects.sh は partial-Projects 失敗を
-        # exit 0 + JSON の .warnings[] で返す (Issue #669)。jq parse が clean に
+        # exit 0 + JSON の .warnings[] で返す。jq parse が clean に
         # なった今、その warning を silent に捨てず link-warning と同形式で surface
         # する (Wiki: stderr ノイズは truncate でなく selective surface で解く)。
         printf '%s' "$sub_result" | jq -r '.warnings[]?' 2>/dev/null \
@@ -230,7 +230,7 @@ while IFS= read -r sub_json; do
         # non-blocking failures). Only construct fallback JSON on fatal exit.
         # Build it via `jq -n --arg` so embedded `"` in stderr cannot break the
         # JSON the caller will parse.
-        # 対称修正 (Issue #1206 / Wiki: Asymmetric Fix Transcription)。link-sub-issue.sh は
+        # 対称修正。link-sub-issue.sh は
         # 現状 stderr に書かないため JSON 破損は起きないが、create と同じく stderr を
         # helper_err_file へ分離して将来の regression を防ぐ。fatal exit 時の fallback err は
         # stdout (link_result) と stderr を結合し、診断情報を取りこぼさない。
@@ -251,7 +251,7 @@ while IFS= read -r sub_json; do
             link_failures=$((link_failures + 1))
             ;;
           *)
-            # 未知 status を silent 通過させない (Issue #514 MUST NOT)
+            # 未知 status を silent 通過させない
             echo "⚠️ Unexpected link status '$link_status' for #$sub_number (msg: $link_msg)" >&2
             link_failures=$((link_failures + 1))
             ;;

--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -5,7 +5,7 @@
 # caller can append a Sub-Issues section.
 #
 # Extracted from `commands/issue/create.md` ステップ 5.3+5.4+5.5 Step 1
-#. The old inline block expanded a
+# The old inline block expanded a
 # `{REPEAT_FOR_EACH_SUB_ISSUE}` placeholder and embedded each body via heredoc;
 # both were heredoc/placeholder malform sources. This helper takes a spec JSON
 # whose `body_file` fields point at raw files the caller wrote with the Write

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -4,7 +4,7 @@
 # Migrate review-result JSON files in `.rite/review-results/` from schema
 # 1.0 / 1.0.0 / missing to canonical 1.1.0. Issue #1021 (Epic #1015).
 #
-# Migration adds the two fields introduced in 1.1.0 (Issue #1016):
+# Migration adds the two fields introduced in 1.1.0:
 #   - findings[].scope        — default mapping from severity
 #                                 (CRITICAL/HIGH/MEDIUM → current-pr,
 #                                  LOW-MEDIUM/LOW       → nit-noted)
@@ -94,7 +94,7 @@ DEFAULT_SCOPE_FILTER='
 #   - 1.0/1.0.0 JSON の finding は invariant #5 auto-correct 対象外となり後方互換が保たれる
 # 旧実装は `.pre_existing = false` を初期化していたが、これは migrated LOW finding を
 # scope=nit-noted + pre_existing=false の組合せにし、read 側 invariant #5 で scope を
-# current-pr に書き換えてしまう後方互換破壊だった (Issue #1021 review F-01)。
+# current-pr に書き換えてしまう後方互換破壊だった。
 MIGRATE_FILTER='
   if (.schema_version // "") == "1.1.0" then .
   else

--- a/plugins/rite/scripts/review-findings-maps.sh
+++ b/plugins/rite/scripts/review-findings-maps.sh
@@ -81,7 +81,7 @@ Exit codes:
 EOF
 }
 
-# 各値付きフラグは `shift; shift` で消費する (Issue #1224 の値なしフラグ無限ループ素因を回避)
+# 各値付きフラグは `shift; shift` で消費する
 while [ $# -gt 0 ]; do
   case "$1" in
     --review-source) review_source="${2:-}"; shift; shift ;;
@@ -110,7 +110,7 @@ fi
 cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root '$REPO_ROOT'" >&2; exit 2; }
 
 # tempfile cleanup trap: norm_tmp は同一プロセス内で hand-off されるため、旧 inline block の
-# 「bash block 終了の trap EXIT で削除される」契約 (Issue #1026) をそのまま script 終了時に履行する
+# 「bash block 終了の trap EXIT で削除される」契約をそのまま script 終了時に履行する
 norm_tmp=""
 handed_off_norm_tmp=""
 jq_err=""
@@ -150,7 +150,7 @@ norm_sv=$(jq -r '.schema_version // "unknown"' "$review_source_path" 2>/dev/null
 norm_defaulted_count=0
 norm_corrected_count=0
 norm_demoted_low_count=0
-# auto_demote_low config 読込 (Issue #1018 M2)。section absent → default true。
+# auto_demote_low config 読込。section absent → default true。
 auto_demote_low=$(awk '/^review:/{r=1;next} r && /^  scope_assignment:/{s=1;next} s && /^    auto_demote_low:/{print $2; exit}' rite-config.yml 2>/dev/null | tr -d '"' | tr -d "'" | tr '[:upper:]' '[:lower:]')
 case "$auto_demote_low" in false|no|0) auto_demote_low=false ;; *) auto_demote_low=true ;; esac
 case "$norm_sv" in
@@ -191,7 +191,7 @@ if [ "${norm_defaulted_count:-0}" -gt 0 ] || [ "${norm_corrected_count:-0}" -gt 
       review_source_path="$norm_tmp"
       # hand-off 完了: 下流の severity_map 構築が review_source_path 経由で参照するため、
       # 二重 rm 回避 + downstream 参照保護として handed_off_norm_tmp に path を保持する
-      # (Issue #1026: severity_map build 完了後、script 終了の trap EXIT で削除される)。
+      # (severity_map build 完了後、script 終了の trap EXIT で削除される)。
       handed_off_norm_tmp="$norm_tmp"
       norm_tmp=""
     else

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -10,7 +10,7 @@
 #   fallback  : none usable → caller routes to interactive fallback (ステップ 1.2.0.1)
 #
 # Extracted from `commands/pr/fix.md` ステップ 1.2.0 Selection logic block
-# (refs #1193 / #1195 item #2). The old ~550-line inline bash block required
+#. The old ~550-line inline bash block required
 # the LLM to literal-substitute pr_number / review_file_path / Priority 1
 # decision+receipt directly into the markdown fence; those substitution points
 # are now this helper's CLI arguments. The Priority chain logic, observability
@@ -77,7 +77,7 @@ p1_scan_turns=""
 p1_scan_found=""
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
 # `shift 2` は $# を減らせず set -e 非設定 + `${2:-}` (nounset 非発火) の下で無限ループに
-# 陥る (Issue #1224)。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
+# 陥る。1 回目の shift で $# を確実に 0 にし、2 回目は no-op で安全に抜ける。
 while [ $# -gt 0 ]; do
   case "$1" in
     --pr-number)             pr_number="${2:-}"; shift; shift ;;
@@ -198,7 +198,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
   elif ! jq -e '
     [.findings[]? | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length == 0
   ' "$review_file_path" >/dev/null 2>&1; then
-    # Cross-field invariant #4 (Issue #1016, review-result-schema.md):
+    # Cross-field invariant #4:
     # severity ∈ {CRITICAL, HIGH} ∧ scope == "nit-noted" は禁止 (blocker を nit に降格できない)。
     # 違反時は fallback 経路に route (invariant #2 と同じ FAIL routing)。
     # 1.0/1.0.0 JSON では .scope が欠落しているため `null == "nit-noted"` は false、本 check は
@@ -499,7 +499,7 @@ if [ -z "$review_source" ]; then
       elif ! jq -e '
         [.findings[]? | select((.severity == "CRITICAL" or .severity == "HIGH") and .scope == "nit-noted")] | length == 0
       ' "$latest_file" >/dev/null 2>&1; then
-        # Cross-field invariant #4 (Issue #1016, review-result-schema.md):
+        # Cross-field invariant #4:
         # severity ∈ {CRITICAL, HIGH} ∧ scope == "nit-noted" は禁止。
         # corrupt rename はしない (データは構造的に valid、ビジネスルール違反のみ)。
         # 1.0/1.0.0 JSON では .scope が欠落しているため本 check は規約的に発火しない (後方互換)。

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -10,7 +10,7 @@
 #   fallback  : none usable → caller routes to interactive fallback (ステップ 1.2.0.1)
 #
 # Extracted from `commands/pr/fix.md` ステップ 1.2.0 Selection logic block
-#. The old ~550-line inline bash block required
+# The old ~550-line inline bash block required
 # the LLM to literal-substitute pr_number / review_file_path / Priority 1
 # decision+receipt directly into the markdown fence; those substitution points
 # are now this helper's CLI arguments. The Priority chain logic, observability

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# rite workflow - Status Mismatch Watchdog (Issue #1003 AC-9)
+# rite workflow - Status Mismatch Watchdog
 #
 # Scans repository Issues that are linked to OPEN, Ready-for-review PRs (isDraft=false)
 # and detects ones whose GitHub Projects Status is still "In Progress" — the symptom
@@ -52,7 +52,7 @@ while [ $# -gt 0 ]; do
     -h|--help)
       # here-doc usage で BSD head 互換性問題 (head -n -1) を回避
       cat <<'USAGE_EOF'
-watchdog-status-mismatch.sh - Status Mismatch Watchdog (Issue #1003 AC-9)
+watchdog-status-mismatch.sh - Status Mismatch Watchdog
 
 Scans repository Issues that are linked to OPEN, Ready-for-review PRs (isDraft=false)
 and detects ones whose GitHub Projects Status is still "In Progress" — the symptom


### PR DESCRIPTION
## Summary

`plugins/rite/hooks/`・`scripts/` の shell コメント・WARNING/ERROR 文言から、Why の代替として貼られた説明的 Issue/PR 番号参照を廃止し Why を散文で維持。epic #1393 Sub-6。

## Related Issue

Closes #1397

## Changes

- **説明的 provenance の網羅クリーンアップ**（45 .sh ファイル、162/162 行）: 半角/全角括弧 `(Issue/PR #N)`・`refs/see PR #N`・JP `#N で対応/導入` を削除し Why を散文で維持
- **除外（廃止判定ルール準拠・誤削除防止）**: 検出スクリプト 8 本（`comment-journal-check.sh` 等）の正規表現リテラル `#[0-9]+`、`hooks/tests/` の fixture、正規表現/契約文字列を含む行
- **test assertion 是正**: `projects-board-drift-check.test.sh` / `watchdog-status-mismatch.test.sh` がスクリプトヘッダの Issue 番号を pin していた assertion を、番号ではなく Why 散文アンカー（`Reconciliation drift-guard` / `Status Mismatch Watchdog`）の検証に変更

## 検証

- `run-tests.sh` **69/69 green**（番号削除でヘッダ provenance を pin する 2 test が一旦 fail → assertion を Why 散文に是正して回復）
- 全変更 .sh の `bash -n` 構文 OK
- 検出器 `comment-journal-check.sh` の P5/P6（説明的参照）が hooks/scripts（非 test/非検出）で **39→2** に減少
- `#。` dangling・空括弧・スペース継ぎ目 artifact なし（1 件のスペースを修正済）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass — 69/69
- [x] Documentation updated（shell コメント/文言）

## Scope note

説明的 provenance 形式を網羅クリーンアップ。bare inline `Issue #N` 単体（~87）は load-bearing 判定が個別に必要なため本 PR スコープ外（go-forward 検出 #1395 と後続で扱う）。検出スクリプトの正規表現リテラルと test fixture は維持。

## Out of Scope

- commands / skills / agents（#1396 完了済み）
- docs / references / templates（#1399）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)