### PR TITLE
feat: knowledge_routing（4 チャネル知識ルーティング）を coding-principles に追加 (refs #1406)

### DIFF
--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -11,7 +11,7 @@ This module handles the actual implementation work, commits, pushes, and checkli
 Perform actual implementation work following the implementation plan approved in `pr/open.md` ステップ 3 (実装計画).
 
 > **Reference**: Apply the Phase 5.1 checklist from [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md).
-> In particular, check `simplicity_enforcement`, `scope_discipline`, and `dead_code_hygiene`.
+> In particular, check `simplicity_enforcement`, `scope_discipline`, `dead_code_hygiene`, and `knowledge_routing` — route each finding to its durable medium (How → code, What → tests, Why → commit log, Why not → comments).
 > Also follow [Comment Best Practices](../../skills/rite-workflow/references/comment-best-practices.md) for WHY > WHAT, journal/line-number/cycle-number prohibition, jargon whitelist, and density-by-audience rules.
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing bash hook commands in this file.

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -190,7 +190,7 @@ orchestrator (`pr:open` / `pr:iterate`) が sub-skill 出力の sentinel を gre
 
 ## AI Coding Principles (Summary)
 
-Avoid common AI coding failure patterns: surface assumptions, manage confusion, push back when warranted, enforce simplicity, maintain scope discipline, clean dead code, plan inline, address all discovered issues, and keep documentation in sync with specification changes (`documentation_consistency`) — when the implementation changes user-visible behavior, update related README / docs / CLAUDE.md / plugin .md files in the same PR rather than deferring to a follow-up Issue.
+Avoid common AI coding failure patterns: surface assumptions, manage confusion, push back when warranted, enforce simplicity, maintain scope discipline, clean dead code, plan inline, address all discovered issues, and keep documentation in sync with specification changes (`documentation_consistency`) — when the implementation changes user-visible behavior, update related README / docs / CLAUDE.md / plugin .md files in the same PR rather than deferring to a follow-up Issue. Route each kind of knowledge to its durable medium (`knowledge_routing`): How → code, What → tests, Why → commit log, Why not → code comments.
 
 See [references/coding-principles.md](./references/coding-principles.md) for the full principle list and details.
 

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -457,7 +457,7 @@ git diff origin/develop...HEAD || git diff develop...HEAD || {
 | How (current behavior) | The code itself (naming, structure) | Code is executed, so it is always true — it cannot drift from the running reality |
 | What (specification, behavior) | Test code (test name + assertion) | Tests are executable specification — the name states What, the assertion proves it |
 | Why (motive at change time) | Commit message (Contextual Commits action lines) | The commit is the immutable record of the context at the moment of change |
-| Why not (rejected alternative, hidden constraint) | Code comments | The comment is the only document that stays in the same place as the code it guards |
+| Why not (rejected alternative) — and the Why that must stay beside the code (hidden constraint, invariant, workaround) | Code comments | The comment is the only document that stays in the same place as the code it guards |
 
 **Failure Patterns**:
 - A comment describes How the code works (comment rot — the comment lies as soon as the code changes; promote it to naming instead)

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -2,6 +2,7 @@
 
 A collection of principles to avoid common failure patterns in AI coding agents.
 Structured for rite workflow based on Andrej Karpathy's "Issues with AI Coding".
+The `knowledge_routing` principle additionally draws on t-wada's four quadrants of where knowledge lives: code = How, test code = What, commit log = Why, code comments = Why not.
 
 ## Principle List
 
@@ -19,6 +20,7 @@ Structured for rite workflow based on Andrej Karpathy's "Issues with AI Coding".
 | `reference_discovery` | Discover Reference Implementations | Phase 3 |
 | `question_self_check` | Self-Check Before Asking | All Phases |
 | `documentation_consistency` | Sync Documentation with Specification Changes | Phase 5.1 |
+| `knowledge_routing` | Route Knowledge to Its Durable Medium | Phase 5.1, PR Review |
 
 ---
 
@@ -444,6 +446,43 @@ git diff origin/develop...HEAD || git diff develop...HEAD || {
 
 ---
 
+### knowledge_routing (Route Knowledge to Its Durable Medium)
+
+**Summary**: Every implementation produces four kinds of knowledge, and each has one medium where it survives. The medium's properties — lifespan, visibility, verifiability — decide the routing. Knowledge placed in the wrong medium rots, goes unread, or becomes a lie. For an LLM agent whose session memory vanishes, these four channels are the only persistent memory, so routing them correctly is a first-class discipline. Each channel's detailed rules live in its own SoT; this principle only routes.
+
+**Four Channels**:
+
+| Knowledge | Medium | Why this medium |
+|-----------|--------|-----------------|
+| How (current behavior) | The code itself (naming, structure) | Code is executed, so it is always true — it cannot drift from the running reality |
+| What (specification, behavior) | Test code (test name + assertion) | Tests are executable specification — the name states What, the assertion proves it |
+| Why (motive at change time) | Commit message (Contextual Commits action lines) | The commit is the immutable record of the context at the moment of change |
+| Why not (rejected alternative, hidden constraint) | Code comments | The comment is the only document that stays in the same place as the code it guards |
+
+**Failure Patterns**:
+- A comment describes How the code works (comment rot — the comment lies as soon as the code changes; promote it to naming instead)
+- A comment narrates the change history / motive (journal comment — that belongs in the commit message)
+- A commit body records only What changed, with no Why (the rationale is lost at the next read)
+- A rejected alternative lives only in the commit, leaving no trace on the code side (a future reader "improves" the code straight back into the rejected shape)
+- A test name describes How (an implementation detail), so it becomes a lie the moment the implementation changes
+
+**Routing flowchart** (when unsure where to record a finding):
+- Current behavior of the code → let the code say it (naming, structure)
+- Specification or behavior → a test, with the test name written as a specification sentence
+- Motive / choice / rejected alternative → if a future reader would be tempted to rewrite the code back to the naive shape, a comment (Why not); otherwise the commit message
+- Hidden constraint / invariant / workaround → a comment (Why)
+
+**Rules**:
+1. Route each kind of knowledge to its one channel; do not record the same knowledge in two channels.
+2. Defer each channel's detailed rules to its SoT — do not duplicate them here: comments → [comment-best-practices.md](./comment-best-practices.md), commits → [contextual-commits.md](./contextual-commits.md), tests → [tdd-light.md](../../../references/tdd-light.md) and [reviewers/test.md](../../reviewers/test.md).
+3. Transport misplaced knowledge to its correct medium rather than leaving it: change history found in a comment → move it to the commit; How found in a comment → promote it to naming and delete the comment.
+
+**Where to Apply**:
+- Phase 5.1 (Implementation): Route each finding to its channel while coding
+- PR Review: Flag misplaced knowledge with this principle's ID as the rationale
+
+---
+
 ## Markdown Authoring Conventions
 
 > **Note**: このセクションは Markdown 記述規約であり、上記の `## Principle List` テーブルに登録されているコード規約 (AI Coding Principles) とは別軸のため、独立セクションとして配置している。`## Related` からも参照される。
@@ -544,6 +583,7 @@ OK patterns:
 - [ ] `no_unnecessary_fallback`: Are there fallbacks that hide failure causes?
 - [ ] `issue_accountability`: Are any discovered problems being ignored?
 - [ ] `documentation_consistency`: Has related documentation been updated for any user-visible spec changes?
+- [ ] `knowledge_routing`: Is each finding routed to its durable medium (How → code, What → tests, Why → commit, Why not → comments)?
 
 ### PR Review
 
@@ -552,6 +592,7 @@ OK patterns:
 - [ ] `scope_discipline`: Are there out-of-scope changes?
 - [ ] `no_unnecessary_fallback`: Are there fallbacks that hide failure causes?
 - [ ] `issue_accountability`: Are review comments being addressed genuinely?
+- [ ] `knowledge_routing`: Is any knowledge in the wrong medium (How in a comment, change history in a comment, Why missing from the commit body, a test name describing How)?
 
 ### Before PR Creation
 


### PR DESCRIPTION
## Summary

t-wada の 4 象限（コード=How / テスト=What / コミットログ=Why / コメント=Why not）を「知識のルーティング規律」として定式化し、`coding-principles.md` に 13 番目の原則 `knowledge_routing` を追加した。各チャネルの詳細規則は既存の channel SoT（comment-best-practices / contextual-commits / tdd-light + reviewers/test）へ委譲し、重複定義しない。

## Related Issue

Closes #1406

## Changes

- `skills/rite-workflow/references/coding-principles.md`: Principle List 表に行追加、`knowledge_routing` 原則を Summary / 4 チャネル表 / Failure Patterns / Routing flowchart / Rules / Where to Apply の既存フォーマットで追加、Phase 5.1 / PR Review checklist に各 1 行追加、冒頭出典文に t-wada 4 象限の 1 文を追記
- `skills/rite-workflow/SKILL.md`: AI Coding Principles サマリ散文に knowledge routing の 1 文を追加（原則列挙の整合維持）
- `commands/issue/implement.md`: 5.1 冒頭 Reference blockquote の名指し原則リストに `knowledge_routing` と 4 チャネル一行要約を追加

## Acceptance Criteria

- AC-1: `knowledge_routing` が既存フォーマットで定義（Principle List + Principle Details ともに 13）
- AC-2: SKILL.md / implement.md と coding-principles.md の列挙整合（drift なし）
- AC-3: 既存 12 原則の本文・ID 不変
- AC-4: 追記全文に説明的番号参照なし

## Test

- T-01: Principle List 行数 = Principle Details 原則見出し数 = 13 ✅
- T-02: `/rite:lint`（distributed-fix-drift-check / comment-journal-check）で変更ファイルに新規 drift なし ✅
- T-03: 追記部分に説明的番号参照 0 件 ✅

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
