### PR TITLE
feat: test reviewer にテスト名 = 仕様（What）基準と AC トレーサビリティを追加 (refs #1408)

### DIFF
--- a/plugins/rite/agents/test-reviewer.md
+++ b/plugins/rite/agents/test-reviewer.md
@@ -13,7 +13,7 @@ You are a test quality specialist who believes that tests are the executable spe
 1. **Tests must fail for the right reasons**: A test that passes regardless of implementation correctness is a false positive and a CRITICAL issue.
 2. **Coverage means behavior coverage, not line coverage**: Testing every line but not every branch, edge case, and error path gives misleading confidence.
 3. **Test isolation is non-negotiable**: Tests that depend on execution order, shared mutable state, or external services without mocking are flaky by design.
-4. **Test code is production code**: Tests need the same quality standards — clear naming, no duplication, proper setup/teardown.
+4. **Test code is production code**: Tests need the same quality standards — behavior-describing naming (a test name states What it verifies, not How it is implemented — a name coupled to implementation detail breaks when the implementation changes while the behavior holds), no duplication, proper setup/teardown.
 5. **Missing tests for new functionality are bugs**: Every new feature, endpoint, or utility function should have corresponding tests. No exceptions.
 
 ## Detection Process
@@ -31,6 +31,7 @@ For each test in the diff:
 - Does it have meaningful assertions (not just `expect(result).toBeTruthy()`)?
 - Does it test the actual behavior, not just that the function doesn't throw?
 - Are negative cases tested (invalid input, error conditions)?
+- Does the test name read as a specification sentence (What)? A name coupled to an implementation choice (store, library, internal structure) becomes a lie when that choice changes — flag it and suggest a behavior-based name.
 - `Read` the implementation to verify assertions match actual return values/behavior
 
 ### Step 3: Edge Case and Boundary Review

--- a/plugins/rite/commands/issue/implement.md
+++ b/plugins/rite/commands/issue/implement.md
@@ -159,6 +159,7 @@ For each criterion (up to `tdd.max_skeletons`):
 2. Sanitize summary per [Criterion Summary Sanitization](../../references/tdd-light.md#criterion-summary-sanitization)
 3. Check per-criterion idempotency (tag exists in test files → skip)
 4. Generate skeleton using framework-appropriate template (see [Skeleton Templates](../../references/tdd-light.md#skeleton-templates))
+   - テスト名は criterion の What 文言を維持する。実装で肉付けする際も実装手段を語る名前に書き換えない — [tdd-light.md の test-name discipline note](../../references/tdd-light.md#skeleton-templates) を参照。
 
 If framework cannot be determined, skip generation and record skip stub.
 

--- a/plugins/rite/references/tdd-light.md
+++ b/plugins/rite/references/tdd-light.md
@@ -138,6 +138,8 @@ trap 'rm -f "$output_file"' EXIT
 
 Framework detection is based on project files and `commands.test` configuration.
 
+> **Test-name discipline (What, not How)**: skeleton のテスト名/タイトルは acceptance criterion の文言（既に What 文）をそのまま使う設計である。skeleton を実装で肉付けする際も、テスト名を実装手段（使用ライブラリ・内部構造・ストア）を語る名前に書き換えないこと。テスト名が仕様文として読める限り、テストはリファクタを跨いで真実であり続ける（test reviewer の **Spec-Readable Test Names** 基準と対応）。
+
 ### Jest / Vitest
 
 ```typescript

--- a/plugins/rite/skills/reviewers/test.md
+++ b/plugins/rite/skills/reviewers/test.md
@@ -47,7 +47,7 @@ This skill is activated when reviewing files matching:
 - [ ] **Error Path Coverage**: Only testing happy paths
 - [ ] **Mock Overuse**: Mocking so much that tests don't verify real behavior
 - [ ] **Spec-Readable Test Names (What, not How)**: テスト名が実装詳細（How）を語っている場合に指摘する。テストは実行可能な仕様であり、テスト名は検証している振る舞い（What）を語るべき。実装手段（使用ストア・内部構造・ライブラリ）に結合した名前は、ストアやライブラリを替えただけで嘘になる（例: `test_uses_redis_cache` → 振る舞いベースの「TTL 内の再リクエストはキャッシュ済み結果を返す」を提案）。判定軸は「この仕様は実装手段を替えても不変か」。本項目は How/What の取り違えのみを対象とし、名前の明瞭さ一般（読みやすさ・命名規約）を扱う Recommendations の **Test Naming** とは責務が異なる
-- [ ] **AC Traceability**: 新規機能のテストがどの Acceptance Criteria の仕様文を検証しているか、テスト名・アサーション・配置から判別できない場合に指摘する。判定はタグの有無に依存せず、テスト名・構造からどの AC に対応するかを読み取れるかを主軸とする。`tdd.mode: light` のプロジェクトでは補助として `{tag_prefix}[{hash}]` タグと criterion の対応も確認する（`tdd.mode: off` のプロジェクトではタグがなくとも名前・構造での判別可否で評価する）
+- [ ] **AC Traceability**: 新規機能のテストがどの Acceptance Criteria の仕様文を検証しているか、テスト名・アサーション・配置から判別できない場合に指摘する。判定はタグの有無に依存せず、テスト名・構造からどの AC に対応するかを読み取れるかを主軸とする。`tdd.mode: light` のプロジェクトでは補助として `{tag_prefix}[{criterion_hash}]` タグと criterion の対応も確認する（`tdd.mode: off` のプロジェクトではタグがなくとも名前・構造での判別可否で評価する）
 
 ### Recommendations
 

--- a/plugins/rite/skills/reviewers/test.md
+++ b/plugins/rite/skills/reviewers/test.md
@@ -46,6 +46,8 @@ This skill is activated when reviewing files matching:
 - [ ] **Edge Cases**: Missing boundary condition tests
 - [ ] **Error Path Coverage**: Only testing happy paths
 - [ ] **Mock Overuse**: Mocking so much that tests don't verify real behavior
+- [ ] **Spec-Readable Test Names (What, not How)**: テスト名が実装詳細（How）を語っている場合に指摘する。テストは実行可能な仕様であり、テスト名は検証している振る舞い（What）を語るべき。実装手段（使用ストア・内部構造・ライブラリ）に結合した名前は、ストアやライブラリを替えただけで嘘になる（例: `test_uses_redis_cache` → 振る舞いベースの「TTL 内の再リクエストはキャッシュ済み結果を返す」を提案）。判定軸は「この仕様は実装手段を替えても不変か」。本項目は How/What の取り違えのみを対象とし、名前の明瞭さ一般（読みやすさ・命名規約）を扱う Recommendations の **Test Naming** とは責務が異なる
+- [ ] **AC Traceability**: 新規機能のテストがどの Acceptance Criteria の仕様文を検証しているか、テスト名・アサーション・配置から判別できない場合に指摘する。判定はタグの有無に依存せず、テスト名・構造からどの AC に対応するかを読み取れるかを主軸とする。`tdd.mode: light` のプロジェクトでは補助として `{tag_prefix}[{hash}]` タグと criterion の対応も確認する（`tdd.mode: off` のプロジェクトではタグがなくとも名前・構造での判別可否で評価する）
 
 ### Recommendations
 
@@ -90,3 +92,4 @@ Perform the following investigation before reporting findings:
 | 「テストが不足しているかもしれない」 | 「`calculateTotal` 関数（`src/utils.ts:45`）のテスト不在。Grep で `**/*.test.ts` 検索: 該当なし」 |
 | 「このテストは flaky かもしれない」 | 「`test/api.test.ts:23` で `setTimeout` + `Date.now()` 依存で非決定的。`jest.useFakeTimers()` 使用を」 |
 | 「モックが多すぎる可能性がある」 | 「`test/service.test.ts` で 8 依存関係モック化。統合動作未検証。`UserRepository` と `EmailService` は実装使用推奨」 |
+| 「テスト名がわかりにくい」 | 「`test/cache.test.ts:12` の `test_uses_redis_cache` は実装手段（redis）を語る名前であり、検証している振る舞い（TTL 内の再リクエストはキャッシュ済み結果を返す）はストアを替えても不変。What ベースの名前へ」 |


### PR DESCRIPTION
## Summary

t-wada 4 象限のテストコード = What（仕様）を検出可能にする。test reviewer に **Spec-Readable Test Names**（テスト名が How を語る場合に指摘、Recommendations の Test Naming との責務区別を明記）と **AC Traceability**（タグ非依存判定を主軸）を Important で追加。TDD Light の skeleton 生成ガイダンスにもテスト名 = What 文体維持を配線。`knowledge_routing`（#1406）の What チャネル検出側。

## Related Issue

Closes #1408

## Changes

- `skills/reviewers/test.md`: Important に 2 項目（Spec-Readable Test Names / AC Traceability）、Finding Quality の Prohibited vs Required 表に具体例 1 行
- `agents/test-reviewer.md`: Core Principle #4 を behavior-describing naming に拡張、Step 2 に検証 bullet 1 つ
- `references/tdd-light.md`: Skeleton Templates 直下にテスト名 = What 文体 note
- `commands/issue/implement.md`: 5.1.0.T Step 3 にテスト名維持の 1 行 + tdd-light.md note への配線

## Test

- T-01: test.md に 2 項目 + 責務区別文が存在 ✅
- T-02: implement.md 5.1.0.T → tdd-light.md（#skeleton-templates）参照 anchor が実在 ✅
- T-03: AC Traceability がタグ非依存判定を主軸（tdd.mode: off でも成立）✅
- 既存 Critical 5 項目・Severity Definitions・Activation 不変

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
