### PR TITLE
refactor(phase-6): SPEC/CONFIGURATION 最終同期 + 全体最終検証

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -661,7 +661,7 @@ metrics:
 
 ### pr_review
 
-Settings for PR review **output** recording. This section is intentionally separated from the `review:` section (which configures review **execution**) so that future output destinations (Slack notifications, etc.) can be added without a breaking change to `review:` child keys.
+Settings for PR review **output** recording. This section is intentionally separated from the `review:` section (which configures review **execution**) so that future output destinations can be added without a breaking change to `review:` child keys.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -405,7 +405,7 @@ fi
 # 残骸回収のみ**。`.rite/worktrees/issue-{N}` (multi_session.worktree_base 配下)
 # を `git worktree list` から列挙し、**3 ゲート全通過時のみ** reap する:
 #   1. ディレクトリ名が `^issue-[0-9]+$` に完全一致 (strict regex doctrine。
-#      parallel/team-execute の `.worktrees/` 名前空間や `.rite/wiki-worktree`
+#      `.rite/wiki-worktree` などの非 issue worktree 名前空間
 #      とは交差しない)
 #   2. claim liveness (S3) が live でない (issue-claim.sh check が stale、または
 #      claim 不在 free のとき mtime > 24h の age guard を再利用)

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -127,7 +127,7 @@ repo_root=$("$_SCRIPT_DIR/../state-path-resolve.sh" 2>/dev/null) || repo_root=""
 cd "$repo_root"
 
 # advisory lock for parallel safety.
-# Multiple concurrent invocations (e.g. sprint team-execute running fix /
+# Multiple concurrent invocations (e.g. multiple sessions running fix /
 # review / close on different issues in parallel terminals) share the same
 # working tree and cannot safely run git checkout/stash/commit concurrently.
 # Acquire a non-blocking advisory lock; on contention, exit 0 with an

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -49,7 +49,7 @@
 # - All git operations run with `git -C "$worktree_path"` to scope
 # them to the worktree's HEAD. The dev-branch tree is never touched.
 # - Advisory locking via flock ensures parallel invocations
-# (e.g. sprint team-execute) do not race on the same worktree.
+# (e.g. multiple concurrent sessions) do not race on the same worktree.
 # - Credential prompts are suppressed via GIT_TERMINAL_PROMPT=0 so
 # hook-invoked runs do not hang on missing auth.
 # --- END HEADER ---


### PR DESCRIPTION
## Phase 6 完了報告 + リファクタリング全体の最終報告

> ⚠️ **#1415〜#1419 にスタック（最終 PR）**。#1415 → #1416 → #1417 → #1418 → #1419 → 本 PR の順にマージのこと。

### Phase 6 で実施
- SPEC.md Plugin Structure tree から削除済み reference 行を除去（priority-markers / output-patterns / error-codes）
- CONFIGURATION.md pr_review 節の「Slack notifications」例示（削除済み機能）を除去
- 包括的 dangling-reference スキャン: notification / tdd / sprint / recall / contextual の残骸が SPEC/CONFIGURATION/CLAUDE/README にゼロを確認

### §6 全検証コマンドと結果
- `run-tests.sh`: **68/68 passed**（baseline 69 − notification.test.sh 1 = 期待値 68。preflight 保持のため）
- `orphan-reference-check.sh --all`: **checked=93 orphans=0**（baseline 125 → 93）
- `doc-heavy-patterns-drift-check.sh --all`: exit 0（3-source → 2-source 化済み）
- `distributed-fix-drift-check.sh --all`: 84（**baseline 不変** — origin/develop も 84。全 phase で regression なし）
- `hardcoded-line-number-check.sh`: exit 0
- `sh-cross-ref-check.sh --all`: 2 件（preflight-check.sh→resume.md 3.0 / create-issue-with-projects.sh→fix.md 4.3。**いずれも baseline と同一の既存 drift**、scripts/resume/fix は §11 対象外で不変）
- `bash-heaviness-check.sh`: exit 0

### 数値目標（§1）に対する最終達成状況（Phase 0 比）
| 領域 | Phase 0 | 最終 | 目標 | 達成 |
|---|---|---|---|---|
| commands | 27,491 | **24,473** | ≤24,500 | ✅ |
| skills | 5,674 | **3,548** | ≤4,200 | ✅ |
| docs | 15,948 | **4,404** | ≤5,500 | ✅ |
| references | 6,892 | 5,415 | ≤4,700 | ⚠️ 未達 |
| agents | 1,880 | 2,939 | ≈2,200–2,400 | ⚠️ 超過（「増えてよい」） |
| hooks(tests除く) | 16,577 | 16,414 | ≤16,350 | ⚠️ 未達（+64） |
| review.md / fix.md / lint.md / init.md | 4,111 / 4,020 / 1,503 / 1,148 | 4,066 / 3,974 / 1,440 / 1,148 | ≤3,500 / ≤3,700 / ≤1,400 / ≤1,050 | ⚠️ 未達 |

**累積: 120 files changed, 1,494 insertions(+), 19,428 deletions(−)（正味 −17,934 行）**

### 未達項目の理由（すべて坂口さん確認済みの判断、または §1/§5-6 準拠）
- **references ⚠️**: D-2 の 7 ファイル中、`gh-cli-commands.md` / `state-read-evolution.md`（生きた hook/static-check が引用）/ `sub-issue-link-handler.md`（test が assert_grep）/ `session-id-validation-contract.md`（flow-state.sh §3-4 が SoT 参照）の 4 ファイルを保持（坂口さん確認）。削除は error-codes / priority-markers / output-patterns / sub-skill-return-protocol の 4 + tdd-light。
- **agents ⚠️**: reviewer 統合で skill 固有内容を「一字一句移すだけ」原則で verbatim 移植（§D-3 risk 緩和）。instruction も「増えてよい」と明記。
- **hooks ⚠️**: `preflight-check.sh`（112行）は SKILL.md Preflight Guard / work-memory-format.md Preflight Guard Contract で全コマンドの実行前ガードとして現役配線していることを再検証で確認し、保持（坂口さん確認、§5-1）。`notification.sh` のみ削除。
- **巨大4ファイル ⚠️**: 残りの line 削減は pinned format / behavior-critical（Doc-Heavy / accepted-fingerprint / schema / hook matching logic）に集中するため、§1「行数は副次指標」/ §5-6 に従い安全圧縮のみで確定（坂口さん確認）。**最大のコンテキスト削減（reviewer 二重注入解消）は Phase 4 で達成**し、§1 のコンテキストコスト目標（review 1 回 = 縮小 SKILL.md + spawn agent 本体のみ）は実質達成。

### 指示書との主な相違（再検証で判明し、坂口さんと協議して解決）
1. **preflight-check.sh 保持**（D-1 は削除主張、実際は現役配線。§5-1）
2. **D-2 の 4 ファイル保持**（.sh コメント・test・SoT 参照を指示書が見落とし）
3. **parallel.\* 保持**（D-4/D-9 は「sprint 専用」主張、実際は implement.md の並列実装機能。D-9 protocol 準拠）
4. **D-9 scaffolding キーの大半が現役**（convergence_monitoring 等は review/fix/fact-check が能動読取 → 保持）
5. **iteration フィルタ inline 化**（issue:list の --sprint/--backlog は sprint:current logic 依存だったため inline 移植）
6. **Root Cause Gate decouple**（contextual commits 削除が Quality Signal 2 と entangle → free-form 判定に decouple）
7. **doc-heavy-drift-check 2-source 化**（tech-writer.md skill 削除に伴う §5-2 対応）

### 🔬 坂口さんへの実機確認依頼（2 点）
1. **コアフロー一周の e2e smoke**: `docs/tests/rite-issue-create-e2e-smoke.test.md` の手順で Issue 作成〜PR フローを実機確認
2. **`/rite:pr:review` の実機確認**: reviewer の checklist 注入位置が user prompt → system prompt に変わった（Phase 4）ため、実 PR で `/rite:pr:review` を実行し reviewer 挙動を確認

### 補足
- `~/.claude/settings.json` の `rite@rite-marketplace` が **`true`** でした（CLAUDE.md は `false` 維持を要求）。本リファクタは Edit/Write 直接編集 + `run-tests.sh` 直接実行で行ったためロード状態は検証に影響しませんが、ドッグフーディング運用時は `false` 推奨。
- sh-cross-ref の既存 drift 2 件（resume.md 3.0 / fix.md 4.3 のハードコード参照）は §11 対象外のため別 Issue 候補として残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)