### PR TITLE
docs: CHANGELOG の /rite:lint deprecation warning 記述を実態に整合 (#1423)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -149,7 +149,7 @@ Phase 番号取扱方針: エントリは機能名レベルで変更を記述し
     4. finding quality gate 不通過 — `_reviewer-base.md` に新規追加された `Finding Quality Guardrail` が bikeshedding / 防衛コード / hypothetical / style-only findings を output 前にフィルタ。survivor が 0 件になった reviewer は `### Reviewer self-assessment` セクションで "degraded" を明示的に self-report し escalate する。
   - **finding fingerprint 仕様**: `sha1(normalize(file_path) + ":" + category + ":" + normalize(message))`。identifier マスキングと Jaccard token 類似度 > 0.7 による near-match 検出を含む。完全仕様は `start.md` Phase 5.4.1.0 を参照。
   - **minor version bump**: 0.3.10 → 0.4.0 (6 version files 同期)。
-  - **deprecation warning**: `/rite:lint` (Phase 0.5) が `rite-config.yml` に削除済み 3 キーが残存するかをスキャンし、検出時は stderr と最終レポートに警告を出力。値は runtime で silent に無視される。
+  - **削除キーの扱い**: 削除済み 3 キーは runtime で silent に無視される。これらに対する `/rite:lint` の deprecation scan や警告は行われない。
   - **サイクル数の安全上限は設けない (意図的)**: 非公開ガードを含めて cycle-count ベースの上限は一切存在しない。4 品質シグナルが唯一の終了メカニズムとして設計されており、隠し iteration counter の導入は本リリースのコア目的 (サイクル数縮退の全廃) と矛盾するため採用しない。
 
 ### 移行ガイド
@@ -166,7 +166,7 @@ safety:
   max_review_fix_loops: 7
 ```
 
-v0.4.0 では値は silent に無視されますが、`/rite:lint` は削除されるまで警告を出し続けます。機能的な代替はありません — 非収束は 4 つの品質シグナルが自動検出するため、サイクル数の閾値設定は不要になりました。
+v0.4.0 では値は silent に無視されます。機能的な代替はありません — 非収束は 4 つの品質シグナルが自動検出するため、サイクル数の閾値設定は不要になりました。
 
 これまで `max_review_fix_loops` の hard limit で暴走ループから脱出していた場合、同等の安全性は Quality Signal 1 (fingerprint 循環検知) が提供します。**2 回目**の同一 finding 出現で発火するため、cycle-count による抑制よりも早く escalate します。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ rationale and Keep a Changelog 1.1.0 "Guiding Principles" for conventions.
     4. Finding quality gate failure — new `Finding Quality Guardrail` in `_reviewer-base.md` filters bikeshedding / defensive / hypothetical / style-only findings before output; if nothing remains, reviewer self-reports as "degraded" via a `### Reviewer self-assessment` section and escalates.
   - **Finding fingerprint specification**: `sha1(normalize(file_path) + ":" + category + ":" + normalize(message))` with identifier masking and Jaccard token similarity > 0.7 for near-match detection. See `start.md` Phase 5.4.1.0 for the full spec.
   - **Minor version bump**: 0.3.10 → 0.4.0 (6 version files synchronized).
-  - **Deprecation warning**: `/rite:lint` (Phase 0.5) scans `rite-config.yml` for the three removed keys and emits a warning to stderr + final report when any are found. Keys are silently ignored at runtime.
+  - **Removed-key handling**: The three removed keys are silently ignored at runtime. There is no `/rite:lint` deprecation scan or warning for them.
   - **No cycle-count safety limit (by design)**: There is intentionally no hidden iteration guard. The 4 quality signals are the sole termination mechanism. Reintroducing an iteration counter would contradict the core goal of this release (removing cycle-count-based degradation).
 
 ### Migration guide
@@ -169,7 +169,7 @@ safety:
   max_review_fix_loops: 7
 ```
 
-The keys are silently ignored at runtime in v0.4.0 but `/rite:lint` will warn until they are removed. There is no functional replacement — non-convergence is now detected automatically by the four quality signals and no cycle-count threshold needs to be configured.
+The keys are silently ignored at runtime in v0.4.0. There is no functional replacement — non-convergence is now detected automatically by the four quality signals and no cycle-count threshold needs to be configured.
 
 If you previously relied on `max_review_fix_loops` hitting a hard limit to escape runaway loops, the same safety is now provided by Quality Signal 1 (fingerprint cycling) which fires on the **second** occurrence of any finding — typically faster than any cycle-count threshold would have tripped.
 


### PR DESCRIPTION
## 概要

`CHANGELOG.md` / `CHANGELOG.ja.md` の v0.4.0 エントリが「`/rite:lint` (Phase 0.5) が削除済み 3 キーをスキャンして deprecation warning を出す」と記載していたが、その lint Phase 0.5 deprecation scan は既に削除済みで実装に存在しない（記述の drift）。SPEC.md / README.md は既に実態へ修正済みで、残っていた CHANGELOG 側の同種記述のみを整合させる。

## 実態の裏付け

- `git grep -ic 'deprecat' plugins/rite/commands/lint.md` → **0**（lint に該当 scan なし）
- `docs/SPEC.md`（整合済み）: `removed keys are silently ignored at runtime`

## 変更

- `CHANGELOG.md:155` / `CHANGELOG.ja.md:152`: 「Deprecation warning: lint が scan して警告」→「Removed-key handling: runtime で silent に無視、lint warning なし」
- `CHANGELOG.md:172` / `CHANGELOG.ja.md:169`: 移行ガイドから「`/rite:lint` will warn until they are removed / 削除されるまで警告を出し続けます」を除去

EN/JA parity を維持。

## 受入基準

- [x] CHANGELOG の deprecation scan / lint warning 記述を実態（silently ignored、warning なし）に整合
- [x] SPEC.md / README.md と整合
- [x] EN/JA 両言語を対称に修正

Closes #1423

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
