### PR TITLE
fix(checks): drift-check stale path (A-1) + sh-cross-ref dangling 参照 (B) を解消 (#1425)

### DIFF
--- a/plugins/rite/hooks/preflight-check.sh
+++ b/plugins/rite/hooks/preflight-check.sh
@@ -71,7 +71,7 @@ if [ "$COMPACT_VAL" = "normal" ]; then
 fi
 
 # resuming → always allow (clean up guidance flag)
-# resume.md Phase 3.0 runs Steps 1-3 sequentially before Skill invocation,
+# resume.md runs its cross-check phases sequentially before Skill invocation,
 # so "resuming" is only a transient intermediate state.
 # Orphaned "resuming" (e.g., from a crash) is cleaned up by session-start.sh startup cleanup.
 if [ "$COMPACT_VAL" = "resuming" ]; then

--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -2,7 +2,7 @@
 # distributed-fix-drift-check.sh
 #
 # Detect "distributed fix drift" patterns in large rite-workflow procedural
-# markdown files (fix.md, review.md, tech-writer.md, etc.).
+# markdown files (fix.md, review.md, tech-writer-reviewer.md, etc.).
 #
 # This is the static lint counterpart to LLM agent-based review, which has
 # been observed to miss distributed/asymmetric fix patterns (PR #350 / Issue #361).
@@ -40,7 +40,7 @@ USE_ALL=0
 DEFAULT_ALL_TARGETS=(
   "plugins/rite/commands/pr/fix.md"
   "plugins/rite/commands/pr/review.md"
-  "plugins/rite/agents/tech-writer.md"
+  "plugins/rite/agents/tech-writer-reviewer.md"
   "plugins/rite/scripts/review-findings-maps.sh"
 )
 
@@ -49,7 +49,7 @@ usage() {
 Usage: distributed-fix-drift-check.sh [options]
 
 Options:
-  --all                       Check the default target set (fix.md, review.md, tech-writer.md, review-findings-maps.sh)
+  --all                       Check the default target set (fix.md, review.md, tech-writer-reviewer.md, review-findings-maps.sh)
   --target FILE               Check FILE (repeatable). Path relative to repo root.
   --pattern N                 Only run pattern N (1-6). Default: all patterns.
   --repo-root DIR             Repository root (default: git rev-parse --show-toplevel)

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -29,7 +29,7 @@
 #     "options": {
 #       "source": "interactive|pr_review|pr_create|cleanup|xl_decomposition|fingerprint_split|quality_signal_3_split|quality_signal_4_split",
 #                # Note: 以下の値は legacy 互換のため enum に含めない (caller 消失済):
-#                #   - `pr_fix`:          #1136 で fix.md Phase 4.3 (Automatic Separate Issue Creation) が廃止
+#                #   - `pr_fix`:          #1136 で fix.md の Automatic Separate Issue Creation が廃止
 #                #   - `parent_routing`:  #1079 で parent-routing.md sub-skill が廃止
 #                #   - `lint`:            commands/lint.md は guard 用途のみで invoke しない
 #       "non_blocking_projects": true  # default: true


### PR DESCRIPTION
## 概要

#1425 の静的チェック pre-existing red のうち、**concrete で安全な A-1 と B を解消**する。A-2（distributed-fix-drift の 84 findings）は過検出と実 drift の混在で pinned format 合意 or check ロジックの慎重な調整が必要なため、調査結果を添えて #1432 に切り出した。

## A-1: drift-check の stale target path

`distributed-fix-drift-check.sh` の `DEFAULT_ALL_TARGETS` が存在しない `plugins/rite/agents/tech-writer.md` を参照していた（reviewer agent は `{type}-reviewer.md` 命名）。`tech-writer-reviewer.md` に修正（header コメント・`--all` ヘルプも同様）。実在ファイルを正しくスキャンするようになり、`tech-writer-reviewer.md` 自体は 0 findings を確認。

## B: sh-cross-ref-check の dangling 番号参照（→ 本 check を green 化）

| ファイル | 修正 |
|---|---|
| `hooks/preflight-check.sh:74` | 「resume.md Phase 3.0」（不在）を、改番で消えた番号を使わず「resume.md runs its cross-check phases sequentially」に rephrase |
| `scripts/create-issue-with-projects.sh:32` | #1136 で機能ごと削除された「fix.md Phase 4.3」の dangling 番号を除去（機能名 Automatic Separate Issue Creation は履歴説明として温存） |

**検証**: `sh-cross-ref-check.sh --all` → **0 findings**（修正前 2 件）。

## A-2 の扱い（#1432 に切り出し）

`distributed-fix-drift-check.sh --all` の 84 findings（fix.md 60 + review.md 24）は精査の結果、**過検出が支配的**（`reason 'foo_'` プレースホルダ、`commit_rc_${rc}` 動的構築の切り詰め等）だが、`mktemp_failed` 等の**実 drift の可能性も混在**する。正しい解消には fix.md/review.md の pinned format 合意（§5-6）か check 抽出ロジックの慎重な調整が必要なため、分析を添えて #1432 にトラッキングする。本 PR では distributed-fix-drift は red のまま（A-1 の path 修正のみ反映）。

## 受入基準（#1425）

- [x] A-1: drift-check の target path を `tech-writer-reviewer.md` に修正
- [x] B: preflight-check.sh / create-issue-with-projects.sh の dangling heading 番号参照を是正（sh-cross-ref green）
- [~] A-2: 調査のうえ #1432 に切り出し（過検出/実 drift 分類 + pinned format 合意が前提）

Closes #1425

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
