### PR TITLE
fix(create): Issue type 表記の非対称を crosswalk SoT 化で正規化

### DIFF
--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -116,7 +116,7 @@ title 類似度 / label 一致 / 更新日時 / state（OPEN > CLOSED）で top 
 AskUserQuestion で Issue の以下を確認/補完する:
 
 - title（slug ベース）
-- type（feat / fix / docs / refactor / chore）
+- type（feat / fix / docs / refactor / chore — これは **Commit Type**。Issue body 構造で使う Contract Type との対応は [`default.md` Type Definitions](../../templates/issue/default.md#type-definitions) の crosswalk が SoT）
 - priority（High / Medium / Low）
 - complexity（XS / S / M / L / XL）
 - labels（推測されたもの + 追加）
@@ -137,7 +137,7 @@ Read tool で以下を読み込む:
 [`references/contract-section-mapping.md`](./references/contract-section-mapping.md) の 4-step rubric に従う:
 
 1. **Complexity Gate 適用**: 確定 Complexity の列で `M`(MUST) を必ず含め、`S`(SHOULD) は Step 1.3 で情報が得られた場合のみ含め、`O`(OMIT) は省略
-2. **Type Core Section (Section 3) 選択**: 確定 Type に対応する Section 3 を [Step 2 mapping](./references/contract-section-mapping.md#step-2-type--type-core-section-section-3-mapping) で 1 つ選択（Feature: User Scenarios / BugFix: Bug Details / Refactor: Before-After Contract / Chore: Operational Context / Docs: Documentation Target）
+2. **Type Core Section (Section 3) 選択**: Step 4.1 で確定した値は **Commit Type**（feat/fix/...）。[`default.md` Type Definitions](../../templates/issue/default.md#type-definitions) の crosswalk で **Contract Type**（Feature/BugFix/...）へ対応付け、その Contract Type に対応する Section 3 を [Step 2 mapping](./references/contract-section-mapping.md#step-2-type--type-core-section-section-3-mapping) で 1 つ選択する。Section 0 Meta の `**Type**` には Step 4.1 で確定した Commit Type をそのまま記載し、Step 4.4 完了レポートの Type と一致させる（crosswalk は Section 3 選択のためにのみ用い、Meta 値は変換しない）
 3. **入力のマッピング**: Step 1.3 で抽出した What/Why/Where/Scope/Constraints を [Step 3 mapping](./references/contract-section-mapping.md#step-3-perspective--target-sections-mapping) と [Section Inclusion Rules](./references/contract-section-mapping.md#section-inclusion-rules) に従って各 Section へ反映（What → Section 1 Goal / Why → Section 1-2 / Where → Section 4.1 Target Files / Scope → Section 2 Scope(In/Out) / Constraints → Section 4.5 / Section 7）
 4. **MUST だが情報未収集の Section**: 空見出しを残さず `<!-- 情報未収集 -->` プレースホルダーを挿入
 

--- a/plugins/rite/commands/issue/references/contract-section-mapping.md
+++ b/plugins/rite/commands/issue/references/contract-section-mapping.md
@@ -48,7 +48,7 @@ Rich template (Section 1-9) を生成する場合の 4 step 構成:
 | Chore | Operational Context | [`3-Chore: Operational Context`](../../../templates/issue/template-structure.md#3-chore-operational-context) |
 | Docs | Documentation Target | [`3-Docs: Documentation Target`](../../../templates/issue/template-structure.md#3-docs-documentation-target) |
 
-**Type 判定の優先順位**: Labels > title keywords > body content analysis。`create.md` ステップ 4.1 の AskUserQuestion option (`feat / fix / docs / refactor / chore`) は LLM がこの優先順位で推定したものを提示する。
+**Type 判定の優先順位**: Labels > title keywords > body content analysis。`create.md` ステップ 4.1 の AskUserQuestion で確定する type は **Commit Type**（feat/fix/...）で、LLM がこの優先順位で推定したものを提示する。本表の `Type` 列は対応する **Contract Type**（Feature/BugFix/...）であり、Commit Type ↔ Contract Type の crosswalk は [`templates/issue/default.md` Type Definitions](../../../templates/issue/default.md#type-definitions) が SoT（本 reference では対応関係を再定義しない）。
 
 ## Step 3: Perspective → Target Sections Mapping
 

--- a/plugins/rite/templates/issue/default.md
+++ b/plugins/rite/templates/issue/default.md
@@ -16,13 +16,24 @@ and dynamically generates the Issue body based on Type and Complexity.
 
 ## Type Definitions
 
-| Type | Characteristic Section | Heuristics |
-|------|----------------------|------------|
-| Feature | User Scenarios | New user-facing functionality or workflow |
-| BugFix | Bug Details (Reproduction, Root Cause) | Symptom + repro steps + incorrect current behavior |
-| Refactor | Before/After Contract, Compatibility Policy | Internal structure improvement, compatibility considerations |
-| Chore | Operational Context | Maintenance/tooling/dependency update, no behavior change |
-| Docs | Documentation Target | Documentation addition/update is the primary deliverable |
+> **Type 表記の SoT (crosswalk)**: 下表の `Commit Type` 列が、Issue body 構造で用いる **Contract Type** (Feature/BugFix/...) と Conventional Commits 系の **Commit Type** (feat/fix/...) の対応を定義する単一の Source of Truth。`commands/issue/create.md` (Step 4.1 / 4.2)、`commands/issue/references/contract-section-mapping.md`、`templates/issue/template-structure.md` Section 3 はこの crosswalk を参照する（各箇所で対応関係を再定義しない）。
+
+| Type (Contract) | Commit Type | Characteristic Section | Heuristics |
+|-----------------|-------------|----------------------|------------|
+| Feature | feat | User Scenarios | New user-facing functionality or workflow |
+| BugFix | fix | Bug Details (Reproduction, Root Cause) | Symptom + repro steps + incorrect current behavior |
+| Refactor | refactor | Before/After Contract, Compatibility Policy | Internal structure improvement, compatibility considerations |
+| Chore | chore | Operational Context | Maintenance/tooling/dependency update, no behavior change |
+| Docs | docs | Documentation Target | Documentation addition/update is the primary deliverable |
+
+### Type Notation Policy
+
+rite には 2 つの正当な type 語彙が併存する:
+
+- **Contract Type** (Feature/BugFix/Refactor/Chore/Docs): Issue body の Section 3 名・本テーブルなど **body 構造選択**の語彙。
+- **Commit Type** (feat/fix/refactor/chore/docs): commit message / branch 名 / PR title の語彙（CLAUDE.md が必須と規定する Conventional Commits 由来。`pr/open.md` の branch type 派生もこの系列）。
+
+**判断**: どちらか一方へ統一せず、両系列を残し上表 `Commit Type` 列を単一 crosswalk SoT とする。**根拠**: 統一しても seam は消えず別境界（Issue body ↔ commit/branch）へ移動するだけで、Conventional Commits は外部標準として commit/branch に不可欠、Contract Type は section 名として可読。境界マッピングを 1 箇所で明示するのが drift を最小化する。非自明な対応は `feat↔Feature` / `fix↔BugFix` のみ（他は大文字小文字差）。
 
 ## Complexity Gate
 

--- a/plugins/rite/templates/issue/template-structure.md
+++ b/plugins/rite/templates/issue/template-structure.md
@@ -4,7 +4,7 @@ This file contains the section-by-section template structure for Issue body gene
 Extracted from `default.md` for targeted reading — `create.md` reads this file
 only when generating the Issue body (ステップ 4.2), reducing context consumption.
 
-For the Complexity Gate, Type Definitions, and overview, see [default.md](./default.md).
+For the Complexity Gate, Type Definitions (incl. the Commit Type ↔ Contract Type crosswalk SoT), and overview, see [default.md](./default.md).
 
 ---
 
@@ -46,7 +46,7 @@ For the Complexity Gate, Type Definitions, and overview, see [default.md](./defa
 
 ### 3. Type Core Section
 
-Select ONE matching the Issue type.
+Select ONE matching the Issue type. The type confirmed in `create.md` ステップ 4.1 is a **Commit Type** (feat/fix/...); map it to the **Contract Type** (the `3-Feature` / `3-BugFix` / ... subsections below) via the Commit Type ↔ Contract Type crosswalk in [default.md Type Definitions](./default.md#type-definitions) — the single SoT, not redefined here.
 
 #### 3-Feature: User Scenarios
 


### PR DESCRIPTION
## 概要

`/rite:issue:create` の Issue **type** 表記が 2 系統で非対称なまま放置されていた問題を解消する。

- **Commit Type**（`feat / fix / docs / refactor / chore`）: `create.md` Step 4.1 の AskUserQuestion 選択肢。Conventional Commits 由来で commit / branch / PR title の語彙。
- **Contract Type**（`Feature / BugFix / Refactor / Chore / Docs`）: Implementation Contract の Section 3 名・Type Definitions など Issue body 構造選択の語彙。

特に `feat↔Feature` / `fix↔BugFix` の対応が 2 箇所に暗黙のまま存在し、片側を変更すると silent drift を起こすリスクがあった。

Closes #1436

## 設計判断（AC-2）

**両表記系を残し、明示クロスウォークを単一 SoT 化**する（どちらか一方への統一はしない）。

- 統一しても seam は消えず別境界（Issue body ↔ commit/branch）へ移動するだけ。
- Conventional Commits は外部標準として commit/branch/PR に不可欠、Contract Type は section 名として可読。
- 境界マッピングを 1 箇所で明示するのが drift を最小化する。

判断と根拠は `templates/issue/default.md` の「Type Notation Policy」に永続記録した。

## 変更内容

- `templates/issue/default.md`: Type Definitions テーブルに `Commit Type` 列を追加し crosswalk の単一 SoT 化 + Type Notation Policy ノート（AC-2 の判断・根拠）を追記
- `commands/issue/create.md` Step 4.1: type 選択肢は不変のまま SoT crosswalk への参照を付与（dialog 挙動を維持）
- `commands/issue/create.md` Step 4.2: Section 3 選択が crosswalk に従う旨を明示。Section 0 Meta の `**Type**` は確定 Commit Type をそのまま記載（完了レポートと一致、Meta 値は変換しない＝新たな非対称を作らない）
- `commands/issue/references/contract-section-mapping.md`: feat/fix の独立列挙を SoT crosswalk 参照へ置換
- `templates/issue/template-structure.md` Section 3: Section 3 選択が SoT crosswalk（feat→3-Feature 等）に従う旨を明示

## 受け入れ条件

- [x] AC-1: type 表記の対応関係が単一 SoT として定義され、4 箇所がそれを参照（`default.md#type-definitions`）
- [x] AC-2: 表記系の判断と根拠を記録（Type Notation Policy）
- [x] AC-3: Step 4.1 選択肢不変・body 生成挙動を保持

## 検証

- 4 箇所すべてが `default.md#type-definitions` を参照し、crosswalk データ実体は default.md のみ（再定義なし）を grep で確認
- アンカー `## Type Definitions` 実在、orphan な独立列挙の残存なし
- プラグイン固有 drift チェックを実行し、変更 4 ファイルは新規 finding 0（既存の repo 全体 warning は本変更と無関係であることを固定文字列 grep で確認）

## Known Issues

- 従来 lint コマンド（`commands.lint`）は本リポジトリで未設定のため未実行。品質確認は rite プラグイン固有の drift チェック群で代替した。
