### PR TITLE
fix(init): --upgrade の新規セクション/サブキー/multi_session 取りこぼしを解消し最新デフォルトに追従

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -365,10 +365,12 @@ Display the changes to the user:
 廃止キー削除: {deprecated_keys}
 新規セクション追加: {new_sections}
 サブキー補完: {new_subkeys}
-multi_session back-add: {multi_session_added ? "enabled: true" : "（既存のため変更なし）"}
+multi_session back-add: {multi_session_status}
 Advanced セクション追加（コメントアウト）: {advanced_sections}
 保持される既存設定: {preserved_keys}
 ```
+
+> `{multi_session_status}` は back-add を実行した場合 `enabled: true`、既存ブロックが存在し変更しなかった場合 `（既存のため変更なし）` を表示する。
 
 Ask with `AskUserQuestion`:
 

--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -344,13 +344,16 @@ Compare current config against the template and classify each key:
 |---------------|--------|
 | **User-customized value** (project_number, owner, iteration settings, branch.base, language, etc.) | **Preserve** — keep the user's value |
 | **Deprecated key** (`project.name`, `commit.style`, `commit.enforce`, `commit.contextual`, `branch.release`, `branch.types`, `version`) | **Remove** — delete from config |
-| **Missing section** (review.debate, review.fact_check, verification, etc. — **excluding wiki and multi_session**) | **Add** — insert from template with default values |
-| **`multi_session:` section** | **Do NOT back-add on --upgrade**. `multi_session:` is declared above the `--- Advanced ---` marker (active, #1391) so new generation (Phase 4.1.2 Step 2) emits it with `enabled: true`. On the `--upgrade` path it is intentionally **left absent** when missing from an existing config, so the `pr:open` parser fallback keeps it `false` — this preserves backward compat for projects created before #1391 ("the default-on change takes effect only at new /rite:init generation"). If a user's config already has a `multi_session:` block, it is preserved as a User-customized value (no overwrite) |
+| **Missing section** — any active top-level section above the `--- Advanced ---` marker (github, iteration, branch, commands, verification, issue, review, `fix`, `flow_state`, etc. — **excluding `wiki:` and `multi_session:`**, which have dedicated rows below) | **Add** — insert the whole section from the template with default values |
+| **Missing sub-key** — a key newly added to the template *inside* a section the config already has (e.g., `review.fact_check.verify_internal_likelihood`) | **Add the missing key only** from the template default; **preserve** all existing sibling values (e.g., a customized `review.fact_check.max_claims`). No-op when the key already exists |
+| **`multi_session:` section** | **Back-add on --upgrade with `enabled: true`** (#1391 default-on; #1446 D-01). `multi_session:` is declared above the `--- Advanced ---` marker (active). When missing from an existing config, insert the template active block (`enabled: true` + `worktree_base`) so `--upgrade`-ed projects receive the same default-on behavior as new `/rite:init` generation. If a user's config already has a `multi_session:` block, it is preserved as a User-customized value (no overwrite — **including an explicit `enabled: false`**). Idempotent: no-op when the active section already exists |
 | **Advanced section** (parallel, metrics, safety, investigate) | **Add as comments** — insert commented-out with default values |
 | **`wiki:` section** | **Step 3/4 は扱わない**。wiki セクションの追加は **Phase 4.1.2 Step 2 (新規生成: template の Advanced 境界より上にある active block が自動コピーされる) および Phase 4.1.3 Step 3.5 / Step 6 item 5 (Upgrade path: 未存在時に active block として append) の専権**。template 側にはコメント形式の `# wiki:` ブロックは存在しない (`#491` で active 位置に移動済み) ため、重複追加経路はない |
 | **Unknown key** (user-added keys not in template) | **Preserve with warning** — keep but display warning |
 
 **Unknown key 判定の scope**: Step 4 の "Unknown key" 判定 (user-added keys not in template) は、**template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。境界より下 (コメント形式の Advanced sections + 末尾コメント) は template 側で意図的に省略または注記のため存在する領域であり、ユーザー設定の classification 対象外。
+
+**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `fix`, `language`, `wiki`, `flow_state`, `multi_session`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
 
 **Step 5: Preview and confirm**
 
@@ -361,6 +364,8 @@ Display the changes to the user:
 
 廃止キー削除: {deprecated_keys}
 新規セクション追加: {new_sections}
+サブキー補完: {new_subkeys}
+multi_session back-add: {multi_session_added ? "enabled: true" : "（既存のため変更なし）"}
 Advanced セクション追加（コメントアウト）: {advanced_sections}
 保持される既存設定: {preserved_keys}
 ```
@@ -381,8 +386,16 @@ If the user confirms:
 1. Update `schema_version` to latest value
 2. Remove deprecated keys using the Edit tool. Display "廃止キーを削除しました: {keys}".
 3. Add missing sections from the template using the Edit tool. Display "新しいセクションを追加しました: {sections}".
-4. Add Advanced sections as comments (prefixed with `#`) using the Edit tool
-5. **If `wiki:` section is absent**: append the active `wiki:` block from the template (single source of truth) so Phase 4.7 can auto-initialize Wiki.
+4. **Merge missing sub-keys**: for each active section already present in the config, compare its keys against the template section and add **only the missing sub-keys** (with their template default values) using the Edit tool, preserving every existing sibling value. No-op for keys already present (idempotent). Display "サブキーを補完しました: {section.key, ...}" only when at least one key was added.
+5. Add Advanced sections as comments (prefixed with `#`) using the Edit tool
+6. **If `multi_session:` section is absent**: append the active `multi_session:` block from the template (`enabled: true` + `worktree_base`) so `--upgrade`-ed projects get the same default-on session-worktree behavior as new generation (#1446 D-01).
+
+   **Block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the active `multi_session:` block (the `multi_session:` key line through its last sub-key, above the `# --- Advanced (below this line) ---` marker). Do not duplicate the literal here — any change to template defaults propagates to both new-install and `--upgrade`.
+
+   **Idempotency guard**: Before inserting, Grep `^multi_session:` (excluding comment lines starting with `#`) in the project's `rite-config.yml`. If an active section already exists, skip the Edit entirely (no-op) — this preserves a user's existing block, **including an explicit `enabled: false`** (never overwrite `enabled`).
+
+   **Anchor selection**: insert immediately before the `# --- Advanced (below this line) ---` marker line (`old_string` = marker line, `new_string` = multi_session block + `\n\n` + marker line). If the Advanced marker is absent (user-trimmed config), append after the last top-level active key. Display `rite-config.yml に multi_session セクションを追加しました（active, enabled: true）。` only when the Edit actually ran.
+7. **If `wiki:` section is absent**: append the active `wiki:` block from the template (single source of truth) so Phase 4.7 can auto-initialize Wiki.
 
    **Wiki block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the block from `# Wiki settings` through the end of the `wiki:` section (the lines above the `# --- Advanced (below this line) ---` marker). This avoids literal duplication between `init.md` and the template — any change to default values (e.g., `auto_ingest`, `branch_strategy`) in the template automatically propagates to both new-install and `--upgrade` paths.
 
@@ -399,7 +412,7 @@ If the user confirms:
    (For the Advanced-marker fallback, swap: `new_string` = wiki block + `\n\n` + marker line)
 
    Display `rite-config.yml に wiki セクションを追加しました（active）。` only when the Edit actually ran (skip the message on idempotency no-op).
-6. Preserve all user-customized values
+8. Preserve all user-customized values
 
 Display "rite-config.yml をアップグレードしました (v{current} → v{latest})".
 

--- a/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+++ b/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Static / offline drift + consistency tests for the `/rite:init --upgrade` config
+# follow-through (Issue #1446).
+#
+# Verifies:
+#   T-10 (AC-10): every active top-level key in the template above the
+#        `# --- Advanced (below this line) ---` marker is enumerated in init.md's
+#        "Active top-level sections covered on --upgrade" drift anchor. A new
+#        template section that is not listed in init.md fails this test, forcing
+#        init.md to be updated so `--upgrade` does not silently miss it.
+#   T-11 (AC-11): the template and init.md agree that `multi_session:` is
+#        back-added on --upgrade (with `enabled: true`), and no stale "do NOT
+#        back-add" / "NOT back-added" / "left absent" wording survives in either
+#        file.
+#
+# Usage: bash plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+INIT_MD="$REPO_ROOT/plugins/rite/commands/init.md"
+TEMPLATE="$REPO_ROOT/plugins/rite/templates/config/rite-config.yml"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILURES+=("$1"); echo "  ✗ $1" >&2; }
+
+assert_contains() { # file pattern description
+  if grep -qE -e "$2" "$1"; then pass "$3"; else fail "$3 (missing pattern: $2)"; fi
+}
+assert_absent() { # file fixed-string description
+  if grep -qF -- "$2" "$1"; then fail "$3 (stale text present: $2)"; else pass "$3"; fi
+}
+
+# --- Preconditions ---
+[ -f "$INIT_MD" ]   || { echo "FATAL: init.md not found at $INIT_MD" >&2; exit 1; }
+[ -f "$TEMPLATE" ]  || { echo "FATAL: template not found at $TEMPLATE" >&2; exit 1; }
+
+echo "=== T-10: template active top-level sections ⊆ init.md upgrade enumeration ==="
+
+# Active top-level keys in the template above the Advanced boundary.
+template_sections=$(awk '
+  /# --- Advanced \(below this line\) ---/ { exit }
+  /^[a-z_]+:/ { key=$0; sub(/:.*/, "", key); print key }
+' "$TEMPLATE")
+
+[ -n "$template_sections" ] || { echo "FATAL: no template sections extracted (parser drift?)" >&2; exit 1; }
+
+# The init.md drift anchor line (single source of the enumeration).
+enum_line=$(grep -nF 'Active top-level sections covered on --upgrade' "$INIT_MD" | head -1 | cut -d: -f1 || true)
+if [ -z "$enum_line" ]; then
+  fail "init.md is missing the 'Active top-level sections covered on --upgrade' drift anchor"
+else
+  pass "init.md drift anchor present"
+  enum_text=$(sed -n "${enum_line}p" "$INIT_MD")
+  for sec in $template_sections; do
+    if printf '%s' "$enum_text" | grep -qF -- "\`$sec\`"; then
+      pass "template section '$sec' is enumerated in init.md"
+    else
+      fail "template section '$sec' is NOT enumerated in init.md upgrade handling"
+    fi
+  done
+fi
+
+echo "=== T-11: multi_session back-add wording is consistent (no stale text) ==="
+
+# Positive: both files state the back-add policy.
+assert_contains "$INIT_MD" 'multi_session.*[Bb]ack-add on --upgrade with .enabled: true.' \
+  "init.md Step 4 row states multi_session is back-added with enabled: true"
+assert_contains "$TEMPLATE" 'back-added with .enabled: true.' \
+  "template comment states multi_session is back-added with enabled: true on --upgrade"
+
+# Negative: no stale "do not back-add" wording remains.
+assert_absent "$INIT_MD" 'Do NOT back-add on --upgrade' \
+  "init.md no longer says 'Do NOT back-add on --upgrade'"
+assert_absent "$TEMPLATE" 'intentionally NOT back-added' \
+  "template no longer says 'intentionally NOT back-added'"
+assert_absent "$INIT_MD" 'left absent' \
+  "init.md no longer says multi_session is 'left absent' on upgrade"
+
+# --- Summary ---
+echo ""
+echo "==============================="
+echo "init-upgrade-drift: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+echo "All init-upgrade-drift checks passed!"

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -156,8 +156,10 @@ flow_state:
 # (node_modules, venv, build caches) are NOT shared and may be rebuilt per worktree.
 # Declared ABOVE the `--- Advanced ---` marker (like wiki / flow_state, #491) so
 # /rite:init new-generation emits it as an active block (so new projects actually
-# get the default-on behavior). On --upgrade it is intentionally NOT back-added to
-# existing configs (see init.md Step 4 classification) to preserve backward compat.
+# get the default-on behavior). On --upgrade it is back-added with `enabled: true`
+# to existing configs (see init.md Step 4 classification, #1446 D-01) so upgraded
+# projects receive the same default-on behavior; an existing explicit
+# `enabled: false` is preserved.
 multi_session:
   enabled: true                    # per-session worktrees (on by default, #1391); false to disable
   worktree_base: ".rite/worktrees" # session worktree base (issue-{N} subdirs)


### PR DESCRIPTION
## 概要

`/rite:init --upgrade` が既存 `rite-config.yml` を最新スキーマへ追従させる際、(1) 新規トップレベルセクション、(2) 既存セクション内の新規サブキー、(3) `multi_session:` を取りこぼし、新規 `init` ユーザと `--upgrade` ユーザで設定内容が乖離する二層挙動を解消する。`--upgrade` した既存ユーザも新規 `init` ユーザと同等の最新デフォルト/新規設定を確実に受け取れる状態にする。

## 関連 Issue

Closes #1446

## 変更内容

- `plugins/rite/commands/init.md` Phase 4.1.3:
  - **Step 4 分類表**: `multi_session:` 行を「Do NOT back-add」→「`enabled: true` で back-add（既存ブロック・明示 `enabled: false` は preserve・冪等）」へ変更
  - **Step 4**: 「Missing sub-key」分類行を追加（既存セクション内の新規サブキーを欠落キーのみ template default で補完し、既存兄弟値を preserve）
  - **Step 4**: active トップレベルセクション列挙（drift アンカー）を追加。template の Advanced 境界より上の active セクションを明示列挙し、新規セクション追加時に init.md 追従を強制
  - **Step 6 Apply**: `multi_session:` back-add 手順（SSOT 抽出・冪等ガード・アンカー選択）とサブキーマージ手順を追加。Step 5 preview にも反映
- `plugins/rite/templates/config/rite-config.yml`: `multi_session:` コメントを新方針（`--upgrade` で `enabled: true` back-add、明示 `false` は preserve）へ更新。ブロック本体は不変
- `plugins/rite/hooks/tests/init-upgrade-drift.test.sh`（新規）: template active セクション ⊆ init.md 列挙の drift 検出（T-10）と multi_session back-add 記述整合・旧記述非残存（T-11）を決定的 bash テストとして追加

## 受入基準マッピング

| AC | 対応 |
|----|------|
| AC-1 / AC-5 / AC-9 | Step 4 multi_session 行 + Step 6 back-add（enabled:true、明示 false 保持、冪等） |
| AC-2 | Step 4 Missing section 行 + active セクション列挙（`fix:` / `flow_state:` 含む） |
| AC-3 / AC-6 | Step 4 Missing sub-key 行 + Step 6 サブキーマージ手順 |
| AC-4 | 既存 User-customized value 行（不変・preserve 担保） |
| AC-7 / AC-8 | wiki / Advanced 行は不変（非回帰） |
| AC-10 | `init-upgrade-drift.test.sh` T-10 |
| AC-11 | template コメント更新 + T-11 |

## テスト

- 新規 `init-upgrade-drift.test.sh`: **19 件パス**（T-10 ドリフト検出 13 / T-11 整合 6）
- ドリフト検出の negative ケース検証: template に未列挙セクションを一時注入すると fail し、復元で pass（vacuous でないことを確認）
- hook テストスイート全体: **72/72 パス**（回帰なし）
- 私の変更が新規に追加した drift / comment-journal finding は **0 件**（既存の 84 drift・102 journal はそれぞれ Issue #1432 系の先行課題で warning・非ブロッキング）

## スコープ遵守

- `pr/open.md` の `multi_session` パーサ fallback（欠落時 `false`）は Non-Target として温存（セーフティネット）
- helper script 化はスコープ外。prose 駆動を維持し、ドリフト検出テストで回帰防止（#1446 D-03）

## Decision Log

- D-01: `--upgrade` で multi_session を `enabled: true` で back-add（#1391 デフォルト ON に追従、後方互換コメント撤回）
- D-02: スコープ = `--upgrade` 全般の取りこぼし監査・修正（サブキーマージ + 新規セクション + ドリフト検出テスト）を 1 Issue で扱う
- D-03: complexity L。helper script 化（XL）はスコープ外

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
