### PR TITLE
test(init): --upgrade サブキーマージの drift 検出テスト (T-12) を追加

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -355,6 +355,22 @@ Compare current config against the template and classify each key:
 
 **Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `fix`, `language`, `wiki`, `flow_state`, `multi_session`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
 
+**Active sub-keys covered on --upgrade** (drift anchor — the `init-upgrade-drift` test T-12 asserts, per section, this list ⊇ each template active section's **direct** sub-keys above the `--- Advanced ---` marker; Step 6 item 4 adds any missing sub-key while preserving existing siblings). Sections whose value is a scalar (`schema_version`, `language`) have no sub-keys and are omitted:
+
+- `github`: `projects`
+- `iteration`: `enabled`, `field_name`, `auto_assign`, `show_in_list`
+- `branch`: `base`, `pattern`
+- `commands`: `build`, `test`, `lint`
+- `verification`: `run_tests_before_pr`, `acceptance_criteria_check`
+- `issue`: `auto_decompose_threshold`
+- `review`: `min_reviewers`, `criteria`, `loop`, `security_reviewer`, `debate`, `confidence_threshold`, `fact_check`, `scope_assignment`
+- `fix`: `fail_fast_response`
+- `wiki`: `enabled`, `branch_strategy`, `branch_name`, `auto_ingest`, `auto_query`
+- `flow_state`: `schema_version`
+- `multi_session`: `enabled`, `worktree_base`
+
+**When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it (the same guard as the top-level list, one level down).
+
 **Step 5: Preview and confirm**
 
 Display the changes to the user:

--- a/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+++ b/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
@@ -12,6 +12,13 @@
 #        back-added on --upgrade (with `enabled: true`), and no stale "do NOT
 #        back-add" / "NOT back-added" / "left absent" wording survives in either
 #        file.
+#   T-12 (Issue #1448): every DIRECT sub-key of each active top-level section
+#        (above the `# --- Advanced ---` marker) is enumerated in init.md's
+#        "Active sub-keys covered on --upgrade" drift anchor, under its section's
+#        row. This extends T-10's protection one level down: a new sub-key added
+#        to an existing template section that init.md fails to list fails this
+#        test, forcing init.md to be updated so `--upgrade` does not silently
+#        miss it (mirrors the sub-key merge rule, init.md Step 6 item 4).
 #
 # Usage: bash plugins/rite/hooks/tests/init-upgrade-drift.test.sh
 set -euo pipefail
@@ -42,9 +49,12 @@ assert_absent() { # file fixed-string description
 echo "=== T-10: template active top-level sections ⊆ init.md upgrade enumeration ==="
 
 # Active top-level keys in the template above the Advanced boundary.
+# Key regex allows digits/hyphens after the first char (e.g. a future `oauth2:`),
+# a strict superset of the current all-lowercase keys so this does not change
+# T-10's extraction for today's template.
 template_sections=$(awk '
   /# --- Advanced \(below this line\) ---/ { exit }
-  /^[a-z_]+:/ { key=$0; sub(/:.*/, "", key); print key }
+  /^[a-z_][a-zA-Z0-9_-]*:/ { key=$0; sub(/:.*/, "", key); print key }
 ' "$TEMPLATE")
 
 [ -n "$template_sections" ] || { echo "FATAL: no template sections extracted (parser drift?)" >&2; exit 1; }
@@ -80,6 +90,45 @@ assert_absent "$TEMPLATE" 'intentionally NOT back-added' \
   "template no longer says 'intentionally NOT back-added'"
 assert_absent "$INIT_MD" 'left absent' \
   "init.md no longer says multi_session is 'left absent' on upgrade"
+
+echo "=== T-12: template active section direct sub-keys ⊆ init.md sub-key drift anchor ==="
+
+# Direct (exactly 2-space indented) sub-keys per active top-level section in the
+# template, emitted as "section.subkey". Deeper-nested keys (4+ spaces) and list
+# items are excluded so only one level below each section is asserted.
+template_subkeys=$(awk '
+  /# --- Advanced \(below this line\) ---/ { exit }
+  /^[a-z_][a-zA-Z0-9_-]*:/ { section=$0; sub(/:.*/, "", section); next }
+  /^  [a-z_][a-zA-Z0-9_-]*:/ { key=$0; sub(/^  /, "", key); sub(/:.*/, "", key); print section "." key }
+' "$TEMPLATE")
+
+[ -n "$template_subkeys" ] || { echo "FATAL: no template sub-keys extracted (parser drift?)" >&2; exit 1; }
+
+# The init.md sub-key drift anchor block: from the marker line through its closing
+# "When a new sub-key is added" guard line (single source of the enumeration).
+sub_anchor_start=$(grep -nF 'Active sub-keys covered on --upgrade' "$INIT_MD" | head -1 | cut -d: -f1 || true)
+if [ -z "$sub_anchor_start" ]; then
+  fail "init.md is missing the 'Active sub-keys covered on --upgrade' drift anchor"
+else
+  pass "init.md sub-key drift anchor present"
+  sub_anchor_end=$(awk -v s="$sub_anchor_start" 'NR>s && /When a new sub-key is added/ { print NR; exit }' "$INIT_MD")
+  [ -n "$sub_anchor_end" ] || sub_anchor_end=$(wc -l < "$INIT_MD")
+  anchor_block=$(sed -n "${sub_anchor_start},${sub_anchor_end}p" "$INIT_MD")
+
+  for pair in $template_subkeys; do
+    sec=${pair%%.*}
+    key=${pair#*.}
+    # The anchor row for this section, e.g. "- `review`: `min_reviewers`, ...".
+    row=$(printf '%s\n' "$anchor_block" | grep -F -- "- \`$sec\`:" | head -1 || true)
+    if [ -z "$row" ]; then
+      fail "init.md sub-key anchor has no row for section '$sec' (needed for '$pair')"
+    elif printf '%s' "$row" | grep -qF -- "\`$key\`"; then
+      pass "template sub-key '$pair' is enumerated in init.md"
+    else
+      fail "template sub-key '$pair' is NOT enumerated in init.md sub-key anchor"
+    fi
+  done
+fi
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## 概要

Issue #1448: `/rite:init --upgrade` のサブキーマージに対する**構造的 drift 保護**を追加。`init-upgrade-drift.test.sh` の T-10（トップレベルセクションのみ検証）の保護を 1 階層下（サブキー）へ拡張する。

## 変更内容

- **init.md**: トップレベル drift anchor の直後に「Active sub-keys covered on --upgrade」サブキー列挙 drift anchor を新設（11 セクション・30 直下サブキー）。新サブキー追加時にこのリストへの追記を強制するガード文を併記。
- **init-upgrade-drift.test.sh**:
  - **T-12** を追加: template 各 active トップレベルセクションの**直下**サブキー集合 ⊆ init.md サブキー anchor を、セクション行単位で検証。未記述があれば fail。
  - **T-10 パーサ regex** を `^[a-z_]+:` → `^[a-z_][a-zA-Z0-9_-]*:` に拡張（将来の digit/hyphen キー対応、現行キーは superset マッチで挙動不変／test-reviewer の boundary 指摘）。

## 受入基準

- **AC-1** ✅ サブキー未記述で fail する drift テスト（T-12）が存在
- **AC-2** ✅ 既存 T-10 / T-11（19 assertions）は不変で pass（全体 72/72 pass）
- **AC-3** ✅ 非 vacuous 実証: template に `branch.drift_probe` を一時注入すると T-12 が fail（rc=1）、revert で復帰

## テスト

```
init-upgrade-drift: 50 passed, 0 failed
run-tests.sh: Results: 72/72 passed, 0 failed
```

## 関連

- 元 Issue: #1446 / 元 PR: #1447（test-reviewer, design_confirmation）

Closes #1448

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
