### PR TITLE
docs(getting-started): --upgrade の multi_session back-add を追記

### DIFF
--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -188,6 +188,14 @@ What `/rite:init --upgrade` does:
     append is applied without an additional prompt)
   ✓ Appends the `wiki:` section if it is absent, so the Wiki
     auto-initialization step of `/rite:init` can run for existing projects
+  ✓ Back-adds the `multi_session:` section with `enabled: true` if it is
+    absent, so upgraded projects get the default-on per-session worktree
+    behavior; an existing explicit `enabled: false` is preserved
+  ✓ Fills in sub-keys that are missing from a section you already have,
+    adding only the absent keys from the template default while preserving
+    every existing sibling value you customized
+  ✓ Adds any new active top-level section the template introduces, so the
+    upgrade keeps pace with newly added defaults
   ✓ Updates `schema_version` to the latest value on success
 
 The upgrade is non-destructive: user-customized values are preserved, and a

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -191,9 +191,9 @@ What `/rite:init --upgrade` does:
   ✓ Back-adds the `multi_session:` section with `enabled: true` if it is
     absent, so upgraded projects get the default-on per-session worktree
     behavior; an existing explicit `enabled: false` is preserved
-  ✓ Fills in sub-keys that are missing from a section you already have,
-    adding only the absent keys from the template default while preserving
-    every existing sibling value you customized
+  ✓ Fills in sub-keys that are missing from an active section you already
+    have, adding only the absent keys from the template default while
+    preserving every existing sibling value you customized
   ✓ Adds any new active top-level section the template introduces, so the
     upgrade keeps pace with newly added defaults
   ✓ Updates `schema_version` to the latest value on success


### PR DESCRIPTION
## 概要

Issue #1449: `getting-started.md` の「What `/rite:init --upgrade` does」リストに、#1446 で追加した `--upgrade` の挙動を追記し、ユーザー向けドキュメントを最新方針に追従させる。

## 変更内容

`What /rite:init --upgrade does:` リストに 3 項目を追加（既存の `wiki:` append 項目の直後）:

- `multi_session:` セクションを `enabled: true` で back-add（既存の明示 `enabled: false` は保持）
- 既存セクション内の欠落サブキーのみを補完（既存兄弟値は保持）
- 新規 active トップレベルセクションの追加保証

## 受入基準

- **AC-1** ✅ multi_session back-add（`enabled: true`、明示 `false` 保持）を記載
- **AC-2** ✅ サブキー補完（欠落キーのみ）・新規 active トップレベルセクション追加保証を記載
- **AC-3** ✅ init.md（SoT）の Step 4 classification / Step 6 item 4 と記述一致（矛盾なし）

## 関連

- 元 Issue: #1446 / 元 PR: #1447（prompt-engineer, boundary）

Closes #1449

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
