### PR TITLE
refactor(test): init-upgrade-drift.test.sh を _test-helpers.sh に統一

### DIFF
--- a/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+++ b/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
@@ -2,6 +2,11 @@
 # Static / offline drift + consistency tests for the `/rite:init --upgrade` config
 # follow-through (Issue #1446).
 #
+# Sources the shared `_test-helpers.sh` (Issue #1450) for pass / fail /
+# assert_grep / assert_not_grep / _helpers_resolve_repo_root / print_summary,
+# so the pass/fail stream, glyphs (✅/❌) and summary block follow the same
+# convention as the other source-based tests in this directory.
+#
 # Verifies:
 #   T-10 (AC-10): every active top-level key in the template above the
 #        `# --- Advanced (below this line) ---` marker is enumerated in init.md's
@@ -24,23 +29,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+REPO_ROOT="$(_helpers_resolve_repo_root "$SCRIPT_DIR")"
 INIT_MD="$REPO_ROOT/plugins/rite/commands/init.md"
 TEMPLATE="$REPO_ROOT/plugins/rite/templates/config/rite-config.yml"
-
-PASS=0
-FAIL=0
-FAILURES=()
-
-pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
-fail() { FAIL=$((FAIL + 1)); FAILURES+=("$1"); echo "  ✗ $1" >&2; }
-
-assert_contains() { # file pattern description
-  if grep -qE -e "$2" "$1"; then pass "$3"; else fail "$3 (missing pattern: $2)"; fi
-}
-assert_absent() { # file fixed-string description
-  if grep -qF -- "$2" "$1"; then fail "$3 (stale text present: $2)"; else pass "$3"; fi
-}
 
 # --- Preconditions ---
 [ -f "$INIT_MD" ]   || { echo "FATAL: init.md not found at $INIT_MD" >&2; exit 1; }
@@ -78,18 +70,22 @@ fi
 echo "=== T-11: multi_session back-add wording is consistent (no stale text) ==="
 
 # Positive: both files state the back-add policy.
-assert_contains "$INIT_MD" 'multi_session.*[Bb]ack-add on --upgrade with .enabled: true.' \
-  "init.md Step 4 row states multi_session is back-added with enabled: true"
-assert_contains "$TEMPLATE" 'back-added with .enabled: true.' \
-  "template comment states multi_session is back-added with enabled: true on --upgrade"
+# assert_grep takes ERE patterns; the originals already used grep -E so the
+# patterns carry over unchanged.
+assert_grep "init.md Step 4 row states multi_session is back-added with enabled: true" \
+  "$INIT_MD" 'multi_session.*[Bb]ack-add on --upgrade with .enabled: true.'
+assert_grep "template comment states multi_session is back-added with enabled: true on --upgrade" \
+  "$TEMPLATE" 'back-added with .enabled: true.'
 
-# Negative: no stale "do not back-add" wording remains.
-assert_absent "$INIT_MD" 'Do NOT back-add on --upgrade' \
-  "init.md no longer says 'Do NOT back-add on --upgrade'"
-assert_absent "$TEMPLATE" 'intentionally NOT back-added' \
-  "template no longer says 'intentionally NOT back-added'"
-assert_absent "$INIT_MD" 'left absent' \
-  "init.md no longer says multi_session is 'left absent' on upgrade"
+# Negative: no stale "do not back-add" wording remains. The original assert_absent
+# matched fixed strings; these three patterns contain no ERE metacharacters, so
+# assert_not_grep (ERE) is exactly equivalent.
+assert_not_grep "init.md no longer says 'Do NOT back-add on --upgrade'" \
+  "$INIT_MD" 'Do NOT back-add on --upgrade'
+assert_not_grep "template no longer says 'intentionally NOT back-added'" \
+  "$TEMPLATE" 'intentionally NOT back-added'
+assert_not_grep "init.md no longer says multi_session is 'left absent' on upgrade" \
+  "$INIT_MD" 'left absent'
 
 echo "=== T-12: template active section direct sub-keys ⊆ init.md sub-key drift anchor ==="
 
@@ -131,12 +127,8 @@ else
 fi
 
 # --- Summary ---
-echo ""
-echo "==============================="
-echo "init-upgrade-drift: $PASS passed, $FAIL failed"
-if [ "$FAIL" -gt 0 ]; then
-  echo "Failures:"
-  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+if ! print_summary "init-upgrade-drift" \
+  "Drift: sync init.md's '--upgrade' anchors ('Active top-level sections covered on --upgrade' and 'Active sub-keys covered on --upgrade') with the template's active sections/sub-keys above the '--- Advanced ---' marker."; then
   exit 1
 fi
 echo "All init-upgrade-drift checks passed!"


### PR DESCRIPTION
## 概要

Issue #1450: `init-upgrade-drift.test.sh`（#1446 で追加、#1448 で T-12 追加）がローカル再実装していた `pass`/`fail`/`assert_contains`/`assert_absent`/REPO_ROOT 解決/summary ブロックを、共有ヘルパー `_test-helpers.sh` に統一する任意の品質改善。

## 変更内容

- `pass` / `fail` → helper 同名関数（グリフ `✓/✗` → `✅/❌`、fail marker を stderr → stdout に統一）
- `assert_contains` → `assert_grep`（ERE、引数順 label 先頭）
- `assert_absent` → `assert_not_grep`（ERE）。対象 3 パターン（`Do NOT back-add on --upgrade` / `intentionally NOT back-added` / `left absent`）は ERE メタ文字を含まないため固定文字列 `grep -F` と**完全に等価**（コメントで根拠を明示）
- REPO_ROOT 自前解決 → `_helpers_resolve_repo_root`
- summary ブロック → `print_summary`

T-10 / T-11 / T-12 の判定ロジックと非 vacuous 性は維持。

## 受入基準

- **AC-1** ✅ `_test-helpers.sh` を source し、ローカル再実装（pass/fail/assert_contains/assert_absent/REPO_ROOT/summary）を除去
- **AC-2** ✅ T-10/T-11 の検証内容が等価。negative ケースを実証:
  - T-12 drift 注入（template に偽サブキー）→ fail（rc=1）
  - T-11 stale 文言再導入（init.md に `left absent`）→ `assert_not_grep` が anti-pattern 検出で fail（rc=1）
- **AC-3** ✅ `run-tests.sh` で auto-discover され全 72/72 pass

## 備考（スコープ外の明示）

- 他テストファイルの inline→source 一括移行は行わない（本 Issue は init-upgrade-drift.test.sh のみ／Out of Scope）
- Goal の「約 30 行削減」は目安。実際の純減は 8 行（boilerplate 除去 ~18 行 − `assert_not_grep` の ERE 等価性根拠コメント ~10 行）。コメントは将来の誤った「簡略化」で固定文字列セマンティクスを壊すのを防ぐため意図的に保持

## 関連

- 元 Issue: #1446 / 元 PR: #1447（code-quality / test-reviewer, design_confirmation）

Closes #1450

---

🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
