### PR TITLE
fix(init): --upgrade 短絡経路の drift back-add 取りこぼしを解消

### DIFF
--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -303,16 +303,16 @@ Read both files with the Read tool:
 - Current: Read `schema_version` from existing file. If missing, treat as v1.
 - Latest: Read `schema_version` from template. If missing, treat as v1.
 
-**Branching** (AC-3 compliance — #491): schema 同等であっても Wiki 未初期化の既存ユーザーを追従させる必要があるため、以下のとおり分岐する。**表の実行順序は左から右** (Step 番号順ではなく矢印順):
+**Branching** (#491 Wiki follow-through を含む全 drift 追従 — #1459): schema 同等であってもテンプレートはスキーマ版を bump せずに active セクション/サブキー（`multi_session`・新規セクション・Wiki 等）を獲得し得るため、`current >= latest` 経路でも config に欠落している drift を back-add して最新デフォルトへ追従させる必要がある。以下のとおり分岐する。**表の実行順序は左から右** (Step 番号順ではなく矢印順):
 
 | Condition | Execution order (left → right) |
 |-----------|--------------------------------|
 | `current < latest` | (1) Step 3 Backup → (2) Step 4 Identify → (3) Step 5 Preview → (4) Step 6 Apply → (5) Step 7 Phase 4.7 |
-| `current >= latest` | (1) Step 3 Backup → (2) Step 3.5 Wiki Section Append (conditional) → (3) Step 7 Phase 4.7。Step 4-6 はスキップ |
+| `current >= latest` | (1) Step 3 Backup → (2) Step 4 Identify（drift のみ）→ (3) Step 6 Apply（multi_session/新規セクション/欠落サブキー/Wiki の back-add。User-customized 保全・冪等・preview なし）→ (4) Step 7 Phase 4.7 |
 
-`current >= latest` 経路では Step 3.5 が config を変更する可能性があるため Step 3 Backup を必ず先に実行する (precondition)。
+両経路とも Step 6 が config を変更し得るため Step 3 Backup を必ず先に実行する (precondition)。`current >= latest` 経路は Step 5 Preview/confirm を挟まず、欠落している active セクション/サブキーのみを冪等に back-add する（テンプレート defaults への追従であり、User-customized 値（明示的な `enabled: false` を含む）は保全されるため無確認で適用する）。旧 Step 3.5 の Wiki 専用救済（#491）はこの一般化に吸収され、Wiki も他の active セクションと同様に Step 6 item 7 で back-add される（drift anchor SoT に一貫化）。
 
-schema 同等 + Wiki 既に初期化済みの場合、Step 3.5 は「既に `^wiki:` active section が存在する」ことを検出して no-op となる。この経路で `rite-config.yml は最新です (v{current})` を表示するタイミングは **Step 3.5 の no-op 確定時** (Phase 4.7 進入前) とする。Phase 4.7 はそのまま実行され、Phase 4.7.2 が `wiki_status=already_initialized` を set して Skill 呼び出しは skip される (冪等)。
+`current >= latest` 経路で back-add 対象が皆無（全 active セクション/サブキーが既存）の場合、Step 6 は config を書き換えず `rite-config.yml は最新です (v{current})` を表示する。Phase 4.7 はそのまま実行され、Wiki 初期化済みなら Phase 4.7.2 が `wiki_status=already_initialized` を set して Skill 呼び出しは skip される (冪等)。
 
 **Step 3: Create backup**
 
@@ -321,20 +321,6 @@ cp rite-config.yml "rite-config.yml.bak.$(date +%Y%m%d-%H%M%S)"
 ```
 
 Display "バックアップを作成しました: {path}".
-
-**Step 3.5: Wiki Section Append (conditional — #491)**
-
-**Precondition**: Step 3 Backup must have completed successfully.
-
-**Execution condition**: This step runs only on the `current >= latest` short-circuit path (see Step 2 branching table). On the `current < latest` path, wiki append is handled by Step 6 item 5 instead, so Step 3.5 is skipped.
-
-**Procedure**:
-
-1. Grep `rite-config.yml` for `^wiki:` (excluding lines starting with `#`) to detect an existing active wiki section.
-2. **If an active `^wiki:` match is found** (Wiki section already present): no-op. Display `rite-config.yml は最新です (v{current})` and proceed to Step 7 (Phase 4.7). Phase 4.7.2 will subsequently detect the initialized Wiki and set `wiki_status=already_initialized`.
-3. **If no active `^wiki:` match**: invoke the same append procedure defined in Step 6 item 5 below (single source of truth for the wiki block literal source and anchor selection). After the append completes, display `rite-config.yml に wiki セクションを追加しました（active）。` and proceed to Step 7.
-
-**Anchor/append handoff**: Step 3.5 does NOT duplicate the wiki block literal or anchor-selection logic. Both are defined in Step 6 item 5 below; Step 3.5 simply invokes that same procedure. This keeps the wiki block definition in a single location within `init.md` and prevents drift between the two paths.
 
 **Step 4: Identify changes**
 
@@ -348,7 +334,7 @@ Compare current config against the template and classify each key:
 | **Missing sub-key** — a key newly added to the template *inside* a section the config already has (e.g., `review.fact_check.verify_internal_likelihood`) | **Add the missing key only** from the template default; **preserve** all existing sibling values (e.g., a customized `review.fact_check.max_claims`). No-op when the key already exists |
 | **`multi_session:` section** | **Back-add on --upgrade with `enabled: true`** (#1391 default-on; #1446 D-01). `multi_session:` is declared above the `--- Advanced ---` marker (active). When missing from an existing config, insert the template active block (`enabled: true` + `worktree_base`) so `--upgrade`-ed projects receive the same default-on behavior as new `/rite:init` generation. If a user's config already has a `multi_session:` block, it is preserved as a User-customized value (no overwrite — **including an explicit `enabled: false`**). Idempotent: no-op when the active section already exists |
 | **Advanced section** (parallel, metrics, safety, investigate) | **Add as comments** — insert commented-out with default values |
-| **`wiki:` section** | **Step 3/4 は扱わない**。wiki セクションの追加は **Phase 4.1.2 Step 2 (新規生成: template の Advanced 境界より上にある active block が自動コピーされる) および Phase 4.1.3 Step 3.5 / Step 6 item 5 (Upgrade path: 未存在時に active block として append) の専権**。template 側にはコメント形式の `# wiki:` ブロックは存在しない (`#491` で active 位置に移動済み) ため、重複追加経路はない |
+| **`wiki:` section** | **Step 3/4 は扱わない**。wiki セクションの追加は **Phase 4.1.2 Step 2 (新規生成: template の Advanced 境界より上にある active block が自動コピーされる) および Phase 4.1.3 Step 6 item 7 (Upgrade path: 未存在時に active block として append。`current < latest` / `current >= latest` 両経路で実行) の専権**。template 側にはコメント形式の `# wiki:` ブロックは存在しない (`#491` で active 位置に移動済み) ため、重複追加経路はない |
 | **Unknown key** (user-added keys not in template) | **Preserve with warning** — keep but display warning |
 
 **Unknown key 判定の scope**: Step 4 の "Unknown key" 判定 (user-added keys not in template) は、**template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。境界より下 (コメント形式の Advanced sections + 末尾コメント) は template 側で意図的に省略または注記のため存在する領域であり、ユーザー設定の classification 対象外。
@@ -371,7 +357,7 @@ Compare current config against the template and classify each key:
 
 **When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it (the same guard as the top-level list, one level down).
 
-**Step 5: Preview and confirm**
+**Step 5: Preview and confirm** (`current < latest` 経路のみ — `current >= latest` 短絡経路は Step 5 を挟まず Step 6 で欠落 drift を冪等に back-add する)
 
 Display the changes to the user:
 
@@ -399,7 +385,9 @@ Ask with `AskUserQuestion`:
 
 **Step 6: Apply changes**
 
-If the user confirms:
+**Path-dependent application**: On the `current < latest` path, apply all items below after the user confirms in Step 5. On the `current >= latest` short-circuit path (Step 5 skipped), apply **only items 3, 4, 6, 7** — the drift back-add (missing active sections / missing sub-keys / multi_session / wiki) — directly without confirmation. Items 1, 2, 5 (schema_version bump / deprecated-key removal / Advanced-section comments) are full-upgrade-only and are skipped on the short-circuit path (schema is already current, so item 1 would be a no-op anyway). Every back-add item (3, 4, 6, 7) is idempotent and preserves User-customized values (including an explicit `enabled: false`), so the short-circuit path applies unattended; when no item finds anything missing, the config is left unchanged and `rite-config.yml は最新です (v{current})` is displayed.
+
+Apply the following:
 
 1. Update `schema_version` to latest value
 2. Remove deprecated keys using the Edit tool. Display "廃止キーを削除しました: {keys}".

--- a/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+++ b/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
@@ -143,12 +143,16 @@ echo "=== T-13 (Issue #1459): current >= latest short-circuit path runs drift ba
 # runtime, not by a fixture here; these static assertions guard that init.md keeps
 # the corrected routing so the short-circuit path cannot silently regress.
 
-# Positive: the short-circuit row drives Step 4 Identify -> Step 6 Apply in order,
-# and still backs up first (AC-6 precondition preserved).
-assert_grep "init.md 'current >= latest' row runs Step 4 Identify then Step 6 Apply" \
-  "$INIT_MD" 'current >= latest.*Step 4 Identify.*Step 6 Apply'
-assert_grep "init.md 'current >= latest' row keeps the Step 3 Backup precondition" \
-  "$INIT_MD" 'current >= latest.*Step 3 Backup'
+# Positive: the short-circuit row backs up FIRST, then routes Step 4 Identify -> Step 6
+# Apply, asserted as one ordered pattern so it doubles as the AC-6 Backup-precondition
+# guard AND the routing guard. Ordering matters: a regression that restores the old
+# "Step 3 Backup -> Step 3.5 Wiki Append -> skip Step 4-6" routing fails this assertion
+# because Step 4 Identify / Step 6 Apply are absent from that row. (A bare
+# 'current >= latest.*Step 3 Backup' would pass even on the buggy old row, since Backup
+# was always present on the short-circuit row — anchoring Backup *before* Step 4/6 is
+# what gives the assertion its regression-detecting power.)
+assert_grep "init.md 'current >= latest' row backs up first, then routes Step 4 Identify -> Step 6 Apply (AC-6 precondition + routing order)" \
+  "$INIT_MD" 'current >= latest.*Step 3 Backup.*Step 4 Identify.*Step 6 Apply'
 # Step 6 spells out which items the short-circuit path applies (the drift back-add set).
 assert_grep "init.md Step 6 applies only the drift back-add items on the short-circuit path" \
   "$INIT_MD" 'short-circuit path.*only items 3, 4, 6, 7'

--- a/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
+++ b/plugins/rite/hooks/tests/init-upgrade-drift.test.sh
@@ -24,6 +24,12 @@
 #        to an existing template section that init.md fails to list fails this
 #        test, forcing init.md to be updated so `--upgrade` does not silently
 #        miss it (mirrors the sub-key merge rule, init.md Step 6 item 4).
+#   T-13 (Issue #1459): the `--upgrade` `current >= latest` short-circuit path is
+#        routed through Step 4 Identify -> Step 6 Apply (drift back-add) instead of
+#        skipping Step 4-6, and the Wiki-only Step 3.5 block is folded into Step 6
+#        item 7. Static guards on init.md's branching table + Step 6 wording; the
+#        back-add behavior itself runs in the LLM procedure (init.md), not a fixture,
+#        so these assert the corrected routing cannot silently regress.
 #
 # Usage: bash plugins/rite/hooks/tests/init-upgrade-drift.test.sh
 set -euo pipefail
@@ -125,6 +131,33 @@ else
     fi
   done
 fi
+
+echo "=== T-13 (Issue #1459): current >= latest short-circuit path runs drift back-add ==="
+
+# Issue #1459: the `current >= latest` short-circuit path previously ran only
+# "Step 3 Backup -> Step 3.5 Wiki Append -> Step 7" and skipped Step 4-6, so
+# multi_session / new active sections / missing sub-keys were silently omitted.
+# The fix routes the short-circuit path through Step 4 Identify -> Step 6 Apply
+# (drift back-add) and folds the Wiki-only Step 3.5 into Step 6 item 7. init.md is
+# an LLM procedure doc, so the back-add behavior itself is exercised by the LLM at
+# runtime, not by a fixture here; these static assertions guard that init.md keeps
+# the corrected routing so the short-circuit path cannot silently regress.
+
+# Positive: the short-circuit row drives Step 4 Identify -> Step 6 Apply in order,
+# and still backs up first (AC-6 precondition preserved).
+assert_grep "init.md 'current >= latest' row runs Step 4 Identify then Step 6 Apply" \
+  "$INIT_MD" 'current >= latest.*Step 4 Identify.*Step 6 Apply'
+assert_grep "init.md 'current >= latest' row keeps the Step 3 Backup precondition" \
+  "$INIT_MD" 'current >= latest.*Step 3 Backup'
+# Step 6 spells out which items the short-circuit path applies (the drift back-add set).
+assert_grep "init.md Step 6 applies only the drift back-add items on the short-circuit path" \
+  "$INIT_MD" 'short-circuit path.*only items 3, 4, 6, 7'
+
+# Negative: the old skip wording and the folded-away Wiki-only Step 3.5 block are gone.
+assert_not_grep "init.md no longer says the short-circuit path skips Step 4-6" \
+  "$INIT_MD" 'Step 4-6 はスキップ'
+assert_not_grep "init.md no longer carries the Wiki-only 'Step 3.5: Wiki Section Append' block" \
+  "$INIT_MD" 'Step 3\.5: Wiki Section Append'
 
 # --- Summary ---
 if ! print_summary "init-upgrade-drift" \


### PR DESCRIPTION
## Summary

`/rite:init --upgrade` の `current >= latest` 短絡経路が Step 4-6 をスキップし、`multi_session`・新規 active セクション・欠落サブキーの back-add を silent に取りこぼしていた問題を修正。短絡経路を Step 4 Identify → Step 6 Apply 経由の drift back-add に変更し、Wiki 専用救済の Step 3.5 を Step 6 item 7 に吸収して drift anchor SoT に一貫化（方針A）。

## Related Issue

Closes #1459

## Changes

- `init.md` Phase 4.1.3 Step 2 分岐テーブル: `current >= latest` 行を「Step 3 Backup → Step 4 Identify(drift のみ) → Step 6 Apply(multi_session/新規セクション/欠落サブキー/Wiki の back-add、preview なし・冪等・User-customized 保全) → Step 7」へ変更
- Wiki 専用救済の Step 3.5 を Step 6 item 7 に吸収して廃止（短絡経路でも Step 6 を通るため一本化）
- Step 6 に path-dependent application を明記（短絡経路は items 3,4,6,7 のみ適用、items 1,2,5 は full-upgrade 専用）
- `init-upgrade-drift.test.sh` に T-13 を追加（短絡経路 routing の静的検証 5 アサーション）

## 設計判断（実装時に決定したオープンクエスチョン）

- **方針A 採用**: 短絡経路に drift back-add を追加。`current < latest` 経路は一切触らず非退行を保証。方針B（短絡撤廃で常に Step 4-6）は `current < latest` 経路も統合経路に巻き込み非退行リスクが高いため不採用。
- **テスト形態（前提崩壊の表面化）**: Issue の Test Spec（T-01〜T-08 = fixture 挙動テスト）は `init.md` が LLM 手順書であり back-add の実体が LLM の Edit 操作のため、シェル fixture では構造的に実装不可。既存 `init-upgrade-drift.test.sh` と同じ静的 drift テストパターンで短絡経路の routing を検証する方針に変更（坂口さん確認済み）。

## Acceptance Criteria 対応

- AC-1〜AC-5（multi_session/新規セクション/欠落サブキー back-add・冪等 no-op）: 短絡経路を Step 6 経由に変更し、各 item の既存冪等 guard で担保
- AC-6（Backup precondition 維持）: 分岐テーブル両経路とも Step 3 Backup 先行を明記、T-13 で静的検証
- AC-7（`current < latest` 非退行）: 当該経路は無変更

## Checklist

- [x] Code follows project conventions
- [x] Tests pass（init-upgrade-drift T-13 含む全 hooks テスト 72/72 green）
- [x] Documentation updated（`init.md` = 仕様ドキュメント自体が変更対象）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
