### PR TITLE
test: stale 化した flow_state.schema_version test fixture/ラベルを中立 marker 化 (#1462)

### DIFF
--- a/plugins/rite/hooks/tests/atomic-write.test.sh
+++ b/plugins/rite/hooks/tests/atomic-write.test.sh
@@ -23,7 +23,6 @@
 #   TC-3: Mutation test — sandbox に hook をコピー、create mode の `mv` を `false` に改変、
 #         改変版を実行後 (a) exit code 非 0 (b) state file が baseline のまま を verify
 #         (mutation 検出 → test の identification power、Wiki 経験則「Test pin protection theater」)
-#   TC-4: per-session と legacy 両 schema で atomic invariant 成立
 #   TC-5: 連続 SIGKILL 後の最終 state file が完全な JSON object (key 数 ≥ 5) を保持
 #
 # Out of scope:
@@ -84,25 +83,17 @@ pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  ❌ FAIL: $1"; }
 
 make_test_dir() {
-  local schema="${1:-2}"
   local d
   d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
   cleanup_dirs+=("$d")
-  cat > "$d/rite-config.yml" <<EOF
-flow_state:
-  schema_version: $schema
-EOF
+  printf '# rite test sandbox config\n' > "$d/rite-config.yml"
   echo "$d"
 }
 
 # Per-session state file path lookup
 state_path() {
-  local d="$1" sid="$2" schema="${3:-2}"
-  if [ "$schema" = "2" ]; then
-    echo "$d/.rite/sessions/${sid}.flow-state"
-  else
-    echo "$d/.rite-flow-state"
-  fi
+  local d="$1" sid="$2"
+  echo "$d/.rite/sessions/${sid}.flow-state"
 }
 
 # state file integrity predicate: ENOENT は許容、存在時は jq parse 成功必須
@@ -125,7 +116,7 @@ echo ""
 # (c) mid_or_temp + post >= 1 を assert して race が実際に当たったことを実証
 # (旧実装は全 100 iter pre のみで PASS する false positive 経路があった)
 echo "TC-1: 50 iter SIGKILL probe → integral + race window 実証"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="aaaaaaaa-9999-9999-9999-999999999999"
 ITERATIONS=50
 flake_partial=0
@@ -144,7 +135,7 @@ for i in $(seq 1 "$ITERATIONS"); do
   kill -KILL "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
 
-  state_file=$(state_path "$TD" "$SID" 2)
+  state_file=$(state_path "$TD" "$SID")
   outcome=$(classify_outcome "$state_file")
   case "$outcome" in
     pre)         pre_count=$((pre_count + 1)) ;;
@@ -174,9 +165,9 @@ fi
 # still produce the expected final state. This guards against "atomic
 # property holds because nothing ever wrote" false-positive.
 echo "TC-2: 連続 patch 50 回 (no kill) → 最終 phase が完了 patch と一致"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="bbbbbbbb-9999-9999-9999-999999999999"
-state_file=$(state_path "$TD" "$SID" 2)
+state_file=$(state_path "$TD" "$SID")
 
 (cd "$TD" && bash "$HOOK" set --session "$SID" \
   --phase "phase_init" --issue 684 --branch "feat/test" --pr 0 --next "init" >/dev/null 2>&1)
@@ -219,9 +210,9 @@ fi
 # trap の cleanup 経路と独立に mutation を検出できる。
 # -------------------------------------------------------------------------
 echo "TC-5: SIGKILL'd writes 後の state file が完全 JSON object を保持"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="eeeeeeee-9999-9999-9999-999999999999"
-state_file=$(state_path "$TD" "$SID" 2)
+state_file=$(state_path "$TD" "$SID")
 
 # Make a clean baseline with full keys
 (cd "$TD" && bash "$HOOK" set --session "$SID" \

--- a/plugins/rite/hooks/tests/cleanup-on-session-end.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-on-session-end.test.sh
@@ -68,10 +68,7 @@ make_test_dir() {
   local d
   d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
   cleanup_dirs+=("$d")
-  cat > "$d/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+  printf '# rite test sandbox config\n' > "$d/rite-config.yml"
   echo "$d"
 }
 

--- a/plugins/rite/hooks/tests/concurrent-sessions.test.sh
+++ b/plugins/rite/hooks/tests/concurrent-sessions.test.sh
@@ -8,7 +8,7 @@
 #   - T-LOCAL-1  : flake-free 100 連続実行 (concurrent create)
 #
 # Issue #672 の core value proposition (lock 不要で並行性が構造的に保証される) を
-# verify する CRITICAL path。マルチステート (per-session file, schema_version=2)
+# verify する CRITICAL path。マルチステート (per-session file)
 # の上でのみ pass する設計。
 #
 # Out of scope (#684 で扱う):
@@ -42,12 +42,9 @@ make_test_dir() {
 }
 
 write_config() {
-  # $1=test_dir, $2=schema_version
-  local d="$1" sv="$2"
-  cat > "$d/rite-config.yml" << EOF
-flow_state:
-  schema_version: $sv
-EOF
+  # $1=test_dir
+  local d="$1"
+  printf '# rite test sandbox config\n' > "$d/rite-config.yml"
 }
 
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
@@ -74,7 +71,7 @@ echo ""
 # --------------------------------------------------------------------------
 echo "TC-1: sequential interleave (independent per-session files)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_A="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa01"
 SID_B="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb01"
 
@@ -115,7 +112,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-2: concurrent create (parallel subshells with wait)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_C="cccccccc-cccc-cccc-cccc-cccccccccc01"
 SID_D="dddddddd-dddd-dddd-dddd-dddddddddd01"
 
@@ -155,7 +152,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-3: concurrent patch (cross-session isolation)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_E="eeeeeeee-eeee-eeee-eeee-eeeeeeeeee01"
 SID_F="ffffffff-ffff-ffff-ffff-ffffffffff01"
 
@@ -203,7 +200,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-4: same-issue concurrent (両 session が同 Issue でも state は分離)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_G="11111111-1111-1111-1111-111111111101"
 SID_H="22222222-2222-2222-2222-222222222201"
 
@@ -244,7 +241,7 @@ echo "T-LOCAL-1: 100 iteration flake-free check (concurrent create)"
 ITERATIONS=100
 flake=0
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 
 # Each iteration uses fresh session UUIDs to avoid file reuse interference.
 for i in $(seq 1 "$ITERATIONS"); do

--- a/plugins/rite/hooks/tests/crash-resume.test.sh
+++ b/plugins/rite/hooks/tests/crash-resume.test.sh
@@ -6,8 +6,7 @@
 #   `mktemp ${FLOW_STATE}.XXXXXX` → 書込 → `mv` の atomic write pattern を採るため、
 #   write 中に SIGKILL されても state file 本体は (a) 直前の整合状態を保持するか
 #   (b) ENOENT のいずれかであり、partial-write は構造的に不在となる。本テストは
-#   その invariant を per-session file (schema_version=2) と legacy (schema_version=1)
-#   両経路で empirical 検証する。
+#   その invariant を per-session file 経路で empirical 検証する。
 #
 # Test cases:
 #   TC-1: write 中 SIGKILL → state file 整合 (jq parse 成功 or ENOENT)、partial-write 不在
@@ -15,7 +14,6 @@
 #         phase / issue_number / branch) が読み出せる
 #   TC-3: per-session file 構造で session A SIGKILL 中に session B が独立に create 可能
 #         (兄弟 session blast radius なし)
-#   TC-4: legacy mode (schema_version=1) でも crash resume invariant が成立
 #   TC-5: stale tempfile (`${FLOW_STATE}.XXXXXX`) は filesystem に残るが、state file 本体
 #         には流入しない (atomic property の structural guarantee)
 #
@@ -82,25 +80,17 @@ pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  ❌ FAIL: $1"; }
 
 make_test_dir() {
-  local schema="${1:-2}"
   local d
   d=$(mktemp -d) || { echo "ERROR: mktemp -d failed" >&2; return 1; }
   cleanup_dirs+=("$d")
-  cat > "$d/rite-config.yml" <<EOF
-flow_state:
-  schema_version: $schema
-EOF
+  printf '# rite test sandbox config\n' > "$d/rite-config.yml"
   echo "$d"
 }
 
-# Look up the state file path for a given (test_dir, session_id, schema).
+# Look up the state file path for a given (test_dir, session_id).
 state_path() {
-  local d="$1" sid="$2" schema="${3:-2}"
-  if [ "$schema" = "2" ]; then
-    echo "$d/.rite/sessions/${sid}.flow-state"
-  else
-    echo "$d/.rite-flow-state"
-  fi
+  local d="$1" sid="$2"
+  echo "$d/.rite/sessions/${sid}.flow-state"
 }
 
 # Detect partial-write artefacts in the state directory. Atomic property
@@ -137,7 +127,7 @@ echo ""
 # wait iter を 1 回追加し、jq empty が dead code でないことも mechanical に
 # 通す。
 echo "TC-1: write 中 SIGKILL → state file 整合 (atomic invariant + race window 実証)"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="aabbccdd-eeff-0011-2233-445566778899"
 ITERATIONS=50
 flake_partial=0
@@ -156,7 +146,7 @@ for i in $(seq 1 "$ITERATIONS"); do
   kill -KILL "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
 
-  state_file=$(state_path "$TD" "$SID" 2)
+  state_file=$(state_path "$TD" "$SID")
   outcome=$(classify_outcome "$state_file")
   case "$outcome" in
     pre)         pre_count=$((pre_count + 1)) ;;
@@ -185,7 +175,7 @@ fi
 # (旧実装のコメント line 105-107 で謳いつつ未実装だった意図を実装化)
 (cd "$TD" && bash "$HOOK" set --session "$SID" \
   --phase "phase_final" --issue 684 --branch "feat/final" --pr 0 --next "nfinal" >/dev/null 2>&1)
-state_file=$(state_path "$TD" "$SID" 2)
+state_file=$(state_path "$TD" "$SID")
 if [ -f "$state_file" ] && jq empty "$state_file" 2>/dev/null; then
   pass "TC-1.3: kill しない iter で state file integral (jq empty 経路を mechanical に通過)"
 else
@@ -196,9 +186,9 @@ fi
 # TC-2: active=true state を pre-place → resume 用 fields が読み出せる
 # -------------------------------------------------------------------------
 echo "TC-2: pre-placed active state → resume fields readable"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="11223344-5566-7788-99aa-bbccddeeff00"
-state_file=$(state_path "$TD" "$SID" 2)
+state_file=$(state_path "$TD" "$SID")
 
 # flow-state.sh resolves session_id from `.rite-session-id` when no --session is
 # passed. Pre-place the file so a fresh process can locate the per-session state.
@@ -231,7 +221,7 @@ fi
 # TC-3: per-session file → session A SIGKILL 中に session B 独立 create 可能
 # -------------------------------------------------------------------------
 echo "TC-3: session A SIGKILL → session B 独立 create (兄弟 blast radius なし)"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID_A="aaaa1111-2222-3333-4444-555566667777"
 SID_B="bbbb1111-2222-3333-4444-555566667777"
 
@@ -251,7 +241,7 @@ b_rc=0
 (cd "$TD" && bash "$HOOK" set --session "$SID_B" \
   --phase "phaseB" --issue 684 --branch "fb" --pr 0 --next "nb" >/dev/null 2>&1) || b_rc=$?
 
-state_b=$(state_path "$TD" "$SID_B" 2)
+state_b=$(state_path "$TD" "$SID_B")
 if [ "$b_rc" -eq 0 ] && [ -f "$state_b" ] && [ "$(jq -r '.phase' "$state_b")" = "phaseB" ]; then
   pass "TC-3.1: session B create succeeded after session A SIGKILL"
 else
@@ -259,7 +249,7 @@ else
 fi
 
 # Verify session A's file (if it exists) is integral — partial-write guard
-state_a=$(state_path "$TD" "$SID_A" 2)
+state_a=$(state_path "$TD" "$SID_A")
 if state_file_is_integral "$state_a"; then
   pass "TC-3.2: session A state file is integral (jq parse ok or ENOENT)"
 else
@@ -267,12 +257,12 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# TC-4: legacy mode (schema_version=1) でも crash resume invariant 成立
+# TC-5: stale tempfile residue does not corrupt state file
 # -------------------------------------------------------------------------
 echo "TC-5: stale tempfile residue does not corrupt state file"
-TD=$(make_test_dir 2)
+TD=$(make_test_dir)
 SID="cccc1111-2222-3333-4444-555566667777"
-state_file=$(state_path "$TD" "$SID" 2)
+state_file=$(state_path "$TD" "$SID")
 
 # First, create a baseline state
 (cd "$TD" && bash "$HOOK" set --session "$SID" \

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -182,17 +182,14 @@ fi
 
 # --- TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true + recovering → recovery output ---
 # Verifies post-compact reads & writes the per-session file (not legacy) when
-# schema_version=2 + valid SID + per-session file exists, and that the
+# a valid SID + per-session file exists, and that the
 # `.active=true` precondition path still triggers recovery.
 echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session + recovering → auto-recovery from per-session file"
 TC_DIR=$(setup_test "tc680a")
 sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
 mkdir -p "$TC_DIR/.rite/sessions"
 echo "$sid680a" > "$TC_DIR/.rite-session-id"
-cat > "$TC_DIR/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$TC_DIR/rite-config.yml"
 per_session_file="$TC_DIR/.rite/sessions/${sid680a}.flow-state"
 jq -n '{active: true, issue_number: 680, phase: "phase5_review", next_action: "review", loop_count: 0, pr_number: 0, branch: "refactor/issue-680-test", session_id: "'"$sid680a"'"}' > "$per_session_file"
 cs680a="$(compact_state_path "$TC_DIR" "$sid680a")"
@@ -218,10 +215,7 @@ TC_DIR=$(setup_test "tc680b")
 sid680b="22222222-3333-4444-5555-666666666666"
 mkdir -p "$TC_DIR/.rite/sessions"
 echo "$sid680b" > "$TC_DIR/.rite-session-id"
-cat > "$TC_DIR/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$TC_DIR/rite-config.yml"
 jq -n '{active: false, issue_number: 681}' > "$TC_DIR/.rite/sessions/${sid680b}.flow-state"
 cs680b="$(compact_state_path "$TC_DIR" "$sid680b")"
 jq -n '{compact_state: "recovering"}' > "$cs680b"

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -230,17 +230,14 @@ fi
 echo ""
 
 # --- TC-POST-WM-PER-SESSION-1: per-session state file (Issue #681) → phase diff detection works ---
-# Verifies flow-state.sh integration: when schema_version=2 with a valid SID
+# Verifies flow-state.sh integration: when a valid SID
 # and a per-session file exists, the hook reads from `.rite/sessions/<sid>.flow-state`
 # (not the legacy `.rite-flow-state`). Phase diff detection must still work end-to-end.
 echo "TC-POST-WM-PER-SESSION-1: per-session state file → phase diff detected"
 dir_ps="$TEST_DIR/tc_per_session"
 mkdir -p "$dir_ps/.rite-work-memory" "$dir_ps/.rite/sessions"
 echo "existing wm" > "$dir_ps/.rite-work-memory/issue-42.md"
-cat > "$dir_ps/rite-config.yml" <<'CFG_EOF'
-flow_state:
-  schema_version: 2
-CFG_EOF
+printf '# rite test sandbox config\n' > "$dir_ps/rite-config.yml"
 sid_ps="00000000-0000-4000-8000-000000000042"
 printf '%s' "$sid_ps" > "$dir_ps/.rite-session-id"
 cat > "$dir_ps/.rite/sessions/${sid_ps}.flow-state" <<STATE_EOF
@@ -255,12 +252,12 @@ cat > "$dir_ps/.rite/sessions/${sid_ps}.flow-state" <<STATE_EOF
 }
 STATE_EOF
 # Intentionally do NOT create the legacy `.rite-flow-state` — the resolver must
-# pick the per-session path when schema_version=2 + valid SID + per-session file exists.
+# pick the per-session path when a valid SID + per-session file exists.
 export RITE_DEBUG=1
 run_hook "$dir_ps" || true
 unset RITE_DEBUG
 if [ -f "$dir_ps/.rite-flow-debug.log" ] && grep -q "phase changed:" "$dir_ps/.rite-flow-debug.log" 2>/dev/null; then
-  pass "Phase change detected via per-session state file (schema 2)"
+  pass "Phase change detected via per-session state file"
 else
   fail "Phase change not detected when reading from per-session state file"
 fi
@@ -271,10 +268,7 @@ echo "TC-POST-WM-PER-SESSION-2: per-session state → last_synced_phase atomic w
 dir_ps2="$TEST_DIR/tc_per_session_2"
 mkdir -p "$dir_ps2/.rite-work-memory" "$dir_ps2/.rite/sessions"
 echo "existing wm" > "$dir_ps2/.rite-work-memory/issue-42.md"
-cat > "$dir_ps2/rite-config.yml" <<'CFG_EOF'
-flow_state:
-  schema_version: 2
-CFG_EOF
+printf '# rite test sandbox config\n' > "$dir_ps2/rite-config.yml"
 sid_ps2="00000000-0000-4000-8000-000000000043"
 printf '%s' "$sid_ps2" > "$dir_ps2/.rite-session-id"
 ps2_state="$dir_ps2/.rite/sessions/${sid_ps2}.flow-state"

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -607,17 +607,14 @@ echo ""
 
 # --- TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → updated_at touched ---
 # Verifies pre-compact reads & writes the per-session file (not legacy) when
-# schema_version=2 + valid SID + per-session file exists. Also confirms the
+# a valid SID + per-session file exists. Also confirms the
 # `.active=true` precondition path still fires the workflow-active branch.
 echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → updated_at touched"
 dir680a="$TEST_DIR/tc680a"
 mkdir -p "$dir680a/.rite/sessions"
 sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
 echo "$sid680a" > "$dir680a/.rite-session-id"
-cat > "$dir680a/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$dir680a/rite-config.yml"
 per_session_file="$dir680a/.rite/sessions/${sid680a}.flow-state"
 echo '{"active": true, "phase": "phase5_review", "issue_number": 680, "branch": "refactor/issue-680-test", "updated_at": "2020-01-01T00:00:00+00:00"}' \
   > "$per_session_file"

--- a/plugins/rite/hooks/tests/same-issue-conflict.test.sh
+++ b/plugins/rite/hooks/tests/same-issue-conflict.test.sh
@@ -2,7 +2,7 @@
 # Tests for same-issue concurrent target — Issue #672 / #684 (T-05 / AC-5)
 #
 # Contract (Option C, decided in #684 Phase 3):
-#   schema_version=2 (per-session file) では「両 session が同一 issue_number を
+#   per-session file では「両 session が同一 issue_number を
 #   target にしても、それぞれ独立した per-session file (`.rite/sessions/{sid}.flow-state`)
 #   に書き込まれるため両方成功する」を **明示的 contract として固定** する。
 #
@@ -11,9 +11,9 @@
 #   明示的競合エラー reject」は別 Issue で tracking する (本 PR scope 外)。
 #
 # Test cases:
-#   TC-1: schema=2 sequential 同 issue 2 session create → 両方成功 + 独立 file (Option C)
-#   TC-2: schema=2 concurrent 同 issue 2 session create → 両方成功 (race-free)
-#   TC-3: schema=2 同 issue patch → 各 session 独立に更新 (no field leak)
+#   TC-1: sequential 同 issue 2 session create → 両方成功 + 独立 file (Option C)
+#   TC-2: concurrent 同 issue 2 session create → 両方成功 (race-free)
+#   TC-3: 同 issue patch → 各 session 独立に更新 (no field leak)
 #   TC-6: contract sentence regression guard — 本ファイル冒頭の Option C 文言を pin
 #
 # Removed (PR 2a refactor, v3 SoT):
@@ -71,9 +71,9 @@ echo "=== same-issue-conflict tests (Issue #672 / #684 T-05 AC-5, Option C) ==="
 echo ""
 
 # -------------------------------------------------------------------------
-# TC-1: schema=2 sequential 同 issue 2 session create → 両方成功
+# TC-1: sequential 同 issue 2 session create → 両方成功
 # -------------------------------------------------------------------------
-echo "TC-1: schema=2 sequential 同 issue 2 session → 両方成功 + 独立 file (Option C)"
+echo "TC-1: sequential 同 issue 2 session → 両方成功 + 独立 file (Option C)"
 TD=$(make_test_dir)
 ISSUE=684
 SID_A="aaaaaaaa-1111-2222-3333-444455556601"
@@ -106,7 +106,7 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# TC-2: schema=2 concurrent 同 issue 2 session create → 両方成功
+# TC-2: concurrent 同 issue 2 session create → 両方成功
 # -------------------------------------------------------------------------
 # F-06 fix (Issue #760): barrier sync で起動 jitter を排除し true concurrent 化。
 # 旧実装は単純な `cmd & cmd &` で両 process を background 起動していたが、
@@ -117,7 +117,7 @@ fi
 # canonical 防御: barrier file (`$TD/.barrier-tc2`) を pre-create し、各 child は
 # `while [ -f barrier ]; do sleep 0.001; done` で busy-wait → parent が rm barrier
 # して同時 release。これで両 child が ms 単位で同時起動することを保証する。
-echo "TC-2: schema=2 concurrent 同 issue 2 session create → race-free 両方成功"
+echo "TC-2: concurrent 同 issue 2 session create → race-free 両方成功"
 TD=$(make_test_dir)
 SID_C="cccccccc-1111-2222-3333-444455556601"
 SID_D="dddddddd-1111-2222-3333-444455556601"
@@ -160,9 +160,9 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# TC-3: schema=2 同 issue patch → 各 session 独立に更新 (no field leak)
+# TC-3: 同 issue patch → 各 session 独立に更新 (no field leak)
 # -------------------------------------------------------------------------
-echo "TC-3: schema=2 同 issue patch → 独立更新 (no cross-session leak)"
+echo "TC-3: 同 issue patch → 独立更新 (no cross-session leak)"
 TD=$(make_test_dir)
 SID_E="eeeeeeee-1111-2222-3333-444455556601"
 SID_F="ffffffff-1111-2222-3333-444455556601"

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -427,10 +427,7 @@ dir680a="$TEST_DIR/tc680a"
 mkdir -p "$dir680a/.rite/sessions"
 sid680a="abcdef01-2345-6789-abcd-ef0123456789"
 echo "$sid680a" > "$dir680a/.rite-session-id"
-cat > "$dir680a/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$dir680a/rite-config.yml"
 per_session_file="$dir680a/.rite/sessions/${sid680a}.flow-state"
 echo '{"active": true, "phase": "phase5_review", "issue_number": 680, "branch": "refactor/issue-680-test"}' > "$per_session_file"
 run_hook "$dir680a" >/dev/null || true
@@ -466,10 +463,7 @@ dir680c="$TEST_DIR/tc680c"
 mkdir -p "$dir680c/.rite/sessions"
 sid680c="11111111-2222-3333-4444-555555555555"
 echo "$sid680c" > "$dir680c/.rite-session-id"
-cat > "$dir680c/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$dir680c/rite-config.yml"
 echo '{"active": true, "phase": "create_interview", "issue_number": 682, "branch": "feat/issue-682"}' \
   > "$dir680c/.rite/sessions/${sid680c}.flow-state"
 run_hook "$dir680c" >/dev/null || true

--- a/plugins/rite/hooks/tests/session-id-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/session-id-mismatch.test.sh
@@ -2,7 +2,7 @@
 # Tests for session_id mismatch hook no-op — Issue #672 / #684 (T-04 / AC-4)
 #
 # Purpose:
-#   schema_version=2 (per-session file) では `_resolve-flow-state-path.sh` が
+#   per-session file では `_resolve-flow-state-path.sh` が
 #   resolver を経由する caller には現セッションの per-session path のみを返すため
 #   ownership は構造的に保証される。しかし将来 resolver を経由しない caller が
 #   foreign per-session file を直接渡した場合のために `check_session_ownership`
@@ -210,10 +210,7 @@ mkdir -p "$TD/.rite/sessions"
 SID_OWN="abcdef01-2345-6789-abcd-ef0123456789"
 SID_HOOK_FOREIGN="00000000-0000-0000-0000-deadbeef0001"
 echo "$SID_OWN" > "$TD/.rite-session-id"
-cat > "$TD/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$TD/rite-config.yml"
 state_file="$TD/.rite/sessions/${SID_OWN}.flow-state"
 echo "{\"active\":true,\"phase\":\"phase5_test\",\"session_id\":\"$SID_OWN\"}" > "$state_file"
 

--- a/plugins/rite/hooks/tests/session-ownership-regression.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership-regression.test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Session Ownership 系列 (#173 / #206 / #216 / #558 / #660) regression on
-# multi-state format (per-session file, schema_version=2).
+# multi-state format (per-session file).
 #
 # Issue #683 / parent #672 AC-7 を verify する。
 # 過去 5 件の Issue で導入した防御層が、新形式上でも構造的に成立することを mechanical に確認する。
@@ -50,11 +50,8 @@ make_test_dir() {
 }
 
 write_config() {
-  local d="$1" sv="$2"
-  cat > "$d/rite-config.yml" << EOF
-flow_state:
-  schema_version: $sv
-EOF
+  local d="$1"
+  printf '# rite test sandbox config\n' > "$d/rite-config.yml"
 }
 
 write_session_id() {
@@ -85,7 +82,7 @@ echo ""
 # --------------------------------------------------------------------------
 echo "TC-173 (Per-session isolation): 2 session が異なる per-session file に独立書き込み"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_A="11111111-1111-1111-1111-111111111111"
 SID_B="22222222-2222-2222-2222-222222222222"
 
@@ -118,7 +115,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-216 (.rite-session-id auto-read):"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_AUTO="33333333-3333-3333-3333-333333333333"
 write_session_id "$TD" "$SID_AUTO"
 
@@ -151,7 +148,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-206 + TC-558 (SOURCE=startup reset semantics):"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_OWN="55555555-5555-5555-5555-555555555555"
 write_session_id "$TD" "$SID_OWN"
 
@@ -183,7 +180,7 @@ fi
 # AC-02: 他 session の state は reset しない
 echo "TC-558 AC-02: 他 session の per-session state は reset されない"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_ME="77777777-7777-7777-7777-777777777777"
 SID_OTHER="88888888-8888-8888-8888-888888888888"
 write_session_id "$TD" "$SID_ME"
@@ -217,7 +214,7 @@ fi
 # AC-03: SOURCE=clear でも同様
 echo "TC-206 AC-2 (SOURCE=clear reset)"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_CLEAR="99999999-9999-9999-9999-999999999999"
 write_session_id "$TD" "$SID_CLEAR"
 (cd "$TD" && bash "$HOOK" set --session "$SID_CLEAR" \
@@ -246,7 +243,7 @@ fi
 # --------------------------------------------------------------------------
 echo "TC-660 (active=true gate, AND-logic):"
 TD=$(make_test_dir); cleanup_dirs+=("$TD")
-write_config "$TD" 2
+write_config "$TD"
 SID_GATE="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 write_session_id "$TD" "$SID_GATE"
 

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -856,7 +856,7 @@ echo ""
 # --------------------------------------------------------------------------
 # TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → "Active rite workflow detected"
 # Verifies that session-start reads the per-session file (not legacy) when
-# schema_version=2 + valid SID + per-session file exists, and that the
+# a valid SID + per-session file exists, and that the
 # `.active=true` precondition still fires the workflow-detected output.
 # --------------------------------------------------------------------------
 echo "TC-680-A (Issue #680, AC-LOCAL-2): per-session active=true → workflow detected"
@@ -864,10 +864,7 @@ dir680a="$TEST_DIR/tc680a"
 mkdir -p "$dir680a/.rite/sessions"
 sid680a="aaaabbbb-cccc-dddd-eeee-ffffaaaa1111"
 echo "$sid680a" > "$dir680a/.rite-session-id"
-cat > "$dir680a/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$dir680a/rite-config.yml"
 ts_t680a=$(iso8601_now 0)
 cat > "$dir680a/.rite/sessions/${sid680a}.flow-state" <<EOF
 {"active": true, "issue_number": 680, "branch": "refactor/issue-680-test", "phase": "phase5_review", "next_action": "review", "loop_count": 0, "session_id": "$sid680a", "updated_at": "$ts_t680a"}
@@ -891,10 +888,7 @@ dir680b="$TEST_DIR/tc680b"
 mkdir -p "$dir680b/.rite/sessions"
 sid680b="22222222-3333-4444-5555-666666666666"
 echo "$sid680b" > "$dir680b/.rite-session-id"
-cat > "$dir680b/rite-config.yml" <<EOF
-flow_state:
-  schema_version: 2
-EOF
+printf '# rite test sandbox config\n' > "$dir680b/rite-config.yml"
 ts_t680b=$(iso8601_now 0)
 cat > "$dir680b/.rite/sessions/${sid680b}.flow-state" <<EOF
 {"active": false, "issue_number": 681, "branch": "refactor/issue-681-test", "phase": "completed", "session_id": "$sid680b", "updated_at": "$ts_t680b"}

--- a/plugins/rite/hooks/tests/work-memory-update.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-update.test.sh
@@ -3,9 +3,9 @@
 #
 # Covers Issue #687 acceptance criteria from caller perspective:
 #   AC-4 — caller (work-memory-update.sh) integrates with flow-state.sh transparently:
-#          (TC-1) schema_version=2 + per-session file present + legacy absent + WM_REQUIRE_FLOW_STATE=true
+#          (TC-1) per-session file present + legacy absent + WM_REQUIRE_FLOW_STATE=true
 #                 → return 0 with WM updated (cycle 12 false negative regression guard)
-#          (TC-2) schema_version=2 + both files absent + WM_REQUIRE_FLOW_STATE=true
+#          (TC-2) both files absent + WM_REQUIRE_FLOW_STATE=true
 #                 → return 1 (skip, no WM written)
 #          (TC-3) WM_READ_FROM_FLOW_STATE=true + per-session file with pr_number=100/loop_count=3
 #                 → generated WM frontmatter contains pr_number: 100 / loop_count: 3
@@ -118,10 +118,10 @@ run_update() {
     'source "$WM_PLUGIN_ROOT/hooks/work-memory-update.sh" && update_local_work_memory')
 }
 
-# --- TC-1: schema_version=2 + per-session present + legacy absent + WM_REQUIRE_FLOW_STATE=true ---
+# --- TC-1: per-session present + legacy absent + WM_REQUIRE_FLOW_STATE=true ---
 # cycle 12 fix の core invariant: WM_REQUIRE_FLOW_STATE check が legacy file 直接 [ -f ] check ではなく
 # flow-state.sh 経由になったので per-session のみで skip しない
-echo "TC-1: schema_v=2 + per-session present + legacy absent + WM_REQUIRE_FLOW_STATE=true → return 0 (cycle 12 false negative regression guard)"
+echo "TC-1: per-session present + legacy absent + WM_REQUIRE_FLOW_STATE=true → return 0 (cycle 12 false negative regression guard)"
 SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config "$SBX"
 SID="11111111-1111-1111-1111-111111111111"
@@ -157,8 +157,8 @@ assert_eq "TC-1.1: return 0 (per-session resolved via flow-state.sh, branch pars
 assert_eq "TC-1.2: WM file created via branch parsing (issue-${EXPECTED_ISSUE_NUM}.md)" "yes" \
   "$([ -f "$SBX/.rite-work-memory/issue-${EXPECTED_ISSUE_NUM}.md" ] && echo yes || echo no)"
 
-# --- TC-2: schema_version=2 + both files absent + WM_REQUIRE_FLOW_STATE=true ---
-echo "TC-2: schema_v=2 + per-session/legacy 両不在 + WM_REQUIRE_FLOW_STATE=true → return 1 (skip)"
+# --- TC-2: both files absent + WM_REQUIRE_FLOW_STATE=true ---
+echo "TC-2: per-session/legacy 両不在 + WM_REQUIRE_FLOW_STATE=true → return 1 (skip)"
 SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config "$SBX"
 write_session_id "$SBX" "22222222-2222-2222-2222-222222222222"
@@ -177,7 +177,7 @@ assert_eq "TC-2.2: WM file NOT created" "no" \
   "$([ -f "$SBX/.rite-work-memory/issue-687.md" ] && echo yes || echo no)"
 
 # --- TC-3: WM_READ_FROM_FLOW_STATE=true + per-session has pr_number/loop_count ---
-echo "TC-3: schema_v=2 + per-session pr_number=100 loop_count=3 + WM_READ_FROM_FLOW_STATE=true → frontmatter 反映 (cycle 10 stale residue regression guard)"
+echo "TC-3: per-session pr_number=100 loop_count=3 + WM_READ_FROM_FLOW_STATE=true → frontmatter 反映 (cycle 10 stale residue regression guard)"
 SBX=$(make_sandbox --branch fix/issue-687-test); cleanup_dirs+=("$SBX")
 write_config "$SBX"
 SID="33333333-3333-3333-3333-333333333333"


### PR DESCRIPTION
## 概要

PR #1460 (#1458 の per-session 一本化) で dead key 化された `flow_state.schema_version` config キーを書き続けていた test fixture と、vestigial な `schema=2` / `schema_v=2` ラベル/コメントを中立化し、test 記述を self-consistent にした。

Closes #1462

## 変更内容

### config fixture の中立化
`cat > rite-config.yml <<EOF / flow_state:\n  schema_version: N / EOF` を `printf '# rite test sandbox config\n' > rite-config.yml`（PR #1460 が same-issue-conflict / work-memory-update に施した方針）に統一:

- `session-id-mismatch`, `post-compact`, `pre-compact`, `post-tool-wm-sync`, `session-end`, `session-start`(vestigial 箇所のみ), `cleanup-on-session-end`
- helper の `$schema`/`$sv` パラメータと dead な legacy 分岐を撤去: `atomic-write`, `crash-resume`, `concurrent-sessions`, `session-ownership-regression`
  - `make_test_dir` / `write_config` / `state_path` が引数なしで per-session を返すよう簡素化（全 caller は元々 `2` のみを渡しており legacy 分岐は到達不能だった）

### stale ラベル/コメントの除去
- `same-issue-conflict` / `work-memory-update`: TC echo ラベルの `schema=2` / `schema_v=2` トークン除去
- 隣接コメントの「schema_version=2 selection」前提の記述を per-session 前提に修正

## 保持した正当な参照（中立化しなかったもの）

- **`session-start.test.sh` TC-DEP-1..4**: `flow_state.schema_version: 1` deprecation warning を検証する正当なテスト（`flow_state.schema_version` が SUT 入力）。Issue は session-start.test.sh を一括対象に列挙していたが、TC-DEP を壊さないよう除外した。
- flow-state **ファイル**版数 `"schema_version": 2/3`（migration テストの fixture 内容、concept A）
- review-result schema version `"1.x.0"`（`scope-enum-check` / `review-helpers-gate-behavior`、無関係）
- `schema_version=1` を含む removed-test の履歴説明コメント

## 検証

- 全 hook テストスイート: **72/72 passed, 0 failed**（`run-tests.sh`）
- 残存 vestigial トークン・schema 引数付き helper 呼び出しが 0 であることを grep で確認（TC-DEP の正当な参照を除く）

## 関連
- 元の PR: #1460 / 親 Issue: #1458
