### PR TITLE
docs(hooks): 存在しない _resolve-flow-state-path.sh 参照を flow-state.sh path に一括更新 (#1463)

### DIFF
--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -33,7 +33,7 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "post-compact" \
   "resolve-flow-state-err" \
-  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
+  "flow-state.sh path の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 # SIGINT before the explicit rm below leaves `$_resolve_err` orphaned in /tmp;
 # clean up on any exit signal so the path never leaks even if the script aborts
 # mid-resolve.

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -41,7 +41,7 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "pre-compact" \
   "resolve-flow-state-err" \
-  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
+  "flow-state.sh path の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 # Single-pass branch (filter runs once regardless of resolver exit status).
 _resolve_failed=0
 FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1

--- a/plugins/rite/hooks/session-end.sh
+++ b/plugins/rite/hooks/session-end.sh
@@ -40,7 +40,7 @@ STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_RO
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "session-end" \
   "resolve-flow-state-err" \
-  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
+  "flow-state.sh path の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 # Single-pass branch (filter runs once regardless of resolver exit status).
 _resolve_failed=0
 STATE_FILE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>"${_resolve_err:-/dev/null}") || _resolve_failed=1

--- a/plugins/rite/hooks/session-ownership.sh
+++ b/plugins/rite/hooks/session-ownership.sh
@@ -17,14 +17,14 @@
 #
 # Role transition: With schema_version=2 (per-session files),
 # session ownership is structurally guaranteed by the session_id encoded in
-# the filename — the resolver (`_resolve-flow-state-path.sh`) only returns
+# the filename — the resolver (`flow-state.sh path`) only returns
 # a per-session path that matches the current session. `check_session_ownership`
 # therefore uses a fast-path "own" classification when the path matches the
 # `*/.rite/sessions/*.flow-state` pattern, falling through to the legacy
 # 4-state classification only for `<root>/.rite-flow-state` (schema 1).
 # `is_per_session_state_file` exposes the same predicate to callers that want
 # to short-circuit ownership checks (e.g., when reading a path that has just
-# been resolved by `_resolve-flow-state-path.sh`).
+# been resolved by `flow-state.sh path`).
 
 # shellcheck source=control-char-neutralize.sh
 source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
@@ -90,7 +90,7 @@ get_state_session_id() {
 # Exit code: 0 or 1 (boolean — usable in `if is_per_session_state_file ...`)
 #
 # Why this exists: With schema_version=2 the resolver
-# (`_resolve-flow-state-path.sh`) only returns a per-session path whose session_id
+# (`flow-state.sh path`) only returns a per-session path whose session_id
 # segment matches the current session, so the file is structurally owned by
 # this session and the 4-state legacy classification is unnecessary. Callers
 # that already hold a resolver output can use this predicate to short-circuit

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -364,18 +364,18 @@ fi
 # - chmod 600 / TMPDIR 尊重を helper 経由で取得
 # - filter は flow-state.sh の cross-session guard pass-through (3-pattern:
 #   `^WARNING:|^  |^jq: `) を `^ERROR:` で superset 化した 4-pattern 拡張版。
-#   `_resolve-flow-state-path.sh` は `_validate-helpers.sh` / `_validate-state-root.sh`
+#   `flow-state.sh path` は `_validate-helpers.sh` / `_validate-state-root.sh`
 #   経由で `ERROR:` 行を emit する (resolver self-validation contract) ため、
 #   reader-side filter より広い範囲を要求する。indented continuation 行と
 #   raw `jq:` parse error は flow-state.sh と同じく pass-through する
-# - success arm でも tempfile を inspect する (`_resolve-flow-state-path.sh`
+# - success arm でも tempfile を inspect する (`flow-state.sh path`
 #   が graceful-degrade で exit 0 を返す経路、例えば `_resolve-session-id-from-file.sh`
 #   の tr IO failure による empty SID + WARNING 出力 + exit 0 経路で
 #   inner helper の WARNING を silent drop しないため)
 _resolve_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
   "session-start" \
   "resolve-flow-state-err" \
-  "_resolve-flow-state-path.sh の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
+  "flow-state.sh path の WARNING/ERROR / jq parse error / indented 補助行が pass-through されません")
 # Single-pass branch: capture resolver outcome, then run filter once regardless
 # of success/failure (helper may graceful-degrade exit 0 with WARNING in stderr,
 # e.g., empty SID via tr IO failure — both paths require pass-through).

--- a/plugins/rite/hooks/tests/session-id-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/session-id-mismatch.test.sh
@@ -2,7 +2,7 @@
 # Tests for session_id mismatch hook no-op — Issue #672 / #684 (T-04 / AC-4)
 #
 # Purpose:
-#   per-session file では `_resolve-flow-state-path.sh` が
+#   per-session file では `flow-state.sh path` が
 #   resolver を経由する caller には現セッションの per-session path のみを返すため
 #   ownership は構造的に保証される。しかし将来 resolver を経由しない caller が
 #   foreign per-session file を直接渡した場合のために `check_session_ownership`


### PR DESCRIPTION
## 概要

PR #1460 (#1458 の per-session 一本化) 後も複数 hook に残存していた、存在しないファイル `_resolve-flow-state-path.sh` への stale な参照（診断文字列・コメント）を、実体である `flow-state.sh path`（`cmd_path`）に一括更新した。

Closes #1463

## 変更内容（`_resolve-flow-state-path.sh` → `flow-state.sh path`）

- **stderr-guard descriptor 文字列**（`_mktemp-stderr-guard.sh` の第3引数）: `post-compact.sh`, `pre-compact.sh`, `session-start.sh`, `session-end.sh`
- **resolver 説明コメント**: `session-start.sh`（self-validation contract / success-arm inspect）, `session-ownership.sh`（Role transition / is_per_session_state_file コメント 3 箇所）
- **test purpose コメント**: `session-id-mismatch.test.sh`（「grep で全件洗い出し」方針で検出した同種の stale dead-file 参照。production hook と同じ修正クラスのため self-consistency 完遂のため含めた）

## 検証

- 全ツリー（`plugins/` + `docs/`）で `_resolve-flow-state-path` 残存 **0 件** を grep で確認
- 全 hook テストスイート: **72/72 passed, 0 failed**（`run-tests.sh`）
- 変更は診断文字列・コメントのみ（実行ロジック非変更）。descriptor 文字列は mktemp 失敗時 WARNING のテキストにのみ影響し、テスト assertion には不使用

## 関連
- 元の PR: #1460 / 親 Issue: #1458
