### PR TITLE
docs(init): --upgrade 短絡経路の drift back-add 挙動変更に SPEC.md / getting-started.md を追従 (#1464)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -524,9 +524,8 @@ followed by AskUserQuestion confirmation)
  Copy the existing file to `rite-config.yml.bak.YYYYMMDD-HHMMSS` for rollback.
 3. **Branching**
  - `current < latest`: Run Step 4–6 (identify changes → preview → apply after approval), then Step 7 (Phase 4.7 Wiki initialization).
- - `current == latest` and `wiki:` section absent: After backup, append the `wiki:` block from the template and run Phase 4.7.
- - `current == latest` and `wiki:` section present: No-op; display "configuration is up to date" and run Phase 4.7 (idempotent — no-op if Wiki is already initialized).
-4. **Identify and classify changes** (Step 4, only on the `current < latest` path)
+ - `current >= latest`: Run Step 4 (identify drift only) → Step 6 (back-add any missing `multi_session` section, newly added active top-level sections, missing sub-keys, and the `wiki:` section — preserving all user-customized values, idempotent, applied without a preview/confirmation prompt), then Step 7. The schema is already current, but the template can gain active sections/sub-keys without a schema bump; this path follows that drift. When nothing is missing, the config is left unchanged and "configuration is up to date (v{current})" is displayed; Phase 4.7 still runs (idempotent — no-op if Wiki is already initialized).
+4. **Identify and classify changes** (Step 4, runs on both paths; on the `current >= latest` short-circuit path only the drift back-add items — missing `multi_session` / active sections / sub-keys / `wiki:` — are identified)
  Each key is classified as one of:
  - **User-customized value** (preserve): `project_number`, `owner`, `iteration` settings, `branch.base`, `language`, etc.
  - **Deprecated key** (remove): `project.name`, `commit.style`, `commit.enforce`, `branch.release`, `branch.types`, `version`
@@ -536,14 +535,14 @@ followed by AskUserQuestion confirmation)
 5. **Preview and confirm** (Step 5)
  Display deprecated keys to be removed, sections to be added, and preserved existing settings; ask via `AskUserQuestion` to either apply or cancel.
 6. **Apply** (Step 6)
- On approval, update `schema_version` to the latest value, remove deprecated keys, add missing sections (including commented-out Advanced sections), and append the `wiki:` section if it was absent. All user-customized values are preserved.
+ On the `current < latest` path, after approval, update `schema_version` to the latest value, remove deprecated keys, add missing sections (including commented-out Advanced sections), and append the `wiki:` section if it was absent. On the `current >= latest` short-circuit path (no preview), apply only the idempotent drift back-add items — missing `multi_session` / active sections / sub-keys / `wiki:` — without confirmation. All user-customized values (including an explicit `enabled: false`) are preserved on both paths.
 7. **Run Phase 4.7 (Wiki initialization)** (Step 7)
  Invoke Phase 4.7 to bring existing users up to the Wiki-initialized state. If Wiki is already initialized, the phase is an idempotent no-op. Phase 4.7 is non-blocking: its failure does not affect `--upgrade` success. A final Wiki status line is displayed before the command exits.
 
 **Relationship with `schema_version`:**
 
 - The `schema_version` key at the top of `rite-config.yml` is an integer that identifies the configuration schema version (e.g., `schema_version: 2`). It is incremented whenever the rite workflow introduces a backward-incompatible schema change.
-- `--upgrade` compares the `schema_version` in the current file against the one in the bundled template and runs the Phase 4.1.3 flow above when the current file is behind.
+- `--upgrade` compares the `schema_version` in the current file against the one in the bundled template. When the current file is behind it runs the full Step 4–6 flow (preview + confirm); when the schema is already current it still runs the `current >= latest` short-circuit to back-add any active-section / sub-key / `multi_session` / `wiki:` drift the template introduced without a schema bump.
 - Configuration files without a `schema_version` key are implicitly treated as v1 and can be brought up to date via `--upgrade`.
 
 **Relationship with Phase 5 (new-install completion report):**

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -502,7 +502,7 @@ followed by AskUserQuestion confirmation)
 
 #### --upgrade Option (Existing Configuration Schema Upgrade)
 
-**Purpose:** Bring an existing project's `rite-config.yml` up to the latest schema while preserving user-customized values (`project_number`, `owner`, `branch.base`, `language`, and so on). The upgrade applies the additions (new sections), removals (deprecated keys), and `schema_version` bump in a single confirmed batch.
+**Purpose:** Bring an existing project's `rite-config.yml` up to the latest schema while preserving user-customized values (`project_number`, `owner`, `branch.base`, `language`, and so on). On the schema-upgrade path (`current < latest`) the upgrade applies the additions (new sections), removals (deprecated keys), and `schema_version` bump in a single confirmed batch; when the schema is already current (`current >= latest`) it instead back-adds any missing active-section / sub-key / `multi_session` / `wiki:` drift without a confirmation prompt (see Phase 4.1.3 below).
 
 **When to use:**
 
@@ -524,7 +524,7 @@ followed by AskUserQuestion confirmation)
  Copy the existing file to `rite-config.yml.bak.YYYYMMDD-HHMMSS` for rollback.
 3. **Branching**
  - `current < latest`: Run Step 4–6 (identify changes → preview → apply after approval), then Step 7 (Phase 4.7 Wiki initialization).
- - `current >= latest`: Run Step 4 (identify drift only) → Step 6 (back-add any missing `multi_session` section, newly added active top-level sections, missing sub-keys, and the `wiki:` section — preserving all user-customized values, idempotent, applied without a preview/confirmation prompt), then Step 7. The schema is already current, but the template can gain active sections/sub-keys without a schema bump; this path follows that drift. When nothing is missing, the config is left unchanged and "configuration is up to date (v{current})" is displayed; Phase 4.7 still runs (idempotent — no-op if Wiki is already initialized).
+ - `current >= latest`: Run Step 4 (identify drift only) → Step 6 (back-add any missing `multi_session` section, newly added active top-level sections, missing sub-keys, and the `wiki:` section — preserving all user-customized values, idempotent, applied without a preview/confirmation prompt), then Step 7. The schema is already current, but the template can gain active sections/sub-keys without a schema bump; this path follows that drift. When nothing is missing, the config is left unchanged and "configuration is up to date" is displayed; Phase 4.7 still runs (idempotent — no-op if Wiki is already initialized).
 4. **Identify and classify changes** (Step 4, runs on both paths; on the `current >= latest` short-circuit path only the drift back-add items — missing `multi_session` / active sections / sub-keys / `wiki:` — are identified)
  Each key is classified as one of:
  - **User-customized value** (preserve): `project_number`, `owner`, `iteration` settings, `branch.base`, `language`, etc.

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -206,9 +206,8 @@ missing drift (all active sections, their sub-keys, and the `multi_session` /
 `wiki:` sections are already present) and Wiki is already initialized, the
 command makes no changes to `rite-config.yml` itself — it still creates a
 timestamped backup, reports "configuration is up to date", then runs the Wiki
-auto-initialization
-idempotency check of `/rite:init` and displays a final Wiki status line
-before exiting.
+auto-initialization idempotency check of `/rite:init` and displays a final
+Wiki status line before exiting.
 
 Check if `rite-config.yml` exists:
 

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -180,12 +180,14 @@ What `/rite:init --upgrade` does:
   ✓ Shows a preview of changes: deprecated keys to remove, new sections to
     add (including commented-out Advanced sections), and values that will be
     preserved (e.g., `project_number`, `owner`, `branch.base`, `language`)
-  ✓ Asks for confirmation via AskUserQuestion before applying any schema
-    changes (this single apply/cancel prompt also gates the wiki-section
-    append below when both are pending, though the `wiki:` section may not
-    be itemized separately in the preview list; when the schema is already
-    up to date and only the `wiki:` section happens to be missing, the
-    append is applied without an additional prompt)
+  ✓ Asks for confirmation via AskUserQuestion before applying schema changes
+    on the upgrade path (deprecated-key removal, `schema_version` bump, new
+    sections); this single apply/cancel prompt also gates the drift back-add
+    items below when a schema upgrade is pending. When the schema is already
+    up to date, the short-circuit path back-adds any missing drift — the
+    `multi_session` / `wiki:` sections, newly added active sections, and
+    missing sub-keys — idempotently and without an additional prompt (the
+    preview/confirm step is shown only on the schema-upgrade path)
   ✓ Appends the `wiki:` section if it is absent, so the Wiki
     auto-initialization step of `/rite:init` can run for existing projects
   ✓ Back-adds the `multi_session:` section with `enabled: true` if it is
@@ -199,10 +201,12 @@ What `/rite:init --upgrade` does:
   ✓ Updates `schema_version` to the latest value on success
 
 The upgrade is non-destructive: user-customized values are preserved, and a
-backup is created before any edits are made. If your configuration is already
-up to date and Wiki is already initialized, the command makes no changes to
-`rite-config.yml` itself — it still creates a timestamped backup, reports
-"configuration is up to date", then runs the Wiki auto-initialization
+backup is created before any edits are made. If your configuration has no
+missing drift (all active sections, their sub-keys, and the `multi_session` /
+`wiki:` sections are already present) and Wiki is already initialized, the
+command makes no changes to `rite-config.yml` itself — it still creates a
+timestamped backup, reports "configuration is up to date", then runs the Wiki
+auto-initialization
 idempotency check of `/rite:init` and displays a final Wiki status line
 before exiting.
 


### PR DESCRIPTION
## 概要

`/rite:init --upgrade` の `current >= latest` 短絡経路の挙動変更（#1459 / PR #1461）に伴い、旧挙動（wiki セクションだけを救済する短絡経路）のまま残っていたユーザー向けドキュメントを新挙動に追従させた。

Closes #1464

## 背景

#1459 / PR #1461 で短絡経路が「Step 3 Backup → Step 3.5 Wiki Append → Step 7（Step 4-6 スキップ）」から「Step 3 Backup → Step 4 Identify → Step 6 Apply（multi_session / 新規 active セクション / 欠落サブキー / Wiki を冪等に back-add、無確認）→ Step 7」へ変更された。`init.md`（実装 SoT）は更新済みだが、以下の doc が旧「wiki だけ救済」前提のまま残っていた。

## 変更内容

### docs/SPEC.md Phase 4.1.3 Behavior 節
- **Branching (Step 3)**: 旧 `current == latest` + wiki 有無による 2 分岐（wiki 単独 append / no-op）を、`current >= latest` の一般 drift back-add（multi_session / 新規 active セクション / 欠落サブキー / wiki を無確認・冪等に back-add、drift 皆無時のみ no-op）に更新
- **Step 4 framing**: 「only on the `current < latest` path」→ 両経路で実行（短絡経路は drift back-add 項目のみ identify）
- **Step 6 Apply**: 短絡経路が preview なしで drift 項目のみ適用することを明記
- **schema_version 節**: 「when the current file is behind」→ schema 同等でも短絡経路で drift 追従することを明記

### plugins/rite/commands/getting-started.md
- no-confirmation 短絡を「wiki セクションだけが欠落しているとき」と狭く枠付けていた記述を、一般 drift back-add（multi_session / wiki / active セクション / 欠落サブキー）に拡張
- no-op 条件を「configuration is already up to date」から「missing drift なし（全 active セクション・サブキー・multi_session・wiki が存在）」に精緻化

## 検証

- `init.md`（実装 SoT、Step 3-6 の Branching / Path-dependent application）と doc 記述の整合を確認
- bang-backtick check: **0 findings**（getting-started.md 含む 93 ファイル）
- 全 hook テストスイート: **72/72 passed**（doc-only 変更のため tests 非影響だが回帰確認）

## 関連
- 元の PR: #1461 / 元の Issue: #1459
