### PR TITLE
docs(spec): SPEC.md の Deprecated key 一覧に commit.contextual を追加し init.md と一致させる

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -528,7 +528,7 @@ followed by AskUserQuestion confirmation)
 4. **Identify and classify changes** (Step 4, runs on both paths; on the `current >= latest` short-circuit path only the drift back-add items — missing `multi_session` / active sections / sub-keys / `wiki:` — are identified)
  Each key is classified as one of:
  - **User-customized value** (preserve): `project_number`, `owner`, `iteration` settings, `branch.base`, `language`, etc.
- - **Deprecated key** (remove): `project.name`, `commit.style`, `commit.enforce`, `branch.release`, `branch.types`, `version`
+ - **Deprecated key** (remove): `project.name`, `commit.style`, `commit.enforce`, `commit.contextual`, `branch.release`, `branch.types`, `version`
  - **Missing section** (add with template defaults): `review.debate`, `review.fact_check`, `verification`, etc.
  - **Advanced section** (add as commented-out block): `parallel`, `metrics`, `safety`, `investigate`
  - **Unknown key** (preserve with warning): user-added keys not present in the template


### PR DESCRIPTION
## 概要

`docs/SPEC.md:531` の `--upgrade` Deprecated key 一覧に `commit.contextual` が欠落しており、実装 SoT である `plugins/rite/commands/init.md:332/451` と乖離していた。`commit.enforce` の後に `commit.contextual` を追加し、init.md と完全一致させる doc-only 修正。

Closes #1468

## 変更内容

- `docs/SPEC.md:531` の Deprecated key 一覧に `commit.contextual` を追加

## 検証

- SPEC.md:531 と init.md:332 のキー集合が完全一致することを確認（`project.name, commit.style, commit.enforce, commit.contextual, branch.release, branch.types, version`）
- doc-only のため lint 対象コマンドなし

## 関連

- 検出元 PR: #1467 / 元 Issue: #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
