### PR TITLE
docs: SPEC.md のスクリプト一覧に number-reference-check.sh (Phase 3.19) を追記 (refs #1487)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -240,6 +240,7 @@ rite-workflow/
 │ │ ├── distributed-fix-drift-check.sh / doc-heavy-patterns-drift-check.sh
 │ │ ├── gitignore-health-check.sh
 │ │ ├── projects-board-drift-check.sh # lint Phase 3.18 CLOSED+COMPLETED board≠Done 検出
+│ │ ├── number-reference-check.sh # lint Phase 3.19 Issue/PR 番号参照 (#NNN) 検出 (CHANGELOG + lint.md)
 │ │ ├── lib/ # 共有ライブラリ (wiki-config.sh / worktree-git.sh)
 │ │ └── tests/ # hooks/scripts レベルのテストスイート
 │ └── tests/ # Hook-level test suite (shell-based)
@@ -1344,6 +1345,7 @@ Non-hook helper scripts invoked either directly from orchestrator commands or by
 | `doc-heavy-patterns-drift-check.sh` | Detect Doc-Heavy PR Mode drift signals | — |
 | `gitignore-health-check.sh` | Verify the `.rite/wiki/` last-line-of-defense `.gitignore` rule, emit `gitignore_drift` sentinel on mismatch | — |
 | `projects-board-drift-check.sh` | `/rite:lint` Phase 3.18 — detect CLOSED+COMPLETED Issues whose Projects board Status is not `Done` (NOT_PLANNED excluded), optionally reconcile via `--reconcile` | — |
+| `number-reference-check.sh` | `/rite:lint` Phase 3.19 — detect Issue/PR number references (`#NNN` / `Issue #NNN` / `PR #NNN`) that crept back into the number-free documentation surface (`CHANGELOG.md` / `CHANGELOG.ja.md` / `lint.md`) | — |
 | `wiki-branch-init.sh` | `/rite:wiki:init` ステップ 3.1 — orphan wiki ブランチ作成 + push + 元ブランチ復帰 (stash 退避/復帰、same_branch 両対応) | — |
 | `wiki-lint-skipped-refs.sh` | `/rite:wiki:lint` ステップ 6.0 — log.md の `ingest:skip` 集合を marker block + `log_read_ok` 4 値 enum で構築 (6.2 `wiki-lint-source-refs.sh` と対称) | — |
 | `wiki-lint-source-refs.sh` | `/rite:wiki:lint` ステップ 6.2 — Wiki ページの Sources 行から `all_source_refs` 集合を構築 (6.0 `wiki-lint-skipped-refs.sh` と対称) | — |


### PR DESCRIPTION
## 概要

番号参照排除の取り組み（親 #1478）で新設した `plugins/rite/hooks/scripts/number-reference-check.sh` が `docs/SPEC.md` のスクリプト一覧に未記載だったため、Phase 3.19 のエントリを追記する。

Closes #1487

## 変更内容

`docs/SPEC.md` の 2 箇所に `number-reference-check.sh` を追記:
1. hooks/scripts ディレクトリツリー（projects-board-drift-check.sh の次）
2. スクリプト一覧表（projects-board-drift-check.sh 行の次）

いずれも `/rite:lint` Phase 3.19（Issue/PR 番号参照検出、対象: CHANGELOG.md / CHANGELOG.ja.md / lint.md）として、既存の Phase 3.18 エントリと同じ形式で記載。

## 備考

- 日本語版 SPEC は存在しない（`docs/SPEC.md` のみ）ため対象は SPEC.md 1 ファイル。
- 追記した `#NNN` はスクリプトが検出するパターンの literal 例示であり digit 番号参照ではない（`#[0-9]{3,4}` 非該当、SPEC.md の number-free 方針に抵触しない）。
- orphan-reference-check で number-reference-check.sh は orphan 扱いされていないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
