### PR TITLE
chore: ユーザー対面の設定・ドキュメントから暗黙の歴史依存表現を除去 (refs #1496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## ⚠️ Breaking Changes (v0.4.0)
 
-**v0.4.0 — Cycle-count-based review-fix degradation removed**: Three configuration keys (`review.loop.severity_gating_cycle_threshold`, `review.loop.scope_lock_cycle_threshold`, `safety.max_review_fix_loops`) are no longer honored. The review-fix loop now terminates only on 0 findings or when one of four **quality signals** fires (fingerprint cycling / root-cause-missing fix / cross-validation disagreement / reviewer self-degraded). Existing users should remove the three keys from `rite-config.yml`. See [CHANGELOG](CHANGELOG.md#040---2026-04-17) for the migration guide.
+**Cycle-count-based review-fix degradation removed**: Three configuration keys (`review.loop.severity_gating_cycle_threshold`, `review.loop.scope_lock_cycle_threshold`, `safety.max_review_fix_loops`) are no longer honored — remove them from `rite-config.yml` when upgrading. The review-fix loop terminates only on 0 findings (normal exit) or manual abort (`Ctrl+C` → `/rite:resume`). See [CHANGELOG](CHANGELOG.md#040---2026-04-17) for the full migration guide.
 
 ## Why "Rite"?
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -430,8 +430,6 @@ The review-fix loop has two exit paths and no automatic abnormal-exit mechanism:
 | Normal | 0 findings remaining → `[review:mergeable]` |
 | Manual abort | User aborts via `Ctrl+C` → `/rite:resume` (or selects "中止" in `fix.md` AskUserQuestion → `[fix:cancelled-by-user]`) |
 
-> **Note**: Four detection heuristics exist in code on the reviewer side — fingerprint cycling (`commands/issue/references/fingerprint-cycling.md`), root-cause-missing (`fix.md` Phase 3.2.1 commit body gate), cross-validation disagreement (`review.md` Phase 5.2 + debate phase), and reviewer self-degraded (`_reviewer-base.md` Finding Quality Guardrail). They inform reviewer judgment but do not escalate via `AskUserQuestion` or trigger an early loop exit — the loop's only exits are the two above (0 findings / manual abort). The design rationale is "指摘ゼロになるまでループ" with manual abort only (see `commands/pr/iterate.md` 設計判断).
-
 **Fix settings:**
 
 | Field | Type | Default | Description |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,11 +92,9 @@ review:
     verification_mode: false    # Enable verification mode as supplement to full review (default: false)
     allow_new_findings_in_unchanged_code: false  # Block new findings in unchanged code (default: false)
     # Review-fix loop termination
-    # Cycle-count-based degradation (v0.4.0 introduced 4 quality signals as the abnormal-exit
-    # mechanism) was retired along with the entire quality-signal escalation. The current
-    # loop terminates only on (a) 0 findings remaining → [review:mergeable] (normal exit), or
+    # The loop terminates only on (a) 0 findings remaining → [review:mergeable] (normal exit), or
     # (b) manual abort via Ctrl+C → /rite:resume (or fix.md AskUserQuestion "中止" → [fix:cancelled-by-user]).
-    # The keys below remain as config scaffolding for historical compatibility but have no
+    # The keys below remain as config scaffolding but have no
     # runtime effect on loop termination — see commands/pr/iterate.md ループ仕様 and
     # commands/pr/references/fix-relaxation-rules.md "Loop Termination" for the live spec.
     convergence_monitoring: true          # (scaffolding only — see comment above)
@@ -155,8 +153,8 @@ pr_review:
 # Safety settings (fail-closed thresholds)
 safety:
   max_implementation_rounds: 20    # implementation round hard limit per Issue (default: 20)
-  # max_review_fix_loops was removed in v0.4.0; the 4-signal escalation that replaced it
-  # was itself retired. Loop now exits only on 0 findings or manual Ctrl+C / /rite:resume.
+  # The review-fix loop has no iteration-count limit key; it exits only on 0 findings
+  # or manual abort (Ctrl+C / /rite:resume).
   time_budget_minutes: 120         # time budget per Issue in minutes (advisory) (default: 120)
   auto_stop_on_repeated_failure: true   # stop when same failure class repeats (default: true)
   repeated_failure_threshold: 3         # consecutive same-class failure count to trigger stop (default: 3)
@@ -377,7 +375,7 @@ These variables are used in `branch.pattern` to generate new branch names:
 | `M` | Skip XS/S; analyze body at M; show proposal for L and above (default) |
 | `L` | Skip XS-M; analyze body at L; show proposal for XL |
 | `XL` | Skip XS-L; analyze body at XL only (no proposal, as XL is maximum) |
-| `none` | Always show decomposition prompt (legacy behavior) |
+| `none` | Always show decomposition prompt |
 
 **Three-tier judgment logic:**
 
@@ -406,7 +404,7 @@ issue:
 | `criteria` | array | `[file_types, content_analysis]` | Review criteria |
 | `loop.verification_mode` | boolean | `false` | Enable verification mode as supplement to full review. When enabled, reviews after the first cycle perform both full review and verification of previous fixes with incremental diff regression checks |
 | `loop.allow_new_findings_in_unchanged_code` | boolean | `false` | Whether new findings in unchanged code should be blocking. When `false`, new MEDIUM/LOW findings in unchanged code are reported as "stability concerns" (non-blocking) |
-| `loop.convergence_monitoring` | boolean | `true` | **Scaffolding only** — the original fingerprint-based cycling detection (Quality Signal 1) escalated via `AskUserQuestion`, but the entire quality-signal escalation mechanism was retired. The current review-fix loop only exits on 0 findings (normal) or manual abort (Ctrl+C → `/rite:resume`). Setting this key has no runtime effect — see `commands/pr/iterate.md` for the live spec |
+| `loop.convergence_monitoring` | boolean | `true` | **Scaffolding only** — setting this key has no runtime effect. The review-fix loop exits only on 0 findings (normal) or manual abort (Ctrl+C → `/rite:resume`) — see `commands/pr/iterate.md` for the live spec |
 | `loop.auto_propagation_scan` | boolean | `true` | After a fix is applied, automatically scan for similar patterns elsewhere in the codebase to catch propagation gaps |
 | `loop.pre_commit_drift_check` | boolean | `true` | Run `distributed-fix-drift-check` before committing fix changes to catch inconsistent partial applications |
 | `doc_heavy.enabled` | boolean | `true` | Enable Doc-Heavy PR detection. When a PR's diff is dominated by documentation changes, the `tech-writer` reviewer is boosted and verifies five doc-implementation consistency categories via Grep/Read/Glob |
@@ -432,7 +430,7 @@ The review-fix loop has two exit paths and no automatic abnormal-exit mechanism:
 | Normal | 0 findings remaining → `[review:mergeable]` |
 | Manual abort | User aborts via `Ctrl+C` → `/rite:resume` (or selects "中止" in `fix.md` AskUserQuestion → `[fix:cancelled-by-user]`) |
 
-> **Historical note**: v0.4.0 introduced "4 quality signals" as the abnormal-exit mechanism (fingerprint cycling / root-cause missing / cross-validation disagreement / reviewer self-degraded) with an `AskUserQuestion` that offered `本 PR 内で再試行 / 別 Issue として切り出す / PR を取り下げる / 手動レビューへエスカレーション` options. A subsequent release retired this entire mechanism — the design rationale is "指摘ゼロになるまでループ" with manual abort only (see `commands/pr/iterate.md` 設計判断)。 The 4 underlying detection points still exist in code as reviewer-side heuristics: fingerprint cycling (`commands/issue/references/fingerprint-cycling.md`), root-cause-missing (`fix.md` Phase 3.2.1 commit body gate), cross-validation disagreement (`review.md` Phase 5.2 + debate phase), reviewer self-degraded (`_reviewer-base.md` Finding Quality Guardrail) — but they no longer escalate to `AskUserQuestion` or trigger early loop exit.
+> **Note**: Four detection heuristics exist in code on the reviewer side — fingerprint cycling (`commands/issue/references/fingerprint-cycling.md`), root-cause-missing (`fix.md` Phase 3.2.1 commit body gate), cross-validation disagreement (`review.md` Phase 5.2 + debate phase), and reviewer self-degraded (`_reviewer-base.md` Finding Quality Guardrail). They inform reviewer judgment but do not escalate via `AskUserQuestion` or trigger an early loop exit — the loop's only exits are the two above (0 findings / manual abort). The design rationale is "指摘ゼロになるまでループ" with manual abort only (see `commands/pr/iterate.md` 設計判断).
 
 **Fix settings:**
 

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -140,12 +140,14 @@ investigate:
 # Flow state ファイル形式
 # 仕様詳細: docs/designs/multi-session-state.md
 #
-# 本セクションの schema_version は state ファイル形式の世代マーカー。
+# 本セクションの schema_version は非推奨で、state ファイル形式の選択には使われない。
 # ファイル冒頭の top-level `schema_version` (rite-config.yml 自身のスキーマ) とは別系統。
 #
-# 2: per-session ファイル (`.rite/sessions/{session_id}.flow-state`)。並行セッションを first-class サポート（現行の既定）。
-# 1: 非推奨。設定しても無視され、削除を促す deprecation 警告が出る。
-# schema_version が 3 未満／未設定の状態ファイル (`.rite-flow-state` 含む) は session 開始時に現行 schema へ in-place で移行される（別途 backup ファイルは作成しない）。
+# state ファイルの現行スキーマは v3。flow-state は per-session ファイル
+# (`.rite/sessions/{session_id}.flow-state`) で動作し、並行セッションを first-class サポートする。
+# schema_version が 3 未満／未設定の状態ファイル (`.rite-flow-state` 含む) は
+# session 開始時に v3 へ in-place で移行される（別途 backup ファイルは作成しない）。
+# `1` を設定すると無視され、削除を促す deprecation 警告が出る。
 flow_state:
   schema_version: 2
 

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -115,7 +115,7 @@ parallel:
 # 複数の Claude Code セッションが同一リポジトリで別 Issue を並行して進められるようにする。
 # /rite:pr:open がセッション worktree (.rite/worktrees/issue-{N}) を作成し EnterWorktree で入場する。
 # `parallel`（1 セッション内の Issue 別サブエージェント並列）とは直交する別軸のため統合しない。
-# default `enabled: true`（デフォルト ON）。false にすると従来の単一セッション挙動に戻る。
+# default `enabled: true`（デフォルト ON）。false にすると 1 セッション 1 作業ツリーで動作する。
 multi_session:
   enabled: true                    # セッション別 worktree（default ON）。false で無効化
   worktree_base: ".rite/worktrees" # セッション worktree のベース（issue-{N} サブディレクトリ）
@@ -144,8 +144,8 @@ investigate:
 # ファイル冒頭の top-level `schema_version` (rite-config.yml 自身のスキーマ) とは別系統。
 #
 # 2: per-session ファイル (`.rite/sessions/{session_id}.flow-state`)。並行セッションを first-class サポート。
-# 1: legacy 単一ファイル (`.rite-flow-state`)。rollback 用。
-# 旧形式は `.rite-flow-state.legacy.{timestamp}` に backup された上で自動マイグレーションされる。
+# 1: 単一ファイル形式 (`.rite-flow-state`)。rollback 用。
+# schema_version 1 の `.rite-flow-state` を検出すると `.rite-flow-state.legacy.{timestamp}` に backup した上で per-session 形式へ移行する。
 flow_state:
   schema_version: 2
 

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -140,12 +140,12 @@ investigate:
 # Flow state ファイル形式
 # 仕様詳細: docs/designs/multi-session-state.md
 #
-# 本セクションの schema_version は `.rite-flow-state` ファイル形式のみを制御する。
+# 本セクションの schema_version は state ファイル形式の世代マーカー。
 # ファイル冒頭の top-level `schema_version` (rite-config.yml 自身のスキーマ) とは別系統。
 #
-# 2: per-session ファイル (`.rite/sessions/{session_id}.flow-state`)。並行セッションを first-class サポート。
-# 1: 単一ファイル形式 (`.rite-flow-state`)。rollback 用。
-# schema_version 1 の `.rite-flow-state` を検出すると `.rite-flow-state.legacy.{timestamp}` に backup した上で per-session 形式へ移行する。
+# 2: per-session ファイル (`.rite/sessions/{session_id}.flow-state`)。並行セッションを first-class サポート（現行の既定）。
+# 1: 非推奨。設定しても無視され、削除を促す deprecation 警告が出る。
+# schema_version が 3 未満／未設定の状態ファイル (`.rite-flow-state` 含む) は session 開始時に現行 schema へ in-place で移行される（別途 backup ファイルは作成しない）。
 flow_state:
   schema_version: 2
 


### PR DESCRIPTION
## 概要

Issue #1496: ユーザーが最初に読むファイル（`rite-config.yml`・`docs/CONFIGURATION.md`・`README.md`）から、比較基準が新規ユーザーに不明な**暗黙の歴史依存表現**を除去し、現在の挙動を絶対的に述べる表現へ書き換えた。

## 変更内容

### `rite-config.yml`（root）
- multi_session コメント「false にすると**従来の**単一セッション挙動に戻る」→「false にすると **1 セッション 1 作業ツリーで動作する**」
- flow_state コメント「**旧形式は**…自動マイグレーションされる」を現在形化（「schema_version 1 の `.rite-flow-state` を検出すると…per-session 形式へ移行する」）。`legacy 単一ファイル`→`単一ファイル形式`

### `docs/CONFIGURATION.md`
- 撤去済みの「4 quality signals」機構の歴史ナラティブ（`v0.4.0 introduced … was retired` / `Historical note`）を除去し、現在の review-fix ループ挙動を絶対的に記述
- `none` の `(legacy behavior)` 注記を除去
- Historical note を、撤去済み経緯を含まない present-tense Note（現存する reviewer-side heuristics の説明）へ置換

### `README.md`
- Breaking Changes (v0.4.0) 節の陳腐化した「4 quality signals」記述を現在の挙動（0 findings / manual abort）へ修正。**移行情報（3 キー削除）は保持**

## 設計判断（要判断項目）
- **README の v0.4.0 Breaking Changes**: Issue の「保持 or 言い換え」のうち**言い換え保持**を採用。アップグレード移行情報（削除すべき3キー名は明示され基準点が明確）は残しつつ、撤去済み機構の陳腐化記述のみ現在形へ修正。情報損失ゼロ。

## 受入基準
- AC-1: 対象ファイルから比較基準が不明な暗黙の歴史参照が除去された（残存は基準点が明確な移行注記のみ）✅
- AC-2: 新規ユーザーが過去の基準点を知らずに現在の挙動を理解できる ✅
- AC-3: 設定キー・値・スキーマは不変（rite-config.yml はコメント行のみ変更）✅
- T-03 非回帰: `plugins/rite/hooks/tests/` 74/74 緑、変更3ファイルは新規 lint finding 0 ✅

## テスト
- `plugins/rite/hooks/tests/run-tests.sh`: 74/74 passed
- プラグイン固有 lint チェック: 変更3ファイルで新規 finding 0（既存の warning は repo 全体の non-blocking）

Closes #1496

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
