### PR TITLE
chore: コマンド/スキル/エージェントの暗黙の歴史依存表現を除去 (refs #1498)

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -272,8 +272,8 @@ fi
 
 original_args="$ARGUMENTS"
 # sentinel を `null` から `__RITE_UNSET__` に変更
-# (旧実装は `--review-file null` を渡したユーザーが「`null` という名前のファイル」を意図した場合と
-# 衝突する。`__RITE_UNSET__` は legitimate な file path として現実に存在しないため衝突しない)
+# (`null` を sentinel に使うと `--review-file null` を渡したユーザーが「`null` という名前のファイル」を
+# 意図した場合と衝突する。`__RITE_UNSET__` は legitimate な file path として現実に存在しないため衝突しない)
 review_file_path="__RITE_UNSET__"  # explicit set (undefined 参照防止、衝突安全な sentinel)
 remaining_args="$original_args"
 # flag style を別変数に保持してエラーメッセージで区別する
@@ -523,7 +523,7 @@ else
   #   (a) Broad Retrieval が `📜 rite レビュー結果` コメントを発見せず tempfile を作成しなかった
   #       legitimate な経路 (新規 PR / rite:pr:review 未実行 / 既に削除済み等)
   #   (b) Claude が Priority 3 進入時に Broad Retrieval bash block を skip した前提条件違反経路
-  # 旧実装は (b) を検出する guard が無く silent fallthrough に落ちていた。本 [INFO] emit により、
+  # (b) を検出する guard が無いと silent fallthrough に落ちる。本 [INFO] emit により、
   # ステップ 1.2 Broad Retrieval が本当に実行されたかを後から trace できるようにする。
   # 機械的 enforcement (Broad Retrieval 呼出フラグの参照) は複雑で scope 外のため、
   # 最低限 observability を確保する対症療法として [INFO] を stderr に emit する。
@@ -542,14 +542,14 @@ fi
 #
 # findings の description / suggestion 列内に
 # 「### 📄 Raw JSON」リテラル文字列が含まれる場合 (本 PR 自体がまさにそういう文字列を生成する)、
-# 旧実装は finding 内の literal を `### 📄 Raw JSON` 行頭マッチとして誤検出して in_section を
-# 早期に立ててしまい、誤った JSON 抽出を招く。ステップ 6.1.b の Raw JSON section は必ず
+# finding 内の literal を `### 📄 Raw JSON` 行頭マッチとして拾うと in_section を
+# 早期に立て、誤った JSON 抽出を招く。ステップ 6.1.b の Raw JSON section は必ず
 # `---\n\n### 📄 Raw JSON\n\n```json` の構造を持つため、`---` separator の後に出現する
 # **最後** の `### 📄 Raw JSON` のみを採用する。
 #
-# 旧実装は「`---` 後の最初の `### 📄 Raw JSON`」で `in_section` を
-# 立てる構造で、コメントと実装が乖離していた (本 PR の review.md / fix.md 自体が finding 列に
-# `### 📄 Raw JSON` literal を含むため、本来の Raw JSON section より早く誤検出される反例)。
+# 「`---` 後の最初の `### 📄 Raw JSON`」で `in_section` を
+# 立てると、finding 列に `### 📄 Raw JSON` literal を含む場合 (本 PR の review.md / fix.md 自体が
+# 該当) に本来の Raw JSON section より早く誤検出される。
 # 1-pass で末尾の section start を tracking し、END 内で逆方向スキャンして「最後」を確実に採用する。
 # 以下の実装は POSIX awk のみで動作し、tac (GNU coreutils 専用) や 2-pass 読み込みを必要としない。
 raw_json=$(awk '
@@ -578,8 +578,8 @@ if [ "$awk_pr_comment_raw_json_rc" -ne 0 ]; then
   raw_json=""
 fi
 
-# 旧実装は「raw_json なし」「raw_json あるが jq empty 失敗」
-# 「raw_json あるが必須 fields 欠落」の 3 ケースをまとめて else の no-op に流していた。
+# 「raw_json なし」「raw_json あるが jq empty 失敗」
+# 「raw_json あるが必須 fields 欠落」の 3 ケースをまとめて else の no-op に流すと silent regression になる。
 # raw_json="" だけが legitimate な legacy fallthrough であり、それ以外は壊れた新形式 JSON を
 # 検出して WARNING + reason emit してから legacy parser に流すべき (silent regression 防止)。
 if [ -z "$raw_json" ]; then
@@ -734,9 +734,9 @@ else
       fi
 
       # jq exit code を明示捕捉する。
-      # 旧実装は `severity_map_json=$(printf | jq -c ...)` で jq の exit code を一切 check せず、
-      # 失敗時は severity_map_json="" のまま後段に流れ「0 件で正常終了」に見える silent regression
-      # を起こしていた。if-else で exit code を独立 capture し、失敗時は明示 fallthrough する
+      # `severity_map_json=$(printf | jq -c ...)` で jq の exit code を check しないと、
+      # 失敗時に severity_map_json="" のまま後段に流れ「0 件で正常終了」に見える silent regression
+      # になる。if-else で exit code を独立 capture し、失敗時は明示 fallthrough する
       # (legacy Markdown parser に flow を移す — review_source は pr_comment のまま維持)。
       p3_jq_err=$(mktemp /tmp/rite-fix-p3-smap-err-XXXXXX 2>/dev/null) || p3_jq_err=""
       # line nullable sentinel 正規化 (Priority 2 severity_map と同じ処理)
@@ -3089,7 +3089,7 @@ else
       ;;
     *)
       # IO/権限/構文エラー: H-2 で fail-fast から soft failure に統一:
-      # 旧実装は `exit 1` で fix.md 全体を異常終了させる意図だったが、bash の `exit 1` は Bash tool の
+      # `exit 1` は fix.md 全体を異常終了させる意図に見えるが、bash の `exit 1` は Bash tool の
       # exit code に変換されるだけで Claude のフロー制御にはならない (line 1868 に明記)。Claude は次の Phase
       # に進み、ステップ 5.1 が会話履歴で `[CONTEXT] WM_UPDATE_FAILED=1` を検出して `[fix:pushed-wm-stale]` を
       # 出力する。コメント宣言 (`[fix:error]` 相当) と実動作の矛盾を解消するため、soft failure (exit 1 削除)
@@ -3116,15 +3116,14 @@ fi
 # 2. PR 本文で見つからない場合、ブランチ名から抽出
 # 同様に IO error と「マッチなし」を融合させない。
 #
-# 旧実装は
 # `git branch --show-current 2>"$err" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+'`
-# の 3 段 pipeline で、`git branch` の rc を末尾 grep の rc=1 (空入力) が隠蔽する
-# pipefail 罠を持っていた。git branch の終了コードを直接 if-else で捕捉し、
+# の 3 段 pipeline は、`git branch` の rc を末尾 grep の rc=1 (空入力) が隠蔽する
+# pipefail 罠を持つため使わない。git branch の終了コードを直接 if-else で捕捉し、
 # issue 番号抽出は sed -n に移譲する形に分解する。
 # wm_emit_done guard (M-5 対応): pr_body grep IO error 経路で既に retained flag emit 済みの場合、
-# branch fallback を実行せず skip する。旧実装は issue_number="" にするだけで直後の
+# branch fallback を実行せず skip する。issue_number を空にするだけだと直後の
 # `if [[ -z "$issue_number" ]]` が常に true になり、branch grep が誤起動して意図しない
-# 「IO error 経路なのに issue_number が設定される」semantics 破壊を引き起こしていた。
+# 「IO error 経路なのに issue_number が設定される」semantics 破壊を引き起こす。
 if [[ -z "$issue_number" ]] && [ "$wm_emit_done" = "0" ]; then
   branch_grep_err=$(mktemp /tmp/rite-fix-branch-grep-err-XXXXXX) || {
     echo "ERROR: branch_grep_err 一時ファイルの作成に失敗" >&2
@@ -3274,8 +3273,8 @@ wm_reason_of() { printf '%s\n' "$1" | sed -n 's/.*reason=\([a-z_]*\).*/\1/p' | h
 if [ "$git_diff_failed" -eq 0 ]; then
   # helper の stderr (root-cause 診断: auth/rate/network/safety-check 詳細 + backup path) を退避する。
   # review.md ステップ 6.2 (本 4.5 と対称化済みの Update Work Memory Phase) と同じ stderr-capture 規約。
-  # 旧実装は 2>/dev/null で helper stderr を破棄し、WM_UPDATE_FAILED 時に operator が失敗理由を
-  # 追えなかった (status reason カテゴリのみ表示)。mktemp 失敗時は /dev/null に fallback する。
+  # `2>/dev/null` で helper stderr を破棄すると、WM_UPDATE_FAILED 時に operator が失敗理由を
+  # 追えない (status reason カテゴリのみ表示)。mktemp 失敗時は /dev/null に fallback する。
   wm_sync_err=$(mktemp 2>/dev/null) || wm_sync_err=""
   # --- transform 1: 進捗サマリー + 変更ファイル更新 ---
   # {impl_status} / {test_status} / {doc_status} は Claude が git diff 結果から判定して substitute する。

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -193,9 +193,9 @@ if [ "$flag_post" = "true" ] && [ "$flag_no_post" = "true" ]; then
 fi
 
 # --- Step 3: rite-config.yml の pr_review.post_comment 読取 (C-2: SIGPIPE-safe) ---
-# 旧実装は `sed | awk | sed | sed | tr | tr` の 6 段 pipeline で pipefail 下で SIGPIPE
-# rc=141 が発生し、fallback branch が config 値を silent に false へ上書きする latent
-# regression を抱えていた。本実装は **単一 awk 呼び出し** に統合し pipeline を排除する
+# `sed | awk | sed | sed | tr | tr` の 6 段 pipeline は pipefail 下で SIGPIPE
+# rc=141 を起こし、fallback branch が config 値を silent に false へ上書きする latent
+# regression を生む。本実装は **単一 awk 呼び出し** に統合し pipeline を排除する
 # ことで SIGPIPE 経路自体を消す。awk は file を直接読むため上流コマンドが存在しない。
 # Source: GNU bash manual — Pipelines / POSIX awk exit semantics
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root=""
@@ -836,7 +836,7 @@ Determination block の計算が完了した直後 (上記 3 flag を explicit s
 echo "[CONTEXT] doc_heavy_pr=${doc_heavy_pr_value}; doc_heavy_pr_value=${doc_heavy_pr_value}; doc_heavy_pr_decision_summary=${doc_heavy_pr_decision_summary}"
 ```
 
-**理由**: 旧実装では skip 経路 (例: `inconsistent_files_count_between_phase_1_1_and_1_2_7`) のみ `[CONTEXT]` 行を emit し、正常経路は emit しない**非対称設計**だった。後続 phase (ステップ 2.2.1 / 5.1.3 / 5.4) は「`[CONTEXT]` 行が会話履歴に存在しない = 正常」という negative inference に依存していたが、これは Claude の context grep が前 session の `[CONTEXT] doc_heavy_pr=true` を誤拾いするリスクを生む。全経路で対称に emit することで、後続 phase の grep は常に最新の `[CONTEXT]` 行を decisive に拾える。
+**理由**: skip 経路 (例: `inconsistent_files_count_between_phase_1_1_and_1_2_7`) のみ `[CONTEXT]` 行を emit し正常経路は emit しない**非対称設計**だと、後続 phase (ステップ 2.2.1 / 5.1.3 / 5.4) が「`[CONTEXT]` 行が会話履歴に存在しない = 正常」という negative inference に依存するため、Claude の context grep が前 session の `[CONTEXT] doc_heavy_pr=true` を誤拾いするリスクを生む。全経路で対称に emit することで、後続 phase の grep は常に最新の `[CONTEXT]` 行を decisive に拾える。
 
 **Note**: ゼロ除算ガード (`total_diff_lines == 0` および `total_files_count == 0`) は疑似コードブロック内にインラインで配置済みで、両方とも `doc_heavy_pr = false` を **explicit set** してから `skip to ステップ 1.3` する。Skip conditions section の `changedFiles == 0` と併せて、空 PR・分母 0・undefined 参照の三方向を防ぐ多重ガードとなる。ステップ 2.2.1 で `{doc_heavy_pr} == true` を判定する時点で `{doc_heavy_pr}` が必ず boolean として set されていることが保証される。
 
@@ -937,10 +937,10 @@ When the PR is doc-heavy, override reviewer selection to ensure documentation qu
  # diff 全体に fenced code block の追加が含まれるかをスキャン
  # `^+` で始まる行 (追加行) のうち ```{lang} で始まる行を grep
  #
- # 歴史的背景 — pipefail の経緯:
- # 旧実装では `git diff | grep | head` の pipeline を使用しており、`set -o pipefail`
+ # pipefail を維持する理由:
+ # `git diff | grep | head` の pipeline では `set -o pipefail`
  # がないと git diff が exit != 0 で失敗しても後段の grep / head が exit 0 + 空文字列を
- # 返し、silent failure が発生していた。
+ # 返し silent failure になる。
  # 現行実装では pipeline を廃止し、`diff_out=$(git diff ...)` で独立実行 +
  # exit code 明示 check (下記 `if ! diff_out=` 行) → `grep ... <<< "$diff_out"` の here-string 構成に
  # 移行したため、pipefail が直接必要な pipeline は存在しない。ただし将来の pipeline
@@ -1000,10 +1000,6 @@ When the PR is doc-heavy, override reviewer selection to ensure documentation qu
  # subprocess (printf) が存在せず、grep -m 1 の早期終了で SIGPIPE を受ける相手がいない。
  # これにより pipefail 下でも grep の exit 0 (マッチあり) / 1 (なし) / 2 (IO error) を
  # そのまま捕捉できる。
- #
- # (旧実装では「`grep -m 1` に変更すれば下流に SIGPIPE が届かない」と記述していたが、
- # これは pipeline 方向を誤解していた。printf が上流なので SIGPIPE は上流 printf に
- # 届く。)
  grep_out=$(grep -m 1 -E '^\+[[:space:]]*```[a-zA-Z]' <<< "$diff_out")
  grep_rc=$?
  case "$grep_rc" in

--- a/plugins/rite/commands/wiki/init.md
+++ b/plugins/rite/commands/wiki/init.md
@@ -163,8 +163,8 @@ else
 fi
 
 # 2 行に分離して emit する (F-04 対応)。
-# 旧実装は `GITIGNORE_NEGATION_STATE=$state; reason=$reason` の 1 行 emit だったが、
-# bash としてはセミコロンが statement 区切りとなり意味論が混乱する。分離することで、
+# `GITIGNORE_NEGATION_STATE=$state; reason=$reason` の 1 行 emit だと、
+# bash ではセミコロンが statement 区切りとなり意味論が混乱する。分離することで、
 # LLM の marker grep も後述テーブルの列挙も単一 key=value 行として扱える。
 echo "GITIGNORE_NEGATION_STATE=$state"
 echo "GITIGNORE_NEGATION_REASON=$reason"

--- a/plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md
+++ b/plugins/rite/commands/wiki/references/bash-cross-boundary-state-transfer.md
@@ -172,9 +172,9 @@ if log_content=$(git show "${wiki_branch}:.rite/wiki/log.md" 2>"${log_err:-/dev/
  log_read_ok="true"
 else
  # else 分岐冒頭で `rc=$?` を明示 capture する。
- # 旧実装は `rc=$?` を欠落させ、後段の `[ -n "..." ] && [ -s "..." ] && grep -qE ...` で `$?` が
- # grep の rc に上書きされた状態で `echo "...(rc=$rc)..."` が表示され、`rc=` が常に grep の
- # 0/1/2 を表示する silent failure 例になっていた。本 reference は canonical 教材なので、
+ # `rc=$?` を欠落させると、後段の `[ -n "..." ] && [ -s "..." ] && grep -qE ...` で `$?` が
+ # grep の rc に上書きされ、`echo "...(rc=$rc)..."` が表示される際に `rc=` が常に grep の
+ # 0/1/2 を表示する silent failure になる。本 reference は canonical 教材なので、
  # lint.md ステップ 6.0 の委譲先 wiki-lint-skipped-refs.sh (`else rc=$?;` と明示 capture する実装) と一字一句揃える。
  rc=$?
  # 2 primary pattern + 2 safety pattern = 4 pattern 網羅


### PR DESCRIPTION
## 概要

Issue #1498: コマンド/スキル/エージェント定義（`plugins/rite/commands/**`, `skills/**`, `agents/**` の `*.md`、tests 除く）から、比較基準が不明な暗黙の歴史依存表現を除去し現在形へ書き換えた。

## 変更内容（15箇所 / 4ファイル、コメント・散文のみ）

`旧実装は/では X だった` 形式の**経緯ジャーナルコメント**を、技術的根拠（pitfall・why）を現在形で保持しつつ journal framing を除去:
- **`commands/pr/fix.md`**（10箇所）: sentinel 衝突 / Raw JSON 誤検出 / jq exit code / pipefail 罠 / WM stderr 破棄 等の防御コードの根拠を現在形 pitfall 制約文へ
- **`commands/pr/review.md`**（3箇所 + 1除去）: 6段 pipeline SIGPIPE / `[CONTEXT]` 非対称設計 / pipefail 維持理由を現在形へ。自身の旧コメント文を訂正する meta journal（L1004）を除去
- **`commands/wiki/init.md`**（1箇所）: 1行 emit のセミコロン混乱を現在形へ
- **`commands/wiki/references/bash-cross-boundary-state-transfer.md`**（1箇所）: `rc=$?` 欠落の silent failure を現在形へ

実行コード行・手順ロジック・Phase 見出し・プレースホルダは一切不変。

## 設計判断・保持（KEEP）
- プロジェクトの `comment-best-practices` SoT（経緯は git/PR メタデータ、コメントは現在形の制約文＝no_journal_comment 原則）に整合。`comment-journal-check` の P2（`旧実装は/では`）をスコープ内 0 件に解消。
- **KEEP**: `agents/tech-writer-reviewer.md` の no_journal_comment 違反の**悪い例の例示**（変更すると教材が壊れる）、`skills/wiki/SKILL.md` の Issue/PR 番号参照（兄弟 epic #1478 の領域＝#1495 の Out of scope）、migration anchor / 明示的歴史記録（`Status: Retired` / `(formerly step N)` / 基準点が明確な `旧 X`）約 30 件。

## 受入基準
- AC-1: 比較基準が不明な暗黙の歴史参照を現在形へ（正当な技術記述・機能マーカーを除く）✅
- AC-2: 過去の基準点を知らずに手順が読める ✅
- AC-3: `drift-check-ignore`・手順/Phase 見出し・プレースホルダは不変 ✅
- T-04 非回帰: hooks/tests 74/74 緑 ✅

Closes #1498

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
