### PR TITLE
chore: フック/スクリプトの暗黙の歴史依存表現を除去（migration コメントは現在形化） (refs #1499)

### DIFF
--- a/plugins/rite/hooks/_resolve-session-id-from-file.sh
+++ b/plugins/rite/hooks/_resolve-session-id-from-file.sh
@@ -50,10 +50,10 @@ source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # verified-review MEDIUM (silent-failure-hunter):
 # `_resolve-session-id.sh` の存在 check を upfront で実施する。
-# 旧実装 (cycle 39 helper check 追加前) は本ファイル末尾の `_resolve-session-id.sh` invocation
-# (`if validated=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$raw" 2>/dev/null); then ...`) で
-# stderr を suppress していたため、helper missing (rc=127) / permission denied / bash 起動失敗 と
-# validation 失敗 (rc=1) が区別不能 (両方とも「stdout 空文字 + exit 0」で復帰) だった。
+# 本ファイル末尾の `_resolve-session-id.sh` invocation
+# (`if validated=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$raw" 2>/dev/null); then ...`) は
+# stderr を suppress するため、upfront check が無いと helper missing (rc=127) / permission denied /
+# bash 起動失敗 と validation 失敗 (rc=1) が区別不能 (両方とも「stdout 空文字 + exit 0」で復帰) になる。
 # state-read.sh / flow-state-update.sh は upfront で `[ ! -x ]` check を実施しているため、
 # それらの caller 経由では deploy regression が早期に検出されるが、本 helper を直接呼ぶ
 # 新規 caller が出現した場合に同種の silent skip 経路を作る。
@@ -90,19 +90,19 @@ bash "$SCRIPT_DIR/_validate-state-root.sh" "$STATE_ROOT" || exit $?
 sid_file="$STATE_ROOT/.rite-session-id"
 
 # File-absent path: return empty string (legitimate "no session id stored yet").
-# This matches the previous inline behavior `if [ -f ... ]; then ... fi` where
-# the absent branch left `sid=""` untouched.
+# This matches the inline `if [ -f ... ]; then ... fi` contract where the
+# absent branch leaves `sid=""` untouched.
 if [ ! -f "$sid_file" ]; then
   exit 0
 fi
 
 # Whitespace-stripped read.
 #
-# 旧実装の `2>/dev/null || raw=""` は permission denied / inode race / EIO 等の IO エラーを「空ファイル」と
-# 区別不能化していた。攻撃者が `.rite-session-id` を chmod 000 にした状態で別 session の
+# `2>/dev/null || raw=""` の素朴な実装は permission denied / inode race / EIO 等の IO エラーを「空ファイル」と
+# 区別不能にする。攻撃者が `.rite-session-id` を chmod 000 にした状態で別 session の
 # session_id を持つ legacy `.rite-flow-state` を残すと、helper が空文字を返し state-read.sh が
 # legacy 経路にフォールバック → cross-session guard が空 SID で意図しない経路を通る。
-# stderr を tempfile に退避し、IO error は WARNING を emit してから空文字復帰する (caller の
+# そのため stderr を tempfile に退避し、IO error は WARNING を emit してから空文字復帰する (caller の
 # graceful degradation 動作は維持しつつ、observability を確保)。
 # cycle 43 F-08 (MEDIUM) 対応: mktemp 失敗 WARNING 統一 + chmod 600 + canonical 4 行 trap。
 # verified-review F-03 (MEDIUM) 対応:
@@ -112,9 +112,9 @@ fi
 # 該当 4 site はすでに drift 済 (実行番号と乖離) のため、semantic anchor に置換した。
 # 他 5 helper の canonical pattern (`_mktemp-stderr-guard.sh` 呼び出しブロック / canonical mktemp
 # pattern / mktemp 失敗 WARNING ブロック) と対称化する。
-# 旧実装は (a) mktemp 失敗時に WARNING emit せず silent fallback、(b) chmod 600 path-disclosure
-# defense なし、(c) trap 不在で SIGINT/SIGTERM/SIGHUP 経路で _tr_err orphan のリスク があった。
-# error-handling-reviewer Likelihood-Evidence: existing_call_site で実証済み。
+# この helper を経由しない素朴な実装では (a) mktemp 失敗時に WARNING emit せず silent fallback、
+# (b) chmod 600 path-disclosure defense なし、(c) trap 不在で SIGINT/SIGTERM/SIGHUP 経路で _tr_err orphan
+# のリスクが生じる。error-handling-reviewer Likelihood-Evidence: existing_call_site で実証済み。
 _tr_err=""
 _rite_resolve_sid_cleanup() {
   rm -f "${_tr_err:-}"
@@ -152,9 +152,9 @@ fi
 
 # Run through the canonical UUID validator. On validation failure, fall through
 # to the implicit empty-string output (exit 0 with no stdout). Callers cannot
-# distinguish "file empty" from "file invalid" from "validation failed", which
-# matches the prior inline semantics — all three paths previously collapsed to
-# `sid=""` and downstream code treated the session as effectively missing.
+# distinguish "file empty" from "file invalid" from "validation failed": all three
+# paths collapse to `sid=""` and downstream code treats the session as effectively
+# missing. This is the contract the inline caller logic relies on.
 if validated=$(bash "$SCRIPT_DIR/_resolve-session-id.sh" "$raw" 2>/dev/null); then
   printf '%s' "$validated"
 fi

--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -61,7 +61,7 @@ neutralize_ctrl() {
 
 # Detection-side counterpart: reject-purpose call sites
 # (flow-state.sh _validate_session_id, wiki-ingest-trigger.sh SOURCE_REF /
-# TITLE) previously used bash `=~ [[:cntrl:]]`, which on glibc misses the same
+# TITLE) must not rely on bash `=~ [[:cntrl:]]`, which on glibc misses the same
 # C1 8-bit range the neutralize side closes — letting e.g. 0x9b slip through
 # validation. Sharing the byte-range definition here keeps detection and
 # replacement symmetric.

--- a/plugins/rite/hooks/pre-compact.sh
+++ b/plugins/rite/hooks/pre-compact.sh
@@ -56,10 +56,10 @@ fi
 
 # Derive the per-session compact-state path from the resolved flow-state path
 # .rite/sessions/{sid}.flow-state → .rite/sessions/{sid}.compact-state.
-# This makes each session's compact snapshot independent, removing the
-# last-writer-wins race on the previously shared single file. Falls back to the
-# legacy shared path only when the session id is unresolvable, preserving
-# pre-per-session behavior for sessions without a session id.
+# This makes each session's compact snapshot independent, avoiding a
+# last-writer-wins race that a single shared file would otherwise cause. Falls
+# back to the legacy shared path only when the session id is unresolvable, so
+# sessions without a session id still have a working compact-state location.
 if [ -n "$FLOW_STATE" ]; then
   COMPACT_STATE="${FLOW_STATE%.flow-state}.compact-state"
 else

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -164,9 +164,8 @@ cd "$REPO_ROOT" || {
 # として surface する (init.md は exit code を読まず stdout/stderr で分岐し ステップ 2 へ進む)。
 #
 # コア検証 (git add --dry-run + grep -qF "add '<probe>'") は同ファイル same_branch case の
-# `DRIFT-CHECK ANCHOR: same_branch ...` 節と意図的に同型。旧構成では init.md がこのロジックの
-# inline copy を持ち両者を「一字一句同期」していたが、本モード導入で init.md は委譲呼び出しに
-# 置換され、同期対象は同一ファイル内の 2 箇所に閉じた (cross-file drift を解消)。
+# `DRIFT-CHECK ANCHOR: same_branch ...` 節と意図的に同型。init.md はこのロジックの inline copy を
+# 持たず本モードへ委譲するため、同期対象は同一ファイル内の 2 箇所に閉じる (cross-file drift を防ぐ)。
 if [ "$VERIFY_NEGATION" -eq 1 ]; then
   negation_probe=".rite/wiki/raw/.rite-lint-negation-probe"
   # probe 作成失敗は non-blocking skip (init.md §1.3.4 契約: WARNING + ステップ 2 進行)。
@@ -408,7 +407,7 @@ case "$branch_strategy" in
     # Sibling reference: the `--verify-negation` early-exit block above (its
     # `(verify-negation copy)` ANCHOR). Keep the mktemp stderr capture + if-wrapper rc
     # capture structure one-for-one with that copy — Wiki 経験則 patterns/high
-    # 「canonical 実装と一字一句同期」. (wiki/init.md ステップ 1.3.4 no longer holds an
+    # 「canonical 実装と一字一句同期」. (wiki/init.md ステップ 1.3.4 holds no
     # inline copy; it delegates here via `gitignore-health-check.sh --verify-negation`.)
     add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
     add_dry_out=""

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -83,13 +83,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../control-char-neutralize.sh"
 # -----------------------------------------------------------------------
 # verify_worktree_branch: confirm a worktree's HEAD is on an expected branch.
 #
-# Responsibility: eliminate the duplicated rev-parse
-# --abbrev-ref HEAD verification block that previously lived in both
-# wiki-worktree-commit.sh and wiki-ingest-commit.sh. Both callers ran
-# essentially the same sequence (mktemp stderr tempfile + scope-limited
-# trap + `set +e` / `set -e` fence + rev-parse + ERROR + `head -3` + rm -f
-# + branch compare) with only the tempfile prefix differing. This helper
-# centralizes that logic so fixes propagate to both callers automatically.
+# Responsibility: hold the single rev-parse --abbrev-ref HEAD verification
+# block shared by wiki-worktree-commit.sh and wiki-ingest-commit.sh. Both
+# callers need essentially the same sequence (mktemp stderr tempfile +
+# scope-limited trap + `set +e` / `set -e` fence + rev-parse + ERROR +
+# `head -3` + rm -f + branch compare) with only the tempfile prefix differing.
+# Centralizing that logic here lets fixes propagate to both callers automatically.
 #
 # Usage:
 # verify_worktree_branch "$worktree_path" "$wiki_branch" "wwc" "$extra_hint"

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -172,8 +172,8 @@ if wt_list=$(git worktree list --porcelain 2>"${wt_list_err:-/dev/null}"); then
             safe_branch=$(printf '%s' "$branch_name" | neutralize_ctrl)
             echo "[dry-run] would remove worktree: $safe_path (branch=$safe_branch)"
           else
-            # 失敗時は git の stderr を診断として surface する (従来は
-            # `2>/dev/null` で失敗理由 — lock / 権限 / submodule 等 — が落ちていた)。
+            # 失敗時は git の stderr を診断として surface する (`2>/dev/null` で抑制すると
+            # 失敗理由 — lock / 権限 / submodule 等 — が落ちる)。
             if wt_rm_err=$(git worktree remove --force "$current_path" 2>&1); then
               worktrees_removed=$((worktrees_removed + 1))
             else

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -514,22 +514,21 @@ checked_out_wiki=false
 
 # HIGH #1 / HIGH #2 — rollback-safety rewrite.
 #
-# Previous design had two latent bugs that could only surface on error /
-# signal paths (happy path was unaffected — AC-1/2/3 dogfooding still
-# passed, which is why the bugs were not caught by empirical testing):
+# This rollback-safety design guards two latent failure modes that surface only
+# on error / signal paths (the happy path is unaffected, so empirical AC-1/2/3
+# dogfooding does not catch them):
 #
-# (a) stash pop was attempted unconditionally even after checkout-back
-# to $current_branch failed, meaning a dev-branch stash could get
-# applied while the HEAD was still on the wiki branch — corrupting
-# the wiki branch working tree with unrelated dev-branch changes.
+# (a) Attempting stash pop unconditionally even after checkout-back to
+# $current_branch fails would apply a dev-branch stash while the HEAD is
+# still on the wiki branch — corrupting the wiki branch working tree with
+# unrelated dev-branch changes.
 #
-# (b) The cleanup function captured `local rc=$?` on entry. When the
-# cleanup was reached via a signal trap (INT/TERM/HUP), bash's `$?`
-# at that point reflects the last completed command (usually 0 on
-# the happy path — e.g. after `echo "[wiki-ingest-commit] ..."`),
-# not the signal. As a result, cleanup would see rc=0, skip the
-# staging-dir restore block, and exit 0. A SIGINT mid-run would
-# therefore silently drop the raw sources on the floor.
+# (b) Capturing `local rc=$?` on cleanup entry is unsafe when cleanup is
+# reached via a signal trap (INT/TERM/HUP): bash's `$?` at that point
+# reflects the last completed command (usually 0 on the happy path — e.g.
+# after `echo "[wiki-ingest-commit] ..."`), not the signal. cleanup would
+# then see rc=0, skip the staging-dir restore block, and exit 0, so a SIGINT
+# mid-run would silently drop the raw sources on the floor.
 #
 # Fix:
 # - cleanup_body takes an explicit rc parameter (`$1`) instead of
@@ -890,10 +889,10 @@ committed_sha=$(git rev-parse HEAD 2>/dev/null || echo unknown)
 
 # Push is best-effort vs caller-observable:
 # Push failure MUST be observable by the
-# caller. Previous design exited 0 on push failure with only a stdout
-# `push=failed` marker, which the callers (review.md / fix.md / close.md Phase
-# X.X.W.2) did not parse — so flaky remote / auth expiry / rate limit drove
-# all push failures through the success branch and silently emitted
+# caller. Exiting 0 on push failure with only a stdout `push=failed` marker
+# is unsafe: the callers (review.md / fix.md / close.md Phase X.X.W.2) do not
+# parse that marker, so flaky remote / auth expiry / rate limit would drive
+# all push failures through the success branch and silently emit
 # WIKI_INGEST_DONE=1 without surfacing a push-failure warning.
 #
 # Fix: exit 4 on push failure so the caller's bash `if commit_out=$(...)`

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -651,11 +651,11 @@ done
 # を再び有効にする。
 #
 # Cycle 2 MEDIUM (noise reduction): only dump stderr on failure paths.
-# Previous design called `dump_git_err` after **every** git command, including
-# successful ones, which surfaced git informational messages like `Switched to
-# branch 'wiki'` on stderr — noise that drowned out real error signals. The
-# helper is now failure-only; success paths call `surface_git_warnings` which
-# only prints lines matching `^(warning|hint|error):`.
+# Calling `dump_git_err` after **every** git command, including successful ones,
+# surfaces git informational messages like `Switched to branch 'wiki'` on stderr —
+# noise that drowns out real error signals. So the helper is failure-only; success
+# paths call `surface_git_warnings` which only prints lines matching
+# `^(warning|hint|error):`.
 #
 # git_err cleanup is delegated to `cleanup_body` (see the EXIT/INT/TERM/HUP
 # traps below). A separate trap would overwrite cleanup_body's and break the
@@ -686,16 +686,16 @@ dump_git_err() {
  fi
 }
 
-# surface_git_warnings <label>: called on success paths. Instead of silently
-# truncating the captured git stderr (which previously dropped legitimate
-# warnings like "unable to rmdir 'foo': Directory not empty" or remote-side
-# hook advice), selectively surface lines that look like warnings / hints,
-# then truncate. This preserves operator visibility without re-introducing
-# informational noise like "Switched to branch 'wiki'" (which git emits
-# without a "warning:" / "hint:" prefix and which `-q` already suppresses).
+# surface_git_warnings <label>: called on success paths. Silently truncating
+# the captured git stderr drops legitimate warnings like "unable to rmdir
+# 'foo': Directory not empty" or remote-side hook advice, so instead
+# selectively surface lines that look like warnings / hints, then truncate.
+# This preserves operator visibility without re-introducing informational
+# noise like "Switched to branch 'wiki'" (which git emits without a
+# "warning:" / "hint:" prefix and which `-q` already suppresses).
 #
-# Cycle 3 MEDIUM #1 fix — replaces the old unconditional `clear_git_err`
-# truncation on success paths, which silently dropped warnings.
+# Cycle 3 MEDIUM #1 fix — an unconditional `clear_git_err` truncation on
+# success paths would silently drop warnings, so it is not used here.
 #
 # LOW #5 — all writes to git_err in this helper are `|| true` guarded so an
 # ENOSPC / EACCES truncate failure does not abort the script under set -e.
@@ -734,9 +734,9 @@ for f in "${pending_files[@]}"; do
  echo " 3) re-run wiki-ingest-commit.sh" >&2
  exit 3
  fi
- # rm -f stderr was
- # previously suppressed entirely. Propagate failures so the operator can
- # see which file could not be removed (EACCES / EIO / race).
+ # Capture rm -f stderr rather than suppressing it entirely. Propagate
+ # failures so the operator can see which file could not be removed
+ # (EACCES / EIO / race).
  if ! rm -f "$f" 2>"${git_err:-/dev/null}"; then
  echo "ERROR: failed to remove untracked raw source '$f' from '$current_branch'" >&2
  dump_git_err "rm -f $f"

--- a/plugins/rite/hooks/scripts/wiki-lint-broken-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-broken-refs.sh
@@ -18,11 +18,11 @@
 #   (same structural guarantee as wiki-lint-skipped-refs.sh /
 #   wiki-lint-source-refs.sh for ステップ 6.0 / 6.2).
 #
-# Fence handling improvement over the inline implementation:
-#   The old `sed -E '/^```/,/^```/d'` only removed fences starting at column 0.
-#   This helper tracks fence open/close indent-agnostically with awk
-#   (`/^[[:space:]]*```/`), so list-indented fences no longer leak their
-#   contents into link extraction (旧 lint.md ステップ 7 リンク抽出の既知の限界の解消)。
+# Fence handling:
+#   A column-0-only `sed -E '/^```/,/^```/d'` removes fences starting at column 0
+#   but misses list-indented fences. This helper tracks fence open/close
+#   indent-agnostically with awk (`/^[[:space:]]*```/`), so list-indented fences
+#   do not leak their contents into link extraction.
 #
 # Inputs:
 #   --branch-strategy {separate_branch|same_branch}  (required)

--- a/plugins/rite/hooks/scripts/wiki-lint-orphans.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-orphans.sh
@@ -143,7 +143,7 @@ _emit_skipped() {
 # ---- index.md 読出 (旧 lint.md の index.md 事前読出ステップを内包) ------------
 # LC_ALL=C で locale 固定 (localize された diagnostic による stderr pattern 不一致を予防 —
 # sibling helpers と同じ規約)。読出失敗は legitimate absence / IO error を区別せず
-# index_unreadable に一本化する (旧 inline 実装も index_read_ok=false の単一経路だった。
+# index_unreadable に一本化する (index_read_ok=false の単一経路に集約する。
 # 孤児検出は index.md が無ければ全ページ orphan 誤検出になるため、いずれの失敗でも skip が正解)。
 index_err=$(mktemp /tmp/rite-wiki-lint-orphans-err-XXXXXX 2>/dev/null) || {
   echo "WARNING: stderr 退避 tempfile (index_err) の mktemp に失敗しました。index.md 読出の詳細エラー情報は失われます" >&2

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -222,8 +222,8 @@ esac
 
 # `|| true` で silent に握り潰さず、IO error / permission denied / broken worktree
 # の場合は WARNING + exit 3 で fail-fast する (cycle 2 MEDIUM F-12 fix)。
-# 旧実装は `untracked=""` → `has_untracked=false` で本来検出すべき untracked を
-# silent miss し、`reason=no-pending` で skip してしまう経路があった。
+# `|| true` で `untracked=""` → `has_untracked=false` に倒すと、本来検出すべき untracked を
+# silent miss し、`reason=no-pending` で skip してしまう経路が生じる。
 lsf_err=""
 trap 'rm -f "${lsf_err:-}"' EXIT INT TERM HUP
 lsf_err=$(mktemp /tmp/rite-wwc-lsf-err-XXXXXX 2>/dev/null) || lsf_err=""
@@ -292,9 +292,8 @@ fi
 # -----------------------------------------------------------------------
 # Stage all changes under .rite/wiki, commit, and push via shared helper.
 # worktree_commit_push (lib/worktree-git.sh) handles the stderr capture +
-# head -n 10 extraction pattern that was previously inlined here. Exit
-# codes: 3 = add/commit failure, 4 = commit ok / push failed, 5 = no
-# staged diff after add (no-op).
+# head -n 10 extraction pattern for the caller. Exit codes: 3 = add/commit
+# failure, 4 = commit ok / push failed, 5 = no staged diff after add (no-op).
 # -----------------------------------------------------------------------
 set +e
 wtcp_out=$(worktree_commit_push "$worktree_path" "$wiki_branch" "$COMMIT_MSG" "$wiki_rel")

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -34,8 +34,8 @@
 #     exists remotely, the caller (e.g. /rite:wiki:init) is responsible
 #     for running `git fetch origin wiki:wiki` first.
 #   - The script does NOT prune stale worktrees. If `.rite/wiki-worktree`
-#     was previously deleted without `git worktree remove`, run
-#     `git worktree prune` manually before re-invoking this script.
+#     was deleted without `git worktree remove`, run `git worktree prune`
+#     manually before re-invoking this script.
 
 set -euo pipefail
 

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -239,8 +239,8 @@ if [ "$SOURCE" = "startup" ]; then
     # The JSON transform (rite-hook detection via RITE_HOOK_RE + selective removal) is
     # delegated to the shared scripts/settings-local-rite-hook-cleanup.py — the same
     # single-source script the .sh wrapper uses — so the regex lives in exactly one place
-    # (previously an inline python3 copy duplicated both the regex and the
-    # whole transform). Its documented exit codes are reused here: 0 = rite hooks removed
+    # rather than being duplicated as an inline python3 copy of both the regex and
+    # the whole transform. Its documented exit codes are reused here: 0 = rite hooks removed
     # (cleaned JSON on stdout → captured into _repair_tmp), 1 = intentional no-op (no
     # hooks key / no rite entries), 2 = invalid JSON. Distinguishing the no-op (rc=1) from
     # real failures (rc=2, etc.) is required so settings.local.json corruption surfaces

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -62,16 +62,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/work-memory-lock.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 
 # verified-review F-04 MEDIUM: flow-state.sh 呼び出し boilerplate を helper 関数に抽出。
-# 旧実装は (a) helper executable check と (b) `if cmd; then :; else rc=$?; ...; return 2; fi` 形式の
-# fail-fast capture を 3 箇所 (line 96-110 / 175-186 / 187-193) で完全に同一構造で複製していた。
-# 共通 helper に集約することで spec 変更を 1 箇所で完結させる。
+# (a) helper executable check と (b) `if cmd; then :; else rc=$?; ...; return 2; fi` 形式の
+# fail-fast capture は本ファイル内の複数 site で同一構造になるため、共通 helper に集約して
+# spec 変更を 1 箇所で完結させる。
 #
-# verified-review F-05 (MEDIUM) 対応: 旧コメントは
-# 「resume-active-flag-restore.sh にも 2 site 存在し計 5 site の boilerplate 重複を集約する
-# (writer/reader/resume 3 layer DRY 化)」と主張していたが、resume layer の 2 site
-# (resume-active-flag-restore.sh の curr_phase / curr_next 抽出ブロック) は **本 PR では consolidate
-# されていない**。したがって本 helper の集約スコープは work-memory-update.sh 内 3 site のみで、
-# resume layer の片肺更新リスクは別 Issue で追跡する必要がある (claim と実装の整合性回復)。
+# verified-review F-05 (MEDIUM): 本 helper の集約スコープは work-memory-update.sh 内 3 site のみ。
+# resume layer の 2 site (resume-active-flag-restore.sh の curr_phase / curr_next 抽出ブロック) は
+# **この helper では consolidate しない**。したがって resume layer の片肺更新リスクは別 Issue で
+# 追跡する必要がある (「writer/reader/resume 3 layer DRY 化」を謳わないこと — 実装と整合させる)。
 #
 # Arguments:
 #   $1 var_name  caller 側で値を受け取る変数名 (e.g., "_phase")

--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -186,9 +186,9 @@ created_numbers=()
 expected_sub_count=$(printf '%s' "$SPEC_JSON" | jq '.sub_issues | length')
 # labels_csv を --arg で渡し stdin を経由しない。`jq -R` 方式は空の labels_csv に対し
 # 空出力 + exit 0 を返すため sub_labels_json="" となり、直後の `--argjson labels ""` が
-# invalid JSON で落ちる一方 `|| "[]"` ガードは exit 0 なので発火しなかった（空ラベルでの
-# 分解が必ず失敗する境界バグ）。--arg なら "" → [] が常に有効な JSON 配列として得られ、
-# 非空 CSV も従来同等に動く。ガードは malformed 入力への保険として残す。
+# invalid JSON で落ちる一方 `|| "[]"` ガードは exit 0 なので発火しない（空ラベルでの
+# 分解が必ず失敗する境界バグになる）。--arg なら "" → [] が常に有効な JSON 配列として得られ、
+# 非空 CSV も同じ結果になる。ガードは malformed 入力への保険として残す。
 sub_labels_json=$(jq -cn --arg csv "$labels_csv" '$csv | split(",") | map(select(length>0) | gsub("^\\s+|\\s+$"; ""))' 2>/dev/null) || {
   echo "WARNING: labels_csv の jq パースに失敗。labels を空で続行: $labels_csv" >&2
   sub_labels_json="[]"

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -92,9 +92,9 @@ DEFAULT_SCOPE_FILTER='
 #   - 欠落のままで Cross-field invariant #5 (pre_existing=false × scope=nit-noted) が
 #     発火しない (`null != false`)
 #   - 1.0/1.0.0 JSON の finding は invariant #5 auto-correct 対象外となり後方互換が保たれる
-# 旧実装は `.pre_existing = false` を初期化していたが、これは migrated LOW finding を
-# scope=nit-noted + pre_existing=false の組合せにし、read 側 invariant #5 で scope を
-# current-pr に書き換えてしまう後方互換破壊だった。
+# `.pre_existing = false` を初期化してはならない。初期化すると migrated LOW finding が
+# scope=nit-noted + pre_existing=false の組合せになり、read 側 invariant #5 で scope を
+# current-pr に書き換えてしまう後方互換破壊を招く。
 MIGRATE_FILTER='
   if (.schema_version // "") == "1.1.0" then .
   else

--- a/plugins/rite/scripts/review-findings-maps.sh
+++ b/plugins/rite/scripts/review-findings-maps.sh
@@ -209,16 +209,16 @@ if [ "${norm_defaulted_count:-0}" -gt 0 ] || [ "${norm_corrected_count:-0}" -gt 
 fi
 
 # verified-review H-1/H-2 対応: jq の exit code を明示捕捉する。
-# 旧実装 `duplicate_keys=$(jq ...)` / `severity_map_json=$(jq -c ...)` は exit code を一切
-# check せず、jq バイナリ異常 / OOM / TOCTOU (別プロセスが file を rm / truncate) で
-# silent に空文字になっていた。重複警告が silent skip し、severity_map 構築が無音で空にな
-# る regression を防ぐため、if-else で exit code を独立 capture する。
+# `duplicate_keys=$(jq ...)` / `severity_map_json=$(jq -c ...)` を exit code を check せずに書くと、
+# jq バイナリ異常 / OOM / TOCTOU (別プロセスが file を rm / truncate) で silent に空文字になる。
+# 重複警告が silent skip し、severity_map 構築が無音で空になる regression を防ぐため、
+# if-else で exit code を独立 capture する。
 jq_err=$(mktemp /tmp/rite-fix-jq-err-XXXXXX 2>/dev/null) || jq_err=""
 
 # line フィールドの nullable sentinel 正規化
 # review-result-schema.md L92 で line は `integer | null` (null が行非依存指摘の sentinel) に変更。
-# 旧実装は `(.line | tostring)` で `null` が `"null"` 文字列に変換される (jq `tostring` の仕様) ため
-# `src/foo.ts:null` のような key が生成され、従来の `line: 0` legacy と混在すると key 衝突するリスクがあった。
+# `(.line | tostring)` を素朴に使うと `null` が `"null"` 文字列に変換される (jq `tostring` の仕様) ため
+# `src/foo.ts:null` のような key が生成され、`line: 0` legacy の key と混在すると key 衝突するリスクがある。
 # 後方互換で `line == 0` / `line == null` の両方を `"anchor"` sentinel に正規化することで、
 # 同一ファイル複数の行非依存指摘が key 衝突で silent に畳み込まれるのを防ぐ。
 if duplicate_keys=$(jq -r '[.findings[] | (.file + ":" + (if .line == null or .line == 0 then "anchor" else (.line | tostring) end))] | group_by(.) | map(select(length > 1) | .[0]) | .[]' "$review_source_path" 2>"${jq_err:-/dev/null}"); then

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -135,14 +135,13 @@ review_source_path=""
 # canonical pattern: references/bash-trap-patterns.md#signal-specific-trap-template を参照。
 # Block 全体の scope を cover するため Priority 2 のネスト内ではなく block 冒頭に配置する。
 #
-# 旧実装の `local _saved_rc=$?; rm -f ...; return $_saved_rc` は
-# 意図と実挙動が乖離していた。trap handler が `'rc=$?; _rite_fix_p120_cleanup; exit $rc'` 形式で
-# 関数を呼ぶとき、関数入場時の `$?` は trap handler 内の直前 assignment `rc=$?` の exit code
-# (= 0) であり、真のエラーコードは既に trap handler 側の `rc` 変数に捕捉されている。したがって
-# 関数内で `$?` を保存しても常に 0 となり、`return $_saved_rc` は常に 0 を返していた (コメントと
-# 実挙動の乖離)。trap handler が最終 `exit $rc` で outer rc を使うため運用上は無害だが、将来
-# 関数を直接呼び出す拡張で silent regression する罠を残していた。簡素化して trap handler の
-# rc 捕捉に一本化する。
+# cleanup 関数内で `local _saved_rc=$?; rm -f ...; return $_saved_rc` を書いてはならない。
+# trap handler が `'rc=$?; _rite_fix_p120_cleanup; exit $rc'` 形式で関数を呼ぶとき、関数入場時の
+# `$?` は trap handler 内の直前 assignment `rc=$?` の exit code (= 0) であり、真のエラーコードは
+# 既に trap handler 側の `rc` 変数に捕捉されている。したがって関数内で `$?` を保存しても常に 0 となり、
+# `return $_saved_rc` は常に 0 を返す (コメントと実挙動が乖離する)。trap handler が最終 `exit $rc` で
+# outer rc を使うため運用上は無害だが、将来関数を直接呼び出す拡張で silent regression する罠になる。
+# trap handler の rc 捕捉に一本化する。
 find_err=""
 jq_val_err_p0=""
 jq_val_err_p2=""
@@ -245,7 +244,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
         # (ユーザーは「レビュー実行 / 別ファイル指定 / 中止」を選択可能)。
         # [CONTEXT] REVIEW_SOURCE_STALE=1 を emit して observability は維持する。
         # jq バイナリ異常 / I/O エラーと「.commit_sha フィールド不在 (legacy schema)」を区別する。
-        # 旧実装 `2>/dev/null || echo ""` はこの 2 ケースを silent に融合させ、stale detection を silent 無効化していた。
+        # `2>/dev/null || echo ""` の素朴な実装はこの 2 ケースを silent に融合させ、stale detection を silent 無効化してしまう。
         json_commit_sha_err=$(mktemp /tmp/rite-fix-p0-commit-sha-err-XXXXXX 2>/dev/null) || json_commit_sha_err=""
         if json_commit_sha=$(jq -r '.commit_sha // empty' "$review_file_path" 2>"${json_commit_sha_err:-/dev/null}"); then
           : # jq 成功 (空 or 非空)
@@ -263,9 +262,9 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
           head_sha=""
         fi
         if [ -n "$json_commit_sha" ] && [ -n "$head_sha" ] && [ "$json_commit_sha" != "$head_sha" ]; then
-          # stale file 検出時は fallback 経路に route する。旧実装は `RITE_FIX_ACKNOWLEDGE_STALE=1` 環境変数による
-          # opt-in 続行経路を持っていたが、Claude Code Bash tool は呼び出し境界で env var を継承しないため
-          # (anthropics/claude-code#2508)、ユーザーが env var を set する手段がなく dead code だった。
+          # stale file 検出時は fallback 経路に route する。`RITE_FIX_ACKNOWLEDGE_STALE=1` 環境変数による
+          # opt-in 続行経路は設けない。Claude Code Bash tool は呼び出し境界で env var を継承しないため
+          # (anthropics/claude-code#2508)、ユーザーが env var を set する手段がなく dead code になる。
           # stale を承知で続行したいユーザーは Priority 4 Interactive fallback の「レビュー実行」or「別ファイル指定」
           # を選択する。stale な検出結果を無視したい特殊ケースは Priority 4 で「別ファイル指定」に同じ path を
           # 再入力することで実質的に対応可能 (ただし再度 stale warning が出る — 設計意図通り)。
@@ -435,9 +434,9 @@ if [ -z "$review_source" ]; then
         [ -n "${jq_val_err_p2:-}" ] && [ -s "$jq_val_err_p2" ] && head -3 "$jq_val_err_p2" | sed 's/^/  /' >&2
         echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=local_file_json_parse_failure" >&2
         # verified-review M-6 (M10) 対応: corrupted file を .corrupt-{epoch} にリネームし、
-        # 次回の lexicographic sort で選ばれないようにする。旧実装は WARNING を出すだけで
-        # corrupted file を残していたため、次回呼び出し時も同じファイルが最新 timestamp として
-        # 選ばれ、同一 WARNING が繰り返される無限 ring を起こしていた。
+        # 次回の lexicographic sort で選ばれないようにする。WARNING を出すだけで corrupted file を
+        # 残すと、次回呼び出し時も同じファイルが最新 timestamp として選ばれ、同一 WARNING が
+        # 繰り返される無限 ring に陥る。
         # ⚠️ corrupt file rename ロジック (Instance 1/2 — jq parse failure path)
         # 同一ロジックが下の schema_required_fields_missing path (Instance 2/2) にも複製されている。
         # 変更時は両方を同時に更新すること (ドリフト防止)。
@@ -593,11 +592,11 @@ if [ -z "$review_source" ]; then
 fi
 
 # Priority 0/2/3/fallback の最終 review_source 値を
-# machine-readable marker として emit する。旧実装は Priority 1 `use` branch のみが
-# `[CONTEXT] REVIEW_SOURCE=conversation` を emit しており、他 4 経路は observability 欠落だった。
+# machine-readable marker として emit する。Priority 1 `use` branch のみが
+# `[CONTEXT] REVIEW_SOURCE=conversation` を emit する状態では、他 4 経路の observability が欠落する。
 # schema.md `読取優先順位` セクションは「ステップ 4.5.3 / 4.6 で `{review_source}` を log に出すため
 # conversation 経由で取り込んだ場合も他の Priority と同様に provenance を残す必要がある」と
-# 明記するが、実装は Priority 1 のみで契約違反。本修正で全経路に展開する。
+# 明記するため、全経路で emit して契約を満たす。
 # 対象: explicit_file (Priority 0)、conversation (Priority 1、既存 emit は残し defense-in-depth
 # として後段でも emit)、local_file (Priority 2)、pr_comment (Priority 3)、fallback (Priority 0
 # 失敗 → Interactive Fallback 経路)。

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -142,8 +142,8 @@ if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}")
   exit 1
 fi
 # cycle 8 C7-F02 対応: jq の `// empty` fallback + 明示 fail で `set -euo pipefail` 下の silent abort を防ぐ。
-# 旧実装は `jq -r '.owner.login'` で auth-scope 縮退時に `null` 文字列代入されるか jq exit 5 で
-# 診断情報破棄。新実装は空文字列で fail-fast し、stderr に root cause を出力する。
+# `// empty` を付けない素朴な `jq -r '.owner.login'` は auth-scope 縮退時に `null` 文字列を代入するか
+# jq exit 5 で診断情報を破棄する。空文字列で fail-fast し、stderr に root cause を出力する。
 REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>/dev/null) || REPO_OWNER=""
 REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>/dev/null) || REPO_NAME=""
 if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then


### PR DESCRIPTION
## 概要

Issue #1499: フック・スクリプト（`plugins/rite/hooks/**`, `scripts/**` の `*.sh`、tests 除く）のコメントから、比較基準が不明な暗黙の歴史依存表現を除去。**migration コメントは除去せず現在形化**を徹底した。

## 変更内容（18ファイル、コメント行のみ）

`旧実装は/では/の`・`previously`・`従来` 等の**経緯ジャーナル framing** を除去し、技術的根拠（pitfall・why・migration の意図）を現在形で保持:
- `review-source-resolve.sh`, `_resolve-session-id-from-file.sh`, `review-findings-maps.sh`, `work-memory-update.sh`, `migrate-review-state-to-1.1.sh`, `watchdog-status-mismatch.sh`, `wiki-ingest-commit.sh`, `wiki-worktree-commit.sh`, `wiki-worktree-setup.sh`, `gitignore-health-check.sh`, `pr-cycle-cleanup.sh`, `decompose-issues.sh`, `session-start.sh`, 他

「旧実装は X だった → X すると Y になる（ため Z）」の現在形 pitfall 制約文へ。migration を説明するコメントは現に何をするかを述べる現在形へ。

## MUST NOT 遵守
- **実行ロジック・正規表現リテラル・migration 動作・`{issue_number}`/`issue-[0-9]+` 抽出・`drift-check-ignore` マーカーは不変**（diff は `#` コメント行のみ、非コメント行の変更 0）

## 設計判断・保持（KEEP）
- `comment-journal-check.sh`（self-referential なパターン定義/例示）
- `session-start.sh` の `legacy single-file format` / `legacy residue` 等の正当な技術用語、`flow_state.schema_version: 1 は非推奨…無視されます` 等の正確な現在形 migration 説明
- 明示的 commit anchor 付き歴史記録（`before commit 5212573` 等、基準点が明確なもの）

## 受入基準
- AC-1: 比較基準が不明な暗黙参照を除去/現在形化（現在形化した migration 説明・正当な技術用語を除く）✅
- AC-2: migration コメントが現在形で「何をするか」を述べている ✅
- AC-3: bash 構文 OK、`hooks/tests` 74/74・`scripts/tests` 7/7 緑、実行ロジック不変 ✅
- comment-journal-check P2（`旧実装は/では`）スコープ内 0 件 ✅

Closes #1499

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
