### PR TITLE
docs: README から v0.4.0 Breaking Changes セクションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 [![Version](https://img.shields.io/badge/version-0.5.2-blue.svg)](https://github.com/asakaguchi/cc-rite-workflow/releases/tag/v0.5.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## ⚠️ Breaking Changes (v0.4.0)
-
-**Cycle-count-based review-fix degradation removed**: Three configuration keys (`review.loop.severity_gating_cycle_threshold`, `review.loop.scope_lock_cycle_threshold`, `safety.max_review_fix_loops`) are no longer honored — remove them from `rite-config.yml` when upgrading. The review-fix loop terminates only on 0 findings (normal exit) or manual abort (`Ctrl+C` → `/rite:resume`). See [CHANGELOG](CHANGELOG.md#040---2026-04-17) for the full migration guide.
-
 ## Why "Rite"?
 
 The name comes from the English word **rite**, meaning "ritual" or "ceremony." Issue-driven development — creating Issues, cutting branches, implementing, reviewing, and merging — is a set of practices that every team should follow as second nature. Rite Workflow embeds these practices as a repeatable ritual so they become the natural way you build software.


### PR DESCRIPTION
## 概要

README.md トップの `## ⚠️ Breaking Changes (v0.4.0)` セクション（見出し + 本文）を削除しました。利用者が現状作者本人のみで、今後の公開を見据えても特定の古いバージョン（v0.4.0）の破壊的変更通知を README トップに残す必要がないためです。移行情報は CHANGELOG.md の `[0.4.0]` エントリに完全な migration guide が保持されており、README から削除しても情報は失われません。

## 関連 Issue

Closes #1508

## 変更内容

- `README.md`: badges ブロック直後の `## ⚠️ Breaking Changes (v0.4.0)` 見出しと本文（計 4 行）を削除。badges 直後に空行 1 行を挟んで `## Why "Rite"?` が続く構造に整理

## 受入基準の確認

- **AC-1**: `grep -c "Breaking Changes" README.md` が 0、`severity_gating_cycle_threshold` 等の v0.4.0 移行記述も 0 件
- **AC-2**: badges 直後が `## Why "Rite"?` 見出しで、連続空行・見出しレベルの崩れなし
- **AC-3**: `git diff CHANGELOG.md` が空（CHANGELOG 未変更、`[0.4.0]` 移行ガイドを保持）

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし: `commands.test` / `commands.lint` 未設定。plugin 固有チェックは実行済み・既存 warning のみ）
- [x] ドキュメント更新（本変更自体がドキュメント整理）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
