### PR TITLE
chore(pr): merge success path 末尾を exit 0 固定の no-op で堅牢化

### DIFF
--- a/plugins/rite/commands/pr/merge.md
+++ b/plugins/rite/commands/pr/merge.md
@@ -78,6 +78,7 @@ if gh pr merge {pr_number} --squash --delete-branch=false 2>"${gh_err:-/dev/null
     echo "  WARNING (gh stderr):" >&2
     head -5 "$gh_err" | sed 's/^/    /' >&2
   fi
+  : # success path を exit 0 に固定。warning surface を if…fi で書いても &&チェーンに崩して転記しても、末尾の no-op により block が成功扱いで終わり trap の exit $rc が偽の 1 を返さない
   # 完了通知は ステップ 3 で表示
 else
   merge_rc=$?


### PR DESCRIPTION
## Summary

`/rite:pr:merge` のステップ2 squash merge bash block の success path 末尾を、LLM が即席実行時に `if…fi` を bare `&&` チェーンへ崩して転記しても偽の exit code 1 を返さないよう堅牢化しました。warning surface の `fi` 直後に no-op (`:`) を 1 行追加するだけの変更です。

## Related Issue

Closes #1510

## Background

gh が stderr を出さない通常ケース（`gh_err` が空ファイル）では、warning surface を `&&` チェーン（`[ -n "$gh_err" ] && [ -s "$gh_err" ] && { … }`）へ転記すると `-s` 判定が false となり末尾コマンドが exit 1 を返し、`trap 'rc=$?; … exit $rc' EXIT` が偽の `exit 1` を返していました（Issue #1508 の `/rite:pr:merge` 実行時に実際に発生）。末尾に exit code 非依存の no-op を置くことで、`if…fi` / `&&` チェーンのどちらに転記されても block が exit 0 で終わるよう免疫化します。

## Changes

- `plugins/rite/commands/pr/merge.md`: ステップ2 success path（then ブランチ）の warning surface `fi` 直後に `:` no-op を 1 行追加

## Acceptance Criteria 検証

- **AC-1**: `if…fi` 形式 + 空 `gh_err` → block 末尾 exit code が 0（偽の exit 1 が発生しない）✓
- **AC-2**: 非空 `gh_err` → `WARNING (gh stderr):` + head -5 が stderr に表示され exit code 0 ✓
- **AC-3**: 失敗パス（else 側）は未変更のため挙動不変、`[merge:error]` / `exit $merge_rc` 維持 ✓
- 転記揺れ免疫を `&&` チェーン形式でも検証（末尾 `:` 無しでは exit 1 を再現、有りで exit 0）✓

## Non-goal（スコープ外）

- else（失敗）側ブロック・`[merge:returned-to-caller]` sentinel は未変更
- 他コマンド（fix.md / review.md / cleanup.md）への横展開。本変更着手時に精査した結果、これらに同種の「success path 末尾が gh stderr warning surface 条件分岐で終わる」構造は存在せず（merge.md の "fix.md ステップ2.4 と対称" は signal-specific trap パターンの対称性を指す）、横展開対象はないことを確認済み

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — plugin 固有チェック群で merge.md は findings ゼロ
- [x] Documentation updated (if applicable) — 仕様変更なし（bash block の exit code 堅牢化のみ）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
