### PR TITLE
refactor(wiki-ingest): write 失敗経路の Step 3 を content_write_failed reason に分岐

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -3571,7 +3571,7 @@ fi
 echo "content_write_failed=$content_write_failed"
 ```
 
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 4.6.W.2 when it is non-zero. Ingest failure does not block the fix workflow.
+**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 4.6.W.2 when it is non-zero. The LLM **also reads `content_write_failed` from the prior Step 2 stdout** (`echo "content_write_failed=$content_write_failed"`) and re-establishes it before evaluating Step 3 — a separate bash invocation does not inherit shell state, so the carry-forward of `content_write_failed` is required exactly as for `trigger_exit`. `content_write_failed=1` means the heredoc content write failed and the trigger was never invoked. Ingest failure does not block the fix workflow.
 
 **Step 3 — Failure surfacing**: 2 つの失敗経路を区別して surface する。
 

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -3522,6 +3522,7 @@ tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
 # rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
 trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
+content_write_failed=0  # heredoc write 失敗フラグ (Step 3 で genuine trigger 失敗と区別するため carry-forward)
 
 # heredoc 書き込みの exit code を捕捉 (disk full / permission 拒否で truncated content が
 # silent に ingest される regression を防ぐ。wiki ingest は非ブロッキングのため write 失敗時は ingest をスキップ)
@@ -3544,6 +3545,7 @@ then
   echo "[CONTEXT] WIKI_CONTENT_WRITE_FAILED=1; reason=cat_redirection_failed" >&2
   echo "WARNING: fix ステップ 4.6.W: tmpfile への heredoc 書き込みに失敗 (/tmp full / permission 拒否 / inode 枯渇)。wiki ingest を非ブロッキングにスキップ。" >&2
   trigger_exit=1
+  content_write_failed=1
   echo "trigger_exit=$trigger_exit"
 else
   bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
@@ -3566,18 +3568,34 @@ else
     echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
   fi
 fi
+echo "content_write_failed=$content_write_failed"
 ```
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 4.6.W.2 when it is non-zero. Ingest failure does not block the fix workflow.
 
-**Step 3 — Failure surfacing**: When `trigger_exit != 0` AND `trigger_exit != 2` (exit 2 = Wiki disabled/uninitialized = legitimate skip already covered by Step 1), surface the failure as a plain WARNING so the operator can triage it from stderr:
+**Step 3 — Failure surfacing**: 2 つの失敗経路を区別して surface する。
+
+- **(a) content write 失敗** (`content_write_failed=1`): trigger は**起動していない**ため `trigger_exit` の値 (1) を reason にすると誤帰属になる。root cause は Step 2 の `WIKI_CONTENT_WRITE_FAILED` で既出だが、W Phase Completion Gate (ステップ 5.0) は `WIKI_INGEST_*` 接頭辞の sentinel しか認識しないため、gate-visible な `WIKI_INGEST_FAILED` を `reason=content_write_failed` で emit する。
+- **(b) genuine trigger 失敗** (`trigger_exit != 0` AND `trigger_exit != 2`、exit 2 = Wiki disabled/uninitialized = legitimate skip は Step 1 で既出): `wiki-ingest-trigger.sh` が実際に非ゼロ終了したので `reason=trigger_exit_$trigger_exit` で emit する。
 
 ```bash
-if [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
+if [ "${content_write_failed:-0}" -eq 1 ]; then
+  # write 失敗経路: trigger は未起動。gate (ステップ 5.0) は WIKI_INGEST_* のみ認識するため
+  # accurate な reason を付けて WIKI_INGEST_FAILED を emit する (trigger_exit_1 への誤帰属を防ぐ)。
+  echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=content_write_failed; exit_code=1"
+  echo "WARNING: fix ステップ 4.6.W: content write 失敗のため wiki ingest をスキップ (trigger は未起動)。" >&2
+elif [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
   echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
   echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during pr/fix.md ステップ 4.6.W" >&2
 fi
 ```
+
+**ステップ 4.6.W Step 3 failure surfacing reason** (`WIKI_INGEST_FAILED` flag の reason 値):
+
+| reason | Description |
+|--------|-------------|
+| `content_write_failed` | tmpfile への heredoc write 失敗 (`content_write_failed=1`)。trigger は未起動。root cause の `WIKI_CONTENT_WRITE_FAILED` とは別に、gate-visible な `WIKI_INGEST_FAILED` を accurate reason で surface する (`trigger_exit_*` への誤帰属を防ぐ) |
+| `trigger_exit_<n>` | `wiki-ingest-trigger.sh` が exit `<n>` (≠0, ≠2) で終了した genuine trigger 失敗 |
 
 ### 4.6.W.2 Wiki Raw Commit (Shell — deterministic path)
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3478,6 +3478,7 @@ tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX)
 trigger_stderr=$(mktemp /tmp/rite-wiki-trigger-err-XXXXXX) || trigger_stderr=/dev/null
 # rm -f /dev/null は EPERM (exit 1) を返すため trap で条件分岐する (F-07 対応)
 trap 'rm -f "$tmpfile"; [ "$trigger_stderr" != "/dev/null" ] && rm -f "$trigger_stderr"' EXIT
+content_write_failed=0  # heredoc write 失敗フラグ (Step 3 で genuine trigger 失敗と区別するため carry-forward)
 
 # heredoc 書き込みの exit code を捕捉 (disk full / permission 拒否で truncated content が
 # silent に ingest される regression を防ぐ。wiki ingest は非ブロッキングのため write 失敗時は ingest をスキップ)
@@ -3502,6 +3503,7 @@ then
  echo "[CONTEXT] WIKI_CONTENT_WRITE_FAILED=1; reason=cat_redirection_failed" >&2
  echo "WARNING: review ステップ 6.5.W: tmpfile への heredoc 書き込みに失敗 (/tmp full / permission 拒否 / inode 枯渇)。wiki ingest を非ブロッキングにスキップ。" >&2
  trigger_exit=1
+ content_write_failed=1
  echo "trigger_exit=$trigger_exit"
 else
  bash {plugin_root}/hooks/wiki-ingest-trigger.sh \
@@ -3524,6 +3526,7 @@ else
   echo "[CONTEXT] WIKI_TRIGGER_STDERR=${_wiki_err_snippet}" >&2
  fi
 fi
+echo "content_write_failed=$content_write_failed"
 ```
 
 **ステップ 6.5.W content write failure reason** (reason table drift prevention — heredoc redirection の exit code を `WIKI_CONTENT_WRITE_FAILED` flag の reason 値として surface する):
@@ -3534,14 +3537,29 @@ fi
 
 **Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.
 
-**Step 3 — Failure surfacing**: When `trigger_exit != 0` AND `trigger_exit != 2` (exit 2 = Wiki disabled/uninitialized = legitimate skip already covered by Step 1), surface the failure as a plain WARNING so the operator can triage it from stderr:
+**Step 3 — Failure surfacing**: 2 つの失敗経路を区別して surface する。
+
+- **(a) content write 失敗** (`content_write_failed=1`): trigger は**起動していない**ため `trigger_exit` の値 (1) を reason にすると誤帰属になる。root cause は Step 2 の `WIKI_CONTENT_WRITE_FAILED` で既出だが、W Phase Completion Gate (ステップ 8.0.1) は `WIKI_INGEST_*` 接頭辞の sentinel しか認識しないため、gate-visible な `WIKI_INGEST_FAILED` を `reason=content_write_failed` で emit する。
+- **(b) genuine trigger 失敗** (`trigger_exit != 0` AND `trigger_exit != 2`、exit 2 = Wiki disabled/uninitialized = legitimate skip は Step 1 で既出): `wiki-ingest-trigger.sh` が実際に非ゼロ終了したので `reason=trigger_exit_$trigger_exit` で emit する。
 
 ```bash
-if [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
+if [ "${content_write_failed:-0}" -eq 1 ]; then
+ # write 失敗経路: trigger は未起動。gate (ステップ 8.0.1) は WIKI_INGEST_* のみ認識するため
+ # accurate な reason を付けて WIKI_INGEST_FAILED を emit する (trigger_exit_1 への誤帰属を防ぐ)。
+ echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=content_write_failed; exit_code=1"
+ echo "WARNING: review ステップ 6.5.W: content write 失敗のため wiki ingest をスキップ (trigger は未起動)。" >&2
+elif [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
  echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
  echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during pr/review.md ステップ 6.5.W" >&2
 fi
 ```
+
+**ステップ 6.5.W Step 3 failure surfacing reason** (`WIKI_INGEST_FAILED` flag の reason 値):
+
+| reason | Description |
+|--------|-------------|
+| `content_write_failed` | tmpfile への heredoc write 失敗 (`content_write_failed=1`)。trigger は未起動。root cause の `WIKI_CONTENT_WRITE_FAILED` とは別に、gate-visible な `WIKI_INGEST_FAILED` を accurate reason で surface する (`trigger_exit_*` への誤帰属を防ぐ) |
+| `trigger_exit_<n>` | `wiki-ingest-trigger.sh` が exit `<n>` (≠0, ≠2) で終了した genuine trigger 失敗 |
 
 #### 6.5.W.2 Wiki Raw Commit (Shell — deterministic path)
 

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3535,7 +3535,7 @@ echo "content_write_failed=$content_write_failed"
 |--------|-------------|
 | `cat_redirection_failed` | tmpfile への heredoc redirection の exit code が非ゼロ (disk full / write permission denied / inode 枯渇 / IO error)。truncated content の silent ingest を防ぐため wiki ingest を非ブロッキングにスキップする |
 
-**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 6.5.W.2 when it is non-zero. Ingest failure does not block the review workflow.
+**Non-blocking**: `wiki-ingest-trigger.sh` exit 2 (Wiki disabled/uninitialized) and other errors are captured in `trigger_exit` and do not halt the workflow. The LLM reads `trigger_exit` from stdout and skips ステップ 6.5.W.2 when it is non-zero. The LLM **also reads `content_write_failed` from the prior Step 2 stdout** (`echo "content_write_failed=$content_write_failed"`) and re-establishes it before evaluating Step 3 — a separate bash invocation does not inherit shell state, so the carry-forward of `content_write_failed` is required exactly as for `trigger_exit`. `content_write_failed=1` means the heredoc content write failed and the trigger was never invoked. Ingest failure does not block the review workflow.
 
 **Step 3 — Failure surfacing**: 2 つの失敗経路を区別して surface する。
 


### PR DESCRIPTION
## 概要

`commands/pr/review.md` 6.5.W / `commands/pr/fix.md` 4.6.W の **Step 3 failure-surfacing** が、wiki-ingest の heredoc write 失敗時に `trigger_exit=1`（借用値）を reason に流用し、`WIKI_INGEST_FAILED=1; reason=trigger_exit_1` を誤帰属していた問題を修正する。`trigger_exit_1` は「`wiki-ingest-trigger.sh` が exit 1 で失敗」を含意するが、write 失敗時は trigger は**起動すらしていない**ため triage 時に誤誘導的だった。

## 調査で判明した重要制約

W Phase Completion Gate（`review.md` §8.0.1 / `fix.md` §5.0、W フェーズ skip に対する sole defense layer）は `WIKI_INGEST_*` 接頭辞の sentinel しか認識しない。`WIKI_CONTENT_WRITE_FAILED` はゲートに認識されない（リポジトリ全体で emit 2 箇所のみ・消費者なし）。

→ write 失敗経路で gate を満たしているのは Step 3 が emit する `WIKI_INGEST_FAILED` **だけ**。このため Issue の改善案 1（`trigger_exit=2` への remap）/ 改善案 2（Step 3 単純 skip）は、そのままでは `WIKI_INGEST_*` sentinel を消して **gate を「W skip」と誤判定させる回帰**を生む。

## 採用アプローチ（Approach Y: gate 無変更・blast radius 最小）

- write 失敗分岐で `content_write_failed=1` フラグを立て carry-forward する。
- Step 3 を分岐:
  - **(a) content write 失敗**: trigger 未起動。`reason=content_write_failed` で `WIKI_INGEST_FAILED` を emit（gate-visible・正確）。
  - **(b) genuine trigger 失敗**（`trigger_exit != 0` かつ `!= 2`）: 従来通り `reason=trigger_exit_$trigger_exit`。
- W Phase Completion Gate は**無変更**（write 失敗時も `WIKI_INGEST_FAILED` が残り gate を通過）。

write 失敗時の出力（両方とも正確）:

```
[CONTEXT] WIKI_CONTENT_WRITE_FAILED=1; reason=cat_redirection_failed
[CONTEXT] WIKI_INGEST_FAILED=1; reason=content_write_failed; exit_code=1
```

`review.md`（6.5.W）/ `fix.md`（4.6.W）に対称適用。

## 変更内容

- `plugins/rite/commands/pr/review.md`: 6.5.W Step 2（`content_write_failed` 初期化 + write 失敗分岐 + carry-forward echo）/ Step 3 分岐化 / reason table 追記
- `plugins/rite/commands/pr/fix.md`: 4.6.W に同等の対称適用

## 検証

- Step 3 ロジックを実機で 5 経路検証:
  - write 失敗 → `reason=content_write_failed`（誤帰属解消）
  - genuine trigger fail（exit 3）→ `reason=trigger_exit_3`（不変）
  - trigger exit 2（disabled）→ emit なし（不変）
  - success（exit 0）→ emit なし（不変）
  - write 成功時の genuine exit 1 → `reason=trigger_exit_1`（正しく維持）
- 全 write 失敗ケースで `WIKI_INGEST_FAILED` は emit され続け、**gate 回帰なし**を確認。
- `distributed-fix-drift-check.sh --all` パス（新 reason は reason table に記載済）。
- bang-backtick / doc-heavy-patterns-drift / bash-heaviness チェックパス。

## 関連 Issue

Closes #1515

- 元の PR: #1514
- 親 Issue: #1512

## チェックリスト

- [x] review.md / fix.md に対称適用
- [x] W Phase Completion Gate を壊さない（write 失敗時も `WIKI_INGEST_*` sentinel を保持）
- [x] genuine trigger 失敗の挙動は不変
- [x] 新 reason を reason table に記載（drift-check パス）
