### PR TITLE
fix(multi-session): 使用中セッション worktree の reap 保護と /clear dangling 自己修復

### DIFF
--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -513,7 +513,7 @@ case "${1:-}" in
   path) shift; cmd_path "$@" ;;
   *)
     cat >&2 <<EOF
-Usage: $0 {set|get|deactivate|consume-handoff|migrate|path} [options]
+Usage: $0 {set|get|deactivate|clear-worktree|consume-handoff|migrate|path} [options]
   set --phase <P> --next <T> [--issue N] [--branch S] [--pr N] [--parent-issue N]
       [--active true|false] [--handoff CMD] [--session UUID] [--if-exists] [--preserve-error-count]
   get --field <F> [--default V] [--session UUID]

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -280,6 +280,40 @@ cmd_set() {
   _atomic_write "$path" "$new" || return 1
 }
 
+# clear-worktree: surgically remove the `worktree` field from a session's
+# flow-state, returning the file to its non-worktree (additive-key-absent) shape.
+# Mirrors cmd_deactivate's single-field write (`.active=false`) rather than going
+# through cmd_set, so callers need NOT know/preserve --phase/--next: cmd_set
+# requires both and would overwrite phase, forcing a read-modify-write of the
+# owner's phase/next just to clear one key (wider race window). Two callers:
+#   1. pr-cycle-cleanup.sh Step 5 reap → null the owning session's dangling
+#      `worktree` after the directory is removed (--session targets the owner).
+#   2. session-start.sh dangling self-heal → null the current session's `worktree`
+#      when the recorded path no longer exists.
+# Idempotent: no-op (no write, no updated_at churn) when the key is already
+# absent or the state file does not exist — keeps wm-sync's diff guard quiet and
+# preserves the merge-preserve contract of cmd_set untouched (the `--worktree ""`
+# merge-preserve path in cmd_set is intentionally NOT changed). Routes through
+# `_atomic_write` per the corruption-prevention convention; rc is propagated.
+cmd_clear_worktree() {
+  local session=""
+  while [ $# -gt 0 ]; do case "$1" in
+    --session) session="$2"; shift 2 ;;
+    *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
+  esac; done
+  local sid path; sid=$(_resolve_session_id "$session") || return 1
+  path=$(_state_path "$sid"); [ ! -f "$path" ] && return 0
+  # Idempotent: skip the write when there is no worktree key. jq read failure
+  # (corrupt JSON) falls through to "false" → no-op; a corrupt file is left for
+  # the cmd_set/cmd_get WARNING paths to surface rather than rewritten blindly here.
+  local has_wt; has_wt=$(jq -r 'has("worktree")' "$path" 2>/dev/null) || has_wt="false"
+  [ "$has_wt" = "true" ] || return 0
+  local now updated; now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  updated=$(jq --arg ts "$now" 'del(.worktree) | .updated_at = $ts' "$path") || return 1
+  # `_atomic_write` rc 伝播 (cmd_set / cmd_deactivate / `_migrate_file` と対称、header 契約遵守)。
+  _atomic_write "$path" "$updated" || return 1
+}
+
 cmd_get() {
   local field="" default="" session="" jq_filter=""
   while [ $# -gt 0 ]; do case "$1" in
@@ -473,6 +507,7 @@ case "${1:-}" in
   set) shift; cmd_set "$@" ;;
   get) shift; cmd_get "$@" ;;
   deactivate) shift; cmd_deactivate "$@" ;;
+  clear-worktree) shift; cmd_clear_worktree "$@" ;;
   consume-handoff) shift; cmd_consume_handoff "$@" ;;
   migrate) shift; cmd_migrate "$@" ;;
   path) shift; cmd_path "$@" ;;
@@ -484,6 +519,7 @@ Usage: $0 {set|get|deactivate|consume-handoff|migrate|path} [options]
   get --field <F> [--default V] [--session UUID]
       | --jq-filter <FILTER> [--default V] [--session UUID]
   deactivate [--next T] [--session UUID]
+  clear-worktree [--session UUID]    # surgically del(.worktree); idempotent, no phase/next needed
   consume-handoff [--session UUID]   # print + clear the one-shot handoff marker
   migrate [--dry-run] [--verbose]
   path [--session UUID]

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -473,6 +473,72 @@ _rite_dir_is_self() {
 rite_self_dir="${RITE_WORKTREE:-$rite_invocation_pwd}"
 rite_self_canon=$(_rite_canonical_dir "$rite_self_dir")
 
+# Cross-session liveness guard (Issue #1524). The 4th protection layer: extend
+# Gate 0 self-exclusion to ALL live sessions. Scans `.rite/sessions/*.flow-state`
+# for a session that records this worktree as its active `worktree`. flow-state
+# liveness takes priority over the claim liveness gate (Gate 2): a session can be
+# live and standing in the worktree while its claim heartbeat has gone
+# stale/free, so the claim alone would wrongly mark the tree reapable. Returns:
+#   0 = a LIVE session (active=true) records $1 (canonical wt_path) → protect (skip reap)
+#   2 = the sessions dir cannot be enumerated, or a flow-state cannot be parsed
+#       → caller skips conservatively (AC-4): we cannot prove no live session needs it
+#   1 = no live session references it → reap may proceed (subject to other gates)
+# Reads the shared-root sessions dir ($repo_root/.rite/sessions).
+_rite_worktree_live_referenced() {
+  local target_canon="$1"
+  local sdir="$repo_root/.rite/sessions"
+  [ -d "$sdir" ] || return 1
+  # Existing-but-unreadable dir is an enumeration failure → conservative skip.
+  [ -r "$sdir" ] && [ -x "$sdir" ] || return 2
+  local f parse_failed=0
+  for f in "$sdir"/*.flow-state; do
+    [ -f "$f" ] || continue   # literal glob (no matches) or non-file → skip
+    local _row _active _wt
+    # Single composite read so a corrupt flow-state is caught as a parse failure
+    # (→ conservative skip) rather than silently degrading active/worktree to empty.
+    _row=$(jq -r '[(.active // false | tostring), (.worktree // "")] | join("")' "$f" 2>/dev/null) || { parse_failed=1; continue; }
+    IFS=$'\x1f' read -r _active _wt <<< "$_row"
+    [ "$_active" = "true" ] || continue
+    [ -n "$_wt" ] || continue
+    if [ "$_wt" = "$target_canon" ] || [ "$(_rite_canonical_dir "$_wt")" = "$target_canon" ]; then
+      return 0
+    fi
+  done
+  [ "$parse_failed" -eq 1 ] && return 2
+  return 1
+}
+
+# After a session worktree is reaped, clear the `worktree` reference from every
+# flow-state that still records it, so neither rite's own re-entry path
+# (open.md Step 0.5 / resume.md) nor a later harness cwd-restore is pointed at the
+# now-deleted directory (Issue #1524 MUST: reap → null the owner's flow-state
+# worktree). The write is routed through `flow-state.sh clear-worktree` to honor
+# the `_atomic_write` convention; per-session failure WARNs and is non-blocking
+# (AC-5). $1 = raw wt_path (already removed), $2 = its canonical form captured
+# BEFORE removal (post-removal canonicalization of a deleted dir would not match).
+_rite_null_worktree_refs() {
+  local wt_raw="$1" wt_canon="$2"
+  local sdir="$repo_root/.rite/sessions"
+  [ -d "$sdir" ] && [ -r "$sdir" ] || return 0
+  local f
+  for f in "$sdir"/*.flow-state; do
+    [ -f "$f" ] || continue
+    local _wt; _wt=$(jq -r '.worktree // ""' "$f" 2>/dev/null) || continue
+    [ -n "$_wt" ] || continue
+    if [ "$_wt" = "$wt_raw" ] || [ "$_wt" = "$wt_canon" ] || [ "$(_rite_canonical_dir "$_wt")" = "$wt_canon" ]; then
+      local _sid; _sid=$(basename "$f"); _sid="${_sid%.flow-state}"
+      if RITE_STATE_ROOT="$repo_root" bash "$SCRIPT_DIR/../flow-state.sh" clear-worktree --session "$_sid" >/dev/null 2>&1; then
+        :
+      else
+        echo "WARNING: reap 後の flow-state worktree クリアに失敗しました (session=$(printf '%s' "$_sid" | neutralize_ctrl))。非blocking で継続します。" >&2
+      fi
+    fi
+  done
+  # Explicit rc so the for-loop's trailing exit status (a non-matching `if`) never
+  # trips the caller's `set -e` when this is invoked as a standalone statement.
+  return 0
+}
+
 if [ -d "$session_wt_root" ]; then
   while IFS= read -r _wt_line; do
     case "$_wt_line" in
@@ -495,6 +561,29 @@ if [ -d "$session_wt_root" ]; then
     # silent) per AC-2.
     if [ -n "$rite_self_canon" ] && _rite_dir_is_self "$rite_self_canon" "$(_rite_canonical_dir "$wt_path")"; then
       echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は実行中の自セッション worktree のため reap をスキップします (self-exclusion)。" >&2
+      continue
+    fi
+
+    # Canonicalize once (worktree still exists here): reused by the cross-session
+    # liveness guard below AND by the post-reap null-ing (which must use the
+    # pre-removal canonical form — a deleted dir no longer canonicalizes).
+    _wt_canon=$(_rite_canonical_dir "$wt_path")
+
+    # Gate (cross-session liveness, Issue #1524): never reap a worktree that a
+    # DIFFERENT live session records as its active `worktree`, even when that
+    # session's claim has gone stale/free (flow-state liveness > claim liveness).
+    # Evaluated before Gate 3/Gate 2, like Gate 0, so a clean+stale+aged worktree
+    # still held by a live session is preserved. Enumeration/parse failure of
+    # `.rite/sessions/` → conservative skip (AC-4). Skip is logged (not silent).
+    # `func || rc=$?` (not `func; rc=$?`): under `set -e` a bare non-zero return
+    # (rc=1 no live ref / rc=2 enum failure) would abort the whole reap loop.
+    _live_rc=0
+    _rite_worktree_live_referenced "$_wt_canon" || _live_rc=$?
+    if [ "$_live_rc" -eq 0 ]; then
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は別の live セッションが参照中のため reap をスキップします (cross-session liveness)。" >&2
+      continue
+    elif [ "$_live_rc" -eq 2 ]; then
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' の保護判定に必要な flow-state の列挙/parse に失敗したため、安全側で reap をスキップします。" >&2
       continue
     fi
 
@@ -545,6 +634,10 @@ if [ -d "$session_wt_root" ]; then
     if git worktree remove --force "$wt_path" 2>/dev/null || rm -rf "$wt_path" 2>/dev/null; then
       session_worktrees_reaped=$((session_worktrees_reaped + 1))
       rm -f "$repo_root/.rite/state/issue-claims/issue-${issue_num}.json" 2>/dev/null || true
+      # Null the dangling `worktree` reference in the owning session's flow-state
+      # (uses the pre-removal canonical path) so re-entry / harness cwd-restore is
+      # not pointed at the just-removed dir. Non-blocking (AC-5).
+      _rite_null_worktree_refs "$wt_path" "$_wt_canon"
     else
       echo "WARNING: failed to reap session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)'" >&2
       errors=$((errors + 1))

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -396,6 +396,33 @@ if [ -z "$STATE_FILE" ] || [ ! -f "$STATE_FILE" ]; then
   exit 0
 fi
 
+# --- Dangling session-worktree self-heal (multi-session §8 / Issue #1524) ---
+# If the recorded `worktree` path no longer exists (e.g. it was reaped by another
+# session's lazy GC while this session was paused), null the field so neither the
+# orchestrator's re-entry path (open.md Step 0.5 / resume.md) nor a later
+# EnterWorktree is aimed at a dead directory. The harness's own /clear cwd-restore
+# cannot be intercepted by rite, so this is the SECONDARY defense (the primary is
+# the reap-side cross-session liveness guard in pr-cycle-cleanup.sh). Runs on both
+# startup and clear, for active and inactive state alike (a dangling reference is
+# harmful to a later resume regardless of `active`). `flow-state.sh clear-worktree`
+# resolves the same session_id as `path` above (same .rite-session-id + RITE_STATE_ROOT),
+# so it targets THIS session's own state file. Non-blocking: failures WARN and the
+# hook continues (AC-5).
+_recorded_wt_err=$(mktemp 2>/dev/null) || _recorded_wt_err=""
+_recorded_wt=$(jq -r '.worktree // ""' "$STATE_FILE" 2>"${_recorded_wt_err:-/dev/null}") || _recorded_wt=""
+if [ -n "$_recorded_wt_err" ] && [ -s "$_recorded_wt_err" ]; then
+  echo "rite: session-start: WARNING: jq read of .worktree failed (STATE_FILE may be corrupt)" >&2
+  head -3 "$_recorded_wt_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+fi
+[ -n "$_recorded_wt_err" ] && rm -f "$_recorded_wt_err"
+if [ -n "$_recorded_wt" ] && [ ! -d "$_recorded_wt" ]; then
+  if RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" clear-worktree >/dev/null 2>&1; then
+    echo "[rite] worktree '$(printf '%s' "$_recorded_wt" | neutralize_ctrl)' が存在しないため flow-state から参照をクリアしました（再入場は試みません）。" >&2
+  else
+    echo "[rite] WARNING: session-start: dangling worktree 参照のクリアに失敗しました（非blocking で継続します）。" >&2
+  fi
+fi
+
 _active_err=$(mktemp 2>/dev/null) || _active_err=""
 ACTIVE=$(jq -r '.active // false' "$STATE_FILE" 2>"${_active_err:-/dev/null}") || ACTIVE=false
 if [ -n "$_active_err" ] && [ -s "$_active_err" ]; then

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1062,6 +1062,34 @@ else
   fail "TC-24.4: --session override non-UUID rejected/degraded. stderr: '$err'"
 fi
 
-if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + silent-failure fixes + security/observability hardening + handoff marker + consume-handoff corrupt-read WARNING + jq stderr snippet control-char neutralization + C1 8-bit coverage via shared neutralize_ctrl + --worktree merge-preserve field + non-UUID acceptance (Layer 1 format-agnostic contract pin)"; then
+# --- TC-25: clear-worktree subcommand (Issue #1524) ---
+# Surgical del(.worktree) mirroring cmd_deactivate: removes only the worktree key,
+# preserves phase/active/branch, idempotent (no-op + no file churn when absent),
+# non-blocking on a missing state file. Used by pr-cycle-cleanup.sh reap null-ing
+# and session-start.sh dangling self-heal.
+echo ""
+echo "=== TC-25: clear-worktree removes worktree key, preserves others, idempotent ==="
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+(cd "$d" && bash "$HOOK" set --phase implement --issue 1524 --branch "fix/issue-1524" --pr 0 --next "n" \
+  --worktree "$d/.rite/worktrees/issue-1524")
+sfile="$d/.rite/sessions/${sid}.flow-state"
+assert "TC-25: worktree set via cmd_set" "$d/.rite/worktrees/issue-1524" "$(jq -r '.worktree // "ABSENT"' "$sfile")"
+(cd "$d" && bash "$HOOK" clear-worktree)
+assert "TC-25: worktree key removed" "false" "$(jq -r 'has("worktree")' "$sfile")"
+assert "TC-25: phase preserved" "implement" "$(jq -r '.phase' "$sfile")"
+assert "TC-25: active preserved" "true" "$(jq -r '.active' "$sfile")"
+assert "TC-25: branch preserved" "fix/issue-1524" "$(jq -r '.branch' "$sfile")"
+# Idempotent: re-clearing is a no-op (rc 0) AND must NOT rewrite the file (no
+# updated_at churn → wm-sync diff guard stays quiet).
+before=$(cat "$sfile")
+(cd "$d" && bash "$HOOK" clear-worktree); rc=$?
+assert "TC-25: idempotent re-clear rc=0" "0" "$rc"
+assert "TC-25: idempotent re-clear is a no-op (no file rewrite)" "$before" "$(cat "$sfile")"
+# Non-blocking on a missing state file: resolving a sid with no file returns rc 0.
+miss_rc=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID \
+  bash "$HOOK" clear-worktree --session "no-such-session-1524" >/dev/null 2>&1); echo $? )
+assert "TC-25: clear-worktree on missing state file is non-blocking (rc 0)" "0" "$miss_rc"
+
+if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + silent-failure fixes + security/observability hardening + handoff marker + consume-handoff corrupt-read WARNING + jq stderr snippet control-char neutralization + C1 8-bit coverage via shared neutralize_ctrl + --worktree merge-preserve field + clear-worktree surgical del (Issue #1524) + non-UUID acceptance (Layer 1 format-agnostic contract pin)"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1080,11 +1080,17 @@ assert "TC-25: phase preserved" "implement" "$(jq -r '.phase' "$sfile")"
 assert "TC-25: active preserved" "true" "$(jq -r '.active' "$sfile")"
 assert "TC-25: branch preserved" "fix/issue-1524" "$(jq -r '.branch' "$sfile")"
 # Idempotent: re-clearing is a no-op (rc 0) AND must NOT rewrite the file (no
-# updated_at churn → wm-sync diff guard stays quiet).
-before=$(cat "$sfile")
+# updated_at churn → wm-sync diff guard stays quiet). Pin updated_at to a known
+# PAST value after the first clear, then re-clear: the has("worktree") early-return
+# guard means the second clear performs no write, so updated_at MUST stay pinned.
+# (A `before==after` cat compare would NOT catch guard removal — the rewritten
+# updated_at would equal the original within the same wall-clock second. Pinning a
+# past value makes the assertion non-vacuous regardless of second-boundary timing.)
+pin_ts="2020-01-01T00:00:00Z"
+tmp_pin=$(mktemp); jq --arg ts "$pin_ts" '.updated_at = $ts' "$sfile" > "$tmp_pin" && mv "$tmp_pin" "$sfile"
 (cd "$d" && bash "$HOOK" clear-worktree); rc=$?
 assert "TC-25: idempotent re-clear rc=0" "0" "$rc"
-assert "TC-25: idempotent re-clear is a no-op (no file rewrite)" "$before" "$(cat "$sfile")"
+assert "TC-25: idempotent re-clear performs no write (updated_at stays pinned)" "$pin_ts" "$(jq -r '.updated_at' "$sfile")"
 # Non-blocking on a missing state file: resolving a sid with no file returns rc 0.
 miss_rc=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID \
   bash "$HOOK" clear-worktree --session "no-such-session-1524" >/dev/null 2>&1); echo $? )

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -162,5 +162,79 @@ assert "TC-11 RITE_WORKTREE-named worktree survives" "1" "$( [ -d "$R/.rite/work
 assert_grep "TC-11 self-exclusion WARNING on stderr" "$R/pcc.err" "self-exclusion"
 case "$out" in *"session_worktrees=0"*) pass "TC-11 status reports session_worktrees=0" ;; *) fail "TC-11 status: $out" ;; esac
 
+# ===========================================================================
+# Issue #1524 — cross-session liveness guard (4th protection layer) + reap-time
+# flow-state worktree null-ing. The guard protects a worktree that ANOTHER live
+# session (flow-state active=true) records as its `worktree`, EVEN when that
+# session's claim has gone stale — flow-state liveness > claim liveness (Gate 2).
+# SID_C = a third (distinct) holder session used by the prefix-collision test.
+# ===========================================================================
+SID_C="cccccccc-9999-aaaa-bbbb-cccccccccccc"
+
+# Helper: age a flow-state's updated_at so the holder's CLAIM goes stale while
+# keeping active=true + worktree recorded — the exact incident shape (live session,
+# expired claim heartbeat). Without aging, the claim stays "other" (live) and Gate 2
+# alone would protect the worktree, making the new guard's contribution vacuous.
+age_flow_state() {
+  local sf="$1" tmp
+  tmp=$(mktemp) || return 1
+  jq '.updated_at = "2020-01-01T00:00:00Z"' "$sf" > "$tmp" && mv "$tmp" "$sf"
+}
+
+echo "=== T-01 (AC-1): live-session flow-state worktree ref → NOT reaped even when claim stale ==="
+R=$(make_repo 70); cleanup_dirs+=("$R")
+# Record the worktree in SID_A's flow-state (the live-session reference), then age
+# updated_at so the claim is "stale" (Gate 2 would reap) while active=true (guard protects).
+RITE_STATE_ROOT="$R" bash "$FS" set --session "$SID_A" --phase implement --issue 70 \
+  --branch "feat/issue-70" --next n --worktree "$R/.rite/worktrees/issue-70" >/dev/null 2>&1
+age_flow_state "$R/.rite/sessions/${SID_A}.flow-state"
+claim_now=$(RITE_STATE_ROOT="$R" bash "$IC" check --issue 70 --session "$SID_B" 2>/dev/null)
+out=$(run_pcc "$R")
+assert "T-01 claim is stale (guard non-vacuous: Gate 2 alone would reap)" "stale" "$claim_now"
+assert "T-01 live-referenced worktree survives (cross-session liveness)" "1" "$( [ -d "$R/.rite/worktrees/issue-70" ] && echo 1 || echo 0 )"
+assert_grep "T-01 cross-session liveness WARNING on stderr" "$R/pcc.err" "cross-session liveness"
+case "$out" in *"session_worktrees=0"*) pass "T-01 status reports session_worktrees=0" ;; *) fail "T-01 status: $out" ;; esac
+
+echo "=== T-03 (AC-3): inactive flow-state worktree ref does NOT over-protect → reaped + owner ref nulled ==="
+R=$(make_repo 71); cleanup_dirs+=("$R")
+# SID_A records the worktree but is then deactivated (active=false) → NOT a live ref.
+RITE_STATE_ROOT="$R" bash "$FS" set --session "$SID_A" --phase implement --issue 71 \
+  --branch "feat/issue-71" --next n --worktree "$R/.rite/worktrees/issue-71" >/dev/null 2>&1
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "T-03 orphan worktree reaped (inactive ref not over-protected)" "0" "$( [ -d "$R/.rite/worktrees/issue-71" ] && echo 1 || echo 0 )"
+assert "T-03 claim file deleted" "0" "$( [ -f "$R/.rite/state/issue-claims/issue-71.json" ] && echo 1 || echo 0 )"
+assert "T-03 owner flow-state worktree nulled after reap" "false" "$(jq -r 'has("worktree")' "$R/.rite/sessions/${SID_A}.flow-state" 2>/dev/null)"
+case "$out" in *"session_worktrees=1"*) pass "T-03 status reports session_worktrees=1" ;; *) fail "T-03 status: $out" ;; esac
+
+echo "=== T-04 (AC-4): flow-state parse failure → conservative skip + WARNING ==="
+R=$(make_repo 72); cleanup_dirs+=("$R")
+# Stale the claim so the worktree WOULD be reaped (non-vacuous), then drop a corrupt
+# flow-state so the guard's jq parse fails → conservative skip. Corrupt-file (vs
+# chmod) keeps the test uid-independent (root would bypass an unreadable dir).
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+printf '{ this is not valid json' > "$R/.rite/sessions/corrupt-sess.flow-state"
+out=$(run_pcc "$R")
+assert "T-04 worktree survives (conservative skip on parse failure)" "1" "$( [ -d "$R/.rite/worktrees/issue-72" ] && echo 1 || echo 0 )"
+assert_grep "T-04 conservative-skip WARNING on stderr" "$R/pcc.err" "保護判定に必要な flow-state"
+case "$out" in *"session_worktrees=0"*) pass "T-04 status reports session_worktrees=0" ;; *) fail "T-04 status: $out" ;; esac
+
+echo "=== T-06 (AC-6): new guard + strict regex — issue-1 (live-ref) protected, issue-12 (orphan) reaped, no prefix bleed ==="
+R=$(make_repo 1); cleanup_dirs+=("$R")
+# issue-1: live flow-state ref (active + worktree) with a stale claim → guard protects.
+RITE_STATE_ROOT="$R" bash "$FS" set --session "$SID_A" --phase implement --issue 1 \
+  --branch "feat/issue-1" --next n --worktree "$R/.rite/worktrees/issue-1" >/dev/null 2>&1
+age_flow_state "$R/.rite/sessions/${SID_A}.flow-state"
+# issue-12: a sibling orphan held by a DIFFERENT inactive session → reapable. Proves the
+# guard's path matching + Gate 1 strict regex do not let issue-1 protect issue-12.
+( cd "$R" && $GIT worktree add -q -b "feat/issue-12" ".rite/worktrees/issue-12" >/dev/null 2>&1 )
+RITE_STATE_ROOT="$R" bash "$IC" claim --issue 12 --session "$SID_C" --worktree "$R/.rite/worktrees/issue-12" >/dev/null 2>&1
+RITE_STATE_ROOT="$R" bash "$FS" set --session "$SID_C" --phase implement --issue 12 --branch "feat/issue-12" --next n >/dev/null 2>&1
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_C" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "T-06 issue-1 (live-ref) survives" "1" "$( [ -d "$R/.rite/worktrees/issue-1" ] && echo 1 || echo 0 )"
+assert "T-06 issue-12 (orphan) reaped (no prefix bleed from issue-1)" "0" "$( [ -d "$R/.rite/worktrees/issue-12" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "T-06 status reports session_worktrees=1 (only issue-12)" ;; *) fail "T-06 status: $out" ;; esac
+
 print_summary "$(basename "$0")" \
-  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + cross-session liveness guard (Issue #1524: another live session's flow-state worktree ref → never reap; reap → null owner ref) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -1190,6 +1190,108 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-1524-* : dangling session-worktree self-heal (Issue #1524, AC-2 / AC-5)
+# When flow-state records a `worktree` path that no longer exists (reaped by
+# another session's GC while this session was paused), session-start nulls the
+# field so re-entry / harness cwd-restore is not aimed at a dead dir.
+# --------------------------------------------------------------------------
+# Shared sandbox builder: copies session-start.sh + its real deps and stubs
+# session-ownership.sh (mirrors TC-T04). Echoes the sandbox hooks dir.
+_mk_wt_sandbox() {
+  local dir="$1" sbx src f
+  mkdir -p "$dir/sandbox/hooks"
+  sbx="$dir/sandbox/hooks"
+  src="$(cd "$SCRIPT_DIR/.." && pwd)"
+  for f in session-start.sh hook-preamble.sh state-path-resolve.sh control-char-neutralize.sh flow-state.sh _mktemp-stderr-guard.sh; do
+    cp "$src/$f" "$sbx/"
+  done
+  cat > "$sbx/session-ownership.sh" <<'STUB_EOF'
+#!/bin/bash
+extract_session_id() { echo ""; }
+get_state_session_id() { echo ""; }
+parse_iso8601_to_epoch() { echo 0; }
+STUB_EOF
+  printf '%s' "$sbx"
+}
+
+echo "TC-1524-a (AC-2): /clear with dangling worktree → flow-state worktree nulled, no re-entry"
+dirWT="$TEST_DIR/tc1524a"
+sbx_wt="$(_mk_wt_sandbox "$dirWT")"
+sid_wt="ses-1524a"
+ts_wt=$(iso8601_now 0)
+mkdir -p "$dirWT/.rite/sessions"
+printf '%s' "$sid_wt" > "$dirWT/.rite-session-id"
+# `worktree` points at a path that does NOT exist (the reaped session worktree).
+cat > "$dirWT/.rite/sessions/${sid_wt}.flow-state" <<EOF
+{"active": true, "issue_number": 1524, "branch": "fix/issue-1524", "phase": "implement", "session_id": "$sid_wt", "worktree": "$dirWT/.rite/worktrees/issue-1524", "updated_at": "$ts_wt"}
+EOF
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+out_wt=$(jq -n --arg cwd "$dirWT" --arg src "clear" --arg sid "$sid_wt" \
+  '{cwd: $cwd, source: $src, session_id: $sid}' \
+  | bash "$sbx_wt/session-start.sh" 2>"$LAST_STDERR_FILE") && rc_wt=0 || rc_wt=$?
+wt_after=$(jq -r 'has("worktree")' "$dirWT/.rite/sessions/${sid_wt}.flow-state" 2>/dev/null)
+if [ "$rc_wt" -eq 0 ] && [ "$wt_after" = "false" ] \
+   && grep -q "存在しないため flow-state から参照をクリア" "$LAST_STDERR_FILE"; then
+  pass "TC-1524-a: dangling worktree nulled on /clear (rc=0, self-heal WARNING shown)"
+else
+  fail "TC-1524-a: expected worktree cleared; rc=$rc_wt has_worktree=$wt_after stderr=$(cat "$LAST_STDERR_FILE")"
+fi
+echo ""
+
+echo "TC-1524-b (AC-2 boundary): existing worktree dir → NOT cleared (self-heal does not over-fire)"
+dirWTb="$TEST_DIR/tc1524b"
+sbx_wtb="$(_mk_wt_sandbox "$dirWTb")"
+sid_wtb="ses-1524b"
+ts_wtb=$(iso8601_now 0)
+mkdir -p "$dirWTb/.rite/sessions"
+mkdir -p "$dirWTb/.rite/worktrees/issue-1525"   # the recorded worktree DOES exist
+printf '%s' "$sid_wtb" > "$dirWTb/.rite-session-id"
+cat > "$dirWTb/.rite/sessions/${sid_wtb}.flow-state" <<EOF
+{"active": true, "issue_number": 1525, "branch": "fix/issue-1525", "phase": "implement", "session_id": "$sid_wtb", "worktree": "$dirWTb/.rite/worktrees/issue-1525", "updated_at": "$ts_wtb"}
+EOF
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+jq -n --arg cwd "$dirWTb" --arg src "clear" --arg sid "$sid_wtb" \
+  '{cwd: $cwd, source: $src, session_id: $sid}' \
+  | bash "$sbx_wtb/session-start.sh" >/dev/null 2>"$LAST_STDERR_FILE" || true
+wt_after_b=$(jq -r '.worktree // "ABSENT"' "$dirWTb/.rite/sessions/${sid_wtb}.flow-state" 2>/dev/null)
+if [ "$wt_after_b" = "$dirWTb/.rite/worktrees/issue-1525" ]; then
+  pass "TC-1524-b: existing worktree dir preserved (self-heal correctly scoped to missing dir)"
+else
+  fail "TC-1524-b: expected worktree preserved, got '$wt_after_b'"
+fi
+echo ""
+
+echo "TC-1524-c (AC-5): clear-worktree write failure → session-start non-blocking (exit 0) + WARNING"
+if [ "$(id -u)" -eq 0 ]; then
+  # root bypasses dir-permission bits, so a read-only sessions dir cannot force the
+  # atomic-write failure this case exercises. Not a product failure — skip honestly.
+  pass "TC-1524-c: skipped under root (chmod cannot force a write failure as uid 0)"
+else
+  dirWTc="$TEST_DIR/tc1524c"
+  sbx_wtc="$(_mk_wt_sandbox "$dirWTc")"
+  sid_wtc="ses-1524c"
+  ts_wtc=$(iso8601_now 0)
+  mkdir -p "$dirWTc/.rite/sessions"
+  printf '%s' "$sid_wtc" > "$dirWTc/.rite-session-id"
+  cat > "$dirWTc/.rite/sessions/${sid_wtc}.flow-state" <<EOF
+{"active": true, "issue_number": 1526, "branch": "fix/issue-1526", "phase": "implement", "session_id": "$sid_wtc", "worktree": "$dirWTc/.rite/worktrees/issue-1526", "updated_at": "$ts_wtc"}
+EOF
+  # Read-only sessions dir → clear-worktree's _atomic_write (mktemp in dir) fails.
+  chmod 555 "$dirWTc/.rite/sessions"
+  LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+  jq -n --arg cwd "$dirWTc" --arg src "clear" --arg sid "$sid_wtc" \
+    '{cwd: $cwd, source: $src, session_id: $sid}' \
+    | bash "$sbx_wtc/session-start.sh" >/dev/null 2>"$LAST_STDERR_FILE" && rc_wtc=0 || rc_wtc=$?
+  chmod 755 "$dirWTc/.rite/sessions"   # restore so the EXIT trap can rm -rf
+  if [ "$rc_wtc" -eq 0 ] && grep -q "dangling worktree 参照のクリアに失敗" "$LAST_STDERR_FILE"; then
+    pass "TC-1524-c: clear-worktree write failure is non-blocking (exit 0) + WARNING emitted"
+  else
+    fail "TC-1524-c: expected non-blocking WARNING; rc=$rc_wtc stderr=$(cat "$LAST_STDERR_FILE")"
+  fi
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## 概要

マルチセッション（`multi_session.enabled: true`）で、あるセッション A が作成・作業中の `.rite/worktrees/issue-{N}` を、別セッション B の session-start で走る lazy reap（`pr-cycle-cleanup.sh` Step 5）が誤って回収してしまい、セッション A で `/clear` を実行した際にハーネスの作業ツリー復元が `Error: Path "..." does not exist` で失敗する問題を解消する。

claim heartbeat（flow-state `updated_at`）が期限切れでもセッション A 自体は live で worktree 内に立っていることがあり得るため、claim liveness だけでは live セッションを保護しきれていなかった。これを「(1) reap させない保護」「(2) 万一 reap された場合の自己修復」の二段構えで対処する。

## 関連 Issue

Closes #1524

## 変更内容

- **`plugins/rite/hooks/flow-state.sh`**: `worktree` フィールドを明示的に null 化する `clear-worktree` サブコマンドを追加。`cmd_deactivate`（`.active=false` を surgical に書く）と同型で、`del(.worktree)` を `_atomic_write` 経由で実行する。`--phase`/`--next` を要求せず冪等（キー不在・ファイル不在は no-op）。`cmd_set` の `--worktree` merge-preserve 動作は不変（後方互換）。
- **`plugins/rite/hooks/scripts/pr-cycle-cleanup.sh`** Step 5: クロスセッション liveness ガード（第 4 保護層）を Gate 0 self-exclusion の直後に追加。別の live セッション（flow-state `active=true`）が当該 worktree を `worktree` として参照していれば、claim が stale/free でも reap しない（flow-state liveness が claim liveness=Gate 2 に優先）。`.rite/sessions/` の列挙・parse に失敗した場合は安全側で reap を skip する。reap 成功時には、その worktree を参照する所有セッションの flow-state `worktree` を `clear-worktree` で null 化する。
- **`plugins/rite/hooks/session-start.sh`**: STATE_FILE 解決後、flow-state `worktree` が指すディレクトリが存在しない場合に `worktree` を null 化する dangling 自己修復を追加（startup / clear 両対応、非blocking）。これにより再入場経路が死んだパスを踏まない。

設計判断: クリア手段は Issue §4.3 の「例: `--worktree-clear` フラグ」ではなく専用 `clear-worktree` サブコマンドを採用した。`cmd_set` は `--phase`/`--next` 必須のため、他セッション／自セッションの worktree を phase を乱さずクリアするには既存 phase/next の読み戻しが必要で read-modify-write の race 窓が広がる。既存 `cmd_deactivate` と同型にすることで surgical かつ冪等な単一フィールド削除を実現する。

## テスト

- `pr-cycle-cleanup-session-reap.test.sh`: T-01（live 参照 → 保護）/ T-03（inactive 参照は過保護しない → reap + 所有 ref null 化）/ T-04（flow-state parse 失敗 → 保守的 skip）/ T-06（issue-1 live-ref 保護 + issue-12 orphan reap の prefix 非干渉）を追加
- `session-start.test.sh`: TC-1524-a（dangling → null 化）/ TC-1524-b（実在 worktree は非クリア）/ TC-1524-c（クリア書き込み失敗 → 非blocking + WARNING、root では honest skip）を追加
- `flow-state.test.sh`: TC-25（`clear-worktree` の削除・他フィールド保持・冪等・非blocking）を追加
- hooks テストスイート全 74 ファイル green、非回帰なし

## 受入基準マッピング

- AC-1 → T-01 / AC-2 → TC-1524-a,b / AC-3 → T-03 / AC-4 → T-04 / AC-5 → TC-1524-c / AC-6 → T-06（および既存 TC-3/5/7/10/11）

## チェックリスト

- [x] 対象ファイルのみ変更（non-target の `open.md` / `resume.md` / `issue-claim.sh` は不変）
- [x] 全 MUST / MUST NOT 要件を満たす
- [x] 全 AC を検証
- [x] hooks テスト全 green（非回帰なし）
- [x] プロジェクト規約（strict regex / `_atomic_write` / `neutralize_ctrl` / 非blocking hook）に準拠

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
