### PR TITLE
fix(pr-cleanup): 一時ブランチ・worktree を名前非依存で回収する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ temp/
 .rite/fix-cycle-state/
 .rite/fix-cycle-state.json
 .rite/state/
+# Issue #1526 — name-independent reap manifest (rite-tmp-artifact.sh が記録、
+# pr-cycle-cleanup.sh が参照・回収する一時ブランチ/worktree の台帳)。runtime state。
+.rite/tmp-artifacts.tsv
 # Issue #672 — マルチセッション対応 per-session flow-state files (Option A)。
 # 各 Claude Code セッションが `.rite/sessions/{session_id}.flow-state` に独立して
 # state を保持する。session 終了時に該当ファイルが cleanup される設計。

--- a/plugins/rite/commands/pr/iterate.md
+++ b/plugins/rite/commands/pr/iterate.md
@@ -117,6 +117,18 @@ args: "{pr_number}"
 
 > **構造的保証**: 終了 sentinel (`[review:mergeable]` / `[fix:replied-only]` / `[fix:cancelled-by-user]`) 到達時、sub-skill が `FINALIZE:...` handoff をセットしており、`Stop` hook が本ステップの完了通知を出力せず turn を終えようとする停止を **1 回だけ** 差し戻す。詳細は「ループ継続・終了の構造的保証」節を参照。完了通知は必ず出力すること。
 
+### ステップ 5.0: 一時残骸の最終回収 (terminal cleanup)
+
+完了通知を出力する**前に**、本ループが残した一時ブランチ・worktree を回収する。`pr-cycle-cleanup.sh` は review entry (review.md ステップ 0) でも走るが、それは各 review **開始時** の発火であり、**最後の** review/fix cycle が残した残骸 (例: 最終 cycle の `rite-review-mutation-*` / `rite-revert-test-*` detached worktree、外部 checkout 由来の bare `pr-{N}` ブランチ) を sweep する後続 review が存在しない。本ループの終端で明示的に発火させ、回収の到達性を担保する (Issue #1526 AC-2)。non-blocking — 失敗してもループ完了を妨げない (AC-5):
+
+```bash
+bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
+```
+
+これは正常終了・ユーザー中断の**両経路**で実行する (どちらの出口でも残骸の累積を防ぐ)。出力 status 行 (`[pr-cycle-cleanup] status=...`) はそのまま表示し、何を回収したかを可視化する。
+
+> **24h age guard との関係**: `rite-review-mutation-*` / `rite-revert-test-*` detached worktree は cross-session in-flight 保護のため mtime 24h 未満は保護される (`pr-cycle-cleanup.sh` Step 4)。よって本ループが直前に作った若い worktree はこの発火では消えず、次回 cleanup (24h 経過後) で確実に回収される。即時 0 残骸ではなく **確実な最終回収** を担保する設計 (Issue #1526 D-04)。即時回収には reviewer 側の session-scoped 記録が必要だが reviewer (`agents/_reviewer-base.md`) は本 Issue の Non-Target。
+
 ### 正常終了 (`[review:mergeable]` or `[fix:replied-only]`)
 
 ```

--- a/plugins/rite/commands/pr/iterate.md
+++ b/plugins/rite/commands/pr/iterate.md
@@ -119,7 +119,7 @@ args: "{pr_number}"
 
 ### ステップ 5.0: 一時残骸の最終回収 (terminal cleanup)
 
-完了通知を出力する**前に**、本ループが残した一時ブランチ・worktree を回収する。`pr-cycle-cleanup.sh` は review entry (review.md ステップ 0) でも走るが、それは各 review **開始時** の発火であり、**最後の** review/fix cycle が残した残骸 (例: 最終 cycle の `rite-review-mutation-*` / `rite-revert-test-*` detached worktree、外部 checkout 由来の bare `pr-{N}` ブランチ) を sweep する後続 review が存在しない。本ループの終端で明示的に発火させ、回収の到達性を担保する (Issue #1526 AC-2)。non-blocking — 失敗してもループ完了を妨げない (AC-5):
+完了通知を出力する**前に**、本ループが残した一時ブランチ・worktree を回収する。`pr-cycle-cleanup.sh` は review entry (review.md ステップ 1.0.0 PR Cycle Branch Cleanup) でも走るが、それは各 review **開始時** の発火であり、**最後の** review/fix cycle が残した残骸 (例: 最終 cycle の `rite-review-mutation-*` / `rite-revert-test-*` detached worktree、外部 checkout 由来の bare `pr-{N}` ブランチ) を sweep する後続 review が存在しない。本ループの終端で明示的に発火させ、回収の到達性を担保する (Issue #1526 AC-2)。non-blocking — 失敗してもループ完了を妨げない (AC-5):
 
 ```bash
 bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -33,6 +33,16 @@
 # worktree (`.rite/wiki-worktree`) is excluded unconditionally — see
 # commands/pr/cleanup.md §2.6.
 #
+# Also reaps (Issue #1526):
+#   - bare `pr-{N}` (no suffix, `^pr-[0-9]+$`): external/manual PR-checkout leak
+#     (`git fetch origin pull/{N}/head:pr-{N}`). rite work branches are
+#     `{type}/issue-{N}-{slug}`, so the exact match cannot collide (AC-1/D-02).
+#   - `rite-revert-test-*` detached worktrees: same `rite-` reviewer-tmp namespace
+#     as `rite-review-mutation-*`, swept by path name in Step 4 (AC-2/D-03).
+#   - manifest-recorded artifacts (`.rite/tmp-artifacts.tsv`): name-independent
+#     reap of branches/worktrees a producer recorded via rite-tmp-artifact.sh —
+#     Step 4.5 deletes ONLY recorded entries, never by guessing names (AC-4/D-05).
+#
 # Variation history:
 #   - `cycle{N}`: orchestrator-created (`/rite:pr:review` cycle worktrees)
 #   - `test` / `experiment` / `mutation` / `verify` / `check` / `sandbox`:
@@ -47,7 +57,7 @@
 #   bash pr-cycle-cleanup.sh [--dry-run]
 #
 # Output (stdout): one structured status line per invocation
-#   [pr-cycle-cleanup] status=<cleaned|noop|failed>; worktrees=<N>; branches=<N>; workdirs=<N>; mutation_worktrees=<N>
+#   [pr-cycle-cleanup] status=<cleaned|noop|failed>; worktrees=<N>; branches=<N>; workdirs=<N>; mutation_worktrees=<N>; session_worktrees=<N>; manifest=<N>
 #
 # Exit codes:
 #   0  cleanup completed (or nothing to clean)
@@ -110,13 +120,27 @@ cd -- "$repo_root"
 # 直接参照することで、worktree-loop と branch-loop の 2 箇所で literal regex を
 # duplicate していた drift リスクを解消する (`readonly` で immutable 化)。
 readonly PATTERN='^pr-[0-9]+-(cycle[0-9]+|test|experiment|mutation|verify|check|sandbox)$'
+# Bare `pr-{N}` (no suffix). Not created by rite's own code — it leaks from
+# external/manual PR checkout (`git fetch origin pull/{N}/head:pr-{N}`,
+# `gh pr checkout`) during the workflow (Issue #1526 §3.2 Open Question resolved:
+# rite-internal grep finds no producer). rite's own work branches are
+# `{type}/issue-{N}-{slug}`, so an exact `^pr-[0-9]+$` sweep cannot collide with
+# them — the same low-risk, naming-convention basis as the suffixed PATTERN above
+# (Issue #1526 AC-1 / D-02).
+readonly BARE_PR_PATTERN='^pr-[0-9]+$'
 readonly WIKI_WORKTREE_PATH=".rite/wiki-worktree"
+# Name-independent reap manifest (Issue #1526 D-01/D-05). Producers append
+# `<type>\t<value>` via hooks/scripts/rite-tmp-artifact.sh; cleanup reaps each
+# recorded branch/worktree by identity, never by guessing the name. Resolved
+# under repo_root (the SHARED state root — we already cd'd there).
+readonly TMP_ARTIFACT_MANIFEST=".rite/tmp-artifacts.tsv"
 
 worktrees_removed=0
 branches_deleted=0
 workdirs_reaped=0
 mutation_worktrees_reaped=0
 session_worktrees_reaped=0
+manifest_reaped=0
 errors=0
 
 # trap + cleanup パターン (canonical: references/bash-trap-patterns.md#signal-specific-trap-template)
@@ -127,14 +151,19 @@ prune_err=""
 ref_err=""
 workdir_find_err=""
 mutation_find_err=""
+revert_find_err=""
 # Step 3/4 の find -print0 出力を保持する NUL-delimited 一時ファイル。
 # command substitution は NUL バイトを除去するため list を変数に持てない。find rc 捕捉を
 # 保ちつつ改行安全に読むには、出力を一時ファイルに退避して `read -r -d ''` で読む。
 workdir_find_out=""
 mutation_find_out=""
+revert_find_out=""
+# Step 4.5 manifest reap の survivor 書き出し用 (NUL 不使用だが trap で確実に掃除する)
+manifest_keep=""
 _rite_pr_cycle_cleanup() {
   rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}" "${workdir_find_err:-}" "${mutation_find_err:-}" \
-        "${workdir_find_out:-}" "${mutation_find_out:-}"
+        "${revert_find_err:-}" "${workdir_find_out:-}" "${mutation_find_out:-}" "${revert_find_out:-}" \
+        "${manifest_keep:-}"
 }
 trap 'rc=$?; _rite_pr_cycle_cleanup; exit $rc' EXIT
 trap '_rite_pr_cycle_cleanup; exit 130' INT
@@ -166,7 +195,7 @@ if wt_list=$(git worktree list --porcelain 2>"${wt_list_err:-/dev/null}"); then
           current_path=""
           continue
         fi
-        if [[ "$branch_name" =~ $PATTERN ]]; then
+        if [[ "$branch_name" =~ $PATTERN ]] || [[ "$branch_name" =~ $BARE_PR_PATTERN ]]; then
           if [ "$DRY_RUN" = "1" ]; then
             safe_path=$(printf '%s' "$current_path" | neutralize_ctrl)
             safe_branch=$(printf '%s' "$branch_name" | neutralize_ctrl)
@@ -229,7 +258,7 @@ ref_err=$(mktemp /tmp/rite-pr-cycle-cleanup-ref-err-XXXXXX 2>/dev/null) || ref_e
 if branches=$(git for-each-ref --format='%(refname:short)' refs/heads/ 2>"${ref_err:-/dev/null}"); then
   while IFS= read -r br; do
     [ -z "$br" ] && continue
-    if [[ "$br" =~ $PATTERN ]]; then
+    if [[ "$br" =~ $PATTERN ]] || [[ "$br" =~ $BARE_PR_PATTERN ]]; then
       if [ "$DRY_RUN" = "1" ]; then
         echo "[dry-run] would delete branch: $(printf '%s' "$br" | neutralize_ctrl)"
       else
@@ -371,28 +400,36 @@ reap_orphan_dirs "orphan workdir" "$workdir_tmp_base" 'rite-pr-create-*' \
   _reap_workdir "$workdir_find_out" "$workdir_find_err"
 
 # -----------------------------------------------------------------------
-# Step 4: Reap orphaned `rite-review-mutation-*` worktrees.
+# Step 4: Reap orphaned reviewer detached tmp worktrees (`rite-` namespace).
 # reviewer subagent の mutation/verification 検証は `_reviewer-base.md` の
 # worktree-only mutation pattern (`mktemp -d -t rite-review-mutation-XXXXXX`
 # + `git worktree add --detach`) に従って detached worktree を作るが、reviewer は
 # READ-ONLY 契約で `git worktree remove` を実行禁止のため自己回収できず、
 # orchestrator 側の本 GC が回収する (doc と実装の drift 解消)。
 #
-# Step 1 の branch-pattern sweep では捕捉できない: mutation worktree は
-# `--detach` で named branch を持たないため porcelain 出力に `branch refs/heads/...`
-# 行が無く、Step 1 の `$PATTERN` (branch 名マッチ) を素通りする。よって path 命名
-# (`rite-review-mutation-*`) を find で直接 sweep する。
+# 名前空間: sanctioned な `rite-review-mutation-*` に加え、実機で観測された
+# `rite-revert-test-*` (revert して挙動を確認する検証 worktree) も同じ `rite-`
+# reviewer-tmp 名前空間として回収する (Issue #1526 AC-2 / D-03)。prefix 自体が
+# name-independent な「これは rite 由来 tmp worktree」マーカーとして機能するため、
+# 個別命名を regex で追い続けるモグラ叩きを避けられる。
+#
+# Step 1 の branch-pattern sweep では捕捉できない: これらは `--detach` で named
+# branch を持たないため porcelain 出力に `branch refs/heads/...` 行が無く、Step 1 の
+# `$PATTERN` (branch 名マッチ) を素通りする。よって path 命名を find で直接 sweep する。
 #
 # age ガード (mtime > WORKDIR_REAP_AGE_MINUTES) は Step 3 workdir reap と同一閾値
-# (24h) を共有する: 健全な mutation 検証は reviewer subagent の当該ターン (数分) で
-# 完結するため、閾値超過の worktree は確実に orphan。並行 session の in-flight worktree
-# を誤回収しないための保守的マージン。走査先は create.md / `mktemp -d -t` と同じ
-# `${TMPDIR:-/tmp}` を尊重する (テスト時の TMPDIR 隔離も効く)。
+# (24h) を共有する: 健全な検証は reviewer subagent の当該ターン (数分) で完結するため、
+# 閾値超過の worktree は確実に orphan。並行 session の in-flight worktree を誤回収しない
+# ための保守的マージン (Issue #1526 D-04: 即時 0 残骸ではなく cross-session 安全と両立する
+# 確実な最終回収。即時回収は reviewer 側 session-scoped 記録を要し本 Issue の Non-Target)。
+# 走査先は create.md / `mktemp -d -t` と同じ `${TMPDIR:-/tmp}` を尊重する。
 #
 # 回収は `git worktree remove --force` を第一手とする (worktree 登録メタデータと
 # ディレクトリを atomically 除去)。登録が既に失われた dir には `rm -rf` で fallback し、
 # ループ後の `git worktree prune` で stale メタデータを掃除する。Step 1/3 と同様、
-# 失敗は WARNING + errors++ で surface し silent 化しない。
+# 失敗は WARNING + errors++ で surface し silent 化しない。両命名とも reviewer detached
+# tmp worktree であり、回収手段が同一のため reaper / counter (`mutation_worktrees_reaped`)
+# を共有する (status line の `mutation_worktrees=` は両者の合計を報告)。
 # -----------------------------------------------------------------------
 mutation_tmp_base="${TMPDIR:-/tmp}"
 mutation_tmp_base="${mutation_tmp_base%/}"  # strip trailing slash
@@ -403,9 +440,121 @@ mutation_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-out-XXXXXX 2>/dev
 mutation_reaped_any=0
 reap_orphan_dirs "orphan mutation worktree" "$mutation_tmp_base" 'rite-review-mutation-*' \
   _reap_mutation_worktree "$mutation_find_out" "$mutation_find_err"
+# 同じ reviewer-tmp 名前空間の `rite-revert-test-*` も同一 reaper / counter で回収する。
+revert_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-revert-err-XXXXXX 2>/dev/null) || revert_find_err=""
+revert_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-revert-out-XXXXXX 2>/dev/null) || revert_find_out=""
+reap_orphan_dirs "orphan revert-test worktree" "$mutation_tmp_base" 'rite-revert-test-*' \
+  _reap_mutation_worktree "$revert_find_out" "$revert_find_err"
 # rm -rf fallback で残った stale worktree メタデータを掃除する (remove --force 経路では不要だが冪等)
 if [ "$DRY_RUN" = "0" ] && [ "$mutation_reaped_any" = "1" ]; then
   git worktree prune 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------
+# Step 4.5: Name-independent reap of manifest-recorded tmp artifacts
+# (Issue #1526 D-01/D-05, AC-4). A producer that creates a throw-away branch /
+# worktree whose name no strict pattern above would match records it via
+# `rite-tmp-artifact.sh record`; here we reap each recorded entry BY IDENTITY,
+# never by guessing the name. 誤削除防止 (AC-3): only entries the manifest lists
+# are touched — an unrelated user branch/worktree is invisible to this step.
+#
+# No age guard: presence in the manifest is an explicit rite-origin "reap me"
+# intent, so there is no in-flight ambiguity to protect against (unlike the
+# path-name sweeps of Steps 3/4). Worktree entries still honor AC-6 — a dirty
+# worktree is skipped (and kept in the manifest for a later retry) so uncommitted
+# work is never destroyed. The manifest is contract-bound to EPHEMERAL tmp
+# artifacts; session worktrees go through Step 5's gated reap, never here.
+#
+# Manifest rewrite: lines we reap (or find already-gone) are dropped; skipped
+# (dirty) and failed entries are preserved so the next run retries them.
+# Malformed / unparseable lines are preserved untouched (conservative).
+# -----------------------------------------------------------------------
+manifest_path="$repo_root/$TMP_ARTIFACT_MANIFEST"
+if [ -f "$manifest_path" ]; then
+  manifest_keep=$(mktemp /tmp/rite-pr-cycle-cleanup-manifest-keep-XXXXXX 2>/dev/null) || manifest_keep=""
+  if [ -z "$manifest_keep" ]; then
+    echo "WARNING: manifest reap 用の一時ファイル mktemp に失敗しました。今回の manifest 回収をスキップします" >&2
+    errors=$((errors + 1))
+  else
+    _tab=$'\t'
+    while IFS= read -r _m_line || [ -n "$_m_line" ]; do
+      [ -z "$_m_line" ] && continue
+      # Split on the FIRST tab only (worktree paths may contain further tabs is
+      # already excluded by the recorder, but be defensive): type / value.
+      case "$_m_line" in
+        *"$_tab"*)
+          _m_type="${_m_line%%"$_tab"*}"
+          _m_val="${_m_line#*"$_tab"}"
+          ;;
+        *)
+          # Malformed (no TAB) — cannot act, preserve verbatim.
+          printf '%s\n' "$_m_line" >> "$manifest_keep"
+          continue
+          ;;
+      esac
+      case "$_m_type" in
+        branch)
+          if ! git rev-parse --verify --quiet "refs/heads/$_m_val" >/dev/null 2>&1; then
+            # Already gone → drop the stale entry silently (nothing to reap).
+            continue
+          fi
+          if [ "$DRY_RUN" = "1" ]; then
+            echo "[dry-run] would reap manifest branch: $(printf '%s' "$_m_val" | neutralize_ctrl)"
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+          elif git branch -D "$_m_val" >/dev/null 2>&1; then
+            manifest_reaped=$((manifest_reaped + 1))
+          else
+            echo "WARNING: failed to reap manifest branch '$(printf '%s' "$_m_val" | neutralize_ctrl)'" >&2
+            errors=$((errors + 1))
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+          fi
+          ;;
+        worktree)
+          if [ ! -e "$_m_val" ]; then
+            # Path already gone → drop, but prune any dangling registration.
+            [ "$DRY_RUN" = "0" ] && git worktree prune 2>/dev/null || true
+            continue
+          fi
+          # AC-6: never destroy uncommitted work. An indeterminate status
+          # (rc != 0, e.g. not a git worktree) is treated as "do not reap".
+          _m_st=$(git -C "$_m_val" status --porcelain 2>/dev/null); _m_st_rc=$?
+          if [ "$_m_st_rc" -ne 0 ] || [ -n "$_m_st" ]; then
+            echo "WARNING: manifest worktree '$(printf '%s' "$_m_val" | neutralize_ctrl)' は未コミット変更があるか status 判定不能のため reap をスキップし manifest に保持します。" >&2
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+            continue
+          fi
+          if [ "$DRY_RUN" = "1" ]; then
+            echo "[dry-run] would reap manifest worktree: $(printf '%s' "$_m_val" | neutralize_ctrl)"
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+          elif git worktree remove --force "$_m_val" 2>/dev/null || rm -rf "$_m_val" 2>/dev/null; then
+            manifest_reaped=$((manifest_reaped + 1))
+            git worktree prune 2>/dev/null || true
+          else
+            echo "WARNING: failed to reap manifest worktree '$(printf '%s' "$_m_val" | neutralize_ctrl)'" >&2
+            errors=$((errors + 1))
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+          fi
+          ;;
+        *)
+          # Unknown type — preserve verbatim (forward-compat / conservative).
+          printf '%s\n' "$_m_line" >> "$manifest_keep"
+          ;;
+      esac
+    done < "$manifest_path"
+
+    if [ "$DRY_RUN" = "0" ]; then
+      if [ -s "$manifest_keep" ]; then
+        if ! cp "$manifest_keep" "$manifest_path" 2>/dev/null; then
+          echo "WARNING: manifest '$manifest_path' の書き戻しに失敗しました (回収済エントリが残存する可能性)" >&2
+          errors=$((errors + 1))
+        fi
+      else
+        # All entries reaped/dropped → remove the now-empty manifest.
+        rm -f "$manifest_path" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$manifest_keep" 2>/dev/null || true
+  fi
 fi
 
 # -----------------------------------------------------------------------
@@ -655,11 +804,11 @@ fi
 if [ "$DRY_RUN" = "1" ]; then
   echo "[pr-cycle-cleanup] status=dry-run; pattern=$PATTERN"
 elif [ "$errors" -gt 0 ]; then
-  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; errors=$errors"
-elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ]; then
-  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0"
+  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; manifest=$manifest_reaped; errors=$errors"
+elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ] && [ "$manifest_reaped" -eq 0 ]; then
+  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0; manifest=0"
 else
-  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped"
+  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; manifest=$manifest_reaped"
 fi
 
 exit 0

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -501,7 +501,7 @@ if [ -f "$manifest_path" ]; then
           if [ "$DRY_RUN" = "1" ]; then
             echo "[dry-run] would reap manifest branch: $(printf '%s' "$_m_val" | neutralize_ctrl)"
             printf '%s\n' "$_m_line" >> "$manifest_keep"
-          elif git branch -D "$_m_val" >/dev/null 2>&1; then
+          elif git branch -D -- "$_m_val" >/dev/null 2>&1; then
             manifest_reaped=$((manifest_reaped + 1))
           else
             echo "WARNING: failed to reap manifest branch '$(printf '%s' "$_m_val" | neutralize_ctrl)'" >&2
@@ -515,9 +515,27 @@ if [ -f "$manifest_path" ]; then
             [ "$DRY_RUN" = "0" ] && git worktree prune 2>/dev/null || true
             continue
           fi
+          # Containment guard: the manifest is contract-bound to EPHEMERAL tmp
+          # artifacts. A poisoned/buggy entry pointing at the main checkout would
+          # otherwise delete repo_root — catastrophic. Canonicalize (`cd && pwd -P`,
+          # matching repo_root's resolved form) and never reap repo_root itself.
+          _m_canon=$( cd -- "$_m_val" 2>/dev/null && pwd -P ) || _m_canon=""
+          if [ -n "$_m_canon" ] && [ "$_m_canon" = "$repo_root" ]; then
+            echo "WARNING: manifest worktree '$(printf '%s' "$_m_val" | neutralize_ctrl)' は repo_root 自身を指すため reap をスキップし manifest に保持します。" >&2
+            printf '%s\n' "$_m_line" >> "$manifest_keep"
+            continue
+          fi
           # AC-6: never destroy uncommitted work. An indeterminate status
-          # (rc != 0, e.g. not a git worktree) is treated as "do not reap".
-          _m_st=$(git -C "$_m_val" status --porcelain 2>/dev/null); _m_st_rc=$?
+          # (rc != 0, e.g. the path exists but is not a git worktree) is treated
+          # as "do not reap". `if/else` (not `var=$(...); rc=$?`) is REQUIRED: a
+          # bare command-substitution assignment that fails (git rc=128 on a
+          # non-worktree path) aborts the whole script under `set -e` BEFORE the
+          # rc is captured, turning this safety branch into dead code.
+          if _m_st=$(git -C "$_m_val" status --porcelain 2>/dev/null); then
+            _m_st_rc=0
+          else
+            _m_st_rc=$?
+          fi
           if [ "$_m_st_rc" -ne 0 ] || [ -n "$_m_st" ]; then
             echo "WARNING: manifest worktree '$(printf '%s' "$_m_val" | neutralize_ctrl)' は未コミット変更があるか status 判定不能のため reap をスキップし manifest に保持します。" >&2
             printf '%s\n' "$_m_line" >> "$manifest_keep"
@@ -526,7 +544,7 @@ if [ -f "$manifest_path" ]; then
           if [ "$DRY_RUN" = "1" ]; then
             echo "[dry-run] would reap manifest worktree: $(printf '%s' "$_m_val" | neutralize_ctrl)"
             printf '%s\n' "$_m_line" >> "$manifest_keep"
-          elif git worktree remove --force "$_m_val" 2>/dev/null || rm -rf "$_m_val" 2>/dev/null; then
+          elif git worktree remove --force -- "$_m_val" 2>/dev/null || rm -rf -- "$_m_val" 2>/dev/null; then
             manifest_reaped=$((manifest_reaped + 1))
             git worktree prune 2>/dev/null || true
           else

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -470,6 +470,12 @@ fi
 # Malformed / unparseable lines are preserved untouched (conservative).
 # -----------------------------------------------------------------------
 manifest_path="$repo_root/$TMP_ARTIFACT_MANIFEST"
+# Canonical form of repo_root for the containment guard below. `repo_root` comes
+# from git rev-parse / state-path-resolve and is NOT symlink-resolved, but the
+# per-entry `_m_canon` is (`cd && pwd -P`); on a symlinked-path host (e.g. macOS
+# `/tmp`→`/private/tmp`, this script's portability floor) an un-canonicalized
+# compare could let the guard miss. Resolve once so the compare holds.
+_repo_canon=$( cd -- "$repo_root" 2>/dev/null && pwd -P ) || _repo_canon="$repo_root"
 if [ -f "$manifest_path" ]; then
   manifest_keep=$(mktemp /tmp/rite-pr-cycle-cleanup-manifest-keep-XXXXXX 2>/dev/null) || manifest_keep=""
   if [ -z "$manifest_keep" ]; then
@@ -517,10 +523,10 @@ if [ -f "$manifest_path" ]; then
           fi
           # Containment guard: the manifest is contract-bound to EPHEMERAL tmp
           # artifacts. A poisoned/buggy entry pointing at the main checkout would
-          # otherwise delete repo_root — catastrophic. Canonicalize (`cd && pwd -P`,
-          # matching repo_root's resolved form) and never reap repo_root itself.
+          # otherwise delete repo_root — catastrophic. Both sides are symlink-
+          # resolved (`cd && pwd -P`) so the compare holds on symlinked-path hosts.
           _m_canon=$( cd -- "$_m_val" 2>/dev/null && pwd -P ) || _m_canon=""
-          if [ -n "$_m_canon" ] && [ "$_m_canon" = "$repo_root" ]; then
+          if [ -n "$_m_canon" ] && [ "$_m_canon" = "$_repo_canon" ]; then
             echo "WARNING: manifest worktree '$(printf '%s' "$_m_val" | neutralize_ctrl)' は repo_root 自身を指すため reap をスキップし manifest に保持します。" >&2
             printf '%s\n' "$_m_line" >> "$manifest_keep"
             continue

--- a/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
+++ b/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
@@ -78,6 +78,34 @@ case "$art_id" in
     ;;
 esac
 
+# Reject a leading dash and enforce a conservative shape per type. This is the
+# SoT-side defense for the "cleanup deletes ONLY what a producer recorded"
+# contract: a value beginning with `-` would be read as an option by the
+# downstream `git branch -D` / `git worktree remove` / `rm` (option injection),
+# and a relative worktree path could resolve unpredictably at reap time. The
+# cleanup side also passes `--` end-of-options as defense in depth.
+case "$art_id" in
+  -*) echo "ERROR: --id must not start with '-' (option-injection guard)" >&2; exit 1 ;;
+esac
+case "$art_type" in
+  branch)
+    # git branch names: allow the common safe set; reject anything exotic so a
+    # poisoned value can never carry shell/option metacharacters into reap.
+    case "$art_id" in
+      *[!A-Za-z0-9._/-]*)
+        echo "ERROR: branch --id may contain only [A-Za-z0-9._/-]" >&2; exit 1 ;;
+    esac
+    ;;
+  worktree)
+    # Worktree paths recorded by rite are always absolute (git worktree list /
+    # mktemp -d -t emit absolute paths); a relative path here is a producer bug.
+    case "$art_id" in
+      /*) : ;;
+      *) echo "ERROR: worktree --id must be an absolute path" >&2; exit 1 ;;
+    esac
+    ;;
+esac
+
 # Resolve the SHARED state root (main checkout) so every session appends to the
 # same manifest, mirroring pr-cycle-cleanup.sh's resolution exactly.
 repo_root=$("$SCRIPT_DIR/../state-path-resolve.sh" 2>/dev/null) || repo_root=""

--- a/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
+++ b/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# rite workflow - temporary-artifact manifest recorder (Issue #1526)
+#
+# Single source of truth for the name-independent reap manifest read by
+# `pr-cycle-cleanup.sh`. A producer that creates a throw-away branch or worktree
+# whose name is NOT covered by the cleanup script's strict patterns records it
+# here at creation time; cleanup then reaps it by identity (the manifest entry),
+# not by guessing the name. This is the "生成時マニフェスト" half of Issue #1526's
+# name-independent reap contract (D-01): cleanup deletes ONLY what a rite producer
+# explicitly recorded, so an unrelated user branch/worktree is never touched.
+#
+# Subcommand:
+#   record --type <branch|worktree> --id <value>
+#       Append one entry to the manifest. `value` is a local branch name
+#       (type=branch) or an absolute worktree path (type=worktree).
+#
+# Data contract (`<shared-root>/.rite/tmp-artifacts.tsv`, TAB-separated):
+#   <type>\t<value>
+#   - <shared-root> is resolved via state-path-resolve.sh so linked worktrees
+#     and the main checkout share ONE manifest (multi-session design §1).
+#   - `.rite/tmp-artifacts.tsv` is gitignored (added with this change) so the
+#     manifest never lands in a diff.
+#   - Duplicate entries are harmless: cleanup reaping a gone artifact is a no-op.
+#
+# Exit codes:
+#   0  recorded (or non-blocking append failure — WARNING on stderr)
+#   1  usage error (bad/missing --type or --id, or value with TAB/newline)
+#
+# Non-blocking by contract: a producer must never crash because manifest
+# recording failed, so append failures WARN and return 0. Only caller misuse
+# (invalid arguments) is a hard error.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MANIFEST_REL=".rite/tmp-artifacts.tsv"
+
+usage() {
+  echo "Usage: rite-tmp-artifact.sh record --type <branch|worktree> --id <value>" >&2
+}
+
+cmd="${1:-}"
+[ -n "$cmd" ] && shift || true
+if [ "$cmd" != "record" ]; then
+  echo "ERROR: unknown or missing subcommand: '${cmd}'" >&2
+  usage
+  exit 1
+fi
+
+art_type=""
+art_id=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --type) art_type="${2:-}"; shift 2 ;;
+    --id)   art_id="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+case "$art_type" in
+  branch|worktree) : ;;
+  *) echo "ERROR: --type must be 'branch' or 'worktree' (got '${art_type}')" >&2; exit 1 ;;
+esac
+if [ -z "$art_id" ]; then
+  echo "ERROR: --id is required and must be non-empty" >&2
+  exit 1
+fi
+# A TAB or newline in the value would corrupt the TSV record (split one entry
+# into two fields / two lines), so reject it rather than silently mangle the
+# manifest. Branch names and worktree paths never legitimately contain these.
+# `$'\t'`/`$'\n'` (bash ANSI-C quoting) yields the literal control char; a
+# `$(printf '\n')` substitution would be stripped to "" and match everything.
+_tab=$'\t'
+_nl=$'\n'
+case "$art_id" in
+  *"$_tab"*|*"$_nl"*)
+    echo "ERROR: --id must not contain TAB or newline characters" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve the SHARED state root (main checkout) so every session appends to the
+# same manifest, mirroring pr-cycle-cleanup.sh's resolution exactly.
+repo_root=$("$SCRIPT_DIR/../state-path-resolve.sh" 2>/dev/null) || repo_root=""
+[ -n "$repo_root" ] || repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root=""
+if [ -z "$repo_root" ]; then
+  echo "WARNING: rite-tmp-artifact: shared root を解決できず manifest 記録をスキップします (not inside a git repository?)" >&2
+  exit 0
+fi
+
+manifest="$repo_root/$MANIFEST_REL"
+manifest_dir=$(dirname "$manifest")
+if ! mkdir -p "$manifest_dir" 2>/dev/null; then
+  echo "WARNING: rite-tmp-artifact: '$manifest_dir' を作成できず manifest 記録をスキップします (non-blocking)" >&2
+  exit 0
+fi
+if printf '%s\t%s\n' "$art_type" "$art_id" >> "$manifest" 2>/dev/null; then
+  exit 0
+fi
+echo "WARNING: rite-tmp-artifact: manifest '$manifest' への追記に失敗しました (non-blocking)" >&2
+exit 0

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -712,6 +712,167 @@ if [ -n "$t17_nl_name" ]; then
   cleanup_temp_repo "$TEST_REPO"
 fi
 
+# =======================================================================
+# Issue #1526 — name-independent reap (bare pr-N / revert-test / manifest).
+# IDs below map to Issue #1526 §6 Test Specification:
+#   T-18 → Issue T-01 / AC-1: bare `pr-{N}` branch reaped
+#   T-19 → Issue T-03 / AC-3: near-miss branches survive (bare pattern is exact)
+#   T-20 → Issue T-02 / AC-2: aged `rite-revert-test-*` worktree reaped
+#   T-21 → Issue T-07 / AC-1: `pr-{N}-cycle{X}` regression still reaped
+#   T-22 → Issue T-04 / AC-4: manifest unknown-named branch reaped (name-independent)
+#   T-23 → Issue T-04 / AC-4: manifest worktree reaped + manifest emptied
+#   T-24 → Issue T-06 / AC-6: dirty manifest worktree skipped + kept in manifest
+#   T-25 → Issue T-03 / AC-3: non-recorded weird branch survives (誤削除防止)
+# (Issue T-05 / AC-5 non-blocking is already covered by T-10..T-16: status=failed
+#  with exit 0. Issue T-06 session-worktree protection by the gated Step 5 reap is
+#  covered in pr-cycle-cleanup-session-reap.test.sh.)
+# -----------------------------------------------------------------------
+ARTIFACT_HELPER="$SCRIPT_DIR/../scripts/rite-tmp-artifact.sh"
+
+# T-18: bare `pr-{N}` branch reaped (AC-1)
+echo "T-18: bare pr-{N} ブランチ回収 (AC-1)"
+TEST_REPO=$(make_temp_repo)
+( cd "$TEST_REPO" && git branch pr-2024 >/dev/null 2>&1 )
+t18_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t18_remaining=$( cd "$TEST_REPO" && git for-each-ref --format='%(refname:short)' refs/heads/ | { grep -cx 'pr-2024' || true; } )
+if [ "$t18_remaining" = "0" ] && echo "$t18_output" | grep -q 'status=cleaned'; then
+  pass "T-18: bare pr-2024 が削除された"
+else
+  fail "T-18: remaining=$t18_remaining. Output: $t18_output"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-19: near-miss branches are NOT deleted by the bare/suffix patterns (AC-3 boundary)
+echo "T-19: near-miss ブランチ保護 (AC-3)"
+TEST_REPO=$(make_temp_repo)
+(
+  cd "$TEST_REPO"
+  # None of these match `^pr-[0-9]+$` or the suffixed PATTERN.
+  git branch pr-100-feature >/dev/null 2>&1   # suffix not in allowed set
+  git branch pr-fix >/dev/null 2>&1           # not all-digits after pr-
+  git branch my-pr-123 >/dev/null 2>&1        # not anchored at start
+  git branch develop >/dev/null 2>&1
+)
+( cd "$TEST_REPO" && bash "$CLEANUP" >/dev/null 2>&1 )
+t19_survivors=$( cd "$TEST_REPO" && git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | { grep -Exc 'pr-100-feature|pr-fix|my-pr-123|develop' || true; } )
+if [ "$t19_survivors" = "4" ]; then
+  pass "T-19: near-miss ブランチ 4 件すべて保護された"
+else
+  fail "T-19: survivors=$t19_survivors (expected 4)"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-20: aged `rite-revert-test-*` detached worktree reaped (AC-2)
+echo "T-20: 古い orphan revert-test worktree 回収 (AC-2)"
+rm -rf "$WORKDIR_SCAN_TMP"/rite-revert-test-* 2>/dev/null || true
+TEST_REPO=$(make_temp_repo)
+( cd "$TEST_REPO" && git worktree add --detach -q "$WORKDIR_SCAN_TMP/rite-revert-test-old" HEAD )
+touch -t 202001010000 "$WORKDIR_SCAN_TMP/rite-revert-test-old"
+t20_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t20_registered=$( cd "$TEST_REPO" && git worktree list | { grep -c 'rite-revert-test-old' || true; } )
+if [ ! -e "$WORKDIR_SCAN_TMP/rite-revert-test-old" ] \
+   && echo "$t20_output" | grep -q 'status=cleaned' \
+   && echo "$t20_output" | grep -q 'mutation_worktrees=1' \
+   && [ "$t20_registered" = "0" ]; then
+  pass "T-20: 古い revert-test worktree が回収され mutation_worktrees=1 + deregistered"
+else
+  fail "T-20: dir=$([ -e "$WORKDIR_SCAN_TMP/rite-revert-test-old" ] && echo present || echo gone), registered=$t20_registered. Output: $t20_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/rite-revert-test-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# T-21: `pr-{N}-cycle{X}` regression — still reaped alongside the new patterns (AC-1)
+echo "T-21: pr-{N}-cycle{X} 回収の非退行 (AC-1)"
+TEST_REPO=$(make_temp_repo)
+( cd "$TEST_REPO" && git worktree add --quiet -b pr-777-cycle3 .review-wt main >/dev/null 2>&1 )
+( cd "$TEST_REPO" && bash "$CLEANUP" >/dev/null 2>&1 )
+t21_remaining=$(count_pr_cycle_branches "$TEST_REPO")
+if [ "$t21_remaining" = "0" ]; then
+  pass "T-21: pr-777-cycle3 が引き続き回収される"
+else
+  fail "T-21: $t21_remaining branch(es) remaining (expected 0)"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-22: manifest-recorded unknown-named branch reaped name-independently (AC-4)
+echo "T-22: マニフェスト記録の未知命名ブランチ回収 (AC-4)"
+TEST_REPO=$(make_temp_repo)
+(
+  cd "$TEST_REPO"
+  # A name no strict pattern would ever match.
+  git branch zztmp-experiment-42 >/dev/null 2>&1
+  bash "$ARTIFACT_HELPER" record --type branch --id "zztmp-experiment-42" >/dev/null 2>&1
+)
+t22_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t22_remaining=$( cd "$TEST_REPO" && git for-each-ref --format='%(refname:short)' refs/heads/ | { grep -cx 'zztmp-experiment-42' || true; } )
+t22_manifest_gone=$([ ! -f "$TEST_REPO/.rite/tmp-artifacts.tsv" ] && echo yes || echo no)
+if [ "$t22_remaining" = "0" ] \
+   && echo "$t22_output" | grep -q 'status=cleaned' \
+   && echo "$t22_output" | grep -q 'manifest=1' \
+   && [ "$t22_manifest_gone" = "yes" ]; then
+  pass "T-22: 未知命名ブランチが manifest 経由で回収され manifest=1 + 空 manifest 削除"
+else
+  fail "T-22: remaining=$t22_remaining, manifest_gone=$t22_manifest_gone. Output: $t22_output"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-23: manifest-recorded worktree reaped (AC-4)
+echo "T-23: マニフェスト記録の worktree 回収 (AC-4)"
+rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
+TEST_REPO=$(make_temp_repo)
+(
+  cd "$TEST_REPO"
+  git worktree add --detach -q "$WORKDIR_SCAN_TMP/mf-wt-clean" HEAD
+  bash "$ARTIFACT_HELPER" record --type worktree --id "$WORKDIR_SCAN_TMP/mf-wt-clean" >/dev/null 2>&1
+)
+t23_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t23_registered=$( cd "$TEST_REPO" && git worktree list | { grep -c 'mf-wt-clean' || true; } )
+if [ ! -e "$WORKDIR_SCAN_TMP/mf-wt-clean" ] \
+   && echo "$t23_output" | grep -q 'manifest=1' \
+   && [ "$t23_registered" = "0" ]; then
+  pass "T-23: manifest 記録の worktree が回収され manifest=1 + deregistered"
+else
+  fail "T-23: dir=$([ -e "$WORKDIR_SCAN_TMP/mf-wt-clean" ] && echo present || echo gone), registered=$t23_registered. Output: $t23_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# T-24: dirty manifest worktree is skipped + kept in manifest (AC-6)
+echo "T-24: dirty な manifest worktree は保護 + manifest 保持 (AC-6)"
+rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
+TEST_REPO=$(make_temp_repo)
+(
+  cd "$TEST_REPO"
+  git worktree add --detach -q "$WORKDIR_SCAN_TMP/mf-wt-dirty" HEAD
+  echo "uncommitted" > "$WORKDIR_SCAN_TMP/mf-wt-dirty/scratch.txt"   # untracked → dirty
+  bash "$ARTIFACT_HELPER" record --type worktree --id "$WORKDIR_SCAN_TMP/mf-wt-dirty" >/dev/null 2>&1
+)
+t24_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t24_kept=$( { grep -c 'mf-wt-dirty' "$TEST_REPO/.rite/tmp-artifacts.tsv" 2>/dev/null || true; } )
+if [ -e "$WORKDIR_SCAN_TMP/mf-wt-dirty" ] \
+   && echo "$t24_output" | grep -q 'manifest=0' \
+   && [ "$t24_kept" = "1" ]; then
+  pass "T-24: dirty worktree は reap されず manifest=0 + manifest にエントリ保持"
+else
+  fail "T-24: dir=$([ -e "$WORKDIR_SCAN_TMP/mf-wt-dirty" ] && echo present || echo gone), kept=$t24_kept. Output: $t24_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# T-25: a non-recorded weird-named branch survives (誤削除防止 — manifest reaps only recorded) (AC-3)
+echo "T-25: 未記録の未知命名ブランチは保護 (AC-3)"
+TEST_REPO=$(make_temp_repo)
+( cd "$TEST_REPO" && git branch zztmp-not-recorded >/dev/null 2>&1 )   # weird name, NOT in manifest
+( cd "$TEST_REPO" && bash "$CLEANUP" >/dev/null 2>&1 )
+t25_survives=$( cd "$TEST_REPO" && git for-each-ref --format='%(refname:short)' refs/heads/ | { grep -cx 'zztmp-not-recorded' || true; } )
+if [ "$t25_survives" = "1" ]; then
+  pass "T-25: 未記録の未知命名ブランチは削除されず保護された"
+else
+  fail "T-25: survives=$t25_survives (expected 1)"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
 # -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -723,9 +723,13 @@ fi
 #   T-23 → Issue T-04 / AC-4: manifest worktree reaped + manifest emptied
 #   T-24 → Issue T-06 / AC-6: dirty manifest worktree skipped + kept in manifest
 #   T-25 → Issue T-03 / AC-3: non-recorded weird branch survives (誤削除防止)
-# (Issue T-05 / AC-5 non-blocking is already covered by T-10..T-16: status=failed
-#  with exit 0. Issue T-06 session-worktree protection by the gated Step 5 reap is
-#  covered in pr-cycle-cleanup-session-reap.test.sh.)
+#   T-26 → Issue T-05 / AC-5: manifest branch reap FAILURE → status=failed, exit 0
+#   T-27 → Issue T-06 / AC-6: manifest worktree pointing at a non-git path is
+#          skipped WITHOUT aborting the run (regression for the set -e rc-capture fix)
+#   T-28 → Issue T-04 / AC-4: stale manifest entry (branch already gone) is dropped
+# (Steps 1-4 non-blocking failure paths are covered by T-10..T-16; T-26 adds the
+#  same contract for the new Step 4.5 manifest reap. Issue T-06 session-worktree
+#  protection by the gated Step 5 reap lives in pr-cycle-cleanup-session-reap.test.sh.)
 # -----------------------------------------------------------------------
 ARTIFACT_HELPER="$SCRIPT_DIR/../scripts/rite-tmp-artifact.sh"
 
@@ -870,6 +874,76 @@ if [ "$t25_survives" = "1" ]; then
   pass "T-25: 未記録の未知命名ブランチは削除されず保護された"
 else
   fail "T-25: survives=$t25_survives (expected 1)"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-26: manifest branch reap FAILURE surfaces as status=failed + exit 0 (AC-5)
+# Force `git branch -D` to fail by making refs/heads read-only (same technique as
+# T-12). root bypasses DAC perms, so skip under root to avoid a false failure.
+echo "T-26: manifest branch reap 失敗が status=failed + exit 0 (AC-5)"
+if [ "$IS_ROOT" = "1" ]; then
+  skip "T-26: root では refs/heads read-only による削除失敗を再現できない"
+else
+  TEST_REPO=$(make_temp_repo)
+  (
+    cd "$TEST_REPO"
+    git branch zztmp-reap-fail >/dev/null 2>&1
+    bash "$ARTIFACT_HELPER" record --type branch --id "zztmp-reap-fail" >/dev/null 2>&1
+    chmod 0500 .git/refs/heads
+  )
+  t26_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 ); t26_rc=$?
+  ( cd "$TEST_REPO" && chmod 0700 .git/refs/heads )   # restore so cleanup_temp_repo can rm
+  t26_kept=$( { grep -c 'zztmp-reap-fail' "$TEST_REPO/.rite/tmp-artifacts.tsv" 2>/dev/null || true; } )
+  if echo "$t26_output" | grep -q 'status=failed' \
+     && echo "$t26_output" | grep -q 'manifest=0' \
+     && [ "$t26_rc" = "0" ] \
+     && [ "$t26_kept" = "1" ]; then
+    pass "T-26: 削除失敗が WARNING + status=failed + manifest=0 + exit 0、entry は manifest に保持"
+  else
+    fail "T-26: rc=$t26_rc, kept=$t26_kept. Output: $t26_output"
+  fi
+  cleanup_temp_repo "$TEST_REPO"
+fi
+
+# T-27: manifest worktree pointing at a NON-git path is skipped without aborting.
+# Regression for the `set -e` rc-capture fix: a bare `var=$(git -C ... status)`
+# would abort the whole run at git rc=128, never reaching the status line.
+echo "T-27: 非 git path の manifest worktree は abort せず skip (AC-6 / set -e 回帰)"
+rm -rf "$WORKDIR_SCAN_TMP"/mf-nongit-* 2>/dev/null || true
+TEST_REPO=$(make_temp_repo)
+mkdir -p "$WORKDIR_SCAN_TMP/mf-nongit-dir"   # exists but is NOT a git worktree
+( cd "$TEST_REPO" && bash "$ARTIFACT_HELPER" record --type worktree --id "$WORKDIR_SCAN_TMP/mf-nongit-dir" >/dev/null 2>&1 )
+t27_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 ); t27_rc=$?
+t27_kept=$( { grep -c 'mf-nongit-dir' "$TEST_REPO/.rite/tmp-artifacts.tsv" 2>/dev/null || true; } )
+if [ "$t27_rc" = "0" ] \
+   && echo "$t27_output" | grep -q '\[pr-cycle-cleanup\] status=' \
+   && [ -d "$WORKDIR_SCAN_TMP/mf-nongit-dir" ] \
+   && [ "$t27_kept" = "1" ]; then
+  pass "T-27: 非 git path は abort せず status 行に到達 + skip + manifest 保持 + dir 保護"
+else
+  fail "T-27: rc=$t27_rc, kept=$t27_kept, dir=$([ -d "$WORKDIR_SCAN_TMP/mf-nongit-dir" ] && echo present || echo gone). Output: $t27_output"
+fi
+rm -rf "$WORKDIR_SCAN_TMP"/mf-nongit-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# T-28: a stale manifest entry (branch already deleted) is dropped without error (AC-4)
+echo "T-28: stale manifest エントリ (branch 既削除) は無害に drop (AC-4)"
+TEST_REPO=$(make_temp_repo)
+(
+  cd "$TEST_REPO"
+  git branch zztmp-stale >/dev/null 2>&1
+  bash "$ARTIFACT_HELPER" record --type branch --id "zztmp-stale" >/dev/null 2>&1
+  git branch -D zztmp-stale >/dev/null 2>&1   # gone before cleanup runs
+)
+t28_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 ); t28_rc=$?
+t28_manifest_gone=$([ ! -f "$TEST_REPO/.rite/tmp-artifacts.tsv" ] && echo yes || echo no)
+if [ "$t28_rc" = "0" ] \
+   && ! echo "$t28_output" | grep -q 'status=failed' \
+   && echo "$t28_output" | grep -q 'manifest=0' \
+   && [ "$t28_manifest_gone" = "yes" ]; then
+  pass "T-28: stale エントリは status≠failed + manifest=0 + 空 manifest 削除で drop"
+else
+  fail "T-28: rc=$t28_rc, manifest_gone=$t28_manifest_gone. Output: $t28_output"
 fi
 cleanup_temp_repo "$TEST_REPO"
 


### PR DESCRIPTION
## Summary

`/rite:pr:iterate`（および内部の review/fix サイクル）が残す一時ブランチ・worktree の後始末漏れを、ブランチ名・worktree パスの命名に依存せず確実に回収するよう改善する。生成は許容し、回収（reap）の確実性を上げることが目的。

## Related Issue

Closes #1526

## Changes

- **bare `pr-{N}` ブランチ回収**（AC-1）: `pr-cycle-cleanup.sh` の branch/worktree sweep に `^pr-[0-9]+$` を追加。外部/手動 PR checkout（`git fetch origin pull/{N}/head:pr-{N}`）由来の残骸を回収。rite 作業ブランチは `{type}/issue-{N}-{slug}` 命名のため衝突しない
- **`rite-revert-test-*` worktree 回収**（AC-2）: Step 4 を `rite-` reviewer-tmp 名前空間（mutation + revert-test）に一般化。prefix が name-independent マーカーとして機能
- **マニフェスト方式の名前非依存 reap**（AC-4, AC-3）: 新規 `hooks/scripts/rite-tmp-artifact.sh` が `.rite/tmp-artifacts.tsv` に記録、`pr-cycle-cleanup.sh` Step 4.5 が記録済 branch/worktree を命名に依らず回収。**未記録は削除しない**（誤削除防止）。dirty worktree は保護（AC-6）
- **iterate 終端 cleanup 発火点**（AC-2 到達性, AC-5）: `commands/pr/iterate.md` ステップ 5.0 を追加。review entry でしか走らなかった cleanup を loop 終端でも発火させ、最終 cycle 残骸の回収到達性を担保。non-blocking
- **`.gitignore`**: `.rite/tmp-artifacts.tsv` を追加

## 生成元調査の発見（Open Question 解消）

- bare `pr-{N}` / `rite-revert-test-*` は **rite コード内に生成元が無い**（外部操作 / reviewer 側）。よって pattern/namespace sweep で回収する
- 即時 0 残骸は 24h age guard（cross-session in-flight 保護 = AC-6）と原理的に両立しないため、§1 Goal「回収の**確実性**」に準拠し確実な最終回収を主眼とする（D-04）。即時回収には reviewer（`_reviewer-base.md` = Non-Target）への session 記録が必要

## Test

`pr-cycle-cleanup.test.sh` に T-18〜T-25 を追加（AC-1〜AC-6 + regression）。

- 全 27 テスト PASS（既存 19 + 新規 8）
- フック全 74 テストファイル PASS（`run-tests.sh`）
- gitignore-health-check: findings 0

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
