### PR TITLE
feat(pr-run): /rite:pr:run のデフォルトを open→iterate (draft 止まり) にし merge→cleanup を --merge でオプトイン化

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -68,7 +68,7 @@ The command prefix `rite` was chosen for:
 | `/rite:pr:review` | Multi-reviewer review | `[PR number]` |
 | `/rite:pr:fix` | Address review feedback | `[PR number]` |
 | `/rite:pr:cleanup` | Post-merge cleanup | `[branch name]` |
-| `/rite:pr:run` | Run open→iterate→ready→merge→cleanup for each Issue (stop on first failure) | `<Issue number>...` |
+| `/rite:pr:run` | Run open→iterate (draft only) for each Issue; `--merge` opts into ready→merge→cleanup (stop on first failure) | `[--merge] <Issue number>...` |
 | `/rite:lint` | Run quality checks | `[file path]` |
 | `/rite:template:reset` | Regenerate templates | `[--force]` |
 | `/rite:wiki:init` | Initialize Experience Wiki (branch, directories, templates) | None |
@@ -159,7 +159,7 @@ rite-workflow/
 │ │ ├── review.md # /rite:pr:review
 │ │ ├── fix.md # /rite:pr:fix
 │ │ ├── cleanup.md # /rite:pr:cleanup
-│ │ ├── run.md # /rite:pr:run (Issue ごとに open→iterate→ready→merge→cleanup を順次実行)
+│ │ ├── run.md # /rite:pr:run (Issue ごとに open→iterate を順次実行し draft 止まり、--merge で ready→merge→cleanup まで完走)
 │ │ └── references/ # Protocol documents referenced by pr/ commands
 │ │ ├── assessment-rules.md # Review assessment rules
 │ │ ├── archive-procedures.md # Archive procedures
@@ -1763,7 +1763,7 @@ The contract ends only when the orchestrator's terminal completion marker has be
 | `/rite:pr:iterate` | `[review:mergeable]` or `[fix:replied-only]` (whichever sub-skill returns first terminates the loop) / `[fix:cancelled-by-user]` (user-initiated cancel via fix.md AskUserQuestion) |
 | `/rite:pr:ready` | `[ready:returned-to-caller]` (E2E flow) / completion display message (standalone) |
 | `/rite:pr:merge` | `[merge:returned-to-caller]` |
-| `/rite:pr:run` | `<!-- [run:all-completed] -->` (all Issues completed) / `<!-- [run:stopped] -->` (stopped on first failure; processed/remaining Issues reported). Does NOT use flow-state handoff; per-Issue continuation rides each sub-skill's own mechanism |
+| `/rite:pr:run` | `<!-- [run:all-completed] -->` (all Issues completed; default = draft PRs left for review, `--merge` = merged/cleaned up) / `<!-- [run:stopped] -->` (stopped on first failure; processed/remaining Issues reported). Mode (`default`/`merge`) is persisted in `run-queue.json` (missing field → `default` for backward compat). Does NOT use flow-state handoff; per-Issue continuation rides each sub-skill's own mechanism |
 | `/rite:issue:create` | `<!-- [create:returned-to-caller:{N}] -->` (HTML-comment wrap form) preceded by user-visible `✅ Issue #{N} を作成しました: {url}` and next-step guidance |
 
 ### Phase-aware continuation hints

--- a/plugins/rite/commands/pr/run.md
+++ b/plugins/rite/commands/pr/run.md
@@ -316,7 +316,7 @@ echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remainin
 
 復旧:
 - この Issue を続きから: /rite:resume {current_issue}
-- 残りをまとめて再開: /rite:pr:run{ --merge}（引数省略で run-queue.json の cursor とモードから再開）
+- 残りをまとめて再開: /rite:pr:run（引数省略で run-queue.json の cursor とモードから再開。明示再開する場合の `--merge` 併記は下記の補足を参照）
 
 <!-- [run:stopped] -->
 ```

--- a/plugins/rite/commands/pr/run.md
+++ b/plugins/rite/commands/pr/run.md
@@ -1,44 +1,46 @@
 ---
-description: 複数 Issue に対して open→iterate→ready→merge→cleanup を順次自律実行
+description: 複数 Issue に対して open→iterate (draft 止まり) を順次自律実行。--merge で ready→merge→cleanup までオプトイン
 ---
 
 # /rite:pr:run
 
-1 個以上の Issue に対して `/rite:pr:open` → `/rite:pr:iterate` → `/rite:pr:ready` → `/rite:pr:merge` → `/rite:pr:cleanup` を **順次・完全自律（無確認）で実行** する。やることは以下のシーケンシャルなタスク列:
+1 個以上の Issue に対して、**デフォルトでは** `/rite:pr:open` → `/rite:pr:iterate` を **順次・完全自律（無確認）で実行** して draft PR を残す（merge せずレビュー待ち）。`--merge` 指定時のみ `/rite:pr:ready` → `/rite:pr:merge` → `/rite:pr:cleanup` まで完走する。やることは以下のシーケンシャルなタスク列:
 
-0. 引数の Issue 群でキューを初期化 / 既存キューから再開（`.rite/state/run-queue.json`）
+0. 引数の Issue 群とモード（`--merge` の有無）でキューを初期化 / 既存キューから再開（`.rite/state/run-queue.json`）
 1. キュー先頭（cursor）の Issue を取り出す（既に CLOSED なら coarse スキップ）。残りが無ければ完了通知（ステップ 7）
 2. `/rite:pr:open` を invoke → PR 番号とブランチ名を取得
-3. `/rite:pr:iterate` を invoke → `[review:mergeable]` まで
-4. `/rite:pr:ready` を invoke
-5. `/rite:pr:merge` を invoke
-6. `/rite:pr:cleanup` を invoke → cursor を +1 → ステップ 1 へループ
-7. 全 Issue 完了通知
+3. `/rite:pr:iterate` を invoke → `[review:mergeable]` まで。**デフォルト（draft 止まり）はここで cursor を +1 してステップ 1 へループ**（ステップ 4-6 をスキップ）
+4. （`--merge` 時のみ）`/rite:pr:ready` を invoke
+5. （`--merge` 時のみ）`/rite:pr:merge` を invoke
+6. （`--merge` 時のみ）`/rite:pr:cleanup` を invoke → cursor を +1 → ステップ 1 へループ
+7. 全 Issue 完了通知（モード別の文言）
 8. （いずれかの段で失敗した場合）即停止して残り Issue を報告
 
-**設計の核**: 成功する限り無確認で最後まで走り、失敗（iterate 非収束 / merge 不可 等）したら即停止する。本コマンドは flow-state の `handoff` を **一切 set しない**（iterate / cleanup が内部で使う handoff / FINALIZE と衝突させない）。継続は flat な順次ステップ構造で担保する（`/rite:pr:open` の Step 1→6 と同じ設計）。
+**設計の核**: 成功する限り無確認で走る。デフォルトは各 Issue を draft PR まで進めて止め（自動 merge しない安全側に倒し人間のレビューを待つ）、`--merge` 指定時のみ merge→cleanup まで完走する。失敗（open 失敗 / iterate 非収束 / merge 不可 等）したら即停止する。本コマンドは flow-state の `handoff` を **一切 set しない**（iterate / cleanup が内部で使う handoff / FINALIZE と衝突させない）。継続は flat な順次ステップ構造で担保する（`/rite:pr:open` の Step 1→6 と同じ設計）。
 
-途中で止まったら: 処理中 Issue は各 sub-skill が flow-state に phase を残すので `/rite:resume {issue}` で個別復帰する。残りキューは `.rite/state/run-queue.json` に残るので、引数省略 `/rite:pr:run` で cursor から再開する。
+途中で止まったら: 処理中 Issue は各 sub-skill が flow-state に phase を残すので `/rite:resume {issue}` で個別復帰する。残りキューは `.rite/state/run-queue.json` に残るので、引数省略 `/rite:pr:run` で cursor から再開する（モード（`--merge` の有無）も run-queue.json に永続化されるため再開時も維持される）。
 
 `{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) で解決する。run-queue.json のパスは `state-path-resolve.sh` で解決した state root 基準とし、linked worktree を跨いでも同一ファイルを指す（各 Issue の open/cleanup が worktree を出入りしても一貫させるため）。
 
 ## Contract
 
-**Input**: Issue number(s) — 1 個以上、空白区切り（省略時は run-queue.json から再開）
-**Output**: 全 Issue 完走の完了通知（ステップ 7）、または最初の失敗での停止報告（残り Issue 含む、ステップ 8）
-**自律度**: 完全自律（無確認）。merge を含め確認を挟まない。失敗時のみ停止。
+**Input**: `[--merge]` + Issue number(s) — 1 個以上、空白区切り（省略時は run-queue.json からモードごと再開）
+**Output**: 全 Issue 処理完了の完了通知（ステップ 7。デフォルトは draft PR 群、`--merge` は merge/cleanup 完走）、または最初の失敗での停止報告（残り Issue 含む、ステップ 8）
+**自律度**: 完全自律（無確認）。デフォルトは draft PR まで、`--merge` 時は merge を含め確認を挟まない。失敗時のみ停止。
 
 ## Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `<issue_number>...` | 処理対象の Issue 番号（1 個以上、空白区切り）。省略時は `.rite/state/run-queue.json` の未処理分（cursor 以降）から再開 |
+| `--merge` | （任意フラグ）指定すると open→iterate に加え ready→merge→cleanup まで完走する。省略時は各 Issue を draft PR で止める。Issue 番号との順序は問わない（例: `--merge 1527 1528` / `1527 --merge 1528`） |
+| `<issue_number>...` | 処理対象の Issue 番号（1 個以上、空白区切り）。省略時は `.rite/state/run-queue.json` の未処理分（cursor 以降）をモードごと再開 |
 
 ## Placeholder Legend
 
 | Placeholder | Source |
 |-------------|--------|
-| `{issue_numbers}` | 引数（空白区切りの Issue 番号群。省略可） |
+| `{issue_numbers}` | 引数（`--merge` フラグ + 空白区切りの Issue 番号群。省略可） |
+| `{run_mode}` | ステップ 0 / 1 の `mode=` marker 値（`default` = draft 止まり / `merge` = フルパイプライン） |
 | `{current_issue}` | ステップ 1 の `RUN_NEXT=process; issue=` が指す Issue |
 | `{pr_number}` | ステップ 2 の open 完了通知（`[pr:created:N]`）から抽出 |
 | `{branch_name}` | ステップ 2 の open 完了通知「ブランチ: ...」行から抽出（ステップ 6 の cleanup に渡す） |
@@ -50,32 +52,36 @@ description: 複数 Issue に対して open→iterate→ready→merge→cleanup 
 
 ## ステップ 0: キュー初期化 / 再開判定
 
-`.rite/state/run-queue.json`（`{issues, cursor}` の最小形）を Single Source of Truth として、引数の Issue 群と既存キューを突き合わせる。
+`.rite/state/run-queue.json`（`{issues, cursor, mode}` の形）を Single Source of Truth として、引数の Issue 群・モード（`--merge` の有無）と既存キューを突き合わせる。`mode` 欠落の旧形式キューは `default`（draft 止まり）として扱う（後方互換）。
 
 ```bash
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 queue_file="$state_root/.rite/state/run-queue.json"
 mkdir -p "$(dirname "$queue_file")"
 
-# 引数パース（"#1527, 1528" のような記号混在も許容して数値のみ抽出）
+# 引数パース（"#1527, 1528" のような記号混在も許容して数値のみ抽出。--merge は位置非依存で検出）
 arg_str="{issue_numbers}"
+case "$arg_str" in *--merge*) arg_mode=merge ;; *) arg_mode=default ;; esac
 arg_issues_json=$(printf '%s' "$arg_str" | grep -oE '[0-9]+' | jq -R 'tonumber' | jq -s '.' 2>/dev/null || echo '[]')
 arg_count=$(echo "$arg_issues_json" | jq 'length')
 
 if [ "$arg_count" -gt 0 ]; then
   if [ -f "$queue_file" ] && \
      [ "$(jq -cS '.issues' "$queue_file" 2>/dev/null)" = "$(echo "$arg_issues_json" | jq -cS '.')" ]; then
+    # 同一 Issue 群での再開: cursor は保ちつつ、今回指定のモードを権威として上書きする
     cursor=$(jq -r '.cursor // 0' "$queue_file")
-    echo "[CONTEXT] RUN_QUEUE=resume_match; cursor=$cursor; total=$arg_count"
+    jq --arg mode "$arg_mode" '.mode = $mode' "$queue_file" > "$queue_file.tmp" && mv "$queue_file.tmp" "$queue_file"
+    echo "[CONTEXT] RUN_QUEUE=resume_match; cursor=$cursor; total=$arg_count; mode=$arg_mode"
   else
     # 新規 / 既存と不一致 → 上書き（古いキューは破棄）
-    jq -n --argjson issues "$arg_issues_json" '{issues:$issues, cursor:0}' > "$queue_file"
-    echo "[CONTEXT] RUN_QUEUE=initialized; cursor=0; total=$arg_count"
+    jq -n --argjson issues "$arg_issues_json" --arg mode "$arg_mode" '{issues:$issues, cursor:0, mode:$mode}' > "$queue_file"
+    echo "[CONTEXT] RUN_QUEUE=initialized; cursor=0; total=$arg_count; mode=$arg_mode"
   fi
 else
   if [ -f "$queue_file" ]; then
     cursor=$(jq -r '.cursor // 0' "$queue_file"); total=$(jq -r '.issues | length' "$queue_file")
-    echo "[CONTEXT] RUN_QUEUE=resume_no_args; cursor=$cursor; total=$total"
+    mode=$(jq -r '.mode // "default"' "$queue_file")   # 旧形式 (mode 欠落) は default 互換
+    echo "[CONTEXT] RUN_QUEUE=resume_no_args; cursor=$cursor; total=$total; mode=$mode"
   else
     echo "[CONTEXT] RUN_QUEUE=empty"
   fi
@@ -84,8 +90,8 @@ fi
 
 | `RUN_QUEUE` marker | アクション |
 |---|---|
-| `initialized` / `resume_match` / `resume_no_args` | ステップ 1 へ進む |
-| `empty` | 引数もキューも無い。使い方 `/rite:pr:run <issue_number>...` を案内して終了 |
+| `initialized` / `resume_match` / `resume_no_args` | `mode=` を `{run_mode}` として retain → ステップ 1 へ進む |
+| `empty` | 引数もキューも無い。使い方 `/rite:pr:run [--merge] <issue_number>...` を案内して終了 |
 
 ---
 
@@ -96,25 +102,26 @@ state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 queue_file="$state_root/.rite/state/run-queue.json"
 cursor=$(jq -r '.cursor // 0' "$queue_file")
 total=$(jq -r '.issues | length' "$queue_file")
+mode=$(jq -r '.mode // "default"' "$queue_file")   # 旧形式は default 互換。ステップ 3 の分岐判定に使う
 
 if [ "$cursor" -ge "$total" ]; then
-  echo "[CONTEXT] RUN_NEXT=all-done"
+  echo "[CONTEXT] RUN_NEXT=all-done; mode=$mode"
 else
   current=$(jq -r ".issues[$cursor]" "$queue_file")
   # coarse スキップ: 既に CLOSED の Issue（= 処理済み）は open し直さず cursor を進める
   state=$(gh issue view "$current" --json state --jq '.state' 2>/dev/null || echo "OPEN")
   if [ "$state" = "CLOSED" ]; then
     jq '.cursor += 1' "$queue_file" > "$queue_file.tmp" && mv "$queue_file.tmp" "$queue_file"
-    echo "[CONTEXT] RUN_NEXT=skip-closed; issue=$current; new_cursor=$((cursor+1)); total=$total"
+    echo "[CONTEXT] RUN_NEXT=skip-closed; issue=$current; new_cursor=$((cursor+1)); total=$total; mode=$mode"
   else
-    echo "[CONTEXT] RUN_NEXT=process; issue=$current; cursor=$cursor; total=$total"
+    echo "[CONTEXT] RUN_NEXT=process; issue=$current; cursor=$cursor; total=$total; mode=$mode"
   fi
 fi
 ```
 
 | `RUN_NEXT` marker | アクション |
 |---|---|
-| `process` | `issue=` を `{current_issue}` として retain → ステップ 2（open）へ |
+| `process` | `issue=` を `{current_issue}`、`mode=` を `{run_mode}` として retain → ステップ 2（open）へ |
 | `skip-closed` | この Issue は既に処理済み。ステップ 1 を再実行（次の Issue へ） |
 | `all-done` | 残り Issue 無し → ステップ 7（全完了通知）へ |
 
@@ -140,26 +147,32 @@ args: "{current_issue}"
 
 ## ステップ 3: /rite:pr:iterate を invoke
 
-> 本コマンドは iterate invoke の **前後で `flow-state.sh set` を呼ばない**（iterate 内部の handoff / FINALIZE 機構を壊さないため）。iterate は内部で review⇄fix を mergeable まで回し、完了通知を出して制御を戻す。`[review:mergeable]` 経由の正常終了では、続くステップ 4 ready の `flow-state.sh set` が残存 FINALIZE handoff を default-clear する（失敗終了時に残る handoff はステップ 8 で消費する）。
+> 本コマンドは iterate invoke の **前後で `flow-state.sh set` を呼ばない**（iterate 内部の handoff / FINALIZE 機構を壊さないため）。iterate は内部で review⇄fix を mergeable まで回し、完了通知を出して制御を戻す。`--merge` モードの正常終了では、続くステップ 4 ready の `flow-state.sh set` が残存 FINALIZE handoff を default-clear する。デフォルトモードは ready を経由しないが、残存 FINALIZE handoff は次 Issue の open（ステップ 1.6 の `flow-state.sh set`）が default-clear し、最後の Issue 分はステップ 7 完了通知前の `consume-handoff` が消費する（失敗終了時に残る handoff はステップ 8 で消費する）。
 
 ```text
 skill: rite:pr:iterate
 args: "{pr_number}"
 ```
 
-| Sentinel | アクション |
-|---------|-----------|
-| `[review:mergeable]` | iterate 収束 → ステップ 4 へ |
-| `[fix:replied-only]` | **非収束として失敗扱い** → ステップ 8（段階=iterate）。reply のみで mergeable 未到達のまま merge すると未解決指摘を握り潰すため。停止報告に続行コマンド `/rite:pr:ready {pr_number} && /rite:pr:merge {pr_number}` を案内 |
-| `[fix:cancelled-by-user]` | ユーザー中断 → ステップ 8（段階=iterate） |
-| `[fix:error]` / sentinel 不在 | **失敗** → ステップ 8（段階=iterate） |
+iterate の終了 sentinel を `{run_mode}`（ステップ 1 の `mode=` marker）で出し分ける:
 
-<!-- run orchestration: after iterate returns [review:mergeable], do NOT stop — proceed to ステップ 4 -->
+| Sentinel + `{run_mode}` | アクション |
+|---------|-----------|
+| `[review:mergeable]` + `merge` | iterate 収束 → ステップ 4（ready）へ |
+| `[review:mergeable]` + `default` | iterate 収束。**ready/merge/cleanup はスキップ**し、draft PR を残したまま **ステップ 6 の cursor 前進 bash へ直行**（cleanup invoke はしない） |
+| `[fix:replied-only]` + `merge` | **非収束として失敗扱い** → ステップ 8（段階=iterate）。reply のみで mergeable 未到達のまま merge すると未解決指摘を握り潰すため。停止報告に続行コマンド `/rite:pr:ready {pr_number} && /rite:pr:merge {pr_number}` を案内 |
+| `[fix:replied-only]` + `default` | merge しないため即停止は不要。**「Issue #{current_issue} の draft PR #{pr_number} は未解決指摘あり」を会話に明示** したうえで draft PR を残し、**ステップ 6 の cursor 前進 bash へ直行**してキューを次へ進める |
+| `[fix:cancelled-by-user]`（両モード） | ユーザー中断 → ステップ 8（段階=iterate） |
+| `[fix:error]` / sentinel 不在（両モード） | **失敗** → ステップ 8（段階=iterate） |
+
+<!-- run orchestration: after iterate returns a terminal sentinel, do NOT stop. merge mode + [review:mergeable] -> ステップ 4. default mode + [review:mergeable] or [fix:replied-only] -> ステップ 6 cursor advance (skip ready/merge/cleanup). -->
 
 ---
 
-## ステップ 4: /rite:pr:ready を invoke
+## ステップ 4: /rite:pr:ready を invoke（`--merge` 時のみ）
 
+> **`{run_mode}=merge` のときだけ実行する。デフォルトモードはステップ 3 から直接ステップ 6 の cursor 前進へ遷移済みのため、本ステップには到達しない。**
+>
 > iterate 完走後は flow-state phase が `review`/`fix` のままのため、ready は E2E flow と判定し standalone 確認をスキップする（= 無確認自律）。run 側の追加操作は不要。
 
 ```text
@@ -176,7 +189,9 @@ args: "{pr_number}"
 
 ---
 
-## ステップ 5: /rite:pr:merge を invoke
+## ステップ 5: /rite:pr:merge を invoke（`--merge` 時のみ）
+
+> **`{run_mode}=merge` のときだけ実行する。** デフォルトモードは本ステップに到達しない。
 
 ```text
 skill: rite:pr:merge
@@ -192,7 +207,9 @@ args: "{pr_number}"
 
 ---
 
-## ステップ 6: /rite:pr:cleanup を invoke → cursor を進める
+## ステップ 6: cleanup（`--merge` 時のみ）→ cursor を進める
+
+**`{run_mode}=merge` のときのみ**、下記で `/rite:pr:cleanup` を invoke する。**デフォルト（draft 止まり）モードはステップ 3 から直接このステップに遷移し、cleanup invoke をスキップして下段の cursor 前進 bash のみ実行する**（draft PR はレビュー待ちのため close せず残す）。
 
 ```text
 skill: rite:pr:cleanup
@@ -201,12 +218,12 @@ args: "{branch_name}"
 
 > cleanup は branch / worktree 削除・Projects Status → Done・Issue close・未完タスクの follow-up Issue 化 + Projects 登録・Wiki ingest を担う。**follow-up Issue + Projects 登録は cleanup 内部に完全委譲**し、run は関与しない。
 
-| Sentinel | アクション |
+| Sentinel（`--merge` 時のみ） | アクション |
 |---------|-----------|
 | `[cleanup:returned-to-caller]` | この Issue 完了。下記 bash で cursor を +1 してステップ 1 へループ |
 | sentinel 不在（cleanup 途中で停止） | merge は既に完了済み（成功扱い）。下記 bash で cursor を +1 してステップ 1 へ進む（cleanup の未完分は `/rite:resume {current_issue}` で個別補完できる旨を表示） |
 
-cleanup から制御が戻ったら cursor を進める:
+cursor を進める（**両モード共有**。`--merge` 時は cleanup から制御が戻った後、デフォルト時はステップ 3 から直接ここへ到達する）:
 
 ```bash
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
@@ -218,23 +235,44 @@ echo "[CONTEXT] RUN_ADVANCE; cursor=$new_cursor; total=$total"
 
 `new_cursor < total` ならステップ 1 へ戻る（次の Issue を処理）。`new_cursor >= total` ならステップ 7 へ。
 
-<!-- run orchestration: after cleanup returns, do NOT stop — advance cursor and loop back to ステップ 1 (next issue) or go to ステップ 7 -->
+<!-- run orchestration: after this cursor advance, do NOT stop — loop back to ステップ 1 (next issue) or go to ステップ 7. (merge mode reaches here after cleanup returns; default mode reaches here directly from ステップ 3.) -->
 
 ---
 
 ## ステップ 7: 全 Issue 完了通知
 
-全 Issue を処理し終えたら run-queue.json を削除して完了を報告する:
+全 Issue を処理し終えたら、残存する終了 handoff を消費してから run-queue.json を削除して完了を報告する:
 
 ```bash
 state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
 queue_file="$state_root/.rite/state/run-queue.json"
+# デフォルトモードでは最後の Issue の iterate が残した FINALIZE handoff が未消費で残りうる
+# （merge モードは ready の flow-state set が消費済み）。完了通知前に one-shot 消費して
+# Stop hook による差し戻しを防ぐ。merge モードでは既に空のため harmless no-op。
+bash {plugin_root}/hooks/flow-state.sh consume-handoff >/dev/null 2>&1 || true
+mode=$(jq -r '.mode // "default"' "$queue_file" 2>/dev/null || echo "default")
 processed=$(jq -rc '.issues' "$queue_file" 2>/dev/null || echo "[]")
 rm -f "$queue_file"
-echo "[CONTEXT] RUN_DONE; processed=$processed"
+echo "[CONTEXT] RUN_DONE; processed=$processed; mode=$mode"
 ```
 
-`processed=` の Issue 一覧を `{processed_issues}` として完了通知に展開する:
+`mode=`（`{run_mode}`）に応じて、`processed=` の Issue 一覧を `{processed_issues}` として完了通知を出し分ける。
+
+**デフォルト（`mode=default`）**: 各 Issue は draft PR で停止しており **merge していない**:
+
+```
+## /rite:pr:run 完了（draft 止まり）
+
+処理した Issue: {processed_issues}
+各 Issue を open→iterate まで実行し draft PR を作成しました（**merge していません**。レビュー待ちです）。
+レビュー後に進めるには各 PR で `/rite:pr:ready <pr>` → `/rite:pr:merge <pr>`、
+または最初からまとめて完走させるなら `/rite:pr:run --merge {processed_issues}` を実行してください。
+（未解決指摘ありで通過した draft PR があれば、上記処理中にその旨を明示しています。）
+
+<!-- [run:all-completed] -->
+```
+
+**`--merge`（`mode=merge`）**: 従来通り全 5 段を完走:
 
 ```
 ## /rite:pr:run 完了
@@ -258,17 +296,18 @@ queue_file="$state_root/.rite/state/run-queue.json"
 # iterate 完了通知を差し戻しうる。停止報告の前に one-shot 消費して出力順序を確定させる。
 bash {plugin_root}/hooks/flow-state.sh consume-handoff >/dev/null 2>&1 || true
 cursor=$(jq -r '.cursor // 0' "$queue_file" 2>/dev/null || echo 0)
+mode=$(jq -r '.mode // "default"' "$queue_file" 2>/dev/null || echo "default")
 done_issues=$(jq -rc ".issues[:$cursor]" "$queue_file" 2>/dev/null || echo "[]")
 remaining=$(jq -rc ".issues[$cursor:]" "$queue_file" 2>/dev/null || echo "[]")
-echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remaining"
+echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remaining; mode=$mode"
 ```
 
-`done=` / `remaining=` を読んで停止報告を出す:
+`done=` / `remaining=` / `mode=` を読んで停止報告を出す。デフォルトモードでは失敗段は `open` / `iterate` のいずれかに限られる（ready/merge/cleanup は実行しないため）:
 
 ```
 ## /rite:pr:run 停止
 
-失敗した Issue: #{current_issue}（段階: {open|iterate|ready|merge|cleanup}）
+失敗した Issue: #{current_issue}（段階: {open|iterate|ready|merge|cleanup}、モード: {run_mode}）
 失敗理由: {受領した失敗 sentinel または「sentinel 不在」}
 失敗時の状態: PR #{pr_number}（{draft | open | 未作成}）
 
@@ -277,12 +316,13 @@ echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remainin
 
 復旧:
 - この Issue を続きから: /rite:resume {current_issue}
-- 残りをまとめて再開: /rite:pr:run（引数省略で run-queue.json の cursor から再開）
+- 残りをまとめて再開: /rite:pr:run{ --merge}（引数省略で run-queue.json の cursor とモードから再開）
 
 <!-- [run:stopped] -->
 ```
 
-> `[fix:replied-only]` で停止した場合は、停止報告に続行コマンドも併記する: `/rite:pr:ready {pr_number} && /rite:pr:merge {pr_number}`
+> 復旧行の `/rite:pr:run` には、`{run_mode}=merge` のときのみ `--merge` を併記する（引数省略再開でも run-queue.json の `mode` が維持されるため必須ではないが、明示再開する場合の指針として示す）。
+> `--merge` モードで `[fix:replied-only]` により停止した場合は、停止報告に続行コマンドも併記する: `/rite:pr:ready {pr_number} && /rite:pr:merge {pr_number}`（デフォルトモードでは `[fix:replied-only]` は停止せず draft を残して次へ進むため、この併記は不要）
 
 ---
 
@@ -297,9 +337,10 @@ echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remainin
 
 ## 設計判断
 
-- **固定パイプライン特化**: 自由記述ゴールの自律解釈（汎用ゴールソルバー）はしない。rite の決定的 sentinel/handoff 設計と相性が悪いため、Issue 番号 → 固定 5 段パイプラインに限定する
-- **handoff 不使用**: flow-state の `handoff` は単一フィールド + default-clear で、iterate / cleanup が内部で排他使用する。run が割り込むと sub-skill の継続保証（Stop hook 差し戻し）が壊れるため、run は handoff を一切 set しない。継続は flat step 構造に委ねる（`/rite:pr:open` と同じ）
+- **デフォルトは draft 止まり / `--merge` でフル完走**: デフォルトは各 Issue を open→iterate まで進めて draft PR を残し、自動 merge しない安全側に倒して人間のレビューを待つ。`ready→merge→cleanup` まで進めるのは `--merge` フラグの明示オプトインに限る。merge→cleanup の意図が名前で明示されることを重視した（Issue #1536 D-01）
+- **固定パイプライン特化**: 自由記述ゴールの自律解釈（汎用ゴールソルバー）はしない。rite の決定的 sentinel/handoff 設計と相性が悪いため、Issue 番号 → 固定パイプライン（デフォルト 2 段 / `--merge` 5 段）に限定する
+- **handoff 不使用**: flow-state の `handoff` は単一フィールド + default-clear で、iterate / cleanup が内部で排他使用する。run が割り込むと sub-skill の継続保証（Stop hook 差し戻し）が壊れるため、run は handoff を一切 set しない。継続は flat step 構造に委ねる（`/rite:pr:open` と同じ）。ただしデフォルトモードは ready を経由しないため、iterate の残存 FINALIZE handoff は次 Issue の open（`flow-state.sh set`）が default-clear し、最後の Issue 分のみステップ 7 の `consume-handoff` で消費する（merge モードでは ready が clear するため no-op）
 - **phase enum を拡張しない / resume.md を変更しない**: 各 sub-skill が自分の phase を書くため、中断時の個別 Issue 復帰は既存 `/rite:resume` がそのままカバーする。run 専用 phase は持たない
-- **キュー永続化**: 複数 Issue の残りキューは `state_root/.rite/state/run-queue.json`（`{issues, cursor}` の最小形）に持つ。会話コンテキストでなくディスクに置くことで compact / 中断を跨いでも残り Issue が失われない。linked worktree を跨ぐため `state-path-resolve.sh` で解決した main checkout root 基準で配置する
-- **`[fix:replied-only]` は停止扱い**: iterate にとっては正常終了だが、run では mergeable 未到達とみなし merge 前に停止する（未解決指摘の握り潰し防止）
-- **専用ヘルパー/hook を作らない**: run-queue.json は run.md 内 bash の `jq` 直接操作で完結する（既存の `.rite/state/` PR-state ファイルと同じく helper なし。単一セッションが順次書くため atomic は `jq → 一時ファイル → mv` で十分）
+- **キュー永続化**: 複数 Issue の残りキューは `state_root/.rite/state/run-queue.json`（`{issues, cursor, mode}`）に持つ。会話コンテキストでなくディスクに置くことで compact / 中断を跨いでも残り Issue とモードが失われない。`mode` 欠落の旧形式は `default` 互換として扱う（Issue #1536 D-03）。linked worktree を跨ぐため `state-path-resolve.sh` で解決した main checkout root 基準で配置する
+- **`[fix:replied-only]` の扱いはモード依存**: `--merge` では mergeable 未到達とみなし merge 前に停止する（未解決指摘の握り潰し防止）。デフォルトでは merge しないため即停止は不要で、draft PR を残し「未解決指摘あり」を明示してキューを次へ進める（Issue #1536 Open Question 暫定方針）
+- **専用ヘルパー/hook を作らない**: run-queue.json は run.md 内 bash の `jq` 直接操作で完結する（既存の `.rite/state/` PR-state ファイルと同じく helper なし。単一セッションが順次書くため atomic は `jq → 一時ファイル → mv` で十分）。`mode` 追加もこの方針内で `jq` フィールド 1 つの読み書きに留める

--- a/plugins/rite/skills/rite-workflow/SKILL.md
+++ b/plugins/rite/skills/rite-workflow/SKILL.md
@@ -106,7 +106,7 @@ Detect current state from:
 | On feature branch, PR open / draft, review-fix cycle | `/rite:pr:iterate <pr>` (mergeable まで review ⇄ fix を無限ループ) |
 | Review mergeable, want to mark Ready | `/rite:pr:ready <pr>` then `/rite:pr:merge <pr>` |
 | Merge 完了、branch 削除 / Wiki ingest / Projects Status Done 後処理が必要 | `/rite:pr:cleanup <pr>` |
-| 複数 Issue を open→cleanup まで一括自律実行したい | `/rite:pr:run <issue>...` (各 Issue に open→iterate→ready→merge→cleanup を順次実行、失敗で即停止) |
+| 複数 Issue を draft PR まで一括自律実行したい | `/rite:pr:run <issue>...` (各 Issue に open→iterate を順次実行し draft 止まり、失敗で即停止)。merge→cleanup まで完走するなら `/rite:pr:run --merge <issue>...` |
 | Long session (30+ minutes elapsed) | `/rite:issue:update` |
 
 ## Question Management
@@ -167,7 +167,7 @@ See [references/work-memory-format.md](./references/work-memory-format.md) for w
 
 `/rite:issue:create` は引き続き flat single-file workflow を維持。マージ後の cleanup は `/rite:pr:cleanup` (既存) を別途実行する。
 
-複数 Issue をまとめて回す場合は `/rite:pr:run <issue>...` が各 Issue に対し `pr:open → pr:iterate → pr:ready → pr:merge → pr:cleanup` を順次・完全自律で実行する (meta-orchestrator。成功する限り無確認、失敗で即停止、残りキューは `.rite/state/run-queue.json` に永続化)。flow-state の handoff は使わず、継続は flat step 構造に委ねる。
+複数 Issue をまとめて回す場合は `/rite:pr:run <issue>...` が各 Issue に対し **デフォルトでは** `pr:open → pr:iterate` を順次・完全自律で実行して draft PR を残し (merge せずレビュー待ち)、`--merge` 指定時のみ `pr:ready → pr:merge → pr:cleanup` まで完走する (meta-orchestrator。成功する限り無確認、失敗で即停止、残りキューとモードは `.rite/state/run-queue.json` に永続化)。flow-state の handoff は使わず、継続は flat step 構造に委ねる。
 
 LLM が途中で停止した場合の正規復帰経路は `/rite:resume` で、`commands/resume.md` Phase 5.3 (Phase enum → Step mapping (SoT)) の phase→新 4 コマンド routing 表に従う。implicit-stop 対策の hook 群 (`auto-fire-step0.sh` / `stop-create-interview-block.sh` / `verify-terminal-output.sh`) は撤去済み。
 
@@ -184,7 +184,7 @@ LLM が途中で停止した場合の正規復帰経路は `/rite:resume` で、
 | `rite:pr:merge` | `[merge:returned-to-caller]` / `[merge:not-ready]` / `[merge:error]` | ユーザー直接 / `pr:run` orchestrator |
 | `rite:pr:cleanup` | `[cleanup:returned-to-caller]` | ユーザー直接 / `pr:run` orchestrator |
 
-orchestrator (`pr:open` / `pr:iterate`) が sub-skill 出力の sentinel を grep で routing する。`pr:ready` / `pr:merge` / `pr:cleanup` は self-contained だが、`pr:run` (meta-orchestrator) が各 Issue に対し `pr:open → pr:iterate → pr:ready → pr:merge → pr:cleanup` を順に invoke し、それぞれの sentinel を grep して次段へ進む (失敗で即停止)。`pr:run` は flow-state の handoff を使わず、継続は flat step 構造に委ねる。
+orchestrator (`pr:open` / `pr:iterate`) が sub-skill 出力の sentinel を grep で routing する。`pr:ready` / `pr:merge` / `pr:cleanup` は self-contained だが、`pr:run` (meta-orchestrator) が各 Issue に対しデフォルトでは `pr:open → pr:iterate` を、`--merge` 指定時のみ続けて `pr:ready → pr:merge → pr:cleanup` を順に invoke し、それぞれの sentinel を grep して次段へ進む (失敗で即停止)。`pr:run` は flow-state の handoff を使わず、継続は flat step 構造に委ねる。
 
 現行の continuation enforcement は Layer 3 caller-continuation hints + Layer 4a/4b orchestrator-side reinforcements + flat sequential structure による (旧 Layer 1 prompt contract は cleanup.md flat 化と同時に物理排除済)。
 


### PR DESCRIPTION
## 概要

`/rite:pr:run` のデフォルト動作を **open→iterate（draft 止まり）** に変更し、`ready→merge→cleanup` までの完走を `--merge` フラグによる明示オプトインにします。

これまではデフォルトで `open→iterate→ready→merge→cleanup` を完全自律で完走し、レビュー前に develop へ自動 merge していました。これを安全側に倒し、デフォルトでは各 Issue を draft PR で残して人間のレビューを待ちます。

Closes #1536

## 変更内容

- **`plugins/rite/commands/pr/run.md`**: フロー再構成
  - ステップ 0: `--merge` を位置非依存（`*--merge*`）でパースし、run-queue.json に `mode`(default/merge) を永続化。引数省略 resume 時は `.mode // "default"` で後方互換
  - ステップ 1: `RUN_NEXT` marker に `mode=` を付与（ステップ 3 の分岐判定用）
  - ステップ 3: iterate routing を mode 分岐。default は `[review:mergeable]` / `[fix:replied-only]` で ready/merge/cleanup をスキップし cursor を進めて draft を残す（replied-only は「未解決指摘あり」を明示）。merge は従来通り
  - ステップ 4-6: ready/merge/cleanup を `--merge` 時のみに限定。ステップ 6 を「cleanup（--merge 時のみ）→ cursor 前進（両モード共有）」へ再構成
  - ステップ 7: 完了通知を mode 分岐（default は「N 件の draft PR を作成・merge していない」。両モードとも `[run:all-completed]`）。デフォルトモードで最後の Issue が残す FINALIZE handoff を `consume-handoff` で消費し、Stop hook の差し戻しを防止
  - ステップ 8: 停止報告を mode 分岐（default は `/rite:resume` 案内）
  - frontmatter / Contract / Arguments / Placeholder Legend / 設計判断 を更新
- **`plugins/rite/skills/rite-workflow/SKILL.md`**: pr:run の説明（Suggested Actions / meta-orchestrator 解説 / sentinel 節）を mode 差分に同期
- **`docs/SPEC.md`**: コマンド表・ツリー・terminal marker 表を同期（run-queue.json の `mode` 永続化と後方互換を追記）

## 設計判断

- run-queue.json のスキーマ追加は `mode` フィールド 1 つのみ（PR 番号トラッキングは追加せず、`jq` 直接操作で完結）。handoff 不使用・flat step 構造は維持し、専用 helper / hook は新設していません（CLAUDE.md「シンプルさを死守」「スコープを越えない」）
- CHANGELOG（en/ja）は v0.5.3 リリース済みエントリの履歴記録のため未変更。新挙動の記載は次リリースの `release` 工程に委ねます

## 受入基準マッピング

| AC | 内容 | 対応 |
|----|------|------|
| AC-1 | デフォルトは draft 止まり | ステップ 3（default+mergeable で ready/merge/cleanup スキップ） |
| AC-2 | `--merge` でフルパイプライン | ステップ 0 mode=merge → ステップ 4-6 完走 |
| AC-3 | 複数 Issue を batch で draft 化 | default ループ + ステップ 7 完了通知 |
| AC-4 | mode 永続化と resume | run-queue.json `mode`（引数省略 resume で維持） |
| AC-5 | 後方互換（mode 欠落） | `.mode // "default"` |
| AC-6 | デフォルト完了通知の文言 | ステップ 7 default ブランチ + `[run:all-completed]` |
| AC-7 | 失敗時の即停止（open 段） | ステップ 8（run-queue.json 保持 + `[run:stopped]`） |
| AC-8 | `--merge` と Issue 番号の混在順序 | `*--merge*` 位置非依存パース |

## 検証

- run-queue.json の mode パース・永続化・後方互換・resume_match を bash シミュレーションで検証（AC-2/4/5/8 + 記号混在 + empty すべて期待通り）
- ステップ 1/7/8 の mode 読込を新旧スキーマ両方で確認
- プラグイン固有 lint（distributed-fix-drift / hardcoded-line-number / bash-heaviness / number-reference / sh-cross-ref 等）で本変更3ファイルは全て clean
- merge モードのステップ 4-6 は無変更で回帰なし

## チェックリスト

- [x] 実装完了（run.md / SKILL.md / SPEC.md）
- [x] 受入基準（AC-1〜8）を検証
- [x] 対象ファイルのみ変更、非対象ファイル（sub-skill / hook / config）は無変更
- [x] handoff 不使用・flat step 構造を維持

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
