### PR TITLE
feat(wiki): concept frontmatter に type / okf_version を追加し OKF v0.1 最小準拠

### DIFF
--- a/plugins/rite/commands/wiki/ingest.md
+++ b/plugins/rite/commands/wiki/ingest.md
@@ -602,8 +602,10 @@ fi
 
 | プレースホルダー | 値 |
 |----------------|-----|
+| `{type}` | OKF v0.1 必須フィールド。`{domain}` と同値（`patterns` / `heuristics` / `anti-patterns`）。OKF consumer の type ベース routing 用に concept 種別を明示する。domain と意味的に一致させる |
 | `{title}` | ステップ 4.1 で生成したタイトル |
 | `{domain}` | `patterns` / `heuristics` / `anti-patterns` |
+| `{description}` | ステップ 4.1 のサマリー（1 行要約）。OKF 推奨の concept 説明文。Sub-2 以降の index 箇条書きで説明源として活用される（`{summary}` と同源だが frontmatter メタデータとして機械可読に保持する） |
 | `{created}` / `{updated}` | 現在の ISO 8601 タイムスタンプ |
 | `{source_type}` | Raw Source の `type` フィールド (`reviews` / `retrospectives` / `fixes` の 3 値のみ — `wiki-ingest-trigger.sh` が受理する値と一致) |
 | `{source_ref}` | Raw Source の wiki-root 起点ファイル相対パス（例: `raw/reviews/20260413T...md`）。template 側で `../../` prefix を hardcode するため、placeholder 値自体には prefix を含めない。**⚠️ raw frontmatter の `source_ref` フィールド値（PR 識別子、例: `pr-1143`）をそのまま使ってはならない** — page の `sources[].ref` は常に Raw Source の**ファイルパス形式** `raw/{type}/{filename}` であり、PR 識別子形式ではない（同名 placeholder と raw フィールドの dual-use 混同による drift。概念は Wiki anti-pattern `placeholder-dual-use-resolution-drift`〔wiki ブランチに蓄積される経験則ページ。develop ツリーには実体なし〕）。lint はこの `ref` をファイルパス形式で raw と突合するため、PR 識別子だと raw→page 追跡が切れ false `missing_concept` を量産する |

--- a/plugins/rite/commands/wiki/ingest.md
+++ b/plugins/rite/commands/wiki/ingest.md
@@ -602,10 +602,10 @@ fi
 
 | プレースホルダー | 値 |
 |----------------|-----|
-| `{type}` | OKF v0.1 必須フィールド。`{domain}` と同値（`patterns` / `heuristics` / `anti-patterns`）。OKF consumer の type ベース routing 用に concept 種別を明示する。domain と意味的に一致させる |
+| `{concept_type}` | OKF v0.1 必須フィールド。page-template.md の frontmatter トップレベル `type:` に substitute する concept 種別。値は `{domain}` と同じ literal（`patterns` / `heuristics` / `anti-patterns`）を入れる。OKF consumer の type ベース routing 用。**⚠️ 本 placeholder は同名衝突回避のため `{concept_type}` と命名している** — ステップ 4.2 / 5.0 の `raw/{type}/{filename}` パスや `sources[].type` 追記で使う `{type}` は Raw Source type（`reviews` / `retrospectives` / `fixes`、`{source_type}` 由来）であり別物 |
 | `{title}` | ステップ 4.1 で生成したタイトル |
 | `{domain}` | `patterns` / `heuristics` / `anti-patterns` |
-| `{description}` | ステップ 4.1 のサマリー（1 行要約）。OKF 推奨の concept 説明文。Sub-2 以降の index 箇条書きで説明源として活用される（`{summary}` と同源だが frontmatter メタデータとして機械可読に保持する） |
+| `{description}` | ステップ 4.1 のサマリー（`{summary}` と同源の 1-2 文）。OKF 推奨の concept 説明文として frontmatter メタデータに機械可読で保持する。本 Sub では frontmatter に保持されるのみで index 表示には未反映（現行 index はテーブル形式。将来 Sub-2 で index の表示形式と合わせて説明源として活用予定） |
 | `{created}` / `{updated}` | 現在の ISO 8601 タイムスタンプ |
 | `{source_type}` | Raw Source の `type` フィールド (`reviews` / `retrospectives` / `fixes` の 3 値のみ — `wiki-ingest-trigger.sh` が受理する値と一致) |
 | `{source_ref}` | Raw Source の wiki-root 起点ファイル相対パス（例: `raw/reviews/20260413T...md`）。template 側で `../../` prefix を hardcode するため、placeholder 値自体には prefix を含めない。**⚠️ raw frontmatter の `source_ref` フィールド値（PR 識別子、例: `pr-1143`）をそのまま使ってはならない** — page の `sources[].ref` は常に Raw Source の**ファイルパス形式** `raw/{type}/{filename}` であり、PR 識別子形式ではない（同名 placeholder と raw フィールドの dual-use 混同による drift。概念は Wiki anti-pattern `placeholder-dual-use-resolution-drift`〔wiki ブランチに蓄積される経験則ページ。develop ツリーには実体なし〕）。lint はこの `ref` をファイルパス形式で raw と突合するため、PR 識別子だと raw→page 追跡が切れ false `missing_concept` を量産する |

--- a/plugins/rite/templates/wiki/index-template.md
+++ b/plugins/rite/templates/wiki/index-template.md
@@ -1,6 +1,13 @@
+---
+okf_version: "0.1"
+description: "rite Experience Wiki — プロジェクト固有の経験則 bundle（OKF v0.1 準拠）"
+---
+
 # Wiki Index
 
 このファイルは Wiki 全ページのカタログです。Ingest サイクルごとに自動更新されます。
+
+bundle-root の frontmatter で OKF（Open Knowledge Format）v0.1 への準拠を `okf_version: "0.1"` として宣言します。
 
 ## ページ一覧
 

--- a/plugins/rite/templates/wiki/page-template.md
+++ b/plugins/rite/templates/wiki/page-template.md
@@ -1,6 +1,8 @@
 ---
+type: "{type}"
 title: "{title}"
 domain: "{domain}"
+description: "{description}"
 created: "{created}"
 updated: "{updated}"
 sources:

--- a/plugins/rite/templates/wiki/page-template.md
+++ b/plugins/rite/templates/wiki/page-template.md
@@ -1,5 +1,5 @@
 ---
-type: "{type}"
+type: "{concept_type}"
 title: "{title}"
 domain: "{domain}"
 description: "{description}"

--- a/plugins/rite/templates/wiki/schema-template.md
+++ b/plugins/rite/templates/wiki/schema-template.md
@@ -27,8 +27,10 @@
 
 ```yaml
 ---
+type: patterns | heuristics | anti-patterns
 title: "ページタイトル"
 domain: patterns | heuristics | anti-patterns
+description: "1 行の要約（OKF index の説明文・検索補助に使用）"
 created: "YYYY-MM-DDTHH:MM:SS+09:00"
 updated: "YYYY-MM-DDTHH:MM:SS+09:00"
 sources:
@@ -41,13 +43,17 @@ confidence: high | medium | low
 
 | フィールド | 必須 | 説明 |
 |-----------|------|------|
+| `type` | yes | OKF v0.1 の唯一の必須フィールド。concept の種別。rite では `domain` と同値（例 domain=heuristics → type=heuristics）。OKF consumer が type ベースで routing/filtering できるようにするための標準キー |
 | `title` | yes | ページタイトル（検索・インデックスに使用） |
-| `domain` | yes | 蓄積ドメイン（上記3種） |
+| `domain` | yes | 蓄積ドメイン（上記3種）。rite 拡張キーとして温存（query/lint は引き続き domain を参照） |
+| `description` | no | 1 行要約（OKF 推奨。index 箇条書きの説明源・検索補助） |
 | `created` | yes | 作成日時（ISO 8601） |
 | `updated` | yes | 最終更新日時（ISO 8601） |
 | `sources` | yes | 元データへの参照（空配列可） |
 | `tags` | no | 自由タグ（検索補助） |
 | `confidence` | no | 知見の確信度（デフォルト: medium） |
+
+> **`type` と `domain` の関係**: OKF v0.1 は `type` のみを必須とする。rite は既存の `domain` を機械可読キー（query スコアリング・lint カテゴリ集計）として温存しつつ、OKF 準拠のため `type` を同値で併記する。両者の統合（redundancy 解消）は別 Issue のスコープで、本規約では両併存を正とする。
 
 ### 蓄積トリガー
 

--- a/plugins/rite/templates/wiki/schema-template.md
+++ b/plugins/rite/templates/wiki/schema-template.md
@@ -43,7 +43,7 @@ confidence: high | medium | low
 
 | フィールド | 必須 | 説明 |
 |-----------|------|------|
-| `type` | yes | OKF v0.1 の唯一の必須フィールド。concept の種別。rite では `domain` と同値（例 domain=heuristics → type=heuristics）。OKF consumer が type ベースで routing/filtering できるようにするための標準キー |
+| `type` | yes | **OKF v0.1 が要求する唯一のフィールド**（本表の他の `yes` 項目は rite が運用上必須とする拡張で、OKF 仕様上の必須ではない）。concept の種別。rite では `domain` と同値（例 domain=heuristics → type=heuristics）。OKF consumer が type ベースで routing/filtering できるようにするための標準キー |
 | `title` | yes | ページタイトル（検索・インデックスに使用） |
 | `domain` | yes | 蓄積ドメイン（上記3種）。rite 拡張キーとして温存（query/lint は引き続き domain を参照） |
 | `description` | no | 1 行要約（OKF 推奨。index 箇条書きの説明源・検索補助） |

--- a/plugins/rite/templates/wiki/schema-template.md
+++ b/plugins/rite/templates/wiki/schema-template.md
@@ -46,7 +46,7 @@ confidence: high | medium | low
 | `type` | yes | **OKF v0.1 が要求する唯一のフィールド**（本表の他の `yes` 項目は rite が運用上必須とする拡張で、OKF 仕様上の必須ではない）。concept の種別。rite では `domain` と同値（例 domain=heuristics → type=heuristics）。OKF consumer が type ベースで routing/filtering できるようにするための標準キー |
 | `title` | yes | ページタイトル（検索・インデックスに使用） |
 | `domain` | yes | 蓄積ドメイン（上記3種）。rite 拡張キーとして温存（query/lint は引き続き domain を参照） |
-| `description` | no | 1 行要約（OKF 推奨。index 箇条書きの説明源・検索補助） |
+| `description` | no | 1 行要約（OKF 推奨。検索補助。現行 index はテーブル形式で未使用、将来 Sub-2 で index 表示の説明源として活用予定） |
 | `created` | yes | 作成日時（ISO 8601） |
 | `updated` | yes | 最終更新日時（ISO 8601） |
 | `sources` | yes | 元データへの参照（空配列可） |

--- a/plugins/rite/templates/wiki/schema-template.md
+++ b/plugins/rite/templates/wiki/schema-template.md
@@ -30,7 +30,7 @@
 type: patterns | heuristics | anti-patterns
 title: "ページタイトル"
 domain: patterns | heuristics | anti-patterns
-description: "1 行の要約（OKF index の説明文・検索補助に使用）"
+description: "1-2 文の要約"
 created: "YYYY-MM-DDTHH:MM:SS+09:00"
 updated: "YYYY-MM-DDTHH:MM:SS+09:00"
 sources:
@@ -46,7 +46,7 @@ confidence: high | medium | low
 | `type` | yes | **OKF v0.1 が要求する唯一のフィールド**（本表の他の `yes` 項目は rite が運用上必須とする拡張で、OKF 仕様上の必須ではない）。concept の種別。rite では `domain` と同値（例 domain=heuristics → type=heuristics）。OKF consumer が type ベースで routing/filtering できるようにするための標準キー |
 | `title` | yes | ページタイトル（検索・インデックスに使用） |
 | `domain` | yes | 蓄積ドメイン（上記3種）。rite 拡張キーとして温存（query/lint は引き続き domain を参照） |
-| `description` | no | 1 行要約（OKF 推奨。検索補助。現行 index はテーブル形式で未使用、将来 Sub-2 で index 表示の説明源として活用予定） |
+| `description` | no | 1-2 文の要約（OKF 推奨。`{summary}` と同源）。現状は frontmatter 保持のみで未使用（query は title/domain/summary のみ参照）。将来 Sub-2 で index 表示の説明源として活用予定 |
 | `created` | yes | 作成日時（ISO 8601） |
 | `updated` | yes | 最終更新日時（ISO 8601） |
 | `sources` | yes | 元データへの参照（空配列可） |


### PR DESCRIPTION
## 概要

rite Experience Wiki を OKF（Open Knowledge Format）v0.1 準拠 bundle にする epic の Sub-1。OKF v0.1 の唯一の必須フィールドである concept の `type` と、bundle-root の `okf_version` 宣言を後方互換で追加し、最小限の変更で「ほぼ準拠」producer にする。

index/log の予約構造 reshape は後続 Sub（Sub-2 / Sub-3）に分離し、本 PR は frontmatter 追加のみに留めることで早期の価値確定点／フォールバック地点とする。

## 変更内容

- `templates/wiki/page-template.md`: frontmatter 先頭に `type: "{type}"`（OKF 必須）と `description: "{description}"`（OKF 推奨・Sub-2 の index 説明源）を追加
- `templates/wiki/schema-template.md`: frontmatter 規約表・YAML 例に `type`（必須）行を追加し、`domain` との関係（両併存・統合は別 Issue）を明記
- `templates/wiki/index-template.md`: bundle-root に `okf_version: "0.1"` を宣言する frontmatter ブロックを追加
- `commands/wiki/ingest.md`: ステップ 5.3 placeholder 置換表に `{type}` / `{description}` 行を追加（domain 由来の導出規約を記載）

## 設計判断

- `domain` は query スコアリング・lint カテゴリ集計の機械可読キーとして温存し、`type` を同値で併記する（OKF 準拠と rite 既存ロジックの両立）。
- 追加のみ・後方互換のため、`type` 欠落の旧ページは lint がブロックしない（OKF permissive consumption 整合）。
- index.md への frontmatter 追加は `| ページ | ドメイン` テーブルヘッダ検出より上に位置するため、`wiki-query-inject.sh` の現行テーブルパースに干渉しない（回帰なしを確認）。

## テスト

- `plugins/rite/hooks/tests/` の Wiki 系テスト 11 件すべて green。
- plugin 固有 lint チェックで変更 4 ファイルに新規警告ゼロを確認。

## 受入基準

- [x] AC-1: ingest 生成ページ frontmatter に非空 `type`、`domain` も保持
- [x] AC-2: bundle-root index.md に `okf_version: "0.1"` 宣言
- [x] AC-3: `type` 欠落の旧ページで lint がブロックしない（後方互換）
- [x] AC-4: `type` 追加後も query が従来どおり domain ベースで動作（回帰なし）

Closes #1518
