### PR TITLE
refactor(pr): review/fix の Step 3 で $trigger_exit に defensive default を付与

### DIFF
--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -3584,7 +3584,7 @@ if [ "${content_write_failed:-0}" -eq 1 ]; then
   # accurate な reason を付けて WIKI_INGEST_FAILED を emit する (trigger_exit_1 への誤帰属を防ぐ)。
   echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=content_write_failed; exit_code=1"
   echo "WARNING: fix ステップ 4.6.W: content write 失敗のため wiki ingest をスキップ (trigger は未起動)。" >&2
-elif [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
+elif [ "${trigger_exit:-1}" -ne 0 ] && [ "${trigger_exit:-1}" -ne 2 ]; then
   echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
   echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during pr/fix.md ステップ 4.6.W" >&2
 fi

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -3548,7 +3548,7 @@ if [ "${content_write_failed:-0}" -eq 1 ]; then
  # accurate な reason を付けて WIKI_INGEST_FAILED を emit する (trigger_exit_1 への誤帰属を防ぐ)。
  echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=content_write_failed; exit_code=1"
  echo "WARNING: review ステップ 6.5.W: content write 失敗のため wiki ingest をスキップ (trigger は未起動)。" >&2
-elif [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]; then
+elif [ "${trigger_exit:-1}" -ne 0 ] && [ "${trigger_exit:-1}" -ne 2 ]; then
  echo "[CONTEXT] WIKI_INGEST_FAILED=1; reason=trigger_exit_$trigger_exit; exit_code=$trigger_exit"
  echo "WARNING: wiki-ingest-trigger.sh exited $trigger_exit during pr/review.md ステップ 6.5.W" >&2
 fi


### PR DESCRIPTION
## 概要

`commands/pr/review.md` 6.5.W / `commands/pr/fix.md` 4.6.W の wiki ingest failure-surfacing（Step 3）で、`elif [ "$trigger_exit" -ne 0 ] && [ "$trigger_exit" -ne 2 ]` の `$trigger_exit` 参照を defensive default 付き `${trigger_exit:-1}` に揃え、先行する `content_write_failed`（`:-0`）と対称化する。

## 背景・Why

Step 2 と Step 3 は別々の fenced bash block（= 別々の Bash tool 起動）であり shell 変数が持続しない。そのため両変数とも Step 2 stdout からの carry-forward に依存する。`content_write_failed` はすでに `:-0` で防御されているが、`$trigger_exit` は bare 参照のまま非対称だった。

「Step 3 を別 bash block で実行し `content_write_failed` のみ carry して `trigger_exit` を carry し忘れる」経路では、bare `$trigger_exit` が空文字に展開され `[: : 整数の式が予期されます` エラーが発生しうる。`:-1`（trigger 失敗扱いの安全側 default）を付与することでこのエラーを構造的に防ぐ。

なお `issue/close.md` Phase 4.4.W にも同種の判定があるが、close.md は判定まで含めて**単一 bash block** で完結し carry-forward 非依存のため bare 参照でも空文字リスクがなく、本 PR のスコープ外（review/fix 固有の非対称性のみを是正）。

## 変更内容

- `plugins/rite/commands/pr/review.md` (6.5.W Step 3): `elif` 条件を `${trigger_exit:-1}` に変更
- `plugins/rite/commands/pr/fix.md` (4.6.W Step 3): 同一変更を対称適用

スコープは Issue 対応方針案どおり `elif` 条件のみ。echo body の bare `$trigger_exit` は算術比較ではなく整数式エラーを起こさないため変更しない（`content_write_failed:-0` が条件のみに付与されているのと完全対称）。

## 関連 Issue

Closes #1523

## チェックリスト

- [x] review.md 6.5.W Step 3 の `elif` 条件を `${trigger_exit:-1}` に揃える
- [x] fix.md 4.6.W Step 3 の `elif` 条件を `${trigger_exit:-1}` に対称適用する
- [x] 空文字展開で整数式エラーが出ないことを検証
- [ ] テスト追加（該当なし: bash スニペットの defensive default 修正のため）
