### PR TITLE
fix(pr): live プロセスが立つ worktree を保護し /clear の Path does not exist 再発を防止

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -281,13 +281,21 @@ fi
 - `CLEANUP_WT=in_worktree`（cwd がセッション worktree）:
   1. `dirty=yes` なら **AskUserQuestion**（「`git stash push` して続行 / 中止」）。stash は common git dir に格納されるため worktree 削除後も `git stash pop` 可能（完了報告の stash 案内は従来文面を流用）。
   2. `ExitWorktree` ツールを `action: "keep"` で呼び出し、main checkout に復帰する（path 入場した worktree は remove でも消えない仕様のため**常に keep**）。
-  3. main から worktree を削除する:
+  3. main から worktree を削除する。**削除前に live-cwd guard（Issue #1544）を通す**: 別のセッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、live プロセスが cwd を置いているときは削除せず遅延 reap（S4）へ委譲する:
      ```bash
-     git worktree remove "{flow_wt}" 2>/dev/null || git worktree remove --force "{flow_wt}" 2>/dev/null || echo "[CONTEXT] WORKTREE_REMOVE_FAILED=1; path={flow_wt}" >&2
-     git worktree prune 2>/dev/null || true
+     _lc_rc=0
+     bash {plugin_root}/hooks/scripts/worktree-live-cwd.sh "{flow_wt}" >/dev/null 2>&1 || _lc_rc=$?
+     if [ "$_lc_rc" -eq 0 ]; then
+       echo "WARNING: worktree '{flow_wt}' に live プロセスが cwd を置いているため削除を skip しました（遅延 reap S4 に委譲。harness cwd dangling → /clear エラーの防止）。" >&2
+       echo "[CONTEXT] WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1; path={flow_wt}" >&2
+     else
+       git worktree remove "{flow_wt}" 2>/dev/null || git worktree remove --force "{flow_wt}" 2>/dev/null || echo "[CONTEXT] WORKTREE_REMOVE_FAILED=1; path={flow_wt}" >&2
+       git worktree prune 2>/dev/null || true
+     fi
      ```
-  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）は **WARNING を表示して続行**（non-blocking。S4 の遅延 reap へ委譲。ステップ 12 報告に失敗と手動コマンドを表示）。
-- `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。
+     > `in_worktree` 経路ではステップ 2 の `ExitWorktree` で harness cwd が main に退避済みのため、この guard は通常 rc=1（live cwd 不在）で削除へ進む。`worktree-live-cwd.sh` が rc=2（`/proc` も `lsof` も無い環境で判定不能）を返す場合は `if` が false となり従来どおり削除を実行する（後方互換）。
+  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）または live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）は **WARNING を表示して続行**（non-blocking。S4 の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。
+- `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の live-cwd guard が特に重要。
 - `CLEANUP_WT=none`（multi_session 無効 or worktree 未記録）: 4-W 全体を no-op でスキップ。
 
 ### 4 base ブランチの更新（安全化）

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -281,12 +281,12 @@ fi
 - `CLEANUP_WT=in_worktree`（cwd がセッション worktree）:
   1. `dirty=yes` なら **AskUserQuestion**（「`git stash push` して続行 / 中止」）。stash は common git dir に格納されるため worktree 削除後も `git stash pop` 可能（完了報告の stash 案内は従来文面を流用）。
   2. `ExitWorktree` ツールを `action: "keep"` で呼び出し、main checkout に復帰する（path 入場した worktree は remove でも消えない仕様のため**常に keep**）。
-  3. main から worktree を削除する。**削除前に live-cwd guard（Issue #1544）を通す**: 別のセッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、live プロセスが cwd を置いているときは削除せず遅延 reap（S4）へ委譲する:
+  3. main から worktree を削除する。**削除前に live-cwd guard（Issue #1544）を通す**: 別のセッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、live プロセスが cwd を置いているときは削除せず遅延 reap（`pr-cycle-cleanup.sh` の session worktree reap）へ委譲する:
      ```bash
      _lc_rc=0
      bash {plugin_root}/hooks/scripts/worktree-live-cwd.sh "{flow_wt}" >/dev/null 2>&1 || _lc_rc=$?
      if [ "$_lc_rc" -eq 0 ]; then
-       echo "WARNING: worktree '{flow_wt}' に live プロセスが cwd を置いているため削除を skip しました（遅延 reap S4 に委譲。harness cwd dangling → /clear エラーの防止）。" >&2
+       echo "WARNING: worktree '{flow_wt}' に live プロセスが cwd を置いているため削除を skip しました（遅延 reap pr-cycle-cleanup.sh に委譲。harness cwd dangling → /clear エラーの防止）。" >&2
        echo "[CONTEXT] WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1; path={flow_wt}" >&2
      else
        git worktree remove "{flow_wt}" 2>/dev/null || git worktree remove --force "{flow_wt}" 2>/dev/null || echo "[CONTEXT] WORKTREE_REMOVE_FAILED=1; path={flow_wt}" >&2
@@ -294,7 +294,7 @@ fi
      fi
      ```
      > `in_worktree` 経路ではステップ 2 の `ExitWorktree` で harness cwd が main に退避済みのため、この guard は通常 rc=1（live cwd 不在）で削除へ進む。`worktree-live-cwd.sh` が rc=2（`/proc` も `lsof` も無い環境で判定不能）を返す場合は `if` が false となり従来どおり削除を実行する（後方互換）。
-  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）または live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）は **WARNING を表示して続行**（non-blocking。S4 の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。
+  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）または live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の live-cwd guard が特に重要。
 - `CLEANUP_WT=none`（multi_session 無効 or worktree 未記録）: 4-W 全体を no-op でスキップ。
 
@@ -512,11 +512,18 @@ Status: {projects_status_result}
 
 各チェックボックスおよび placeholder の判定:
 
-- `{session_worktree_check}`: multi_session 無効 or worktree 未使用なら行ごと省略。worktree 削除成功なら `x`。`WORKTREE_REMOVE_FAILED=1` のときは ` ` + 手動コマンドを付記:
-  ```
-  ⚠️ セッション worktree の削除に失敗しました（遅延 reap が後で回収します）。
-    手動削除: git worktree remove --force {flow_wt} && git worktree prune
-  ```
+- `{session_worktree_check}`: multi_session 無効 or worktree 未使用なら行ごと省略。以下を**上から評価し最初に一致したもの**を採用する（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD` と `WORKTREE_REMOVE_FAILED` は Step 4-W guard の if/else で排他だが、両 `[CONTEXT]` 行が文脈に残る可能性に備えて評価順序を固定する）:
+  - `WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1` のとき（live-cwd guard が削除を skip）: ` ` + 以下を付記
+    ```
+    ℹ️ セッション worktree は別セッションが cwd を置いているため削除を skip しました（遅延 reap が後で回収します）。
+      手動削除（当該セッションの /clear 後）: git worktree remove --force {flow_wt} && git worktree prune
+    ```
+  - `WORKTREE_REMOVE_FAILED=1` のとき（削除そのものが失敗）: ` ` + 以下を付記
+    ```
+    ⚠️ セッション worktree の削除に失敗しました（遅延 reap が後で回収します）。
+      手動削除: git worktree remove --force {flow_wt} && git worktree prune
+    ```
+  - いずれの `[CONTEXT]` 行も無い（削除成功）とき: `x`
 - `{projects_status_result}`: `projects_status_updated=true` なら `Done`、false なら `⚠️ 更新失敗（手動確認が必要）`
 - `{review_cleanup_check}`: `REVIEW_CLEANUP_PARTIAL_FAILURE=1` なら ` ` + 警告付記、なければ `x`
 - `{projects_check}`: `projects_status_updated=true` なら `x`、false なら ` ` + 「GitHub Projects 画面で Issue #{issue_number} の Status を Done に変更」を付記

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -760,6 +760,28 @@ if [ -d "$session_wt_root" ]; then
       continue
     fi
 
+    # Gate (OS-level live cwd, Issue #1544): never reap a worktree that ANY live
+    # process is standing in (cwd at or under it). This is the flow-state-
+    # independent backstop for #1524's recurrence: the cross-session liveness
+    # guard above only protects worktrees a session records as its `active`
+    # `worktree`, so it misses the dangling cases where the owning session's
+    # harness cwd is still in the tree but its flow-state has drifted (active=false,
+    # empty/nulled `worktree` field, or stale session-id). Removing such a tree
+    # leaves the harness cwd pointing at a deleted dir → `/clear` fails with
+    # `Path does not exist`. Delegated to worktree-live-cwd.sh (SoT, shared with
+    # cleanup.md Step 4-W). rc 0 = live cwd present → skip; rc 2 = undeterminable
+    # (no /proc & no lsof, e.g. older macOS) → fall through to the existing
+    # claim/dirty gates (no behavior change vs pre-#1544). `|| _cwd_rc=$?` keeps a
+    # non-zero rc from aborting the loop under `set -e`. Evaluated before Gate 3/2,
+    # like the other liveness guards, so a clean+stale worktree someone stands in
+    # is still preserved.
+    _cwd_rc=0
+    bash "$SCRIPT_DIR/worktree-live-cwd.sh" "$_wt_canon" >/dev/null 2>&1 || _cwd_rc=$?
+    if [ "$_cwd_rc" -eq 0 ]; then
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は live プロセスが cwd を置いているため reap をスキップします (live-cwd guard)。" >&2
+      continue
+    fi
+
     # Gate 3: dirty worktree is NEVER auto-reaped. An indeterminate status
     # (rc != 0) is treated conservatively as "do not reap" to avoid data loss.
     _st_out=$(git -C "$wt_path" status --porcelain 2>/dev/null)

--- a/plugins/rite/hooks/scripts/worktree-live-cwd.sh
+++ b/plugins/rite/hooks/scripts/worktree-live-cwd.sh
@@ -47,32 +47,54 @@ else
 fi
 [ -n "$target_canon" ] || target_canon="$target"
 
-# Primary: Linux /proc. readlink of /proc/<pid>/cwd is the OS ground truth for a
-# process's working directory. This script's own cwd is the caller's (repo root
-# for the reaper, main checkout for cleanup), never the candidate worktree, so it
-# does not false-match itself — and the reaper's own active worktree is already
-# excluded upstream (Gate 0 self-exclusion) before this probe is consulted.
-if [ -d /proc ]; then
+# Detection backend selection. Default auto-detects (/proc → lsof → undeterminable).
+# RITE_WORKTREE_LIVE_CWD_PROBE forces a specific backend so the lsof and
+# undeterminable branches — unreachable on Linux where /proc always exists — stay
+# test-covered, and so a Linux operator can exercise the fallback if /proc is
+# unexpectedly unusable. Values: proc | lsof | none | auto (default).
+probe="${RITE_WORKTREE_LIVE_CWD_PROBE:-auto}"
+
+# /proc backend: readlink of /proc/<pid>/cwd is the OS ground truth for a process's
+# working directory. This script's own cwd is the caller's (repo root for the reaper,
+# main checkout for cleanup), never the candidate worktree, so it does not false-match
+# itself — and the reaper's own active worktree is already excluded upstream (Gate 0
+# self-exclusion) before this probe is consulted.
+_rite_probe_proc() {
+  local _pdir _cwd
   for _pdir in /proc/[0-9]*; do
     _cwd=$(readlink "$_pdir/cwd" 2>/dev/null) || continue
     [ -n "$_cwd" ] || continue
-    [ "$_cwd" = "$target_canon" ] && exit 0
+    [ "$_cwd" = "$target_canon" ] && return 0
     # Trailing-slash prefix test: `issue-1` must not match `issue-12`.
     case "$_cwd/" in
-      "$target_canon"/*) exit 0 ;;
+      "$target_canon"/*) return 0 ;;
     esac
   done
-  exit 1
-fi
+  return 1
+}
 
-# Fallback: lsof (where /proc is absent). `-a -d cwd +D <dir>` lists processes
-# whose working directory is at or under <dir>; any hit means a live cwd.
-if command -v lsof >/dev/null 2>&1; then
+# lsof backend (where /proc is absent, e.g. BSD/macOS). `-a -d cwd +D <dir>` lists
+# processes whose working directory is at or under <dir>; any hit means a live cwd.
+# Returns 2 (undeterminable) when lsof itself is unavailable.
+_rite_probe_lsof() {
+  command -v lsof >/dev/null 2>&1 || return 2
   if lsof -a -d cwd +D "$target_canon" >/dev/null 2>&1; then
-    exit 0
+    return 0
   fi
-  exit 1
-fi
+  return 1
+}
 
-# Neither /proc nor lsof — undeterminable.
-exit 2
+case "$probe" in
+  proc) _rite_probe_proc; exit $? ;;
+  lsof) _rite_probe_lsof; exit $? ;;
+  none) exit 2 ;;  # forced undeterminable (neither /proc nor lsof)
+  auto)
+    if [ -d /proc ]; then _rite_probe_proc; exit $?; fi
+    if command -v lsof >/dev/null 2>&1; then _rite_probe_lsof; exit $?; fi
+    exit 2  # neither /proc nor lsof — undeterminable
+    ;;
+  *)
+    echo "ERROR: worktree-live-cwd.sh: invalid RITE_WORKTREE_LIVE_CWD_PROBE='$probe' (expected proc|lsof|none|auto)" >&2
+    exit 2
+    ;;
+esac

--- a/plugins/rite/hooks/scripts/worktree-live-cwd.sh
+++ b/plugins/rite/hooks/scripts/worktree-live-cwd.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# worktree-live-cwd.sh — OS-ground-truth liveness probe for a worktree directory.
+#
+# Answers a single question: "is any live process standing in this directory
+# (cwd at it or nested under it)?" — independent of rite's own flow-state
+# bookkeeping.
+#
+# Why this exists (Issue #1544, regression of #1524):
+#   When a session enters a session worktree via `EnterWorktree`, the harness
+#   records that worktree as the session's cwd and restores it on `/clear`. If the
+#   worktree is removed (cross-session lazy reap in pr-cycle-cleanup.sh Step 5, or
+#   a cleanup from a different cwd in cleanup.md Step 4-W) while the owning
+#   session's harness cwd still points there, `/clear` fails with
+#   `Error: Path "..." does not exist`. #1524's guards key off flow-state
+#   (`active` flag + `worktree` field); those can DRIFT from where harness cwds
+#   actually are (active=false but still standing in it, empty/nulled `worktree`
+#   field, stale session-id). This probe does not depend on that bookkeeping — it
+#   reads the OS's own record of each process's cwd, so "don't delete a tree
+#   someone is standing in" holds even when flow-state is wrong.
+#
+# Usage:
+#   worktree-live-cwd.sh <dir>
+#
+# Exit codes:
+#   0 = a live process has cwd == <dir> or nested under it  → DO NOT remove
+#   1 = no live process is standing in <dir>                → safe (per other gates)
+#   2 = cannot determine (no /proc and no lsof)             → caller decides
+#
+# Portability: avoids GNU `realpath` (canonicalizes via `cd && pwd -P`) to keep
+# the macOS bash 3.2 floor shared with pr-cycle-cleanup.sh. `/proc` is the
+# primary source (Linux); `lsof` is the fallback (BSD/macOS). Same-user processes
+# are readable, and Claude Code sessions run as the same user.
+set -uo pipefail
+
+target="${1:-}"
+if [ -z "$target" ]; then
+  echo "ERROR: worktree-live-cwd.sh: <dir> argument required" >&2
+  exit 2
+fi
+
+# Canonicalize. A non-directory target (already-removed path) falls back to its
+# raw string so a string comparison still has something to match against.
+if [ -d "$target" ]; then
+  target_canon=$( cd -- "$target" 2>/dev/null && pwd -P ) || target_canon="$target"
+else
+  target_canon="$target"
+fi
+[ -n "$target_canon" ] || target_canon="$target"
+
+# Primary: Linux /proc. readlink of /proc/<pid>/cwd is the OS ground truth for a
+# process's working directory. This script's own cwd is the caller's (repo root
+# for the reaper, main checkout for cleanup), never the candidate worktree, so it
+# does not false-match itself — and the reaper's own active worktree is already
+# excluded upstream (Gate 0 self-exclusion) before this probe is consulted.
+if [ -d /proc ]; then
+  for _pdir in /proc/[0-9]*; do
+    _cwd=$(readlink "$_pdir/cwd" 2>/dev/null) || continue
+    [ -n "$_cwd" ] || continue
+    [ "$_cwd" = "$target_canon" ] && exit 0
+    # Trailing-slash prefix test: `issue-1` must not match `issue-12`.
+    case "$_cwd/" in
+      "$target_canon"/*) exit 0 ;;
+    esac
+  done
+  exit 1
+fi
+
+# Fallback: lsof (where /proc is absent). `-a -d cwd +D <dir>` lists processes
+# whose working directory is at or under <dir>; any hit means a live cwd.
+if command -v lsof >/dev/null 2>&1; then
+  if lsof -a -d cwd +D "$target_canon" >/dev/null 2>&1; then
+    exit 0
+  fi
+  exit 1
+fi
+
+# Neither /proc nor lsof — undeterminable.
+exit 2

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -39,7 +39,17 @@ IC="$SCRIPT_DIR/../issue-claim.sh"
 GIT="git -c user.email=t@test.local -c user.name=test -c commit.gpgsign=false"
 
 cleanup_dirs=()
-cleanup() { local d; for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; return 0; }
+holder_pids=()   # background processes that hold cwd inside a worktree (Issue #1544 TCs)
+cleanup() {
+  local p d
+  # `|| true`: a holder killed inline earlier is already dead here, so kill returns
+  # non-zero — without the guard, set -e would abort the EXIT trap and the whole
+  # test would exit non-zero despite all assertions passing.
+  for p in "${holder_pids[@]:-}"; do [ -n "$p" ] && kill "$p" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+  for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+  return 0
+}
 trap cleanup EXIT
 
 # SID_A = the "working" session that holds the claim; SID_B = the (different)
@@ -244,5 +254,42 @@ assert "T-06 issue-1 (live-ref) survives" "1" "$( [ -d "$R/.rite/worktrees/issue
 assert "T-06 issue-12 (orphan) reaped (no prefix bleed from issue-1)" "0" "$( [ -d "$R/.rite/worktrees/issue-12" ] && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=1"*) pass "T-06 status reports session_worktrees=1 (only issue-12)" ;; *) fail "T-06 status: $out" ;; esac
 
+# ===========================================================================
+# Issue #1544 — OS-level live-cwd guard (regression of #1524). The cross-session
+# liveness guard only protects worktrees a session records as its `active`
+# `worktree`; it misses the dangling cases where the owning session's harness cwd
+# is still IN the tree but its flow-state has drifted (active=false, no `worktree`
+# field, stale session-id). The live-cwd guard (worktree-live-cwd.sh) closes that
+# gap by reading the OS's own per-process cwd, independent of flow-state.
+# ===========================================================================
+echo "=== T-07 (Issue #1544): a live process standing in a clean+stale worktree → NOT reaped (live-cwd guard) ==="
+R=$(make_repo 80); cleanup_dirs+=("$R")
+# Fully drift flow-state: deactivate the holder (active=false) and leave NO
+# `worktree` field (make_repo's flow-state set records none) → neither the
+# cross-session liveness guard nor the claim gate protects issue-80. Only the
+# OS-level live-cwd guard can save it (non-vacuous: drop the guard and T-07 flips).
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+# A live process stands in the worktree — the exact "harness cwd still in the
+# tree" shape that makes /clear fail when the tree is reaped out from under it.
+( cd "$R/.rite/worktrees/issue-80" && sleep 30 ) & _h80=$!
+holder_pids+=("$_h80")
+sleep 0.3
+out=$(run_pcc "$R")
+assert "T-07 worktree with live cwd survives (live-cwd guard)" "1" "$( [ -d "$R/.rite/worktrees/issue-80" ] && echo 1 || echo 0 )"
+assert "T-07 claim file survives (not reaped)" "1" "$( [ -f "$R/.rite/state/issue-claims/issue-80.json" ] && echo 1 || echo 0 )"
+assert_grep "T-07 live-cwd guard WARNING on stderr" "$R/pcc.err" "live-cwd guard"
+case "$out" in *"session_worktrees=0"*) pass "T-07 status reports session_worktrees=0" ;; *) fail "T-07 status: $out" ;; esac
+kill "$_h80" 2>/dev/null; wait "$_h80" 2>/dev/null || true
+
+echo "=== T-08 (Issue #1544 non-regression): same clean+stale worktree with NO live cwd → reaped ==="
+R=$(make_repo 81); cleanup_dirs+=("$R")
+# Identical drift to T-07 but with nobody standing in the tree → the live-cwd
+# guard must NOT over-protect: a genuine orphan is still reaped.
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "T-08 free clean+stale worktree reaped (no over-protection)" "0" "$( [ -d "$R/.rite/worktrees/issue-81" ] && echo 1 || echo 0 )"
+assert "T-08 claim file deleted" "0" "$( [ -f "$R/.rite/state/issue-claims/issue-81.json" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "T-08 status reports session_worktrees=1" ;; *) fail "T-08 status: $out" ;; esac
+
 print_summary "$(basename "$0")" \
-  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + cross-session liveness guard (Issue #1524: another live session's flow-state worktree ref → never reap; reap → null owner ref) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + cross-session liveness guard (Issue #1524: another live session's flow-state worktree ref → never reap; reap → null owner ref) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -264,9 +264,11 @@ case "$out" in *"session_worktrees=1"*) pass "T-06 status reports session_worktr
 # ===========================================================================
 echo "=== T-07 (Issue #1544): a live process standing in a clean+stale worktree → NOT reaped (live-cwd guard) ==="
 R=$(make_repo 80); cleanup_dirs+=("$R")
-# Fully drift flow-state: deactivate the holder (active=false) and leave NO
-# `worktree` field (make_repo's flow-state set records none) → neither the
-# cross-session liveness guard nor the claim gate protects issue-80. Only the
+# Fully drift flow-state so neither flow-state-based guard protects issue-80:
+# `deactivate` sets SID_A's flow-state active=false, so the cross-session liveness
+# guard short-circuits at its `active=true` requirement (_rite_worktree_live_referenced)
+# — the `worktree` field value is irrelevant once active=false — and the deactivated
+# claim resolves to `stale`, which the claim gate treats as reapable. Only the
 # OS-level live-cwd guard can save it (non-vacuous: drop the guard and T-07 flips).
 RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
 # A live process stands in the worktree — the exact "harness cwd still in the
@@ -279,7 +281,7 @@ assert "T-07 worktree with live cwd survives (live-cwd guard)" "1" "$( [ -d "$R/
 assert "T-07 claim file survives (not reaped)" "1" "$( [ -f "$R/.rite/state/issue-claims/issue-80.json" ] && echo 1 || echo 0 )"
 assert_grep "T-07 live-cwd guard WARNING on stderr" "$R/pcc.err" "live-cwd guard"
 case "$out" in *"session_worktrees=0"*) pass "T-07 status reports session_worktrees=0" ;; *) fail "T-07 status: $out" ;; esac
-kill "$_h80" 2>/dev/null; wait "$_h80" 2>/dev/null || true
+kill "$_h80" 2>/dev/null || true; wait "$_h80" 2>/dev/null || true
 
 echo "=== T-08 (Issue #1544 non-regression): same clean+stale worktree with NO live cwd → reaped ==="
 R=$(make_repo 81); cleanup_dirs+=("$R")

--- a/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Tests for worktree-live-cwd.sh — OS-ground-truth liveness probe (Issue #1544).
+#
+#   TC-1: missing <dir> argument                       → rc 2
+#   TC-2: directory with NO process standing in it     → rc 1
+#   TC-3: a process whose cwd IS the directory         → rc 0
+#   TC-4: a process whose cwd is NESTED under the dir  → rc 0
+#   TC-5: sibling-prefix dir (issue-1 vs issue-12)     → no false match (rc 1)
+#   TC-6: after the holder exits, the dir is free again → rc 1
+#
+# These pin the contract the reap gate (pr-cycle-cleanup.sh Step 5) and the
+# cleanup removal (cleanup.md Step 4-W) depend on: "don't delete a worktree a
+# live process is standing in", independent of rite flow-state.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+PROBE="$SCRIPT_DIR/../scripts/worktree-live-cwd.sh"
+
+cleanup_dirs=()
+holders=()
+cleanup() {
+  local p d
+  # `|| true`: a holder may already have exited (e.g. TC-6's short sleep), so kill
+  # returns non-zero — without the guard, set -e would abort the EXIT trap.
+  for p in "${holders[@]:-}"; do [ -n "$p" ] && kill "$p" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+  for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+  return 0
+}
+trap cleanup EXIT
+
+# Run the probe and echo its exit code (probe rc is the contract under test).
+probe_rc() { bash "$PROBE" "$@" >/dev/null 2>&1; echo "$?"; }
+
+echo "=== TC-1: missing argument → rc 2 ==="
+assert "TC-1 no arg → rc 2" "2" "$(bash "$PROBE" >/dev/null 2>&1; echo $?)"
+
+echo "=== TC-2: empty directory, no process inside → rc 1 ==="
+D=$(mktemp -d); cleanup_dirs+=("$D")
+assert "TC-2 free dir → rc 1" "1" "$(probe_rc "$D")"
+
+echo "=== TC-3: a process holds cwd == dir → rc 0 ==="
+( cd "$D" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-3 held dir → rc 0" "0" "$(probe_rc "$D")"
+
+echo "=== TC-4: a process holds cwd nested under dir → rc 0 ==="
+D2=$(mktemp -d); cleanup_dirs+=("$D2")
+mkdir -p "$D2/sub/deep"
+( cd "$D2/sub/deep" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-4 nested-held dir → rc 0" "0" "$(probe_rc "$D2")"
+
+echo "=== TC-5: sibling-prefix dir must not false-match (issue-1 vs issue-12) ==="
+D3=$(mktemp -d); cleanup_dirs+=("$D3")
+mkdir -p "$D3/issue-1" "$D3/issue-12"
+( cd "$D3/issue-12" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-5 issue-1 not matched by issue-12 holder → rc 1" "1" "$(probe_rc "$D3/issue-1")"
+assert "TC-5 issue-12 itself matched → rc 0" "0" "$(probe_rc "$D3/issue-12")"
+
+echo "=== TC-6: after holder exits the dir is free again → rc 1 ==="
+D4=$(mktemp -d); cleanup_dirs+=("$D4")
+( cd "$D4" && sleep 1 ) & hp=$!
+sleep 0.3
+assert "TC-6 while held → rc 0" "0" "$(probe_rc "$D4")"
+wait "$hp" 2>/dev/null || true
+assert "TC-6 after holder exits → rc 1" "1" "$(probe_rc "$D4")"
+
+if ! print_summary "$(basename "$0")" "worktree-live-cwd.sh の OS 接地 liveness 判定 (Issue #1544)"; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
@@ -69,6 +69,48 @@ assert "TC-6 while held → rc 0" "0" "$(probe_rc "$D4")"
 wait "$hp" 2>/dev/null || true
 assert "TC-6 after holder exits → rc 1" "1" "$(probe_rc "$D4")"
 
+# --- Backend-selection seam coverage (RITE_WORKTREE_LIVE_CWD_PROBE) ---
+# On Linux the auto path always takes /proc, leaving the lsof and undeterminable
+# branches dead at runtime. cleanup.md's backward-compat note explicitly relies on
+# rc=2 (undeterminable → delete proceeds), so force each backend to pin it.
+
+echo "=== TC-7: forced 'none' backend → rc 2 (undeterminable) ==="
+D5=$(mktemp -d); cleanup_dirs+=("$D5")
+assert "TC-7 probe=none → rc 2" "2" "$(RITE_WORKTREE_LIVE_CWD_PROBE=none bash "$PROBE" "$D5" >/dev/null 2>&1; echo $?)"
+
+echo "=== TC-8: invalid backend value → rc 2 ==="
+assert "TC-8 probe=bogus → rc 2" "2" "$(RITE_WORKTREE_LIVE_CWD_PROBE=bogus bash "$PROBE" "$D5" >/dev/null 2>&1; echo $?)"
+
+echo "=== TC-9: forced 'proc' backend behaves like auto on Linux ==="
+D6=$(mktemp -d); cleanup_dirs+=("$D6")
+assert "TC-9 probe=proc free dir → rc 1" "1" "$(RITE_WORKTREE_LIVE_CWD_PROBE=proc bash "$PROBE" "$D6" >/dev/null 2>&1; echo $?)"
+( cd "$D6" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-9 probe=proc held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=proc bash "$PROBE" "$D6" >/dev/null 2>&1; echo $?)"
+
+echo "=== TC-10: forced 'lsof' backend (the BSD/macOS fallback) ==="
+D7=$(mktemp -d); cleanup_dirs+=("$D7")
+if command -v lsof >/dev/null 2>&1; then
+  ( cd "$D7" && sleep 30 ) & holders+=("$!")
+  sleep 0.3
+  assert "TC-10 probe=lsof held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
+else
+  # lsof absent → the lsof backend reports undeterminable (rc 2), not a false negative.
+  assert "TC-10 probe=lsof w/o lsof → rc 2" "2" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
+fi
+
+echo "=== TC-11: canonicalization matches a symlinked parent (pwd -P / readlink converge) ==="
+# The probe canonicalizes its arg with `cd && pwd -P`; /proc/<pid>/cwd is already
+# physical. A holder entering via a symlinked path must still match both the real
+# and the linked target — pins the canonicalization contract against a future
+# realpath swap.
+Dreal=$(mktemp -d); cleanup_dirs+=("$Dreal"); mkdir -p "$Dreal/wt/sub"
+Dlink=$(mktemp -d); cleanup_dirs+=("$Dlink"); ln -s "$Dreal/wt" "$Dlink/wtlink"
+( cd "$Dlink/wtlink/sub" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-11 real path → rc 0" "0" "$(probe_rc "$Dreal/wt")"
+assert "TC-11 symlinked path → rc 0" "0" "$(probe_rc "$Dlink/wtlink")"
+
 if ! print_summary "$(basename "$0")" "worktree-live-cwd.sh の OS 接地 liveness 判定 (Issue #1544)"; then
   exit 1
 fi

--- a/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
@@ -7,6 +7,11 @@
 #   TC-4: a process whose cwd is NESTED under the dir  → rc 0
 #   TC-5: sibling-prefix dir (issue-1 vs issue-12)     → no false match (rc 1)
 #   TC-6: after the holder exits, the dir is free again → rc 1
+#   TC-7: forced 'none' backend (RITE_WORKTREE_LIVE_CWD_PROBE) → rc 2
+#   TC-8: invalid backend value                        → rc 2
+#   TC-9: forced 'proc' backend (free → rc 1, held → rc 0)
+#   TC-10: forced 'lsof' backend (held → rc 0, free → rc 1; rc 2 if lsof absent)
+#   TC-11: symlinked-parent canonicalization (real & linked path both → rc 0)
 #
 # These pin the contract the reap gate (pr-cycle-cleanup.sh Step 5) and the
 # cleanup removal (cleanup.md Step 4-W) depend on: "don't delete a worktree a
@@ -64,6 +69,7 @@ assert "TC-5 issue-12 itself matched → rc 0" "0" "$(probe_rc "$D3/issue-12")"
 echo "=== TC-6: after holder exits the dir is free again → rc 1 ==="
 D4=$(mktemp -d); cleanup_dirs+=("$D4")
 ( cd "$D4" && sleep 1 ) & hp=$!
+holders+=("$hp")   # also register for trap-based teardown (defensive; wait below is the primary)
 sleep 0.3
 assert "TC-6 while held → rc 0" "0" "$(probe_rc "$D4")"
 wait "$hp" 2>/dev/null || true
@@ -91,6 +97,8 @@ assert "TC-9 probe=proc held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=p
 echo "=== TC-10: forced 'lsof' backend (the BSD/macOS fallback) ==="
 D7=$(mktemp -d); cleanup_dirs+=("$D7")
 if command -v lsof >/dev/null 2>&1; then
+  # free dir → rc 1 (the "delete proceeds" branch cleanup.md relies on)
+  assert "TC-10 probe=lsof free dir → rc 1" "1" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
   ( cd "$D7" && sleep 30 ) & holders+=("$!")
   sleep 0.3
   assert "TC-10 probe=lsof held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"


### PR DESCRIPTION
## 概要

マルチセッション環境で、セッションが `EnterWorktree` で入場したセッション worktree（`.rite/worktrees/issue-{N}`）が削除された後に `/clear` を実行すると、ハーネスの cwd 復元が失敗し `Error: Path "..." does not exist` が発生する不具合（#1524 の再発 / regression）を修正する。

`#1524` の cross-session liveness guard は所有セッションの flow-state（`active` フラグ・`worktree` フィールド）に依存しており、harness cwd の実態とドリフトする経路（`active=false` だが cwd は worktree 内 / `worktree` フィールドが空・null 化済み / stale session-id）では live worktree を reap 可能と誤判定して削除し、`/clear` 失敗を招いていた。

本 PR は **flow-state bookkeeping に依存せず OS の per-process cwd を直接読む live-cwd guard** を全削除経路に追加し、「誰かが立っているディレクトリは消さない」を構造的に担保する。

## 関連 Issue

Closes #1544

- Regression-of: #1524（CLOSED） — 同一クラスの `/clear` worktree エラー

## 変更内容

| ファイル | 変更 |
|---|---|
| `plugins/rite/hooks/scripts/worktree-live-cwd.sh` | **新規**。`/proc/*/cwd`（fallback `lsof`）で worktree に cwd を置く live プロセスを検出する SoT ヘルパー（exit 0=live / 1=なし / 2=判定不能） |
| `plugins/rite/hooks/scripts/pr-cycle-cleanup.sh` | Step 5 reap に live-cwd gate を追加（cross-session liveness の後段）。rc=2 判定不能時は従来 gate へフォールスルー＝非 Linux 後方互換 |
| `plugins/rite/commands/pr/cleanup.md` | Step 4-W の worktree 削除前に live-cwd guard を通し、live cwd があれば削除を skip して遅延 reap へ委譲 |
| `plugins/rite/hooks/tests/worktree-live-cwd.test.sh` | **新規**。ヘルパー単体テスト（8 件） |
| `plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh` | reap の live-cwd gate テスト T-07（保護）/ T-08（非回帰）を追加 |

## 設計判断

- **OS 接地の liveness 判定**: flow-state の `active`/`worktree` は harness cwd の実態とドリフトしうる。`/proc/*/cwd` は OS が保持する各プロセスの cwd そのものであり、bookkeeping が誤っていても「立っているか」を正しく判定できる。これが #1524 の根本的なギャップを塞ぐ。
- **後方互換**: `/proc` も `lsof` も無い環境では rc=2 を返し、reap は従来 gate（claim/dirty）へフォールスルー、cleanup は従来どおり削除を実行する（挙動不変）。
- **過保護の回避**: 真の orphan（誰も立っておらず claim stale）は従来どおり reap される（T-08 で担保）。
- **scope の絞り込み（D-04）**: Issue では `session-start.sh` も対象候補だったが、その dangling self-heal は既に非 blocking で AC-4 を満たしており、`/clear` の harness cwd 復元自体は rite から intercept 不能。本不具合の実効的な解決は「削除前に live cwd を検出して削除しない」予防であるため、session-start.sh は無改修とした（既存の secondary defense は維持）。

## テスト

- `worktree-live-cwd.test.sh`: 8/8 合格（引数欠落→2 / 不在→1 / cwd 一致→0 / ネスト→0 / sibling prefix 非誤検出 / holder 終了後→1）
- `pr-cycle-cleanup-session-reap.test.sh`: 45/45 合格（T-07: live cwd で reap skip + WARNING / T-08: live cwd 無しは reap）
- フックテストスイート全体: **76/76 合格**（回帰ゼロ）
- scripts テスト・drift チェック群: 全合格

## チェックリスト

- [x] テスト追加（新規ヘルパー単体 8 件 + reap gate 2 件）
- [x] 既存テストに回帰なし（hooks 76/76）
- [x] 後方互換（非 /proc 環境はフォールスルーで挙動不変）
- [x] 対象ファイルのみ変更・非対象ファイル不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
