### PR TITLE
fix(pr): bang-backtick ゲートを consumer repo 対応化し rc=2 強制バイパスを解消

### DIFF
--- a/plugins/rite/commands/pr/create.md
+++ b/plugins/rite/commands/pr/create.md
@@ -129,11 +129,17 @@ if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-che
   exit 1
 fi
 
-bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1)
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1)
 bang_rc=$?
 case "$bang_rc" in
   0)
-    : # clean — proceed to next sub-phase
+    # A clean scan and a not-applicable skip both mean "proceed". The skip happens
+    # in a consumer repo (rite used as a marketplace plugin only — no plugins/rite/
+    # in this working tree, hence --skip-if-no-target above). Surface a one-line
+    # informational note for the skip case so the gate pass is not silent.
+    if printf '%s' "$bang_output" | grep -q '\[bang-backtick\] not applicable'; then
+      echo "ℹ️ Bang-backtick gate: 本リポジトリは plugins/rite/ を self-host していないため N/A（clean skip）。" >&2
+    fi
     ;;
   1)
     echo "❌ Bang-backtick adjacency detected — PR submission blocked:" >&2

--- a/plugins/rite/commands/pr/ready.md
+++ b/plugins/rite/commands/pr/ready.md
@@ -102,11 +102,17 @@ if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-che
   exit 1
 fi
 
-bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1)
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1)
 bang_rc=$?
 case "$bang_rc" in
   0)
-    : # clean — proceed to next sub-phase
+    # A clean scan and a not-applicable skip both mean "proceed". The skip happens
+    # in a consumer repo (rite used as a marketplace plugin only — no plugins/rite/
+    # in this working tree, hence --skip-if-no-target above). Surface a one-line
+    # informational note for the skip case so the gate pass is not silent.
+    if printf '%s' "$bang_output" | grep -q '\[bang-backtick\] not applicable'; then
+      echo "ℹ️ Bang-backtick gate: 本リポジトリは plugins/rite/ を self-host していないため N/A（clean skip）。" >&2
+    fi
     ;;
   1)
     echo "❌ Bang-backtick adjacency detected — Ready transition blocked:" >&2

--- a/plugins/rite/hooks/scripts/bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-check.sh
@@ -100,8 +100,19 @@
 #
 # Usage:
 #   bang-backtick-check.sh [--all] [--target FILE]... [--repo-root DIR] [--quiet]
+#                          [--skip-if-no-target]
 #
-# Exit codes: 0 = clean, 1 = pattern detected, 2 = invocation error.
+# Exit codes: 0 = clean (or not-applicable skip), 1 = pattern detected,
+#             2 = invocation error.
+#
+# --skip-if-no-target: when --all finds NO scan directory under the repo root
+#   (i.e. this repo does not self-host plugins/rite/{commands,skills,agents,
+#   references} — the "consumer repo" case where rite is used as a marketplace
+#   plugin only), treat the run as not-applicable and exit 0 instead of the
+#   exit-2 invocation-error diagnostic. Without this flag the exit-2 diagnostic
+#   is preserved (default), so a genuinely misconfigured self-hosting invocation
+#   still surfaces an error. The bang-backtick gate only protects rite's own
+#   plugin markdown; a repo without that markdown has nothing to gate.
 
 set -uo pipefail
 
@@ -109,6 +120,7 @@ REPO_ROOT=""
 QUIET=0
 declare -a TARGETS=()
 USE_ALL=0
+SKIP_IF_NO_TARGET=0
 
 usage() {
   cat <<'EOF'
@@ -122,10 +134,15 @@ Options:
                      output on stdout is preserved; still exits non-zero on
                      detection). Use for CI log noise reduction while keeping
                      findings machine-readable.
+  --skip-if-no-target
+                     With --all, exit 0 (not 2) when no scan directory exists
+                     under the repo root — the "consumer repo" case where rite
+                     is a marketplace plugin only and there is no rite markdown
+                     to gate. Without this flag the exit-2 diagnostic is kept.
   -h, --help         Show this help
 
 Exit codes:
-  0  No bang-backtick adjacency detected
+  0  No bang-backtick adjacency detected (or not-applicable skip)
   1  Pattern detected
   2  Invocation error (bad args, missing files)
 EOF
@@ -139,6 +156,7 @@ while [ $# -gt 0 ]; do
     --target) TARGETS+=("$2"); shift 2 ;;
     --repo-root) REPO_ROOT="$2"; shift 2 ;;
     --quiet) QUIET=1; shift ;;
+    --skip-if-no-target) SKIP_IF_NO_TARGET=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -168,10 +186,17 @@ if [ "$USE_ALL" -eq 1 ]; then
     fi
   done
   if [ "${#scan_dirs[@]}" -eq 0 ]; then
+    if [ "$SKIP_IF_NO_TARGET" -eq 1 ]; then
+      # Consumer repo (rite used as a marketplace plugin only): there is no
+      # rite plugin markdown in this working tree to gate, so the check is
+      # not applicable. Treat as a clean skip rather than an invocation error.
+      echo "[bang-backtick] not applicable: no plugins/rite/{commands,skills,agents,references} scan directory under $REPO_ROOT — clean skip (--skip-if-no-target)" >&2
+      exit 0
+    fi
     echo "ERROR: --all requested but no scan directory exists under $REPO_ROOT" >&2
     echo "  Expected one or more of: plugins/rite/{commands,skills,agents,references}" >&2
     echo "  Likely cause: this script was invoked outside the rite plugin repo (e.g. marketplace install)" >&2
-    echo "  Recovery: run from the rite plugin source tree, or pass --target FILE explicitly" >&2
+    echo "  Recovery: run from the rite plugin source tree, pass --target FILE explicitly, or pass --skip-if-no-target to treat as not-applicable" >&2
     exit 2
   fi
   while IFS= read -r f; do

--- a/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
@@ -252,6 +252,36 @@ out=$("$SCRIPT" --target "$FIXTURE_CLEAN" 2>&1)
 rc=$?
 assert "innocent fixture (including fenced block) exits 0" "0" "$rc"
 
+# --- Test 11: consumer repo (no plugins/rite) — skip vs diagnostic (Issue #1550)
+# Two invariants are pinned here:
+#   (1) Without --skip-if-no-target, --all with no scan directory exits 2 — the
+#       marketplace-install / misconfiguration diagnostic is preserved (MUST NOT
+#       drop it unconditionally).
+#   (2) With --skip-if-no-target, the same invocation exits 0 (not-applicable
+#       clean skip) and emits the "not applicable" note. This is the consumer
+#       repo case: rite is used as a marketplace plugin only, so there is no rite
+#       markdown in this working tree to gate.
+CONSUMER_ROOT=$(mktemp -d)
+TMPFILES+=("$CONSUMER_ROOT")
+
+"$SCRIPT" --repo-root "$CONSUMER_ROOT" --all --quiet >/dev/null 2>&1
+rc=$?
+assert "consumer repo: --all without flag exits 2 (diagnostic preserved)" "2" "$rc"
+
+skip_out=$("$SCRIPT" --repo-root "$CONSUMER_ROOT" --all --skip-if-no-target 2>&1)
+rc=$?
+assert "consumer repo: --all --skip-if-no-target exits 0 (not-applicable skip)" "0" "$rc"
+skip_note=$(grep -c 'not applicable' <<< "$skip_out")
+assert_ge "consumer repo: skip emits 'not applicable' note" 1 "$skip_note"
+
+# --- Test 12: --skip-if-no-target is a no-op when scan dirs exist ------------
+# In the self-hosting repo (scan dirs present) the flag must not change the
+# result: a clean tree still exits 0, exactly as without the flag. This pins
+# that the flag only affects the no-scan-directory branch.
+"$SCRIPT" --all --skip-if-no-target --quiet >/dev/null 2>&1
+rc=$?
+assert "self-host repo: --skip-if-no-target is a no-op on a clean tree (exit 0)" "0" "$rc"
+
 # --- Summary -----------------------------------------------------------------
 echo ""
 echo "==> PASS: $PASS / FAIL: $FAIL"

--- a/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-bang-backtick-check.sh
@@ -282,6 +282,21 @@ assert_ge "consumer repo: skip emits 'not applicable' note" 1 "$skip_note"
 rc=$?
 assert "self-host repo: --skip-if-no-target is a no-op on a clean tree (exit 0)" "0" "$rc"
 
+# --- Test 13: --skip-if-no-target does NOT mask real detection (Issue #1550) -
+# The critical safety invariant for the flag: it must affect ONLY the
+# no-scan-directory branch. When scan dirs DO exist and contain a real
+# bang-backtick pattern, the flag must not suppress detection — exit 1 stands.
+# Test 12 pins the clean-tree no-op; this pins the dirt case, so a future
+# refactor that short-circuits on the flag (before scanning) is caught here.
+DIRT_ROOT=$(mktemp -d)
+TMPFILES+=("$DIRT_ROOT")
+mkdir -p "$DIRT_ROOT/plugins/rite/commands"
+# P1 pattern: closing backtick preceded by space+! inside an inline code span.
+printf 'Bad: `if !` adjacency must still trigger.\n' > "$DIRT_ROOT/plugins/rite/commands/dirty.md"
+"$SCRIPT" --repo-root "$DIRT_ROOT" --all --skip-if-no-target --quiet >/dev/null 2>&1
+rc=$?
+assert "self-host repo: --skip-if-no-target does NOT mask real detection (dirt+flag → exit 1)" "1" "$rc"
+
 # --- Summary -----------------------------------------------------------------
 echo ""
 echo "==> PASS: $PASS / FAIL: $FAIL"

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -122,8 +122,8 @@ rm -f "$sentinel_stderr"
 # We pin three sentinels: the scanner invocation, the sentinel emit literal,
 # and the sub-section header.
 echo "TC-4: §7 MUST — DRIFT-CHECK ANCHOR between create.md and ready.md"
-inv_create=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1' "$CREATE_MD" || true)
-inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all 2>&1' "$READY_MD" || true)
+inv_create=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1' "$CREATE_MD" || true)
+inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1' "$READY_MD" || true)
 if [ "$inv_create" -ge 1 ] && [ "$inv_ready" -ge 1 ]; then
   pass "TC-4 scanner invocation literal present in BOTH create.md and ready.md"
 else
@@ -156,6 +156,18 @@ if [ "$anchor_create" -ge 1 ] && [ "$anchor_ready" -ge 1 ]; then
   pass "TC-4 DRIFT-CHECK ANCHOR comment present in BOTH"
 else
   fail "TC-4 DRIFT-CHECK ANCHOR comment missing (create=$anchor_create, ready=$anchor_ready)"
+fi
+
+# The not-applicable skip-note handling added to the 0) case (Issue #1550) MUST
+# also be symmetric between create.md and ready.md. The literal lives inside a
+# grep pattern with escaped brackets (\[bang-backtick\] not applicable), so pin
+# the unescaped, always-present substring "not applicable".
+skipnote_create=$(grep -cF 'not applicable' "$CREATE_MD" || true)
+skipnote_ready=$(grep -cF 'not applicable' "$READY_MD" || true)
+if [ "$skipnote_create" -ge 1 ] && [ "$skipnote_ready" -ge 1 ]; then
+  pass "TC-4 not-applicable skip-note present in BOTH create.md and ready.md"
+else
+  fail "TC-4 skip-note mismatch (create=$skipnote_create, ready=$skipnote_ready)"
 fi
 
 # ----- TC-5: AC-4 — /rite:lint Phase 3.6 still invokes the same scanner ----
@@ -193,6 +205,36 @@ for f in "$CREATE_MD" "$READY_MD"; do
     pass "TC-12 $fname free of backtick-quoted 'if ! cmd; then' literal"
   fi
 done
+
+# ----- TC-6: AC-1/AC-2 — consumer repo (no plugins/rite) skips the gate ------
+# A repo that uses rite as a marketplace plugin only (no plugins/rite/ in the
+# working tree) must NOT hard-error the gate. With --skip-if-no-target — which
+# the Phase 1.0 blocks now pass — --all exits 0 (not-applicable clean skip) and
+# emits an informational note; without the flag the exit-2 diagnostic is still
+# preserved (MUST NOT drop it unconditionally). (Issue #1550)
+echo "TC-6: AC-1/AC-2 — consumer repo (no plugins/rite) gate skip"
+consumer_root=$(mktemp -d)
+skip_rc=0
+skip_output=$(bash "$CHECK_SCRIPT" --repo-root "$consumer_root" --all --skip-if-no-target 2>&1) || skip_rc=$?
+if [ "$skip_rc" -eq 0 ]; then
+  pass "TC-6 --all --skip-if-no-target exits 0 on consumer repo"
+else
+  fail "TC-6 expected exit 0 with --skip-if-no-target, got $skip_rc"
+  printf '%s\n' "$skip_output" | head -5 >&2
+fi
+if printf '%s\n' "$skip_output" | grep -q 'not applicable'; then
+  pass "TC-6 skip emits 'not applicable' informational note"
+else
+  fail "TC-6 skip note missing"
+fi
+diag_rc=0
+bash "$CHECK_SCRIPT" --repo-root "$consumer_root" --all --quiet >/dev/null 2>&1 || diag_rc=$?
+if [ "$diag_rc" -eq 2 ]; then
+  pass "TC-6 without flag, consumer repo still exits 2 (diagnostic preserved)"
+else
+  fail "TC-6 expected exit 2 without flag, got $diag_rc"
+fi
+rm -rf "$consumer_root"
 
 # ----- Summary --------------------------------------------------------------
 echo ""

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -159,11 +159,13 @@ else
 fi
 
 # The not-applicable skip-note handling added to the 0) case (Issue #1550) MUST
-# also be symmetric between create.md and ready.md. The literal lives inside a
-# grep pattern with escaped brackets (\[bang-backtick\] not applicable), so pin
-# the unescaped, always-present substring "not applicable".
-skipnote_create=$(grep -cF 'not applicable' "$CREATE_MD" || true)
-skipnote_ready=$(grep -cF 'not applicable' "$READY_MD" || true)
+# also be symmetric between create.md and ready.md. Pin the skip-note's
+# user-facing echo message ("...self-host していないため N/A..."), which is
+# unique to the 0)-case skip-note block. The bare substring "not applicable"
+# is NOT used: it also appears in unrelated review-scope prose elsewhere in
+# create.md, so it would pass even if the real skip-note line were deleted.
+skipnote_create=$(grep -cF 'self-host していないため N/A' "$CREATE_MD" || true)
+skipnote_ready=$(grep -cF 'self-host していないため N/A' "$READY_MD" || true)
 if [ "$skipnote_create" -ge 1 ] && [ "$skipnote_ready" -ge 1 ]; then
   pass "TC-4 not-applicable skip-note present in BOTH create.md and ready.md"
 else


### PR DESCRIPTION
## 概要

rite をマーケットプレイス参照のみで利用する**消費側 repo**（作業ツリーに `plugins/rite/` を self-host しない repo）で、`/rite:pr:ready` / `/rite:pr:create` の Phase 1.0 bang-backtick adjacency ハードゲートが構造的に誤発火する問題を解消する。

`bang-backtick-check.sh --all` は走査対象を CWD repo root 配下の `plugins/rite/{commands,skills,agents,references}` に固定しており、消費側 repo では走査対象がゼロのため `rc=2`（invocation error）を返す。Phase 1.0 はこれを hard ERROR 扱いして `exit 1` し、orchestrator が「再試行 / 強制続行 / 中止」の AskUserQuestion を強制するため、消費側 repo では毎回ハードゲートを手動バイパスさせられていた。

ゲートの本来の目的は rite 自身の plugin markdown を保護することであり、消費側 repo は当該 markdown を編集しないためゲートは**構造的に N/A**。エラーではなく clean skip が正しい挙動。

## 関連 Issue

Closes #1550

## 変更内容

- **`bang-backtick-check.sh`**: `--skip-if-no-target` フラグを追加。`--all` で走査ディレクトリがゼロのとき `rc=2` ではなく `rc=0` + informational note（`[bang-backtick] not applicable ...`）を返す。フラグ未指定時は従来の `rc=2` 診断を維持し、self-host repo の誤設定診断（marketplace install 誤実行）を温存する（MUST NOT: 無条件撤廃しない）。
- **`commands/pr/ready.md` / `commands/pr/create.md` §1.0**: invocation に `--skip-if-no-target` を付与し、`0)` case で N/A skip note を surface（DRIFT-CHECK ANCHOR で対称修正）。
- **テスト**: `test-bang-backtick-check.sh`（単体）に N/A skip / 診断維持 / no-op のケースを追加。`bang-backtick-pr-create-pre-check.test.sh`（統合）に消費側 repo skip ケースを追加し、TC-4 invocation literal を新 literal に更新、`0)` skip-note の対称性を pin。

## 設計判断

「自動検出 + silent skip」を採用。config 追加（シンプルさ原則違反）や install 済みツリー走査（read-only / 検証済みで既存 finding により再ブロックし得る弱案）より優れる。self-host repo の既存 exit code 契約（clean=0 / detected=1 / 真の invocation error=2）は不変。

## テスト

- 単体 `test-bang-backtick-check.sh`: **24 PASS / 0 FAIL**（N/A skip → rc=0、フラグなし → rc=2 維持、unknown option → rc=2、self-host clean で no-op を検証）
- 統合 `bang-backtick-pr-create-pre-check.test.sh`: **19 PASS / 0 FAIL**（消費側 repo skip / 診断維持 / DRIFT-CHECK ANCHOR 対称性）
- フックテスト全体 `run-tests.sh`: **76 / 76 passed**

## チェックリスト

- [x] AC-1〜AC-6 をテストで検証（N/A skip / create 対称 / self-host 非退行 / 真の invocation error 維持 / 対称性）
- [x] self-host repo の既存挙動に退行なし（フックテスト 76/76）
- [x] ready.md §1.0 と create.md §1.0 を対称修正（drift-anchor）
- [x] config 項目を追加していない（自動検出で解決）

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
