### PR TITLE
fix(pr): active-but-idle セッションの worktree を claim-join で保護し /clear の Path does not exist 再々発を防止

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -301,9 +301,9 @@ fi
 > **復旧: `/clear` が `Path does not exist` で失敗する場合（Issue #1552）**
 > セッション worktree（`.rite/worktrees/issue-{N}`）が遅延 reap または手動削除で消えた後、所有セッションをハーネスが resume すると cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗することがある。`pr-cycle-cleanup.sh` の worktree liveness guard（Issue #1524/#1544/#1552）はこれを予防するが、ハーネスの cwd レコード自体は rite から intercept できないため、万一発生した場合は次のいずれかで復旧する:
 > 1. リポジトリ root（main checkout）で**新しいセッションを開始**する（cwd が有効になり `/clear` が機能する）。
-> 2. 作業を続けるなら、有効なディレクトリで `/rite:resume {N}` を実行する（worktree が消えていれば再構築経路に入る）。
+> 2. 作業を続けるなら、有効なディレクトリで `/rite:resume {issue_number}` を実行する（worktree が消えていれば再構築経路に入る）。
 > 3. 残骸が残っていれば `git worktree prune` で参照を整理する。
-> session-start hook は dangling cwd を検出すると上記ガイドを stderr に表示し、flow-state の dangling worktree 参照を自動クリアする（非blocking）。
+> session-start hook の挙動は 2 経路に分かれる（相互排他、同一フック実行内では片方のみ発火、いずれも非blocking）: (a) cwd 自体が消えた session worktree を指す場合は上記ガイドを stderr に表示してその場で `exit 0` する、(b) cwd は有効だが記録された worktree 参照だけが消えた場合は flow-state の dangling 参照を自動クリアする。
 
 ### 4 base ブランチの更新（安全化）
 

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -298,6 +298,13 @@ fi
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の live-cwd guard が特に重要。
 - `CLEANUP_WT=none`（multi_session 無効 or worktree 未記録）: 4-W 全体を no-op でスキップ。
 
+> **復旧: `/clear` が `Path does not exist` で失敗する場合（Issue #1552）**
+> セッション worktree（`.rite/worktrees/issue-{N}`）が遅延 reap または手動削除で消えた後、所有セッションをハーネスが resume すると cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗することがある。`pr-cycle-cleanup.sh` の worktree liveness guard（Issue #1524/#1544/#1552）はこれを予防するが、ハーネスの cwd レコード自体は rite から intercept できないため、万一発生した場合は次のいずれかで復旧する:
+> 1. リポジトリ root（main checkout）で**新しいセッションを開始**する（cwd が有効になり `/clear` が機能する）。
+> 2. 作業を続けるなら、有効なディレクトリで `/rite:resume {N}` を実行する（worktree が消えていれば再構築経路に入る）。
+> 3. 残骸が残っていれば `git worktree prune` で参照を整理する。
+> session-start hook は dangling cwd を検出すると上記ガイドを stderr に表示し、flow-state の dangling worktree 参照を自動クリアする（非blocking）。
+
 ### 4 base ブランチの更新（安全化）
 
 main checkout の不可侵規約（[git-worktree-patterns.md](../../references/git-worktree-patterns.md#multi-checkout-不可侵-inviolability-convention)）に従い、**main checkout が `{base_branch}` 上にある場合のみ** pull する。別 branch 上では切り替えず WARNING + skip する:

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -646,19 +646,49 @@ _rite_dir_is_self() {
 rite_self_dir="${RITE_WORKTREE:-$rite_invocation_pwd}"
 rite_self_canon=$(_rite_canonical_dir "$rite_self_dir")
 
-# Cross-session liveness guard (Issue #1524). The 4th protection layer: extend
-# Gate 0 self-exclusion to ALL live sessions. Scans `.rite/sessions/*.flow-state`
-# for a session that records this worktree as its active `worktree`. flow-state
-# liveness takes priority over the claim liveness gate (Gate 2): a session can be
-# live and standing in the worktree while its claim heartbeat has gone
-# stale/free, so the claim alone would wrongly mark the tree reapable. Returns:
-#   0 = a LIVE session (active=true) records $1 (canonical wt_path) → protect (skip reap)
+# Worktree liveness guard (Issue #1524 + #1552). The 4th protection layer:
+# extend Gate 0 self-exclusion to ALL sessions that may still resume into this
+# worktree. Two independent signals, either of which protects (skip reap):
+#   (A) flow-state.worktree scan — a session's per-session flow-state records
+#       this worktree as its `active` `worktree` (Issue #1524). No time bound:
+#       an active session protects its tree regardless of idle time.
+#   (B) claim-join (Issue #1552) — the issue's claim file records this worktree
+#       and its holder session is still `active=true`, EVEN IF the claim's
+#       heartbeat (flow-state `updated_at`) has aged past the 2h staleness window
+#       used by issue-claim.sh `check`. A session that is active=true but idle
+#       >2h has a `stale` claim, which Gate 2 alone would treat as reapable —
+#       reaping a worktree the harness can still resume into and restore as cwd,
+#       breaking `/clear` with `Path does not exist`. (B) closes that window for
+#       sessions whose flow-state.worktree drifted empty/mismatched so (A) misses
+#       them, since the claim reliably records the worktree↔holder binding.
+# Both signals protect ONLY active=true holders: a deactivated/abandoned holder
+# (active=false) stays reapable (subject to the other gates), preserving the
+# lazy-reap purpose and bounding worktree leak. Returns:
+#   0 = an active=true session references $2 (canonical wt_path) → protect
 #   2 = the sessions dir cannot be enumerated, or a flow-state cannot be parsed
-#       → caller skips conservatively (AC-4): we cannot prove no live session needs it
-#   1 = no live session references it → reap may proceed (subject to other gates)
-# Reads the shared-root sessions dir ($repo_root/.rite/sessions).
-_rite_worktree_live_referenced() {
-  local target_canon="$1"
+#       → caller skips conservatively (AC-4): cannot prove no live session needs it
+#   1 = no active session references it → reap may proceed (subject to other gates)
+# Reads the shared-root sessions dir + issue-claims dir ($repo_root/.rite/...).
+_rite_worktree_protected_by_flow_state() {
+  local issue_num="$1" target_canon="$2"
+  # (B) claim-join: protect when the issue's claim holder is still active=true,
+  # regardless of the claim's 2h heartbeat staleness. Independent of the sessions
+  # dir (the claim lives under .rite/state/issue-claims), so it runs first. A
+  # missing/unreadable/corrupt claim simply yields no protection here (the (A)
+  # scan and the downstream gates still apply) — NOT a conservative-skip, to avoid
+  # over-protecting on a stray claim read error.
+  local cfile="$repo_root/.rite/state/issue-claims/issue-${issue_num}.json"
+  if [ -f "$cfile" ] && [ -r "$cfile" ]; then
+    local _holder _cwt _hactive
+    _holder=$(jq -r '.session_id // ""' "$cfile" 2>/dev/null) || _holder=""
+    _cwt=$(jq -r '.worktree // ""' "$cfile" 2>/dev/null) || _cwt=""
+    if [ -n "$_holder" ] && [ -n "$_cwt" ] && { [ "$_cwt" = "$target_canon" ] || [ "$(_rite_canonical_dir "$_cwt")" = "$target_canon" ]; }; then
+      _hactive=$(RITE_STATE_ROOT="$repo_root" bash "$SCRIPT_DIR/../flow-state.sh" \
+                 get --session "$_holder" --field active --default "false" 2>/dev/null) || _hactive="false"
+      [ "$_hactive" = "true" ] && return 0
+    fi
+  fi
+  # (A) flow-state.worktree scan (Issue #1524).
   local sdir="$repo_root/.rite/sessions"
   [ -d "$sdir" ] || return 1
   # Existing-but-unreadable dir is an enumeration failure → conservative skip.
@@ -742,18 +772,20 @@ if [ -d "$session_wt_root" ]; then
     # pre-removal canonical form — a deleted dir no longer canonicalizes).
     _wt_canon=$(_rite_canonical_dir "$wt_path")
 
-    # Gate (cross-session liveness, Issue #1524): never reap a worktree that a
-    # DIFFERENT live session records as its active `worktree`, even when that
-    # session's claim has gone stale/free (flow-state liveness > claim liveness).
+    # Gate (worktree liveness, Issue #1524 + #1552): never reap a worktree that a
+    # session may still resume into — either a session records it as its active
+    # `worktree` (#1524), OR the issue's claim holder is still active=true even
+    # though its claim heartbeat aged past the 2h staleness window (#1552: an
+    # active-but-idle session whose `stale` claim Gate 2 would otherwise reap).
     # Evaluated before Gate 3/Gate 2, like Gate 0, so a clean+stale+aged worktree
-    # still held by a live session is preserved. Enumeration/parse failure of
+    # still owned by an active session is preserved. Enumeration/parse failure of
     # `.rite/sessions/` → conservative skip (AC-4). Skip is logged (not silent).
     # `func || rc=$?` (not `func; rc=$?`): under `set -e` a bare non-zero return
-    # (rc=1 no live ref / rc=2 enum failure) would abort the whole reap loop.
+    # (rc=1 no active ref / rc=2 enum failure) would abort the whole reap loop.
     _live_rc=0
-    _rite_worktree_live_referenced "$_wt_canon" || _live_rc=$?
+    _rite_worktree_protected_by_flow_state "$issue_num" "$_wt_canon" || _live_rc=$?
     if [ "$_live_rc" -eq 0 ]; then
-      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は別の live セッションが参照中のため reap をスキップします (cross-session liveness)。" >&2
+      echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' は所有セッションが active（resume 可能）のため reap をスキップします (worktree liveness)。" >&2
       continue
     elif [ "$_live_rc" -eq 2 ]; then
       echo "WARNING: session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' の保護判定に必要な flow-state の列挙/parse に失敗したため、安全側で reap をスキップします。" >&2

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -48,7 +48,23 @@ SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"' 2>/dev/null) || SOURCE="st
 # Pass extract_session_id stderr through so corrupt hook payload WARNINGs reach
 # triage; suppressing them would hide cross-session classification failures.
 SESSION_ID=$(extract_session_id "$INPUT") || SESSION_ID=""
-if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+if [ ! -d "$CWD" ]; then
+  # Dangling harness cwd (Issue #1552): the session's working directory no longer
+  # exists. When it looks like a reaped session worktree, the harness restored cwd
+  # to a tree that rite's lazy reap (or a manual cleanup) removed — the exact shape
+  # that makes `/clear` fail with `Path does not exist`. rite cannot repair the
+  # harness's own cwd record, but it CAN tell the user how to recover. Best-effort:
+  # emitted to stderr; if the harness aborts before this hook runs, the guidance is
+  # delivered on the next startup in the same (still-dangling) cwd. Non-blocking.
+  case "$CWD" in
+    */worktrees/issue-*)
+      echo "[rite] 作業ディレクトリ '$(printf '%s' "$CWD" | neutralize_ctrl)' が存在しません（session worktree が削除済みの可能性）。" >&2
+      echo "[rite] /clear が 'Path does not exist' で失敗する場合の復旧: リポジトリ root で新しいセッションを開始するか、作業を続けるには有効なディレクトリで /rite:resume を実行してください。" >&2
+      ;;
+  esac
   exit 0
 fi
 
@@ -425,6 +441,7 @@ fi
 if [ -n "$_recorded_wt" ] && [ ! -d "$_recorded_wt" ]; then
   if RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" clear-worktree >/dev/null 2>&1; then
     echo "[rite] worktree '$(printf '%s' "$_recorded_wt" | neutralize_ctrl)' が存在しないため flow-state から参照をクリアしました（再入場は試みません）。" >&2
+    echo "[rite] この worktree で /clear が 'Path does not exist' を出していた場合、参照クリアにより次回以降は解消されます。" >&2
   else
     echo "[rite] WARNING: session-start: dangling worktree 参照のクリアに失敗しました（非blocking で継続します）。" >&2
   fi

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -181,10 +181,12 @@ assert_grep "TC-11 self-exclusion WARNING on stderr" "$R/pcc.err" "self-exclusio
 case "$out" in *"session_worktrees=0"*) pass "TC-11 status reports session_worktrees=0" ;; *) fail "TC-11 status: $out" ;; esac
 
 # ===========================================================================
-# Issue #1524 — cross-session liveness guard (4th protection layer) + reap-time
-# flow-state worktree null-ing. The guard protects a worktree that ANOTHER live
-# session (flow-state active=true) records as its `worktree`, EVEN when that
-# session's claim has gone stale — flow-state liveness > claim liveness (Gate 2).
+# Issue #1524 — worktree liveness guard, signal (A): flow-state.worktree scan
+# (4th protection layer) + reap-time flow-state worktree null-ing. The guard
+# protects a worktree that ANOTHER live session (flow-state active=true) records
+# as its `worktree`, EVEN when that session's claim has gone stale — flow-state
+# liveness > claim liveness (Gate 2). (Signal (B), the #1552 claim-join, is
+# covered by T-09/T-10 below for the case where flow-state.worktree drifted empty.)
 # SID_C = a third (distinct) holder session used by the prefix-collision test.
 # ===========================================================================
 SID_C="cccccccc-9999-aaaa-bbbb-cccccccccccc"
@@ -209,8 +211,8 @@ age_flow_state "$R/.rite/sessions/${SID_A}.flow-state"
 claim_now=$(RITE_STATE_ROOT="$R" bash "$IC" check --issue 70 --session "$SID_B" 2>/dev/null)
 out=$(run_pcc "$R")
 assert "T-01 claim is stale (guard non-vacuous: Gate 2 alone would reap)" "stale" "$claim_now"
-assert "T-01 live-referenced worktree survives (cross-session liveness)" "1" "$( [ -d "$R/.rite/worktrees/issue-70" ] && echo 1 || echo 0 )"
-assert_grep "T-01 cross-session liveness WARNING on stderr" "$R/pcc.err" "cross-session liveness"
+assert "T-01 live-referenced worktree survives (worktree liveness)" "1" "$( [ -d "$R/.rite/worktrees/issue-70" ] && echo 1 || echo 0 )"
+assert_grep "T-01 worktree-liveness WARNING on stderr" "$R/pcc.err" "worktree liveness"
 case "$out" in *"session_worktrees=0"*) pass "T-01 status reports session_worktrees=0" ;; *) fail "T-01 status: $out" ;; esac
 
 echo "=== T-03 (AC-3): inactive flow-state worktree ref does NOT over-protect → reaped + owner ref nulled ==="
@@ -265,8 +267,9 @@ case "$out" in *"session_worktrees=1"*) pass "T-06 status reports session_worktr
 echo "=== T-07 (Issue #1544): a live process standing in a clean+stale worktree → NOT reaped (live-cwd guard) ==="
 R=$(make_repo 80); cleanup_dirs+=("$R")
 # Fully drift flow-state so neither flow-state-based guard protects issue-80:
-# `deactivate` sets SID_A's flow-state active=false, so the cross-session liveness
-# guard short-circuits at its `active=true` requirement (_rite_worktree_live_referenced)
+# `deactivate` sets SID_A's flow-state active=false, so the worktree liveness
+# guard short-circuits at its `active=true` requirement (_rite_worktree_protected_by_flow_state:
+# both the flow-state scan and the #1552 claim-join protect only active=true holders)
 # — the `worktree` field value is irrelevant once active=false — and the deactivated
 # claim resolves to `stale`, which the claim gate treats as reapable. Only the
 # OS-level live-cwd guard can save it (non-vacuous: drop the guard and T-07 flips).
@@ -293,5 +296,43 @@ assert "T-08 free clean+stale worktree reaped (no over-protection)" "0" "$( [ -d
 assert "T-08 claim file deleted" "0" "$( [ -f "$R/.rite/state/issue-claims/issue-81.json" ] && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=1"*) pass "T-08 status reports session_worktrees=1" ;; *) fail "T-08 status: $out" ;; esac
 
+# ===========================================================================
+# Issue #1552 — claim-join (regression of #1524/#1544). The claim's liveness is
+# `active=true` AND flow-state.updated_at within 2h; an active-but-idle (>2h)
+# session has a `stale` claim that Gate 2 alone would reap — destroying a tree the
+# harness can still resume into, so `/clear` fails with `Path does not exist`. The
+# claim-join protects when the issue's claim records this tree AND its holder is
+# still active=true, regardless of the 2h heartbeat staleness.
+# ===========================================================================
+echo "=== T-09 (Issue #1552): active=true holder with a STALE claim (idle >2h) → NOT reaped (claim-join) ==="
+R=$(make_repo 82); cleanup_dirs+=("$R")
+# Holder stays active=true (resumable), but its claim heartbeat ages out: claim
+# liveness = active=true AND flow-state.updated_at within 2h. Backdate updated_at
+# so issue-claim.sh classifies the claim as `stale` → Gate 2 alone would reap it.
+# make_repo does NOT set flow-state.worktree, so the (A) flow-state scan cannot
+# match; only the (B) claim-join (claim.worktree==tree AND holder active=true) can
+# save it. Non-vacuous: revert the claim-join and issue-82 reaps (stale, no live cwd).
+hf82="$R/.rite/sessions/$SID_A.flow-state"
+tmp82=$(mktemp); jq --arg ts "2000-01-01T00:00:00Z" '.updated_at=$ts' "$hf82" > "$tmp82" && mv "$tmp82" "$hf82"
+out=$(run_pcc "$R")
+assert "T-09 active+idle(stale-claim) worktree survives (claim-join)" "1" "$( [ -d "$R/.rite/worktrees/issue-82" ] && echo 1 || echo 0 )"
+assert "T-09 claim file survives (not reaped)" "1" "$( [ -f "$R/.rite/state/issue-claims/issue-82.json" ] && echo 1 || echo 0 )"
+assert_grep "T-09 worktree-liveness WARNING on stderr" "$R/pcc.err" "worktree liveness"
+case "$out" in *"session_worktrees=0"*) pass "T-09 status reports session_worktrees=0" ;; *) fail "T-09 status: $out" ;; esac
+
+echo "=== T-10 (Issue #1552 surgical): active+stale holder whose claim records a DIFFERENT worktree → candidate still reaped ==="
+R=$(make_repo 83); cleanup_dirs+=("$R")
+# Same active+idle(stale) holder as T-09, but rewrite the claim's `worktree` to a
+# path that does NOT match issue-83's tree. The claim-join MUST require a real
+# worktree match — a blanket "holder active → protect" would wrongly save issue-83
+# (and, by the same exact-match logic, an `issue-1` claim never protects `issue-12`).
+hf83="$R/.rite/sessions/$SID_A.flow-state"
+tmp83=$(mktemp); jq --arg ts "2000-01-01T00:00:00Z" '.updated_at=$ts' "$hf83" > "$tmp83" && mv "$tmp83" "$hf83"
+cf83="$R/.rite/state/issue-claims/issue-83.json"
+tmpc=$(mktemp); jq --arg wt "$R/.rite/worktrees/issue-999-bogus" '.worktree=$wt' "$cf83" > "$tmpc" && mv "$tmpc" "$cf83"
+out=$(run_pcc "$R")
+assert "T-10 mismatched-claim worktree IS reaped (no blanket protection)" "0" "$( [ -d "$R/.rite/worktrees/issue-83" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "T-10 status reports session_worktrees=1" ;; *) fail "T-10 status: $out" ;; esac
+
 print_summary "$(basename "$0")" \
-  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + cross-session liveness guard (Issue #1524: another live session's flow-state worktree ref → never reap; reap → null owner ref) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -1338,6 +1338,44 @@ else
 fi
 echo ""
 
+echo "TC-1552 (AC-5): dangling harness cwd at a reaped session worktree → recovery guide + exit 0"
+# A non-existent cwd shaped like a reaped session worktree (.../worktrees/issue-N).
+# rite cannot repair the harness's own cwd record, but session-start surfaces a
+# recovery guide to stderr and exits 0 (non-blocking) — the user-facing half of
+# the /clear `Path does not exist` fix. _RITE_HOOK_RUNNING_SESSIONSTART must be
+# unset or the double-execution guard exits 0 before reaching the cwd check.
+dir1552_root="$TEST_DIR/dangling-cwd"
+mkdir -p "$dir1552_root"
+dangling_cwd="$dir1552_root/.rite/worktrees/issue-1231"   # intentionally NOT created
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+jq -n --arg cwd "$dangling_cwd" --arg src "clear" \
+  '{cwd: $cwd, source: $src, hook_event_name: "SessionStart"}' \
+  | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID -u _RITE_HOOK_RUNNING_SESSIONSTART \
+      bash "$HOOK" >/dev/null 2>"$LAST_STDERR_FILE"; rc1552=$?
+if [ "$rc1552" -eq 0 ]; then
+  pass "TC-1552a: dangling cwd → hook exits 0 (non-blocking)"
+else
+  fail "TC-1552a: expected exit 0, got rc=$rc1552"
+fi
+if grep -q "Path does not exist" "$LAST_STDERR_FILE" && grep -q "/rite:resume" "$LAST_STDERR_FILE"; then
+  pass "TC-1552b: recovery guide emitted to stderr (mentions /clear failure + /rite:resume)"
+else
+  fail "TC-1552b: recovery guide missing on stderr: $(cat "$LAST_STDERR_FILE")"
+fi
+
+echo "TC-1552c (boundary): dangling cwd NOT shaped like a session worktree → no recovery guide"
+LAST_STDERR_FILE="$(mktemp "$TEST_DIR/stderr.XXXXXX")"
+jq -n --arg cwd "$dir1552_root/some/unrelated/deleted-dir" --arg src "clear" \
+  '{cwd: $cwd, source: $src, hook_event_name: "SessionStart"}' \
+  | env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID -u _RITE_HOOK_RUNNING_SESSIONSTART \
+      bash "$HOOK" >/dev/null 2>"$LAST_STDERR_FILE"; rc1552c=$?
+if [ "$rc1552c" -eq 0 ] && ! grep -q "/rite:resume" "$LAST_STDERR_FILE"; then
+  pass "TC-1552c: non-worktree dangling cwd → exit 0, no recovery guide (no false positive)"
+else
+  fail "TC-1552c: unexpected output rc=$rc1552c stderr=$(cat "$LAST_STDERR_FILE")"
+fi
+echo ""
+
 # --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

session worktree の lazy reap（`pr-cycle-cleanup.sh` Step 5）が、**active なまま一定時間アイドルしたセッション**の worktree を誤って reap してしまい、ハーネスがそのセッションを resume した際に cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗する問題を修正する。#1524 → #1544（#1545 で修正）に続く 3 度目の再発で、別リポジトリ（marketplace 経由インストールの consumer repo、v0.5.4 = #1545 入り）での再発を確認済み。

Closes #1552

## 根本原因

claim の liveness は `holder flow-state.active=true` **かつ** `updated_at` が 2h 以内（`CLAIM_STALE_SECONDS`）で判定される。そのため:

- active=true のまま 2h 以上アイドルしたセッションは claim が `stale` 化し、Gate 2 が即 reap する（stale path に age guard が無い）
- 既存の cross-session liveness guard（#1524）は `flow-state.worktree` フィールドのマッチを要するため、その値が空/不一致に drift していると守れない
- OS-level live-cwd guard（#1545）は live プロセスが立っている場合のみ守るため、サスペンド/アイドル中のセッションは守れない

結果として、resume 可能なセッションの worktree が消え、resume + `/clear` で dangling cwd 復元が失敗していた。

## 変更内容

### Prong A: claim-join によるガード拡張（`pr-cycle-cleanup.sh`）

cross-session guard を `_rite_worktree_live_referenced` → `_rite_worktree_protected_by_flow_state` に拡張し、2 つの保護シグナル（いずれか成立で保護）に統一:

- **(A) flow-state.worktree スキャン**（#1524, 既存）: セッションが `active` な `worktree` として当該 tree を記録
- **(B) claim-join**（本 PR, #1552）: issue の claim holder の flow-state が `active=true` なら、claim heartbeat が 2h アイドルで `stale` 化していても reap しない。claim は worktree↔holder の binding を確実に保持するため、`flow-state.worktree` が drift しても保護できる

両シグナルとも **`active=true` の holder のみ保護**する加法的変更。`active=false`（deactivate 済み/放棄）は従来どおり reap 対象のままで、lazy-reap 本来の目的と worktree leak 防止を維持する（既存 reap テストは不変）。

### Prong B: dangling cwd の復旧ガイド（`session-start.sh` / `cleanup.md`）

ハーネスの cwd レコード自体は rite から intercept できないため、万一 dangling 化した場合の復旧経路を明文化:

- `session-start.sh`: harness cwd 自体が削除済み session worktree（`*/worktrees/issue-*`）を指す early-exit 経路で、復旧ガイド（リポジトリ root で新セッション開始 / `/rite:resume`）を stderr に surface。self-heal メッセージにも復旧文脈を追記
- `cleanup.md`: `/clear` が `Path does not exist` で失敗した場合の復旧手順を Step 4-W に追記

## 設計判断

- **active=false を reap 対象に残す（D-01）**: ハーネスが無期限に resume できる現実に対し、flow-state を権威シグナルとする。active=true のみ保護することで、deactivate 済みの真の orphan は従来どおり回収され、worktree leak を防ぐ（D-02 のトレードオフ）。
- **claim-join は worktree 一致を必須とする**: 「holder が active なら無条件保護」ではなく、claim が記録する worktree が候補と一致する場合のみ保護（surgical。prefix 衝突 `issue-1` vs `issue-12` も exact match で安全）。

## テスト

`plugins/rite/hooks/tests/run-tests.sh` 全 76 ファイル green。本 PR で追加:

- `pr-cycle-cleanup-session-reap.test.sh`:
  - **T-09**: active=true + claim stale（2h アイドル）+ flow-state.worktree 空 → claim-join で**保護**（非 vacuous: 修正前は reap）
  - **T-10**: active+stale だが claim.worktree 不一致 → 候補は**reap**（blanket 保護でないことを検証 = surgical）
  - 既存 T-01〜T-08 / TC-1〜TC-10 は不変（WARNING 文言統一に伴い T-01 の grep のみ追従）
- `session-start.test.sh`:
  - **TC-1552 a/b/c**: dangling cwd → exit 0（非blocking）+ 復旧ガイド surface + 非 worktree パスでは誤検出しない

その他 drift/品質チェック（distributed-fix-drift / bang-backtick / hardcoded-line-number / sh-cross-ref / bash-heaviness）は変更ファイルで 0 findings。

## 残課題・スコープ外

- 本修正は防御の多層化 + 復旧ガイドであり、consumer repo での厳密な再現は静的解析からは未確定（Issue の Open Questions に明記）。`flow-state.worktree` が完全に drift した状態でセッションを長期サスペンド後 resume する残余ケースは、Prong B の復旧ガイドでカバーする。
- worktree leak（真に放棄された active=true セッション）とのトレードオフは D-02 として記録。能動的 GC は別 Issue 候補。

## チェックリスト

- [x] 全 MUST 要件を実装
- [x] 受入基準（AC）に対応するテストを追加（T-09/T-10/TC-1552）
- [x] 既存機能の非回帰を確認（#1524/#1544/#1545 のテスト含む全 76 file green）
- [x] 対象ファイルのみ変更・非対象ファイルは不変
- [x] プロジェクト規約（READ-ONLY 契約 / 非blocking hook / macOS bash 3.2 floor）に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)
