### PR TITLE
fix(commands): read-only コマンドから context: fork を除去し実出力リレー欠落を修正

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -321,7 +321,6 @@ Each command file in `commands/` must include YAML frontmatter:
 ```markdown
 ---
 description: Short description of the command
-context: fork # Optional: run in isolated context
 ---
 
 # /rite:command-name
@@ -334,15 +333,13 @@ Command documentation...
 | `description` | Yes | Short description used for command discovery |
 | `context` | No | Set to `fork` for commands that don't need main conversation context |
 
-**context: fork Usage:**
+**context: fork Usage in rite:**
 
-Commands that display information without modifying state use `context: fork` for better context efficiency:
+rite commands do **not** use `context: fork`. Although the field is available for read-only commands, forked (isolated) execution does not relay a command's own output back to the user inline — only the harness control wrapper surfaces. State-changing / interactive commands were switched away from `context: fork` in #436, and the remaining read-only commands (`/rite:issue:list`, `/rite:investigate`, `/rite:workflow`, `/rite:skill:suggest`) in #1554.
 
 | Command | context: fork | Reason |
 |---------|---------------|--------|
-| `/rite:issue:list` | ✅ | Information display only |
-| `/rite:skill:suggest` | ✅ | Independent analysis |
-| Others | ❌ | Require user interaction or state changes |
+| All rite commands | ❌ | Forked execution does not relay command output inline (#436, #1554) |
 
 ### Skill File Format
 

--- a/plugins/rite/commands/investigate.md
+++ b/plugins/rite/commands/investigate.md
@@ -1,6 +1,5 @@
 ---
 description: コード調査（/investigate）
-context: fork
 ---
 
 # /rite:investigate

--- a/plugins/rite/commands/issue/list.md
+++ b/plugins/rite/commands/issue/list.md
@@ -1,6 +1,5 @@
 ---
 description: GitHub Issue の一覧を表示
-context: fork
 ---
 
 # /rite:issue:list

--- a/plugins/rite/commands/skill/suggest.md
+++ b/plugins/rite/commands/skill/suggest.md
@@ -1,6 +1,5 @@
 ---
 description: 現在のコンテキストを分析し、適用可能なスキルを提案
-context: fork
 ---
 
 # /rite:skill:suggest

--- a/plugins/rite/commands/workflow.md
+++ b/plugins/rite/commands/workflow.md
@@ -1,6 +1,5 @@
 ---
 description: rite ワークフロー全体のガイドを表示
-context: fork
 ---
 
 # /rite:workflow


### PR DESCRIPTION
## 概要

read-only な `context: fork` コマンド（`/rite:issue:list` / `/rite:investigate` / `/rite:workflow` / `/rite:skill:suggest`）の frontmatter から `context: fork` を除去し、forked（isolated）execution でコマンド本来の出力がユーザーへ inline にリレーされず、ハーネスの制御ラッパー文（`return control to the user and STOP ...` + `<system-reminder>`）だけが surface される問題を修正する。#436 で interactive/state-changing コマンドに適用した方針を、未対応だった read-only 系 4 コマンドへ展開して完了させる。

## 関連 Issue

Closes #1554

### 作業中に発見した別件（別 Issue として追跡）

- #1555: `orphan-reference-check.sh` が worktree（`.rite/worktrees`）実行時に `--all` で全ファイルを除外し `exit 2` になる（本 PR とは独立のツーリングバグ。本作業の lint 実行中に発見）

## 変更内容

- `plugins/rite/commands/issue/list.md` / `investigate.md` / `workflow.md` / `skill/suggest.md`: frontmatter の `context: fork` 行を除去（各 -1 行、`description` のみ残す）
- `docs/SPEC.md`: 「context: fork Usage」節を実態（rite はどのコマンドでも `context: fork` を使用しない）へ更新し、Command File Format の frontmatter 例からも `context: fork` 行を削除

> **仕様メモ**: Issue #1554 が更新対象に挙げた `docs/BEST_PRACTICES_ALIGNMENT.md` は #641 でアーカイブ削除済みで存在しないため、`context: fork` 適用テーブルの現在地である `docs/SPEC.md` へ AC-3 を読み替えて反映した（ユーザー承認済み）。

## 受入基準

- AC-1（`/rite:issue:list` が一覧を inline 表示）: コード上 `context: fork` 除去済み。実機での最終確認は plugin リロード後（マージ後）に行う
- AC-2（`grep -rl "context: fork" plugins/rite/commands/` が 0 件）: ✅ 確認済み（0 件）
- AC-3（doc が実態一致）: ✅ `docs/SPEC.md` を更新済み（BEST_PRACTICES_ALIGNMENT.md は不在のため読み替え）
- AC-4（review/create/fix/lint および各 Phase 本文が無変更）: ✅ diff は frontmatter 行 + SPEC.md doc 節のみ

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable) — テストコマンド未設定（`commands.test: null`）。plugin 固有チェックは変更ファイルに新規 finding 0 件
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
