### PR TITLE
fix(hooks): orphan-reference-check.sh の --all を worktree 実行で全除外しないよう修正

### DIFF
--- a/plugins/rite/hooks/scripts/orphan-reference-check.sh
+++ b/plugins/rite/hooks/scripts/orphan-reference-check.sh
@@ -108,9 +108,15 @@ fi
 
 if [ "$USE_ALL" -eq 1 ]; then
   FILES=()
+  # find は REPO_ROOT 相対で走査し、結果に REPO_ROOT を再付加して絶対パス化する。
+  # セッション worktree (.rite/worktrees/issue-N) では REPO_ROOT 自体のパスに
+  # `/.rite/` セグメントが含まれるため、絶対パス基準で `-not -path "*/.rite/*"` を
+  # 適用すると配下の全ファイルが誤って除外され `--all expansion empty` (exit 2) に
+  # 陥る。相対パス基準なら除外パターンは plugins/rite 配下にネストした成果物
+  # ディレクトリのみに作用し、通常 checkout との走査結果も一致する。
   while IFS= read -r f; do
-    FILES+=("$f")
-  done < <(find "$REPO_ROOT/plugins/rite" \
+    FILES+=("$REPO_ROOT/$f")
+  done < <(cd "$REPO_ROOT" && find "plugins/rite" \
     -not -path "*/.git/*" \
     -not -path "*/.rite/*" \
     -not -path "*/.rite-work-memory/*" \

--- a/plugins/rite/hooks/tests/orphan-reference-check.test.sh
+++ b/plugins/rite/hooks/tests/orphan-reference-check.test.sh
@@ -159,6 +159,29 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-010: --all from a worktree-like REPO_ROOT (path contains /.rite/) → scan succeeds
+# Regression guard for the bug where a session worktree path
+# (.rite/worktrees/issue-N) made every file's absolute path match the
+# `*/.rite/*` exclusion, emptying the --all expansion and forcing exit 2.
+# --------------------------------------------------------------------------
+echo "TC-010: --all from worktree-like REPO_ROOT (.rite/ in path) → scan succeeds"
+WT_ROOT="$TEST_DIR/.rite/worktrees/issue-999"
+mkdir -p "$WT_ROOT/plugins/rite/commands/issue/references"
+mkdir -p "$WT_ROOT/plugins/rite/hooks/tests"
+echo "# Orphan in worktree" > "$WT_ROOT/plugins/rite/commands/issue/references/wt-orphan-doc.md"
+rc=0
+output=$(bash "$TARGET" --all --repo-root "$WT_ROOT" 2>&1) || rc=$?
+# Must NOT be the empty-expansion usage error (exit 2). The orphan should be
+# detected (exit 1), proving the find walked the worktree subtree.
+if [ "$rc" -eq 1 ] && echo "$output" | grep -q "ORPHAN: plugins/rite/commands/issue/references/wt-orphan-doc.md"; then
+  pass "worktree-like REPO_ROOT scanned, orphan detected → exit 1"
+elif [ "$rc" -eq 2 ] && echo "$output" | grep -q "expansion empty"; then
+  fail "regression: --all expansion empty under worktree-like REPO_ROOT (the bug), output: $output"
+else
+  fail "expected rc=1 + wt-orphan-doc ORPHAN, got rc=$rc, output: $output"
+fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要

`orphan-reference-check.sh --all` がセッション worktree（`.rite/worktrees/issue-N`）内から実行されたとき、対象ファイルを 1 件も拾えず `exit 2`（`--all expansion empty`）になる問題を修正する。

`multi_session.enabled: true`（テンプレートのデフォルト ON）では `/rite:lint` が常に worktree 内から走るため、Phase 3.15 orphan-reference-check がデフォルト構成で恒常的に invocation error（非ブロッキング warning 扱い）となり、orphan 検出が事実上無効化されていた。

## 根本原因

`--all` の `find` は `REPO_ROOT="$(git rev-parse --show-toplevel)"` を基準に絶対パスで走査していた。worktree 内では `REPO_ROOT` 自体が `…/.rite/worktrees/issue-N` という形で `/.rite/` セグメントを含むため、配下の全ファイルの絶対パスが除外パターン `-not -path "*/.rite/*"` に一致し、`find` の結果が 0 件になっていた。通常の checkout（リポジトリルート直下）では `/.rite/` がパスに現れないため発現しない。

## 変更内容

- `plugins/rite/hooks/scripts/orphan-reference-check.sh`: `--all` の `find` を **REPO_ROOT 相対**で走査し（`cd "$REPO_ROOT" && find "plugins/rite" ...`）、読み込みループで結果に `$REPO_ROOT/` を再付加して絶対パス化する。これにより除外パターンは REPO_ROOT prefix に左右されず、`plugins/rite` 配下にネストした成果物ディレクトリのみへ正しく作用する。`cd` はプロセス置換のサブシェル内で実行されるためスクリプト本体の cwd には影響しない。
- `plugins/rite/hooks/tests/orphan-reference-check.test.sh`: worktree 様パス（`.rite/` を含む REPO_ROOT）での `--all` 走査が成立すること（`expansion empty` の exit 2 にならないこと）を固定する TC-010 を追加。

## 受入基準

- **AC-1**（worktree 実行で対象ファイルを拾える）: 修正版を worktree から `--all` 実行 → `checked=94 orphans=0`（exit 0）。`expansion empty` にならない。
- **AC-2**（通常 checkout の挙動が不変）: 相対パスに `$REPO_ROOT/` を再付加するため従来と同一の絶対パス集合を生成。既存 TC-007（通常 `--all`）パス。
- **AC-3**（テストで worktree ケースを固定）: TC-010 を追加し、全 10 ケースパス。

## テスト

- `bash plugins/rite/hooks/tests/orphan-reference-check.test.sh` → PASS 10 / FAIL 0
- worktree 内での実走 `orphan-reference-check.sh --all` → exit 0（修正前は exit 2）

## スコープ外

- 他の plugin-specific check スクリプト（bang-backtick / comment-line-ref 等）が同種の worktree 起因問題を持つかの横展開調査は別 Issue で扱う。

## チェックリスト

- [x] 根本原因を特定し最小修正で対応
- [x] 受入基準 AC-1 / AC-2 / AC-3 を検証
- [x] テスト追加（TC-010）・全ケースパス
- [x] 通常 checkout の regression なしを確認

Closes #1555

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
