### PR TITLE
feat(config): tdd セクションをデフォルトオンで導入

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -173,7 +173,7 @@ metrics:
   enabled: true            # Enable/disable metrics recording (default: true)
   baseline_issues: 3       # Number of Issues for baseline collection (default: 3)
 
-# Test-Driven Development (Canon TDD) settings
+# Test-Driven Development (Canon TDD) settings (scaffolding only — not yet wired)
 tdd:
   enabled: true   # true: implementation phase runs the Canon TDD cycle (default: true, opt-out)
 
@@ -718,13 +718,13 @@ wiki:
 
 ### tdd
 
-Settings for Test-Driven Development (Canon TDD). This key controls whether the implementation phase (`/rite:issue:implement`) follows a Canon TDD cycle — write a test, confirm it fails (Red), make it pass with the minimal change (Green), then Refactor, one behavior at a time. This section documents the `tdd` configuration key itself; the implementation-phase cycle it gates is delivered by `/rite:issue:implement`.
+Settings for Test-Driven Development (Canon TDD). This key controls whether the implementation phase (`/rite:issue:implement`) follows a Canon TDD cycle — write a test, confirm it fails (Red), make it pass with the minimal change (Green), then Refactor, one behavior at a time. This section documents the `tdd` configuration key itself.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | boolean | `true` | Enable the Canon TDD cycle in the implementation phase (opt-out). Set `false` for doc-centric / non-software projects to restore the previous non-TDD implementation flow (behavior identical to before the feature). A config that omits the `tdd:` key is treated as `enabled: true` (opt-out convention), so configs predating the feature get the default-on behavior |
+| `enabled` | boolean | `true` | Enable the Canon TDD cycle in the implementation phase (opt-out). Set `false` for doc-centric / non-software projects to restore the previous non-TDD implementation flow (behavior identical to before the feature). A config that omits the `tdd:` key is treated as `enabled: true` (opt-out convention), so configs predating the feature get the default-on behavior. **⚠️ Known limitation**: config scaffolding only — the implementation-phase Canon TDD cycle is not yet wired into `/rite:issue:implement`; until it lands, this key has no runtime effect |
 
-**Graceful degrade:** when `commands.test` is `null` (no test runner configured) the Red/Green auto-run is skipped with a warning, while the one-behavior-at-a-time discipline still applies. When `enabled: false`, the Canon TDD cycle is skipped entirely and the implementation phase behaves exactly as it did before this feature.
+**Graceful degrade (intended semantics once wired):** when `commands.test` is `null` (no test runner configured) the Red/Green auto-run is skipped with a warning, while the one-behavior-at-a-time discipline still applies. When `enabled: false`, the Canon TDD cycle is skipped entirely and the implementation phase behaves exactly as it did before this feature.
 
 **Example (opt out — doc-centric project):**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -173,6 +173,10 @@ metrics:
   enabled: true            # Enable/disable metrics recording (default: true)
   baseline_issues: 3       # Number of Issues for baseline collection (default: 3)
 
+# Test-Driven Development (Canon TDD) settings
+tdd:
+  enabled: true   # true: implementation phase runs the Canon TDD cycle (default: true, opt-out)
+
 # Language setting
 language: auto  # auto | ja | en
 ```
@@ -711,6 +715,23 @@ wiki:
 ```
 
 **Related commands:** `/rite:wiki:init` (one-time setup), `/rite:wiki:ingest`, `/rite:wiki:query`, `/rite:wiki:lint`.
+
+### tdd
+
+Settings for Test-Driven Development (Canon TDD). When enabled, the implementation phase (`/rite:issue:implement`) drives a Canon TDD cycle: build a test list (seeded from the Issue's Section 6 Test Specification), pick one behavior, write a test and confirm it fails (Red), make it pass with the minimal change (Green), then Refactor — repeating until the test list is empty.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable the Canon TDD cycle in the implementation phase (opt-out). Set `false` for doc-centric / non-software projects to restore the previous non-TDD implementation flow (behavior identical to before the feature). A config that omits the `tdd:` key is treated as `enabled: true` (opt-out convention), so configs predating the feature get the default-on behavior |
+
+**Graceful degrade:** when `commands.test` is `null` (no test runner configured) the Red/Green auto-run is skipped with a warning, while the test-list discipline (implement one behavior at a time) is still followed. When `enabled: false`, the Canon TDD cycle is skipped entirely.
+
+**Example (opt out — doc-centric project):**
+
+```yaml
+tdd:
+  enabled: false
+```
 
 ### language
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -718,13 +718,13 @@ wiki:
 
 ### tdd
 
-Settings for Test-Driven Development (Canon TDD). When enabled, the implementation phase (`/rite:issue:implement`) drives a Canon TDD cycle: build a test list (seeded from the Issue's Section 6 Test Specification), pick one behavior, write a test and confirm it fails (Red), make it pass with the minimal change (Green), then Refactor — repeating until the test list is empty.
+Settings for Test-Driven Development (Canon TDD). This key controls whether the implementation phase (`/rite:issue:implement`) follows a Canon TDD cycle — write a test, confirm it fails (Red), make it pass with the minimal change (Green), then Refactor, one behavior at a time. This section documents the `tdd` configuration key itself; the implementation-phase cycle it gates is delivered by `/rite:issue:implement`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable the Canon TDD cycle in the implementation phase (opt-out). Set `false` for doc-centric / non-software projects to restore the previous non-TDD implementation flow (behavior identical to before the feature). A config that omits the `tdd:` key is treated as `enabled: true` (opt-out convention), so configs predating the feature get the default-on behavior |
 
-**Graceful degrade:** when `commands.test` is `null` (no test runner configured) the Red/Green auto-run is skipped with a warning, while the test-list discipline (implement one behavior at a time) is still followed. When `enabled: false`, the Canon TDD cycle is skipped entirely.
+**Graceful degrade:** when `commands.test` is `null` (no test runner configured) the Red/Green auto-run is skipped with a warning, while the one-behavior-at-a-time discipline still applies. When `enabled: false`, the Canon TDD cycle is skipped entirely and the implementation phase behaves exactly as it did before this feature.
 
 **Example (opt out — doc-centric project):**
 

--- a/plugins/rite/commands/init.md
+++ b/plugins/rite/commands/init.md
@@ -339,7 +339,7 @@ Compare current config against the template and classify each key:
 
 **Unknown key 判定の scope**: Step 4 の "Unknown key" 判定 (user-added keys not in template) は、**template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。境界より下 (コメント形式の Advanced sections + 末尾コメント) は template 側で意図的に省略または注記のため存在する領域であり、ユーザー設定の classification 対象外。
 
-**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `fix`, `language`, `wiki`, `multi_session`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
+**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `fix`, `language`, `wiki`, `multi_session`, `tdd`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
 
 **Active sub-keys covered on --upgrade** (drift anchor — the `init-upgrade-drift` test T-12 asserts, per section, this list ⊇ each template active section's **direct** sub-keys above the `--- Advanced ---` marker; Step 6 item 4 adds any missing sub-key while preserving existing siblings). Sections whose value is a scalar (`schema_version`, `language`) have no sub-keys and are omitted:
 
@@ -353,6 +353,7 @@ Compare current config against the template and classify each key:
 - `fix`: `fail_fast_response`
 - `wiki`: `enabled`, `branch_strategy`, `branch_name`, `auto_ingest`, `auto_query`
 - `multi_session`: `enabled`, `worktree_base`
+- `tdd`: `enabled`
 
 **When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it (the same guard as the top-level list, one level down).
 

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -161,6 +161,8 @@ multi_session:
 # /rite:init new-generation emits it as an active block (new projects get the
 # default-on behavior). On --upgrade it is back-added with `enabled: true` to
 # existing configs; an existing explicit `enabled: false` is preserved.
+# NOTE (known limitation): config scaffolding (宣言のみ)。implementation phase への
+# Canon TDD サイクル配線は未完で、現時点では本キーに runtime 効果はありません。
 tdd:
   enabled: true   # true: implementation phase runs the Canon TDD cycle (default: true, opt-out)
 

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -151,6 +151,19 @@ multi_session:
   enabled: true                    # per-session worktrees (on by default); false to disable
   worktree_base: ".rite/worktrees" # session worktree base (issue-{N} subdirs)
 
+# Test-Driven Development (Canon TDD) settings
+# Default ON (opt-out). When enabled, the implementation phase drives a Canon TDD
+# cycle (test list -> pick one -> Red -> minimal Green -> Refactor -> repeat).
+# Set `enabled: false` for doc-centric / non-software projects, or where
+# `commands.test` is null (Red/Green auto-run is then skipped). A config that
+# omits the `tdd:` key is treated as `enabled: true` (opt-out convention).
+# Declared ABOVE the `--- Advanced ---` marker (like wiki / multi_session) so
+# /rite:init new-generation emits it as an active block (new projects get the
+# default-on behavior). On --upgrade it is back-added with `enabled: true` to
+# existing configs; an existing explicit `enabled: false` is preserved.
+tdd:
+  enabled: true   # true: implementation phase runs the Canon TDD cycle (default: true, opt-out)
+
 # --- Advanced (below this line) ---
 # These sections are omitted during new generation (/rite:init).
 # They are added as comments during --upgrade.

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -164,5 +164,12 @@ wiki:
     threshold_prs: 5                   # この件数の merged PR が raw-source ingest なしに蓄積したら lint で警告
     pr_raw_threshold: 3                # 直近 threshold_prs 件のうち raw を持たない PR がこの数以上で警告
 
+# Canon TDD 設定
+# 本リポは markdown 中心（commands.test: null）のため、Red/Green を実行できる
+# テストコマンドが存在しない。配布テンプレートのデフォルトは ON（opt-out）だが、
+# ここでは明示的に false とし、ドッグフーディング時に TDD サイクルが空振りしないようにする。
+tdd:
+  enabled: false   # markdown 中心・commands.test: null のため明示 OFF
+
 # 言語設定
 language: ja


### PR DESCRIPTION
## 概要

Canon TDD を制御する `tdd:` config セクションを導入する（Sub-1）。配布テンプレートは **デフォルト ON**（opt-out）とし、`wiki` / `multi_session` と同じ active-section back-add 方式で既存プロジェクトにも `init --upgrade` で展開する。本リポ（cc-rite-workflow）自身は markdown 中心・`commands.test: null` のため `tdd.enabled: false` を明記する。

implement.md の Canon TDD サイクル本体（Sub-2 / #1564）、テストリスト framing・docs 反映（Sub-3 / #1565）は本 PR のスコープ外。

## 関連 Issue

Closes #1563

## 変更内容

- `plugins/rite/templates/config/rite-config.yml`: `--- Advanced ---` マーカーの**上**に `tdd:` セクション（`enabled: true` + 説明コメント）を追加。新規 `/rite:init` で active ブロックとして展開される（`wiki` / `multi_session` と同列）
- `docs/CONFIGURATION.md`: Full Configuration Example に `tdd:` を追加し、`### tdd` 詳細セクション（キー・デフォルト・degrade 概要・opt-out 規約）を追加してテンプレと同期
- `plugins/rite/commands/init.md`: `--upgrade` drift anchor の「Active top-level sections covered on --upgrade」に `tdd`、「Active sub-keys covered on --upgrade」に `- tdd: enabled` を追加。汎用 Missing section 行 + sub-key merge 経由で back-add され、既存の明示 `enabled: false` は sub-key merge の no-op で保全される（専用行は追加せず CLAUDE.md「新しい構造を持ち込まない」に準拠）
- `rite-config.yml`（本リポ）: markdown 中心・`commands.test: null` のため `tdd: { enabled: false }` を理由コメント付きで明示 OFF

## 設計判断

- `tdd:` を `--- Advanced ---` マーカーの**上**に配置（Issue の Open Question 通り）。新規 init で active 展開させるため
- `schema_version` は bump しない（active-section back-add 方式のため。`wiki` / `multi_session` の先例に倣う）
- init.md には専用分類行を足さず、既存の汎用「Missing section」行 + sub-key merge に委ねた（`multi_session` のような特殊 back-add セマンティクスは不要なため）

## Acceptance Criteria

- [x] AC-1: テンプレ config の `tdd.enabled: true` が `--- Advanced ---` マーカーより上に存在（164 行 < 167 行で確認）
- [x] AC-2: `CONFIGURATION.md` にテンプレと同期した `tdd` 記述（キー・デフォルト・degrade 概要）
- [x] AC-3: `init.md` drift anchor に `tdd` / `tdd.enabled` が back-add 対象として列挙
- [x] AC-4: 既存 `tdd.enabled: false` は sub-key merge の no-op で保全（汎用 Missing section 行は欠落時のみ発火）
- [x] AC-5: 本リポ `rite-config.yml` の `tdd.enabled` が `false`、理由コメント付き

## 検証

- `bash plugins/rite/hooks/tests/init-upgrade-drift.test.sh` → **PASS 54 / FAIL 0**（新規の `tdd` top-level・`tdd.enabled` sub-key の列挙チェックを含む）
- YAML パース確認（template `tdd={enabled: true}` / repo `tdd={enabled: false}`）
- プラグイン固有 lint チェック: 変更 4 ファイルに新規 finding なし（既存 warning は非ブロッキング）

🤖 Generated with [Claude Code](https://claude.com/claude-code)