### PR TITLE
fix(pr-open): EnterWorktree の git 誤判定失敗時に再起動案内 fallback を追加

### DIFF
--- a/docs/designs/multi-session-worktree.md
+++ b/docs/designs/multi-session-worktree.md
@@ -135,7 +135,7 @@ multi_session:
      | branch も worktree もなし | `git worktree add -b {branch} {path} origin/{base}` |
      | branch が**別の worktree** で checkout 中 | **中止**（他セッション作業中の可能性を表示 — git が構造的に保証する二重着手ガード） |
   3. `.rite-plugin-root` を worktree root へコピー → `EnterWorktree(path: {path})`
-  4. **EnterWorktree 不在/失敗時**: AskUserQuestion（(a) 中止＝推奨。worktree は保持し再実行で再利用 / (b) 従来方式で続行＝他セッション併走中は危険である旨を警告）。**silent fallback はしない**。
+  4. **EnterWorktree 不在/失敗時**: **silent fallback はしない**。失敗原因を切り分ける — (A) harness の git 誤判定（`.git` 存在 + `git -C {path} rev-parse` 成功 + 起動コンテキスト git=false / 「not in a git repository」）＝推奨。リポジトリ root から Claude Code を再起動し再実行すれば worktree は `WT_CASE=reuse` で継続（worktree は保持され破壊しない）/ (B) worktree 消失等の別要因＝S8 / `/rite:resume` 再構築経路へ委譲 / (C) 従来 `git switch -c` は recommended にせず、worktree 分離を破棄する明示エスケープとしてのみ残す（併走時の危険を警告）。Bash 永続 cwd 駆動は導入しない。
 - Step 2.6 / 6.3 の flow-state set に `--worktree {path}` を追加。
 - Step 3〜6（implement / lint / push / PR create）は cwd 相対で完結するため**無変更**（§1 の state root 統一が前提）。
 

--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -384,6 +384,13 @@ Operating rules (important):
   • Start every session from the repository ROOT (not inside a worktree).
     /rite:pr:open does the worktree creation + entry for you.
 
+  • If EnterWorktree fails with "not in a git repository" even though .git
+    exists and git works (the harness mis-detected the launch directory as
+    non-git at startup): RESTART Claude Code from the repository ROOT and
+    re-run the same command. The already-created worktree is preserved and
+    reused (WT_CASE=reuse on /rite:pr:open, RESUME_WT=reenter on /rite:resume),
+    so nothing is rebuilt. rite never silently falls back to git switch -c.
+
   • Keep the main checkout on your base branch (rite-config.yml branch.base, e.g. develop).
     rite never moves the main checkout's branch — that is a human-only action,
     and /rite:pr:cleanup's "git pull" of the base only runs when the main

--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -233,9 +233,11 @@ worktree を作成・再利用したら、`.rite-plugin-root` を worktree root 
 
 その後 `EnterWorktree` ツールを `path: {wt_path}` で呼び出す（`{wt_path}` は 2.2-W の `WT_CASE` marker の `path=` 値。EnterWorktree のツール側ガード「ユーザー / プロジェクト指示で明示された場合のみ」は、`rite-config.yml` の `multi_session.enabled: true`（リポジトリにコミットされた**プロジェクト指示**。値がテンプレートのデフォルト ON 由来かユーザーの明示編集由来かに依らずプロジェクト指示として成立する）+ 本コマンド定義の明示指示の両方で満たす。デフォルトが ON でも、この `enabled: true` を marker 経由で確認した分岐内でのみ EnterWorktree を呼ぶため、ガードの根拠は default off 時と変わらず成立する）。
 
-- **EnterWorktree が不在 / 失敗の場合**: **silent fallback はしない**。AskUserQuestion で選択する:
-  - 「中止（推奨）」: worktree は保持し、再実行で再利用できる旨を案内して終了。
-  - 「従来方式で続行」: 他セッション併走中は作業ツリーを破壊し合う危険がある旨を**警告**した上で、ステップ 2.3（従来の `git switch -c`）にフォールバックする。
+- **EnterWorktree が不在 / 失敗の場合**: **silent fallback はしない**。まず失敗原因を切り分ける（補助情報として `git -C "{wt_path}" rev-parse --is-inside-work-tree` の結果を提示してよい）:
+  - **(A) harness の git 誤判定**（`.git` が存在し `git -C "{wt_path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。これは harness がセッション起動時に launch ディレクトリを git リポジトリと認識できなかったことが原因で、プラグインからは直せない。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:pr:open {issue_number}` を再実行すれば、作成済み worktree が 2.2-W で `WT_CASE=reuse` と判定され**再作成せず継続**できる」と案内する。worktree は保持済みのため破壊しない。
+  - **(B) worktree path 消失などの別要因**（harness 誤判定以外）→ 既存どおりステップ 8（resume / S8）の worktree 再構築経路 / `/rite:resume {issue_number}` に委譲する（本コマンドでは新規 worktree を作らない。再起動案内へ誤誘導しない）。
+  - **(C) エスケープハッチ**（ユーザーが明示選択した場合のみ）: 「従来 `git switch -c` で続行」は **recommended にしない**。worktree 分離を破棄する明示的な選択肢としてのみ残し、他セッション併走中は作業ツリーを破壊し合う危険がある旨を**警告**した上でステップ 2.3 にフォールバックする。
+  - Bash 永続 cwd 駆動（cwd を main checkout に残したまま絶対パスで操作する経路）は**導入しない**（main tree を誤更新するリスクのため）。
 
 入場後、claim に worktree path を記録する（reap / resume の discovery 用）:
 

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -188,6 +188,11 @@ fi
 | `missing` + `branch_local=yes` | branch ローカル有 → `git worktree add "{path}" "{branch}"`（`-b` なし）→ `EnterWorktree(path)` |
 | `missing` + `branch_local=no` | リモート確認 → 有れば `git fetch origin {branch}` + `git worktree add --track -b "{branch}" "{path}" "origin/{branch}"` → `EnterWorktree(path)`。どこにも無ければ **矛盾サマリ + AskUserQuestion**（新規セッション扱い / 中止）— silent に新規扱いしない |
 
+**EnterWorktree が失敗した場合**（`reenter` / `missing` 経路の `EnterWorktree(path)` がエラー）: pr:open Step 2.3-W と同じ切り分けを行い、**silent に新規セッション扱いしない**。
+
+- **harness の git 誤判定**（`.git` が存在し `git -C "{path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:resume {issue_number}` を再実行すれば、登録済み worktree が `RESUME_WT=reenter` で再入場される」と案内する。worktree は保持済みのため破壊しない。
+- **worktree path 消失などの別要因** → 上表の `missing` 経路（branch ローカル有 / リモート確認 → 再構築）に従う。再起動案内へ誤誘導しない。
+
 再入場後、claim に worktree path を再記録してもよい（`issue-claim.sh claim --issue {issue_number} --worktree "{path}"`、best-effort）。
 
 ### 3.2 git 状態取得

--- a/plugins/rite/references/git-worktree-patterns.md
+++ b/plugins/rite/references/git-worktree-patterns.md
@@ -357,6 +357,32 @@ to 3 times:
 n=0; until git fetch origin "$base" 2>/dev/null; do n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 1; done
 ```
 
+### `EnterWorktree` fails with "not in a git repository" (harness git mis-detection)
+
+`/rite:pr:open` (Step 2.3-W) and `/rite:resume` (re-entry) enter the session
+worktree via the `EnterWorktree` tool. If the harness mis-detected the launch
+directory as non-git **at session startup** (`Is a git repository: false` in the
+launch context even though `.git` exists and `git -C {wt_path} rev-parse` succeeds),
+`EnterWorktree` rejects entry with
+`Error: ... the current directory is not in a git repository.`
+
+This is a **harness-side** startup judgement that rite cannot fix from a plugin.
+The remedy is to **restart Claude Code from the repository ROOT** and re-run the
+command:
+
+- The session worktree created by `git worktree add` is **preserved** — the failure
+  does not destroy it.
+- On re-run, `pr:open` Step 2.2-W classifies it as `WT_CASE=reuse` (and `/rite:resume`
+  as `RESUME_WT=reenter`), so the workflow continues on the existing worktree without
+  rebuilding it.
+
+rite **never** silently falls back to `git switch -c` (which would discard worktree
+isolation) or to a Bash-persisted-cwd path (which would leave the harness cwd on the
+main checkout and risk relative-path edits hitting the main tree); the workflow
+surfaces the diagnosis and the restart guidance instead. Failures from other causes
+(e.g. the worktree path vanished) follow the normal `RESUME_WT=missing` rebuild path,
+not the restart guidance.
+
 ### main-checkout-不可侵 (inviolability) convention
 
 In `multi_session` mode rite **never switches the main checkout's current branch**


### PR DESCRIPTION
## 概要

`multi_session` 有効時（デフォルト ON）の `/rite:pr:open` Step 2.3-W で `EnterWorktree` ツールが失敗する経路に、根本原因（harness の git リポジトリ誤判定）を検出して「リポジトリ root から Claude Code を再起動すれば EnterWorktree が成功する」と案内する fallback を追加した。

従来の二択 fallback（中止 / 従来 `git switch -c`）はどちらも根本原因に対処できず、ユーザーが場当たり的な回避（Bash 永続 cwd 駆動）を強いられていた。本変更で失敗原因を切り分け、再起動 → 再実行で作成済み worktree が `WT_CASE=reuse` として継続できることを recommended として案内する。同種の失敗が起こりうる `resume.md` の再入場経路と利用者向けドキュメントにも対応を波及させた。

## 関連 Issue

Closes #1573

## 変更内容

| File | 変更 |
|------|------|
| `plugins/rite/commands/pr/open.md` | Step 2.3-W の EnterWorktree 失敗時 fallback を「(A) harness git 誤判定 → 再起動案内（推奨） / (B) worktree 消失等は S8・resume 委譲 / (C) `git switch -c` は明示エスケープのみ」へ改善。Bash 永続 cwd 駆動は不採用。`git -C {wt_path} rev-parse` を補助診断に提示 |
| `plugins/rite/commands/resume.md` | `reenter` / `missing` 経路の `EnterWorktree(path)` 失敗に同等の検出 + 再起動案内（`/rite:resume` 再実行 → `RESUME_WT=reenter`）を追加。silent な新規セッション扱いをしない既存方針を維持 |
| `plugins/rite/commands/getting-started.md` | multi_session operating rules に harness git 誤判定の失敗モードと「リポジトリ root から起動 / 再起動」remedy を追記 |
| `plugins/rite/references/git-worktree-patterns.md` | Multi-Session Patterns 節に EnterWorktree の harness git 誤判定挙動と再起動 remedy のサブセクションを追加 |
| `docs/designs/multi-session-worktree.md` | §3（pr:open 改修仕様）の EnterWorktree fallback 記述を新挙動へ同期（drift 解消） |

## 受入基準（Issue AC）

- [x] AC-1: harness git 誤判定の検出と再起動案内を recommended で提示（open.md 2.3-W (A)）
- [x] AC-2: 破壊的 fallback（`git switch -c`）を自動/recommended で実行しない・Bash 永続 cwd 駆動を導入しない
- [x] AC-3: 再起動後の再実行で worktree が `WT_CASE=reuse` で継続（案内文に明記、既存 2.2-W reuse 分岐は無変更）
- [x] AC-4: resume 再入場経路でも同等案内（resume.md）
- [x] AC-5: no-silent-fallback 原則の維持
- [x] AC-6: getting-started.md / git-worktree-patterns.md にドキュメント記載
- [x] AC-7: 別要因の失敗は既存 S8 / resume routing を維持（open.md (B)・resume.md・git-worktree-patterns.md）

## スコープに関する補足

Issue 4.1 の対象 4 ファイルに加え、`docs/designs/multi-session-worktree.md` §3 を更新した。これは実装 fallback と同一の挙動を記述する設計ドキュメント（git-worktree-patterns.md が "Canonical spec" として参照）であり、本変更による直接的な drift。implement の Documentation Impact Investigation（5.1.0.7、stale doc は同一ブランチで即修正・別 Issue へ先送り禁止）に従い同期した。

## テスト

本変更は command の指示文（Markdown）であり自動テストランナー対象外。T-01〜T-07 はシナリオ検証（指示文レビュー + `/rite:lint` + セルフレビュー）として実施。`/rite:lint` のプラグイン固有チェック（drift / hardcoded-line-number / comment-journal / sh-cross-ref / bash-heaviness 等）で変更 5 ファイルに新規 finding ゼロを確認済み。

## Known Issues

- lint 未実行（`commands.lint: null` + 自動検出対象なし）。リポジトリの実質的な品質ゲートであるプラグイン固有チェックは実行済みで、本変更に対してクリーン。

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
