### PR TITLE
docs: README に紹介動画の Demo セクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,7 @@
 
 Issue から PR まで、開発を"儀式"に変える — 約100秒で分かる紹介動画（日本語字幕）。
 
-<!-- rite-intro-video: この PR の説明欄に rite-intro-bgm.mp4 をドラッグ&ドロップしてアップロードし、
-     生成された https://github.com/user-attachments/assets/<id> の URL で次行の
-     VIDEO_EMBED_URL_PLACEHOLDER を置き換える（URL を単独行に置くと動画プレイヤーとして埋め込まれる）。
-     GitHub は user-attachments / user-images の添付 URL のみ動画プレイヤー化する。
-     外部リンク・raw パス・リポジトリへの MP4 コミットは不可。 -->
-
-VIDEO_EMBED_URL_PLACEHOLDER
+https://github.com/user-attachments/assets/53c21728-d085-45c1-abe9-d83ec23369bb
 
 ## Why "Rite"?
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 [![Version](https://img.shields.io/badge/version-0.6.1-blue.svg)](https://github.com/asakaguchi/cc-rite-workflow/releases/tag/v0.6.1)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+## Demo
+
+Issue から PR まで、開発を"儀式"に変える — 約100秒で分かる紹介動画（日本語字幕）。
+
+<!-- rite-intro-video: この PR の説明欄に rite-intro-bgm.mp4 をドラッグ&ドロップしてアップロードし、
+     生成された https://github.com/user-attachments/assets/<id> の URL で次行の
+     VIDEO_EMBED_URL_PLACEHOLDER を置き換える（URL を単独行に置くと動画プレイヤーとして埋め込まれる）。
+     GitHub は user-attachments / user-images の添付 URL のみ動画プレイヤー化する。
+     外部リンク・raw パス・リポジトリへの MP4 コミットは不可。 -->
+
+VIDEO_EMBED_URL_PLACEHOLDER
+
 ## Why "Rite"?
 
 The name comes from the English word **rite**, meaning "ritual" or "ceremony." Issue-driven development — creating Issues, cutting branches, implementing, reviewing, and merging — is a set of practices that every team should follow as second nature. Rite Workflow embeds these practices as a repeatable ritual so they become the natural way you build software.


### PR DESCRIPTION
## 概要

README 冒頭（バッジ直後・Overview の前）に CC Rite Workflow の紹介動画（約104秒・1920x1080・日本語字幕・BGM 入り）の Demo セクションを追加します。

Closes #1579

## 変更内容

- `README.md` の License バッジ直後に `## Demo` セクションを追加
  - 日本語の導入文 1 行
  - 動画埋め込み枠（`VIDEO_EMBED_URL_PLACEHOLDER`）＋反映手順のコメント
- リポジトリに動画バイナリ（MP4）はコミットしない方針

## ⚠️ レビュー前にお願い（動画 URL の反映）

GitHub は README へ MP4 を直接埋め込めず、`user-attachments` の添付 URL のみ動画プレイヤー化されます。お手数ですが以下をお願いします:

1. **この PR の説明欄（または下のコメント欄）に `rite-intro-bgm.mp4` をドラッグ&ドロップ**してアップロード
2. 生成される `https://github.com/user-attachments/assets/<id>` の URL を教えてください
3. こちらで README の `VIDEO_EMBED_URL_PLACEHOLDER` をその URL に差し替えてコミットします

> 動画ソース（無音版 `rite-intro.mp4` / BGM 入り `rite-intro-bgm.mp4`）はローカルの `rite-intro-video/` にあります。

## テスト

- [ ] GitHub の README プレビューで動画プレイヤーが表示・再生される（URL 反映後）
- [x] `git ls-files` に `*.mp4` が含まれない（リポジトリにバイナリを残さない）
- [x] 動画近傍に日本語の導入文が 1 行ある
- [x] 既存セクション（Installation / Commands / Workflow 等）は無改変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
