### PR TITLE
docs: README を英語版動画に差し替え + 日本語 README を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,167 @@
+# Claude Code Rite Workflow
+
+> Claude Code のための汎用 Issue ドリブン開発ワークフロー
+
+[![Version](https://img.shields.io/badge/version-0.6.2-blue.svg)](https://github.com/asakaguchi/cc-rite-workflow/releases/tag/v0.6.2)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | **日本語**
+
+## Demo
+
+Issue から PR まで、開発を“儀式”に変える — 約100秒で分かる紹介動画（日本語字幕）。
+
+https://github.com/user-attachments/assets/53c21728-d085-45c1-abe9-d83ec23369bb
+
+## なぜ "Rite" なのか
+
+名前は英単語の **rite**（「儀式」「式典」の意）に由来します。Issue ドリブン開発 — Issue を立て、ブランチを切り、実装し、レビューし、マージする — は、どのチームも当たり前の習慣として身につけるべき一連の実践です。Rite Workflow はこれらの実践を繰り返し可能な「儀式」として組み込み、ソフトウェア開発の自然な流儀になるようにします。
+
+## 概要
+
+**Claude Code Rite Workflow** は、Issue ドリブン開発の完全なワークフローを提供する Claude Code プラグインです。言語やフレームワークを問わず、あらゆるソフトウェア開発プロジェクトで動作します。
+
+### 特徴
+
+- **汎用 (Universal)**: 特定の技術スタックに依存しない
+- **自動化 (Automated)**: 自動検出・自動設定
+- **カスタマイズ可能 (Customizable)**: YAML による柔軟な設定
+- **統合 (Integrated)**: GitHub Projects 連携
+- **スマートレビュー (Smart Reviews)**: ドキュメント中心の PR 向け **Doc-Heavy PR Mode** を備えた動的マルチレビュアーコードレビュー。PR が doc-heavy と判定されると、tech-writer レビュアーが Grep/Read/Glob を使って 5 つのドキュメント–実装整合カテゴリ（Implementation Coverage / Enumeration Completeness / UX Flow Accuracy / Order-Emphasis Consistency / Screenshot Presence）を検証します。完全な検証プロトコルは [`plugins/rite/commands/pr/references/internal-consistency.md`](plugins/rite/commands/pr/references/internal-consistency.md) を参照
+- **外部レビュー連携 (External Review Integration)**: `/rite:pr:fix` は PR URL またはコメント URL を引数に取れるため、外部レビューツールの出力をそのまま fix ループに流し込めます
+- **イテレーション追跡 (Iteration Tracking)**: 任意の GitHub Projects Iteration フィールド連携（`/rite:pr:open` 時に自動割当、`/rite:issue:list` の `--sprint` / `--backlog` フィルタ）
+- **プリフライトチェック (Preflight Check)**: 全コマンド共通の実行前検証
+- **ローカル作業メモリ (Local Work Memory)**: lock / 再開サポート付きの compact 耐性のある作業状態管理
+- **Implementation Contract**: 仕様を明確にする構造化 Issue テンプレート形式
+- **仮定の表面化 (Assumption Surfacing)**: Implementation Contract を生成する前に、`/rite:issue:create` はモデルが暗黙に補った仮定を表面化し、3 つのカテゴリで処理します — 導出可能（リポジトリ/Wiki から自己解決）、ユーザー固有の判断（推奨選択肢付きの質問を最大 3 件で確認）、保留可能（Issue 本文に Assumptions / Open Questions として記録）。**設計原則**: 質問はユーザーの頭の中にしか存在しない情報に限定し、リポジトリや Wiki から導出可能なものはモデルが解決します。これにより、暗黙の推測が下流パイプライン全体を駆動する contract に黙って固定化されるのを防ぎます
+- **Experience Wiki**: LLM 駆動のプロジェクト知識ベース。[OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog) 準拠のバンドル（`type`/`okf_version` frontmatter、OKF index/log）として保存されます。レビュー/修正の結果をトピック別ページへ自動取り込み（ingest）し、各 Issue の冒頭で関連する経験則を注入します（opt-out 可）。準拠バンドルは上流 OKF の静的ビジュアライザで概念グラフとして閲覧できます（同梱はしていません。`plugins/rite/references/wiki-patterns.md` を参照）
+
+## インストール
+
+Rite Workflow は 2 ステップでインストールします。まずマーケットプレイスを登録し、次にそこからプラグインをインストールします。
+
+**ステップ 1**: マーケットプレイスを追加
+
+```bash
+/plugin marketplace add asakaguchi/cc-rite-workflow
+```
+
+**ステップ 2**: プラグインをインストール
+
+```bash
+/plugin install rite@rite-marketplace
+```
+
+**インストール確認**: `/rite:init` を実行してプラグインが動作することを確認します。
+
+## クイックスタート
+
+```bash
+/rite:init
+```
+
+これにより以下が実行されます:
+1. プロジェクトタイプを検出
+2. GitHub Projects 連携をセットアップ
+3. Issue/PR テンプレートを生成
+4. 設定ファイルを作成
+
+## コマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `/rite:init` | 初回セットアップウィザード |
+| `/rite:init --upgrade` | 既存の `rite-config.yml` を最新スキーマバージョンへアップグレード |
+| `/rite:getting-started` | 対話的オンボーディングガイド |
+| `/rite:workflow` | ワークフローガイドを表示 |
+| `/rite:issue:list` | Issue 一覧を表示 |
+| `/rite:issue:create` | 新規 Issue を作成 |
+| `/rite:issue:update` | 作業メモリを更新 |
+| `/rite:issue:close` | Issue の完了状態を確認 |
+| `/rite:issue:edit` | 既存 Issue を対話的に編集 |
+| `/rite:pr:open` | 作業を一気通貫で開始（ブランチ → 計画 → 実装 → lint → draft PR） |
+| `/rite:pr:iterate` | mergeable になるまで review ⇄ fix をループ |
+| `/rite:pr:merge` | PR を squash merge |
+| `/rite:pr:create` | draft PR を作成 |
+| `/rite:pr:ready` | Ready for review に変更 |
+| `/rite:pr:review` | マルチレビュアーレビュー |
+| `/rite:pr:fix` | レビュー指摘に対応 |
+| `/rite:pr:cleanup` | マージ後のクリーンアップ |
+| `/rite:investigate` | 構造化コード調査 |
+| `/rite:lint` | 品質チェックを実行 |
+| `/rite:template:reset` | テンプレートを再生成 |
+| `/rite:wiki:init` | Experience Wiki のブランチとディレクトリ構成を初期化 |
+| `/rite:wiki:query` | キーワードに一致する経験則を Wiki ページから検索 |
+| `/rite:wiki:ingest` | Raw Source（レビュー・修正・Issue）を Wiki ページへ取り込み |
+| `/rite:wiki:lint` | 矛盾・陳腐化・孤児・欠落概念（`missing_concept`）・未登録 raw（`unregistered_raw`、informational — `n_warnings` には加算しない）・壊れた相互参照を Wiki ページについて lint |
+| `/rite:resume` | 中断した作業を再開 |
+| `/rite:skill:suggest` | コンテキストを分析し適用可能なスキルを提案 |
+
+## ワークフロー
+
+```
+/rite:issue:create → /rite:pr:open (ブランチ → 計画 → 実装 → /rite:lint → draft PR)
+                  → /rite:pr:iterate (mergeable になるまで review ⇄ fix ループ)
+                  → /rite:pr:ready → /rite:pr:merge → /rite:pr:cleanup
+```
+
+**注意:** 一気通貫のフローは単一責務の 4 コマンドに分割されています。`/rite:pr:open <issue>` はブランチ作成・実装・品質チェック・draft PR 作成を担当します。`/rite:pr:iterate <pr>` は mergeable になるまで review と fix をループします。`/rite:pr:ready <pr>` は PR を Ready for review に切り替えます。`/rite:pr:merge <pr>` は squash merge を実行します。いずれかのステップが中断した場合（例: `Context limit reached`）、`/rite:resume` を実行して復旧します。
+
+ステータス遷移:
+```
+Todo → In Progress → In Review → Done
+ ↑         ↑            ↑         ↑
+作成     作業開始     Ready 設定  マージ済
+```
+
+## 設定
+
+プロジェクトのルートに `rite-config.yml` を作成します:
+
+```yaml
+schema_version: 2
+
+project:
+  type: webapp  # generic | webapp | library | cli | documentation
+
+github:
+  projects:
+    enabled: true
+
+branch:
+  base: "main"       # フィーチャーブランチのベースブランチ（Git Flow なら "develop"）
+  pattern: "{type}/issue-{number}-{slug}"
+
+# 任意: Iteration（GitHub Projects Iteration フィールド）連携
+iteration:
+  enabled: false  # 有効にするには true
+```
+
+全オプションは [設定リファレンス](docs/CONFIGURATION.md) を参照してください。
+
+## トラブルシューティング
+
+| 問題 | 解決策 |
+|------|--------|
+| 長時間実行コマンド中の `Context limit reached` | `/clear` を実行してから `/rite:resume` で継続 |
+
+## ドキュメント
+
+- [完全な仕様](docs/SPEC.md)
+- [設定リファレンス](docs/CONFIGURATION.md)
+
+## 要件
+
+- [GitHub CLI (gh)](https://cli.github.com/) - GitHub 操作に必須
+
+## ライセンス
+
+MIT License - 詳細は [LICENSE](LICENSE) を参照してください。
+
+## コントリビューション
+
+コントリビューションを歓迎します。ガイドラインは [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+---
+
+Made with 📜 rite

--- a/README.md
+++ b/README.md
@@ -11,14 +11,7 @@
 
 From Issue to PR — see Rite Workflow turn development into a *rite*. A ~100-second intro (English).
 
-<!--
-VIDEO EMBED — replace the placeholder line below with the GitHub user-attachments URL.
-GitHub renders a video player only for files uploaded as attachments: drag & drop
-`rite-intro-en-bgm-1080p-lite.mp4` (from the rite-intro-video-en project) into this PR or a
-comment, then paste the resulting https://github.com/user-attachments/assets/<id> URL here,
-replacing the VIDEO_EMBED_URL_PLACEHOLDER line.
--->
-VIDEO_EMBED_URL_PLACEHOLDER
+https://github.com/user-attachments/assets/d6e42398-4299-40ff-9bac-86e5333880b1
 
 ## Why "Rite"?
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@
 [![Version](https://img.shields.io/badge/version-0.6.2-blue.svg)](https://github.com/asakaguchi/cc-rite-workflow/releases/tag/v0.6.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+**English** | [日本語](README.ja.md)
+
 ## Demo
 
-Issue から PR まで、開発を"儀式"に変える — 約100秒で分かる紹介動画（日本語字幕）。
+From Issue to PR — see Rite Workflow turn development into a *rite*. A ~100-second intro (English).
 
-https://github.com/user-attachments/assets/53c21728-d085-45c1-abe9-d83ec23369bb
+<!--
+VIDEO EMBED — replace the placeholder line below with the GitHub user-attachments URL.
+GitHub renders a video player only for files uploaded as attachments: drag & drop
+`rite-intro-en-bgm-1080p-lite.mp4` (from the rite-intro-video-en project) into this PR or a
+comment, then paste the resulting https://github.com/user-attachments/assets/<id> URL here,
+replacing the VIDEO_EMBED_URL_PLACEHOLDER line.
+-->
+VIDEO_EMBED_URL_PLACEHOLDER
 
 ## Why "Rite"?
 


### PR DESCRIPTION
## 概要

README を二言語構成にする。英語 README（`README.md`）の Demo を英語版紹介動画に差し替え、日本語版 README（`README.ja.md`）を新設する。

## 変更内容

- **README.md**（英語・主）
  - Demo セクションの説明文を英語化、動画埋め込みを英語版へ差し替え（URL は下記手順で取得し差し替え）
  - 冒頭に言語切替リンク `**English** | [日本語](README.ja.md)` を追加
- **README.ja.md**（新規・日本語）
  - README.md 全体の日本語訳
  - Demo は既存の日本語版動画 URL を使用
  - 言語切替リンク `[English](README.md) | **日本語**` を追加

## ⚠️ レビュー前にお願い（英語版動画 URL の反映）

GitHub は README へ MP4 を直接埋め込めず、`user-attachments` の添付 URL のみ動画プレイヤー化されます。お手数ですが以下をお願いします:

1. **この PR の説明欄（または下のコメント欄）に `rite-intro-en-bgm-1080p-lite.mp4` をドラッグ&ドロップ**してアップロード
2. 生成される `https://github.com/user-attachments/assets/<id>` の URL を教えてください
3. こちらで README.md の `VIDEO_EMBED_URL_PLACEHOLDER` をその URL に差し替えてコミットします

> 英語版動画ソース（無音 `rite-intro-en.mp4` / BGM 入り `rite-intro-en-bgm.mp4` / 軽量版 `rite-intro-en-bgm-1080p-lite.mp4`）はローカルの `rite-intro-video-en/` にあります。README には軽量版（約 3.9MB）の URL を使う想定です。

## テスト

- [ ] GitHub の README プレビューで英語版動画プレイヤーが表示・再生される（URL 反映後）
- [x] 言語切替リンクが README.md / README.ja.md 双方にあり相互に解決する
- [x] README.ja.md の参照リンク（docs/CONFIGURATION.md, docs/SPEC.md, CONTRIBUTING.md, LICENSE 等）が全て存在する
- [x] 英語 README 本文（Installation / Commands / Workflow 等）は Demo 以外無改変

Closes #1585