### PR TITLE
docs: README.ja.md の Demo を v0.6.2 日本語版動画に差し替え

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,14 @@
 
 Issue から PR まで、開発を“儀式”に変える — 約100秒で分かる紹介動画（日本語字幕）。
 
-https://github.com/user-attachments/assets/53c21728-d085-45c1-abe9-d83ec23369bb
+<!--
+動画埋め込み — 下のプレースホルダ行を GitHub の user-attachments URL に差し替える。
+GitHub は添付アップロードしたファイルのみ動画プレイヤー化する: rite-intro-video/ の
+`rite-intro-bgm-1080p-lite.mp4`（v0.6.2・約 3.85MB）をこの PR またはコメントにドラッグ&
+ドロップし、生成された https://github.com/user-attachments/assets/<id> URL でこの
+VIDEO_EMBED_URL_PLACEHOLDER 行を置き換える。
+-->
+VIDEO_EMBED_URL_PLACEHOLDER
 
 ## なぜ "Rite" なのか
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,14 +11,7 @@
 
 Issue から PR まで、開発を“儀式”に変える — 約100秒で分かる紹介動画（日本語字幕）。
 
-<!--
-動画埋め込み — 下のプレースホルダ行を GitHub の user-attachments URL に差し替える。
-GitHub は添付アップロードしたファイルのみ動画プレイヤー化する: rite-intro-video/ の
-`rite-intro-bgm-1080p-lite.mp4`（v0.6.2・約 3.85MB）をこの PR またはコメントにドラッグ&
-ドロップし、生成された https://github.com/user-attachments/assets/<id> URL でこの
-VIDEO_EMBED_URL_PLACEHOLDER 行を置き換える。
--->
-VIDEO_EMBED_URL_PLACEHOLDER
+https://github.com/user-attachments/assets/76255c86-c999-4731-8ba2-4dbab4d57e1d
 
 ## なぜ "Rite" なのか
 


### PR DESCRIPTION
## 概要

`README.ja.md` の Demo セクションの動画を、v0.6.2 に作り直した日本語版紹介動画に差し替える。

## 変更内容

- README.ja.md の Demo 動画 URL を新しい v0.6.2 日本語版動画へ差し替え（URL は下記手順で取得）

## ⚠️ レビュー前にお願い（日本語版動画 URL の反映）

1. **この PR の説明欄（または下のコメント欄）に `rite-intro-bgm-1080p-lite.mp4`（v0.6.2・約 3.85MB）をドラッグ&ドロップ**してアップロード
2. 生成される `https://github.com/user-attachments/assets/<id>` の URL を教えてください
3. こちらで README.ja.md の `VIDEO_EMBED_URL_PLACEHOLDER` をその URL に差し替えてコミットします

> 新しい日本語版動画ソース（無音 `rite-intro.mp4` / BGM 入り `rite-intro-bgm.mp4` / 軽量版 `rite-intro-bgm-1080p-lite.mp4`）はローカルの `rite-intro-video/` にあります。scene-1 バッジ・scene-7 メタともに v0.6.2 表記を確認済み。

## テスト

- [ ] GitHub の README.ja.md プレビューで v0.6.2 日本語版動画プレイヤーが表示・再生される（URL 反映後）
- [x] 旧 v0.6.1 動画 URL（53c21728...）が残っていない
- [x] README.ja.md の本文は Demo 以外無改変

Closes #1587