### PR TITLE
fix(pr-open): multi_session 有効時のブランチ作成 worktree 化を hard invariant 化

### DIFF
--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -208,7 +208,7 @@ git switch {base_branch} && git pull --ff-only origin {base_branch} && git switc
 
 ### 2.2-W セッション worktree の冪等準備（multi_session 有効時、2.2/2.3 を置換）
 
-worktree path は `{worktree_base}/issue-{issue_number}`（`{worktree_base}` は 1.4 の `WORKTREE_BASE` marker 値、絶対パスは `{repo_root}/{worktree_base}/issue-{issue_number}`）。base ref は checkout 中 branch の fetch 更新不可制約のため **`origin/{base_branch}` を直接指定**する（local {base_branch} を経由しない）:
+worktree path は `{worktree_base}/issue-{issue_number}`（`{worktree_base}` は 2.1-G で再確定した `WORKTREE_BASE` marker 値。2.1-G を経ずに到達した場合のみ 1.4 の同名 marker を参照する — 両者は同一パースで値が常に一致する。絶対パスは `{repo_root}/{worktree_base}/issue-{issue_number}`）。base ref は checkout 中 branch の fetch 更新不可制約のため **`origin/{base_branch}` を直接指定**する（local {base_branch} を経由しない）:
 
 ```bash
 worktree_base="{worktree_base}"
@@ -280,12 +280,17 @@ cur_top=$(git rev-parse --show-toplevel 2>/dev/null) || cur_top=""
 if [ "$cur_top" = "{wt_path}" ]; then
   echo "[CONTEXT] WORKTREE_INVARIANT=ok; toplevel=$cur_top"
 else
-  echo "[CONTEXT] WORKTREE_INVARIANT=violated; expected={wt_path}; actual=${cur_top:-<none>}"
+  # violated 経路は prose 指示だけに頼らず bash の hard stop で機械的に遮断する。
+  # echo の exit code は ok/violated とも 0 で bash 上は区別不能なため、marker を stderr に出し
+  # 非ゼロ exit することで「main ツリーで implement/commit を続行する」silent fallback を構造的に止める
+  # (2.1-G が branch 分岐を Bash で hard 化したのと対称。git-worktree-patterns.md の "stops the flow" 保証を実装で満たす)。
+  echo "[CONTEXT] WORKTREE_INVARIANT=violated; expected={wt_path}; actual=${cur_top:-<none>}" >&2
+  exit 1
 fi
 ```
 
-- `WORKTREE_INVARIANT=ok`（cwd が worktree path と一致）→ ステップ 2.4 以降へ進む。
-- `WORKTREE_INVARIANT=violated`（EnterWorktree 失敗等で cwd が main checkout 等に残存）→ **silent に続行しない**。main ツリー上での implement / commit を**行わず**、上記「EnterWorktree が不在 / 失敗の場合」の (A) harness git 誤判定 / (B) worktree path 消失 / (C) ユーザー明示選択 の切り分けへ戻る。`violated` のままブランチ実装へ進むことは禁止。
+- `WORKTREE_INVARIANT=ok`（cwd が worktree path と一致、bash exit 0）→ ステップ 2.4 以降へ進む。
+- `WORKTREE_INVARIANT=violated`（EnterWorktree 失敗等で cwd が main checkout 等に残存）→ 本ブロックは **`exit 1` で停止**するため Bash ツールが非ゼロを返す（fail-loud）。**silent に続行しない**。main ツリー上での implement / commit を**行わず**、上記「EnterWorktree が不在 / 失敗の場合」の (A) harness git 誤判定 / (B) worktree path 消失 / (C) ユーザー明示選択 の切り分けへ戻る。`violated` のままブランチ実装へ進むことは禁止。
 
 ステップ 3〜6（implement / lint / push / PR create）は cwd 相対で完結するため**無変更**（S1 の state root 統一が前提）。`WORKTREE_INVARIANT=ok` が前提条件。
 

--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -166,7 +166,31 @@ echo "[CONTEXT] ISSUE_CLAIM=$claim_out; rc=$claim_rc"
 - **type**: labels / title から推定（`bug`/`bugfix` → `fix`、`docs` → `docs`、`refactor` → `refactor`、`chore`/`maintenance` → `chore`、それ以外 → `feat`）
 - **slug**: Issue title を kebab-case 化 (英数字 + ハイフン、50 文字上限)
 
-> **ステップ 2.2 / 2.3 の分岐**: ステップ 1.4 の `[CONTEXT] MULTI_SESSION_ENABLED=` marker を読む。`true`（新規プロジェクトのデフォルト）→ 下記 **2.2-W / 2.3-W**（セッション worktree）を実行し、従来の 2.2 / 2.3 は **置換**してスキップする。`false`（`enabled: false` 明示設定 / `multi_session:` ブロック欠落の旧 config）→ 下記 **2.2 / 2.3**（従来動作、単一セッション時と完全一致）を実行する。
+### 2.1-G ブランチ作成前の multi_session hard 再確定（marker 非依存ゲート）
+
+> **Why（#1595）**: 旧版はステップ 2.2/2.3 の分岐を **ステップ 1.4 が emit した `[CONTEXT] MULTI_SESSION_ENABLED=` marker の会話 context 残存に依存**させていた。resume / context 圧縮 / フロー途中入場で marker が context から失われると「marker 欠落 → 従来 2.2/2.3」に倒れ、`multi_session.enabled: true` でも main ツリーへ `git switch -c` する **silent fallback** が起きた（F3）。これを防ぐため、**ブランチ作成という副作用の直前に必ず本ゲートを実行**し、`multi_session` 状態を記憶に頼らず Bash で再確定する。
+
+ブランチ作成（2.2/2.3 または 2.2-W/2.3-W）へ分岐する**前に**、`multi_session` 状態を rite-config.yml から再取得する。下記はステップ 1.4 と**同一のパース**（F4 で正常確認済の解析ロジック。本ゲートはそれを変更せず再利用するだけ）であり、毎回 marker を確実に再生成する:
+
+```bash
+ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || ms_section=""
+ms_enabled=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+enabled:/ {print; exit}' \
+  | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
+case "$ms_enabled" in true|yes|1) ms_enabled=true ;; *) ms_enabled=false ;; esac
+ms_base=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+worktree_base:/ {print; exit}' \
+  | sed 's/[[:space:]]#.*//' | sed 's/.*worktree_base:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+[ -n "$ms_base" ] || ms_base=".rite/worktrees"
+echo "[CONTEXT] MULTI_SESSION_ENABLED=$ms_enabled; WORKTREE_BASE=$ms_base; SOURCE=branch-gate"
+```
+
+この `SOURCE=branch-gate` の marker が、ステップ 1.4 由来の古い marker を**上書きする最新の真実**である。分岐は必ず本ゲートの値で行う:
+
+| 本ゲートの `MULTI_SESSION_ENABLED` | 経路 |
+|---|---|
+| `true`（新規プロジェクトのデフォルト） | **2.2-W / 2.3-W**（セッション worktree）を実行し、従来の 2.2 / 2.3 は **置換**してスキップする |
+| `false`（`enabled: false` 明示設定 / `multi_session:` ブロック欠落の旧 config） | **2.2 / 2.3**（従来動作、単一セッション時と完全一致）を実行する |
+
+**silent fallback の禁止（hard invariant）**: 「marker が context に無い」ことを理由に従来 2.2/2.3 へ進む経路は **存在しない**。本ゲートは毎回 Bash で marker を再生成するため、分岐時に値が未取得になることはない。万一このゲートを実行せずにブランチ作成段へ到達した場合は、`git switch -c`（2.3）を実行せず**本ゲートに戻って再確定**すること。`true` のとき 2.2-W/2.3-W 以外でブランチを checkout してはならない。
 
 ### 2.2 既存ブランチチェック（multi_session 無効時）
 
@@ -174,7 +198,11 @@ echo "[CONTEXT] ISSUE_CLAIM=$claim_out; rc=$claim_rc"
 
 ### 2.3 ブランチ作成（multi_session 無効時）
 
+> **Hard gate（#1595）**: 本ブロックは 2.1-G で再確定した `MULTI_SESSION_ENABLED=false` のときのみ実行する。`true` のとき本経路は **実行禁止** — 下記は cwd を main checkout に置いたまま新規ブランチを checkout するため、これが旧バグの silent fallback そのものを構成する。`true` のまま本ブロックへ到達した場合は実行せず 2.2-W へ戻ること。
+
 ```bash
+# GUARD (#1595): multi_session 有効時に本経路へ来てはならない。
+# 2.1-G で false を再確定済の場合のみ実行する（true なら 2.2-W/2.3-W が正路）。
 git switch {base_branch} && git pull --ff-only origin {base_branch} && git switch -c {branch_name}
 ```
 
@@ -245,7 +273,21 @@ worktree を作成・再利用したら、`.rite-plugin-root` を worktree root 
 bash {plugin_root}/hooks/issue-claim.sh claim --issue {issue_number} --worktree "{wt_path}" >/dev/null 2>&1 || true
 ```
 
-ステップ 3〜6（implement / lint / push / PR create）は cwd 相対で完結するため**無変更**（S1 の state root 統一が前提）。
+続けて、**セッション worktree 上にいることを invariant として検証**する（#1595。EnterWorktree が失敗したのに気付かず main ツリーで implement/commit してしまう silent fallback を遮断する最終ガード）:
+
+```bash
+cur_top=$(git rev-parse --show-toplevel 2>/dev/null) || cur_top=""
+if [ "$cur_top" = "{wt_path}" ]; then
+  echo "[CONTEXT] WORKTREE_INVARIANT=ok; toplevel=$cur_top"
+else
+  echo "[CONTEXT] WORKTREE_INVARIANT=violated; expected={wt_path}; actual=${cur_top:-<none>}"
+fi
+```
+
+- `WORKTREE_INVARIANT=ok`（cwd が worktree path と一致）→ ステップ 2.4 以降へ進む。
+- `WORKTREE_INVARIANT=violated`（EnterWorktree 失敗等で cwd が main checkout 等に残存）→ **silent に続行しない**。main ツリー上での implement / commit を**行わず**、上記「EnterWorktree が不在 / 失敗の場合」の (A) harness git 誤判定 / (B) worktree path 消失 / (C) ユーザー明示選択 の切り分けへ戻る。`violated` のままブランチ実装へ進むことは禁止。
+
+ステップ 3〜6（implement / lint / push / PR create）は cwd 相対で完結するため**無変更**（S1 の state root 統一が前提）。`WORKTREE_INVARIANT=ok` が前提条件。
 
 ### 2.4 GitHub Projects Status 更新
 
@@ -263,7 +305,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --next "実装計画策定へ進む"
 ```
 
-`MULTI_SESSION_ENABLED=true` のときは末尾に `--worktree "{wt_path}"` を追加する（`{wt_path}` は 2.2-W の `path=` 値）。`--worktree` は merge-preserve かつ conditional-write のため、無効時（値が空）は state file に key を付与せず挙動は不変。
+`MULTI_SESSION_ENABLED=true`（2.1-G で再確定した値）のときは末尾に `--worktree "{wt_path}" --require-worktree` を追加する（`{wt_path}` は 2.2-W の `path=` 値）。`--worktree` は merge-preserve かつ conditional-write のため、無効時（値が空）は state file に key を付与せず挙動は不変。`--require-worktree` は worktree path 不在のまま branch phase を記録しようとした場合に loud WARNING + `[CONTEXT] WORKTREE_INVARIANT=missing` marker を emit するデータ層検知（#1595。書き込み自体は完了するため work は失われない）。marker が `missing` の場合は worktree 化が漏れているため 2.2-W へ戻ること。
 
 ---
 
@@ -406,7 +448,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --next "レビュー/修正ループへ進む (/rite:pr:iterate {pr_number})"
 ```
 
-`MULTI_SESSION_ENABLED=true` のときは末尾に `--worktree "{wt_path}"` を追加する（merge-preserve のため省略しても保持されるが、明示することで `--worktree` を伴わない他経路の set との順序非依存を担保する）。
+`MULTI_SESSION_ENABLED=true` のときは末尾に `--worktree "{wt_path}" --require-worktree` を追加する（merge-preserve のため省略しても保持されるが、明示することで `--worktree` を伴わない他経路の set との順序非依存を担保する）。`--require-worktree` 検知の意味は 2.6 と同じ（#1595）。
 
 ---
 

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -173,7 +173,7 @@ _emit_jq_err_snippet() {
 cmd_set() {
   # Merge semantics: unspecified scalar fields preserve existing values (旧 patch 互換).
   # Required: --phase, --next. Optional fields fall back to existing JSON or defaults.
-  local phase="" next="" session="" if_exists=0 preserve_error=0
+  local phase="" next="" session="" if_exists=0 preserve_error=0 require_worktree=0
   local issue="" branch="" pr="" parent_issue="" active="" handoff="" worktree=""
   while [ $# -gt 0 ]; do case "$1" in
     --phase) phase="$2"; shift 2 ;;
@@ -188,6 +188,7 @@ cmd_set() {
     --session) session="$2"; shift 2 ;;
     --if-exists) if_exists=1; shift ;;
     --preserve-error-count) preserve_error=1; shift ;;
+    --require-worktree) require_worktree=1; shift ;;
     *) echo "ERROR: unknown option: $1" >&2; return 1 ;;
   esac; done
   [ -z "$phase" ] && { echo "ERROR: --phase is required" >&2; return 1; }
@@ -250,6 +251,20 @@ cmd_set() {
   # in the jq below so non-worktree sessions never gain the key (additive → no
   # schema bump, byte-identical state file for single-session use).
   [ -z "$worktree" ] && worktree=$cur_worktree
+  # --require-worktree (#1595): データ層で「multi_session 有効経路の set は worktree path を伴う」
+  # invariant を検知する。merge-preserve 後も worktree が空 = pr:open の worktree 化漏れ
+  # (Step 1.4 marker 欠落 → legacy `git switch -c` への silent fallback) の兆候。loud に
+  # WARNING + `[CONTEXT] WORKTREE_INVARIANT=` marker を stderr へ emit する (orchestrator の
+  # hard gate が読む)。書き込み自体は継続する — non-blocking で state を失わない。停止判断は
+  # caller (open.md の hard gate) 側に委ねる (flow-state は state 記録の SoT であり制御層ではない)。
+  if [ "$require_worktree" -eq 1 ]; then
+    if [ -z "$worktree" ]; then
+      echo "WARNING: flow-state.sh cmd_set: --require-worktree set but worktree path is empty (phase=$phase; multi_session worktree 化漏れの可能性 — #1595)" >&2
+      echo "[CONTEXT] WORKTREE_INVARIANT=missing; phase=$phase" >&2
+    else
+      echo "[CONTEXT] WORKTREE_INVARIANT=ok; phase=$phase; worktree=$worktree" >&2
+    fi
+  fi
   [ -z "$pr" ] && pr=$cur_pr
   [ -z "$parent_issue" ] && parent_issue=$cur_parent
   [ -z "$active" ] && active=$cur_active
@@ -527,6 +542,7 @@ case "${1:-}" in
 Usage: $0 {set|get|deactivate|clear-worktree|consume-handoff|migrate|path} [options]
   set --phase <P> --next <T> [--issue N] [--branch S] [--pr N] [--parent-issue N]
       [--active true|false] [--handoff CMD] [--session UUID] [--if-exists] [--preserve-error-count]
+      [--worktree PATH] [--require-worktree]   # --require-worktree: warn + emit WORKTREE_INVARIANT marker when worktree empty (non-blocking)
   get --field <F> [--default V] [--session UUID]
       | --jq-filter <FILTER> [--default V] [--session UUID]
   deactivate [--next T] [--session UUID]

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1119,6 +1119,7 @@ assert "TC-26: missing → no worktree key written" "false" "$(jq -r 'has("workt
 out_ok=$( (cd "$d" && bash "$HOOK" set --phase branch --issue 1595 --branch "fix/issue-1595" --pr 0 --next "n" --worktree "$d/.rite/worktrees/issue-1595" --require-worktree) 2>&1 )
 assert "TC-26: present → WORKTREE_INVARIANT=ok marker" "ok" "$(echo "$out_ok" | grep -o 'WORKTREE_INVARIANT=[a-z]*' | head -1 | cut -d= -f2)"
 assert "TC-26: present → worktree path recorded" "$d/.rite/worktrees/issue-1595" "$(jq -r '.worktree // "ABSENT"' "$sfile")"
+assert "TC-26: present → write completes (phase recorded, symmetric with case a)" "branch" "$(jq -r '.phase' "$sfile")"
 # (c) backward compat: without --require-worktree → NO marker (unchanged behavior)
 out_plain=$( (cd "$d" && bash "$HOOK" set --phase branch --issue 1595 --branch "fix/issue-1595" --pr 0 --next "n") 2>&1 )
 assert "TC-26: backward compat → no WORKTREE_INVARIANT marker without flag" "0" "$(echo "$out_plain" | grep -c 'WORKTREE_INVARIANT')"

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1104,6 +1104,25 @@ miss_rc=$( (cd "$d" && env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID \
   bash "$HOOK" clear-worktree --session "no-such-session-1524" >/dev/null 2>&1); echo $? )
 assert "TC-25: clear-worktree on missing state file is non-blocking (rc 0)" "0" "$miss_rc"
 
+# --- TC-26: --require-worktree data-layer detection marker (Issue #1595) ---
+echo ""
+echo "=== TC-26: --require-worktree emits WORKTREE_INVARIANT detection marker ==="
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+sfile="$d/.rite/sessions/${sid}.flow-state"
+# (a) worktree absent + --require-worktree → WORKTREE_INVARIANT=missing + WARNING, but write completes (non-blocking)
+out_missing=$( (cd "$d" && bash "$HOOK" set --phase branch --issue 1595 --branch "fix/issue-1595" --pr 0 --next "n" --require-worktree) 2>&1 )
+assert "TC-26: missing → WORKTREE_INVARIANT=missing marker" "missing" "$(echo "$out_missing" | grep -o 'WORKTREE_INVARIANT=[a-z]*' | head -1 | cut -d= -f2)"
+assert "TC-26: missing → loud WARNING emitted" "1" "$(echo "$out_missing" | grep -c 'require-worktree set but worktree path is empty')"
+assert "TC-26: missing → write still completes (phase recorded, non-blocking)" "branch" "$(jq -r '.phase' "$sfile")"
+assert "TC-26: missing → no worktree key written" "false" "$(jq -r 'has("worktree")' "$sfile")"
+# (b) worktree present + --require-worktree → WORKTREE_INVARIANT=ok, worktree recorded
+out_ok=$( (cd "$d" && bash "$HOOK" set --phase branch --issue 1595 --branch "fix/issue-1595" --pr 0 --next "n" --worktree "$d/.rite/worktrees/issue-1595" --require-worktree) 2>&1 )
+assert "TC-26: present → WORKTREE_INVARIANT=ok marker" "ok" "$(echo "$out_ok" | grep -o 'WORKTREE_INVARIANT=[a-z]*' | head -1 | cut -d= -f2)"
+assert "TC-26: present → worktree path recorded" "$d/.rite/worktrees/issue-1595" "$(jq -r '.worktree // "ABSENT"' "$sfile")"
+# (c) backward compat: without --require-worktree → NO marker (unchanged behavior)
+out_plain=$( (cd "$d" && bash "$HOOK" set --phase branch --issue 1595 --branch "fix/issue-1595" --pr 0 --next "n") 2>&1 )
+assert "TC-26: backward compat → no WORKTREE_INVARIANT marker without flag" "0" "$(echo "$out_plain" | grep -c 'WORKTREE_INVARIANT')"
+
 # --- T-01: AC-1 — distinct env CLAUDE_CODE_SESSION_ID → distinct per-session state files ---
 echo ""
 echo "=== T-01: AC-1 concurrent sessions sharing one state root stay isolated by env ==="

--- a/plugins/rite/references/git-worktree-patterns.md
+++ b/plugins/rite/references/git-worktree-patterns.md
@@ -383,6 +383,38 @@ surfaces the diagnosis and the restart guidance instead. Failures from other cau
 (e.g. the worktree path vanished) follow the normal `RESUME_WT=missing` rebuild path,
 not the restart guidance.
 
+### Branch-creation worktree invariant (marker 再確定・silent fallback 排除)
+
+In `multi_session` mode the feature branch **must** be created on the session worktree
+(`{worktree_base}/issue-{N}`), regardless of the flow entry path (fresh / `/rite:resume` /
+post-compaction mid-flow entry). The earlier failure mode (#1595) was that `/rite:pr:open`
+gated the worktree-vs-main-tree branch decision **only on the in-context
+`[CONTEXT] MULTI_SESSION_ENABLED=` marker** emitted at Step 1.4. When that marker was lost
+from context (resume / compaction / mid-flow re-entry), routing fell back to the legacy
+`git switch -c` path and the branch was created on the **main checkout**, leaving
+`{worktree_base}/` empty and the flow-state `worktree` field unset.
+
+The invariant is enforced by three complementary gates, **none of which trusts remembered
+context**:
+
+- **Re-derive at branch time, not at Step 1.4** (`pr:open` Step 2.1-G): immediately before the
+  branch-creation side effect, `multi_session` is re-parsed from `rite-config.yml` with the
+  same parser as Step 1.4, emitting a fresh `MULTI_SESSION_ENABLED=...; SOURCE=branch-gate`
+  marker. There is **no "marker missing → legacy" branch** — the marker is regenerated every
+  time, so it can never be absent at routing.
+- **Legacy path is `false`-only** (`pr:open` Step 2.3): the `git switch -c` block runs only
+  when the branch-time re-derivation yielded `false`. Reaching it with `true` is prohibited.
+- **Post-entry toplevel check** (`pr:open` Step 2.3-W): after `EnterWorktree`,
+  `git rev-parse --show-toplevel` must equal the worktree path; a mismatch
+  (`WORKTREE_INVARIANT=violated`) stops the flow instead of silently implementing on the main
+  tree. The data layer mirrors this — `flow-state.sh set --require-worktree` emits
+  `WORKTREE_INVARIANT=missing` (loud WARNING, non-blocking write) when a branch/pr-phase set
+  carries no worktree path.
+
+This complements the `EnterWorktree`-failure convention above (which forbids silent fallback
+on *entry*) by forbidding it at *branch creation* too: the worktree is a **hard invariant**,
+not best-effort.
+
 ### main-checkout-不可侵 (inviolability) convention
 
 In `multi_session` mode rite **never switches the main checkout's current branch**


### PR DESCRIPTION
## 概要

`multi_session.enabled: true`（デフォルト ON）の環境で `/rite:pr:open` のブランチ作成が、フロー入場経路（fresh / resume / context 圧縮後の途中入場）に依らず必ずセッション worktree（`{worktree_base}/issue-{N}`）上で行われることを **hard invariant** として強制する。worktree 経路を取れない場合は legacy `git switch -c`（main ツリー直 checkout）へ silent fallback せず、明示警告のうえ停止または明示的なユーザー選択を要求する。

## 背景・根本原因（F3）

旧版は open.md のブランチ分岐を、ステップ 1.4 で emit した `[CONTEXT] MULTI_SESSION_ENABLED=` marker の **会話 context 残存に依存**させていた。resume / context 圧縮 / フロー途中入場で marker が context から失われると、分岐ルールが「marker 欠落 → 従来 2.2/2.3」に倒れ、`multi_session.enabled: true` でも main ツリーへ `git switch -c` する **silent fallback** が発生していた。worktree 化が prose gating でしか保証されていなかったことが構造原因（Issue の F1–F5 で実機・transcript・reflog から確定済み）。

## 変更内容

3 つの補完的ゲートで worktree 化を強制する（いずれも記憶した context を信頼しない）:

1. **ブランチ作成直前の marker 非依存再確定**（`commands/pr/open.md` Step 2.1-G 新設）— ブランチ作成の副作用直前に `multi_session` を rite-config.yml から再パース（Step 1.4 と同一パース。F4 で正常確認済のため変更せず再利用）し、`SOURCE=branch-gate` の fresh marker を emit。「marker 欠落 → legacy」分岐を構造的に排除。
2. **legacy 経路を `false` 限定化**（Step 2.3 に hard ガード）— `git switch -c` ブロックは再確定値が `false` のときのみ実行。`true` での到達は禁止。
3. **入場後の invariant 検証 + データ層検知**（Step 2.3-W + `hooks/flow-state.sh`）— `EnterWorktree` 後に `git rev-parse --show-toplevel` が worktree path と一致することを検証（不一致 `WORKTREE_INVARIANT=violated` で停止、silent 続行しない）。`flow-state.sh set` に `--require-worktree` フラグを追加し、worktree path 不在で branch/pr phase を記録しようとした場合に loud WARNING + `WORKTREE_INVARIANT=missing` marker を emit（非ブロッキング、書き込みは完了させ work を失わない）。

`references/git-worktree-patterns.md` に上記 3 ゲートのパターンを追記。`hooks/tests/flow-state.test.sh` に TC-26（`--require-worktree` の検知挙動と後方互換）を追加。

## 変更ファイル

- `plugins/rite/commands/pr/open.md` — Step 2.1-G 新設、Step 2.3 hard ガード、Step 2.3-W invariant 検証、Step 2.6/6.3 で `--require-worktree` 配線
- `plugins/rite/hooks/flow-state.sh` — `cmd_set` に `--require-worktree` 検証フラグ
- `plugins/rite/references/git-worktree-patterns.md` — branch 作成時 worktree hard invariant の記述
- `plugins/rite/hooks/tests/flow-state.test.sh` — TC-26

## 受入基準マッピング

- AC-1（fresh で worktree 作成）— Step 2.1-G が既存 2.2-W 経路を確実化（本 PR の作業セッション自体が worktree 上で実証）
- AC-2（resume/途中入場でも worktree 化）— Step 2.1-G の marker 再取得（中核）
- AC-3（flow-state worktree 記録）— Step 2.6 + `--require-worktree`（TC-26 で検証）
- AC-4（worktree 失敗時 silent fallback しない）— Step 2.3 ガード + Step 2.3-W invariant 検証
- AC-5（EnterWorktree 失敗時の挙動）— 既存記述を保持・参照
- AC-6（非回帰: multi_session 無効）— Step 2.1-G が `false` 時に従来 2.2/2.3 を選択（flow-state テスト 140 件パスで後方互換確認）

## スコープ

- Step 1.4 の config 解析（F4 で正常確認済）は変更せず再利用のみ。
- `templates/config/rite-config.yml` / wiki worktree / `commands/pr/create.md` は不変。
- `docs/SPEC.md` / `docs/designs/multi-session-worktree.md` は旧バグ挙動を誤記述しておらず stale ではないため、Issue 4.1 のスコープ（3 ファイル + テスト）に限定（D-03）。設計 doc への decision-log 転記が必要なら別途切り出す。

## テスト

- `flow-state.test.sh`: 140 件パス（既存 133 + TC-26 新規 7）。`--require-worktree` の missing/ok/後方互換を検証。
- プラグイン固有 lint チェック（bash-heaviness / drift / orphan / bang-backtick 等）: 本 PR の変更ファイルは新規 finding ゼロ。

## Known Issues

- lint のプラグイン固有チェックで既存の warning（comment-journal / comment-line-ref / number-ref / wiki-growth）が検出されるが、いずれも本 PR の変更ファイル由来ではなくリポジトリ全体の既存指摘（非ブロッキング・スコープ外）。

Closes #1595

---

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
