### PR TITLE
fix(docs): cleanup.md のアンカーリンクを main-checkout に修正

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -307,7 +307,7 @@ fi
 
 ### 4 base ブランチの更新（安全化）
 
-main checkout の不可侵規約（[git-worktree-patterns.md](../../references/git-worktree-patterns.md#multi-checkout-不可侵-inviolability-convention)）に従い、**main checkout が `{base_branch}` 上にある場合のみ** base を更新する。別 branch 上では切り替えず WARNING + skip する:
+main checkout の不可侵規約（[git-worktree-patterns.md](../../references/git-worktree-patterns.md#main-checkout-不可侵-inviolability-convention)）に従い、**main checkout が `{base_branch}` 上にある場合のみ** base を更新する。別 branch 上では切り替えず WARNING + skip する:
 
 ```bash
 cur_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || cur_branch=""


### PR DESCRIPTION
## 概要

`plugins/rite/commands/pr/cleanup.md:310` の `git-worktree-patterns.md` へのアンカーリンクが壊れていたため修正する。リンクは `#multi-checkout-不可侵-inviolability-convention` を指していたが、実見出しは `### main-checkout-不可侵 (inviolability) convention`（`git-worktree-patterns.md:418`）であり、GFM slug は `main-checkout-不可侵-inviolability-convention`。`multi-` vs `main-` でアンカーが一致していなかった。

## 関連 Issue

Closes #1603

## 変更内容

- `plugins/rite/commands/pr/cleanup.md:310`: アンカーを `#multi-checkout-不可侵-inviolability-convention` → `#main-checkout-不可侵-inviolability-convention` に修正

## Acceptance Criteria

- [x] cleanup.md のアンカーが実見出し slug と一致する
- [x] 同一の壊れたアンカーを参照する他箇所がないことを確認（`git grep "multi-checkout-不可侵"` の結果は cleanup.md:310 の 1 箇所のみで、修正により解消）

## チェックリスト

- [x] プロジェクト規約に準拠
- [ ] テスト（該当なし — ドキュメントのアンカー修正）
- [x] ドキュメント更新（本変更自体がドキュメント修正）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
