### PR TITLE
fix: Projects 登録の owner type 判定を撤廃し Organization 所有 Project に対応

### DIFF
--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -245,11 +245,14 @@ ITEM_ID=$(printf '%s\n' "$ITEM_ADD_RESULT" | jq -r '.id // empty' 2>/dev/null)
 # that the real gh CLI does not return on the owner object; that branch therefore
 # always fell back to the user-rooted query and failed for Organization-owned
 # projects, and it inspected the current repo rather than the project owner.
-# Mirrors projects-status-update.sh. REPO_NAME is derived from ISSUE_URL so the
-# helper's input JSON schema is unchanged.
+# Mirrors projects-status-update.sh's GraphQL *shape*. REPO_NAME is derived from
+# ISSUE_URL so the helper's input JSON schema is unchanged; the query owner stays
+# $OWNER (the project owner). This assumes the issue's repo and the project share
+# one owner (project owner == repo owner), which holds for rite's single-owner
+# config; the URL's owner segment is intentionally discarded.
 REPO_NAME=$(printf '%s\n' "$ISSUE_URL" | sed -nE 's#^https?://[^/]+/[^/]+/([^/]+)/issues/[0-9]+.*$#\1#p')
 if [ -z "$REPO_NAME" ]; then
-  add_warning_with_stderr "Could not resolve repository name from Issue URL: $ISSUE_URL"
+  add_warning_with_stderr "Could not resolve repository name for Issue #$ISSUE_NUMBER from URL: $ISSUE_URL"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 fi

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -238,16 +238,18 @@ ITEM_ADD_RESULT=$(retry_with_backoff 3 "$GH_ERR_FILE" gh project item-add "$PROJ
 # Extract ITEM_ID directly from item-add response (avoids race condition with GraphQL query)
 ITEM_ID=$(printf '%s\n' "$ITEM_ADD_RESULT" | jq -r '.id // empty' 2>/dev/null)
 
-# Step 2.2: Detect owner type (User vs Organization)
-OWNER_TYPE=$(gh repo view --json owner --jq '.owner.__typename' 2>"$GH_ERR_FILE" || { add_warning "Owner type detection failed: $(cat "$GH_ERR_FILE")"; printf '%s\n' "User"; })
-GQL_ROOT="user"
-if [ "$OWNER_TYPE" = "Organization" ]; then
-  GQL_ROOT="organization"
-fi
-
-# Whitelist validation for GQL_ROOT (defense against GraphQL injection, CWE-943)
-if [[ "$GQL_ROOT" != "user" && "$GQL_ROOT" != "organization" ]]; then
-  add_warning_with_stderr "Invalid GQL_ROOT value: $GQL_ROOT"
+# Step 2.2: Resolve the repository name from the created Issue URL.
+# Project queries are rooted at repository(owner, name).projectV2(number), which
+# resolves transparently for both User- and Organization-owned projects. This
+# replaces the previous owner-type branch, which relied on a type discriminator
+# that the real gh CLI does not return on the owner object; that branch therefore
+# always fell back to the user-rooted query and failed for Organization-owned
+# projects, and it inspected the current repo rather than the project owner.
+# Mirrors projects-status-update.sh. REPO_NAME is derived from ISSUE_URL so the
+# helper's input JSON schema is unchanged.
+REPO_NAME=$(printf '%s\n' "$ISSUE_URL" | sed -nE 's#^https?://[^/]+/[^/]+/([^/]+)/issues/[0-9]+.*$#\1#p')
+if [ -z "$REPO_NAME" ]; then
+  add_warning_with_stderr "Could not resolve repository name from Issue URL: $ISSUE_URL"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 fi
@@ -255,8 +257,8 @@ fi
 # Step 2.3: Retrieve project item ID and field information
 # 3-attempt exponential backoff for transient API failures.
 GQL_FIELDS_QUERY="
-query(\$owner: String!, \$projectNumber: Int!) {
-  ${GQL_ROOT}(login: \$owner) {
+query(\$owner: String!, \$repo: String!, \$projectNumber: Int!) {
+  repository(owner: \$owner, name: \$repo) {
     projectV2(number: \$projectNumber) {
       id
       items(last: 10) {
@@ -295,14 +297,14 @@ query(\$owner: String!, \$projectNumber: Int!) {
     }
   }
 }"
-GQL_RESULT=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_FIELDS_QUERY" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER") || {
+GQL_RESULT=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_FIELDS_QUERY" -f owner="$OWNER" -f repo="$REPO_NAME" -F projectNumber="$PROJECT_NUMBER") || {
   add_warning_with_stderr "GraphQL query failed for project field retrieval after 3 attempts: $(cat "$GH_ERR_FILE")"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
   exit 0
 }
 
-# Extract project ID (use --arg for safe variable passing to jq)
-PROJECT_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" '.data[$root].projectV2.id // empty')
+# Extract project ID
+PROJECT_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r '.data.repository.projectV2.id // empty')
 if [ -z "$PROJECT_ID" ]; then
   add_warning_with_stderr "Could not extract project ID"
   output_result "$ISSUE_URL" "$ISSUE_NUMBER" "" "" "partial"
@@ -312,13 +314,13 @@ fi
 # Fallback: if ITEM_ID was not captured from item-add (e.g., older gh CLI without --format json),
 # try to find it via GraphQL items query
 if [ -z "$ITEM_ID" ]; then
-  ITEM_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" --argjson num "$ISSUE_NUMBER" '.data[$root].projectV2.items.nodes[] | select(.content.number == $num) | .id // empty')
+  ITEM_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --argjson num "$ISSUE_NUMBER" '.data.repository.projectV2.items.nodes[] | select(.content.number == $num) | .id // empty')
 fi
 if [ -z "$ITEM_ID" ]; then
   # Retry with larger window. 3-attempt exponential backoff for transient failures.
   GQL_ITEMS_QUERY="
-query(\$owner: String!, \$projectNumber: Int!) {
-  ${GQL_ROOT}(login: \$owner) {
+query(\$owner: String!, \$repo: String!, \$projectNumber: Int!) {
+  repository(owner: \$owner, name: \$repo) {
     projectV2(number: \$projectNumber) {
       items(last: 20) {
         nodes {
@@ -333,9 +335,9 @@ query(\$owner: String!, \$projectNumber: Int!) {
     }
   }
 }"
-  GQL_RETRY=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_ITEMS_QUERY" -f owner="$OWNER" -F projectNumber="$PROJECT_NUMBER") || { add_warning_with_stderr "GraphQL items lookup query failed after 3 attempts: $(cat "$GH_ERR_FILE")"; true; }
+  GQL_RETRY=$(retry_with_backoff 3 "$GH_ERR_FILE" gh api graphql -f query="$GQL_ITEMS_QUERY" -f owner="$OWNER" -f repo="$REPO_NAME" -F projectNumber="$PROJECT_NUMBER") || { add_warning_with_stderr "GraphQL items lookup query failed after 3 attempts: $(cat "$GH_ERR_FILE")"; true; }
 
-  ITEM_ID=$(printf '%s\n' "$GQL_RETRY" | jq -r --arg root "$GQL_ROOT" --argjson num "$ISSUE_NUMBER" '.data[$root].projectV2.items.nodes[] | select(.content.number == $num) | .id // empty' 2>"$FIELD_ERR_FILE")
+  ITEM_ID=$(printf '%s\n' "$GQL_RETRY" | jq -r --argjson num "$ISSUE_NUMBER" '.data.repository.projectV2.items.nodes[] | select(.content.number == $num) | .id // empty' 2>"$FIELD_ERR_FILE")
   if [ -z "$ITEM_ID" ]; then
     add_warning_with_stderr "Could not find item ID for Issue #$ISSUE_NUMBER in project"
     output_result "$ISSUE_URL" "$ISSUE_NUMBER" "$PROJECT_ID" "" "partial"
@@ -348,8 +350,8 @@ find_field_option() {
   local field_name="$1"
   local option_name="$2"
 
-  printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" --arg fn "$field_name" --arg on "$option_name" '
-    .data[$root].projectV2.fields.nodes[] | select(.name == $fn) |
+  printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$field_name" --arg on "$option_name" '
+    .data.repository.projectV2.fields.nodes[] | select(.name == $fn) |
     (.id // "") as $fid |
     (if $fid == "" then ""
      else ((.options // [])[] | select(.name == $on) | .id // "") as $oid | "\($fid)|\($oid)"
@@ -390,13 +392,13 @@ set_field "Complexity" "$COMPLEXITY_VALUE"
 
 # Step 2.5: Iteration assignment (optional)
 if [ "$ITERATION_MODE" = "auto" ]; then
-  ITER_FIELD_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" --arg fn "$ITERATION_FIELD_NAME" '.data[$root].projectV2.fields.nodes[] | select(.name == $fn) | .id // empty')
+  ITER_FIELD_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$ITERATION_FIELD_NAME" '.data.repository.projectV2.fields.nodes[] | select(.name == $fn) | .id // empty')
   if [ -n "$ITER_FIELD_ID" ]; then
     # Find current iteration (startDate <= today, sorted by startDate desc)
     # ISO 8601 date strings (YYYY-MM-DD) are lexicographically comparable
     TODAY=$(date -u +%Y-%m-%d)
-    CURRENT_ITER_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg root "$GQL_ROOT" --arg fn "$ITERATION_FIELD_NAME" --arg today "$TODAY" '
-      .data[$root].projectV2.fields.nodes[]
+    CURRENT_ITER_ID=$(printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$ITERATION_FIELD_NAME" --arg today "$TODAY" '
+      .data.repository.projectV2.fields.nodes[]
       | select(.name == $fn)
       | .configuration.iterations
       | map(select(.startDate <= $today))

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -417,9 +417,10 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# TC-014: Organization owner type detection
+# TC-014 (AC-1 / AC-4): Organization-owned Project → fields set successfully via
+# the owner-type-independent repository(owner,name) path (no owner-type branch).
 # --------------------------------------------------------------------------
-echo "TC-014: Organization owner → correct GraphQL root"
+echo "TC-014: Organization owner → fields set via repository() path (AC-1/AC-4)"
 body_file=$(create_body_file "Test org")
 run_script "$(jq -n --arg bf "$body_file" '{
   issue: {title: "Org Test", body_file: $bf},
@@ -427,20 +428,30 @@ run_script "$(jq -n --arg bf "$body_file" '{
     enabled: true,
     project_number: 2,
     owner: "test-org",
-    status: "Todo"
+    status: "Todo",
+    priority: "High",
+    complexity: "M"
   }
 }')" "org_owner"
 if [ "$LAST_RC" -eq 0 ]; then
   reg=$(json_field '.project_registration')
-  if [ "$reg" = "ok" ]; then
-    # Verify GraphQL query used organization(login:) root
-    if grep -q 'organization(login:' "$LAST_GH_LOG" 2>/dev/null; then
-      pass "Organization owner: exit=0, reg=$reg, GraphQL root=organization"
-    else
-      fail "Expected organization(login:) in GraphQL query, got: $(cat "$LAST_GH_LOG")"
-    fi
+  warns_text=$(printf '%s\n' "$LAST_OUTPUT" | jq -r '.warnings[]?' 2>/dev/null)
+  # Field setting actually reached: item-edit invoked with a single-select option id.
+  field_set=false
+  if grep -q "item-edit" "$LAST_GH_LOG" 2>/dev/null && grep -q -- "--single-select-option-id" "$LAST_GH_LOG" 2>/dev/null; then
+    field_set=true
+  fi
+  # Owner-type-independent path: query rooted at repository(owner:, no user/organization(login:).
+  repo_root=false
+  if grep -q 'repository(owner:' "$LAST_GH_LOG" 2>/dev/null \
+     && ! grep -qE '(user|organization)\(login:' "$LAST_GH_LOG" 2>/dev/null; then
+    repo_root=true
+  fi
+  if [ "$reg" = "ok" ] && [ "$field_set" = true ] && [ "$repo_root" = true ] \
+     && ! echo "$warns_text" | grep -q "Could not extract project ID"; then
+    pass "Org owner: reg=ok, fields set, repository() root, no 'Could not extract project ID' warning"
   else
-    fail "Expected reg=ok, got $reg"
+    fail "Expected reg=ok + fields set + repository() root + no project-ID warning, got reg=$reg, field_set=$field_set, repo_root=$repo_root, warns='$warns_text', log='$(cat "$LAST_GH_LOG")'"
   fi
 else
   fail "Expected exit 0, got $LAST_RC"
@@ -886,6 +897,32 @@ if [ "$LAST_RC" -eq 0 ]; then
   fi
 else
   fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-030 (AC-3 / T-03): mock `gh repo view --json owner` matches the real CLI
+# shape — the owner object has {id, login} and NO __typename discriminator. The
+# org_owner scenario must not reintroduce __typename via any branch.
+# --------------------------------------------------------------------------
+echo "TC-030: mock gh repo view owner has no __typename (AC-3)"
+repo_view_out=$(MOCK_GH_SCENARIO=org_owner MOCK_ISSUE_NUMBER=42 PATH="$MOCK_BIN_DIR:$PATH" gh repo view --json owner 2>/dev/null)
+if echo "$repo_view_out" | jq -e '.owner.login' >/dev/null 2>&1 \
+   && echo "$repo_view_out" | jq -e '(.owner | has("__typename")) | not' >/dev/null 2>&1; then
+  pass "mock repo view owner = {id, login}, no __typename key (org_owner scenario)"
+else
+  fail "Expected owner with login and no __typename, got: $repo_view_out"
+fi
+
+# --------------------------------------------------------------------------
+# TC-031 (AC-5 / T-05): the owner-type detection code is fully removed from
+# create-issue-with-projects.sh — no __typename reference and no GQL_ROOT
+# user/org branch remain in the source.
+# --------------------------------------------------------------------------
+echo "TC-031: source has no __typename / GQL_ROOT residue (AC-5)"
+if grep -qE '__typename|GQL_ROOT|OWNER_TYPE' "$TARGET"; then
+  fail "Found owner-type detection residue in $TARGET: $(grep -nE '__typename|GQL_ROOT|OWNER_TYPE' "$TARGET" | head -3)"
+else
+  pass "No __typename / GQL_ROOT / OWNER_TYPE residue in source"
 fi
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -214,8 +214,9 @@ ITEMJSON
           exit 1
         fi
 
-        # Detect query shape: projects-status-update.sh queries `repository(owner:`
-        # while create-issue-with-projects.sh queries `user|organization(login:`.
+        # Detect query shape: both scripts query `repository(owner:`, so discriminate
+        # by sub-shape — create-issue-with-projects.sh uses `projectV2(number:` while
+        # projects-status-update.sh uses `issue(...).projectItems`.
         # gql_items_lookup_fail: fields query (containing
         # `fields(first: 20)`) succeeds with empty items, but the items lookup
         # retry query (containing `items(last: 20)` and NOT `fields(first: 20)`)

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -48,10 +48,11 @@
 #   "pif_normalize_fail"       - gh succeeds (default shapes); the failure is injected by the
 #                                jq shim in projects-items-fetch.test.sh (final `jq -s` exits 2)
 #
-# The projects-status-update.sh script uses a different GraphQL shape
-# (`data.repository.issue.projectItems`) than create-issue-with-projects.sh
-# (`data.{user|organization}.projectV2`), so this mock detects the query shape
-# via the `repository(owner:` token in the query string and branches accordingly.
+# Both create-issue-with-projects.sh and projects-status-update.sh root their
+# GraphQL queries at `repository(owner:, name:)`, but with different sub-shapes:
+# create uses `repository.projectV2(number:)` (-> `data.repository.projectV2`)
+# while status-update uses `repository.issue(number:).projectItems`. This mock
+# discriminates them via the `projectV2(number:` token and branches accordingly.
 set -euo pipefail
 
 SCENARIO="${MOCK_GH_SCENARIO:-success}"
@@ -176,11 +177,12 @@ ITEMJSON
   repo)
     case "$2" in
       view)
-        local_owner_type="User"
-        if [ "$SCENARIO" = "org_owner" ]; then
-          local_owner_type="Organization"
-        fi
-        json_data="{\"owner\":{\"login\":\"test-owner\",\"__typename\":\"${local_owner_type}\"}}"
+        # Real `gh repo view --json owner` returns the owner object as {id, login}
+        # only — there is NO __typename discriminator. The mock mirrors that exact
+        # shape (regression guard for the old owner-type bug, AC-3). The org_owner
+        # scenario no longer branches here; owner type is irrelevant to the new
+        # owner-type-independent repository(owner,name) path.
+        json_data="{\"owner\":{\"id\":\"O_kgM0test\",\"login\":\"test-owner\"}}"
         # Handle --jq flag: apply jq filter like real gh CLI
         jq_filter=""
         prev_arg=""
@@ -219,6 +221,7 @@ ITEMJSON
         # retry query (containing `items(last: 20)` and NOT `fields(first: 20)`)
         # fails with exit 1.
         is_repository_query=false
+        is_projectv2_query=false
         is_mutation=false
         is_items_lookup_only=false
         is_items_pagination_query=false
@@ -227,6 +230,14 @@ ITEMJSON
           if [[ "$arg" == query=* ]]; then
             if [[ "$arg" == *"repository(owner:"* ]]; then
               is_repository_query=true
+            fi
+            # create-issue-with-projects.sh roots its project queries at
+            # repository(owner,name).projectV2(number:...); projects-status-update.sh
+            # instead queries repository(...).issue(...).projectItems. The projectV2
+            # token discriminates the two repository-rooted shapes so the create path
+            # is not misrouted to the projectItems (psu) branch below.
+            if [[ "$arg" == *"projectV2(number:"* ]]; then
+              is_projectv2_query=true
             fi
             if [[ "$arg" == *mutation* ]]; then
               is_mutation=true
@@ -293,6 +304,100 @@ ITEMJSON
           exit 0
         fi
 
+        # --- create-issue-with-projects.sh path (repository.projectV2 shape) ---
+        # Owner-type-independent: the SAME response is returned whether the owner is
+        # a User or an Organization (the org_owner scenario now succeeds, AC-4). Must
+        # be checked before the projectItems (psu) branch since both are rooted at
+        # repository(owner:...).
+        if [ "$is_projectv2_query" = true ]; then
+          ITEMS_NODES="[{\"id\":\"${MOCK_ITEM_ID}\",\"content\":{\"number\":${MOCK_ISSUE_NUMBER}}}]"
+          if [ "$SCENARIO" = "no_item_id" ] || [ "$SCENARIO" = "no_item_id_no_json" ] || [ "$SCENARIO" = "gql_items_lookup_fail" ]; then
+            ITEMS_NODES="[]"
+          fi
+
+          PROJECT_ID_VALUE="\"${MOCK_PROJECT_ID}\""
+          if [ "$SCENARIO" = "no_project_id" ]; then
+            PROJECT_ID_VALUE="null"
+          fi
+
+          # Iteration field (conditionally included based on scenario)
+          ITER_FIELD=""
+          MOCK_CURRENT_SPRINT_START=$(date +%Y-%m-01)
+          if [ "$SCENARIO" = "iteration_success" ] || [ "$SCENARIO" = "iteration_mutation_fail" ]; then
+            ITER_FIELD=',
+            {
+              "id": "FIELD_SPRINT",
+              "name": "Sprint",
+              "configuration": {
+                "iterations": [
+                  {"id": "ITER_PAST", "title": "Past Sprint", "startDate": "2020-01-01"},
+                  {"id": "ITER_CURRENT", "title": "Current Sprint", "startDate": "'"$MOCK_CURRENT_SPRINT_START"'"}
+                ]
+              }
+            }'
+          elif [ "$SCENARIO" = "no_current_iteration" ]; then
+            ITER_FIELD=',
+            {
+              "id": "FIELD_SPRINT",
+              "name": "Sprint",
+              "configuration": {
+                "iterations": [
+                  {"id": "ITER_FUTURE", "title": "Future Sprint", "startDate": "2099-01-01"}
+                ]
+              }
+            }'
+          fi
+
+          cat <<EOJSON
+{
+  "data": {
+    "repository": {
+      "projectV2": {
+        "id": ${PROJECT_ID_VALUE},
+        "items": {
+          "nodes": ${ITEMS_NODES}
+        },
+        "fields": {
+          "nodes": [
+            {
+              "id": "FIELD_STATUS",
+              "name": "Status",
+              "options": [
+                {"id": "OPT_TODO", "name": "Todo"},
+                {"id": "OPT_INPROGRESS", "name": "In Progress"},
+                {"id": "OPT_DONE", "name": "Done"}
+              ]
+            },
+            {
+              "id": "FIELD_PRIORITY",
+              "name": "Priority",
+              "options": [
+                {"id": "OPT_HIGH", "name": "High"},
+                {"id": "OPT_MEDIUM", "name": "Medium"},
+                {"id": "OPT_LOW", "name": "Low"}
+              ]
+            },
+            {
+              "id": "FIELD_COMPLEXITY",
+              "name": "Complexity",
+              "options": [
+                {"id": "OPT_XS", "name": "XS"},
+                {"id": "OPT_S", "name": "S"},
+                {"id": "OPT_M", "name": "M"},
+                {"id": "OPT_L", "name": "L"},
+                {"id": "OPT_XL", "name": "XL"}
+              ]
+            }${ITER_FIELD}
+          ]
+        }
+      }
+    }
+  }
+}
+EOJSON
+          exit 0
+        fi
+
         # --- projects-status-update.sh path ---
         if [ "$is_repository_query" = true ]; then
           # Determine scenario-dependent response shape.
@@ -343,99 +448,8 @@ ITEMJSON
           esac
         fi
 
-        # Determine GQL root based on owner type
-        GQL_ROOT="user"
-        if [ "$SCENARIO" = "org_owner" ]; then
-          GQL_ROOT="organization"
-        fi
-
-        ITEMS_NODES="[{\"id\":\"${MOCK_ITEM_ID}\",\"content\":{\"number\":${MOCK_ISSUE_NUMBER}}}]"
-        if [ "$SCENARIO" = "no_item_id" ] || [ "$SCENARIO" = "no_item_id_no_json" ] || [ "$SCENARIO" = "gql_items_lookup_fail" ]; then
-          ITEMS_NODES="[]"
-        fi
-
-        PROJECT_ID_VALUE="\"${MOCK_PROJECT_ID}\""
-        if [ "$SCENARIO" = "no_project_id" ]; then
-          PROJECT_ID_VALUE="null"
-        fi
-
-        # Iteration field (conditionally included based on scenario)
-        ITER_FIELD=""
-        MOCK_CURRENT_SPRINT_START=$(date +%Y-%m-01)
-        if [ "$SCENARIO" = "iteration_success" ] || [ "$SCENARIO" = "iteration_mutation_fail" ]; then
-          # iteration_mutation_fail も fields query では Sprint field + current iteration を返し、
-          # mutation 段階で初めて失敗させる
-          ITER_FIELD=',
-            {
-              "id": "FIELD_SPRINT",
-              "name": "Sprint",
-              "configuration": {
-                "iterations": [
-                  {"id": "ITER_PAST", "title": "Past Sprint", "startDate": "2020-01-01"},
-                  {"id": "ITER_CURRENT", "title": "Current Sprint", "startDate": "'"$MOCK_CURRENT_SPRINT_START"'"}
-                ]
-              }
-            }'
-        elif [ "$SCENARIO" = "no_current_iteration" ]; then
-          ITER_FIELD=',
-            {
-              "id": "FIELD_SPRINT",
-              "name": "Sprint",
-              "configuration": {
-                "iterations": [
-                  {"id": "ITER_FUTURE", "title": "Future Sprint", "startDate": "2099-01-01"}
-                ]
-              }
-            }'
-        fi
-
-        cat <<EOJSON
-{
-  "data": {
-    "${GQL_ROOT}": {
-      "projectV2": {
-        "id": ${PROJECT_ID_VALUE},
-        "items": {
-          "nodes": ${ITEMS_NODES}
-        },
-        "fields": {
-          "nodes": [
-            {
-              "id": "FIELD_STATUS",
-              "name": "Status",
-              "options": [
-                {"id": "OPT_TODO", "name": "Todo"},
-                {"id": "OPT_INPROGRESS", "name": "In Progress"},
-                {"id": "OPT_DONE", "name": "Done"}
-              ]
-            },
-            {
-              "id": "FIELD_PRIORITY",
-              "name": "Priority",
-              "options": [
-                {"id": "OPT_HIGH", "name": "High"},
-                {"id": "OPT_MEDIUM", "name": "Medium"},
-                {"id": "OPT_LOW", "name": "Low"}
-              ]
-            },
-            {
-              "id": "FIELD_COMPLEXITY",
-              "name": "Complexity",
-              "options": [
-                {"id": "OPT_XS", "name": "XS"},
-                {"id": "OPT_S", "name": "S"},
-                {"id": "OPT_M", "name": "M"},
-                {"id": "OPT_L", "name": "L"},
-                {"id": "OPT_XL", "name": "XL"}
-              ]
-            }${ITER_FIELD}
-          ]
-        }
-      }
-    }
-  }
-}
-EOJSON
+        # Unrecognized GraphQL query shape: return empty (no create/psu/pif/mutation
+        # token matched). Real callers always match one of the branches above.
         ;;
       *)
         echo "mock: unhandled gh api subcommand: $2" >&2


### PR DESCRIPTION
## 概要

`create-issue-with-projects.sh` の owner type 判定（`gh repo view --json owner --jq '.owner.__typename'`）は、実 CLI の owner オブジェクトに `__typename` が無いため常に空文字を返し、`GQL_ROOT` が `user` 固定になっていた。結果 Organization 所有 Project では `user(login:)` が null を返し「Could not extract project ID」で `partial` 終了し、Status/Priority/Complexity が未設定のままになっていた。

owner type 判定を撤廃し、GraphQL を owner-type 非依存の `repository(owner, name).projectV2(number)` 経路に寄せることで、user/org いずれの owner でも透過的に解決する（姉妹スクリプト `projects-status-update.sh` と同型）。

## 関連 Issue

Closes #1609

## 変更内容

- `plugins/rite/scripts/create-issue-with-projects.sh`:
  - owner type 判定ブロック（`OWNER_TYPE` / `GQL_ROOT` / whitelist 検証）を撤廃
  - フィールド取得・item ルックアップの GraphQL を `${GQL_ROOT}(login:$owner)` → `repository(owner:$owner, name:$repo)` に変更
  - JSON path を `.data[$root].projectV2` → `.data.repository.projectV2` に統一
  - `repo` 名は `ISSUE_URL` から導出（helper の入力/出力 JSON スキーマは不変）
  - iteration auto-assign は同一クエリから取得でき**挙動不変**（owner-type 撤廃のスコープ内のみ）
- `plugins/rite/scripts/tests/mock-gh.sh`:
  - `gh repo view --json owner` を実 CLI 形状（`{id, login}`、`__typename` なし）に是正
  - create 経路の GraphQL 応答を `data.repository.projectV2` 形状へ更新し、`projectV2(number:` トークンで create/status-update の query shape を判別
- `plugins/rite/scripts/tests/create-issue-with-projects.test.sh`:
  - org_owner シナリオを「フィールド設定成功 + `repository()` 経路 + project ID 警告なし」検証へ変更（AC-1/AC-4）
  - mock の `__typename` 不在（AC-3）、source の `__typename`/`GQL_ROOT` 残存なし（AC-5）の回帰ガードを追加

## Acceptance Criteria

- [x] AC-1: Organization 所有 Project でフィールド設定が成功する（`project_registration=ok`、project ID 警告なし）
- [x] AC-2: User 所有 Project に回帰がない（既存 33 テスト pass）
- [x] AC-3: mock が実 CLI 形状に一致（owner に `__typename` キーなし）
- [x] AC-4: org_owner シナリオがフィールド設定成功まで検証
- [x] AC-5: `__typename` 参照と `GQL_ROOT` user/org 分岐が source に残存しない

## テスト

- `create-issue-with-projects.test.sh`: 34 passed, 0 failed（org/user/iteration/error 各経路 + AC-3/AC-5 回帰ガード）
- 共有 mock の回帰確認: `projects-status-update.test.sh` 21/21、`projects-items-fetch.test.sh` 21/21
- 実機検証: `repository(owner,name).projectV2(number)` が project_id + fields を owner-type 非依存で返すことを GraphQL で確認済み

## Non-target（変更なし）

- `plugins/rite/scripts/projects-status-update.sh`（手本として参照のみ）
- `plugins/rite/commands/issue/create.md`（helper interface 不変）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
