### PR TITLE
fix: Projects フィールド名を英日エイリアス + config 上書きで解決（日本語名 Project 対応）

### DIFF
--- a/plugins/rite/commands/issue/create.md
+++ b/plugins/rite/commands/issue/create.md
@@ -23,6 +23,7 @@ description: |
 |-------------|--------|
 | `{owner}`, `{repo}` | `gh repo view --json owner,name` |
 | `{project_number}` | `rite-config.yml` の `github.projects.project_number` |
+| `{field_name_status}`, `{field_name_priority}`, `{field_name_complexity}` | `rite-config.yml` の `github.projects.fields.{status,priority,complexity}.name`（任意。未設定は空文字 = helper 内蔵の英日エイリアスで解決） |
 | `{language}` | `rite-config.yml` の `language`（`ja` / `en` / `auto`、未設定 `auto`） |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) |
 
@@ -196,6 +197,8 @@ Read tool で以下を読み込む:
 
 `create-issue-with-projects.sh` に委譲（Issue 作成 + Projects 追加 + status / priority / complexity 設定を 1 ステップで実行）。実 interface は JSON 単一引数 + body は tmpfile 経由（canonical SoT: [`issue-create-with-projects.md`](../../references/issue-create-with-projects.md)）:
 
+> **フィールド名のローカライズ配線**: `rite-config.yml` の `github.projects.fields.{status,priority,complexity}.name`（任意）を読み取り、`{field_name_status}` / `{field_name_priority}` / `{field_name_complexity}` に展開する。未設定のキーは空文字とする（helper 側で内蔵の英日エイリアス + 英語正準名にフォールバックするため、日本語フィールド名 Project でもゼロ設定で解決する）。これらは helper 入力 JSON の `projects.field_names` に additive に詰められる。
+
 ```bash
 # drift-check-ignore: canonical な「JSON を helper へ単一引数で渡す」契約は
 #   create-md-invocation-symmetry.test.sh (TC-1/TC-2/TC-4/TC-1e) と SoT が test 強制している。
@@ -225,6 +228,9 @@ args_json=$(jq -n \
   --arg status "Todo" \
   --arg priority "{priority}" \
   --arg complexity "{complexity}" \
+  --arg field_name_status "{field_name_status}" \
+  --arg field_name_priority "{field_name_priority}" \
+  --arg field_name_complexity "{field_name_complexity}" \
   --arg iter_mode "none" \
   --arg source "interactive" \
   '{
@@ -236,6 +242,7 @@ args_json=$(jq -n \
       status: $status,
       priority: $priority,
       complexity: $complexity,
+      field_names: { status: $field_name_status, priority: $field_name_priority, complexity: $field_name_complexity },
       iteration: { mode: $iter_mode }
     },
     options: { source: $source, non_blocking_projects: true }

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -57,6 +57,9 @@ args_json=$(jq -n \
  --arg status "Todo" \
  --arg priority "Medium" \
  --arg complexity "S" \
+ --arg field_name_status "" \
+ --arg field_name_priority "" \
+ --arg field_name_complexity "" \
  --arg iter_mode "none" \
  --arg source "pr_review" \
  '{
@@ -68,6 +71,7 @@ args_json=$(jq -n \
  status: $status,
  priority: $priority,
  complexity: $complexity,
+ field_names: { status: $field_name_status, priority: $field_name_priority, complexity: $field_name_complexity },
  iteration: { mode: $iter_mode }
  },
  options: { source: $source, non_blocking_projects: true }
@@ -115,6 +119,10 @@ projects:
  iteration:
  mode: "none|auto" # Default: "none". "auto" assigns to current iteration
  field_name: "Sprint" # Default: "Sprint"
+ field_names: # Optional: localized project field-name overrides
+   status: string #   each overrides the built-in EN<->JA alias for that
+   priority: string #   canonical field (Status/Priority/Complexity).
+   complexity: string #   Empty/absent -> built-in aliases only.
 options:
  source: string # Caller identifier (pr_review|pr_create|cleanup|interactive|xl_decomposition|fingerprint_split|quality_signal_3_split|quality_signal_4_split)
                 # Note: 以下の値は legacy 互換のため enum に含めない (caller 消失済、`grep -rn 'source: "<value>"' plugins/rite/` で 0 件確認):

--- a/plugins/rite/references/issue-create-with-projects.md
+++ b/plugins/rite/references/issue-create-with-projects.md
@@ -119,10 +119,7 @@ projects:
  iteration:
  mode: "none|auto" # Default: "none". "auto" assigns to current iteration
  field_name: "Sprint" # Default: "Sprint"
- field_names: # Optional: localized project field-name overrides
-   status: string #   each overrides the built-in EN<->JA alias for that
-   priority: string #   canonical field (Status/Priority/Complexity).
-   complexity: string #   Empty/absent -> built-in aliases only.
+ field_names: { status, priority, complexity } # Optional: each overrides the built-in EN<->JA alias for that canonical field. Empty/absent -> aliases only
 options:
  source: string # Caller identifier (pr_review|pr_create|cleanup|interactive|xl_decomposition|fingerprint_split|quality_signal_3_split|quality_signal_4_split)
                 # Note: 以下の値は legacy 互換のため enum に含めない (caller 消失済、`grep -rn 'source: "<value>"' plugins/rite/` で 0 件確認):

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -24,6 +24,11 @@
 #       "iteration": {
 #         "mode": "none|auto",       # default: "none"
 #         "field_name": "Sprint"     # default: "Sprint"
+#       },
+#       "field_names": {             # optional: localized project field-name overrides
+#         "status": "ステータス",     #   each overrides the built-in EN<->JA alias for
+#         "priority": "優先度",       #   the canonical field. Empty/absent -> built-in
+#         "complexity": "複雑度"      #   aliases only (Status/Priority/Complexity).
 #       }
 #     },
 #     "options": {
@@ -160,6 +165,9 @@ eval "$(printf '%s\n' "$INPUT_JSON" | jq -r '
   @sh "COMPLEXITY_VALUE=\(.projects.complexity // "")",
   @sh "ITERATION_MODE=\(.projects.iteration.mode // "none")",
   @sh "ITERATION_FIELD_NAME=\(.projects.iteration.field_name // "Sprint")",
+  @sh "FIELD_NAME_STATUS=\(.projects.field_names.status // "")",
+  @sh "FIELD_NAME_PRIORITY=\(.projects.field_names.priority // "")",
+  @sh "FIELD_NAME_COMPLEXITY=\(.projects.field_names.complexity // "")",
   @sh "NON_BLOCKING=\(if .options.non_blocking_projects == false then false else true end)"
 ')"
 
@@ -348,43 +356,96 @@ query(\$owner: String!, \$repo: String!, \$projectNumber: Int!) {
   fi
 fi
 
-# Helper: find field ID and option ID from GQL result in a single jq call
-find_field_option() {
-  local field_name="$1"
-  local option_name="$2"
-
-  printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$field_name" --arg on "$option_name" '
-    .data.repository.projectV2.fields.nodes[] | select(.name == $fn) |
-    (.id // "") as $fid |
-    (if $fid == "" then ""
-     else ((.options // [])[] | select(.name == $on) | .id // "") as $oid | "\($fid)|\($oid)"
-     end)
-  '
+# Built-in English<->Japanese field-name aliases. Maps a canonical English field
+# name (Status/Priority/Complexity) to its built-in Japanese alias so that
+# localized Projects resolve with zero config. Extend this single table to add
+# more built-in aliases.
+field_name_alias() {
+  case "$1" in
+    Status) printf 'ステータス' ;;
+    Priority) printf '優先度' ;;
+    Complexity) printf '複雑度' ;;
+    *) printf '' ;;
+  esac
 }
 
-# Step 2.4: Set fields (reuses centralized FIELD_ERR_FILE)
+# Per-field override taken from the input JSON's projects.field_names (empty when
+# absent). Takes precedence over the built-in alias.
+field_name_override() {
+  case "$1" in
+    Status) printf '%s' "$FIELD_NAME_STATUS" ;;
+    Priority) printf '%s' "$FIELD_NAME_PRIORITY" ;;
+    Complexity) printf '%s' "$FIELD_NAME_COMPLEXITY" ;;
+    *) printf '' ;;
+  esac
+}
+
+# Look up a field id by exact name in the cached GraphQL result (empty if absent).
+field_id_by_name() {
+  printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$1" \
+    '[.data.repository.projectV2.fields.nodes[] | select(.name == $fn) | .id][0] // empty'
+}
+
+# Look up an option id within a (resolved) field name (empty if absent).
+option_id_by_name() {
+  printf '%s\n' "$GQL_RESULT" | jq -r --arg fn "$1" --arg on "$2" \
+    '[.data.repository.projectV2.fields.nodes[] | select(.name == $fn) | (.options // [])[] | select(.name == $on) | .id][0] // empty'
+}
+
+# Step 2.4: Set a single-select field. The canonical English field name is
+# resolved against candidate project field names in priority order:
+#   1. input-JSON override (projects.field_names.*)
+#   2. built-in Japanese alias
+#   3. canonical English name
+# This lets localized (e.g. Japanese-named) Projects work with zero config while
+# still allowing per-field overrides. Reuses centralized FIELD_ERR_FILE.
 set_field() {
-  local field_name="$1"
+  local canonical="$1"
   local field_value="$2"
 
   if [ -z "$field_value" ]; then
     return 0
   fi
 
-  local result
-  result=$(find_field_option "$field_name" "$field_value")
-  local field_id="${result%%|*}"
-  local option_id="${result##*|}"
+  # Build the ordered candidate field-name list (override > alias > canonical).
+  local candidates=()
+  local override alias_name
+  override=$(field_name_override "$canonical")
+  [ -n "$override" ] && candidates+=("$override")
+  alias_name=$(field_name_alias "$canonical")
+  [ -n "$alias_name" ] && candidates+=("$alias_name")
+  candidates+=("$canonical")
 
-  if [ -z "$field_id" ] || [ -z "$option_id" ]; then
-    add_warning_with_stderr "Field '$field_name' or option '$field_value' not found in project"
+  # Resolve the first candidate that exists as a field in the project.
+  local matched_name="" field_id="" candidate
+  for candidate in "${candidates[@]}"; do
+    field_id=$(field_id_by_name "$candidate")
+    if [ -n "$field_id" ]; then matched_name="$candidate"; break; fi
+  done
+
+  if [ -z "$field_id" ]; then
+    local tried=""
+    for candidate in "${candidates[@]}"; do
+      tried="${tried:+$tried, }$candidate"
+    done
+    add_warning_with_stderr "Field '$canonical' not found in project for Issue #$ISSUE_NUMBER (tried: $tried)"
+    PROJECT_REG="partial"
+    return 0
+  fi
+
+  # Field name resolved; resolve the option value within it. Reported distinctly
+  # from a field-name resolution failure (option localization is out of scope).
+  local option_id
+  option_id=$(option_id_by_name "$matched_name" "$field_value")
+  if [ -z "$option_id" ]; then
+    add_warning_with_stderr "Option '$field_value' not found in field '$matched_name' for Issue #$ISSUE_NUMBER"
     PROJECT_REG="partial"
     return 0
   fi
 
   # Use retry_with_backoff (3 attempts, exponential backoff) instead of an ad-hoc 1-retry loop.
   if ! retry_with_backoff 3 "$FIELD_ERR_FILE" gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id "$field_id" --single-select-option-id "$option_id" >/dev/null; then
-    add_warning_with_stderr "Failed to set $field_name=$field_value for Issue #$ISSUE_NUMBER after 3 attempts: $(cat "$FIELD_ERR_FILE")"
+    add_warning_with_stderr "Failed to set $matched_name=$field_value for Issue #$ISSUE_NUMBER after 3 attempts: $(cat "$FIELD_ERR_FILE")"
     PROJECT_REG="partial"
   fi
 }

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -926,6 +926,103 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# TC-032 (#1610 AC-1 / T-01 / T-05): Japanese-named Project fields are resolved
+# by the built-in EN<->JA aliases with zero config (no field_names input).
+# --------------------------------------------------------------------------
+echo "TC-032: Japanese field names resolved via built-in aliases (AC-1, zero config)"
+body_file=$(create_body_file "Test jp field names")
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "JP Fields", body_file: $bf},
+  projects: {
+    enabled: true,
+    project_number: 2,
+    owner: "test-owner",
+    status: "Todo",
+    priority: "High",
+    complexity: "M"
+  }
+}')" "jp_field_names"
+if [ "$LAST_RC" -eq 0 ]; then
+  reg=$(json_field '.project_registration')
+  warns_text=$(printf '%s\n' "$LAST_OUTPUT" | jq -r '.warnings[]?' 2>/dev/null)
+  # All three fields set (Status/Priority/Complexity → ステータス/優先度/複雑度).
+  edit_count=$(grep -c "item-edit" "$LAST_GH_LOG" 2>/dev/null || echo 0)
+  if [ "$reg" = "ok" ] && [ "$edit_count" -ge 3 ] \
+     && ! echo "$warns_text" | grep -q "not found"; then
+    pass "JP field names: reg=ok, 3 fields set via aliases, no 'not found' warning"
+  else
+    fail "Expected reg=ok + 3 item-edit + no warning, got reg=$reg, edits=$edit_count, warns='$warns_text'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-033 (#1610 AC-3 / T-03): input field_names mapping takes precedence over
+# the built-in alias — Priority field "重要度" is resolved via the override.
+# --------------------------------------------------------------------------
+echo "TC-033: input field_names mapping overrides built-in alias (AC-3)"
+body_file=$(create_body_file "Test custom field name")
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Custom Field", body_file: $bf},
+  projects: {
+    enabled: true,
+    project_number: 2,
+    owner: "test-owner",
+    status: "Todo",
+    priority: "High",
+    field_names: { priority: "重要度" }
+  }
+}')" "custom_field_name"
+if [ "$LAST_RC" -eq 0 ]; then
+  reg=$(json_field '.project_registration')
+  warns_text=$(printf '%s\n' "$LAST_OUTPUT" | jq -r '.warnings[]?' 2>/dev/null)
+  # Priority resolved via the "重要度" override (the project has no 優先度/Priority field).
+  if [ "$reg" = "ok" ] && ! echo "$warns_text" | grep -q "Field 'Priority' not found"; then
+    pass "Custom field name: reg=ok, Priority resolved via override '重要度'"
+  else
+    fail "Expected reg=ok + no 'Field Priority not found', got reg=$reg, warns='$warns_text'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
+# TC-034 (#1610 AC-4 / T-04): when no candidate field name matches, registration
+# is partial and the warning lists the tried candidate names (alias + canonical).
+# --------------------------------------------------------------------------
+echo "TC-034: unresolvable field → partial + warning lists tried candidates (AC-4)"
+body_file=$(create_body_file "Test missing field")
+run_script "$(jq -n --arg bf "$body_file" '{
+  issue: {title: "Missing Field", body_file: $bf},
+  projects: {
+    enabled: true,
+    project_number: 2,
+    owner: "test-owner",
+    status: "Todo",
+    priority: "High"
+  },
+  options: {non_blocking_projects: true}
+}')" "missing_priority_field"
+if [ "$LAST_RC" -eq 0 ]; then
+  reg=$(json_field '.project_registration')
+  warns_text=$(printf '%s\n' "$LAST_OUTPUT" | jq -r '.warnings[]?' 2>/dev/null)
+  stderr_content=$(cat "$LAST_STDERR" 2>/dev/null)
+  # Warning must name the canonical field and the tried candidates (built-in alias 優先度 + Priority).
+  if [ "$reg" = "partial" ] \
+     && echo "$warns_text" | grep -q "Field 'Priority' not found" \
+     && echo "$warns_text" | grep -q "優先度" \
+     && echo "$warns_text" | grep -q "tried:" \
+     && echo "$stderr_content" | grep -q "ERROR: Projects registration failed:"; then
+    pass "Missing field: reg=partial, warning lists tried candidates (優先度, Priority) + stderr emit"
+  else
+    fail "Expected reg=partial + warning with tried candidates + stderr, got reg=$reg, warns='$warns_text'"
+  fi
+else
+  fail "Expected exit 0, got $LAST_RC"
+fi
+
+# --------------------------------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ $FAIL -gt 0 ]; then

--- a/plugins/rite/scripts/tests/mock-gh.sh
+++ b/plugins/rite/scripts/tests/mock-gh.sh
@@ -24,6 +24,11 @@
 #                              but the iteration assignment mutation fails
 #   "gql_items_lookup_fail"  - GraphQL fields query OK (items.nodes=[]),
 #                              but the GQL_ITEMS_QUERY (items lookup retry) fails
+#   "jp_field_names"         - Project fields use Japanese names (ステータス/優先度/複雑度);
+#                              resolved by the helper's built-in aliases (zero config)
+#   "custom_field_name"      - Priority field named "重要度" (matches an input
+#                              field_names.priority override, not the 優先度 alias)
+#   "missing_priority_field" - Project has no Priority field under any candidate name
 #
 # Scenarios (projects-status-update.sh):
 #   "psu_success"              - Issue in project, Status updated
@@ -349,6 +354,46 @@ ITEMJSON
             }'
           fi
 
+          # Field names default to canonical English. Localized / custom / missing-field
+          # scenarios (Issue #1610) override them so the helper's alias + input-override
+          # resolution is exercised. Option *values* stay English (option localization
+          # is out of scope for #1610).
+          STATUS_FIELD_NAME="Status"
+          PRIORITY_FIELD_NAME="Priority"
+          COMPLEXITY_FIELD_NAME="Complexity"
+          INCLUDE_PRIORITY_FIELD=true
+          case "$SCENARIO" in
+            jp_field_names)
+              # Project uses Japanese field names → resolved by the built-in aliases (zero config).
+              STATUS_FIELD_NAME="ステータス"
+              PRIORITY_FIELD_NAME="優先度"
+              COMPLEXITY_FIELD_NAME="複雑度"
+              ;;
+            custom_field_name)
+              # Priority field is named "重要度" — matches an input field_names.priority
+              # override but NOT the built-in 優先度 alias (exercises override > alias).
+              PRIORITY_FIELD_NAME="重要度"
+              ;;
+            missing_priority_field)
+              # No Priority field under any candidate name (Priority / 優先度 / override).
+              INCLUDE_PRIORITY_FIELD=false
+              ;;
+          esac
+
+          PRIORITY_FIELD_NODE=""
+          if [ "$INCLUDE_PRIORITY_FIELD" = true ]; then
+            PRIORITY_FIELD_NODE=',
+            {
+              "id": "FIELD_PRIORITY",
+              "name": "'"$PRIORITY_FIELD_NAME"'",
+              "options": [
+                {"id": "OPT_HIGH", "name": "High"},
+                {"id": "OPT_MEDIUM", "name": "Medium"},
+                {"id": "OPT_LOW", "name": "Low"}
+              ]
+            }'
+          fi
+
           cat <<EOJSON
 {
   "data": {
@@ -362,25 +407,16 @@ ITEMJSON
           "nodes": [
             {
               "id": "FIELD_STATUS",
-              "name": "Status",
+              "name": "${STATUS_FIELD_NAME}",
               "options": [
                 {"id": "OPT_TODO", "name": "Todo"},
                 {"id": "OPT_INPROGRESS", "name": "In Progress"},
                 {"id": "OPT_DONE", "name": "Done"}
               ]
-            },
-            {
-              "id": "FIELD_PRIORITY",
-              "name": "Priority",
-              "options": [
-                {"id": "OPT_HIGH", "name": "High"},
-                {"id": "OPT_MEDIUM", "name": "Medium"},
-                {"id": "OPT_LOW", "name": "Low"}
-              ]
-            },
+            }${PRIORITY_FIELD_NODE},
             {
               "id": "FIELD_COMPLEXITY",
-              "name": "Complexity",
+              "name": "${COMPLEXITY_FIELD_NAME}",
               "options": [
                 {"id": "OPT_XS", "name": "XS"},
                 {"id": "OPT_S", "name": "S"},

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -7,9 +7,15 @@ github:
     enabled: true
     project_number: null  # Project number (null = auto-detect from repository)
     owner: null           # Project owner (null = use repository owner)
+    # Localized field-name overrides (optional):
+    #   Set `name:` under a field when your Project uses a non-English field name.
+    #   Default (key omitted) resolves via the built-in EN<->JA aliases
+    #   (Status<->ステータス, Priority<->優先度, Complexity<->複雑度), so Japanese-named
+    #   Projects work with zero config. `name:` takes precedence over the alias.
     fields:
       status:
         enabled: true
+        # name: "ステータス"   # optional: actual Status field name in the Project
         options:
           - { name: "Todo", default: true }
           - { name: "In Progress" }
@@ -17,12 +23,14 @@ github:
           - { name: "Done" }
       priority:
         enabled: true
+        # name: "優先度"       # optional: actual Priority field name in the Project
         options:
           - { name: "High" }
           - { name: "Medium", default: true }
           - { name: "Low" }
       complexity:
         enabled: true
+        # name: "複雑度"       # optional: actual Complexity field name in the Project
         options:
           - { name: "XS" }
           - { name: "S" }

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -7,9 +7,15 @@ github:
     enabled: true
     project_number: 1  # cc-rite-workflow project
     owner: "asakaguchi"   # Projects オーナー（user / organization）
+    # フィールド名のローカライズ上書き（任意）:
+    #   Project のフィールド名が英語以外のとき各 field に `name:` を設定する。
+    #   未設定時は helper 内蔵の英日エイリアス（Status↔ステータス, Priority↔優先度,
+    #   Complexity↔複雑度）で解決するため、日本語名 Project もゼロ設定で動作する。
+    #   本リポジトリの Project は英語フィールド名のため `name:` は未設定（既定動作）。
     fields:
       status:
         enabled: true
+        # name: "ステータス"   # 任意: Project 上の Status フィールド名
         options:
           - { name: "Todo", default: true }
           - { name: "In Progress" }
@@ -17,12 +23,14 @@ github:
           - { name: "Done" }
       priority:
         enabled: true
+        # name: "優先度"       # 任意: Project 上の Priority フィールド名
         options:
           - { name: "High" }
           - { name: "Medium", default: true }
           - { name: "Low" }
       complexity:
         enabled: true
+        # name: "複雑度"       # 任意: Project 上の Complexity フィールド名
         options:
           - { name: "XS" }
           - { name: "S" }


### PR DESCRIPTION
## 概要

`create-issue-with-projects.sh` の `set_field` はフィールド名を英語リテラル（`Status`/`Priority`/`Complexity`）で完全一致検索していたため、日本語フィールド名（優先度・複雑度）の Project で「Field not found」となり `partial` 終了していた。

フィールド名解決を**候補リスト方式**に変更し、ゼロ設定で日本語名 Project が動作し、`rite-config.yml` の設定で任意フィールド名へ拡張できるようにする。候補は以下の優先順で評価し、最初に一致したフィールドを解決する:

1. 入力 JSON の `projects.field_names.{status,priority,complexity}`（任意上書き）
2. 内蔵の英日エイリアス（`Status↔ステータス`, `Priority↔優先度`, `Complexity↔複雑度`）
3. 英語正準名

## 関連 Issue

Closes #1610

## 変更内容

- `plugins/rite/scripts/create-issue-with-projects.sh`:
  - `find_field_option` を撤廃し、候補ベースの解決（`field_name_alias` / `field_name_override` / `field_id_by_name` / `option_id_by_name`）へ書き換え
  - 入力 JSON に `projects.field_names`（任意）を additive 追加
  - 解決失敗時は試行候補名を警告に含める。フィールド名解決失敗と option 値解決失敗を区別して報告
- `plugins/rite/commands/issue/create.md`: `rite-config.yml` の `github.projects.fields.{}.name` を読み helper 入力 JSON の `field_names` に配線（AC-5）
- `plugins/rite/templates/config/rite-config.yml` + `rite-config.yml`: フィールド名の任意上書き設定をコメントで追記（既定は内蔵エイリアスのみ）
- `plugins/rite/references/issue-create-with-projects.md`: 入力スキーマに `field_names` を追記（canonical SoT 整合）
- `plugins/rite/scripts/tests/`: 日本語名・入力マッピング優先・解決失敗シナリオを追加

## Acceptance Criteria

- [x] AC-1: 日本語フィールド名で優先度/複雑度が解決・設定される（設定なし、内蔵エイリアスのみ）
- [x] AC-2: 英語フィールド名に回帰がない（既存テスト pass）
- [x] AC-3: 入力 JSON マッピングが内蔵エイリアスより優先（`field_names.priority="重要度"`）
- [x] AC-4: 解決失敗時に試行候補名（英日エイリアス + 正準名）が警告に出る
- [x] AC-5: create.md が config を helper の `field_names` に配線

## Non-goal（スコープ外）

- owner type 判定の修正（#1609 で対応済み）
- option **値**（高/High 等）のローカライズ — フィールド**名**解決に限定
- Iteration フィールド名のローカライズ

## テスト

- `create-issue-with-projects.test.sh`: 37 passed, 0 failed（日本語名 T-01 / マッピング優先 T-03 / 解決失敗候補名警告 T-04 を追加）
- 共有 mock / drift 回帰確認: `projects-status-update` 21/21、`projects-items-fetch` 21/21、`create-md-invocation-symmetry` 25/25
- マニュアル検証: jp_field_names シナリオで FIELD_STATUS/PRIORITY/COMPLEXITY の 3 フィールドがエイリアス経由で解決し `project_registration=ok`

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
