### PR TITLE
fix(pr-cleanup): 4-W の worktree 検出を物理 cwd ベースに頑健化し未記録時の残置を解消

### DIFF
--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -346,11 +346,12 @@ fi
 > **順序**: branch 削除は **worktree 削除後にのみ成功する**（Git 制約: worktree で checkout 中の branch は削除不可）。multi_session 時は必ずステップ 4-W → 本ステップの順で実行する。
 
 ```bash
-# worktree 削除が遅延された場合（ステップ 4-W が WORKTREE_REMOVE_SKIPPED_LIVE_CWD /
-# WORKTREE_REMOVE_FAILED を残した、または in_worktree_unrecorded で自セッションが立つ
-# worktree を消せなかった）、branch は worktree で checkout 中のため削除できない。その場合は
-# 強制削除も無意味なので skip し、残置を marker で surface して遅延 reap / 手動回収に委ねる（#1622）。
-if del_err=$(git branch -d {branch_name} 2>&1); then
+# worktree 削除が遅延/失敗した場合（ステップ 4-W が WORKTREE_REMOVE_SKIPPED_LIVE_CWD /
+# WORKTREE_REMOVE_FAILED を残した場合）、branch は worktree で checkout 中のため削除できない。
+# その場合は強制削除も無意味なので skip し、残置を marker で surface して遅延 reap / 手動回収に
+# 委ねる（#1622）。git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定して substring
+# マッチを安定させる（repo 既存の wiki-lint-*.sh と同規約）。
+if del_err=$(LC_ALL=C git branch -d {branch_name} 2>&1); then
   echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}"
 else
   case "$del_err" in
@@ -367,7 +368,7 @@ fi
 git ls-remote --heads origin {branch_name} && git push origin --delete {branch_name}
 ```
 
-`BRANCH_DELETE_UNMERGED=1`（未マージ変更）のときは「強制削除 (`-D`) / スキップ」を確認する。`BRANCH_DELETE_DEFERRED=1`（worktree checkout 中）のときは**強制削除しない**（worktree 削除後に回収。ステップ 12 で残置を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
+`BRANCH_DELETE_UNMERGED=1`（未マージ変更）のときは「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（worktree checkout 中）のときは**強制削除しない**（worktree 削除後に回収。ステップ 12 で残置を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
 
 ---
 
@@ -570,8 +571,10 @@ Status: {projects_status_result}
     ```
     ℹ️ ローカルブランチ {branch_name} は worktree で checkout 中のため残置しました（worktree 削除の遅延に伴う）。worktree 削除後に手動削除: git branch -D {branch_name}
     ```
-  - `BRANCH_DELETE_FAILED=1` または未解決の `BRANCH_DELETE_UNMERGED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗/保留。`git branch -D {branch_name}` で手動削除」を付記
-  - `BRANCH_DELETED=1` のとき、または上記いずれの `[CONTEXT]` 行も無いとき: `x`
+  - `BRANCH_DELETED=1` のとき（通常削除、または `BRANCH_DELETE_UNMERGED` をユーザーが強制削除 `-D` で解決した場合に emit される。**`BRANCH_DELETE_UNMERGED=1` より先に評価する**）: `x`
+  - `BRANCH_DELETE_FAILED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（worktree で checkout 中なら worktree 削除後）」を付記
+  - `BRANCH_DELETE_UNMERGED=1` のとき（後続に `BRANCH_DELETED=1` が無い = ユーザーが skip 選択）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
+  - いずれの `[CONTEXT]` 行も無いとき: `x`
 - `{projects_status_result}`: `projects_status_updated=true` なら `Done`、false なら `⚠️ 更新失敗（手動確認が必要）`
 - `{review_cleanup_check}`: `REVIEW_CLEANUP_PARTIAL_FAILURE=1` なら ` ` + 警告付記、なければ `x`
 - `{projects_check}`: `projects_status_updated=true` なら `x`、false なら ` ` + 「GitHub Projects 画面で Issue #{issue_number} の Status を Done に変更」を付記

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -573,7 +573,7 @@ Status: {projects_status_result}
     ```
   - `BRANCH_DELETED=1` のとき（通常削除、または `BRANCH_DELETE_UNMERGED` をユーザーが強制削除 `-D` で解決した場合に emit される。**`BRANCH_DELETE_UNMERGED=1` より先に評価する**）: `x`
   - `BRANCH_DELETE_FAILED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（worktree で checkout 中なら worktree 削除後）」を付記
-  - `BRANCH_DELETE_UNMERGED=1` のとき（後続に `BRANCH_DELETED=1` が無い = ユーザーが skip 選択）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
+  - `BRANCH_DELETE_UNMERGED=1` のとき（= ユーザーが skip 選択。強制削除で解決した場合は上位の `BRANCH_DELETED=1` 行で既に `x` 評価済みのため、ここに到達するのは skip 時のみ）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
   - いずれの `[CONTEXT]` 行も無いとき: `x`
 - `{projects_status_result}`: `projects_status_updated=true` なら `Done`、false なら `⚠️ 更新失敗（手動確認が必要）`
 - `{review_cleanup_check}`: `REVIEW_CLEANUP_PARTIAL_FAILURE=1` なら ` ` + 警告付記、なければ `x`

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -268,17 +268,34 @@ ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null
 ms_enabled=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+enabled:/ {print; exit}' \
   | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
 case "$ms_enabled" in true|yes|1) ms_enabled=true ;; *) ms_enabled=false ;; esac
+# worktree_base も読む（物理 cwd 検出時に worktree dir の親 leaf を照合する。#1622）
+ms_base=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+worktree_base:/ {print; exit}' \
+  | sed 's/[[:space:]]#.*//' | sed 's/.*worktree_base:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+[ -n "$ms_base" ] || ms_base=".rite/worktrees"
 flow_wt=$(bash {plugin_root}/hooks/flow-state.sh get --field worktree --default "") || flow_wt=""
 cur_top=$(git rev-parse --show-toplevel 2>/dev/null) || cur_top=""
-if [ "$ms_enabled" = "true" ] && [ -n "$flow_wt" ] && [ "$flow_wt" = "$cur_top" ]; then
-  dirty=$(git status --porcelain 2>/dev/null)
-  echo "[CONTEXT] CLEANUP_WT=in_worktree; worktree=$flow_wt; dirty=$([ -n "$dirty" ] && echo yes || echo no)"
-else
-  echo "[CONTEXT] CLEANUP_WT=$([ "$ms_enabled" = "true" ] && [ -n "$flow_wt" ] && echo in_main || echo none); worktree=$flow_wt"
-fi
+# 検出は helper に委譲する（#1622）。flow-state 未記録（flow_wt 空）でも、物理 cwd が当該
+# Issue の rite セッション worktree（<worktree_base leaf>/issue-{issue_number}）なら
+# in_worktree_unrecorded を返し worktree= に cur_top を導出する。これにより「物理的に
+# worktree 内にいるのに flow-state 未記録 → none で全スキップ → worktree/ブランチ残置」の
+# エアポケットを塞ぐ。
+detect=$(bash {plugin_root}/hooks/scripts/cleanup-worktree-detect.sh \
+  --ms-enabled "$ms_enabled" --flow-wt "$flow_wt" --cur-top "$cur_top" \
+  --issue "{issue_number}" --worktree-base "$ms_base") || detect="CLEANUP_WT=none; worktree=$flow_wt"
+cleanup_wt=${detect#CLEANUP_WT=}; cleanup_wt=${cleanup_wt%%;*}
+flow_wt=${detect##*worktree=}
+case "$cleanup_wt" in
+  in_worktree|in_worktree_unrecorded)
+    dirty=$(git status --porcelain 2>/dev/null)
+    echo "[CONTEXT] CLEANUP_WT=$cleanup_wt; worktree=$flow_wt; dirty=$([ -n "$dirty" ] && echo yes || echo no)"
+    ;;
+  *)
+    echo "[CONTEXT] CLEANUP_WT=$cleanup_wt; worktree=$flow_wt"
+    ;;
+esac
 ```
 
-- `CLEANUP_WT=in_worktree`（cwd がセッション worktree）:
+- `CLEANUP_WT=in_worktree` / `in_worktree_unrecorded`（cwd がセッション worktree。後者は flow-state 未記録だが物理 cwd が当該 Issue の worktree な場合 — #1622。以降の手順 1〜4 は両者で同一）:
   1. `dirty=yes` なら **AskUserQuestion**（「`git stash push` して続行 / 中止」）。stash は common git dir に格納されるため worktree 削除後も `git stash pop` 可能（完了報告の stash 案内は従来文面を流用）。
   2. `ExitWorktree` ツールを `action: "keep"` で呼び出し、main checkout に復帰する（path 入場した worktree は remove でも消えない仕様のため**常に keep**）。
   3. main から worktree を削除する。**削除前に live-cwd guard（Issue #1544）を通す**: 別のセッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、live プロセスが cwd を置いているときは削除せず遅延 reap（`pr-cycle-cleanup.sh` の session worktree reap）へ委譲する:
@@ -296,7 +313,7 @@ fi
      > `in_worktree` 経路ではステップ 2 の `ExitWorktree` で harness cwd が main に退避済みのため、この guard は通常 rc=1（live cwd 不在）で削除へ進む。`worktree-live-cwd.sh` が rc=2（`/proc` も `lsof` も無い環境で判定不能）を返す場合は `if` が false となり従来どおり削除を実行する（後方互換）。
   4. 削除失敗（`WORKTREE_REMOVE_FAILED`）または live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の live-cwd guard が特に重要。
-- `CLEANUP_WT=none`（multi_session 無効 or worktree 未記録）: 4-W 全体を no-op でスキップ。
+- `CLEANUP_WT=none`（multi_session 無効、または worktree 関連なし = 物理 cwd も当該 Issue の worktree でない）: 4-W 全体を no-op でスキップ。**注**: flow-state 未記録でも物理 cwd が当該 Issue の worktree なら `in_worktree_unrecorded` に分類されここには落ちない（#1622）。
 
 > **復旧: `/clear` が `Path does not exist` で失敗する場合（Issue #1552）**
 > セッション worktree（`.rite/worktrees/issue-{N}`）が遅延 reap または手動削除で消えた後、所有セッションをハーネスが resume すると cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗することがある。`pr-cycle-cleanup.sh` の worktree liveness guard（Issue #1524/#1544/#1552）はこれを予防するが、ハーネスの cwd レコード自体は rite から intercept できないため、万一発生した場合は次のいずれかで復旧する:
@@ -329,11 +346,28 @@ fi
 > **順序**: branch 削除は **worktree 削除後にのみ成功する**（Git 制約: worktree で checkout 中の branch は削除不可）。multi_session 時は必ずステップ 4-W → 本ステップの順で実行する。
 
 ```bash
-git branch -d {branch_name}
+# worktree 削除が遅延された場合（ステップ 4-W が WORKTREE_REMOVE_SKIPPED_LIVE_CWD /
+# WORKTREE_REMOVE_FAILED を残した、または in_worktree_unrecorded で自セッションが立つ
+# worktree を消せなかった）、branch は worktree で checkout 中のため削除できない。その場合は
+# 強制削除も無意味なので skip し、残置を marker で surface して遅延 reap / 手動回収に委ねる（#1622）。
+if del_err=$(git branch -d {branch_name} 2>&1); then
+  echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}"
+else
+  case "$del_err" in
+    *"used by worktree"*|*"checked out"*)
+      echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree" >&2
+      echo "WARNING: ローカルブランチ {branch_name} はセッション worktree で checkout 中のため削除を skip しました（worktree 削除の遅延に伴う残置）。worktree 削除後に手動削除してください: git branch -D {branch_name}" >&2 ;;
+    *"not fully merged"*)
+      echo "[CONTEXT] BRANCH_DELETE_UNMERGED=1; branch={branch_name}" >&2 ;;
+    *)
+      echo "[CONTEXT] BRANCH_DELETE_FAILED=1; branch={branch_name}" >&2
+      echo "WARNING: ローカルブランチ {branch_name} の削除に失敗しました: $del_err" >&2 ;;
+  esac
+fi
 git ls-remote --heads origin {branch_name} && git push origin --delete {branch_name}
 ```
 
-ローカル削除が未マージ変更で失敗したら「強制削除 (`-D`) / スキップ」を確認。リモート削除は GitHub auto-delete で既削除のエラーは無視。
+`BRANCH_DELETE_UNMERGED=1`（未マージ変更）のときは「強制削除 (`-D`) / スキップ」を確認する。`BRANCH_DELETE_DEFERRED=1`（worktree checkout 中）のときは**強制削除しない**（worktree 削除後に回収。ステップ 12 で残置を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
 
 ---
 
@@ -506,7 +540,7 @@ Status: {projects_status_result}
 実行した処理:
 - [x] base ブランチを更新 (fetch + merge --ff-only)
 - [{session_worktree_check}] セッション worktree 退出・削除 (multi_session)
-- [x] ローカル/リモートブランチ削除
+- [{local_branch_check}] ローカル/リモートブランチ削除
 - [{review_cleanup_check}] PR-specific state ファイル削除
 - [{projects_check}] Projects Status を Done に更新
 - [{wiki_ingest_check}] Wiki ingest (pending raw source のページ統合)
@@ -531,6 +565,13 @@ Status: {projects_status_result}
       手動削除: git worktree remove --force {flow_wt} && git worktree prune
     ```
   - いずれの `[CONTEXT]` 行も無い（削除成功）とき: `x`
+- `{local_branch_check}`: ステップ 5 の `[CONTEXT]` 行で判定（上から評価し最初に一致したものを採用）:
+  - `BRANCH_DELETE_DEFERRED=1` のとき（worktree で checkout 中のため削除 skip — worktree 削除の遅延に伴う残置。#1622）: ` ` + 以下を付記
+    ```
+    ℹ️ ローカルブランチ {branch_name} は worktree で checkout 中のため残置しました（worktree 削除の遅延に伴う）。worktree 削除後に手動削除: git branch -D {branch_name}
+    ```
+  - `BRANCH_DELETE_FAILED=1` または未解決の `BRANCH_DELETE_UNMERGED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗/保留。`git branch -D {branch_name}` で手動削除」を付記
+  - `BRANCH_DELETED=1` のとき、または上記いずれの `[CONTEXT]` 行も無いとき: `x`
 - `{projects_status_result}`: `projects_status_updated=true` なら `Done`、false なら `⚠️ 更新失敗（手動確認が必要）`
 - `{review_cleanup_check}`: `REVIEW_CLEANUP_PARTIAL_FAILURE=1` なら ` ` + 警告付記、なければ `x`
 - `{projects_check}`: `projects_status_updated=true` なら `x`、false なら ` ` + 「GitHub Projects 画面で Issue #{issue_number} の Status を Done に変更」を付記

--- a/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
+++ b/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
@@ -61,7 +61,9 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$worktree_base" ] || worktree_base=".rite/worktrees"
-wt_leaf=$(basename "$worktree_base")
+# Normalize so the suffix compare is exact: strip a leading `./` and any trailing `/`.
+wt_base_norm=${worktree_base#./}
+wt_base_norm=${wt_base_norm%/}
 
 state="none"
 worktree="$flow_wt"
@@ -69,13 +71,21 @@ worktree="$flow_wt"
 if [ "$ms_enabled" = "true" ]; then
   if [ -n "$flow_wt" ] && [ "$flow_wt" = "$cur_top" ]; then
     state="in_worktree"
-  elif [ -z "$flow_wt" ] && [ -n "$cur_top" ] && [ -n "$issue" ] \
-       && [ "$(basename "$cur_top")" = "issue-${issue}" ] \
-       && [ "$(basename "$(dirname "$cur_top")")" = "$wt_leaf" ]; then
+  elif [ -z "$flow_wt" ] && [ -n "$cur_top" ] && [ -n "$issue" ]; then
     # Physical derivation (#1622): cwd IS this issue's rite session worktree even
-    # though flow-state never recorded it. Route as in_worktree, flagged unrecorded.
-    state="in_worktree_unrecorded"
-    worktree="$cur_top"
+    # though flow-state never recorded it. Match the FULL configured tail
+    # `<worktree_base>/issue-<issue>`, NOT just the leaf — so an unrelated parent
+    # dir that merely shares the base leaf (e.g. `/x/UNRELATED/worktrees/issue-N`)
+    # cannot false-match, and a sibling issue (`issue-12` vs `issue-1`) cannot
+    # prefix-match. A relative base matches as a suffix of the absolute cur_top; an
+    # absolute base matches by exact equality. Route as in_worktree, flagged unrecorded.
+    expected_tail="${wt_base_norm}/issue-${issue}"
+    case "$cur_top" in
+      "$expected_tail"|*/"$expected_tail")
+        state="in_worktree_unrecorded"
+        worktree="$cur_top"
+        ;;
+    esac
   elif [ -n "$flow_wt" ]; then
     state="in_main"
   fi

--- a/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
+++ b/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# cleanup-worktree-detect.sh — classify cleanup.md ステップ 4-W's session-worktree
+# state from pre-resolved inputs, deriving the worktree path from the PHYSICAL cwd
+# when flow-state did not record it.
+#
+# Why this exists (Issue #1622):
+#   ステップ 4-W previously trusted ONLY flow-state's `worktree` field (`flow_wt`)
+#   as the source of truth for "am I in a session worktree?". When a session runs
+#   physically inside `.rite/worktrees/issue-{N}` but flow-state never recorded
+#   that path (path-entered a worktree another session created, post-reset
+#   flow-state, or a worktree-記録漏れ), the equality test `flow_wt == cur_top`
+#   was false with `flow_wt` empty, so 4-W classified `none` and skipped the whole
+#   step. The worktree + its checked-out local branch then fell into an air-pocket:
+#   neither the in-session removal (4-W skipped) nor the lazy reap
+#   (pr-cycle-cleanup.sh Step 5 self-excludes the running session's own worktree)
+#   handled them, and the lazy reap never deletes branches — so the local branch
+#   leaked permanently.
+#
+#   This helper adds a PHYSICAL derivation: with `flow_wt` empty but `cur_top`
+#   shaped like the rite session worktree for THIS issue
+#   (`<worktree_base_leaf>/issue-{issue}`), it derives `flow_wt = cur_top` and
+#   reports `in_worktree_unrecorded` — routed identically to `in_worktree` by the
+#   caller, but distinguished so the completion report can note the unrecorded
+#   detection.
+#
+# Pure path logic (no git / filesystem dependency) so it is unit-testable with
+# synthetic paths. The caller still performs the dirty check and the live-cwd
+# guard against the returned worktree path.
+#
+# Usage:
+#   cleanup-worktree-detect.sh --ms-enabled <true|false> --flow-wt <path> \
+#     --cur-top <path> --issue <N> [--worktree-base <rel|abs path>]
+#
+# Output (stdout, single line):
+#   CLEANUP_WT=<none|in_main|in_worktree|in_worktree_unrecorded>; worktree=<path>
+#
+# State semantics (matches cleanup.md ステップ 4-W routing):
+#   none                    multi_session off, or no worktree association
+#   in_main                 flow-state records a worktree but cwd is elsewhere
+#                           (resume / main checkout)
+#   in_worktree             flow-state records a worktree and cwd is in it
+#   in_worktree_unrecorded  flow-state empty, but cwd is physically this issue's
+#                           rite session worktree (#1622 derivation)
+set -euo pipefail
+
+ms_enabled=""
+flow_wt=""
+cur_top=""
+issue=""
+worktree_base=".rite/worktrees"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ms-enabled)     ms_enabled="${2:-}"; shift 2 ;;
+    --flow-wt)        flow_wt="${2:-}"; shift 2 ;;
+    --cur-top)        cur_top="${2:-}"; shift 2 ;;
+    --issue)          issue="${2:-}"; shift 2 ;;
+    --worktree-base)  worktree_base="${2:-}"; shift 2 ;;
+    *)                shift ;;
+  esac
+done
+
+[ -n "$worktree_base" ] || worktree_base=".rite/worktrees"
+wt_leaf=$(basename "$worktree_base")
+
+state="none"
+worktree="$flow_wt"
+
+if [ "$ms_enabled" = "true" ]; then
+  if [ -n "$flow_wt" ] && [ "$flow_wt" = "$cur_top" ]; then
+    state="in_worktree"
+  elif [ -z "$flow_wt" ] && [ -n "$cur_top" ] && [ -n "$issue" ] \
+       && [ "$(basename "$cur_top")" = "issue-${issue}" ] \
+       && [ "$(basename "$(dirname "$cur_top")")" = "$wt_leaf" ]; then
+    # Physical derivation (#1622): cwd IS this issue's rite session worktree even
+    # though flow-state never recorded it. Route as in_worktree, flagged unrecorded.
+    state="in_worktree_unrecorded"
+    worktree="$cur_top"
+  elif [ -n "$flow_wt" ]; then
+    state="in_main"
+  fi
+fi
+
+echo "CLEANUP_WT=${state}; worktree=${worktree}"

--- a/plugins/rite/hooks/tests/cleanup-worktree-detect.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-worktree-detect.test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Tests for cleanup-worktree-detect.sh — cleanup.md ステップ 4-W の session-worktree
+# 検出を物理 cwd ベースに頑健化する純粋ロジック (Issue #1622)。
+#
+#   AC-1 (T-01): flow-state 未記録でも物理 cwd が当該 Issue の worktree なら
+#                in_worktree_unrecorded を返し worktree= に cur_top を導出する。
+#   AC-3 (T-03): flow_wt 記録ありで cwd 一致 → 従来どおり in_worktree（後方互換）。
+#   AC-4 (T-04): flow_wt 記録あり but cwd 不一致 → in_main / multi_session 無効 → none。
+#   AC-5 (T-05): cur_top 空 → 物理導出を発火させず none（安全側）。
+#   AC-6 (T-06): cwd が別 Issue の worktree（issue-M, M≠N）→ 導出しない（none）。
+#   境界: cwd が main checkout（worktree でない）+ flow_wt 空 → none。
+#         worktree_base が既定以外でも leaf を照合して導出する。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+DETECT="$SCRIPT_DIR/../scripts/cleanup-worktree-detect.sh"
+
+# Helper: run detect and return the bare CLEANUP_WT state token.
+detect_state() {
+  bash "$DETECT" "$@" | sed 's/CLEANUP_WT=\([^;]*\);.*/\1/'
+}
+# Helper: run detect and return the derived worktree= value.
+detect_wt() {
+  bash "$DETECT" "$@" | sed 's/.*worktree=//'
+}
+
+WT="/repo/.rite/worktrees/issue-1622"
+
+# --- TC-1 (AC-1, T-01): unrecorded physical worktree ---
+echo "=== TC-1: flow_wt empty + cwd is this issue's worktree → in_worktree_unrecorded ==="
+assert "TC-1 state" "in_worktree_unrecorded" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "$WT" --issue 1622)"
+assert "TC-1 derives cur_top into worktree=" "$WT" \
+  "$(detect_wt --ms-enabled true --flow-wt "" --cur-top "$WT" --issue 1622)"
+
+# --- TC-2 (AC-3, T-03): recorded worktree, cwd matches → in_worktree (backward compat) ---
+echo "=== TC-2: flow_wt recorded + cwd matches → in_worktree ==="
+assert "TC-2 state" "in_worktree" \
+  "$(detect_state --ms-enabled true --flow-wt "$WT" --cur-top "$WT" --issue 1622)"
+
+# --- TC-3 (AC-4, T-04a): recorded worktree, cwd is main → in_main ---
+echo "=== TC-3: flow_wt recorded + cwd is main checkout → in_main ==="
+assert "TC-3 state" "in_main" \
+  "$(detect_state --ms-enabled true --flow-wt "$WT" --cur-top "/repo" --issue 1622)"
+assert "TC-3 keeps recorded worktree=" "$WT" \
+  "$(detect_wt --ms-enabled true --flow-wt "$WT" --cur-top "/repo" --issue 1622)"
+
+# --- TC-4 (AC-4, T-04b): multi_session disabled → none ---
+echo "=== TC-4: ms_enabled=false → none (even when physically in a worktree) ==="
+assert "TC-4 state" "none" \
+  "$(detect_state --ms-enabled false --flow-wt "" --cur-top "$WT" --issue 1622)"
+
+# --- TC-5 (AC-5, T-05): cur_top empty → none, no derivation ---
+echo "=== TC-5: cur_top empty → none (no physical derivation) ==="
+assert "TC-5 state" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "" --issue 1622)"
+
+# --- TC-6 (AC-6, T-06): cwd is a DIFFERENT issue's worktree → none ---
+echo "=== TC-6: cwd is issue-9999 but target is 1622 → none (no cross-issue match) ==="
+assert "TC-6 state" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/issue-9999" --issue 1622)"
+
+# --- TC-7 (boundary): cwd is main checkout (not a worktree) + flow_wt empty → none ---
+echo "=== TC-7: flow_wt empty + cwd is main checkout (not a worktree) → none ==="
+assert "TC-7 state" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo" --issue 1622)"
+
+# --- TC-8 (boundary): custom worktree_base leaf is honored ---
+echo "=== TC-8: custom worktree_base leaf → still derives in_worktree_unrecorded ==="
+assert "TC-8 state" "in_worktree_unrecorded" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.custom/wt/issue-1622" --issue 1622 --worktree-base ".custom/wt")"
+
+# --- TC-9 (boundary): right leaf but wrong dir name (not issue-N) → none ---
+echo "=== TC-9: parent leaf=worktrees but dir is not issue-{N} → none ==="
+assert "TC-9 state" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/scratch" --issue 1622)"
+
+print_summary "cleanup-worktree-detect.test.sh"

--- a/plugins/rite/hooks/tests/cleanup-worktree-detect.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-worktree-detect.test.sh
@@ -39,6 +39,8 @@ assert "TC-1 derives cur_top into worktree=" "$WT" \
 echo "=== TC-2: flow_wt recorded + cwd matches → in_worktree ==="
 assert "TC-2 state" "in_worktree" \
   "$(detect_state --ms-enabled true --flow-wt "$WT" --cur-top "$WT" --issue 1622)"
+assert "TC-2 keeps recorded worktree=" "$WT" \
+  "$(detect_wt --ms-enabled true --flow-wt "$WT" --cur-top "$WT" --issue 1622)"
 
 # --- TC-3 (AC-4, T-04a): recorded worktree, cwd is main → in_main ---
 echo "=== TC-3: flow_wt recorded + cwd is main checkout → in_main ==="
@@ -76,5 +78,32 @@ assert "TC-8 state" "in_worktree_unrecorded" \
 echo "=== TC-9: parent leaf=worktrees but dir is not issue-{N} → none ==="
 assert "TC-9 state" "none" \
   "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/scratch" --issue 1622)"
+
+# --- TC-10 (AC-6 regression): issue-number prefix collision must NOT match ---
+# issue-12 is NOT this session's worktree when the target issue is 1; the full-tail
+# match (`.rite/worktrees/issue-1`) must not prefix-match `.../issue-12`.
+echo "=== TC-10: cur_top is issue-12 but target is issue-1 → none (no prefix match) ==="
+assert "TC-10 state (issue-1 vs issue-12)" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/issue-12" --issue 1)"
+assert "TC-10 state (issue-12 self matches)" "in_worktree_unrecorded" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/issue-12" --issue 12)"
+
+# --- TC-11 (boundary): absolute worktree_base matches by exact tail equality ---
+echo "=== TC-11: absolute worktree_base → derives in_worktree_unrecorded ==="
+assert "TC-11 state (abs base)" "in_worktree_unrecorded" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/abs/wt/issue-1622" --issue 1622 --worktree-base "/abs/wt")"
+
+# --- TC-12 (F3 regression): unrelated parent sharing only the base leaf must NOT match ---
+# `/repo/UNRELATED/worktrees/issue-1622` shares the leaf `worktrees` with base
+# `expected/worktrees` but the full tail `expected/worktrees/issue-1622` does not
+# match — the helper matches the configured tail, not just the leaf.
+echo "=== TC-12: unrelated parent with matching leaf only → none ==="
+assert "TC-12 state (leaf-only false-positive rejected)" "none" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/UNRELATED/worktrees/issue-1622" --issue 1622 --worktree-base "expected/worktrees")"
+
+# --- TC-13 (boundary): leading ./ and trailing / in worktree_base are normalized ---
+echo "=== TC-13: worktree_base with ./ prefix and trailing / is normalized ==="
+assert "TC-13 state (normalized base)" "in_worktree_unrecorded" \
+  "$(detect_state --ms-enabled true --flow-wt "" --cur-top "/repo/.rite/worktrees/issue-1622" --issue 1622 --worktree-base "./.rite/worktrees/")"
 
 print_summary "cleanup-worktree-detect.test.sh"


### PR DESCRIPTION
## 概要

`/rite:pr:cleanup` のステップ 4-W（セッション worktree の退出・削除）は、worktree 在否を flow-state の `worktree` 記録（`flow_wt`）への完全一致のみで判定していた。そのため、セッションが物理的に `.rite/worktrees/issue-{N}` 内で動作していても flow-state に未記録だと `CLEANUP_WT=none` と判定され 4-W 全体が no-op スキップされ、worktree・ローカルブランチ・base 更新が「即時処理も遅延 reap（self-exclusion）もされない」エアポケットに落ちていた。遅延 reap は branch を削除しない設計のため、merged 済みローカルブランチが恒久リークしていた。

本 PR は 4-W の検出を**物理 cwd ベース**に頑健化し、flow-state 未記録でも物理的に worktree 内にいれば検出・処理する。

## 関連 Issue

Closes #1622

## 変更内容

- **新規** `plugins/rite/hooks/scripts/cleanup-worktree-detect.sh`: 4-W 検出を純粋ロジック化（git 非依存・ユニットテスト可能）。`flow_wt` 空でも `cur_top` が当該 Issue の worktree（`<worktree_base leaf>/issue-{N}`）なら `in_worktree_unrecorded` を返し worktree= に `cur_top` を導出する。
- `plugins/rite/commands/pr/cleanup.md`:
  - 4-W は検出を helper に委譲し、`in_worktree_unrecorded` を `in_worktree` と同経路で処理（worktree_base もパースして leaf 照合）。
  - ステップ 5: worktree checkout 中で `git branch -d` が失敗した場合に `BRANCH_DELETE_DEFERRED` を surface し、強制削除せず残置を報告（未マージ/その他の失敗とも区別）。
  - ステップ 12: 完了報告にローカルブランチ残置（`local_branch_check`）の判定と手動コマンド案内を追加。
- **新規** `plugins/rite/hooks/tests/cleanup-worktree-detect.test.sh`: 検出 9 ケース（T-01〜T-07 + 境界 2 件）を回帰固定。

## テスト

- 新規ヘルパーのユニットテスト 11 アサーション green。
- `plugins/rite/hooks/tests/run-tests.sh` 全 77 テスト green（新規テストを含む、回帰なし）。
- プラグイン品質チェック群（drift / bash-heaviness / comment-journal / orphan-reference / sh-cross-ref 等）で本変更による新規 warning ゼロ（既存 findings はすべて他ファイル由来で範囲外）。

## 後方互換

- 既存の検出経路（`in_worktree` / `in_main` / `none`）は不変。物理導出は `flow_wt` が空のときのみ発火する additive な分岐。
- multi_session 無効時は従来どおり 4-W を no-op スキップ。

## Definition of Done（マージ時に検証）

- [x] 全 MUST 要件の実装
- [x] 全 Acceptance Criteria（AC-1〜AC-7）に対応
- [x] 全テストケース（T-01〜T-07）green
- [x] 既存機能の回帰なし（in_worktree / in_main / none 既存経路）
- [x] 対象ファイルのみ変更・非対象ファイル不変
- [x] プロジェクト規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)
