### PR TITLE
fix(pr-open): ステップ 2.4 に親 Issue ステータス更新(§2.4.7)の発火を表面化

### DIFF
--- a/plugins/rite/commands/pr/open.md
+++ b/plugins/rite/commands/pr/open.md
@@ -296,7 +296,17 @@ fi
 
 ### 2.4 GitHub Projects Status 更新
 
-`rite-config.yml.github.projects.enabled: true` の場合、Projects の Status を `In Progress` に更新。詳細は `../../references/projects-integration.md` 参照。
+`rite-config.yml.github.projects.enabled: true` の場合、以下の **2 種類** の Status 更新を実行する。いずれも詳細ロジックは `../../references/projects-integration.md` を参照し、本コマンドに**複製しない**（DRY）。
+
+**(A) 着手 Issue 自身の Status 更新** — 着手した Issue (`{issue_number}`) 自身の Projects Status を `In Progress` に更新する（`projects-status-update.sh` 経由、§2.4.1–2.4.6）。
+
+**(B) 親 Issue の Status 更新（Sub-Issue 着手時、§2.4.7）** — `{issue_number}` が Sub-Issue の場合、**親 Issue の Status も In Progress に遷移させる**。これは省略不可の必須処理であり、(A) と独立に必ず実行する。ロジックは `projects-integration.md` §2.4.7 を実行する（open.md には複製しない）:
+
+1. **§2.4.7.1 親検出（3-method OR）** を必ず実行する: `## 親 Issue` body meta（PRIMARY）→ Sub-Issues API → tasklist search の順で親を検出する。この 3-method 構造は `../issue/close.md` Phase 4.5.1 と同一に保つ（method 順序・OR 意味・total-failure 時の `[DEBUG] parent not detected` emit を揃える。Method 3 の `--state open` は start 側固有の意図的差異）。
+2. 親が検出されたら **§2.4.7.2–2.4.7.4** を実行する: 親の Projects item / 現 Status を取得し、Status が **Todo または null（未設定）のときのみ** In Progress に更新する。親が既に **In Progress / In Review / Done** のときは上書きしない（sibling child による進捗を保持する）。
+3. 親が見つからない standalone Issue では `[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)` を emit して skip する（**silent skip 禁止**）。
+
+(B) はすべて non-blocking（親検出 / 親更新の失敗・親の Project 未登録は着手フローをブロックしない）。API 呼び出しの詳細とエラーハンドリングは §2.4.7 を参照する（複製しない）。
 
 ### 2.5 Work Memory 初期化
 


### PR DESCRIPTION
## 概要

`/rite:pr:open` で Sub-Issue を着手したとき、親 Issue の GitHub Projects ステータスが Todo のまま In Progress に遷移しない問題を修正する。

親ステータス更新ロジック（`references/projects-integration.md` §2.4.7）は既に完全実装されているが、`commands/pr/open.md` ステップ 2.4 が「Status を In Progress に更新」の 1 行のみで、§2.4.7 の発火がコマンド表面に一切現れていなかった（**根本原因 (A): 命令の表面化不足**）。そのため orchestrator が着手 Issue 自身のステータスのみ更新し、親 Issue 更新を発火させていなかった。

## 根本原因の確定（再現で確認）

| 候補 | 判定 | 根拠 |
|------|------|------|
| (A) 命令の表面化不足 | ✅ **確定** | open.md ステップ 2.4 が 1 行のみで §2.4.7 を参照していない |
| (B) Method 1 grep 不具合 | ❌ 除外 | 分解パス body サンプルから親番号を正しく抽出できることを確認 |
| (C) 親 Project 未登録 | ❌ 除外 | 対象 Issue は Project 登録済み |

## 変更内容

- `plugins/rite/commands/pr/open.md` ステップ 2.4 を、**(A) 着手 Issue 自身**の更新と **(B) 親 Issue (§2.4.7)** の更新の 2 種類として明示的に表面化
  - (B) は §2.4.7.1（3-method OR 親検出）→ §2.4.7.2–2.4.7.4（Todo/null のときのみ In Progress 化）を実行する必須処理として記述
  - 検出・更新ロジックは §2.4.7 を**参照**し、open.md には複製しない（DRY / シンプルさを死守）
  - `close.md` Phase 4.5.1 と同一の 3-method 構造・OR 意味・`[DEBUG] parent not detected` emit を維持する旨を明記（AC-7）

## 関連 Issue

Closes #1628

### 実装中に検出した問題（別 Issue として追跡）

- #1629: Method 3（tasklist search）親検出が standalone Issue で自己/無関係 Issue を誤検出する（GitHub code search の `[`/`]` 不安定性に起因）。本 PR のスコープ外（Non-goal「3-method 検出構造の再設計」に該当、既存挙動）のため follow-up として分離・Projects 登録済み

## 受入基準

- AC-1〜AC-4・AC-6: §2.4.7 の発火を表面化（参照）することで担保
- AC-5（standalone → DEBUG emit）の信頼性は #1629 で担保
- AC-7: close.md Phase 4.5.1 と同一構造を維持する旨を明記

## テスト

本リポは `commands.test: null` / `tdd.enabled: false`（markdown 中心）のため、手動再現と open.md/close.md の突き合わせで検証。plugin 固有 lint チェック（distributed-fix-drift / hardcoded-line-number / sh-cross-ref / bash-heaviness 等）は本変更に起因する findings ゼロ。

## チェックリスト

- [x] 仕様（§2.4.7）への参照で命令を表面化（ロジック複製なし）
- [x] close.md Phase 4.5.1 との整合を維持
- [x] 非対象ファイル（close.md / projects-status-update.sh / projects-integration.md）は無変更
- [x] follow-up Issue (#1629) を Projects 登録

---

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
