### PR TITLE
fix(close): Phase 4.5.1 の DEBUG 文言を methods tried: に統一

### DIFF
--- a/plugins/rite/commands/issue/close.md
+++ b/plugins/rite/commands/issue/close.md
@@ -408,7 +408,7 @@ echo "method3_parent=${parent_number:-none}"
 **3 method すべて失敗（`parent_number` 空）の場合**は standalone として処理する（AC-4 — 正常動作。silent-skip 回帰検出のため debug log は残す）:
 
 ```bash
-echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods: body_meta, sub_issues_api, tasklist_search)"
+echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"
 ```
 
 `親 Issue の参照が見つかりませんでした。親 Issue 更新をスキップします。` を表示し、Phase 4.5 残り + Phase 4.6 をスキップして Phase 5 へ。


### PR DESCRIPTION
## 概要

`commands/issue/close.md` Phase 4.5.1 の standalone DEBUG emit が `(methods: ...)` となっており、`references/projects-integration.md` §2.4.7.1 / `commands/pr/open.md` ステップ 2.4 の `(methods tried: ...)` と「tried」の有無で不一致だった。3 サイトで逐語一致させる。

Closes #1631

## 変更内容

- `plugins/rite/commands/issue/close.md` Phase 4.5.1 の DEBUG emit を `(methods:` → `(methods tried:` に変更

## 検証

3 サイトの DEBUG emit が逐語一致することを確認:

```
[close.md]:        processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)
[projects-int.md]: processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)
[open.md]:         processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)
```

§2.4.7.1 の consistency requirement が要求する total-failure 時の `[DEBUG] parent not detected` emission の 3 サイト一致を満たし、grep 横断集計の決定論性を回復する。

## Definition of Done

- [x] close.md Phase 4.5.1 の DEBUG 文言が `methods tried:` に統一されている
- [x] 3 サイト（projects-integration.md / open.md / close.md）で DEBUG emit が逐語一致
