### PR TITLE
docs(projects-integration): §2.4.7 の skip silently と §2.4.7.1 silent skip 禁止の内部矛盾を解消

### DIFF
--- a/plugins/rite/references/projects-integration.md
+++ b/plugins/rite/references/projects-integration.md
@@ -114,7 +114,7 @@ gh project item-edit --project-id {project_id} --id {item_id} --field-id {status
 
 ### 2.4.7 Parent Issue Status Update (for child Issues)
 
-**Execution condition**: Always execute 2.4.7.1 (parent detection). If a parent is found, proceed to 2.4.7.2–2.4.7.4. If no parent is found, skip silently (this is normal for standalone Issues).
+**Execution condition**: Always execute 2.4.7.1 (parent detection). If a parent is found, proceed to 2.4.7.2–2.4.7.4. If no parent is found, emit the `[DEBUG] parent not detected` log (per 2.4.7.1 — silent skips are prohibited) and then skip 2.4.7.2–2.4.7.4 (this is the normal path for standalone Issues).
 
 **Non-blocking**: All steps in 2.4.7 are non-blocking. Any failure displays a warning and continues the workflow.
 
@@ -288,8 +288,8 @@ Parent Issue Status update failure does **not** block the start of work. Each st
 
 | Step | Error Case | Response |
 |------|-----------|----------|
-| 2.4.7.1 | Sub-Issues API fails | Try Tasklist fallback. If both fail, skip silently |
-| 2.4.7.1 | Tasklist search returns no results | Skip silently (standalone Issue) |
+| 2.4.7.1 | Sub-Issues API fails | Try Tasklist fallback. If both fail, emit `[DEBUG] parent not detected` and skip (per 2.4.7.1 — silent skips prohibited) |
+| 2.4.7.1 | Tasklist search returns no results | Emit `[DEBUG] parent not detected` and skip (standalone Issue — per 2.4.7.1, not silent) |
 | 2.4.7.2 | GraphQL query fails | Display `警告: 親 Issue の Projects 情報取得に失敗しました。Status 更新をスキップします` |
 | 2.4.7.2 | Parent not registered in Project | Display warning and skip (see 2.4.7.2) |
 | 2.4.7.4 | field-list fails | Display `警告: Status フィールド情報の取得に失敗しました` and skip |


### PR DESCRIPTION
## 概要

`references/projects-integration.md` §2.4.7 内で standalone 時の挙動記述が矛盾していた。§2.4.7 Execution condition（L117）と §2.4.7.5 Error Handling（L291/L292）は `skip silently` を指示する一方、§2.4.7.1（When all three methods failed）は `silent skips are prohibited` として `[DEBUG] parent not detected` の emit を要求していた。正しい挙動は §2.4.7.1 側（DEBUG emit してから skip、standalone は正常動作）。

Closes #1632

## 変更内容

§2.4.7 内の矛盾する 3 箇所を §2.4.7.1 と整合させた:

- **L117**（Execution condition）: `skip silently` → `emit the [DEBUG] parent not detected log (per 2.4.7.1 — silent skips are prohibited) and then skip`
- **L291**（Error Handling: Sub-Issues API fails）: `skip silently` → `emit [DEBUG] parent not detected and skip (per 2.4.7.1 — silent skips prohibited)`
- **L292**（Error Handling: Tasklist no results）: `Skip silently (standalone Issue)` → `Emit [DEBUG] parent not detected and skip (standalone Issue — per 2.4.7.1, not silent)`

## スコープ判断

Issue の In Scope は L117 を主対象とするが、§2.4.7.5（L291/L292）も **同一の内部矛盾**（standalone 時に silent skip するか DEBUG emit するか）であり、タイトル「§2.4.7 の skip silently と §2.4.7.1 silent skip 禁止の内部矛盾を解消」が §2.4.7 全体を scoping している。L117 だけ修正すると §2.4.7.5 が §2.4.7.1 と矛盾したまま残り「内部矛盾の解消」が不完全になるため、§2.4.7 内の 3 箇所を一括整合した。

## スコープ外（変更なし）

- §2.4.7.1 の検出ロジック・DEBUG emit 文言そのもの（こちらが正）
- close.md / open.md（既に DEBUG emit 側で正）

## 検証

§2.4.7 内に矛盾する `skip silently` が残っていないことを grep で確認。4 箇所すべて（L117/L188/L291/L292）が「silent skips prohibited / DEBUG emit」で一貫。

## Definition of Done

- [x] §2.4.7 L117 が §2.4.7.1（silent skip 禁止・DEBUG emit）と矛盾しない記述になっている
- [x] §2.4.7.5（L291/L292）も同様に整合（内部矛盾の完全解消）
