### PR TITLE
fix(release): Phase 1 の最新タグ判定を到達可能性非依存にする

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -62,6 +62,12 @@ gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" \
 
 ## Phase 1: リリース情報の確認
 
+> **タグ同期（最新タグ判定の前に必須）**: リリースタグは Phase 3.3 で `--target main`（develop→main マージコミット）に付与されるため、develop からは到達不可能。`git describe --tags --abbrev=0` は HEAD から到達可能なタグしか返さず develop 上では古いタグを拾うため、最新タグの判定には使わない。最新タグは到達可能性に依存しないバージョン順（`git tag --sort=-v:refname`）で判定する。判定の前にリモートのタグをローカルへ同期しておく（ネットワーク不通でもリリースをブロックしない）:
+>
+> ```bash
+> git fetch --tags --force origin >/dev/null 2>&1 || true
+> ```
+
 ### 1.1 現在のバージョン確認
 
 ```bash
@@ -73,7 +79,7 @@ echo "Current version: $current_version"
 
 ユーザーがバージョンを指定していない場合、以下を確認して提案する：
 
-1. `git log $(git describe --tags --abbrev=0)..develop --oneline` で前回リリースからの変更を確認
+1. 前回リリースからの変更を確認: `latest_tag=$(git tag --sort=-v:refname | head -1); [ -n "$latest_tag" ] && git log "${latest_tag}..develop" --oneline`（最新タグはバージョン順で取得。`git describe --tags --abbrev=0` は develop から到達不可能なリリースタグを取りこぼすため使わない）
 2. 変更内容から semver のバンプ種別を判定:
    - **major**: 破壊的変更がある場合
    - **minor**: 新機能追加がある場合
@@ -85,7 +91,9 @@ echo "Current version: $current_version"
 develop ブランチと最新タグの差分から、CHANGELOG に含めるべき変更を一覧表示する。
 
 ```bash
-latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+# 最新タグはバージョン順で取得（HEAD 到達可能性に非依存）。
+# リリースタグは main マージコミットに付くため git describe では取りこぼす。
+latest_tag=$(git tag --sort=-v:refname | head -1)
 if [ -n "$latest_tag" ]; then
   git log "${latest_tag}..develop" --oneline --no-merges
 fi


### PR DESCRIPTION
## 概要

`/release` 実行時、Phase 1 が誤って古いタグ（例: `v0.5.2`）を「ローカル最新タグ」と判定する問題を解消する。`release` skill（`.claude/skills/release/SKILL.md`）の Phase 1.2 / 1.3 が `git describe --tags --abbrev=0` で最新タグを取得していたのが原因。

これは「fetch 漏れ（ローカルタグが古い）」ではなく **構造的な到達可能性の問題**:

- リリースタグは Phase 3.3 で `--target main`（develop→main マージコミット）に付与される
- そのマージコミットは develop の履歴に含まれないため、develop から **到達不可能**
- `git describe --tags --abbrev=0` は HEAD から到達可能なタグのみ返すため、develop から届く古い `v0.5.2` を拾う
- `git fetch --tags` してもタグの所在（main マージコミット）は変わらず解消しない

## 変更内容

`.claude/skills/release/SKILL.md`（Phase 1 のみ、+10/-2 行）:

- Phase 1 冒頭に防御的なタグ同期 `git fetch --tags --force origin`（ネットワーク不通でもリリースをブロックしない）+ 根拠注記を追加
- §1.2 / §1.3 の `git describe --tags --abbrev=0` を、到達可能性に依存しないバージョン順 `git tag --sort=-v:refname | head -1` に置換
- describe を使わない理由（main マージタグが develop から到達不可能）をコメント / 注記として残し、誤戻しを防止

## 検証（実機）

| 項目 | 旧 `git describe` | 新 `git tag --sort=-v:refname \| head -1` |
|------|------------------|------------------------------------------|
| develop からの最新タグ | `v0.5.2`（到達可能のみ・誤） | `v0.6.7`（バージョン順・正） |

- 差分基点 `latest_tag..develop` が正しく算出されることを確認（AC-2）
- 空タグガード（タグ無しリポジトリ）が非エラーで全コミット対象になることを確認（AC-3）

## 関連 Issue

Closes #1642

## Definition of Done

実装ステップ（Issue body）は完了済み。以下はマージ/close 時に確定する完了ゲート:

- [ ] All MUST requirements implemented
- [ ] All Acceptance Criteria (AC-xx) verified
- [ ] All test cases (T-xx) passing
- [ ] No regression in existing functionality
- [ ] Target files modified, non-target files untouched
- [ ] Code follows project conventions

## Known Issues

- 本リポジトリは `commands.lint` 未設定のためメイン lint はスキップ。プラグイン固有チェック 15 種を実行し、本 diff 由来の指摘は 0 件（既存 warning は `plugins/rite/**`・CHANGELOG 内で本 PR と無関係・non-blocking）。
