### PR TITLE
fix(release): 最新タグ判定をリリースタグ形式 vX.Y.Z に限定

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -79,7 +79,7 @@ echo "Current version: $current_version"
 
 ユーザーがバージョンを指定していない場合、以下を確認して提案する：
 
-1. 前回リリースからの変更を確認: `latest_tag=$(git tag --sort=-v:refname | head -1); [ -n "$latest_tag" ] && git log "${latest_tag}..develop" --oneline`（最新タグはバージョン順で取得。`git describe --tags --abbrev=0` は develop から到達不可能なリリースタグを取りこぼすため使わない）
+1. 前回リリースからの変更を確認: `latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1); [ -n "$latest_tag" ] && git log "${latest_tag}..develop" --oneline`（最新タグはリリースタグ形式 `vX.Y.Z` に限定してバージョン順で取得。`grep` で非バージョンタグを除外し、version sort で上位に来る非リリースタグの誤検出を防ぐ。`git describe --tags --abbrev=0` は develop から到達不可能なリリースタグを取りこぼすため使わない）
 2. 変更内容から semver のバンプ種別を判定:
    - **major**: 破壊的変更がある場合
    - **minor**: 新機能追加がある場合
@@ -91,9 +91,11 @@ echo "Current version: $current_version"
 develop ブランチと最新タグの差分から、CHANGELOG に含めるべき変更を一覧表示する。
 
 ```bash
-# 最新タグはバージョン順で取得（HEAD 到達可能性に非依存）。
+# 最新タグはリリースタグ形式 vX.Y.Z に限定してバージョン順で取得（HEAD 到達可能性に非依存）。
+# grep で非バージョンタグ（refactor-pr3-done 等）を除外し、version sort で
+# 上位に来る非リリースタグの誤検出を防ぐ。
 # リリースタグは main マージコミットに付くため git describe では取りこぼす。
-latest_tag=$(git tag --sort=-v:refname | head -1)
+latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 if [ -n "$latest_tag" ]; then
   git log "${latest_tag}..develop" --oneline --no-merges
 fi


### PR DESCRIPTION
## 概要

release skill (`.claude/skills/release/SKILL.md`) の Phase 1 最新タグ判定を、リリースタグ形式 `vX.Y.Z` に限定して堅牢化した。

## 背景

`git tag --sort=-v:refname | head -1` は「version sort で最上位の**任意**タグ」を返す。本リポジトリには `vX.Y.Z` 形式でない非バージョンタグ（`refactor-pr3-done`, `develop-pre-refactor` 等）が存在し、現状は version sort により全 `vX.Y.Z` タグがそれら非バージョンタグより上位に来るため問題は顕在化しない。

ただし将来「全リリースタグより version sort で上位に来る非バージョンタグ」が付与されると、最新リリースタグの判定が誤る可能性がある。

## 変更内容

`.claude/skills/release/SKILL.md` の §1.2 / §1.3 の 2 箇所で、タグ取得をリリースタグ形式に限定:

```bash
latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
```

- `- .claude/skills/release/SKILL.md` - 変更（§1.2 line 82 / §1.3 line 96 の 2 箇所 + §1.3 コメントに意図を追記）

## スコープ外

- Phase 1 の `git fetch --tags --force` の再検討（別 Issue）
- `git tag | head -1` の SIGPIPE pipeline exit の確認（別 Issue）
- Phase 2-4 のロジック変更

## 関連 Issue

Closes #1644

## チェックリスト

- [x] 変更が Issue の受入基準を満たす
- [x] §1.2 / §1.3 の 2 箇所を修正
- [x] lint（プラグイン固有チェック）実行済み — 新規 finding なし
