### PR TITLE
chore: .claude/scheduled_tasks.lock を gitignore して untrack

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f8bb5436-2bcb-4c5e-93ba-78b23b456691","pid":1846915,"procStart":"8999354","acquiredAt":1779700796798}

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ Thumbs.db
 tmp/
 temp/
 
+# Claude Code harness state (auto-generated)
+# scheduled task lock — session 固有の lock (sessionId/pid/procStart/acquiredAt) を
+# Claude Code 本体が毎セッション上書きするため tracked だと常に dirty になり、
+# pull.rebase=true 環境で git pull を abort させる (#1654)。.claude/ 配下の他の
+# tracked ファイル (skills/release/SKILL.md 等) には影響しないようファイル単位で除外する。
+.claude/scheduled_tasks.lock
+
 # rite workflow state (auto-generated)
 .rite-flow-state
 .rite-flow-state.tmp.*


### PR DESCRIPTION
## 概要

`.claude/scheduled_tasks.lock` を `.gitignore` に登録し、`git rm --cached` で追跡解除する。Claude Code ハーネスがセッションごとに上書きするこの lock ファイルが tracked のままだと常に working tree が dirty になり、`pull.rebase=true` 環境で `git pull` を abort させていた（v0.6.8 リリース作業中に実際に発生）。

## 変更内容

- `.gitignore`: `# Claude Code harness state (auto-generated)` セクションを追加し、`.claude/scheduled_tasks.lock` を登録（除外理由をコメントで明記）
- `.claude/scheduled_tasks.lock`: `git rm --cached` で追跡解除（ローカルファイルは保持）

`.claude/` 配下は `skills/release/SKILL.md` が意図的に commit されているため、`.claude/` 全体ではなく**ファイル単位**で除外している。

## 受け入れ条件（すべて検証済み）

- [x] `.gitignore` に `.claude/scheduled_tasks.lock` が登録されている
- [x] `git ls-files .claude/scheduled_tasks.lock` が空（untrack 済み）
- [x] `git check-ignore` で ignore 対象と確認（再起動後も `git status` に現れない）
- [x] `.claude/skills/release/SKILL.md` は tracked のまま（無影響を確認）
- [x] ローカルの実体ファイルは保持

## 検証

- `gitignore-health-check`（lint Phase 3.9）: success（`.rite/wiki/` 除外ルールへの影響なし）
- その他の plugin lint チェックの warning は既存ベースラインで、本変更が新規に増やしたものはない

## 関連 Issue

Closes #1654
