### PR TITLE
fix(wiki): corrupt/orphaned wiki-worktree から raw source 蓄積を自己回復

### DIFF
--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -365,10 +365,14 @@ if [ -d "$worktree_path" ]; then
  exit 1
  ;;
  *)
- # Still unusable after the recovery attempt (e.g. setup skipped because the
- # wiki branch is missing locally). Recovery already removed the stale
- # residue, so the legacy path below runs without hitting "already used by
- # worktree". Fall through.
+ # Still unusable after the recovery attempt. Fall through to the legacy
+ # stash/checkout path. Two sub-cases reach here safely:
+ #   - setup reached its residue-removal step and recreated/cleaned the
+ #     worktree, so the legacy path won't hit "already used by worktree".
+ #   - setup skipped early (e.g. the wiki branch is missing locally → setup
+ #     exits before the residue-removal step), so the residue remains. The
+ #     legacy path is still safe because its own `git show-ref --verify` exits
+ #     on the missing branch before reaching the checkout that would collide.
  : ;;
  esac
 fi

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -365,14 +365,17 @@ if [ -d "$worktree_path" ]; then
  exit 1
  ;;
  *)
- # Still unusable after the recovery attempt. Fall through to the legacy
- # stash/checkout path. Two sub-cases reach here safely:
- #   - setup reached its residue-removal step and recreated/cleaned the
- #     worktree, so the legacy path won't hit "already used by worktree".
- #   - setup skipped early (e.g. the wiki branch is missing locally → setup
- #     exits before the residue-removal step), so the residue remains. The
- #     legacy path is still safe because its own `git show-ref --verify` exits
- #     on the missing branch before reaching the checkout that would collide.
+ # vwb_rc is still 2 here: setup either exited non-zero (so re-verify was
+ # skipped) or returned but re-verify still failed. A successful recreate would
+ # have made re-verify return 0 and taken the case-0 branch, so it never reaches
+ # here. Fall through to the legacy stash/checkout path, which is safe because:
+ #   - the orphaned residue is unregistered, so legacy's `git checkout` does not
+ #     collide with it ("already used by worktree" cannot fire); and
+ #   - when the wiki branch is missing locally, legacy's own `git show-ref
+ #     --verify` exits first, before reaching any checkout.
+ # This covers all paths that land here: setup exit 2 (branch missing, residue
+ # left in place), setup exit 3 (rm failed → residue left, or add failed →
+ # residue already removed), and the rare setup-ok-but-reverify-still-2 case.
  : ;;
  esac
 fi

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -330,18 +330,49 @@ fi
 # stash/checkout path below handles the case (backward compat).
 # -----------------------------------------------------------------------
 worktree_path=".rite/wiki-worktree"
+# Probe the worktree fast path. rc semantics from verify_worktree_branch:
+# 0=on the wiki branch (usable), 2=rev-parse failed (corrupt/orphaned — e.g. a
+# stale `.git` gitdir after the repo was relocated), 3=checked out to a different
+# branch. A corrupt worktree must NOT hard-stop the commit: that silent exit is
+# what halted ALL raw-source accumulation (the failure is non-blocking upstream,
+# so the WARNING went unseen). Self-heal on rc=2, then fall back to the legacy
+# stash/checkout path if the worktree stays unusable.
+wt_usable=false
 if [ -d "$worktree_path" ]; then
- # Confirm the worktree is on the configured wiki branch. A misaligned worktree
- # (e.g. user ran `git -C .rite/wiki-worktree checkout develop` by hand) would
- # otherwise silently fall through to the legacy path below, which fails with
- # "fatal: '<wiki>' is already used by worktree at '...'" — masking the true
- # cause (worktree misalignment) behind a cryptic checkout error.
- # rev-parse + stderr capture + branch compare は
- # lib/worktree-git.sh の verify_worktree_branch() に統合済み。4th arg の extra_hint
- # で「silent fall-through to legacy path」警告を追加して元の挙動を保持する。
+ set +e
  verify_worktree_branch "$worktree_path" "$wiki_branch" "wic-wt" \
- "silent fall-through to legacy path would fail with 'already used by worktree'" \
- || exit 1
+ "silent fall-through to legacy path would fail with 'already used by worktree'"
+ vwb_rc=$?
+ set -e
+ if [ "$vwb_rc" -eq 2 ]; then
+ # Corrupt/orphaned. Delegate recovery to the idempotent setup helper — it
+ # removes the stale residue and recreates the worktree on the wiki branch —
+ # then re-verify. Its status line goes to stderr to keep this script's
+ # stdout contract (parsed by callers) clean.
+ echo "WARNING: .rite/wiki-worktree が壊れています (gitdir stale 等)。wiki-worktree-setup.sh で自己回復を試行します" >&2
+ if bash "$_SCRIPT_DIR/wiki-worktree-setup.sh" >&2; then
+ set +e
+ verify_worktree_branch "$worktree_path" "$wiki_branch" "wic-wt" ""
+ vwb_rc=$?
+ set -e
+ fi
+ fi
+ case "$vwb_rc" in
+ 0) wt_usable=true ;;
+ 3)
+ # Valid worktree but on the wrong branch — a genuine misconfiguration.
+ # Do not guess the intended branch; surface it as before.
+ exit 1
+ ;;
+ *)
+ # Still unusable after the recovery attempt (e.g. setup skipped because the
+ # wiki branch is missing locally). Recovery already removed the stale
+ # residue, so the legacy path below runs without hitting "already used by
+ # worktree". Fall through.
+ : ;;
+ esac
+fi
+if [ "$wt_usable" = "true" ]; then
  # Pre-flight: validate wiki branch name (ステップ 1.1 already validates but
  # defense-in-depth here since `git -C ... add -- "$path"` would silently
  # accept option-like paths if the validation were bypassed).

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -33,9 +33,12 @@
 #   - The script does NOT fetch from origin. If the wiki branch only
 #     exists remotely, the caller (e.g. /rite:wiki:init) is responsible
 #     for running `git fetch origin wiki:wiki` first.
-#   - The script does NOT prune stale worktrees. If `.rite/wiki-worktree`
-#     was deleted without `git worktree remove`, run `git worktree prune`
-#     manually before re-invoking this script.
+#   - The script self-heals stale worktree state so a relocated/copied repo
+#     does not silently break ingest. Two cases are recovered before
+#     `git worktree add`: a `prunable` registration (directory deleted without
+#     `git worktree remove`) is pruned, and an orphaned directory (exists on
+#     disk but unresolvable by `git -C`, e.g. a stale `.git` gitdir pointing at
+#     the old path after relocation) is removed and pruned.
 
 set -euo pipefail
 
@@ -226,6 +229,26 @@ elif [[ -n "$existing_branch" ]]; then
 fi
 [ -n "$wt_list_err" ] && rm -f "$wt_list_err"
 trap - EXIT INT TERM HUP
+
+# -----------------------------------------------------------------------
+# Stale residue recovery: the target directory exists on disk but is NOT a
+# registered worktree of this repo, so `git -C` cannot resolve it. The common
+# trigger is repo relocation/copy: the worktree's `.git` file still holds a
+# `gitdir:` pointer to the OLD absolute path, leaving an orphaned directory that
+# `git worktree list` no longer reports. Reaching this point means the
+# idempotency scan above found no live worktree at this path, so a directory
+# that nevertheless exists is leftover residue and the `git worktree add` below
+# would abort with "already exists" — the exact silent stall that halted
+# raw-source accumulation. Remove the residue and prune dangling metadata so the
+# add starts clean. The `git -C ... rev-parse` guard ensures a genuinely healthy
+# worktree (e.g. one missed by a transiently failed `git worktree list`) is
+# never deleted: a healthy worktree resolves and is left untouched.
+if [ -e "$target_path" ] && ! git -C "$target_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "WARNING: '$abs_target' は git worktree として解決できない残留ディレクトリです (stale .git gitdir — リポジトリ移動/コピー後に発生)" >&2
+  echo "  自動回復: 残留を削除し git worktree prune してから worktree を再作成します" >&2
+  rm -rf "$target_path"
+  git worktree prune 2>/dev/null || true
+fi
 
 # -----------------------------------------------------------------------
 # Create the worktree. Parent directory may already exist (e.g. because

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -246,8 +246,24 @@ trap - EXIT INT TERM HUP
 if [ -e "$target_path" ] && ! git -C "$target_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "WARNING: '$abs_target' は git worktree として解決できない残留ディレクトリです (stale .git gitdir — リポジトリ移動/コピー後に発生)" >&2
   echo "  自動回復: 残留を削除し git worktree prune してから worktree を再作成します" >&2
-  rm -rf "$target_path"
-  git worktree prune 2>/dev/null || true
+  # rm の失敗 (permission denied / EBUSY / read-only filesystem) を診断付きで surface する。
+  # 本ファイルの mktemp / git 各操作と同じ防御スタイル。残留が消えないまま後続の
+  # `git worktree add` が "already exists" で失敗するより、ここで原因を明示して止める。
+  if ! rm -rf "$target_path"; then
+    echo "ERROR: 残留ディレクトリ '$abs_target' の削除に失敗しました" >&2
+    echo "  対処: filesystem permission / EBUSY (プロセスが掴んでいる) / read-only filesystem を確認してください" >&2
+    exit 3
+  fi
+  # prune 失敗を 2>/dev/null で完全抑制せず WARNING として surface する (Issue #1662 の
+  # anti-silent-failure 方針、および本ファイル上方の prunable 回復が prune 失敗を扱う姿勢と整合)。
+  # 非ブロッキング: prune は dangling metadata の掃除であり、失敗しても後続の
+  # `git worktree add` が顕在化させるため exit はしない。
+  prune_err=$(mktemp /tmp/rite-wts-prune-err-XXXXXX 2>/dev/null) || prune_err=""
+  if ! git worktree prune 2>"${prune_err:-/dev/null}"; then
+    echo "WARNING: git worktree prune に失敗しました (stale metadata が残存する可能性があります)" >&2
+    [ -n "$prune_err" ] && [ -s "$prune_err" ] && head -3 "$prune_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
+  fi
+  [ -n "$prune_err" ] && rm -f "$prune_err"
 fi
 
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -258,12 +258,18 @@ if [ -e "$target_path" ] && ! git -C "$target_path" rev-parse --is-inside-work-t
   # anti-silent-failure 方針、および本ファイル上方の prunable 回復が prune 失敗を扱う姿勢と整合)。
   # 非ブロッキング: prune は dangling metadata の掃除であり、失敗しても後続の
   # `git worktree add` が顕在化させるため exit はしない。
+  # scope-limited trap: SIGINT/TERM/HUP during `git worktree prune` must not
+  # orphan the stderr tempfile. Mirrors the wt_list_err / add_err handling in
+  # this file (trap armed before mktemp, disarmed after rm -f).
+  prune_err=""
+  trap 'rm -f "${prune_err:-}"' EXIT INT TERM HUP
   prune_err=$(mktemp /tmp/rite-wts-prune-err-XXXXXX 2>/dev/null) || prune_err=""
   if ! git worktree prune 2>"${prune_err:-/dev/null}"; then
     echo "WARNING: git worktree prune に失敗しました (stale metadata が残存する可能性があります)" >&2
     [ -n "$prune_err" ] && [ -s "$prune_err" ] && head -3 "$prune_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
   fi
   [ -n "$prune_err" ] && rm -f "$prune_err"
+  trap - EXIT INT TERM HUP
 fi
 
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/wiki-worktree-recovery.test.sh
+++ b/plugins/rite/hooks/tests/wiki-worktree-recovery.test.sh
@@ -42,12 +42,19 @@ trap cleanup EXIT INT TERM HUP
 # .rite/wiki-worktree directory whose `.git` pointer is stale. Echoes the repo
 # root on stdout.
 make_fixture() {
-  local root
+  # $1: "yes" (default) creates a local wiki branch; "no" omits it (to exercise
+  #     the legacy fallthrough path where setup + legacy both exit 2 on the
+  #     missing branch).
+  local root with_wiki="${1:-yes}"
   root="$WORK/repo"
   mkdir -p "$root"
   git -C "$root" init -q -b develop
   git -C "$root" config user.email "test@example.com"
   git -C "$root" config user.name "rite test"
+  # Disable commit signing locally so the fixture commits (and the recovery
+  # commit made by the script under test) do not fail under a global
+  # commit.gpgsign=true. Matches the convention in the sibling fixture tests.
+  git -C "$root" config commit.gpgsign false
 
   printf 'wiki:\n  enabled: true\n  branch_strategy: separate_branch\n  branch_name: wiki\n' \
     > "$root/rite-config.yml"
@@ -55,15 +62,17 @@ make_fixture() {
   git -C "$root" add rite-config.yml .gitignore
   git -C "$root" commit -q -m "init develop"
 
-  # wiki branch: tracks .rite/wiki/raw/ structure.
-  git -C "$root" checkout -q --orphan wiki
-  git -C "$root" rm -q -rf . >/dev/null 2>&1 || true
-  mkdir -p "$root/.rite/wiki/raw/retrospectives"
-  printf '# wiki\n' > "$root/.rite/wiki/index.md"
-  : > "$root/.rite/wiki/raw/retrospectives/.gitkeep"
-  git -C "$root" add .rite/wiki/index.md .rite/wiki/raw/retrospectives/.gitkeep
-  git -C "$root" commit -q -m "init wiki"
-  git -C "$root" checkout -q develop
+  if [ "$with_wiki" = "yes" ]; then
+    # wiki branch: tracks .rite/wiki/raw/ structure.
+    git -C "$root" checkout -q --orphan wiki
+    git -C "$root" rm -q -rf . >/dev/null 2>&1 || true
+    mkdir -p "$root/.rite/wiki/raw/retrospectives"
+    printf '# wiki\n' > "$root/.rite/wiki/index.md"
+    : > "$root/.rite/wiki/raw/retrospectives/.gitkeep"
+    git -C "$root" add .rite/wiki/index.md .rite/wiki/raw/retrospectives/.gitkeep
+    git -C "$root" commit -q -m "init wiki"
+    git -C "$root" checkout -q develop
+  fi
 
   # Stage a pending raw source on the dev tree (untracked, as the trigger leaves it).
   mkdir -p "$root/.rite/wiki/raw/retrospectives"
@@ -120,7 +129,12 @@ fi
 echo ""
 
 echo "TC-COMMIT-NOT-SILENT: a WARNING is emitted (no silent stall)"
-if printf '%s' "$commit_err" | grep -q "自己回復\|wiki-worktree-setup.sh"; then
+# Match only the fix-specific recovery token `自己回復`. The earlier broad
+# alternative `wiki-worktree-setup.sh` also matched the pre-fix code's
+# verify_worktree_branch remediation hint ("対処: ... bash .../wiki-worktree-setup.sh"),
+# so the assertion passed even on the broken (reverted) code — a non-discriminating
+# test. `自己回復` appears only on the recovery path this PR adds.
+if printf '%s' "$commit_err" | grep -q "自己回復"; then
   pass "recovery WARNING surfaced on stderr"
 else
   fail "no recovery WARNING — silent-failure regression"
@@ -143,13 +157,40 @@ echo "TC-SETUP-RECOVER: wiki-worktree-setup.sh repairs orphaned .rite/wiki-workt
 set +e
 setup_out="$(cd "$REPO" && bash "$SETUP_SH" 2>setup_err.txt)"
 setup_rc=$?
+recovered_branch="$(git -C "$REPO/.rite/wiki-worktree" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
 set -e
-if [ "$setup_rc" -eq 0 ] && git -C "$REPO/.rite/wiki-worktree" rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-  pass "setup repaired worktree into a resolvable git worktree (rc=$setup_rc)"
+# Assert the recovered worktree is on the wiki branch specifically, not merely
+# resolvable — a worktree recreated on the wrong branch would otherwise pass.
+if [ "$setup_rc" -eq 0 ] && [ "$recovered_branch" = "wiki" ]; then
+  pass "setup repaired worktree onto the wiki branch (rc=$setup_rc, branch=$recovered_branch)"
 else
-  fail "setup did not repair orphaned worktree (rc=$setup_rc)"
+  fail "setup did not repair orphaned worktree onto wiki (rc=$setup_rc, branch='$recovered_branch')"
   printf '%s\n' "$setup_out" | sed 's/^/    out: /'
   cat "$REPO/setup_err.txt" 2>/dev/null | sed 's/^/    err: /'
+fi
+echo ""
+
+# --- TC-FALLTHROUGH-NO-WIKI: legacy fallthrough is graceful when wiki branch is missing ---
+# This pins the case *) fallthrough path that this PR introduced in
+# wiki-ingest-commit.sh. With no local wiki branch: verify rc=2 (corrupt) →
+# setup.sh exits 2 (branch missing, before the residue-removal step) → re-verify
+# skipped → case *) falls through to the legacy stash/checkout path → legacy's own
+# `git show-ref --verify` exits 2 on the missing branch. The expected outcome is a
+# graceful exit 2 (commit_branch_missing), NOT a silent exit-1 stall or a crash.
+rm -rf "$WORK"; WORK="$(mktemp -d)"
+REPO="$(make_fixture no)"
+echo "TC-FALLTHROUGH-NO-WIKI: commit.sh falls through to legacy gracefully (exit 2) when wiki branch missing"
+set +e
+ft_out="$(cd "$REPO" && bash "$COMMIT_SH" 2>ft_err.txt)"
+ft_rc=$?
+ft_err="$(cat "$REPO/ft_err.txt" 2>/dev/null || true)"
+set -e
+if [ "$ft_rc" -eq 2 ] && printf '%s' "$ft_err" | grep -q "自己回復"; then
+  pass "graceful fallthrough exit 2 with recovery WARNING (no silent exit-1 stall)"
+else
+  fail "expected graceful exit 2 + recovery WARNING; got rc=$ft_rc"
+  printf '%s\n' "$ft_out" | sed 's/^/    out: /'
+  printf '%s\n' "$ft_err" | sed 's/^/    err: /'
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/wiki-worktree-recovery.test.sh
+++ b/plugins/rite/hooks/tests/wiki-worktree-recovery.test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Functional regression test for corrupt/orphaned .rite/wiki-worktree recovery.
+#
+# Reproduces the silent raw-source accumulation stall (Issue #1662): when the
+# repository is relocated/copied, the wiki worktree's `.git` file keeps a stale
+# `gitdir:` pointer to the old path, leaving `.rite/wiki-worktree` as a directory
+# that exists on disk but is NOT a registered worktree. Before the fix:
+#   - wiki-ingest-commit.sh hit `verify_worktree_branch ... || exit 1` and
+#     hard-stopped (non-blocking upstream, so nobody saw the WARNING).
+#   - wiki-worktree-setup.sh could not recover it either (`git worktree add`
+#     aborts with "already exists" on the orphaned directory).
+# Both scripts now self-heal. Unlike the sibling static-pin tests, this builds a
+# real git fixture so the recovery cannot silently regress.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$SCRIPT_DIR/../scripts"
+COMMIT_SH="$SCRIPTS_DIR/wiki-ingest-commit.sh"
+SETUP_SH="$SCRIPTS_DIR/wiki-worktree-setup.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+echo "=== wiki-worktree corrupt/orphaned recovery tests ==="
+echo ""
+
+for f in "$COMMIT_SH" "$SETUP_SH"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: $f not found" >&2
+    exit 1
+  fi
+done
+
+WORK=""
+cleanup() { [ -n "$WORK" ] && rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM HUP
+
+# Build a fixture repo with a dev branch + a wiki branch, then leave an orphaned
+# .rite/wiki-worktree directory whose `.git` pointer is stale. Echoes the repo
+# root on stdout.
+make_fixture() {
+  local root
+  root="$WORK/repo"
+  mkdir -p "$root"
+  git -C "$root" init -q -b develop
+  git -C "$root" config user.email "test@example.com"
+  git -C "$root" config user.name "rite test"
+
+  printf 'wiki:\n  enabled: true\n  branch_strategy: separate_branch\n  branch_name: wiki\n' \
+    > "$root/rite-config.yml"
+  printf '.rite/wiki-worktree/\n.rite/state/\n' > "$root/.gitignore"
+  git -C "$root" add rite-config.yml .gitignore
+  git -C "$root" commit -q -m "init develop"
+
+  # wiki branch: tracks .rite/wiki/raw/ structure.
+  git -C "$root" checkout -q --orphan wiki
+  git -C "$root" rm -q -rf . >/dev/null 2>&1 || true
+  mkdir -p "$root/.rite/wiki/raw/retrospectives"
+  printf '# wiki\n' > "$root/.rite/wiki/index.md"
+  : > "$root/.rite/wiki/raw/retrospectives/.gitkeep"
+  git -C "$root" add .rite/wiki/index.md .rite/wiki/raw/retrospectives/.gitkeep
+  git -C "$root" commit -q -m "init wiki"
+  git -C "$root" checkout -q develop
+
+  # Stage a pending raw source on the dev tree (untracked, as the trigger leaves it).
+  mkdir -p "$root/.rite/wiki/raw/retrospectives"
+  printf -- '---\ntype: retrospectives\nsource_ref: "issue-1662"\ningested: false\n---\n\nTest retrospective body.\n' \
+    > "$root/.rite/wiki/raw/retrospectives/20260626T000000Z-issue-1662.md"
+
+  # Orphaned worktree directory with a stale gitdir pointer (the relocation bug):
+  # exists on disk, `git -C` cannot resolve it, and `git worktree list` omits it.
+  mkdir -p "$root/.rite/wiki-worktree"
+  printf 'gitdir: /nonexistent/relocated/.git/worktrees/wiki-worktree\n' \
+    > "$root/.rite/wiki-worktree/.git"
+
+  printf '%s\n' "$root"
+}
+
+# --- Sanity: the fixture really reproduces the broken precondition ---
+WORK="$(mktemp -d)"
+REPO="$(make_fixture)"
+
+echo "TC-PRECONDITION: orphaned .rite/wiki-worktree is unresolvable and unregistered"
+precond_ok=true
+if git -C "$REPO/.rite/wiki-worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  precond_ok=false  # should FAIL to resolve
+fi
+if git -C "$REPO" worktree list --porcelain 2>/dev/null | grep -q "wiki-worktree"; then
+  precond_ok=false  # should NOT be registered
+fi
+if [ "$precond_ok" = "true" ]; then
+  pass "fixture reproduces corrupt + unregistered worktree"
+else
+  fail "fixture did not reproduce the broken precondition"
+fi
+echo ""
+
+# --- TC-COMMIT-RECOVER: wiki-ingest-commit.sh self-heals and commits the raw ---
+echo "TC-COMMIT-RECOVER: wiki-ingest-commit.sh recovers and commits pending raw"
+wiki_before="$(git -C "$REPO" rev-parse wiki)"
+set +e
+commit_out="$(cd "$REPO" && bash "$COMMIT_SH" 2>commit_err.txt)"
+commit_rc=$?
+commit_err="$(cat "$REPO/commit_err.txt" 2>/dev/null || true)"
+set -e
+wiki_after="$(git -C "$REPO" rev-parse wiki)"
+
+# rc 0 (push ok) or 4 (committed locally, push failed: no remote in fixture) both
+# mean the raw landed on the wiki branch. The regression was a silent exit 1.
+if { [ "$commit_rc" -eq 0 ] || [ "$commit_rc" -eq 4 ]; } && [ "$wiki_before" != "$wiki_after" ]; then
+  pass "raw committed to wiki branch via self-heal (rc=$commit_rc)"
+else
+  fail "expected recovery+commit (rc 0/4, wiki advanced); got rc=$commit_rc, wiki_before=$wiki_before wiki_after=$wiki_after"
+  echo "    --- stdout ---"; printf '%s\n' "$commit_out" | sed 's/^/    /'
+  echo "    --- stderr ---"; printf '%s\n' "$commit_err" | sed 's/^/    /'
+fi
+echo ""
+
+echo "TC-COMMIT-NOT-SILENT: a WARNING is emitted (no silent stall)"
+if printf '%s' "$commit_err" | grep -q "自己回復\|wiki-worktree-setup.sh"; then
+  pass "recovery WARNING surfaced on stderr"
+else
+  fail "no recovery WARNING — silent-failure regression"
+fi
+echo ""
+
+echo "TC-COMMIT-RAW-ON-WIKI: committed raw is present on the wiki branch tree"
+if git -C "$REPO" ls-tree -r --name-only wiki | grep -q "raw/retrospectives/20260626T000000Z-issue-1662.md"; then
+  pass "raw source present on wiki branch"
+else
+  fail "raw source missing from wiki branch after recovery"
+fi
+echo ""
+
+# --- TC-SETUP-RECOVER: wiki-worktree-setup.sh recovers the orphaned directory ---
+# Fresh fixture so setup.sh faces the orphaned dir directly.
+rm -rf "$WORK"; WORK="$(mktemp -d)"
+REPO="$(make_fixture)"
+echo "TC-SETUP-RECOVER: wiki-worktree-setup.sh repairs orphaned .rite/wiki-worktree"
+set +e
+setup_out="$(cd "$REPO" && bash "$SETUP_SH" 2>setup_err.txt)"
+setup_rc=$?
+set -e
+if [ "$setup_rc" -eq 0 ] && git -C "$REPO/.rite/wiki-worktree" rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
+  pass "setup repaired worktree into a resolvable git worktree (rc=$setup_rc)"
+else
+  fail "setup did not repair orphaned worktree (rc=$setup_rc)"
+  printf '%s\n' "$setup_out" | sed 's/^/    out: /'
+  cat "$REPO/setup_err.txt" 2>/dev/null | sed 's/^/    err: /'
+fi
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## 概要

OKF v0.1 化以降「wiki ブランチへ raw source が一切蓄積されなくなった回帰」(#1662) を修正する。実機検証の結果、**真因は Issue 仮説の「OKF フォーマット追従漏れ」ではなく、リポジトリ移動（アカウント移管）による `.rite/wiki-worktree` の gitdir stale 化（孤児ディレクトリ）**だった。蓄積経路を corrupt/orphaned worktree に対し自己回復させ、silent 停止を廃止する。

## 真因（実機検証で確定）

`.rite/wiki-worktree/.git` のポインタが旧パス（`/Projects/personal/...`）を指したまま残り（リポジトリは `/Projects/work/...` へ移動済み）、`git worktree list` にも未登録の孤児ディレクトリになっていた。

破断連鎖:

1. `wiki-ingest-commit.sh` の worktree fast-path が `[ -d .rite/wiki-worktree ]` を true 判定
2. `verify_worktree_branch` が `git -C .rite/wiki-worktree rev-parse` で失敗（rc≠0）
3. commit script が `|| exit 1` で **silent に exit 1**
4. caller (close/review/fix の Phase X.X.W.2) では non-blocking WARNING 扱いのため誰にも気付かれず、約 2 週間サイレントに停止

`wiki-ingest-trigger.sh`（`ingested: false` 書込）・`commands/wiki/ingest.md`（`ingest_status` 読取）・caller のフォーマット契約はいずれも実機検証で健全と確認。`wiki-growth-check.sh` も正しく発火することを確認（「surface しなかった理由」は `/rite:lint` が実行されていなかったため）。

これは「`.rite/wiki-worktree` がディスク上に存在するが registered worktree でない（corrupt/orphaned）」ケースを `wiki-ingest-commit.sh` も `wiki-worktree-setup.sh` も想定していなかった**プラグインの堅牢性バグ**でもある。リポジトリ移動・コピーは現実的なシナリオ。

## 変更内容

- **`wiki-ingest-commit.sh`**: worktree fast-path 検証を rc-aware 化。`rc=2`（corrupt/orphaned）で `wiki-worktree-setup.sh` に自己回復を委譲して再検証し、回復不能なら legacy stash/checkout path へフォールバック。`rc=3`（wrong branch）のみ従来どおり exit。silent `exit 1` を廃止し WARNING を出力（= observable signal）。
- **`wiki-worktree-setup.sh`**: ディスク上に存在するが registered worktree でない残留ディレクトリ（stale gitdir）を `rm -rf` + `git worktree prune` で除去してから再作成。ヘッダ注記を自己回復挙動へ整合。
- **`wiki-worktree-recovery.test.sh`**（新規）: 実 git fixture で孤児 worktree を再現し、自己回復（commit/setup 両経路）+ non-silent WARNING + raw が wiki ブランチへ着地することを検証する回帰ガード（5 TC）。

non-blocking / raw lost-prevention 設計は維持。OKF スキーマ・テンプレート（SoT）は不変。

## 検証

- 新規テスト `wiki-worktree-recovery.test.sh`: 5/5 PASS
- 全 hook テストスイート: **78/78 PASS**（回帰なし、AC-6）
- ローカル即復旧: ドッグフード repo の孤児 `.rite/wiki-worktree` を修正版 `wiki-worktree-setup.sh` で復旧（`status=created`、wiki ブランチに登録・gitdir 修正を確認）
- プラグイン固有 lint チェック: 私の変更が導入した新規 finding ゼロ（comment-journal の既存 6 件は変更領域外）

## Acceptance Criteria

- AC-1（raw が wiki へ蓄積）: 機能テストの fixture（close→commit→raw on wiki）で実証。**実 wiki ブランチへの live 蓄積は本 PR の cleanup 時に自然生成され確認予定**
- AC-2（OKF `ingest_status` SoT）: trigger は `ingested: false` を書き log.md に機械状態を残さない（健全・不変）
- AC-3（ingest が OKF raw 統合）: `ingest.md` の `ingest_status` 読取は健全・不変
- AC-4（silent 停止が検知可能）: 自己回復 WARNING + `wiki-growth-check`（発火確認済み）+ 回帰テスト
- AC-5（truncated は ingest しない）: trigger の integrity guard / caller の `content_write_failed` は不変
- AC-6（既存に回帰なし）: 全 78 テスト PASS
- AC-7（`ingest_status=skip` 尊重）: `ingest.md` の skip ロジックは不変

> 注: 本 PR の lint で `wiki-growth-check` が stall 警告（74 PR 分）を出すが、これは**本 PR が修正する当の症状**であり、復旧した worktree により本 PR の cleanup 時の raw 蓄積で解消見込み。

## 関連 Issue

Closes #1662

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
