### PR TITLE
fix(wiki): multi-session worktree で wiki-ingest の raw 書込先を scan ルートに統一

### DIFF
--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -122,6 +122,12 @@ source "$_SCRIPT_DIR/../control-char-neutralize.sh"
 # for rationale — a linked-worktree session must land its wiki worktree + flock
 # on the main checkout's single inode (multi-session design §1). Byte-identical
 # to `git rev-parse --show-toplevel` for non-worktree sessions.
+#
+# INVARIANT (Issue #1664): wiki-ingest-trigger.sh writes the Raw Source under
+# this SAME state-path-resolve.sh root. The scan below (`find .rite/wiki/raw`,
+# run after the `cd "$repo_root"` on the next line) only sees what trigger wrote
+# if both stay keyed off state-path-resolve.sh — do not switch this scan to a
+# `$PWD`-relative root or raw sources written from a linked worktree go missing.
 repo_root=$("$_SCRIPT_DIR/../state-path-resolve.sh" 2>/dev/null) || repo_root=""
 [ -n "$repo_root" ] || repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1063,7 +1063,7 @@ fi
 echo ""
 
 # ==========================================================================
-# Phase: STATE_ROOT write anchoring (Issue #1664) — TC-051 〜 TC-052
+# Phase: STATE_ROOT write anchoring (Issue #1664) — TC-051 〜 TC-053
 # trigger は raw を state-path-resolve ルート (linked worktree では main
 # checkout) 配下へ書く。wiki-ingest-commit.sh の scan ルートと一致させ、
 # multi-session worktree からの起動で raw が silent に取りこぼされる回帰を防ぐ。

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1084,25 +1084,34 @@ wiki:
   enabled: true
 EOF
 wt51="$dir51/session-wt"
-git -C "$dir51" worktree add -q "$wt51" -b wt-issue-1664 >/dev/null 2>&1
-echo "Review body in worktree" > "$wt51/body.md"
-( cd "$wt51" && bash "$HOOK" \
-  --type reviews \
-  --source-ref pr-1664 \
-  --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
-target_path="$(cat "$wt51/out.log" 2>/dev/null | tr -d '[:space:]' || true)"
-# 期待: rc=0、相対パスのまま、main checkout 側に着地、worktree 側には未着地、NOTE 出力
-if [ $rc -eq 0 ] && \
-   echo "$target_path" | grep -q '^\.rite/wiki/raw/reviews/' && \
-   [ -f "$dir51/$target_path" ] && \
-   [ ! -e "$wt51/.rite/wiki/raw" ] && \
-   grep -q 'NOTE:' "$wt51/err.log" && grep -q 'Issue #1664' "$wt51/err.log"; then
-  pass "linked worktree 起動 → raw が main checkout へ着地 + 相対パス維持 + NOTE シグナル"
+# worktree add の失敗は握り潰さない (set -euo pipefail 下で 2>&1 抑制すると、add 失敗時に
+# 原因不明のままスイート全体が silent abort する)。stderr を log に退避し if で明示判定する。
+if git -C "$dir51" worktree add -q "$wt51" -b wt-issue-1664 2>"$dir51/wt-add-err.log"; then
+  echo "Review body in worktree" > "$wt51/body.md"
+  ( cd "$wt51" && bash "$HOOK" \
+    --type reviews \
+    --source-ref pr-1664 \
+    --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
+  target_path="$(cat "$wt51/out.log" 2>/dev/null | tr -d '[:space:]' || true)"
+  # 期待: rc=0、相対パスのまま、main checkout 側に着地 + body 内容が捕捉されている、
+  # worktree 側には未着地、NOTE 出力。body grep は本バグの本質 (content の silent drop) を
+  # 直接検証する — cd リダイレクト後も worktree の content が正しく書かれたことを確認する
+  # (TC-010/TC-011 の body grep 規約に揃える)。
+  if [ $rc -eq 0 ] && \
+     echo "$target_path" | grep -q '^\.rite/wiki/raw/reviews/' && \
+     [ -f "$dir51/$target_path" ] && \
+     grep -q 'Review body in worktree' "$dir51/$target_path" && \
+     [ ! -e "$wt51/.rite/wiki/raw" ] && \
+     grep -q 'NOTE:' "$wt51/err.log" && grep -q 'Issue #1664' "$wt51/err.log"; then
+    pass "linked worktree 起動 → raw が main checkout へ着地 + body 内容捕捉 + 相対パス維持 + NOTE シグナル"
+  else
+    fail "Expected raw under main checkout ($dir51) not worktree ($wt51) with body content and NOTE, got path='$target_path' rc=$rc; worktree raw exists=$([ -e "$wt51/.rite/wiki/raw" ] && echo yes || echo no); stderr=$(cat "$wt51/err.log" 2>/dev/null)"
+  fi
+  # cleanup worktree registration (TEST_DIR rm でも消えるが prune しておく)
+  git -C "$dir51" worktree remove --force "$wt51" >/dev/null 2>&1 || true
 else
-  fail "Expected raw under main checkout ($dir51) not worktree ($wt51) with NOTE, got path='$target_path' rc=$rc; worktree raw exists=$([ -e "$wt51/.rite/wiki/raw" ] && echo yes || echo no); stderr=$(cat "$wt51/err.log" 2>/dev/null)"
+  fail "TC-051 setup: git worktree add が失敗しました: $(head -3 "$dir51/wt-add-err.log" 2>/dev/null)"
 fi
-# cleanup worktree registration (TEST_DIR rm でも消えるが prune しておく)
-git -C "$dir51" worktree remove --force "$wt51" >/dev/null 2>&1 || true
 echo ""
 
 # --------------------------------------------------------------------------
@@ -1122,14 +1131,56 @@ echo "Review body at root" > "$dir52/body.md"
   --source-ref pr-root \
   --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
 target_path="$(cat "$dir52/out.log" 2>/dev/null | tr -d '[:space:]' || true)"
-# STATE_ROOT == $PWD == git root → cd は no-op、NOTE は出さない
+# STATE_ROOT == $PWD == git root → cd は no-op、NOTE は出さない。body grep で
+# 単一セッション時も content が正しく書かれることを確認 (TC-051 と対称)。
 if [ $rc -eq 0 ] && \
    echo "$target_path" | grep -q '^\.rite/wiki/raw/reviews/' && \
    [ -f "$dir52/$target_path" ] && \
+   grep -q 'Review body at root' "$dir52/$target_path" && \
    ! grep -q 'NOTE:' "$dir52/err.log"; then
-  pass "git root 起動 → raw が root へ着地 + 相対パス維持 + NOTE 非出力 (AC-2 非回帰)"
+  pass "git root 起動 → raw が root へ着地 + body 内容捕捉 + 相対パス維持 + NOTE 非出力 (AC-2 非回帰)"
 else
-  fail "Expected raw at root with relative path and NO NOTE, got path='$target_path' rc=$rc; stderr=$(cat "$dir52/err.log" 2>/dev/null)"
+  fail "Expected raw at root with body content, relative path and NO NOTE, got path='$target_path' rc=$rc; stderr=$(cat "$dir52/err.log" 2>/dev/null)"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-053: linked worktree から起動しても path containment ガードが維持される (AC-3)
+#         worktree 起動 (STATE_ROOT != $PWD で cd が実走) の経路でも、ガードは cd の
+#         前に元 $PWD 基準で評価されるため、$PWD 外 / 非 /tmp-rite の content-file は
+#         従来どおり reject される。既存 TC-033/034/036 は git root (非 worktree) 起動
+#         のみをカバーしていたため、worktree 起動経路の AC-3 を本 TC で pin する。
+# --------------------------------------------------------------------------
+echo "TC-053: linked worktree 起動 + content-file が \$PWD 外 → exit 1 (AC-3 path containment 維持)"
+dir53="$TEST_DIR/tc53"
+mkdir -p "$dir53"
+git -C "$dir53" init -q
+git -C "$dir53" -c user.email=t@example.com -c user.name=t commit --allow-empty -q -m init
+cat > "$dir53/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+# worktree の外 (main checkout 直下) に content-file を置く。worktree から見ると $PWD 外。
+echo "outside worktree pwd" > "$dir53/outside-body.md"
+wt53="$dir53/session-wt"
+if git -C "$dir53" worktree add -q "$wt53" -b wt-issue-1664-ac3 2>"$dir53/wt-add-err.log"; then
+  # worktree ($wt53) から、$PWD 外かつ非 /tmp-rite の content-file を相対パスで渡す。
+  ( cd "$wt53" && bash "$HOOK" \
+    --type reviews \
+    --source-ref pr-ac3 \
+    --content-file ../outside-body.md > out.log 2>err.log ) && rc=0 || rc=$?
+  # 期待: exit 1 (path containment reject)、main checkout 側にも worktree 側にも raw 未生成
+  if [ "$rc" -eq 1 ] && \
+     grep -q 'must be under' "$wt53/err.log" && \
+     [ ! -e "$dir53/.rite/wiki/raw" ] && \
+     [ ! -e "$wt53/.rite/wiki/raw" ]; then
+    pass "worktree 起動 + \$PWD 外 content-file → exit 1 + raw 未生成 (AC-3 ガード維持)"
+  else
+    fail "Expected exit 1 with containment rejection and no raw written, got rc=$rc; stderr=$(cat "$wt53/err.log" 2>/dev/null)"
+  fi
+  git -C "$dir53" worktree remove --force "$wt53" >/dev/null 2>&1 || true
+else
+  fail "TC-053 setup: git worktree add が失敗しました: $(head -3 "$dir53/wt-add-err.log" 2>/dev/null)"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1062,6 +1062,77 @@ else
 fi
 echo ""
 
+# ==========================================================================
+# Phase: STATE_ROOT write anchoring (Issue #1664) — TC-051 〜 TC-052
+# trigger は raw を state-path-resolve ルート (linked worktree では main
+# checkout) 配下へ書く。wiki-ingest-commit.sh の scan ルートと一致させ、
+# multi-session worktree からの起動で raw が silent に取りこぼされる回帰を防ぐ。
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# TC-051: linked worktree から起動 → raw は main checkout 配下へ着地 (AC-1)
+#         かつ redirect の検知可能シグナル (NOTE) を stderr に emit する
+# --------------------------------------------------------------------------
+echo "TC-051: linked worktree 起動 → raw は main checkout の .rite/wiki/raw/ へ + NOTE"
+dir51="$TEST_DIR/tc51"
+mkdir -p "$dir51"
+git -C "$dir51" init -q
+# linked worktree add には最低 1 commit が必要 (unborn branch からは add 不可)
+git -C "$dir51" -c user.email=t@example.com -c user.name=t commit --allow-empty -q -m init
+cat > "$dir51/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+wt51="$dir51/session-wt"
+git -C "$dir51" worktree add -q "$wt51" -b wt-issue-1664 >/dev/null 2>&1
+echo "Review body in worktree" > "$wt51/body.md"
+( cd "$wt51" && bash "$HOOK" \
+  --type reviews \
+  --source-ref pr-1664 \
+  --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
+target_path="$(cat "$wt51/out.log" 2>/dev/null | tr -d '[:space:]' || true)"
+# 期待: rc=0、相対パスのまま、main checkout 側に着地、worktree 側には未着地、NOTE 出力
+if [ $rc -eq 0 ] && \
+   echo "$target_path" | grep -q '^\.rite/wiki/raw/reviews/' && \
+   [ -f "$dir51/$target_path" ] && \
+   [ ! -e "$wt51/.rite/wiki/raw" ] && \
+   grep -q 'NOTE:' "$wt51/err.log" && grep -q 'Issue #1664' "$wt51/err.log"; then
+  pass "linked worktree 起動 → raw が main checkout へ着地 + 相対パス維持 + NOTE シグナル"
+else
+  fail "Expected raw under main checkout ($dir51) not worktree ($wt51) with NOTE, got path='$target_path' rc=$rc; worktree raw exists=$([ -e "$wt51/.rite/wiki/raw" ] && echo yes || echo no); stderr=$(cat "$wt51/err.log" 2>/dev/null)"
+fi
+# cleanup worktree registration (TEST_DIR rm でも消えるが prune しておく)
+git -C "$dir51" worktree remove --force "$wt51" >/dev/null 2>&1 || true
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-052: git root から起動 (単一セッション) → 挙動不変・NOTE なし (AC-2)
+# --------------------------------------------------------------------------
+echo "TC-052: git root 起動 → 相対パス維持・NOTE 非出力 (非回帰)"
+dir52="$TEST_DIR/tc52"
+mkdir -p "$dir52"
+git -C "$dir52" init -q
+cat > "$dir52/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+echo "Review body at root" > "$dir52/body.md"
+( cd "$dir52" && bash "$HOOK" \
+  --type reviews \
+  --source-ref pr-root \
+  --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
+target_path="$(cat "$dir52/out.log" 2>/dev/null | tr -d '[:space:]' || true)"
+# STATE_ROOT == $PWD == git root → cd は no-op、NOTE は出さない
+if [ $rc -eq 0 ] && \
+   echo "$target_path" | grep -q '^\.rite/wiki/raw/reviews/' && \
+   [ -f "$dir52/$target_path" ] && \
+   ! grep -q 'NOTE:' "$dir52/err.log"; then
+  pass "git root 起動 → raw が root へ着地 + 相対パス維持 + NOTE 非出力 (AC-2 非回帰)"
+else
+  fail "Expected raw at root with relative path and NO NOTE, got path='$target_path' rc=$rc; stderr=$(cat "$dir52/err.log" 2>/dev/null)"
+fi
+echo ""
+
 # --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -53,6 +53,15 @@ source "$SCRIPT_DIR/control-char-neutralize.sh"
 # a `$PWD`-based rite-config.yml lookup would silently miss the config when the
 # script runs from a subdirectory. CLI tool (not a hook), so $PWD takes the
 # place of the stdin-supplied CWD that hook scripts receive.
+#
+# STATE_ROOT is ALSO the write anchor for the Raw Source (see "Compute target
+# path" below): wiki-ingest-commit.sh scans `.rite/wiki/raw` after `cd
+# "$repo_root"` where repo_root == this same state-path-resolve.sh result. In a
+# multi-session linked worktree state-path-resolve.sh unifies to the main
+# checkout, so anchoring the write here keeps trigger (write) and commit (scan)
+# on the SAME root. A `$PWD`-relative write would land the raw in the worktree's
+# `.rite/wiki/raw` while commit scans the main checkout's — silently dropping it
+# (Issue #1664). The two scripts MUST stay keyed off state-path-resolve.sh.
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$PWD" 2>/dev/null) || STATE_ROOT="$PWD"
 
 TYPE=""
@@ -340,7 +349,30 @@ if [[ -z "$slug" ]]; then
   exit 1
 fi
 
+# --- Anchor the write at STATE_ROOT (Issue #1664) ---
+# All path-containment validation above evaluates `--content-file` against the
+# ORIGINAL $PWD (and reads the body via the absolute realpath result
+# $resolved_content), so they have already completed — moving cwd now does not
+# relax that guard (AC-3). From here on the write must target the same root
+# wiki-ingest-commit.sh scans (state-path-resolve.sh; the main checkout under a
+# linked worktree), so cd into STATE_ROOT and keep target_dir relative. When
+# STATE_ROOT == $PWD (single-session run from repo root, or non-git fallback)
+# this is a no-op and behaviour is byte-identical to before (AC-2).
+if [ "$STATE_ROOT" != "$PWD" ]; then
+  # Detectable signal (re-divergence guard): surface that the raw is written to
+  # the resolved state root rather than cwd, so a multi-session worktree /
+  # subdirectory invocation is observable instead of silently redirecting.
+  echo "NOTE: raw source を state-path-resolve ルート '$STATE_ROOT' 配下へ書き込みます (cwd='$PWD' とは別 — multi-session worktree / サブディレクトリ起動)。wiki-ingest-commit.sh の scan ルートと一致させる整合動作です (Issue #1664)。" >&2
+fi
+cd "$STATE_ROOT" || {
+  echo "ERROR: state root '$STATE_ROOT' への cd に失敗しました — raw source の書込先を確定できません" >&2
+  exit 3
+}
+
 # --- Compute target path ---
+# Relative to STATE_ROOT (we cd'd into it above) so the printed path stays
+# `.rite/wiki/raw/...` — the documented relative-path contract — and matches the
+# relative path wiki-ingest-commit.sh resolves after its own `cd "$repo_root"`.
 target_dir=".rite/wiki/raw/${TYPE}"
 timestamp_iso=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
 timestamp_compact=$(date -u +"%Y%m%dT%H%M%SZ")


### PR DESCRIPTION
## 概要

multi-session worktree モード（`multi_session.enabled: true`）で wiki-ingest の **trigger（書込）と commit（scan）の参照ルートが乖離**し、セッション worktree から起動した review / fix / close 時に raw source が wiki ブランチへ commit されず silent に取りこぼされる問題を修正する。

蓄積経路は non-blocking 設計のため、取りこぼしはエラーを出さずに発生していた。

## Root Cause

- `wiki-ingest-trigger.sh`: raw を `target_dir=".rite/wiki/raw/${TYPE}"` と **`$PWD` 相対**で書き込む。`STATE_ROOT`（state-path-resolve 解決値）は `rite-config.yml` lookup にしか使われていなかった。
- `wiki-ingest-commit.sh`: `repo_root=state-path-resolve.sh`（linked worktree では **main checkout** に統一）へ `cd` して `find .rite/wiki/raw` で scan する。

→ セッション worktree（`.rite/worktrees/issue-{N}`）から trigger すると raw は worktree 側の `.rite/wiki/raw/` に残り、commit は main checkout の `.rite/wiki/raw/` を scan するため commit 対象にならない。

## 変更内容

- **`wiki-ingest-trigger.sh`**: path containment ガード評価後に `cd "$STATE_ROOT"` し、書込先を commit と同一の state-path-resolve ルートへアンカー。`target_dir` は相対のまま維持し、stdout の相対パス契約と caller 挙動を不変に保つ。
- **`wiki-ingest-trigger.sh`**: `$PWD != STATE_ROOT` のとき NOTE を stderr へ emit し、書込先 redirect を観測可能にする（再乖離の検知可能シグナル）。
- **`wiki-ingest-commit.sh`**: scan ルート invariant の相互参照コメントを追加し、両スクリプトが state-path-resolve に key される invariant を文書化（再乖離防止）。
- **テスト**: TC-051（linked worktree から起動 → raw が main checkout へ着地 + NOTE シグナル = AC-1）、TC-052（git root 起動の非回帰 = NOTE なし・相対パス維持 = AC-2）を追加。

## 受入基準

- **AC-1**: multi-session worktree から起動しても raw が commit と同一ルートに着地し commit 対象になる → `cd "$STATE_ROOT"` アンカー + TC-051
- **AC-2**: 単一セッション（`STATE_ROOT == $PWD`）は cd が no-op で byte-identical → TC-052
- **AC-3**: `--content-file` の path containment ガードは cd 前に `$PWD` で評価されるため不変（`$PWD` 外 / 非 `/tmp/rite-*` は従来どおり reject）

## テスト

- `wiki-ingest-trigger.test.sh`: 55 passed, 0 failed（新規 TC-051 / TC-052 含む）
- hooks 全テストスイート: 78/78 passed
- `bash -n` 構文チェック: 両スクリプト OK

## 設計メモ

- caller（review.md 6.5.W / fix.md 4.6.W / close.md 4.4.W）は trigger の stdout パスを消費せず `trigger_exit` のみ参照するため、出力を相対パスのまま維持することで契約は不変。
- commit は引数なしで起動し独立に scan ルートを解決するため、commit 側はコメント追加のみでコード変更なし。

## 関連 Issue

Closes #1664
