### PR TITLE
fix(pr): cleanup の自己ブロッキングを排し遅延ブランチを回収する

### DIFF
--- a/docs/designs/multi-session-worktree.md
+++ b/docs/designs/multi-session-worktree.md
@@ -213,7 +213,8 @@ multi_session:
 **Gate 0 — self-exclusion（後続で追加された第 4 の保護層）**: 上記 3 ゲートの**前段**に、実行中の自セッション worktree（起動時 cwd、または `RITE_WORKTREE` env が候補 worktree と一致/配下）を reap 対象から除外するガードを設ける。long-lived セッションが review 開始時（review.md Step 1.0.0）に**自分の作業中 worktree**（clean かつ claim free/stale で 3 ゲートを全通過しうる）を削除する事故を防ぐ。dirty(3)/claim(2) 保護とは独立した第 4 の保護層。
 
 処理は既存 `_reap_mutation_worktree` と同型: `git worktree remove --force` → fallback `rm -rf` → `git worktree prune` + 対応 claim ファイル削除。
-**branch は削除しない**（push 済み / 未 push 作業の保全。branch 掃除は正常系 cleanup.md の責務のまま）。
+
+**branch recovery（Issue #1670 で精緻化）**: 初期設計は「branch は削除しない（作業保全）」だったが、これだと cleanup.md が別 live セッションの在席で削除を遅延した feature ブランチが回収経路を持たず永久残置（dead-letter）した。現在は worktree reap 後にその branch を**安全に回収**する: `git branch -d`（safe — 未マージは拒否するため**未マージ作業は破壊しない**）を第一手とし、`-d` が squash-merge 残渣で拒否しても **reap manifest に記録された branch**（cleanup.md が PR merged を確認して `rite-tmp-artifact.sh record --type branch` で記録）のみ `git branch -D` で強制削除する。manifest 未記録の未マージ branch は WARNING を出して保持する。これにより「branch は保全」方針は「**merge 確認済み branch のみ回収・未マージ作業は破壊しない**」へと精緻化された。
 
 トリガー: cleanup.md の既存 `pr-cycle-cleanup.sh` 呼び出しに内包 + `session-start.sh`（main checkout 起動時）から `|| true` の best-effort 呼び出し
 （worktree list + status check のみの軽量処理で hook timeout 30s 内に収まることをテストで担保）。

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -381,8 +381,8 @@ fi
 # 自セッションの worktree は 4-W の self-exclusion で即時削除されるため、本経路に来るのは
 # 別 live セッション在席時のみ。git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定して
 # substring マッチを安定させる（repo 既存の wiki-lint-*.sh と同規約）。
-# `{pr_merged}` はステップ 1.3 の PR 状態（`mergedAt` 非 null なら `true`、未マージ PR の
-# 強制 cleanup 時のみ `false`）を Claude が literal substitute する。squash merge では feature の
+# `{pr_merged}` はステップ 1.3 の PR 状態（`mergedAt` 非 null なら `true`、それ以外すべて
+# `false`。Step 1.3 と同一定義）を Claude が literal substitute する。squash merge では feature の
 # コミットが base の祖先にならないため、worktree 解放後でも `git branch -d` が "not fully merged" で
 # 拒否する。PR が merged 済み（{pr_merged}=true）ならこれは squash の残渣であり強制削除して安全
 # （ユニークな未マージ作業は無い）。
@@ -395,11 +395,21 @@ else
       # （{pr_merged}=true）のときのみ reap manifest に記録し、別 live セッションが worktree を
       # 解放したあと pr-cycle-cleanup.sh Step 5 が安全に回収できるようにする。未マージ PR の強制
       # cleanup 時（{pr_merged}=false）は記録しない（作業損失防止 — AC-4）。
-      # **recovery= の意味（AC-6）**: 記録が成功したときだけ「自動回収される」のが事実なので、
-      # marker に recovery=auto/manual を載せてステップ 12 が正しい文面を出し分ける。記録に失敗した
-      # 経路や {pr_merged}=false の経路で「自動で回収されます」と偽の約束を出さない。`&&` 短絡で
-      # 「pr_merged=true かつ記録成功」のときのみ recovery=auto になる。
-      if [ "{pr_merged}" = "true" ] && bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type branch --id "{branch_name}" 2>/dev/null; then
+      # **recovery= の意味（AC-6）**: rite-tmp-artifact.sh は非ブロッキング契約で、append 失敗でも
+      # WARNING を出して exit 0 を返す（非 0 は usage error のみ）。したがって record の exit code では
+      # 記録成否を判定できない。共有 manifest を直接 verify し、エントリが実在するときだけ
+      # recovery=auto を emit する（記録できていない経路で「自動で回収されます」と偽らない）。
+      # {pr_merged}=false / 記録漏れ / shared-root 解決不能はすべて recovery=manual に倒す。
+      _recovery=manual
+      if [ "{pr_merged}" = "true" ]; then
+        bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type branch --id "{branch_name}" 2>/dev/null || true
+        _shared_root=$(bash {plugin_root}/hooks/state-path-resolve.sh 2>/dev/null) || _shared_root=""
+        [ -n "$_shared_root" ] || _shared_root=$(git rev-parse --show-toplevel 2>/dev/null) || _shared_root=""
+        if [ -n "$_shared_root" ] && grep -qxF "branch$(printf '\t'){branch_name}" "$_shared_root/.rite/tmp-artifacts.tsv" 2>/dev/null; then
+          _recovery=auto
+        fi
+      fi
+      if [ "$_recovery" = "auto" ]; then
         echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree; recovery=auto" >&2
         echo "WARNING: ローカルブランチ {branch_name} はまだ別のセッションの作業ツリーで使用中のため、削除を見送りました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で回収されます。" >&2
       else
@@ -423,7 +433,7 @@ fi
 git ls-remote --heads origin {branch_name} && git push origin --delete {branch_name}
 ```
 
-`BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（別セッションが worktree を使用中で削除を遅延したケース）のときは**強制削除しない**（reap manifest に記録済みで、worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が回収。ステップ 12 で残置と自動回収予定を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
+`BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（別セッションが worktree を使用中で削除を遅延したケース）のときは**強制削除しない**。marker の `recovery=` で次セッション回収の可否が決まる: `recovery=auto`（{pr_merged}=true かつ reap manifest への記録を verify 済み）は worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が自動回収する。`recovery=manual`（未マージ PR の強制 cleanup、または記録漏れ）は自動回収されないため手動 `git branch -D` が必要。ステップ 12 はこの `recovery=` 値で残置メッセージを出し分ける。リモート削除は GitHub auto-delete で既削除のエラーは無視。
 
 ---
 

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -66,7 +66,7 @@ gh pr list --head {branch_name} --state all --json number,title,state,mergedAt,u
 
 PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャンセル」を確認。未マージ PR: 「キャンセル (推奨) / 強制クリーンアップ」を確認。
 
-`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true`、未マージ PR の強制クリーンアップを選んだ場合のみ `{pr_merged}=false` として保持する。ステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
+`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。これによりステップ 5 のすべての分岐で `{pr_merged}` が必ず literal substitute 可能になる（未定義値参照を防ぐ）。ステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
 
 ### 1.4 リポジトリ情報取得
 
@@ -391,16 +391,21 @@ if del_err=$(LC_ALL=C git branch -d {branch_name} 2>&1); then
 else
   case "$del_err" in
     *"used by worktree"*|*"checked out"*)
-      echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree" >&2
-      # #1670: 遅延ブランチを次セッション回収へ配線する（dead-letter 解消）。PR は merged 済みなので
-      # reap manifest に記録し、別 live セッションが worktree を解放したあと pr-cycle-cleanup.sh
-      # Step 5 が安全に回収できるようにする。未マージ PR の強制 cleanup 時（{pr_merged}=false）は
-      # 記録しない（作業損失防止 — AC-4）。
-      if [ "{pr_merged}" = "true" ]; then
-        bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type branch --id "{branch_name}" 2>/dev/null \
-          || echo "WARNING: 遅延ブランチ {branch_name} の reap manifest 記録に失敗しました。手動削除: git branch -D {branch_name}（worktree 解放後）。" >&2
-      fi
-      echo "WARNING: ローカルブランチ {branch_name} はまだ別のセッションの作業ツリーで使用中のため、削除を見送りました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で回収されます。" >&2 ;;
+      # #1670: 遅延ブランチを次セッション回収へ配線する（dead-letter 解消）。PR が merged 済み
+      # （{pr_merged}=true）のときのみ reap manifest に記録し、別 live セッションが worktree を
+      # 解放したあと pr-cycle-cleanup.sh Step 5 が安全に回収できるようにする。未マージ PR の強制
+      # cleanup 時（{pr_merged}=false）は記録しない（作業損失防止 — AC-4）。
+      # **recovery= の意味（AC-6）**: 記録が成功したときだけ「自動回収される」のが事実なので、
+      # marker に recovery=auto/manual を載せてステップ 12 が正しい文面を出し分ける。記録に失敗した
+      # 経路や {pr_merged}=false の経路で「自動で回収されます」と偽の約束を出さない。`&&` 短絡で
+      # 「pr_merged=true かつ記録成功」のときのみ recovery=auto になる。
+      if [ "{pr_merged}" = "true" ] && bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type branch --id "{branch_name}" 2>/dev/null; then
+        echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree; recovery=auto" >&2
+        echo "WARNING: ローカルブランチ {branch_name} はまだ別のセッションの作業ツリーで使用中のため、削除を見送りました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で回収されます。" >&2
+      else
+        echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree; recovery=manual" >&2
+        echo "WARNING: ローカルブランチ {branch_name} は作業ツリーで使用中のため、削除を見送りました。その作業ツリーが解放されたあと、手動で削除してください: git branch -D {branch_name}" >&2
+      fi ;;
     *"not fully merged"*)
       if [ "{pr_merged}" = "true" ]; then
         # squash merge の残渣 — PR は merged 済みなので強制削除して安全。
@@ -617,10 +622,15 @@ Status: {projects_status_result}
     ```
   - いずれの `[CONTEXT]` 行も無い（削除成功）とき: `x`
 - `{local_branch_check}`: ステップ 5 の `[CONTEXT]` 行で判定（上から評価し最初に一致したものを採用）:
-  - `BRANCH_DELETE_DEFERRED=1` のとき（別セッションが作業ツリーを使用中で削除を見送った。ブランチは reap manifest に記録済みで自動回収される。#1670）: ` ` + 以下を付記
-    ```
-    ℹ️ ローカルブランチ {branch_name} は、別セッションが使用中の作業ツリーで参照されているため残しました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で削除されます（手動操作は不要）。
-    ```
+  - `BRANCH_DELETE_DEFERRED=1` のとき（別セッションが作業ツリーを使用中で削除を見送った。#1670）。**marker の `recovery=` フィールドで文面を出し分ける**（記録できていない経路で「自動回収」と偽らないため — AC-6）: ` ` + 以下を付記
+    - `recovery=auto`（PR が merged 済みで reap manifest に記録成功 → 次セッションで自動回収される）:
+      ```
+      ℹ️ ローカルブランチ {branch_name} は、別セッションが使用中の作業ツリーで参照されているため残しました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で削除されます（手動操作は不要）。
+      ```
+    - `recovery=manual`（未マージ PR の強制 cleanup、または manifest 記録に失敗 → 自動回収されないため手動が必要）:
+      ```
+      ℹ️ ローカルブランチ {branch_name} は、作業ツリーで参照されているため残しました。その作業ツリーが解放されたあと、手動で削除してください: git branch -D {branch_name}
+      ```
   - `BRANCH_DELETED=1` のとき（通常削除、squash 残渣の自動強制削除 `via=squash-merged`、または `BRANCH_DELETE_UNMERGED` をユーザーが強制削除 `-D` で解決した場合に emit される。**`BRANCH_DELETE_UNMERGED=1` より先に評価する**）: `x`
   - `BRANCH_DELETE_FAILED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（作業ツリーで使用中なら解放後）」を付記
   - `BRANCH_DELETE_UNMERGED=1` のとき（= 未マージ PR の強制 cleanup でユーザーが skip 選択。強制削除で解決した場合は上位の `BRANCH_DELETED=1` 行で既に `x` 評価済みのため、ここに到達するのは skip 時のみ）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記

--- a/plugins/rite/commands/pr/cleanup.md
+++ b/plugins/rite/commands/pr/cleanup.md
@@ -66,6 +66,8 @@ gh pr list --head {branch_name} --state all --json number,title,state,mergedAt,u
 
 PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャンセル」を確認。未マージ PR: 「キャンセル (推奨) / 強制クリーンアップ」を確認。
 
+`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true`、未マージ PR の強制クリーンアップを選んだ場合のみ `{pr_merged}=false` として保持する。ステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
+
 ### 1.4 リポジトリ情報取得
 
 ```bash
@@ -321,21 +323,24 @@ esac
 - `CLEANUP_WT=in_worktree` / `in_worktree_unrecorded`（cwd がセッション worktree。後者は flow-state 未記録だが物理 cwd が当該 Issue の worktree な場合 — #1622。以降の手順 1〜4 は両者で同一）:
   1. `dirty=yes` なら **AskUserQuestion**（「`git stash push` して続行 / 中止」）。stash は common git dir に格納されるため worktree 削除後も `git stash pop` 可能（完了報告の stash 案内は従来文面を流用）。
   2. `ExitWorktree` ツールを `action: "keep"` で呼び出し、main checkout に復帰する（path 入場した worktree は remove でも消えない仕様のため**常に keep**）。
-  3. main から worktree を削除する。**削除前に live-cwd guard（Issue #1544）を通す**: 別のセッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、live プロセスが cwd を置いているときは削除せず遅延 reap（`pr-cycle-cleanup.sh` の session worktree reap）へ委譲する:
+  3. main から worktree を削除する。**削除前に self-exclusion 付き live-cwd guard（Issue #1544 / #1670）を通す**: **別の**セッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、削除せず遅延回収へ委譲する。一方、cleanup を実行している**自セッション自身**（ハーネス = この Bash の親 `$PPID` の process subtree）は除外する — これを除外しないと、ステップ 2 の `ExitWorktree(keep)` が no-op だった経路（`in_worktree_unrecorded` 等で worktree が EnterWorktree 記録なしに path 入場された場合）で自セッションを「live」と誤検出し、cleanup 自身を理由に削除をブロックする自己ブロッキングが起きる（#1670）。判定は self-exclusion を内蔵した `worktree-foreign-cwd.sh` に委譲する（`worktree-live-cwd.sh` 自体は変更しない — #1670 Non-Target）:
      ```bash
-     _lc_rc=0
-     bash {plugin_root}/hooks/scripts/worktree-live-cwd.sh "{flow_wt}" >/dev/null 2>&1 || _lc_rc=$?
-     if [ "$_lc_rc" -eq 0 ]; then
-       echo "WARNING: worktree '{flow_wt}' に live プロセスが cwd を置いているため削除を skip しました（遅延 reap pr-cycle-cleanup.sh に委譲。harness cwd dangling → /clear エラーの防止）。" >&2
+     # rc 0 = 別の live セッションが cwd を置く → 削除を遅延 / rc 1 = 自セッションだけ or 不在
+     #        → 削除 / rc 2 = 判定不能（/proc 無し）→ 削除（従来 worktree-live-cwd.sh rc=2 と同じ後方互換）。
+     # --self-root "$PPID" でこの Bash の親（claude ハーネス）の process subtree を self として除外する。
+     _fc_rc=0
+     bash {plugin_root}/hooks/scripts/worktree-foreign-cwd.sh "{flow_wt}" --self-root "$PPID" >/dev/null 2>&1 || _fc_rc=$?
+     if [ "$_fc_rc" -eq 0 ]; then
+       echo "WARNING: 別のセッションがこの作業ツリー（{flow_wt}）を使用中のため、削除を見送りました。そのセッションが終了したあと、次回のセッション開始時に作業ツリーとローカルブランチが自動で回収されます。" >&2
        echo "[CONTEXT] WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1; path={flow_wt}" >&2
      else
        git worktree remove "{flow_wt}" 2>/dev/null || git worktree remove --force "{flow_wt}" 2>/dev/null || echo "[CONTEXT] WORKTREE_REMOVE_FAILED=1; path={flow_wt}" >&2
        git worktree prune 2>/dev/null || true
      fi
      ```
-     > `in_worktree` 経路ではステップ 2 の `ExitWorktree` で harness cwd が main に退避済みのため、この guard は通常 rc=1（live cwd 不在）で削除へ進む。`worktree-live-cwd.sh` が rc=2（`/proc` も `lsof` も無い環境で判定不能）を返す場合は `if` が false となり従来どおり削除を実行する（後方互換）。
+     > 通常の `in_worktree` 経路ではステップ 2 の `ExitWorktree(keep)` で自セッションの harness cwd が main に退避済みのため、worktree には自他いずれの cwd も無く `worktree-foreign-cwd.sh` は rc=1（削除）を返す。`ExitWorktree(keep)` が no-op だった経路（`in_worktree_unrecorded` 等）でも、残る live cwd は自セッションのハーネス（`$PPID` subtree）だけなので self-exclusion により rc=1（削除）となり、自己ブロッキングしない。rc=0（遅延）になるのは別セッションのハーネスが実際にこの worktree 内に cwd を持つ場合のみ。`/proc` の無い環境では rc=2 となり従来どおり削除を実行する（後方互換）。
   4. 削除失敗（`WORKTREE_REMOVE_FAILED`）または live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。
-- `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の live-cwd guard が特に重要。
+- `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の self-exclusion 付き live-cwd guard が特に重要（別セッション在席時のみ遅延する）。
 - `CLEANUP_WT=none`（multi_session 無効、または worktree 関連なし = 物理 cwd も当該 Issue の worktree でない）: 4-W 全体を no-op でスキップ。**注**: flow-state 未記録でも物理 cwd が当該 Issue の worktree なら `in_worktree_unrecorded` に分類されここには落ちない（#1622）。
 
 > **復旧: `/clear` が `Path does not exist` で失敗する場合（Issue #1552）**
@@ -369,20 +374,42 @@ fi
 > **順序**: branch 削除は **worktree 削除後にのみ成功する**（Git 制約: worktree で checkout 中の branch は削除不可）。multi_session 時は必ずステップ 4-W → 本ステップの順で実行する。
 
 ```bash
-# worktree 削除が遅延/失敗した場合（ステップ 4-W が WORKTREE_REMOVE_SKIPPED_LIVE_CWD /
-# WORKTREE_REMOVE_FAILED を残した場合）、branch は worktree で checkout 中のため削除できない。
-# その場合は強制削除も無意味なので skip し、残置を marker で surface して遅延 reap / 手動回収に
-# 委ねる（#1622）。git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定して substring
-# マッチを安定させる（repo 既存の wiki-lint-*.sh と同規約）。
+# worktree 削除が遅延した場合（ステップ 4-W が WORKTREE_REMOVE_SKIPPED_LIVE_CWD を残した =
+# 別 live セッションが worktree 使用中）、branch は worktree で checkout 中のため削除できない。
+# その場合は強制削除せず reap manifest に記録し（#1670）、worktree が解放されたあと
+# pr-cycle-cleanup.sh Step 5 が次セッションで branch・worktree の双方を回収する（dead-letter 解消）。
+# 自セッションの worktree は 4-W の self-exclusion で即時削除されるため、本経路に来るのは
+# 別 live セッション在席時のみ。git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定して
+# substring マッチを安定させる（repo 既存の wiki-lint-*.sh と同規約）。
+# `{pr_merged}` はステップ 1.3 の PR 状態（`mergedAt` 非 null なら `true`、未マージ PR の
+# 強制 cleanup 時のみ `false`）を Claude が literal substitute する。squash merge では feature の
+# コミットが base の祖先にならないため、worktree 解放後でも `git branch -d` が "not fully merged" で
+# 拒否する。PR が merged 済み（{pr_merged}=true）ならこれは squash の残渣であり強制削除して安全
+# （ユニークな未マージ作業は無い）。
 if del_err=$(LC_ALL=C git branch -d {branch_name} 2>&1); then
   echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}"
 else
   case "$del_err" in
     *"used by worktree"*|*"checked out"*)
       echo "[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}; reason=checked_out_in_worktree" >&2
-      echo "WARNING: ローカルブランチ {branch_name} はセッション worktree で checkout 中のため削除を skip しました（worktree 削除の遅延に伴う残置）。worktree 削除後に手動削除してください: git branch -D {branch_name}" >&2 ;;
+      # #1670: 遅延ブランチを次セッション回収へ配線する（dead-letter 解消）。PR は merged 済みなので
+      # reap manifest に記録し、別 live セッションが worktree を解放したあと pr-cycle-cleanup.sh
+      # Step 5 が安全に回収できるようにする。未マージ PR の強制 cleanup 時（{pr_merged}=false）は
+      # 記録しない（作業損失防止 — AC-4）。
+      if [ "{pr_merged}" = "true" ]; then
+        bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type branch --id "{branch_name}" 2>/dev/null \
+          || echo "WARNING: 遅延ブランチ {branch_name} の reap manifest 記録に失敗しました。手動削除: git branch -D {branch_name}（worktree 解放後）。" >&2
+      fi
+      echo "WARNING: ローカルブランチ {branch_name} はまだ別のセッションの作業ツリーで使用中のため、削除を見送りました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で回収されます。" >&2 ;;
     *"not fully merged"*)
-      echo "[CONTEXT] BRANCH_DELETE_UNMERGED=1; branch={branch_name}" >&2 ;;
+      if [ "{pr_merged}" = "true" ]; then
+        # squash merge の残渣 — PR は merged 済みなので強制削除して安全。
+        LC_ALL=C git branch -D {branch_name} >/dev/null 2>&1 \
+          && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=squash-merged" \
+          || echo "[CONTEXT] BRANCH_DELETE_FAILED=1; branch={branch_name}" >&2
+      else
+        echo "[CONTEXT] BRANCH_DELETE_UNMERGED=1; branch={branch_name}" >&2
+      fi ;;
     *)
       echo "[CONTEXT] BRANCH_DELETE_FAILED=1; branch={branch_name}" >&2
       echo "WARNING: ローカルブランチ {branch_name} の削除に失敗しました: $del_err" >&2 ;;
@@ -391,7 +418,7 @@ fi
 git ls-remote --heads origin {branch_name} && git push origin --delete {branch_name}
 ```
 
-`BRANCH_DELETE_UNMERGED=1`（未マージ変更）のときは「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（worktree checkout 中）のときは**強制削除しない**（worktree 削除後に回収。ステップ 12 で残置を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
+`BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（別セッションが worktree を使用中で削除を遅延したケース）のときは**強制削除しない**（reap manifest に記録済みで、worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が回収。ステップ 12 で残置と自動回収予定を報告）。リモート削除は GitHub auto-delete で既削除のエラーは無視。
 
 ---
 
@@ -578,25 +605,25 @@ Status: {projects_status_result}
 各チェックボックスおよび placeholder の判定:
 
 - `{session_worktree_check}`: multi_session 無効 or worktree 未使用なら行ごと省略。以下を**上から評価し最初に一致したもの**を採用する（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD` と `WORKTREE_REMOVE_FAILED` は Step 4-W guard の if/else で排他だが、両 `[CONTEXT]` 行が文脈に残る可能性に備えて評価順序を固定する）:
-  - `WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1` のとき（live-cwd guard が削除を skip）: ` ` + 以下を付記
+  - `WORKTREE_REMOVE_SKIPPED_LIVE_CWD=1` のとき（別のセッションが作業ツリーを使用中のため削除を見送った）: ` ` + 以下を付記
     ```
-    ℹ️ セッション worktree は別セッションが cwd を置いているため削除を skip しました（遅延 reap が後で回収します）。
-      手動削除（当該セッションの /clear 後）: git worktree remove --force {flow_wt} && git worktree prune
+    ℹ️ この作業ツリーは別のセッションが使用中のため、削除を見送りました。そのセッションが終了したあと、次回のセッション開始時に作業ツリーとローカルブランチが自動で回収されます。
+      すぐに消したい場合（別セッションを閉じたあと）: git worktree remove --force {flow_wt} && git worktree prune
     ```
   - `WORKTREE_REMOVE_FAILED=1` のとき（削除そのものが失敗）: ` ` + 以下を付記
     ```
-    ⚠️ セッション worktree の削除に失敗しました（遅延 reap が後で回収します）。
-      手動削除: git worktree remove --force {flow_wt} && git worktree prune
+    ⚠️ 作業ツリーの削除に失敗しました。次回のセッション開始時に自動で再回収されます。
+      すぐに消したい場合: git worktree remove --force {flow_wt} && git worktree prune
     ```
   - いずれの `[CONTEXT]` 行も無い（削除成功）とき: `x`
 - `{local_branch_check}`: ステップ 5 の `[CONTEXT]` 行で判定（上から評価し最初に一致したものを採用）:
-  - `BRANCH_DELETE_DEFERRED=1` のとき（worktree で checkout 中のため削除 skip — worktree 削除の遅延に伴う残置。#1622）: ` ` + 以下を付記
+  - `BRANCH_DELETE_DEFERRED=1` のとき（別セッションが作業ツリーを使用中で削除を見送った。ブランチは reap manifest に記録済みで自動回収される。#1670）: ` ` + 以下を付記
     ```
-    ℹ️ ローカルブランチ {branch_name} は worktree で checkout 中のため残置しました（worktree 削除の遅延に伴う）。worktree 削除後に手動削除: git branch -D {branch_name}
+    ℹ️ ローカルブランチ {branch_name} は、別セッションが使用中の作業ツリーで参照されているため残しました。その作業ツリーが解放されたあと、次回のセッション開始時に自動で削除されます（手動操作は不要）。
     ```
-  - `BRANCH_DELETED=1` のとき（通常削除、または `BRANCH_DELETE_UNMERGED` をユーザーが強制削除 `-D` で解決した場合に emit される。**`BRANCH_DELETE_UNMERGED=1` より先に評価する**）: `x`
-  - `BRANCH_DELETE_FAILED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（worktree で checkout 中なら worktree 削除後）」を付記
-  - `BRANCH_DELETE_UNMERGED=1` のとき（= ユーザーが skip 選択。強制削除で解決した場合は上位の `BRANCH_DELETED=1` 行で既に `x` 評価済みのため、ここに到達するのは skip 時のみ）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
+  - `BRANCH_DELETED=1` のとき（通常削除、squash 残渣の自動強制削除 `via=squash-merged`、または `BRANCH_DELETE_UNMERGED` をユーザーが強制削除 `-D` で解決した場合に emit される。**`BRANCH_DELETE_UNMERGED=1` より先に評価する**）: `x`
+  - `BRANCH_DELETE_FAILED=1` のとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（作業ツリーで使用中なら解放後）」を付記
+  - `BRANCH_DELETE_UNMERGED=1` のとき（= 未マージ PR の強制 cleanup でユーザーが skip 選択。強制削除で解決した場合は上位の `BRANCH_DELETED=1` 行で既に `x` 評価済みのため、ここに到達するのは skip 時のみ）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
   - いずれの `[CONTEXT]` 行も無いとき: `x`
 - `{projects_status_result}`: `projects_status_updated=true` なら `Done`、false なら `⚠️ 更新失敗（手動確認が必要）`
 - `{review_cleanup_check}`: `REVIEW_CLEANUP_PARTIAL_FAILURE=1` なら ` ` + 警告付記、なければ `x`

--- a/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
+++ b/plugins/rite/hooks/scripts/cleanup-worktree-detect.sh
@@ -13,8 +13,11 @@
 #   step. The worktree + its checked-out local branch then fell into an air-pocket:
 #   neither the in-session removal (4-W skipped) nor the lazy reap
 #   (pr-cycle-cleanup.sh Step 5 self-excludes the running session's own worktree)
-#   handled them, and the lazy reap never deletes branches — so the local branch
-#   leaked permanently.
+#   handled them, and (at the time) the lazy reap never deleted branches — so the
+#   local branch leaked permanently. (Issue #1670 has since added a self-exclusion
+#   to the 4-W live-cwd guard so the running session removes its own worktree, and a
+#   merge-confirmed branch-recovery path to the lazy reap; this helper's
+#   in_worktree_unrecorded routing remains the front-line fix for the detection gap.)
 #
 #   This helper adds a PHYSICAL derivation: with `flow_wt` empty but `cur_top`
 #   shaped like the rite session worktree for THIS issue

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -508,12 +508,28 @@ if [ -f "$manifest_path" ]; then
           if [ "$DRY_RUN" = "1" ]; then
             echo "[dry-run] would reap manifest branch: $(printf '%s' "$_m_val" | neutralize_ctrl)"
             printf '%s\n' "$_m_line" >> "$manifest_keep"
-          elif git branch -D -- "$_m_val" >/dev/null 2>&1; then
+          elif _m_bd_err=$(LC_ALL=C git branch -D -- "$_m_val" 2>&1); then
             manifest_reaped=$((manifest_reaped + 1))
           else
-            echo "WARNING: failed to reap manifest branch '$(printf '%s' "$_m_val" | neutralize_ctrl)'" >&2
-            errors=$((errors + 1))
-            printf '%s\n' "$_m_line" >> "$manifest_keep"
+            # #1670: cleanup.md records a deferred SESSION-worktree branch here while
+            # it is still checked out in its (not-yet-reaped) worktree. At this point
+            # (Step 4.5 < Step 5) `git branch -D` legitimately fails with "used by
+            # worktree" / "checked out" — Step 5 reaps that worktree and recovers the
+            # branch later in THIS run (the manifest contract "session worktrees go
+            # through Step 5's gated reap, never here"). That expected case must NOT
+            # count as an error (it would flip a fully-successful run to status=failed)
+            # nor emit a "failed to reap" WARNING. Preserve the entry silently; it
+            # self-heals on the next run's verify-already-gone drop. LC_ALL=C fixes the
+            # git diagnostic locale so the substring match is stable (same convention as
+            # cleanup.md Step 5).
+            case "$_m_bd_err" in
+              *"used by worktree"*|*"checked out"*)
+                printf '%s\n' "$_m_line" >> "$manifest_keep" ;;
+              *)
+                echo "WARNING: failed to reap manifest branch '$(printf '%s' "$_m_val" | neutralize_ctrl)'" >&2
+                errors=$((errors + 1))
+                printf '%s\n' "$_m_line" >> "$manifest_keep" ;;
+            esac
           fi
           ;;
         worktree)
@@ -887,10 +903,15 @@ if [ -d "$session_wt_root" ]; then
       # commits are not ancestors of base) → force-delete is safe. A non-recorded
       # unmerged branch is kept with a WARNING (never destroy unmerged work).
       if [ -n "$_reaped_branch" ] && [ "$_reaped_branch" != "HEAD" ]; then
-        if git branch -d "$_reaped_branch" >/dev/null 2>&1; then
+        # `--` (end-of-options) on every `git branch -d/-D` is a defense-in-depth
+        # invariant shared with the manifest reap (`git branch -D -- ...`) and
+        # documented in rite-tmp-artifact.sh: `_reaped_branch` comes straight from
+        # `git rev-parse --abbrev-ref HEAD` without the recorder's leading-dash guard,
+        # so `--` is the explicit backstop against an option-injecting branch name.
+        if git branch -d -- "$_reaped_branch" >/dev/null 2>&1; then
           session_branches_deleted=$((session_branches_deleted + 1))
         elif [ -f "$manifest_path" ] && grep -qxF "branch$(printf '\t')$_reaped_branch" "$manifest_path" 2>/dev/null; then
-          if git branch -D "$_reaped_branch" >/dev/null 2>&1; then
+          if git branch -D -- "$_reaped_branch" >/dev/null 2>&1; then
             session_branches_deleted=$((session_branches_deleted + 1))
             # The stale manifest `branch\t<name>` entry self-heals on the next run's
             # Step 4.5 (verify fails → already-gone → dropped), so no rewrite here.

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -140,6 +140,7 @@ branches_deleted=0
 workdirs_reaped=0
 mutation_worktrees_reaped=0
 session_worktrees_reaped=0
+session_branches_deleted=0
 manifest_reaped=0
 errors=0
 
@@ -598,8 +599,16 @@ fi
 #   3. `git -C <wt> status --porcelain` が空 (dirty worktree は絶対に auto-reap
 #      しない — WARNING + 手動コマンド提示で skip)
 # 処理は Step 1/4 と同型: `git worktree remove --force` → fallback `rm -rf` →
-# ループ後 `git worktree prune` + 対応 claim ファイル削除。**branch は削除しない**
-# (push 済み / 未 push 作業の保全。branch 掃除は正常系 cleanup.md の責務のまま)。
+# ループ後 `git worktree prune` + 対応 claim ファイル削除。
+#
+# **Branch recovery (Issue #1670)**: worktree reap 後に、その worktree が checkout
+# していた feature ブランチを **安全に回収する**。従来は branch を一切削除せず、cleanup.md
+# が live-cwd guard で削除を遅延した feature ブランチが回収経路を持たず永久残置 (dead-letter)
+# だった。回収は `git branch -d` (safe — 未マージは拒否 → クラッシュセッションの作業を保全, AC-4)
+# を第一手とし、`-d` が squash-merge 残渣で拒否しても **reap manifest に記録された** ブランチ
+# (cleanup.md が PR merged を確認して記録) のみ `git branch -D` で強制削除する。manifest 未記録の
+# 未マージブランチは保持する。これにより #1524 の「branch は保全」方針は「**merge 確認済み**
+# ブランチのみ回収・未マージ作業は破壊しない」へと精緻化される。
 # -----------------------------------------------------------------------
 session_wt_base=""
 if [ -f "$repo_root/rite-config.yml" ]; then
@@ -855,9 +864,13 @@ if [ -d "$session_wt_root" ]; then
       continue
     fi
 
+    # Capture the checked-out branch BEFORE removal (the worktree is gone after) so
+    # the post-reap branch recovery (#1670) can target it. Detached HEAD yields
+    # "HEAD" → no branch to recover.
+    _reaped_branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || _reaped_branch=""
+
     # Reap: remove --force first (drops worktree metadata + dir atomically),
-    # rm -rf fallback for dirs whose registration was already lost. The branch
-    # is intentionally preserved.
+    # rm -rf fallback for dirs whose registration was already lost.
     if git worktree remove --force "$wt_path" 2>/dev/null || rm -rf "$wt_path" 2>/dev/null; then
       session_worktrees_reaped=$((session_worktrees_reaped + 1))
       rm -f "$repo_root/.rite/state/issue-claims/issue-${issue_num}.json" 2>/dev/null || true
@@ -865,6 +878,30 @@ if [ -d "$session_wt_root" ]; then
       # (uses the pre-removal canonical path) so re-entry / harness cwd-restore is
       # not pointed at the just-removed dir. Non-blocking (AC-5).
       _rite_null_worktree_refs "$wt_path" "$_wt_canon"
+
+      # Branch recovery (#1670): the worktree is gone, so its branch is no longer
+      # checked out and can be deleted. SAFE-delete first — `git branch -d` refuses
+      # an unmerged branch, preserving a crashed session's in-progress work (AC-4).
+      # If `-d` refuses BUT the branch is in the reap manifest, cleanup.md confirmed
+      # its PR merged (the squash-merge case `-d` cannot detect, since squashed
+      # commits are not ancestors of base) → force-delete is safe. A non-recorded
+      # unmerged branch is kept with a WARNING (never destroy unmerged work).
+      if [ -n "$_reaped_branch" ] && [ "$_reaped_branch" != "HEAD" ]; then
+        if git branch -d "$_reaped_branch" >/dev/null 2>&1; then
+          session_branches_deleted=$((session_branches_deleted + 1))
+        elif [ -f "$manifest_path" ] && grep -qxF "branch$(printf '\t')$_reaped_branch" "$manifest_path" 2>/dev/null; then
+          if git branch -D "$_reaped_branch" >/dev/null 2>&1; then
+            session_branches_deleted=$((session_branches_deleted + 1))
+            # The stale manifest `branch\t<name>` entry self-heals on the next run's
+            # Step 4.5 (verify fails → already-gone → dropped), so no rewrite here.
+          else
+            echo "WARNING: failed to reap session worktree branch '$(printf '%s' "$_reaped_branch" | neutralize_ctrl)'" >&2
+            errors=$((errors + 1))
+          fi
+        else
+          echo "WARNING: session worktree branch '$(printf '%s' "$_reaped_branch" | neutralize_ctrl)' は未マージのため保持しました（不要なら手動削除: git branch -D '$(printf '%s' "$_reaped_branch" | neutralize_ctrl)'）。" >&2
+        fi
+      fi
     else
       echo "WARNING: failed to reap session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)'" >&2
       errors=$((errors + 1))
@@ -882,11 +919,11 @@ fi
 if [ "$DRY_RUN" = "1" ]; then
   echo "[pr-cycle-cleanup] status=dry-run; pattern=$PATTERN"
 elif [ "$errors" -gt 0 ]; then
-  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; manifest=$manifest_reaped; errors=$errors"
-elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ] && [ "$manifest_reaped" -eq 0 ]; then
-  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0; manifest=0"
+  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped; errors=$errors"
+elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ] && [ "$session_branches_deleted" -eq 0 ] && [ "$manifest_reaped" -eq 0 ]; then
+  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0; session_branches=0; manifest=0"
 else
-  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; manifest=$manifest_reaped"
+  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped"
 fi
 
 exit 0

--- a/plugins/rite/hooks/scripts/worktree-foreign-cwd.sh
+++ b/plugins/rite/hooks/scripts/worktree-foreign-cwd.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# worktree-foreign-cwd.sh — self-exclusion-aware live-cwd probe for cleanup.md
+# ステップ 4-W.
+#
+# Answers a single question: "is a FOREIGN (non-self) live process standing in
+# this worktree (cwd at it or nested under it)?" — i.e. the same OS-ground-truth
+# question as worktree-live-cwd.sh, but with the cleanup session's OWN process
+# tree excluded.
+#
+# Why this exists (Issue #1670):
+#   cleanup.md ステップ 4-W removes the session worktree it just finished with. It
+#   first calls ExitWorktree(keep), which retreats the harness cwd back to the
+#   main checkout — after that, the plain worktree-live-cwd.sh probe reports rc=1
+#   and removal proceeds. But when ExitWorktree was a no-op (the worktree was
+#   path-entered WITHOUT an EnterWorktree session record — the #1622
+#   in_worktree_unrecorded case — or a resume re-entry), the harness cwd stays
+#   inside the worktree, so the plain probe reports rc=0 and cleanup DEFERS the
+#   removal — blocking on the very session that is running cleanup (self-blocking).
+#   pr-cycle-cleanup.sh Step 5 already avoids this for the lazy reaper via its
+#   Gate 0 self-exclusion; this helper gives cleanup.md the same self-exclusion
+#   WITHOUT modifying worktree-live-cwd.sh (its OS detection method is unchanged —
+#   #1670 Non-Target §4.2). The caller passes --self-root (its harness pid); every
+#   process in that pid subtree is "self" and ignored, so only a genuine OTHER
+#   session standing in the tree defers the removal (Issue #1670 AC-3).
+#
+# Usage:
+#   worktree-foreign-cwd.sh <dir> --self-root <pid>
+#
+# Exit codes:
+#   0 = a FOREIGN live process has cwd == <dir> or nested under it → caller DEFERS
+#   1 = no foreign live cwd (only the self pid-subtree, or nobody) → caller REMOVES
+#   2 = cannot determine (no /proc, or bad arguments) → caller decides. cleanup.md
+#       removes on rc=2, matching the pre-#1670 worktree-live-cwd.sh rc=2
+#       backward-compat behavior (so non-/proc hosts behave exactly as before).
+#
+# Portability: /proc only (Linux). Without /proc (e.g. macOS) returns 2 — the
+# self-exclusion degrades to "remove" exactly as the old rc=2 path did, so there
+# is no regression vs the previous behavior on those hosts. macOS bash 3.2 floor
+# is preserved (no associative arrays, no GNU realpath); shared with
+# pr-cycle-cleanup.sh / worktree-live-cwd.sh.
+set -uo pipefail
+
+target=""
+self_root=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-root) self_root="${2:-}"; shift 2 ;;
+    --*) echo "ERROR: worktree-foreign-cwd.sh: unknown option: $1" >&2; exit 2 ;;
+    *) [ -z "$target" ] && target="$1"; shift ;;
+  esac
+done
+
+if [ -z "$target" ]; then
+  echo "ERROR: worktree-foreign-cwd.sh: <dir> argument required" >&2
+  exit 2
+fi
+case "$self_root" in
+  ''|*[!0-9]*)
+    echo "ERROR: worktree-foreign-cwd.sh: --self-root <pid> required (numeric)" >&2
+    exit 2 ;;
+esac
+
+# Canonicalize target (mirror worktree-live-cwd.sh). A non-directory target
+# (already-removed path) falls back to its raw string so the comparison still has
+# something to match against.
+if [ -d "$target" ]; then
+  target_canon=$( cd -- "$target" 2>/dev/null && pwd -P ) || target_canon="$target"
+else
+  target_canon="$target"
+fi
+[ -n "$target_canon" ] || target_canon="$target"
+
+# Without /proc we cannot read per-process cwd → undeterminable (rc 2). The caller
+# removes on rc=2 (pre-#1670 backward-compat, same as worktree-live-cwd.sh).
+[ -d /proc ] || exit 2
+
+# Robust PPID read from /proc/<pid>/stat. The `comm` field is wrapped in parens and
+# may itself contain spaces or parens (e.g. "(my proc)"), which would shift a naive
+# `awk '{print $4}'`. Strip greedily through the LAST ')' so the remainder is
+# "state ppid ..."; field 2 is then the ppid.
+_ppid_of() {
+  sed 's/.*) //' "/proc/$1/stat" 2>/dev/null | awk '{print $2}'
+}
+
+# rc 0 when $1 is self_root or a descendant of it (self_root appears in its
+# ancestry). Walks UP the ppid chain; the guard bounds a pathological cycle.
+_is_self() {
+  local p="$1" guard=0 pp
+  while [ -n "$p" ] && [ "$p" != "0" ] && [ "$guard" -lt 4096 ]; do
+    [ "$p" = "$self_root" ] && return 0
+    pp=$(_ppid_of "$p")
+    [ -n "$pp" ] || return 1
+    p="$pp"
+    guard=$((guard + 1))
+  done
+  return 1
+}
+
+for _pdir in /proc/[0-9]*; do
+  _pid="${_pdir#/proc/}"
+  _cwd=$(readlink "$_pdir/cwd" 2>/dev/null) || continue
+  [ -n "$_cwd" ] || continue
+  # Is this process standing in the target worktree (cwd at it or nested under it)?
+  # Trailing-slash prefix test so `issue-1` does not match `issue-12`.
+  _in_tree=1
+  if [ "$_cwd" = "$target_canon" ]; then
+    _in_tree=0
+  else
+    case "$_cwd/" in
+      "$target_canon"/*) _in_tree=0 ;;
+    esac
+  fi
+  [ "$_in_tree" -eq 0 ] || continue
+  # In the worktree — foreign unless it belongs to the self pid-subtree.
+  _is_self "$_pid" && continue
+  exit 0   # a foreign live process is standing in the worktree → caller defers
+done
+exit 1     # only the self pid-subtree (or nobody) stands in the worktree → remove

--- a/plugins/rite/hooks/scripts/worktree-foreign-cwd.sh
+++ b/plugins/rite/hooks/scripts/worktree-foreign-cwd.sh
@@ -44,7 +44,13 @@ target=""
 self_root=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --self-root) self_root="${2:-}"; shift 2 ;;
+    --self-root)
+      # Guard the value before `shift 2`: a trailing `--self-root` with no value
+      # would underflow `shift 2` (bash leaves $# unchanged when it exceeds $#),
+      # re-processing the same token forever (hang). Fail fast with the documented
+      # rc=2 "bad arguments" contract instead.
+      [ $# -ge 2 ] || { echo "ERROR: worktree-foreign-cwd.sh: --self-root requires a value" >&2; exit 2; }
+      self_root="$2"; shift 2 ;;
     --*) echo "ERROR: worktree-foreign-cwd.sh: unknown option: $1" >&2; exit 2 ;;
     *) [ -z "$target" ] && target="$1"; shift ;;
   esac

--- a/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Tests for cleanup.md ステップ 4-W / 5 / 12 の message・配線 contract (Issue #1670, T-06).
+#
+# cleanup.md は prose-driven command なので、behavioral 検証は worktree-foreign-cwd.test.sh
+# (self-exclusion 判定) と pr-cycle-cleanup-session-reap.test.sh (branch recovery) が担う。
+# 本テストは、それらに配線する cleanup.md 側の記述が drift しないことを grep で固定する:
+#   1. ステップ 4-W が self-exclusion 付き worktree-foreign-cwd.sh に --self-root を渡している
+#   2. ステップ 5 が squash-merge 確認済みブランチを強制削除し、遅延ブランチを manifest 記録する
+#   3. ユーザー向け遅延メッセージが平易・正確（内部実装語が無く、branch の自動回収を明記）
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+CLEANUP="$SCRIPT_DIR/../../commands/pr/cleanup.md"
+
+echo "=== ステップ 4-W: self-exclusion 付き live-cwd guard の配線 ==="
+assert_grep "4-W uses worktree-foreign-cwd.sh (not the bare live-cwd probe)" "$CLEANUP" "worktree-foreign-cwd\.sh"
+assert_grep "4-W passes --self-root \$PPID (excludes the cleanup session's harness)" "$CLEANUP" 'worktree-foreign-cwd\.sh.*--self-root'
+
+echo "=== ステップ 5: squash-merge 確認済みブランチの強制削除 + 遅延ブランチの manifest 記録 ==="
+assert_grep "Step 5 reads the {pr_merged} signal" "$CLEANUP" "pr_merged"
+assert_grep "Step 5 emits via=squash-merged on confirmed-merged force delete" "$CLEANUP" "via=squash-merged"
+assert_grep "Step 5 records the deferred branch to the reap manifest" "$CLEANUP" "rite-tmp-artifact\.sh record --type branch"
+
+echo "=== ステップ 12: ユーザー向けメッセージの平易化・正確化 (AC-6) ==="
+# branch の遅延メッセージは「自動で削除される（手動不要）」を明記する（実装の自動回収と整合）。
+assert_grep "deferred-branch message states automatic recovery (no manual step)" "$CLEANUP" "自動で削除されます（手動操作は不要）"
+# worktree skip メッセージは次セッションでの自動回収を平易に伝える。
+assert_grep "worktree-skip message states next-session automatic recovery" "$CLEANUP" "次回のセッション開始時に"
+
+echo "=== ステップ 12: 旧・内部実装語/不正確な記述が除去されている ==="
+# 旧 worktree-skip メッセージの内部用語「遅延 reap が後で回収します」は撤去済み。
+assert_not_grep "old jargon '遅延 reap が後で回収します' removed" "$CLEANUP" "遅延 reap が後で回収します"
+# 旧 branch-deferred メッセージ「worktree で checkout 中のため残置しました」は撤去済み。
+assert_not_grep "old branch-deferred residue wording removed" "$CLEANUP" "worktree で checkout 中のため残置しました"
+
+if ! print_summary "$(basename "$0")" "cleanup.md ステップ 4-W/5/12 の self-exclusion 配線・branch 回収・平易メッセージ contract (Issue #1670 T-06)"; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
@@ -22,6 +22,11 @@ echo "=== ステップ 5: squash-merge 確認済みブランチの強制削除 +
 assert_grep "Step 5 reads the {pr_merged} signal" "$CLEANUP" "pr_merged"
 assert_grep "Step 5 emits via=squash-merged on confirmed-merged force delete" "$CLEANUP" "via=squash-merged"
 assert_grep "Step 5 records the deferred branch to the reap manifest" "$CLEANUP" "rite-tmp-artifact\.sh record --type branch"
+# Deferred branch only auto-recovers when the manifest record actually succeeds; the
+# marker carries recovery=auto/manual so Step 12 never promises auto-recovery on a
+# path that did not record (unmerged force-cleanup / record failure) — AC-6.
+assert_grep "Step 5 emits recovery=auto when manifest record succeeds" "$CLEANUP" "recovery=auto"
+assert_grep "Step 5 emits recovery=manual when not recorded" "$CLEANUP" "recovery=manual"
 
 echo "=== ステップ 12: ユーザー向けメッセージの平易化・正確化 (AC-6) ==="
 # branch の遅延メッセージは「自動で削除される（手動不要）」を明記する（実装の自動回収と整合）。

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -380,6 +380,13 @@ out=$(run_pcc "$R")
 assert "B-02 worktree reaped" "0" "$( [ -d "$R/.rite/worktrees/issue-91" ] && echo 1 || echo 0 )"
 assert "B-02 manifest-recorded merged branch FORCE-recovered (gone)" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-91 >/dev/null 2>&1 && echo 1 || echo 0 )"
 case "$out" in *"session_branches=1"*) pass "B-02 status reports session_branches=1" ;; *) fail "B-02 status: $out" ;; esac
+# Clean-recovery contract: the deferred-branch manifest entry is still checked out in
+# its worktree when Step 4.5 runs (before Step 5 reaps it). That expected case must
+# NOT flip the run to status=failed nor emit a "failed to reap manifest branch" WARNING
+# — the recovery is clean (status=cleaned, errors absent). Without this the false
+# "status=failed; errors=1" of the marquee dead-letter path slips through silently.
+case "$out" in *"status=cleaned"*) pass "B-02 reports status=cleaned (no false failure)" ;; *) fail "B-02 status not cleaned: $out" ;; esac
+assert_not_grep "B-02 no misleading 'failed to reap manifest branch' WARNING" "$R/pcc.err" "failed to reap manifest branch"
 
 echo "=== B-03 (#1670 surgical): a manifest entry NEVER force-deletes an unrecorded unmerged sibling ==="
 R=$(make_repo 92); cleanup_dirs+=("$R")
@@ -399,6 +406,14 @@ RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/
 out=$(run_pcc "$R")
 assert "B-03 recorded branch feat/issue-92 force-recovered (gone)" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-92 >/dev/null 2>&1 && echo 1 || echo 0 )"
 assert "B-03 unrecorded sibling feat/issue-93 PRESERVED" "1" "$( cd "$R" && $GIT rev-parse --verify feat/issue-93 >/dev/null 2>&1 && echo 1 || echo 0 )"
+# issue-93's worktree MUST be reaped for the "preserved" assertion to be meaningful:
+# the surgical guarantee (a recorded entry never licenses deleting an unrecorded
+# sibling) only has teeth when issue-93's branch-recovery path actually ran. Pin it so
+# a future regression where issue-93 is never reaped cannot make "preserved" pass for
+# the wrong reason.
+assert "B-03 issue-93 worktree reaped (recovery path ran)" "0" "$( [ -d "$R/.rite/worktrees/issue-93" ] && echo 1 || echo 0 )"
+case "$out" in *"status=cleaned"*) pass "B-03 reports status=cleaned (no false failure)" ;; *) fail "B-03 status not cleaned: $out" ;; esac
+assert_not_grep "B-03 no misleading 'failed to reap manifest branch' WARNING" "$R/pcc.err" "failed to reap manifest branch"
 
 print_summary "$(basename "$0")" \
   "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); Issue #1670 branch recovery: after reap, SAFE-delete the branch (merged → recovered) and FORCE-delete only manifest-recorded (merge-confirmed) branches, preserving unmerged work; wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -91,8 +91,12 @@ assert "TC-2 stale worktree reaped" "0" "$( [ -d "$R/.rite/worktrees/issue-51" ]
 assert "TC-2 claim file deleted" "0" "$( [ -f "$R/.rite/state/issue-claims/issue-51.json" ] && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=1"*) pass "TC-2 status reports session_worktrees=1" ;; *) fail "TC-2 status: $out" ;; esac
 
-echo "=== TC-4 (AC-4): branch preserved after reap ==="
-assert "TC-4 branch feat/issue-51 still exists" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-51 >/dev/null 2>&1; echo $? )"
+echo "=== TC-4 (#1670): merged-into-base branch recovered after reap ==="
+# feat/issue-51 was created from develop with no new commits → merged/even with the
+# base, so `git branch -d` recovers it once the worktree is gone (#1670 branch
+# recovery, closing the dead-letter gap). Previously the branch was preserved.
+assert "TC-4 merged branch feat/issue-51 recovered (gone)" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-51 >/dev/null 2>&1 && echo 1 || echo 0 )"
+case "$out" in *"session_branches=1"*) pass "TC-4 status reports session_branches=1" ;; *) fail "TC-4 status: $out" ;; esac
 
 echo "=== TC-3 (AC-3): dirty worktree (stale claim) → NOT reaped + WARNING ==="
 R=$(make_repo 52); cleanup_dirs+=("$R")
@@ -334,5 +338,67 @@ out=$(run_pcc "$R")
 assert "T-10 mismatched-claim worktree IS reaped (no blanket protection)" "0" "$( [ -d "$R/.rite/worktrees/issue-83" ] && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=1"*) pass "T-10 status reports session_worktrees=1" ;; *) fail "T-10 status: $out" ;; esac
 
+# ===========================================================================
+# Issue #1670 — session-feature-branch recovery after reap (dead-letter fix).
+# The lazy reap used to delete the worktree but NEVER the branch, so a feature
+# branch whose cleanup deferred its worktree (live-cwd guard) leaked forever.
+# Step 5 now recovers the branch after reaping its worktree: SAFE-delete first
+# (preserves unmerged work — AC-4); FORCE-delete only when the branch is recorded
+# in the reap manifest (cleanup.md confirmed its PR merged — the squash-merge case
+# `git branch -d` cannot detect). TC-4 above already covers the merged-into-base
+# branch recovered by the safe delete + session_branches=1 status.
+# ===========================================================================
+GITC() { $GIT -C "$1" "${@:2}"; }   # run git in worktree $1
+
+echo "=== B-01 (#1670 AC-4): UNMERGED branch (not manifest-recorded) is PRESERVED after reap ==="
+R=$(make_repo 90); cleanup_dirs+=("$R")
+# Give feat/issue-90 a commit that is NOT in develop → `git branch -d` refuses it.
+# The commit is COMMITTED (worktree stays clean → Gate 3 passes → worktree reaped),
+# but the branch is NOT in the manifest → must be preserved (no data loss).
+echo "wip" > "$R/.rite/worktrees/issue-90/wip.txt"
+GITC "$R/.rite/worktrees/issue-90" add wip.txt >/dev/null 2>&1
+GITC "$R/.rite/worktrees/issue-90" commit -q -m "wip: unmerged work" >/dev/null 2>&1
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "B-01 unmerged worktree reaped (clean → Gate 3 passes)" "0" "$( [ -d "$R/.rite/worktrees/issue-90" ] && echo 1 || echo 0 )"
+assert "B-01 unmerged branch PRESERVED (not destroyed)" "1" "$( cd "$R" && $GIT rev-parse --verify feat/issue-90 >/dev/null 2>&1 && echo 1 || echo 0 )"
+assert_grep "B-01 unmerged-branch WARNING on stderr" "$R/pcc.err" "未マージのため保持"
+case "$out" in *"session_branches=0"*) pass "B-01 status reports session_branches=0" ;; *) fail "B-01 status: $out" ;; esac
+
+echo "=== B-02 (#1670 AC-3): squash-merged branch RECORDED in manifest → force-recovered after reap ==="
+R=$(make_repo 91); cleanup_dirs+=("$R")
+# Same unmerged shape as B-01 (a commit not in develop, so `git branch -d` refuses —
+# the squash-merge signature), but cleanup.md confirmed the PR merged and recorded
+# the branch in the reap manifest. Step 5 must FORCE-delete it (single-session
+# recovery of the deferred dead-letter branch).
+echo "squashed" > "$R/.rite/worktrees/issue-91/done.txt"
+GITC "$R/.rite/worktrees/issue-91" add done.txt >/dev/null 2>&1
+GITC "$R/.rite/worktrees/issue-91" commit -q -m "feat: squash-merged work" >/dev/null 2>&1
+printf 'branch\tfeat/issue-91\n' > "$R/.rite/tmp-artifacts.tsv"   # cleanup.md's merge-confirmed record
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "B-02 worktree reaped" "0" "$( [ -d "$R/.rite/worktrees/issue-91" ] && echo 1 || echo 0 )"
+assert "B-02 manifest-recorded merged branch FORCE-recovered (gone)" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-91 >/dev/null 2>&1 && echo 1 || echo 0 )"
+case "$out" in *"session_branches=1"*) pass "B-02 status reports session_branches=1" ;; *) fail "B-02 status: $out" ;; esac
+
+echo "=== B-03 (#1670 surgical): a manifest entry NEVER force-deletes an unrecorded unmerged sibling ==="
+R=$(make_repo 92); cleanup_dirs+=("$R")
+# issue-92 has an unmerged commit and IS recorded → force-recovered. A second
+# orphan issue-93 has an unmerged commit but is NOT recorded → preserved. Proves
+# the manifest gate is exact (a recorded branch never licenses deleting another).
+echo "a" > "$R/.rite/worktrees/issue-92/a.txt"
+GITC "$R/.rite/worktrees/issue-92" add a.txt >/dev/null 2>&1
+GITC "$R/.rite/worktrees/issue-92" commit -q -m "feat: 92" >/dev/null 2>&1
+( cd "$R" && $GIT worktree add -q -b "feat/issue-93" ".rite/worktrees/issue-93" >/dev/null 2>&1 )
+RITE_STATE_ROOT="$R" bash "$IC" claim --issue 93 --session "$SID_A" --worktree "$R/.rite/worktrees/issue-93" >/dev/null 2>&1
+echo "b" > "$R/.rite/worktrees/issue-93/b.txt"
+GITC "$R/.rite/worktrees/issue-93" add b.txt >/dev/null 2>&1
+GITC "$R/.rite/worktrees/issue-93" commit -q -m "wip: 93" >/dev/null 2>&1
+printf 'branch\tfeat/issue-92\n' > "$R/.rite/tmp-artifacts.tsv"   # only issue-92 recorded
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+out=$(run_pcc "$R")
+assert "B-03 recorded branch feat/issue-92 force-recovered (gone)" "0" "$( cd "$R" && $GIT rev-parse --verify feat/issue-92 >/dev/null 2>&1 && echo 1 || echo 0 )"
+assert "B-03 unrecorded sibling feat/issue-93 PRESERVED" "1" "$( cd "$R" && $GIT rev-parse --verify feat/issue-93 >/dev/null 2>&1 && echo 1 || echo 0 )"
+
 print_summary "$(basename "$0")" \
-  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); branch preserved; wiki-worktree excluded; session-start best-effort wiring."
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); Issue #1670 branch recovery: after reap, SAFE-delete the branch (merged → recovered) and FORCE-delete only manifest-recorded (merge-confirmed) branches, preserving unmerged work; wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -5,7 +5,7 @@
 #   AC-1: a worktree whose claim is LIVE is NOT reaped.
 #   AC-2: a worktree whose claim is STALE and clean IS reaped, claim file deleted.
 #   AC-3: a DIRTY worktree is NOT reaped (claim stale) — WARNING + manual hint.
-#   AC-4: after reap the corresponding branch still exists.
+#   AC-4: after reap a MERGED branch is recovered (TC-4); an UNMERGED, non-manifest-recorded branch is preserved (B-01) — #1670 refined "preserve the branch" to "recover merge-confirmed branches only, never destroy unmerged work".
 #   AC-5: `.rite/wiki-worktree` and non-issue dirs are NOT matched (regression).
 #
 # Gate 0 — self-exclusion guard. A long-lived session must never

--- a/plugins/rite/hooks/tests/worktree-foreign-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-foreign-cwd.test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Tests for worktree-foreign-cwd.sh — self-exclusion-aware live-cwd probe used by
+# cleanup.md ステップ 4-W (Issue #1670).
+#
+# The contract: "is a FOREIGN (non-self) live process standing in this worktree?"
+#   rc 0 = a foreign process (NOT in the --self-root pid subtree) stands in the dir
+#          → cleanup DEFERS removal
+#   rc 1 = only the self pid-subtree (or nobody) stands in the dir → cleanup REMOVES
+#   rc 2 = bad arguments / no /proc → caller decides (cleanup removes)
+#
+#   TC-1:  missing <dir>                                   → rc 2
+#   TC-2:  missing --self-root                             → rc 2
+#   TC-3:  non-numeric --self-root                         → rc 2
+#   TC-4:  free dir (nobody inside)                        → rc 1
+#   TC-5:  FOREIGN holder (self-root is not its ancestor)  → rc 0  (defer)
+#   TC-6:  SELF holder (self-root IS its ancestor)         → rc 1  (self-exclusion)
+#   TC-7:  foreign holder NESTED under the dir             → rc 0
+#   TC-8:  sibling-prefix dir (issue-1 vs issue-12)        → no false match (rc 1)
+#   TC-9:  self + foreign coexist → rc 0; kill foreign → rc 1 (surgical)
+#   TC-10: after the foreign holder exits, dir is free     → rc 1
+#
+# This is the self-exclusion layer cleanup.md needs WITHOUT modifying
+# worktree-live-cwd.sh (#1670 Non-Target): the cleanup session's own harness
+# (--self-root = the cleanup Bash's $PPID) must never block removal of the very
+# worktree it just finished, while a genuine OTHER session standing in the tree
+# still defers it (AC-1/AC-2/AC-3).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+PROBE="$SCRIPT_DIR/../scripts/worktree-foreign-cwd.sh"
+
+cleanup_dirs=()
+holders=()
+cleanup() {
+  local p d
+  for p in "${holders[@]:-}"; do [ -n "$p" ] && kill "$p" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+  for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+  return 0
+}
+trap cleanup EXIT
+
+# Run the probe and echo its exit code (the rc is the contract under test).
+probe_rc() { bash "$PROBE" "$@" >/dev/null 2>&1; echo "$?"; }
+
+echo "=== TC-1: missing <dir> → rc 2 ==="
+assert "TC-1 no dir → rc 2" "2" "$(bash "$PROBE" --self-root 1 >/dev/null 2>&1; echo $?)"
+
+echo "=== TC-2: missing --self-root → rc 2 ==="
+D=$(mktemp -d); cleanup_dirs+=("$D")
+assert "TC-2 no --self-root → rc 2" "2" "$(probe_rc "$D")"
+
+echo "=== TC-3: non-numeric --self-root → rc 2 ==="
+assert "TC-3 bad --self-root → rc 2" "2" "$(probe_rc "$D" --self-root notapid)"
+
+echo "=== TC-4: free dir, nobody inside → rc 1 ==="
+assert "TC-4 free dir → rc 1" "1" "$(probe_rc "$D" --self-root 99999)"
+
+echo "=== TC-5: FOREIGN holder (self-root not its ancestor) → rc 0 (defer) ==="
+# Holder is a child of THIS test shell; --self-root=99999 (a bogus pid that is NOT
+# in the holder's ancestry) models "a different session is standing in the tree".
+( cd "$D" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-5 foreign holder → rc 0" "0" "$(probe_rc "$D" --self-root 99999)"
+
+echo "=== TC-6: SELF holder (self-root IS its ancestor) → rc 1 (self-exclusion) ==="
+# Same holder, but now --self-root=$$ (this test shell), which IS the holder's
+# ancestor → the holder is part of the self subtree → excluded → removal proceeds.
+# This is the core self-block fix: cleanup's own harness must not block its removal.
+assert "TC-6 self holder excluded → rc 1" "1" "$(probe_rc "$D" --self-root "$$")"
+
+echo "=== TC-7: foreign holder nested UNDER the dir → rc 0 ==="
+D2=$(mktemp -d); cleanup_dirs+=("$D2"); mkdir -p "$D2/sub/deep"
+( cd "$D2/sub/deep" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-7 nested foreign holder → rc 0" "0" "$(probe_rc "$D2" --self-root 99999)"
+
+echo "=== TC-8: sibling-prefix dir must not false-match (issue-1 vs issue-12) ==="
+D3=$(mktemp -d); cleanup_dirs+=("$D3"); mkdir -p "$D3/issue-1" "$D3/issue-12"
+( cd "$D3/issue-12" && sleep 30 ) & holders+=("$!")
+sleep 0.3
+assert "TC-8 issue-1 not matched by issue-12 holder → rc 1" "1" "$(probe_rc "$D3/issue-1" --self-root 99999)"
+assert "TC-8 issue-12 itself (foreign) → rc 0" "0" "$(probe_rc "$D3/issue-12" --self-root 99999)"
+
+echo "=== TC-9: self + foreign coexist → rc 0; kill foreign → rc 1 (surgical) ==="
+D4=$(mktemp -d); cleanup_dirs+=("$D4")
+( cd "$D4" && sleep 30 ) & SELF_PID=$!; holders+=("$SELF_PID")     # this pid IS --self-root → self
+( cd "$D4" && sleep 30 ) & FOREIGN_PID=$!; holders+=("$FOREIGN_PID")  # sibling → foreign vs SELF_PID
+sleep 0.3
+assert "TC-9 self+foreign in dir → rc 0 (foreign defers)" "0" "$(probe_rc "$D4" --self-root "$SELF_PID")"
+kill "$FOREIGN_PID" 2>/dev/null || true; wait "$FOREIGN_PID" 2>/dev/null || true
+assert "TC-9 only self remains → rc 1 (remove)" "1" "$(probe_rc "$D4" --self-root "$SELF_PID")"
+
+echo "=== TC-10: after the foreign holder exits, dir is free → rc 1 ==="
+D5=$(mktemp -d); cleanup_dirs+=("$D5")
+( cd "$D5" && sleep 1 ) & hp=$!; holders+=("$hp")
+sleep 0.3
+assert "TC-10 while foreign held → rc 0" "0" "$(probe_rc "$D5" --self-root 99999)"
+wait "$hp" 2>/dev/null || true
+assert "TC-10 after holder exits → rc 1" "1" "$(probe_rc "$D5" --self-root 99999)"
+
+if ! print_summary "$(basename "$0")" "worktree-foreign-cwd.sh の self-exclusion 付き live-cwd 判定 (Issue #1670): self の harness subtree を除外し、別 live セッションのみ削除を遅延させる"; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/worktree-foreign-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-foreign-cwd.test.sh
@@ -55,6 +55,12 @@ assert "TC-2 no --self-root → rc 2" "2" "$(probe_rc "$D")"
 echo "=== TC-3: non-numeric --self-root → rc 2 ==="
 assert "TC-3 bad --self-root → rc 2" "2" "$(probe_rc "$D" --self-root notapid)"
 
+echo "=== TC-3b: trailing --self-root with NO value → rc 2, no hang ==="
+# A `--self-root` token with no following value must fail-fast (rc 2), not underflow
+# `shift 2` and re-process the same token forever. `timeout` bounds the would-be hang;
+# rc 124 (timeout-killed) would mean the guard regressed.
+assert "TC-3b dangling --self-root → rc 2 (no hang)" "2" "$(timeout 5 bash "$PROBE" "$D" --self-root >/dev/null 2>&1; echo $?)"
+
 echo "=== TC-4: free dir, nobody inside → rc 1 ==="
 assert "TC-4 free dir → rc 1" "1" "$(probe_rc "$D" --self-root 99999)"
 


### PR DESCRIPTION
## 概要

`/rite:pr:cleanup` を駆動するセッション自身が cwd を保持していることを理由に、対象 Issue の worktree とローカルブランチの削除が遅延に倒れる**自己ブロッキング**を解消する。さらに、真に遅延した（別 live セッションが使用中）場合のブランチが回収経路を持たず永久残置していた **dead-letter** ギャップを解消する。

Closes #1670

## 背景

`ExitWorktree(keep)` は通常ハーネスの OS cwd を main checkout へ退避するが、`in_worktree_unrecorded`（EnterWorktree 記録なしに path 入場）や resume 等で no-op になる経路ではハーネスが worktree に残る。cleanup ステップ 4-W の live-cwd guard（`worktree-live-cwd.sh`）は自セッションと他セッションを区別できないため、cleanup 実行セッション自身を「live」と検出して削除を遅延していた。遅延ブランチは回収経路を持たず永久残置していた。

## 変更内容

- **新規 `worktree-foreign-cwd.sh`**: self プロセス木（`--self-root` = ハーネス pid）を除外し「別セッションの live cwd」のみ検出する self-exclusion 付き probe（`worktree-live-cwd.sh` は不変 — Non-Target §4.2）。
- **cleanup.md ステップ 4-W**: live-cwd guard を上記ヘルパー（`--self-root "$PPID"`）へ差し替え。削除遅延は別 live セッション在席時のみ。
- **cleanup.md ステップ 5**: PR が merge 済み（squash）のとき `git branch -d` が拒否する残渣を強制削除。遅延ブランチを reap manifest に記録（次セッション回収へ配線）。
- **pr-cycle-cleanup.sh ステップ 5**: worktree reap 後にブランチを安全回収（`git branch -d` → manifest 記録済みなら `git branch -D`）。未マージは保持。
- **メッセージ**: 内部実装語を排し、ブランチの自動回収を正確に伝える。
- **設計ドキュメント §8**: 「branch は削除しない」を「merge 確認済み branch のみ回収・未マージは破壊しない」へ精緻化。

## テスト

- 新規 `worktree-foreign-cwd.test.sh`（13 件）: self→remove / foreign→defer / surgical / bad-args。
- `pr-cycle-cleanup-session-reap.test.sh`: TC-4 を新挙動（merged→回収）に更新 + B-01/B-02/B-03 追加（未マージ保持 / squash 遅延 manifest 回収 / surgical）。
- 新規 `cleanup-message-contract.test.sh`（9 件）: 4-W/5/12 の配線・平易メッセージ contract。
- 全 80 テストファイル PASS（0 fail）。lint warning は全て既存ファイル由来で本変更は新規 0 件。

## 受入基準

| AC | 内容 | 対応 |
|----|------|------|
| AC-1 | 同一実行で worktree・branch 削除 | 4-W self-exclusion + Step 5 squash force-delete |
| AC-2 | 複数 Issue 順次でも自己ブロッキングなし | self-exclusion |
| AC-3 | 真の遅延のみ→次セッションで双方回収 | manifest 記録 + pr-cycle Step 5 回収 |
| AC-4 | 未マージ/dirty は保護 | safe-delete + manifest gate |
| AC-5 | 既存 reap 非回帰 | 既存テスト全 PASS |
| AC-6 | メッセージ平易・実装整合 | message 平易化 + contract test |

## Definition of Done

- [x] All MUST requirements implemented
- [x] All Acceptance Criteria (AC-xx) verified
- [x] All test cases (T-xx) passing
- [x] No regression in existing functionality
- [x] Target files modified, non-target files untouched
- [x] Code follows project conventions

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
