### PR TITLE
fix(worktree): 入場経路で session worktree 不在を検出・再構築する (#1676)

### DIFF
--- a/plugins/rite/commands/getting-started.md
+++ b/plugins/rite/commands/getting-started.md
@@ -390,7 +390,7 @@ Operating rules (important):
     exists and git works (the harness mis-detected the launch directory as
     non-git at startup): RESTART Claude Code from the repository ROOT and
     re-run the same command. The already-created worktree is preserved and
-    reused (WT_CASE=reuse on /rite:pr:open, RESUME_WT=reenter on /rite:resume),
+    reused (WT_CASE=reuse on /rite:pr:open, WT_ENSURE=reenter on /rite:resume),
     so nothing is rebuilt. rite never silently falls back to git switch -c.
 
   • Keep the main checkout on your base branch (rite-config.yml branch.base, e.g. develop).

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -414,7 +414,7 @@ fi
 - `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。
 - `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
 - `branch_other_worktree` → 中止（並行セッションの可能性。`other=` のパスを表示）。
-- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない。既存の「PR ブランチ未取得」ハンドリングへ委譲し、**develop 上で fix を続行しない**。
+- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない。ただし ステップ 1.1 で `gh pr view {pr_number}` が成功している以上、PR の head ブランチは本来 remote に存在するはずで、`branch_absent` の到達は PR 状態との不整合を意味する。**develop 上で fix を続行せず**、`[fix:error]` を emit して明示停止する（`failed` と同じ機械的停止。ステップ 2 以降の Edit/Write へ進まない＝develop の作業ツリーへ書かない）。
 - `failed` → 再構築失敗（helper rc=1, stderr に原因 + 復旧手順）。**silent fallback せず `[fix:error]` を emit して明示停止**する（develop の作業ツリーへ修正を書かない）。
 
 ### 1.2 Retrieve Review Comments

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -392,6 +392,31 @@ Terminate processing.
 
 Terminate processing.
 
+### 1.1.5 セッション worktree 健全性の保証（multi_session 有効時 / #1676）
+
+fix は ステップ 2 以降で **作業ツリーのファイルを Edit / Write で修正**する。その前に対象 PR の作業ブランチに対応する session worktree を保証する。これがないと、worktree 不在（resume / context 圧縮 / 別セッション跨ぎで欠落）のとき fix がメインツリー（develop）上で実行され、`git branch --show-current` が develop を返して issue 番号抽出が空になり、最悪 **develop の作業ツリーへ修正を書き込む**（§4.4 MUST / MUST NOT）。
+
+ステップ 1.1 で取得した PR の `headRefName`（作業ブランチ）から issue 番号を抽出し、共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh)、検出 + 再構築を bash 側で完結し `[CONTEXT] WT_ENSURE=` を emit）で検出・再構築する（`{head_ref}` は ステップ 1.1 の `gh pr view` が返した `.headRefName`）:
+
+```bash
+issue_number=$(printf '%s' "{head_ref}" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+if [ -n "$issue_number" ]; then
+  bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue "$issue_number" --branch "{head_ref}"
+else
+  # head_ref が issue ブランチでない（session worktree の対象外）→ 従来どおり単一ツリーで続行
+  echo "[CONTEXT] WT_ENSURE=skip (head_ref が issue ブランチでないため worktree 対象外: {head_ref})"
+fi
+```
+
+`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
+
+- `disabled` / `already_in` / `skip` → no-op、ステップ 1.2 へ（`disabled` = `multi_session.enabled: false`。従来どおり単一ツリーで動作し挙動不変）。
+- `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。
+- `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
+- `branch_other_worktree` → 中止（並行セッションの可能性。`other=` のパスを表示）。
+- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない。既存の「PR ブランチ未取得」ハンドリングへ委譲し、**develop 上で fix を続行しない**。
+- `failed` → 再構築失敗（helper rc=1, stderr に原因 + 復旧手順）。**silent fallback せず `[fix:error]` を emit して明示停止**する（develop の作業ツリーへ修正を書かない）。
+
 ### 1.2 Retrieve Review Comments
 
 #### 1.2.0 Hybrid Review Source Resolution <!-- AC-3 / AC-4 / AC-5 / D-01 -->

--- a/plugins/rite/commands/pr/fix.md
+++ b/plugins/rite/commands/pr/fix.md
@@ -408,7 +408,7 @@ else
 fi
 ```
 
-`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
+`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う（`disabled`〜`reconstructed` の共通 case は SoT 表と同一。**終端の `branch_absent` / `failed` のみ caller 固有**で、resume の AskUserQuestion / 停止に対し、非対話サブ起動の fix は機械的に `[fix:error]` 停止する — 下記）:
 
 - `disabled` / `already_in` / `skip` → no-op、ステップ 1.2 へ（`disabled` = `multi_session.enabled: false`。従来どおり単一ツリーで動作し挙動不変）。
 - `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。

--- a/plugins/rite/commands/pr/iterate.md
+++ b/plugins/rite/commands/pr/iterate.md
@@ -55,16 +55,18 @@ LLM は `[CONTEXT] ITERATE_ISSUE` / `ITERATE_BRANCH` から値を読み、後続
 
 ### ステップ 0.5: セッション worktree 健全性の保証（multi_session 有効時 / AC-2 #1676）
 
-ループに入る前に、対象作業ブランチの session worktree を保証する。これがないと、worktree 不在（resume / context 圧縮 / 別セッション跨ぎで欠落）のまま review/fix を invoke し、メインツリー（develop）上で PR 変更を読めないまま degraded に回り続ける（本 Issue の As-Is）。共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh)）で検出・再構築する（`{issue_number}` は `ITERATE_ISSUE` marker の値）:
+ループに入る前に、対象作業ブランチの session worktree を保証する。これがないと、worktree 不在（resume / context 圧縮 / 別セッション跨ぎで欠落）のまま review/fix を invoke し、メインツリー（develop）上で PR 変更を読めないまま degraded に回り続ける（本 Issue の As-Is）。共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh)）で検出・再構築する（`{issue_number}` / `{branch_name}` は ステップ 0 の `ITERATE_ISSUE` / `ITERATE_BRANCH` marker の値）:
 
 ```bash
-bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue {issue_number}
+bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue {issue_number} --branch {branch_name}
 ```
+
+> `--branch {branch_name}` を明示することで（review/fix の `--branch {head_ref}` 渡しと対称）、helper が issue-N の ref から branch を自動推定する経路を回避し、同一 issue に複数ブランチが存在する場合でも決定的に対象ブランチを選ぶ。`ITERATE_BRANCH` が空の場合は省略してよい（helper が ref 推定にフォールバックする）。
 
 `[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
 
 - `disabled` / `already_in` → no-op、ステップ 1 へ。
-- `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1 へ。`reconstructed` は helper が `git worktree add` 済み。
+- `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。
 - `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
 - `branch_other_worktree` → 中止（並行セッションの可能性。`other=` を表示）。
 - `branch_absent` → 対象ブランチが実在しない。**develop 上で続行しない**。AskUserQuestion で「Issue 番号 / ブランチを確認して再実行 / 中止」を提示（誤再構築しない）。

--- a/plugins/rite/commands/pr/iterate.md
+++ b/plugins/rite/commands/pr/iterate.md
@@ -53,6 +53,25 @@ echo "[CONTEXT] ITERATE_ISSUE=$iterate_issue; ITERATE_BRANCH=$iterate_branch"
 
 LLM は `[CONTEXT] ITERATE_ISSUE` / `ITERATE_BRANCH` から値を読み、後続の flow-state.sh set 呼び出しで `--issue` / `--branch` に literal substitute する。値が空の場合は AskUserQuestion で「Issue 番号 / ブランチ名を入力 / 中止」を提示。
 
+### ステップ 0.5: セッション worktree 健全性の保証（multi_session 有効時 / AC-2 #1676）
+
+ループに入る前に、対象作業ブランチの session worktree を保証する。これがないと、worktree 不在（resume / context 圧縮 / 別セッション跨ぎで欠落）のまま review/fix を invoke し、メインツリー（develop）上で PR 変更を読めないまま degraded に回り続ける（本 Issue の As-Is）。共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh)）で検出・再構築する（`{issue_number}` は `ITERATE_ISSUE` marker の値）:
+
+```bash
+bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue {issue_number}
+```
+
+`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
+
+- `disabled` / `already_in` → no-op、ステップ 1 へ。
+- `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1 へ。`reconstructed` は helper が `git worktree add` 済み。
+- `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
+- `branch_other_worktree` → 中止（並行セッションの可能性。`other=` を表示）。
+- `branch_absent` → 対象ブランチが実在しない。**develop 上で続行しない**。AskUserQuestion で「Issue 番号 / ブランチを確認して再実行 / 中止」を提示（誤再構築しない）。
+- `failed` → 再構築失敗（helper rc=1, stderr に原因 + 復旧手順）。**silent fallback せず明示停止**。develop 上で review/fix を回さない。
+
+> 各 review/fix cycle の入場でも `/rite:pr:review` / `/rite:pr:fix` が各自の入場ゲートで同じ helper を通すため、cycle 途中で worktree が失われても次 cycle 頭で再保証される（AC-2 の「cycle 前段で worktree-ensure が通る」を多層で担保）。本ステップ 0.5 はループ全体の前段ゲート。
+
 ---
 
 ## ステップ 1: /rite:pr:review を invoke

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -383,7 +383,7 @@ else
 fi
 ```
 
-`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
+`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う（`disabled`〜`reconstructed` の共通 case は SoT 表と同一。**終端の `branch_absent` / `failed` のみ caller 固有**で、resume の AskUserQuestion / 停止に対し、非対話サブ起動の review は機械的に `[review:error]` 停止する — 下記）:
 
 - `disabled` / `already_in` / `skip` → no-op、ステップ 1.2 へ（`disabled` = `multi_session.enabled: false`。従来どおり単一ツリーで動作し挙動不変）。
 - `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -389,7 +389,7 @@ fi
 - `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。
 - `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
 - `branch_other_worktree` → 中止（並行セッションの可能性。`other=` のパスを表示）。
-- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない（AC-5）。既存の「PR ブランチ未取得」ハンドリングへ委譲し、**develop 上で review を続行しない**。
+- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない（AC-5）。ただし ステップ 1.1 で `gh pr view {pr_number}` が成功している以上、PR の head ブランチは本来 remote に存在するはずで、`branch_absent` の到達は PR 状態との不整合を意味する。**develop 上で review を続行せず**、`[review:error]` を emit して明示停止する（`failed` と同じ機械的停止。silent に develop の作業ツリーを読まない）。
 - `failed` → 再構築失敗（helper rc=1, stderr に原因 + 復旧手順）。**silent fallback せず `[review:error]` を emit して明示停止**する（review を mergeable / completed 扱いにしない / AC-4）。
 
 > **silent fallback 禁止（本 Issue の核）**: `branch_absent` / `failed` のとき、worktree 不在を理由に develop 上で review を継続し PR 変更を読めないまま完了扱いにしてはならない（§4.4 MUST NOT）。

--- a/plugins/rite/commands/pr/review.md
+++ b/plugins/rite/commands/pr/review.md
@@ -367,6 +367,33 @@ Terminate processing.
 
 Terminate processing.
 
+### 1.1.5 セッション worktree 健全性の保証（multi_session 有効時 / AC-1 #1676）
+
+ステップ 1.2 以降は **作業ツリーから PR の変更ファイルを読む**。その前に対象 PR の作業ブランチに対応する session worktree を保証する。これがないと、worktree 不在（resume / context 圧縮 / 別セッション跨ぎで欠落）のとき review がメインツリー（develop）上で実行され、PR 変更を作業ツリーから読めず scratchpad へ退避する **degraded 動作**になる（本 Issue の As-Is）。
+
+ステップ 1.1 で取得した PR の `headRefName`（作業ブランチ）から issue 番号を抽出し、共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh)、検出 + 再構築を bash 側で完結し `[CONTEXT] WT_ENSURE=` を emit）で検出・再構築する（`{head_ref}` は ステップ 1.1 の `gh pr view` が返した `.headRefName`）:
+
+```bash
+issue_number=$(printf '%s' "{head_ref}" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+if [ -n "$issue_number" ]; then
+  bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue "$issue_number" --branch "{head_ref}"
+else
+  # head_ref が issue ブランチでない（session worktree の対象外）→ 従来どおり単一ツリーで続行
+  echo "[CONTEXT] WT_ENSURE=skip (head_ref が issue ブランチでないため worktree 対象外: {head_ref})"
+fi
+```
+
+`[CONTEXT] WT_ENSURE=` marker の分岐は [commands/resume.md](../resume.md) Phase 3.1.5 の **WT_ENSURE 分岐表（SoT）** に従う:
+
+- `disabled` / `already_in` / `skip` → no-op、ステップ 1.2 へ（`disabled` = `multi_session.enabled: false`。従来どおり単一ツリーで動作し挙動不変）。
+- `reenter` / `reconstructed` → `EnterWorktree` ツールを `path: {path}`（marker の `path=` 値）で呼び出してからステップ 1.2 へ。`reconstructed` は helper が `git worktree add` 済み。EnterWorktree 失敗時の切り分けは resume.md Phase 3.1.5 / pr:open Step 2.3-W と同じ（silent に新規扱いしない）。
+- `residue` → AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止）。
+- `branch_other_worktree` → 中止（並行セッションの可能性。`other=` のパスを表示）。
+- `branch_absent` → 対象ブランチがローカル・リモートどこにも実在しない。誤再構築しない（AC-5）。既存の「PR ブランチ未取得」ハンドリングへ委譲し、**develop 上で review を続行しない**。
+- `failed` → 再構築失敗（helper rc=1, stderr に原因 + 復旧手順）。**silent fallback せず `[review:error]` を emit して明示停止**する（review を mergeable / completed 扱いにしない / AC-4）。
+
+> **silent fallback 禁止（本 Issue の核）**: `branch_absent` / `failed` のとき、worktree 不在を理由に develop 上で review を継続し PR 変更を読めないまま完了扱いにしてはならない（§4.4 MUST NOT）。
+
 ### 1.2 Retrieve Changes
 
 > **Reference**: See [Review Context Optimization](./references/review-context-optimization.md) for scale determination and diff retrieval strategies.

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -164,6 +164,8 @@ bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --i
 | `branch_absent` | branch がローカル・リモートどこにも無い → **矛盾サマリ + AskUserQuestion**（新規セッション扱い / 中止）。helper は再構築しない（silent に新規扱いもしない） |
 | `failed` | 再構築（`git fetch` / `git worktree add`）が失敗（helper rc=1, stderr に原因 + 復旧手順）→ **silent fallback せず明示停止**。develop 上で resume を続行しない |
 
+> **caller-local marker `skip` について**: `pr:review` / `pr:fix` の入場ゲートは PR の `headRefName` が issue ブランチ（`issue-N` 命名）でないとき、helper を呼ばず caller 自身が `[CONTEXT] WT_ENSURE=skip` を emit する（session worktree の対象外＝従来どおり単一ツリーで続行する no-op）。`skip` は helper の出力 case ではなく **caller 固有拡張**であり、`disabled` / `already_in` と同じく no-op として扱う。resume は引数 / branch / 候補列挙で issue を確定してから本 helper を呼ぶため、resume 経路で `skip` は emit されない。
+
 **EnterWorktree が失敗した場合**（`reenter` / `reconstructed` 経路の `EnterWorktree(path)` がエラー）: pr:open Step 2.3-W と同じ切り分けを行い、**silent に新規セッション扱いしない**。
 
 - **harness の git 誤判定**（`.git` が存在し `git -C "{path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:resume {issue_number}` を再実行すれば、登録済み worktree が `WT_ENSURE=reenter` で再入場される」と案内する。worktree は保持済みのため破壊しない。

--- a/plugins/rite/commands/resume.md
+++ b/plugins/rite/commands/resume.md
@@ -145,53 +145,29 @@ echo "[CONTEXT] STATE_PARENT_DISPLAY=$parent_issue_display"
 
 git/PR 状態クロスチェック（Phase 3.2 / 3.3 の `git rev-list origin/{base}..HEAD` / `gh pr view`）は**カレントブランチ依存**のため、worktree への再入場は**その前に**行う必要がある（順序が本質）。session ⇄ worktree は 1:1 でない（クラッシュで session_id が変わる）ため、**issue 番号 → worktree パス導出（discovery fallback）が正規の対応関係**であり、flow-state `worktree` field は同一セッション内のヒントに留まる:
 
-```bash
-ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || ms_section=""
-ms_enabled=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+enabled:/ {print; exit}' \
-  | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
-case "$ms_enabled" in true|yes|1) ms_enabled=true ;; *) ms_enabled=false ;; esac
-ms_base=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+worktree_base:/ {print; exit}' \
-  | sed 's/[[:space:]]#.*//' | sed 's/.*worktree_base:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
-[ -n "$ms_base" ] || ms_base=".rite/worktrees"
+検出・再構築は共通ヘルパー `ensure_session_worktree`（[`lib/worktree-git.sh`](../hooks/scripts/lib/worktree-git.sh)、#1676 で #1368 のロジックを SoT 化）に委譲する。ヘルパーは `multi_session` の読取・worktree パス導出（`--git-common-dir` から main checkout root を求める）・branch 解決（issue-N の local/remote ref から自動）・**再構築（`git worktree add`）まで bash 側で完結**し、唯一の `[CONTEXT] WT_ENSURE=` marker を emit する。session ⇄ worktree は 1:1 でない（クラッシュで session_id が変わる）ため、helper は issue 番号 → worktree パス導出を正規の対応とし、flow-state `worktree` field には依存しない:
 
-if [ "$ms_enabled" != "true" ]; then
-  echo "[CONTEXT] RESUME_WT=disabled"
-else
-  # flow-state worktree を優先。空なら（新 session_id では空が正常）issue 番号から導出。
-  flow_wt=$(bash {plugin_root}/hooks/flow-state.sh get --field worktree --default "") || flow_wt=""
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root="$PWD"
-  derived_wt="$repo_root/$ms_base/issue-$issue_arg"
-  wt_path="${flow_wt:-$derived_wt}"
-  cur_top=$(git rev-parse --show-toplevel 2>/dev/null) || cur_top=""
-  registered=$(git worktree list --porcelain 2>/dev/null | awk -v p="$wt_path" '$1=="worktree" && $2==p {print "yes"}')
-  branch_local=$(git rev-parse --verify "{branch}" >/dev/null 2>&1 && echo yes || echo no)
-  if [ "$registered" = "yes" ] && [ "$cur_top" = "$wt_path" ]; then
-    echo "[CONTEXT] RESUME_WT=already_in; path=$wt_path"
-  elif [ "$registered" = "yes" ]; then
-    echo "[CONTEXT] RESUME_WT=reenter; path=$wt_path"
-  elif [ -e "$wt_path" ]; then
-    git worktree prune
-    echo "[CONTEXT] RESUME_WT=$([ -e "$wt_path" ] && echo residue || echo missing); path=$wt_path; branch_local=$branch_local"
-  else
-    echo "[CONTEXT] RESUME_WT=missing; path=$wt_path; branch_local=$branch_local"
-  fi
-fi
+```bash
+bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --issue "$issue_arg"
 ```
 
-`RESUME_WT` で分岐する（branch 名は Phase 1.1 の issue から `{type}/issue-{number}-{slug}` で再構成、`{base_branch}` は Phase 3.2 の base）:
+> **本ブロックは WT_ENSURE 分岐表の SoT**（pr:review / pr:iterate / pr:fix の入場ゲートが参照する。#1676）。EnterWorktree は LLM ツールのため helper からは呼べず、`reenter` / `reconstructed` の入場のみ下記表に従い LLM が実行する。
 
-| `RESUME_WT` | アクション |
+`WT_ENSURE` で分岐する:
+
+| `WT_ENSURE` | アクション |
 |---|---|
 | `disabled` / `already_in` | no-op（従来フロー / 既に worktree 内）。Phase 3.2 へ |
-| `reenter` | `EnterWorktree` ツールを `path: {path}` で呼び出してから Phase 3.2 へ |
-| `residue` | パスは存在するが worktree 未登録（prune 後も残存）→ AskUserQuestion（削除して再構築 / 中止） |
-| `missing` + `branch_local=yes` | branch ローカル有 → `git worktree add "{path}" "{branch}"`（`-b` なし）→ `EnterWorktree(path)` |
-| `missing` + `branch_local=no` | リモート確認 → 有れば `git fetch origin {branch}` + `git worktree add --track -b "{branch}" "{path}" "origin/{branch}"` → `EnterWorktree(path)`。どこにも無ければ **矛盾サマリ + AskUserQuestion**（新規セッション扱い / 中止）— silent に新規扱いしない |
+| `reenter` / `reconstructed` | `EnterWorktree` ツールを `path: {path}` で呼び出してから Phase 3.2 へ（`{path}` は marker の `path=` 値。`reconstructed` は helper が `git worktree add` 済み） |
+| `residue` | パスは存在するが worktree 未登録（prune 後も残存）→ AskUserQuestion（削除 `rm -rf {path}` して再実行 / 中止） |
+| `branch_other_worktree` | branch が**別の worktree** で checkout 中（並行セッションの可能性）→ **中止**。`other=` のパスを表示する（git が構造的に保証する二重着手ガード） |
+| `branch_absent` | branch がローカル・リモートどこにも無い → **矛盾サマリ + AskUserQuestion**（新規セッション扱い / 中止）。helper は再構築しない（silent に新規扱いもしない） |
+| `failed` | 再構築（`git fetch` / `git worktree add`）が失敗（helper rc=1, stderr に原因 + 復旧手順）→ **silent fallback せず明示停止**。develop 上で resume を続行しない |
 
-**EnterWorktree が失敗した場合**（`reenter` / `missing` 経路の `EnterWorktree(path)` がエラー）: pr:open Step 2.3-W と同じ切り分けを行い、**silent に新規セッション扱いしない**。
+**EnterWorktree が失敗した場合**（`reenter` / `reconstructed` 経路の `EnterWorktree(path)` がエラー）: pr:open Step 2.3-W と同じ切り分けを行い、**silent に新規セッション扱いしない**。
 
-- **harness の git 誤判定**（`.git` が存在し `git -C "{path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:resume {issue_number}` を再実行すれば、登録済み worktree が `RESUME_WT=reenter` で再入場される」と案内する。worktree は保持済みのため破壊しない。
-- **worktree path 消失などの別要因** → 上表の `missing` 経路（branch ローカル有 / リモート確認 → 再構築）に従う。再起動案内へ誤誘導しない。
+- **harness の git 誤判定**（`.git` が存在し `git -C "{path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:resume {issue_number}` を再実行すれば、登録済み worktree が `WT_ENSURE=reenter` で再入場される」と案内する。worktree は保持済みのため破壊しない。
+- **worktree path 消失などの別要因** → 再度本ヘルパーを実行すれば `branch_absent` 以外なら再構築される。再起動案内へ誤誘導しない。
 
 再入場後、claim に worktree path を再記録してもよい（`issue-claim.sh claim --issue {issue_number} --worktree "{path}"`、best-effort）。
 
@@ -300,11 +276,11 @@ echo "[CONTEXT] FINAL_PHASE=$user_selected_phase"
 
 ### 5.1 ブランチ切り替え（worktree モードでは検証のみ）
 
-`RESUME_WT=reenter` / `missing`（Phase 3.1.5 で worktree へ再入場・再構築済み）の worktree モードでは、worktree の HEAD は既に state branch を指しているはずなので **`git switch` は行わず検証のみ**にする（worktree 内から base への switch は不可かつ不要）。不一致は WARNING に留める:
+`WT_ENSURE=reenter` / `reconstructed`（Phase 3.1.5 で worktree へ再入場・再構築済み。`already_in` も worktree モード）では、worktree の HEAD は既に state branch を指しているはずなので **`git switch` は行わず検証のみ**にする（worktree 内から base への switch は不可かつ不要）。不一致は WARNING に留める:
 
 ```bash
 if [ "$RESUME_WT_MODE" = "worktree" ]; then
-  # worktree モード: 検証のみ（RESUME_WT が disabled/already_in 以外だったケース）
+  # worktree モード: 検証のみ（WT_ENSURE が already_in/reenter/reconstructed だったケース）
   cur=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || cur=""
   if [ -n "$state_branch" ] && [ "$cur" != "$state_branch" ]; then
     echo "WARNING: worktree のカレントブランチ ($cur) が state branch ($state_branch) と不一致です。手動で git switch '$state_branch' を確認してください。" >&2
@@ -318,7 +294,7 @@ elif [ -n "$state_branch" ] && [ "$git_branch" != "$state_branch" ]; then
 fi
 ```
 
-> `RESUME_WT_MODE` は Phase 3.1.5 の `[CONTEXT] RESUME_WT=` marker が `reenter` / `residue` / `missing`（= worktree に入った / 再構築した）のとき `worktree`、それ以外（`disabled` / `already_in`）は空（従来分岐）として LLM が置換する。
+> `RESUME_WT_MODE` は Phase 3.1.5 の `[CONTEXT] WT_ENSURE=` marker が `already_in` / `reenter` / `reconstructed`（= worktree に入った / 再構築した）のとき `worktree`、それ以外（`disabled`（従来分岐） / `residue` / `branch_other_worktree` / `branch_absent` / `failed`（= worktree に入っていない。停止 or 新規セッション扱いへ分岐）のとき空として LLM が置換する。
 
 ### 5.2 flow-state の active=true 復元
 

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -431,9 +431,14 @@ ensure_session_worktree() {
   local issue="" branch="" wt_base_override=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --issue)         issue="${2:-}"; shift 2 ;;
-      --branch)        branch="${2:-}"; shift 2 ;;
-      --worktree-base) wt_base_override="${2:-}"; shift 2 ;;
+      # `shift 2 || shift`: a value-taking flag passed as the LAST token (no
+      # value) leaves $#=1; bash `shift 2` is then a no-op non-zero return and
+      # the while loop would spin forever. The `|| shift` advances past the
+      # lone flag so the loop terminates (issue/branch stay "" → caught by the
+      # numeric guard below). Mirrors worktree-foreign-cwd.sh's underflow guard.
+      --issue)         issue="${2:-}"; shift 2 || shift ;;
+      --branch)        branch="${2:-}"; shift 2 || shift ;;
+      --worktree-base) wt_base_override="${2:-}"; shift 2 || shift ;;
       *)               shift ;;
     esac
   done
@@ -444,7 +449,7 @@ ensure_session_worktree() {
       return 2 ;;
   esac
 
-  # --- read multi_session (same parser as pr:open Step 2.1-G / resume 3.1.5) ---
+  # --- read multi_session (same parser as pr:open Step 2.1-G / resume.md Phase 1.1) ---
   local ms_section ms_enabled ms_base
   ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || ms_section=""
   ms_enabled=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+enabled:/ {print; exit}' \
@@ -544,10 +549,18 @@ ensure_session_worktree() {
   fi
 
   if [ "$branch_remote" = yes ]; then
-    local n=0
-    until git fetch origin "$branch" >/dev/null 2>&1; do
-      n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 1
+    # fetch is best-effort (do NOT hard-fail — an offline resume must still
+    # reconstruct from the existing origin/$branch ref). But all-retries-
+    # exhausted is surfaced as a WARNING rather than swallowed, so a stale
+    # reconstruction is never silent (Issue #1676 error table: 取得不能を明示).
+    local n=0 fetch_ok=no
+    while [ "$n" -lt 3 ]; do
+      if git fetch origin "$branch" >/dev/null 2>&1; then fetch_ok=yes; break; fi
+      n=$((n+1)); [ "$n" -lt 3 ] && sleep 1
     done
+    if [ "$fetch_ok" != yes ]; then
+      echo "WARNING: ensure_session_worktree: git fetch origin '$branch' が 3 回失敗しました — 既存の origin/$branch（stale の可能性）から再構築します (issue #$issue)" >&2
+    fi
     if git worktree add --track -b "$branch" "$wt_path" "origin/$branch" 1>&2; then
       echo "[CONTEXT] WT_ENSURE=reconstructed; path=$wt_path; branch=$branch"
       return 0

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -1,10 +1,22 @@
-# rite workflow - Worktree-scoped git add/commit/push helper
+# rite workflow - Worktree git helpers (commit/push + session-worktree ensure)
 #
-# Responsibility: provide the canonical `git -C <worktree> add / commit /
-# push` flow with stderr tempfile capture, head -n 10 extraction, and
-# exit-code semantics shared by:
+# Responsibility 1 (source-only): provide the canonical
+# `git -C <worktree> add / commit / push` flow with stderr tempfile
+# capture, head -n 10 extraction, and exit-code semantics shared by:
 # - wiki-worktree-commit.sh (pages/index/log commits on wiki branch)
 # - wiki-ingest-commit.sh (worktree fast path for raw-source ingest)
+#
+# Responsibility 2 (#1676, source OR standalone): provide
+# `ensure_session_worktree`, the single bash-side SoT for the
+# "branch exists ∧ session worktree absent → reconstruct" gate used by
+# the flow ENTRY paths (resume / pr:review / pr:iterate / pr:fix) so a
+# missing worktree never silently degrades the flow onto the main
+# checkout (develop). Callers invoke it standalone as
+# `bash lib/worktree-git.sh ensure-session-worktree --issue <N> ...` and
+# route on the emitted `[CONTEXT] WT_ENSURE=` marker (see the function
+# header below and commands/resume.md Phase 3.1.5 for the canonical
+# marker→action table). The dispatch at the bottom of this file exposes
+# only that subcommand; the commit/push helpers stay source-only.
 #
 # Design rationale: review identified that the
 # add/commit/push block + error handling (stderr tempfile -> head -n 10
@@ -361,3 +373,211 @@ worktree_commit_push() {
  fi
  return 0
 }
+
+# -----------------------------------------------------------------------
+# ensure_session_worktree: detect + reconstruct a multi_session session
+# worktree for an Issue at a flow ENTRY path (#1676).
+#
+# This is the single bash-side SoT for the "branch exists ∧ worktree
+# absent → reconstruct" gate that #1368 first introduced inline in
+# resume.md. It performs detection AND reconstruction (git worktree add);
+# the EnterWorktree tool call and any AskUserQuestion routing stay with the
+# LLM caller, driven by the emitted [CONTEXT] WT_ENSURE marker. The
+# canonical marker→action routing table lives in commands/resume.md
+# Phase 3.1.5 (consumed verbatim by pr:review / pr:iterate / pr:fix).
+#
+# It does NOT call EnterWorktree (an LLM tool, not a shell command) and it
+# NEVER `git switch -c`-es onto the main checkout — a missing worktree is
+# reconstructed in place or reported, never silently bypassed.
+#
+# Usage:
+#   ensure_session_worktree --issue <N> [--branch <branch>] [--worktree-base <base>]
+#   bash lib/worktree-git.sh ensure-session-worktree --issue <N> [...]
+#
+# Arguments:
+#   --issue          Issue number (required, numeric)
+#   --branch         feature branch name. Optional — resolved from
+#                    local/remote refs matching issue-<N> when omitted.
+#   --worktree-base  override multi_session.worktree_base (default: parsed
+#                    from rite-config.yml, fallback .rite/worktrees)
+#
+# stdout (always exactly one marker line):
+#   [CONTEXT] WT_ENSURE=<case>; path=<wt_path>; branch=<branch>[; other=<p>]
+#
+# <case> → caller action:
+#   disabled              multi_session off → no-op, proceed on main checkout
+#   already_in            registered AND cwd already inside it → no-op
+#   reenter               registered, cwd elsewhere → EnterWorktree(path)
+#   reconstructed         was missing, branch existed (local/remote),
+#                         `git worktree add` succeeded → EnterWorktree(path)
+#   residue               path exists but not a registered worktree (prune
+#                         did not clear) → AskUserQuestion (rm -rf + re-run / abort)
+#   branch_other_worktree branch checked out in ANOTHER worktree → caller
+#                         aborts (concurrent session; structural double-start guard)
+#   branch_absent         branch exists nowhere → caller delegates to its
+#                         existing non-existence handling; DO NOT reconstruct
+#   failed                fetch / git worktree add failed → caller STOPS loud;
+#                         NO silent fallback to the main checkout
+#
+# Exit codes:
+#   0  disabled|already_in|reenter|reconstructed|residue|branch_other_worktree|branch_absent
+#   1  failed (cause on stderr; marker still emitted on stdout)
+#   2  argument error (missing/invalid --issue)
+#
+# stdout discipline: every git command that could print to stdout is
+# captured into a variable or redirected to stderr (1>&2) / /dev/null, so
+# the marker line is the ONLY thing on stdout (callers grep for it).
+ensure_session_worktree() {
+  local issue="" branch="" wt_base_override=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --issue)         issue="${2:-}"; shift 2 ;;
+      --branch)        branch="${2:-}"; shift 2 ;;
+      --worktree-base) wt_base_override="${2:-}"; shift 2 ;;
+      *)               shift ;;
+    esac
+  done
+
+  case "$issue" in
+    ''|*[!0-9]*)
+      echo "ERROR: ensure_session_worktree: --issue <N> (numeric) required" >&2
+      return 2 ;;
+  esac
+
+  # --- read multi_session (same parser as pr:open Step 2.1-G / resume 3.1.5) ---
+  local ms_section ms_enabled ms_base
+  ms_section=$(sed -n '/^multi_session:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || ms_section=""
+  ms_enabled=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+enabled:/ {print; exit}' \
+    | sed 's/[[:space:]]#.*//' | sed 's/.*enabled:[[:space:]]*//' | tr -d '[:space:]"'"'"'' | tr '[:upper:]' '[:lower:]')
+  case "$ms_enabled" in true|yes|1) ms_enabled=true ;; *) ms_enabled=false ;; esac
+  if [ -n "$wt_base_override" ]; then
+    ms_base="$wt_base_override"
+  else
+    ms_base=$(printf '%s\n' "$ms_section" | awk '/^[[:space:]]+worktree_base:/ {print; exit}' \
+      | sed 's/[[:space:]]#.*//' | sed 's/.*worktree_base:[[:space:]]*//' | tr -d '[:space:]"'"'"'')
+    [ -n "$ms_base" ] || ms_base=".rite/worktrees"
+  fi
+
+  if [ "$ms_enabled" != "true" ]; then
+    echo "[CONTEXT] WT_ENSURE=disabled; path=; branch=$branch"
+    return 0
+  fi
+
+  # --- derive the MAIN checkout root via --git-common-dir, NOT
+  #     --show-toplevel (which returns the worktree itself when we are
+  #     already inside one, breaking the already_in compare). ---
+  local git_common main_root
+  git_common=$(git rev-parse --git-common-dir 2>/dev/null) || {
+    echo "ERROR: ensure_session_worktree: not in a git repository (issue #$issue)" >&2
+    echo "[CONTEXT] WT_ENSURE=failed; path=; branch=$branch"
+    return 1
+  }
+  case "$git_common" in /*) ;; *) git_common="$(pwd -P)/$git_common" ;; esac
+  main_root=$(cd -- "$(dirname -- "$git_common")" 2>/dev/null && pwd -P) || main_root="$(pwd -P)"
+
+  # --- compute this issue's session worktree path ---
+  local wt_path
+  case "$ms_base" in
+    /*) wt_path="$ms_base/issue-$issue" ;;
+    *)  wt_path="$main_root/$ms_base/issue-$issue" ;;
+  esac
+
+  # --- resolve the branch from issue-<N> refs when not supplied ---
+  if [ -z "$branch" ]; then
+    branch=$(git for-each-ref --format='%(refname:short)' refs/heads/ 2>/dev/null \
+      | grep -E "(^|/)issue-${issue}(-|$)" | head -1)
+    if [ -z "$branch" ]; then
+      branch=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ 2>/dev/null \
+        | sed 's|^origin/||' | grep -E "(^|/)issue-${issue}(-|$)" | head -1)
+    fi
+  fi
+
+  # --- detection: registered / already_in / reenter / residue ---
+  local cur_top registered
+  cur_top=$(git rev-parse --show-toplevel 2>/dev/null) || cur_top=""
+  registered=$(git worktree list --porcelain 2>/dev/null | awk -v p="$wt_path" '$1=="worktree" && $2==p {print "yes"}')
+
+  if [ "$registered" = "yes" ] && [ "$cur_top" = "$wt_path" ]; then
+    echo "[CONTEXT] WT_ENSURE=already_in; path=$wt_path; branch=$branch"
+    return 0
+  fi
+  if [ "$registered" = "yes" ]; then
+    echo "[CONTEXT] WT_ENSURE=reenter; path=$wt_path; branch=$branch"
+    return 0
+  fi
+  if [ -e "$wt_path" ]; then
+    git worktree prune >/dev/null 2>&1 || true
+    if [ -e "$wt_path" ]; then
+      echo "[CONTEXT] WT_ENSURE=residue; path=$wt_path; branch=$branch"
+      return 0
+    fi
+  fi
+
+  # --- worktree missing → reconstruct only if the branch exists somewhere ---
+  # If the branch is checked out in ANOTHER worktree (concurrent session),
+  # do not reconstruct — mirror open.md's branch_other_worktree guard.
+  if [ -n "$branch" ]; then
+    local branch_wt
+    branch_wt=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/$branch" '
+      $1=="worktree"{wt=$2} $1=="branch" && $2==b {print wt}')
+    if [ -n "$branch_wt" ]; then
+      echo "[CONTEXT] WT_ENSURE=branch_other_worktree; path=$wt_path; branch=$branch; other=$branch_wt"
+      return 0
+    fi
+  fi
+
+  local branch_local=no branch_remote=no
+  if [ -n "$branch" ]; then
+    git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1 && branch_local=yes
+    git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1 && branch_remote=yes
+  fi
+
+  if [ "$branch_local" = yes ]; then
+    if git worktree add "$wt_path" "$branch" 1>&2; then
+      echo "[CONTEXT] WT_ENSURE=reconstructed; path=$wt_path; branch=$branch"
+      return 0
+    fi
+    echo "ERROR: ensure_session_worktree: git worktree add '$wt_path' '$branch' failed (issue #$issue)" >&2
+    echo "  recovery: restart Claude Code from the repo root, or run: git worktree add '$wt_path' '$branch'" >&2
+    echo "[CONTEXT] WT_ENSURE=failed; path=$wt_path; branch=$branch"
+    return 1
+  fi
+
+  if [ "$branch_remote" = yes ]; then
+    local n=0
+    until git fetch origin "$branch" >/dev/null 2>&1; do
+      n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 1
+    done
+    if git worktree add --track -b "$branch" "$wt_path" "origin/$branch" 1>&2; then
+      echo "[CONTEXT] WT_ENSURE=reconstructed; path=$wt_path; branch=$branch"
+      return 0
+    fi
+    echo "ERROR: ensure_session_worktree: git worktree add --track -b '$branch' '$wt_path' 'origin/$branch' failed (issue #$issue)" >&2
+    echo "  recovery: restart Claude Code from the repo root, or run the add manually" >&2
+    echo "[CONTEXT] WT_ENSURE=failed; path=$wt_path; branch=$branch"
+    return 1
+  fi
+
+  # branch exists nowhere → delegate to the caller's non-existence handling.
+  echo "[CONTEXT] WT_ENSURE=branch_absent; path=$wt_path; branch=$branch"
+  return 0
+}
+
+# -----------------------------------------------------------------------
+# Standalone CLI dispatch. Sourcing this file is a no-op here (the guard is
+# false); running it as `bash lib/worktree-git.sh <subcommand>` dispatches.
+# Only ensure-session-worktree is exposed; the commit/push helpers above
+# are source-only by design.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    ensure-session-worktree)
+      shift
+      ensure_session_worktree "$@"
+      exit $?
+      ;;
+    *)
+      echo "ERROR: worktree-git.sh: unknown subcommand '${1:-}' (expected: ensure-session-worktree)" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/plugins/rite/hooks/tests/ensure-session-worktree.test.sh
+++ b/plugins/rite/hooks/tests/ensure-session-worktree.test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Tests for ensure_session_worktree (lib/worktree-git.sh, #1676) — the shared
+# bash-side gate that detects + reconstructs a missing session worktree at a
+# flow ENTRY path so review/iterate/fix never silently degrade onto develop.
+#
+#   T-01 / AC-1: branch local ∧ worktree absent → reconstructed (worktree added)
+#   T-04 / AC-4: git worktree add fails → failed (rc 1, NO silent fallback)
+#   T-05 / AC-5: branch absent everywhere → branch_absent (no reconstruction)
+#   Plus: disabled / already_in / reenter / residue / branch_other_worktree /
+#         remote-only reconstruct / arg error / stdout discipline.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+HELPER="$SCRIPT_DIR/../scripts/lib/worktree-git.sh"
+
+# Build a bare "remote" + a main clone with multi_session enabled. Echoes the
+# main checkout path. Creates: develop (pushed), local branch fix/issue-42-foo,
+# remote-only branch feat/issue-77-bar.
+setup_repo() {
+  local root main
+  root=$(make_plain_sandbox) || return 1
+  git init -q --bare "$root/remote.git"
+  git init -q "$root/main"
+  main="$root/main"
+  (
+    cd "$main" || exit 1
+    git config user.email t@t; git config user.name t
+    git remote add origin ../remote.git
+    printf 'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n' > rite-config.yml
+    git add -A; git commit -qm init
+    git branch -m develop
+    git push -q -u origin develop
+    git branch fix/issue-42-foo develop            # local-only feature branch
+    git checkout -q -b feat/issue-77-bar develop
+    echo x > x.txt; git add -A; git commit -qm work
+    git push -q -u origin feat/issue-77-bar
+    git checkout -q develop
+    git branch -D feat/issue-77-bar                # issue-77 now remote-only
+  ) >/dev/null 2>&1 || return 1
+  echo "$main"
+}
+
+# Run the helper from <dir> and print the bare WT_ENSURE case token.
+ens_case() {
+  local dir="$1"; shift
+  ( cd "$dir" && bash "$HELPER" ensure-session-worktree "$@" 2>/dev/null ) \
+    | sed -n 's/.*WT_ENSURE=\([a-z_]*\).*/\1/p'
+}
+# Run the helper from <dir> and print its exit code.
+ens_rc() {
+  local dir="$1"; shift
+  ( cd "$dir" && bash "$HELPER" ensure-session-worktree "$@" >/dev/null 2>&1 ); echo $?
+}
+# "yes"/"no": is a worktree for issue-<N> registered in <main>?
+wt_registered() {
+  git -C "$1" worktree list --porcelain 2>/dev/null | grep -qE "/issue-$2($|/| )" && echo yes || echo no
+}
+
+# --- TC-1: disabled (multi_session.enabled: false) ---
+echo "=== TC-1: enabled:false → disabled (legacy single-tree, unchanged) ==="
+M=$(setup_repo)
+printf 'multi_session:\n  enabled: false\n  worktree_base: ".rite/worktrees"\n' > "$M/rite-config.yml"
+assert "TC-1 disabled token" "disabled" "$(ens_case "$M" --issue 42)"
+assert "TC-1 rc=0" "0" "$(ens_rc "$M" --issue 42)"
+# restore enabled for any reuse
+printf 'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n' > "$M/rite-config.yml"
+
+# --- TC-2 (T-05 / AC-5): branch absent → branch_absent, no reconstruction ---
+echo "=== TC-2 (T-05/AC-5): branch nowhere → branch_absent, no worktree created ==="
+M=$(setup_repo)
+assert "TC-2 branch_absent token" "branch_absent" "$(ens_case "$M" --issue 99)"
+assert "TC-2 no worktree created" "no" "$(wt_registered "$M" 99)"
+
+# --- TC-3 (T-01 / AC-1): local branch ∧ worktree absent → reconstructed ---
+echo "=== TC-3 (T-01/AC-1): local branch, worktree absent → reconstructed ==="
+M=$(setup_repo)
+assert "TC-3 reconstructed token" "reconstructed" "$(ens_case "$M" --issue 42)"
+assert "TC-3 worktree registered" "yes" "$(wt_registered "$M" 42)"
+
+# --- TC-4: remote-only branch → reconstructed (fetch + add --track) ---
+echo "=== TC-4: remote-only branch → reconstructed ==="
+M=$(setup_repo)
+assert "TC-4 reconstructed token" "reconstructed" "$(ens_case "$M" --issue 77)"
+assert "TC-4 worktree registered" "yes" "$(wt_registered "$M" 77)"
+
+# --- TC-5: already_in (run from inside the worktree) ---
+echo "=== TC-5: cwd inside worktree → already_in ==="
+M=$(setup_repo)
+ens_case "$M" --issue 42 >/dev/null   # create+register it first
+assert "TC-5 already_in token" "already_in" "$(ens_case "$M/.rite/worktrees/issue-42" --issue 42)"
+
+# --- TC-6: reenter (registered, cwd elsewhere) ---
+echo "=== TC-6: registered, cwd=main → reenter ==="
+M=$(setup_repo)
+ens_case "$M" --issue 42 >/dev/null
+assert "TC-6 reenter token" "reenter" "$(ens_case "$M" --issue 42)"
+
+# --- TC-7: residue (dir exists at path, not a registered worktree) ---
+echo "=== TC-7: stale dir at path, not registered → residue ==="
+M=$(setup_repo)
+mkdir -p "$M/.rite/worktrees/issue-42"; echo junk > "$M/.rite/worktrees/issue-42/junk"
+assert "TC-7 residue token" "residue" "$(ens_case "$M" --issue 42)"
+
+# --- TC-8: branch checked out in ANOTHER worktree → branch_other_worktree ---
+echo "=== TC-8: branch in a different worktree → branch_other_worktree ==="
+M=$(setup_repo)
+git -C "$M" worktree add -q "$M/../elsewhere-42" fix/issue-42-foo >/dev/null 2>&1
+assert "TC-8 branch_other_worktree token" "branch_other_worktree" "$(ens_case "$M" --issue 42)"
+
+# --- TC-9 (T-04 / AC-4): git worktree add fails → failed (rc 1, NO fallback) ---
+echo "=== TC-9 (T-04/AC-4): reconstruction fails → failed, rc=1 ==="
+M=$(setup_repo)
+rm -rf "$M/.rite"; mkdir -p "$M/.rite"; printf 'blocker' > "$M/.rite/worktrees"  # base is a FILE
+assert "TC-9 failed token" "failed" "$(ens_case "$M" --issue 42)"
+assert "TC-9 rc=1" "1" "$(ens_rc "$M" --issue 42)"
+
+# --- TC-10: argument error (missing --issue) → rc 2 ---
+echo "=== TC-10: missing --issue → rc 2 ==="
+M=$(setup_repo)
+assert "TC-10 rc=2" "2" "$(ens_rc "$M")"
+
+# --- TC-11: stdout discipline — exactly ONE line, the marker (git chatter to stderr) ---
+echo "=== TC-11: stdout is exactly one WT_ENSURE marker line on reconstruct ==="
+M=$(setup_repo)
+stdout_lines=$( ( cd "$M" && bash "$HELPER" ensure-session-worktree --issue 42 2>/dev/null ) | grep -c .)
+assert "TC-11 single stdout line" "1" "$stdout_lines"
+
+print_summary "ensure-session-worktree.test.sh" \
+  "ensure_session_worktree contract changed — sync lib/worktree-git.sh and the resume.md WT_ENSURE table"

--- a/plugins/rite/hooks/tests/ensure-session-worktree.test.sh
+++ b/plugins/rite/hooks/tests/ensure-session-worktree.test.sh
@@ -4,10 +4,11 @@
 # flow ENTRY path so review/iterate/fix never silently degrade onto develop.
 #
 #   T-01 / AC-1: branch local ∧ worktree absent → reconstructed (worktree added)
-#   T-04 / AC-4: git worktree add fails → failed (rc 1, NO silent fallback)
+#   T-04 / AC-4: git worktree add fails → failed (rc 1, NO silent fallback, no residue)
 #   T-05 / AC-5: branch absent everywhere → branch_absent (no reconstruction)
 #   Plus: disabled / already_in / reenter / residue / branch_other_worktree /
-#         remote-only reconstruct / arg error / stdout discipline.
+#         remote-only reconstruct / explicit --branch path / marker path=/other=
+#         fields / arg error / stdout discipline.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,17 +16,25 @@ source "$SCRIPT_DIR/_test-helpers.sh"
 
 HELPER="$SCRIPT_DIR/../scripts/lib/worktree-git.sh"
 
-# Build a bare "remote" + a main clone with multi_session enabled. Echoes the
-# main checkout path. Creates: develop (pushed), local branch fix/issue-42-foo,
+# Sandbox cleanup (suite convention — see worktree-foreign-cwd.test.sh).
+cleanup_dirs=()
+cleanup() { for d in "${cleanup_dirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+# Build a bare "remote" + a main clone with multi_session enabled. Sets the
+# global REPO_MAIN to the main checkout path and registers the sandbox root in
+# cleanup_dirs. Run in PARENT scope (NOT `$(setup_repo)`) so cleanup_dirs+= and
+# REPO_MAIN propagate. Creates: develop (pushed), local branch fix/issue-42-foo,
 # remote-only branch feat/issue-77-bar.
+REPO_MAIN=""
 setup_repo() {
-  local root main
+  local root
   root=$(make_plain_sandbox) || return 1
+  cleanup_dirs+=("$root")
   git init -q --bare "$root/remote.git"
   git init -q "$root/main"
-  main="$root/main"
   (
-    cd "$main" || exit 1
+    cd "$root/main" || exit 1
     git config user.email t@t; git config user.name t
     git remote add origin ../remote.git
     printf 'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n' > rite-config.yml
@@ -39,7 +48,7 @@ setup_repo() {
     git checkout -q develop
     git branch -D feat/issue-77-bar                # issue-77 now remote-only
   ) >/dev/null 2>&1 || return 1
-  echo "$main"
+  REPO_MAIN="$root/main"
 }
 
 # Run the helper from <dir> and print the bare WT_ENSURE case token.
@@ -47,6 +56,12 @@ ens_case() {
   local dir="$1"; shift
   ( cd "$dir" && bash "$HELPER" ensure-session-worktree "$@" 2>/dev/null ) \
     | sed -n 's/.*WT_ENSURE=\([a-z_]*\).*/\1/p'
+}
+# Run the helper from <dir> and print the value of a marker field (e.g. path, other).
+ens_field() {
+  local dir="$1" field="$2"; shift 2
+  ( cd "$dir" && bash "$HELPER" ensure-session-worktree "$@" 2>/dev/null ) \
+    | sed -n "s/.*; ${field}=\([^;]*\).*/\1/p" | head -1
 }
 # Run the helper from <dir> and print its exit code.
 ens_rc() {
@@ -60,70 +75,87 @@ wt_registered() {
 
 # --- TC-1: disabled (multi_session.enabled: false) ---
 echo "=== TC-1: enabled:false → disabled (legacy single-tree, unchanged) ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 printf 'multi_session:\n  enabled: false\n  worktree_base: ".rite/worktrees"\n' > "$M/rite-config.yml"
 assert "TC-1 disabled token" "disabled" "$(ens_case "$M" --issue 42)"
 assert "TC-1 rc=0" "0" "$(ens_rc "$M" --issue 42)"
-# restore enabled for any reuse
-printf 'multi_session:\n  enabled: true\n  worktree_base: ".rite/worktrees"\n' > "$M/rite-config.yml"
 
 # --- TC-2 (T-05 / AC-5): branch absent → branch_absent, no reconstruction ---
 echo "=== TC-2 (T-05/AC-5): branch nowhere → branch_absent, no worktree created ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 assert "TC-2 branch_absent token" "branch_absent" "$(ens_case "$M" --issue 99)"
 assert "TC-2 no worktree created" "no" "$(wt_registered "$M" 99)"
 
 # --- TC-3 (T-01 / AC-1): local branch ∧ worktree absent → reconstructed ---
 echo "=== TC-3 (T-01/AC-1): local branch, worktree absent → reconstructed ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 assert "TC-3 reconstructed token" "reconstructed" "$(ens_case "$M" --issue 42)"
 assert "TC-3 worktree registered" "yes" "$(wt_registered "$M" 42)"
 
+# --- TC-3b: explicit --branch (the form pr:review.md / pr:fix.md actually use) ---
+echo "=== TC-3b: explicit --branch reconstructed (caller invocation form) ==="
+setup_repo; M="$REPO_MAIN"
+assert "TC-3b reconstructed token (explicit branch)" "reconstructed" \
+  "$(ens_case "$M" --issue 42 --branch fix/issue-42-foo)"
+assert "TC-3b worktree registered" "yes" "$(wt_registered "$M" 42)"
+
 # --- TC-4: remote-only branch → reconstructed (fetch + add --track) ---
 echo "=== TC-4: remote-only branch → reconstructed ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 assert "TC-4 reconstructed token" "reconstructed" "$(ens_case "$M" --issue 77)"
 assert "TC-4 worktree registered" "yes" "$(wt_registered "$M" 77)"
 
 # --- TC-5: already_in (run from inside the worktree) ---
 echo "=== TC-5: cwd inside worktree → already_in ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 ens_case "$M" --issue 42 >/dev/null   # create+register it first
 assert "TC-5 already_in token" "already_in" "$(ens_case "$M/.rite/worktrees/issue-42" --issue 42)"
 
-# --- TC-6: reenter (registered, cwd elsewhere) ---
-echo "=== TC-6: registered, cwd=main → reenter ==="
-M=$(setup_repo)
+# --- TC-6: reenter (registered, cwd elsewhere) + path= field is load-bearing ---
+echo "=== TC-6: registered, cwd=main → reenter, path= points at the worktree ==="
+setup_repo; M="$REPO_MAIN"
 ens_case "$M" --issue 42 >/dev/null
 assert "TC-6 reenter token" "reenter" "$(ens_case "$M" --issue 42)"
+# path= is the value the caller feeds to EnterWorktree — assert it resolves to the issue worktree.
+assert "TC-6 path= ends with .rite/worktrees/issue-42" "yes" \
+  "$(case "$(ens_field "$M" path --issue 42)" in */.rite/worktrees/issue-42) echo yes ;; *) echo no ;; esac)"
 
 # --- TC-7: residue (dir exists at path, not a registered worktree) ---
 echo "=== TC-7: stale dir at path, not registered → residue ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 mkdir -p "$M/.rite/worktrees/issue-42"; echo junk > "$M/.rite/worktrees/issue-42/junk"
 assert "TC-7 residue token" "residue" "$(ens_case "$M" --issue 42)"
 
-# --- TC-8: branch checked out in ANOTHER worktree → branch_other_worktree ---
+# --- TC-8: branch checked out in ANOTHER worktree → branch_other_worktree (+ other=, no new wt) ---
 echo "=== TC-8: branch in a different worktree → branch_other_worktree ==="
-M=$(setup_repo)
-git -C "$M" worktree add -q "$M/../elsewhere-42" fix/issue-42-foo >/dev/null 2>&1
+setup_repo; M="$REPO_MAIN"
+git -C "$M" worktree add -q "$M/elsewhere-42" fix/issue-42-foo >/dev/null 2>&1
 assert "TC-8 branch_other_worktree token" "branch_other_worktree" "$(ens_case "$M" --issue 42)"
+# other= must surface the conflicting worktree path (resume.md table 「other= のパスを表示」契約).
+assert "TC-8 other= ends with elsewhere-42" "yes" \
+  "$(case "$(ens_field "$M" other --issue 42)" in */elsewhere-42) echo yes ;; *) echo no ;; esac)"
+# Must NOT create the canonical issue-42 worktree (no silent reconstruction over a conflict).
+assert "TC-8 canonical issue-42 worktree not created" "no" \
+  "$(git -C "$M" worktree list --porcelain | grep -qE '/\.rite/worktrees/issue-42($|/| )' && echo yes || echo no)"
 
-# --- TC-9 (T-04 / AC-4): git worktree add fails → failed (rc 1, NO fallback) ---
-echo "=== TC-9 (T-04/AC-4): reconstruction fails → failed, rc=1 ==="
-M=$(setup_repo)
+# --- TC-9 (T-04 / AC-4): git worktree add fails → failed (rc 1, NO fallback, no residue) ---
+echo "=== TC-9 (T-04/AC-4): reconstruction fails → failed, rc=1, no partial worktree ==="
+setup_repo; M="$REPO_MAIN"
 rm -rf "$M/.rite"; mkdir -p "$M/.rite"; printf 'blocker' > "$M/.rite/worktrees"  # base is a FILE
 assert "TC-9 failed token" "failed" "$(ens_case "$M" --issue 42)"
 assert "TC-9 rc=1" "1" "$(ens_rc "$M" --issue 42)"
+# AC-4 core: no silent fallback means no half-built worktree is registered.
+assert "TC-9 no worktree registered after failure" "no" "$(wt_registered "$M" 42)"
 
-# --- TC-10: argument error (missing --issue) → rc 2 ---
-echo "=== TC-10: missing --issue → rc 2 ==="
-M=$(setup_repo)
-assert "TC-10 rc=2" "2" "$(ens_rc "$M")"
+# --- TC-10: argument error (missing / non-numeric --issue) → rc 2 ---
+echo "=== TC-10: missing / non-numeric --issue → rc 2 ==="
+setup_repo; M="$REPO_MAIN"
+assert "TC-10 rc=2 (missing --issue)" "2" "$(ens_rc "$M")"
+assert "TC-10 rc=2 (non-numeric --issue)" "2" "$(ens_rc "$M" --issue abc)"
 
 # --- TC-11: stdout discipline — exactly ONE line, the marker (git chatter to stderr) ---
 echo "=== TC-11: stdout is exactly one WT_ENSURE marker line on reconstruct ==="
-M=$(setup_repo)
+setup_repo; M="$REPO_MAIN"
 stdout_lines=$( ( cd "$M" && bash "$HELPER" ensure-session-worktree --issue 42 2>/dev/null ) | grep -c .)
 assert "TC-11 single stdout line" "1" "$stdout_lines"
 

--- a/plugins/rite/references/git-worktree-patterns.md
+++ b/plugins/rite/references/git-worktree-patterns.md
@@ -372,16 +372,17 @@ command:
 
 - The session worktree created by `git worktree add` is **preserved** — the failure
   does not destroy it.
-- On re-run, `pr:open` Step 2.2-W classifies it as `WT_CASE=reuse` (and `/rite:resume`
-  as `RESUME_WT=reenter`), so the workflow continues on the existing worktree without
-  rebuilding it.
+- On re-run, `pr:open` Step 2.2-W classifies it as `WT_CASE=reuse` (and the
+  `ensure_session_worktree` helper used by `/rite:resume` / `pr:review` / `pr:iterate` /
+  `pr:fix` as `WT_ENSURE=reenter`), so the workflow continues on the existing worktree
+  without rebuilding it.
 
 rite **never** silently falls back to `git switch -c` (which would discard worktree
 isolation) or to a Bash-persisted-cwd path (which would leave the harness cwd on the
 main checkout and risk relative-path edits hitting the main tree); the workflow
 surfaces the diagnosis and the restart guidance instead. Failures from other causes
-(e.g. the worktree path vanished) follow the normal `RESUME_WT=missing` rebuild path,
-not the restart guidance.
+(e.g. the worktree path vanished) follow the normal `ensure_session_worktree` rebuild
+path (`WT_ENSURE=reconstructed`, #1676), not the restart guidance.
 
 ### Branch-creation worktree invariant (marker 再確定・silent fallback 排除)
 


### PR DESCRIPTION
## 概要

`multi_session.enabled: true`（デフォルト ON）の環境で、作業ブランチが**既にローカルに実在するのに対応する session worktree（`.rite/worktrees/issue-{N}`）が不在**な状態に陥ったとき、フロー入場経路（`/rite:resume`・`/rite:pr:review`・`/rite:pr:iterate`・`/rite:pr:fix`）が当該ブランチを「存在しない扱い」にして develop へ **silent fallback** し、PR 変更を作業ツリーから読めず degraded 動作になる問題（#1676）を修正する。

Closes #1676

## 変更内容

### 共通ヘルパー（bash 側 SoT）
- **`lib/worktree-git.sh`**: `ensure_session_worktree` 関数 + standalone CLI dispatch を追加。
  - 「ブランチ実在 ∧ session worktree 不在」を検出し、**再構築（local: `git worktree add` / remote: fetch + `--track`）まで bash 側で完結**。
  - 唯一の `[CONTEXT] WT_ENSURE=<case>` marker を emit（`disabled` / `already_in` / `reenter` / `reconstructed` / `residue` / `branch_other_worktree` / `branch_absent` / `failed`）。
  - `--git-common-dir` から main checkout root を導出し、worktree 内・main tree いずれから呼ばれても正しく判定。
  - `branch_absent` は誤再構築せず委譲（AC-5）、`failed` は rc=1 で明示停止（AC-4、silent fallback 排除）。
  - #1368 の resume 専用ロジックを共通化・SoT 化。

### 入場経路への適用
- **`commands/resume.md`**: Phase 3.1.5 を helper 呼び出し + `WT_ENSURE` 分岐表へ refactor（routing table SoT 化）。Phase 5.1 の mode 導出を更新（AC-3）。
- **`commands/pr/review.md`**: ステップ 1.1.5 入場ゲート追加（PR 変更読込の前）。develop silent fallback を排除し `failed` で `[review:error]` 停止（AC-1）。
- **`commands/pr/iterate.md`**: ステップ 0.5 でループ前段の worktree 健全性を保証（AC-2）。
- **`commands/pr/fix.md`**: ステップ 1.1.5 入場ゲート追加（編集の前）。develop の作業ツリーへの誤書込を防止。

### テスト・派生
- **`hooks/tests/ensure-session-worktree.test.sh`**: 新規ユニットテスト 16 アサーション（T-01 reconstructed / T-04 failed / T-05 branch_absent ほか全 case）。
- 派生: `git-worktree-patterns.md` / `getting-started.md` の marker 名参照（`RESUME_WT` → `WT_ENSURE`）を更新。

## 受入基準

| AC | 内容 | 対応 |
|----|------|------|
| AC-1 | review 入場で worktree 再構築 | review.md ステップ 1.1.5 |
| AC-2 | iterate 各 cycle で健全性保証 | iterate.md ステップ 0.5 + sub-skill 多層 |
| AC-3 | resume と同一の再構築結果 | 同一 helper 使用 |
| AC-4 | 再構築失敗時に silent fallback しない | helper `failed`(rc=1) + 各 caller loud stop |
| AC-5 | ブランチ非実在で誤再構築しない | helper `branch_absent` |
| AC-6 | pr:open の新規作成 invariant 不変 | open.md 無変更（非対象） |

## テスト結果

- `hooks/tests/run-tests.sh`: **81/81 passed**（新規 16 アサーション含む）
- 全 8 ケース（disabled/already_in/reenter/reconstructed/residue/branch_other_worktree/branch_absent/failed）を合成リポジトリで検証
- drift / bash-heaviness / hardcoded-line / sh-cross-ref / orphan / backlink / bang-backtick: **本変更由来 0 findings**

## 検出スクリプト（変更不要の判断）

`cleanup-worktree-detect.sh` / `worktree-foreign-cwd.sh` / `worktree-live-cwd.sh` は cleanup（削除）経路用で、「ブランチ実在 ∧ worktree 不在 → ブランチ非存在」誤判定は存在しないため**変更不要**（Issue 4.1「必要に応じて」の判断）。

## Decision Log

- D-02: bash 検出/再構築の SoT を helper（`ensure_session_worktree`）に集約し、routing table SoT を resume.md Phase 3.1.5 に置く構成で「共通呼び出し可能な手順として整理し SoT 化」を実現。
- D-03: 共有 marker を `RESUME_WT` → `WT_ENSURE` に一般化（4 入場経路で共通）。派生で 2 doc の参照を更新。

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
