### PR TITLE
docs(media): 紹介動画ソースを本リポへ取り込み v0.7 仕様へ更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,12 @@ __pycache__/
 # negated root .rite/ wiki rules above are left untouched.
 plugins/**/.rite/
 
+
+# Intro video projects (media/intro-video[-en]/): rendered outputs and the stock BGM
+# are NOT committed. Rendered MP4s are re-derivable via `npm run render`; the BGM is a
+# Pixabay stock track whose license forbids standalone redistribution. Both are
+# regenerated/obtained locally — see media/intro-video/PROVENANCE.md.
+media/intro-video*/*.mp4
+media/intro-video*/**/*.mp4
+media/intro-video*/*.mp3
+media/intro-video*/**/*.mp3

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,9 +9,9 @@
 
 ## Demo
 
-Issue から PR まで、開発を“儀式”に変える — 約100秒で分かる紹介動画（日本語字幕）。
+Issue から PR まで、開発を“儀式”に変える — 約115秒で分かる紹介動画（日本語字幕）。
 
-https://github.com/user-attachments/assets/76255c86-c999-4731-8ba2-4dbab4d57e1d
+https://github.com/user-attachments/assets/18160008-e329-4fdd-b170-fac925160e7a
 
 ## なぜ "Rite" なのか
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 ## Demo
 
-From Issue to PR — see Rite Workflow turn development into a *rite*. A ~100-second intro (English).
+From Issue to PR — see Rite Workflow turn development into a *rite*. A ~115-second intro (English).
 
-https://github.com/user-attachments/assets/d6e42398-4299-40ff-9bac-86e5333880b1
+https://github.com/user-attachments/assets/39d7aac7-5a4f-46b6-998f-9c061391af31
 
 ## Why "Rite"?
 

--- a/media/intro-video-en/AGENTS.md
+++ b/media/intro-video-en/AGENTS.md
@@ -1,0 +1,87 @@
+# HyperFrames Composition Project
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before writing or modifying compositions.** Skills encode framework-specific patterns (e.g., `window.__timelines` registration, `data-*` attribute semantics, shader-compatible CSS rules) that are NOT in generic web docs. Skipping them produces broken compositions.
+
+**Doing anything with HyperFrames?** Start at `/hyperframes` — it tells you what HyperFrames can do and which skill or workflow handles your intent (make a video, TTS / BGM, prep footage, author / animate, render, install blocks), and routes every "make me a video" request to the right workflow. Read it first, especially when there's no project context to orient you. The video workflows it routes to:
+
+- `/product-launch-video` — a **product** URL or brief / script → 60-90s product launch / SaaS / promo video.
+- `/website-to-video` — a **general** website / URL → a video _of_ the site (tour / showcase / social clip from captured visuals); a product **launch / promo** is `/product-launch-video`.
+- `/faceless-explainer` — arbitrary text (topic / article / notes), **no URL, no website capture** → 60-90s faceless explainer.
+- `/embedded-captions` — an existing talking-head video (MP4) → the same footage with captions / subtitles added (rail + embed, or pure-cinematic embed); the footage itself is untouched.
+- `/graphic-overlays` — an existing talking-head / interview / podcast video (MP4) → the same footage **packaged with designed graphic overlays** (kinetic titles, lower-thirds, data callouts, pull-quotes, side panels, pip) synced to the transcript; the clip plays unchanged underneath. (Plain captions/subtitles → `/embedded-captions`.)
+- `/pr-to-video` — a GitHub PR (URL / `owner/repo#N` / "this PR") → 30-90s code-change explainer (changelog / feature reveal / fix / refactor).
+- `/motion-graphics` — a short (typically under 10s) design-led **motion graphic**, motion-is-the-message, no narration: kinetic type, a stat / number count-up, a chart, a logo sting, a lower-third / overlay, or an animated tweet / headline / captured-page highlight; rendered to MP4 or a transparent overlay. Longer / narrated / custom → `/general-video`.
+- `/general-video` — fallback for any other video (title card, longer brand / sizzle reel, multi-scene montage, static loop, custom composition); the original hyperframes authoring flow, any length.
+
+**Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
+
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+
+> **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
+
+> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
+> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+
+## Commands
+
+```bash
+npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run check        # lint + validate + inspect
+npm run render       # render to MP4
+npm run publish      # publish and get a shareable link
+npx hyperframes lint --verbose  # include info-level findings
+npx hyperframes lint --json     # machine-readable output for CI
+npx hyperframes docs <topic> # reference docs in terminal
+```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
+> command — it will time out and the server will die, breaking the browser preview.
+
+## Documentation
+
+**For quick reference**, use the local CLI docs command (no network required):
+
+```bash
+npx hyperframes docs <topic>
+```
+
+Topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `examples`, `troubleshooting`
+
+**For full documentation**, discover pages via the machine-readable index — do NOT guess URLs:
+
+```
+https://hyperframes.heygen.com/llms.txt
+```
+
+## Project Structure
+
+- `index.html` — main composition (root timeline)
+- `compositions/` — sub-compositions referenced via `data-composition-src`
+- `meta.json` — project metadata (id, name)
+- `transcript.json` — whisper word-level transcript (if generated)
+
+## Linting — ALWAYS RUN AFTER CHANGES
+
+After creating or editing any `.html` composition, **always** run the full check before considering the task complete:
+
+```bash
+npm run check
+```
+
+Fix all errors before presenting the result. Inspect warnings should be reviewed before rendering.
+
+## Key Rules
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track
+5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
+6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches

--- a/media/intro-video-en/CLAUDE.md
+++ b/media/intro-video-en/CLAUDE.md
@@ -1,0 +1,87 @@
+# HyperFrames Composition Project
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before writing or modifying compositions.** Skills encode framework-specific patterns (e.g., `window.__timelines` registration, `data-*` attribute semantics, shader-compatible CSS rules) that are NOT in generic web docs. Skipping them produces broken compositions.
+
+**Doing anything with HyperFrames?** Start at `/hyperframes` — it tells you what HyperFrames can do and which skill or workflow handles your intent (make a video, TTS / BGM, prep footage, author / animate, render, install blocks), and routes every "make me a video" request to the right workflow. Read it first, especially when there's no project context to orient you. The video workflows it routes to:
+
+- `/product-launch-video` — a **product** URL or brief / script → 60-90s product launch / SaaS / promo video.
+- `/website-to-video` — a **general** website / URL → a video _of_ the site (tour / showcase / social clip from captured visuals); a product **launch / promo** is `/product-launch-video`.
+- `/faceless-explainer` — arbitrary text (topic / article / notes), **no URL, no website capture** → 60-90s faceless explainer.
+- `/embedded-captions` — an existing talking-head video (MP4) → the same footage with captions / subtitles added (rail + embed, or pure-cinematic embed); the footage itself is untouched.
+- `/graphic-overlays` — an existing talking-head / interview / podcast video (MP4) → the same footage **packaged with designed graphic overlays** (kinetic titles, lower-thirds, data callouts, pull-quotes, side panels, pip) synced to the transcript; the clip plays unchanged underneath. (Plain captions/subtitles → `/embedded-captions`.)
+- `/pr-to-video` — a GitHub PR (URL / `owner/repo#N` / "this PR") → 30-90s code-change explainer (changelog / feature reveal / fix / refactor).
+- `/motion-graphics` — a short (typically under 10s) design-led **motion graphic**, motion-is-the-message, no narration: kinetic type, a stat / number count-up, a chart, a logo sting, a lower-third / overlay, or an animated tweet / headline / captured-page highlight; rendered to MP4 or a transparent overlay. Longer / narrated / custom → `/general-video`.
+- `/general-video` — fallback for any other video (title card, longer brand / sizzle reel, multi-scene montage, static loop, custom composition); the original hyperframes authoring flow, any length.
+
+**Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
+
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+
+> **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
+
+> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
+> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+
+## Commands
+
+```bash
+npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run check        # lint + validate + inspect
+npm run render       # render to MP4
+npm run publish      # publish and get a shareable link
+npx hyperframes lint --verbose  # include info-level findings
+npx hyperframes lint --json     # machine-readable output for CI
+npx hyperframes docs <topic> # reference docs in terminal
+```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
+> command — it will time out and the server will die, breaking the browser preview.
+
+## Documentation
+
+**For quick reference**, use the local CLI docs command (no network required):
+
+```bash
+npx hyperframes docs <topic>
+```
+
+Topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `examples`, `troubleshooting`
+
+**For full documentation**, discover pages via the machine-readable index — do NOT guess URLs:
+
+```
+https://hyperframes.heygen.com/llms.txt
+```
+
+## Project Structure
+
+- `index.html` — main composition (root timeline)
+- `compositions/` — sub-compositions referenced via `data-composition-src`
+- `meta.json` — project metadata (id, name)
+- `transcript.json` — whisper word-level transcript (if generated)
+
+## Linting — ALWAYS RUN AFTER CHANGES
+
+After creating or editing any `.html` composition, **always** run the full check before considering the task complete:
+
+```bash
+npm run check
+```
+
+Fix all errors before presenting the result. Inspect warnings should be reviewed before rendering.
+
+## Key Rules
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track
+5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
+6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches

--- a/media/intro-video-en/DESIGN.md
+++ b/media/intro-video-en/DESIGN.md
@@ -1,0 +1,57 @@
+# DESIGN.md — Rite Workflow 紹介動画
+
+## Style Prompt
+
+開発者向けターミナルツールの世界観。深いインクブラックのキャンバスに、巻物（📜）と
+「儀式（rite）」を想起させる暖色のアンバー/ゴールドをアクセントに据える。GitHub Dark を
+基調にしたエンジニアリングらしい落ち着きと、コマンドが次々に成功していく小気味よい動きを
+両立させる。誇張のない、事実に忠実で端正なトーン。
+
+## Colors
+
+| Role | Hex | 用途 |
+|------|-----|------|
+| Canvas (背景) | `#0E1117` | 全シーン共通の背景 |
+| Surface (パネル) | `#161B22` | ターミナル/カードの面 |
+| Border | `#30363D` | 枠線・区切り |
+| Text primary | `#E6EDF3` | 見出し・本文 |
+| Text muted | `#8B949E` | サブ・補助テキスト |
+| Accent amber (儀式) | `#E8B339` | ブランド/強調/ロゴ |
+| Terminal green | `#3FB950` | 成功 ✓ / コマンド出力 OK |
+| Cyan link | `#58A6FF` | コマンド名・リンク・アクセント |
+
+### Severity（findings 表示用）
+
+| Level | Hex |
+|-------|-----|
+| CRITICAL | `#F85149` |
+| HIGH | `#FF9B50` |
+| MEDIUM | `#E3B341` |
+| OK / resolved | `#3FB950` |
+
+## Typography
+
+- 見出し・本文（欧文）: **Inter**
+- ターミナル/コマンド（等幅）: **JetBrains Mono**
+- 日本語: **Noto Sans JP**（フォント stack で欧文等幅の後段に置きフォールバック）
+- 数字カラムは `font-variant-numeric: tabular-nums`
+
+font stack 例:
+- 日本語見出し: `"Inter", "Noto Sans JP", sans-serif`
+- ターミナル内日本語ラベル: `"JetBrains Mono", "Noto Sans JP", monospace`
+
+## Motion
+
+- entrance のみ（exit はトランジションが兼ねる。最終シーンのみ fade out 可）
+- 最初の tween は 0.1–0.3s オフセット、1シーンに最低3種類の ease
+- シーン間はクロスフェード（全シーン同色背景なので 0.5–0.6s の opacity 重ねで自然に繋ぐ）
+- ターミナルのタイプ表示・進捗は決定論的（`SteppedEase`/幅クリップ。乱数・時刻不可）
+
+## What NOT to Do
+
+- 既定色 `#3b82f6` / `#333` / フォント `Roboto` を使わない（必ず上記パレット）
+- 濃色背景にフルスクリーン linear gradient を敷かない（H.264 バンディング。radial か solid+局所 glow）
+- ジャンプカット禁止（必ずトランジション）。シーン内の要素はすべて entrance を持つ
+- 誇張表現を書かない: レビュアーは「13人が常に並列」ではなく
+  「最大13種類から PR 内容に応じて動的選定」と事実どおりに表記する
+- `<br>` で強制改行しない（`max-width` で自然折返し。短い表示見出しの例外のみ可）

--- a/media/intro-video-en/PROVENANCE.md
+++ b/media/intro-video-en/PROVENANCE.md
@@ -1,0 +1,34 @@
+# intro-video-en — Provenance and handling
+
+HyperFrames source for the **English** intro video (~104s) referenced in the "Demo" section of `README.md`.
+
+## Provenance
+
+- Originally produced in the standalone directory `~/Projects/work/rite-intro-video-en/`; imported under repository management (`media/intro-video-en/`) in Issue #1687.
+- Imported as-is without altering the source, then updated to the v0.7 spec in a separate commit.
+
+## Build / preview
+
+```bash
+cd media/intro-video-en
+npm run check    # hyperframes lint && validate && inspect
+npm run dev      # hyperframes preview
+npm run render   # hyperframes render (produces the MP4)
+```
+
+Rendering requires HyperFrames (`npx hyperframes`) + headless Chromium + ffmpeg.
+
+## Not committed (`.gitignore`d)
+
+| Item | Reason |
+|------|--------|
+| `*.mp4` (`rite-intro-en.mp4` / `rite-intro-en-bgm*.mp4`, etc.) | Build artifacts re-derivable via `npm run render`. The playable README video is uploaded separately as a GitHub user-attachment |
+| `*.mp3` (BGM) | License constraint (below) |
+
+## About the BGM
+
+- Track: **BombinSound — Technology** (Pixabay, track ID `499581`)
+- Source: <https://pixabay.com/users/bombinsound-54782632/>
+- License: [Pixabay Content License](https://pixabay.com/service/terms/) — free for commercial use, no attribution required, **but prohibits distributing the Content on a standalone basis** (no creative effort applied, substantially the same form), including as an audio file.
+- Therefore the **raw mp3 is not committed** to this repository (placing it in a public repo would make it standalone-downloadable). To render with BGM, download `bombinsound-technology-tech-technology-90-second-499581.mp3` from the Pixabay page above and place it in this directory.
+- Distributing the **rendered video itself** (a new creative work combining the BGM with the visuals) is permitted under the Pixabay license.

--- a/media/intro-video-en/compositions/scene-1.html
+++ b/media/intro-video-en/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">From Issue to PR — turn development into a rite</div>
         <div class="sub">A Claude Code plugin</div>
-        <div class="badge">v0.6.2 · MIT</div>
+        <div class="badge">v0.7.0 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video-en/compositions/scene-1.html
+++ b/media/intro-video-en/compositions/scene-1.html
@@ -1,0 +1,107 @@
+<template id="scene-1-template">
+  <div data-composition-id="scene-1" id="scene-1" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="logo">
+          <span class="scroll">📜</span>
+          <span class="wordmark"><span class="rite">Rite</span> Workflow</span>
+        </div>
+        <div class="tagline">From Issue to PR — turn development into a rite</div>
+        <div class="sub">A Claude Code plugin</div>
+        <div class="badge">v0.6.2 · MIT</div>
+      </div>
+    </div>
+
+    <style>
+      #scene-1 {
+        width: 1920px;
+        height: 1080px;
+        position: relative;
+        overflow: hidden;
+        background: #0e1117;
+        font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-1 .bg {
+        position: absolute;
+        inset: 0;
+      }
+      #scene-1 .glow {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(
+          ellipse 1300px 700px at 50% 8%,
+          rgba(232, 179, 57, 0.16),
+          rgba(232, 179, 57, 0) 68%
+        );
+      }
+      #scene-1 .scene-content {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 36px;
+        padding: 120px 160px;
+        box-sizing: border-box;
+        text-align: center;
+      }
+      #scene-1 .logo {
+        display: flex;
+        align-items: center;
+        gap: 28px;
+        font-size: 132px;
+        font-weight: 800;
+        letter-spacing: -2px;
+        line-height: 1;
+      }
+      #scene-1 .scroll {
+        font-size: 120px;
+      }
+      #scene-1 .wordmark {
+        color: #e6edf3;
+      }
+      #scene-1 .rite {
+        color: #e8b339;
+      }
+      #scene-1 .tagline {
+        font-size: 50px;
+        font-weight: 600;
+        color: #c9d1d9;
+        max-width: 1300px;
+      }
+      #scene-1 .sub {
+        font-size: 30px;
+        font-weight: 600;
+        color: #58a6ff;
+        padding: 10px 26px;
+        border: 1px solid #30363d;
+        border-radius: 999px;
+        background: #161b22;
+      }
+      #scene-1 .badge {
+        margin-top: 6px;
+        font-size: 22px;
+        font-weight: 500;
+        color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        letter-spacing: 1px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-1 .glow", { opacity: 0, scale: 1.15, duration: 1.2, ease: "power1.out", transformOrigin: "50% 8%" }, 0);
+      tl.from("#scene-1 .logo", { opacity: 0, scale: 0.82, duration: 0.8, ease: "power3.out" }, 0.2);
+      tl.from("#scene-1 .tagline", { opacity: 0, y: 44, duration: 0.6, ease: "power2.out" }, 0.6);
+      tl.from("#scene-1 .sub", { opacity: 0, y: 26, duration: 0.5, ease: "back.out(1.6)" }, 0.95);
+      tl.from("#scene-1 .badge", { opacity: 0, duration: 0.6, ease: "sine.out" }, 1.25);
+      window.__timelines["scene-1"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-2.html
+++ b/media/intro-video-en/compositions/scene-2.html
@@ -14,7 +14,7 @@
             <span class="term-title">claude code — rite</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:open 1234</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:open 1234</span></div>
             <div class="row" data-i="1"><span class="idx">[1/6]</span><span class="label">Prepare — fetch Issue #1234</span><span class="ok">✓</span></div>
             <div class="row" data-i="2"><span class="idx">[2/6]</span><span class="label">Create branch — feat/issue-1234-add-auth</span><span class="ok">✓</span></div>
             <div class="row" data-i="3"><span class="idx">[3/6]</span><span class="label">Plan — analyze files to change and steps</span><span class="ok">✓</span></div>

--- a/media/intro-video-en/compositions/scene-2.html
+++ b/media/intro-video-en/compositions/scene-2.html
@@ -1,0 +1,99 @@
+<template id="scene-2-template">
+  <div data-composition-id="scene-2" id="scene-2" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 02 — OPEN</div>
+          <div class="heading"><span class="hl">Issue → Draft PR</span> in one command</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:open 1234</span></div>
+            <div class="row" data-i="1"><span class="idx">[1/6]</span><span class="label">Prepare — fetch Issue #1234</span><span class="ok">✓</span></div>
+            <div class="row" data-i="2"><span class="idx">[2/6]</span><span class="label">Create branch — feat/issue-1234-add-auth</span><span class="ok">✓</span></div>
+            <div class="row" data-i="3"><span class="idx">[3/6]</span><span class="label">Plan — analyze files to change and steps</span><span class="ok">✓</span></div>
+            <div class="row" data-i="4"><span class="idx">[4/6]</span><span class="label">Implement &amp; test — Canon TDD cycle</span><span class="ok">✓</span></div>
+            <div class="row" data-i="5"><span class="idx">[5/6]</span><span class="label">Quality check — /rite:lint</span><span class="ok">✓</span></div>
+            <div class="row" data-i="6"><span class="idx">[6/6]</span><span class="label">Open Draft PR</span><span class="ok">✓</span></div>
+            <div class="done">✅ Opened Draft PR #5678</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-2 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-2 .bg { position: absolute; inset: 0; }
+      #scene-2 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 20% 0%, rgba(88,166,255,0.12), rgba(88,166,255,0) 65%);
+      }
+      #scene-2 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 44px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-2 .kicker {
+        font-size: 24px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 14px;
+      }
+      #scene-2 .heading { font-size: 66px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-2 .heading .hl { color: #58a6ff; }
+      #scene-2 .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1300px;
+      }
+      #scene-2 .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 16px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-2 .dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
+      #scene-2 .dot.r { background: #f85149; }
+      #scene-2 .dot.y { background: #e3b341; }
+      #scene-2 .dot.g { background: #3fb950; }
+      #scene-2 .term-title {
+        margin-left: 14px; font-size: 20px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-2 .term-body {
+        padding: 30px 40px 36px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 30px; line-height: 1.62; color: #c9d1d9;
+      }
+      #scene-2 .cmdline { margin-bottom: 18px; font-size: 33px; }
+      #scene-2 .prompt { color: #3fb950; margin-right: 14px; }
+      #scene-2 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-2 .row { display: flex; align-items: baseline; gap: 20px; }
+      #scene-2 .idx { color: #8b949e; min-width: 84px; }
+      #scene-2 .label { flex: 1; color: #c9d1d9; }
+      #scene-2 .ok { color: #3fb950; font-weight: 700; }
+      #scene-2 .done {
+        margin-top: 22px; font-size: 32px; color: #3fb950; font-weight: 700;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-2 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-2 .kicker", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-2 .heading", { opacity: 0, y: 28, duration: 0.6, ease: "power3.out" }, 0.28);
+      tl.from("#scene-2 .terminal", { opacity: 0, y: 36, duration: 0.6, ease: "power2.out" }, 0.5);
+      tl.from("#scene-2 .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 0.85);
+      for (let i = 1; i <= 6; i++) {
+        tl.from("#scene-2 .row[data-i='" + i + "']", { opacity: 0, x: -18, duration: 0.4, ease: "power2.out" }, 1.25 + (i - 1) * 0.52);
+      }
+      tl.from("#scene-2 .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 4.55);
+      window.__timelines["scene-2"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-3.html
+++ b/media/intro-video-en/compositions/scene-3.html
@@ -1,0 +1,122 @@
+<template id="scene-3-template">
+  <div data-composition-id="scene-3" id="scene-3" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 03 — REVIEW</div>
+          <div class="heading">Specialists review in parallel, <span class="hl">dynamically selected</span></div>
+          <div class="subnote">Up to 13 reviewer types, selected by PR content and run concurrently</div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:iterate 5678</span></div>
+        </div>
+
+        <div class="columns">
+          <div class="left">
+            <div class="chips">
+              <div class="chip">🔒 Security</div>
+              <div class="chip">⚡ Performance</div>
+              <div class="chip">🧪 Test</div>
+              <div class="chip">🔌 API</div>
+              <div class="chip">📊 Database</div>
+              <div class="chip">🎨 Frontend</div>
+              <div class="chip">⚠️ Error Handling</div>
+              <div class="chip">🔤 Type Design</div>
+              <div class="chip">🎯 Code Quality</div>
+              <div class="chip">📝 Tech Writer</div>
+              <div class="chip">📦 Dependencies</div>
+              <div class="chip">🐳 DevOps</div>
+              <div class="chip">💬 Prompt</div>
+            </div>
+          </div>
+          <div class="right">
+            <div class="panel">
+              <div class="panel-head"><b>5 findings</b><span class="bd">1 CRITICAL · 1 HIGH · 3 MEDIUM</span></div>
+              <div class="finding"><span class="sev c">CRITICAL</span><span class="ftxt">Security — possible SQL injection</span></div>
+              <div class="finding"><span class="sev h">HIGH</span><span class="ftxt">Test — null-input edge case uncovered</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">Performance — N+1 query in a loop</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">API — response schema undocumented</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">Type — unsafe cast to any</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-3 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-3 .bg { position: absolute; inset: 0; }
+      #scene-3 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 600px at 80% 0%, rgba(248,81,73,0.10), rgba(248,81,73,0) 64%);
+      }
+      #scene-3 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 40px; padding: 80px 130px; box-sizing: border-box;
+      }
+      #scene-3 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-3 .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-3 .heading .hl { color: #e8b339; }
+      #scene-3 .subnote { margin-top: 14px; font-size: 27px; color: #8b949e; }
+      #scene-3 .cmdline {
+        margin-top: 18px; font-size: 30px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-3 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-3 .columns { display: flex; gap: 48px; align-items: flex-start; }
+      #scene-3 .left { flex: 1; }
+      #scene-3 .chips { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-3 .chip {
+        font-size: 26px; font-weight: 600; color: #c9d1d9;
+        background: #161b22; border: 1px solid #30363d; border-left: 3px solid #3fb950;
+        border-radius: 10px; padding: 12px 20px;
+      }
+      #scene-3 .right { width: 700px; }
+      #scene-3 .panel {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        padding: 26px 30px; box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+      }
+      #scene-3 .panel-head {
+        font-size: 28px; color: #e6edf3; font-weight: 700; margin-bottom: 20px;
+        display: flex; align-items: baseline; gap: 14px;
+      }
+      #scene-3 .panel-head b { color: #f85149; }
+      #scene-3 .panel-head .bd {
+        font-size: 20px; color: #8b949e; font-weight: 500;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .finding { display: flex; align-items: center; gap: 18px; padding: 11px 0; }
+      #scene-3 .sev {
+        font-size: 18px; font-weight: 700; letter-spacing: 0.5px; min-width: 116px; text-align: center;
+        padding: 6px 0; border-radius: 7px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .sev.c { color: #ffd7d4; background: rgba(248,81,73,0.18); border: 1px solid #f85149; }
+      #scene-3 .sev.h { color: #ffe0c2; background: rgba(255,155,80,0.16); border: 1px solid #ff9b50; }
+      #scene-3 .sev.m { color: #f4e2b0; background: rgba(227,179,65,0.14); border: 1px solid #e3b341; }
+      #scene-3 .ftxt { font-size: 24px; color: #c9d1d9; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-3 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-3 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-3 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-3 .subnote", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-3 .cmdline", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 0.7);
+      tl.from("#scene-3 .chip", { opacity: 0, scale: 0.8, y: 12, duration: 0.42, ease: "back.out(1.5)", stagger: 0.07 }, 1.0);
+      tl.from("#scene-3 .panel", { opacity: 0, x: 40, duration: 0.6, ease: "power3.out" }, 1.7);
+      tl.from("#scene-3 .finding", { opacity: 0, x: 24, duration: 0.4, ease: "power2.out", stagger: 0.13 }, 2.1);
+      window.__timelines["scene-3"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-3.html
+++ b/media/intro-video-en/compositions/scene-3.html
@@ -7,7 +7,7 @@
           <div class="kicker">STEP 03 — REVIEW</div>
           <div class="heading">Specialists review in parallel, <span class="hl">dynamically selected</span></div>
           <div class="subnote">Up to 13 reviewer types, selected by PR content and run concurrently</div>
-          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:iterate 5678</span></div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:iterate 5678</span></div>
         </div>
 
         <div class="columns">

--- a/media/intro-video-en/compositions/scene-4.html
+++ b/media/intro-video-en/compositions/scene-4.html
@@ -1,0 +1,120 @@
+<template id="scene-4-template">
+  <div data-composition-id="scene-4" id="scene-4" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 03 — ITERATE</div>
+          <div class="heading"><span class="hl">Auto-fix</span> until zero findings remain</div>
+          <div class="subnote">/rite:pr:iterate loops review ⇄ fix until mergeable</div>
+        </div>
+
+        <div class="cycles">
+          <div class="cycle" id="cyc1">
+            <div class="clabel">Cycle 1</div>
+            <div class="flow">
+              <span class="pill review">🔄 review</span>
+              <span class="arrow">→</span>
+              <span class="pill warn">⚠️ 5 findings</span>
+              <span class="arrow">→</span>
+              <span class="pill fix">🔧 fix · push</span>
+            </div>
+          </div>
+          <div class="loopback" aria-hidden="true">⟳ Review again</div>
+          <div class="cycle" id="cyc2">
+            <div class="clabel">Cycle 2</div>
+            <div class="flow">
+              <span class="pill review">🔄 review</span>
+              <span class="arrow">→</span>
+              <span class="pill ok">✅ 0 findings</span>
+              <span class="arrow">→</span>
+              <span class="pill merge">🎉 [review:mergeable]</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="counter">
+          <span class="big from">5</span><span class="to-arrow">→</span><span class="big to">0</span>
+          <span class="ctxt">findings</span>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-4 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-4 .bg { position: absolute; inset: 0; }
+      #scene-4 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 50% 6%, rgba(63,185,80,0.10), rgba(63,185,80,0) 66%);
+      }
+      #scene-4 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 46px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-4 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-4 .heading { font-size: 64px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-4 .heading .hl { color: #3fb950; }
+      #scene-4 .subnote {
+        margin-top: 14px; font-size: 26px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .cycles { display: flex; flex-direction: column; gap: 20px; }
+      #scene-4 .cycle {
+        background: #161b22; border: 1px solid #30363d; border-radius: 14px;
+        padding: 22px 30px; display: flex; align-items: center; gap: 30px;
+      }
+      #scene-4 .clabel {
+        font-size: 24px; font-weight: 700; color: #8b949e; min-width: 130px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .flow { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+      #scene-4 .pill {
+        font-size: 28px; font-weight: 700; padding: 12px 24px; border-radius: 999px;
+        border: 1px solid #30363d; background: #0d1117; color: #c9d1d9;
+      }
+      #scene-4 .pill.review { color: #58a6ff; border-color: #1f6feb; }
+      #scene-4 .pill.warn { color: #ff9b50; border-color: #ff9b50; }
+      #scene-4 .pill.fix { color: #e8b339; border-color: #e8b339; }
+      #scene-4 .pill.ok { color: #3fb950; border-color: #3fb950; }
+      #scene-4 .pill.merge { color: #3fb950; border-color: #3fb950; background: rgba(63,185,80,0.12); }
+      #scene-4 .arrow { font-size: 30px; color: #8b949e; }
+      #scene-4 .loopback {
+        font-size: 22px; color: #8b949e; padding-left: 160px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .counter { display: flex; align-items: baseline; gap: 26px; margin-top: 8px; }
+      #scene-4 .big { font-size: 92px; font-weight: 900; letter-spacing: -2px; line-height: 1; }
+      #scene-4 .big.from { color: #f85149; }
+      #scene-4 .big.to { color: #3fb950; }
+      #scene-4 .to-arrow { font-size: 56px; color: #8b949e; }
+      #scene-4 .ctxt { font-size: 30px; color: #8b949e; align-self: center; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-4 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-4 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-4 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-4 .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-4 #cyc1", { opacity: 0, y: 28, duration: 0.55, ease: "power2.out" }, 0.85);
+      tl.from("#scene-4 #cyc1 .pill", { opacity: 0, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.16 }, 1.1);
+      tl.from("#scene-4 .loopback", { opacity: 0, x: -20, duration: 0.5, ease: "power2.out" }, 2.0);
+      tl.from("#scene-4 #cyc2", { opacity: 0, y: 28, duration: 0.55, ease: "power2.out" }, 2.4);
+      tl.from("#scene-4 #cyc2 .pill", { opacity: 0, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.16 }, 2.65);
+      tl.from("#scene-4 .counter .from", { opacity: 0, y: 20, duration: 0.5, ease: "power2.out" }, 3.5);
+      tl.from("#scene-4 .counter .to-arrow", { opacity: 0, duration: 0.4, ease: "sine.out" }, 3.8);
+      tl.from("#scene-4 .counter .to", { opacity: 0, scale: 0.6, duration: 0.6, ease: "back.out(2)" }, 4.0);
+      tl.from("#scene-4 .counter .ctxt", { opacity: 0, duration: 0.4, ease: "sine.out" }, 4.3);
+      window.__timelines["scene-4"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-4.html
+++ b/media/intro-video-en/compositions/scene-4.html
@@ -6,7 +6,7 @@
         <div class="head">
           <div class="kicker">STEP 03 — ITERATE</div>
           <div class="heading"><span class="hl">Auto-fix</span> until zero findings remain</div>
-          <div class="subnote">/rite:pr:iterate loops review ⇄ fix until mergeable</div>
+          <div class="subnote">/rite:iterate loops review ⇄ fix until mergeable</div>
         </div>
 
         <div class="cycles">

--- a/media/intro-video-en/compositions/scene-5.html
+++ b/media/intro-video-en/compositions/scene-5.html
@@ -1,0 +1,104 @@
+<template id="scene-5-template">
+  <div data-composition-id="scene-5" id="scene-5" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">EXPERIENCE WIKI</div>
+          <div class="heading">Your project <span class="hl">learns and gets smarter</span></div>
+          <div class="subnote">Insights from reviews, fixes &amp; Issues accrue to the Wiki automatically (OKF v0.1)</div>
+        </div>
+
+        <div class="diagram">
+          <div class="cluster">
+            <div class="cluster-label">Accumulated experience pages</div>
+            <div class="nodes">
+              <div class="node">📄 security</div>
+              <div class="node">📄 error-handling</div>
+              <div class="node">📄 api</div>
+              <div class="node">📄 performance</div>
+              <div class="node">📄 database</div>
+            </div>
+          </div>
+
+          <div class="inject">
+            <div class="inj-arrow">⟶</div>
+            <div class="inj-label">Auto-injected</div>
+          </div>
+
+          <div class="next">
+            <div class="next-label">On the next Issue or review</div>
+            <div class="bubble">💡 Route external-API errors to a dedicated fallback queue</div>
+            <div class="bubble">💡 Never hardcode tokens — use env vars</div>
+            <div class="bubble">💡 Standardize webhook timeouts at 30s</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-5 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-5 .bg { position: absolute; inset: 0; }
+      #scene-5 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 650px at 50% 4%, rgba(88,166,255,0.11), rgba(88,166,255,0) 66%);
+      }
+      #scene-5 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 56px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-5 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-5 .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-5 .heading .hl { color: #58a6ff; }
+      #scene-5 .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-5 .diagram { display: flex; align-items: center; gap: 44px; }
+      #scene-5 .cluster {
+        flex: 1; background: #161b22; border: 1px solid #30363d; border-radius: 16px; padding: 28px 30px;
+      }
+      #scene-5 .cluster-label, #scene-5 .next-label {
+        font-size: 22px; color: #8b949e; font-weight: 600; margin-bottom: 20px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .nodes { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-5 .node {
+        font-size: 27px; font-weight: 600; color: #c9d1d9;
+        background: #0d1117; border: 1px solid #30363d; border-radius: 10px; padding: 14px 22px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .inject { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+      #scene-5 .inj-arrow { font-size: 64px; color: #e8b339; line-height: 1; }
+      #scene-5 .inj-label {
+        font-size: 22px; color: #e8b339; font-weight: 700;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .next { flex: 1.05; display: flex; flex-direction: column; gap: 16px; }
+      #scene-5 .bubble {
+        font-size: 27px; color: #e6edf3; font-weight: 600;
+        background: rgba(88,166,255,0.10); border: 1px solid #1f6feb; border-radius: 12px; padding: 16px 24px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-5 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-5 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-5 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-5 .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-5 .cluster", { opacity: 0, x: -36, duration: 0.6, ease: "power3.out" }, 0.85);
+      tl.from("#scene-5 .node", { opacity: 0, scale: 0.82, duration: 0.4, ease: "back.out(1.5)", stagger: 0.1 }, 1.15);
+      tl.from("#scene-5 .inj-arrow", { opacity: 0, x: -24, duration: 0.5, ease: "power2.out" }, 1.9);
+      tl.from("#scene-5 .inj-label", { opacity: 0, duration: 0.4, ease: "sine.out" }, 2.15);
+      tl.from("#scene-5 .bubble", { opacity: 0, x: 34, duration: 0.5, ease: "power2.out", stagger: 0.18 }, 2.35);
+      window.__timelines["scene-5"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-6.html
+++ b/media/intro-video-en/compositions/scene-6.html
@@ -9,17 +9,17 @@
         </div>
 
         <div class="pipeline">
-          <span class="stage">issue:create</span>
+          <span class="stage">issue-create</span>
           <span class="sep">→</span>
-          <span class="stage">pr:open</span>
+          <span class="stage">open</span>
           <span class="sep">→</span>
-          <span class="stage">pr:iterate</span>
+          <span class="stage">iterate</span>
           <span class="sep">→</span>
-          <span class="stage">pr:ready</span>
+          <span class="stage">ready</span>
           <span class="sep">→</span>
-          <span class="stage">pr:merge</span>
+          <span class="stage">merge</span>
           <span class="sep">→</span>
-          <span class="stage">pr:cleanup</span>
+          <span class="stage">cleanup</span>
         </div>
 
         <div class="status">

--- a/media/intro-video-en/compositions/scene-6.html
+++ b/media/intro-video-en/compositions/scene-6.html
@@ -1,0 +1,99 @@
+<template id="scene-6-template">
+  <div data-composition-id="scene-6" id="scene-6" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">WORKFLOW</div>
+          <div class="heading">Issue to PR to merge — <span class="hl">end to end</span></div>
+        </div>
+
+        <div class="pipeline">
+          <span class="stage">issue:create</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:open</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:iterate</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:ready</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:merge</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:cleanup</span>
+        </div>
+
+        <div class="status">
+          <span class="st">Todo</span><span class="sa">→</span>
+          <span class="st">In Progress</span><span class="sa">→</span>
+          <span class="st">In Review</span><span class="sa">→</span>
+          <span class="st done">Done</span>
+        </div>
+
+        <div class="badges">
+          <div class="badge">🌐 Universal</div>
+          <div class="badge">🗂 GitHub Projects</div>
+          <div class="badge">🧪 Canon TDD</div>
+          <div class="badge">📚 Experience Wiki</div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-6 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-6 .bg { position: absolute; inset: 0; }
+      #scene-6 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1300px 650px at 50% 5%, rgba(232,179,57,0.12), rgba(232,179,57,0) 66%);
+      }
+      #scene-6 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center; align-items: center;
+        gap: 56px; padding: 90px 110px; box-sizing: border-box; text-align: center;
+      }
+      #scene-6 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 5px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-6 .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-6 .heading .hl { color: #e8b339; }
+      #scene-6 .pipeline {
+        display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: nowrap;
+      }
+      #scene-6 .stage {
+        font-size: 28px; font-weight: 700; color: #58a6ff;
+        background: #161b22; border: 1px solid #1f6feb; border-radius: 999px; padding: 14px 24px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; white-space: nowrap;
+      }
+      #scene-6 .sep { font-size: 28px; color: #8b949e; }
+      #scene-6 .status { display: flex; align-items: center; gap: 18px; }
+      #scene-6 .st {
+        font-size: 24px; font-weight: 600; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-6 .st.done { color: #3fb950; }
+      #scene-6 .sa { font-size: 22px; color: #768390; }
+      #scene-6 .badges { display: flex; gap: 22px; flex-wrap: wrap; justify-content: center; }
+      #scene-6 .badge {
+        font-size: 27px; font-weight: 700; color: #e6edf3;
+        background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px 26px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-6 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-6 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-6 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-6 .stage", { opacity: 0, y: 22, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.14 }, 0.8);
+      tl.from("#scene-6 .sep", { opacity: 0, duration: 0.3, ease: "sine.out", stagger: 0.14 }, 1.0);
+      tl.from("#scene-6 .status", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 2.0);
+      tl.from("#scene-6 .badge", { opacity: 0, y: 22, duration: 0.45, ease: "power2.out", stagger: 0.12 }, 2.35);
+      window.__timelines["scene-6"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-7.html
+++ b/media/intro-video-en/compositions/scene-7.html
@@ -1,0 +1,103 @@
+<template id="scene-7-template">
+  <div data-composition-id="scene-7" id="scene-7" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">GET STARTED</div>
+          <div class="heading">Try it now</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">Claude Code</span>
+          </div>
+          <div class="term-body">
+            <div class="step-c">① Add the marketplace</div>
+            <div class="cmdline"><span class="prompt">/</span><span class="cmd">plugin marketplace add asakaguchi/cc-rite-workflow</span></div>
+            <div class="step-c">② Install the plugin</div>
+            <div class="cmdline"><span class="prompt">/</span><span class="cmd">plugin install rite@rite-marketplace</span></div>
+          </div>
+        </div>
+
+        <div class="outro">
+          <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
+          <div class="meta">v0.6.2 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="made">Made with 📜 rite</div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-7 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-7 .bg { position: absolute; inset: 0; }
+      #scene-7 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1300px 760px at 50% 50%, rgba(232,179,57,0.13), rgba(232,179,57,0) 64%);
+      }
+      #scene-7 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center; align-items: center;
+        gap: 44px; padding: 90px 150px; box-sizing: border-box; text-align: center;
+      }
+      #scene-7 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 5px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-7 .heading { font-size: 64px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-7 .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); width: 1180px; text-align: left;
+      }
+      #scene-7 .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 15px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-7 .dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block; }
+      #scene-7 .dot.r { background: #f85149; }
+      #scene-7 .dot.y { background: #e3b341; }
+      #scene-7 .dot.g { background: #3fb950; }
+      #scene-7 .term-title {
+        margin-left: 12px; font-size: 19px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-7 .term-body { padding: 28px 38px 32px; }
+      #scene-7 .step-c {
+        font-size: 23px; color: #8b949e; font-weight: 600; margin: 8px 0 10px;
+      }
+      #scene-7 .cmdline {
+        font-size: 31px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        margin-bottom: 18px;
+      }
+      #scene-7 .prompt { color: #3fb950; }
+      #scene-7 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-7 .outro { display: flex; flex-direction: column; align-items: center; gap: 14px; }
+      #scene-7 .wordmark { font-size: 46px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-7 .wordmark .rite { color: #e8b339; }
+      #scene-7 .meta {
+        font-size: 23px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; letter-spacing: 0.5px;
+      }
+      #scene-7 .made { font-size: 22px; color: #6e7681; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-7 .glow", { opacity: 0, scale: 1.1, duration: 1.2, ease: "power1.out" }, 0);
+      tl.from("#scene-7 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-7 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-7 .terminal", { opacity: 0, y: 32, duration: 0.6, ease: "power2.out" }, 0.55);
+      tl.from("#scene-7 .term-body .step-c, #scene-7 .term-body .cmdline", { opacity: 0, x: -16, duration: 0.42, ease: "power2.out", stagger: 0.2 }, 0.95);
+      tl.from("#scene-7 .wordmark", { opacity: 0, scale: 0.9, duration: 0.55, ease: "back.out(1.5)" }, 2.0);
+      tl.from("#scene-7 .meta", { opacity: 0, y: 14, duration: 0.5, ease: "power2.out" }, 2.3);
+      tl.from("#scene-7 .made", { opacity: 0, duration: 0.5, ease: "sine.out" }, 2.55);
+      window.__timelines["scene-7"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-7.html
+++ b/media/intro-video-en/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.6.2 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.7.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>

--- a/media/intro-video-en/compositions/scene-create.html
+++ b/media/intro-video-en/compositions/scene-create.html
@@ -14,7 +14,7 @@
             <span class="term-title">claude code — rite</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue:create</span> <span class="arg">"Add user authentication"</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue-create</span> <span class="arg">"Add user authentication"</span></div>
             <div class="row" data-i="1"><span class="idx">[1/4]</span><span class="label">Search duplicates &amp; parent Issues — none similar</span><span class="ok">✓</span></div>
             <div class="row" data-i="2"><span class="idx">[2/4]</span><span class="label">Surface assumptions — ask only what you alone know</span><span class="ok">✓</span></div>
             <div class="row" data-i="3"><span class="idx">[3/4]</span><span class="label">Generate Implementation Contract — What / Why / Where</span><span class="ok">✓</span></div>

--- a/media/intro-video-en/compositions/scene-create.html
+++ b/media/intro-video-en/compositions/scene-create.html
@@ -1,0 +1,96 @@
+<template id="scene-create-template">
+  <div data-composition-id="scene-create" id="scene-create" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 01 — CREATE</div>
+          <div class="heading">Turn a vague idea into an <span class="hl">actionable Issue</span></div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue:create</span> <span class="arg">"Add user authentication"</span></div>
+            <div class="row" data-i="1"><span class="idx">[1/4]</span><span class="label">Search duplicates &amp; parent Issues — none similar</span><span class="ok">✓</span></div>
+            <div class="row" data-i="2"><span class="idx">[2/4]</span><span class="label">Surface assumptions — ask only what you alone know</span><span class="ok">✓</span></div>
+            <div class="row" data-i="3"><span class="idx">[3/4]</span><span class="label">Generate Implementation Contract — What / Why / Where</span><span class="ok">✓</span></div>
+            <div class="row" data-i="4"><span class="idx">[4/4]</span><span class="label">Register in GitHub Projects — Todo</span><span class="ok">✓</span></div>
+            <div class="done">✅ Created Issue #1234</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-create {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-create .bg { position: absolute; inset: 0; }
+      #scene-create .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 20% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 65%);
+      }
+      #scene-create .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 44px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-create .kicker {
+        font-size: 24px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 14px;
+      }
+      #scene-create .heading { font-size: 66px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-create .heading .hl { color: #e8b339; }
+      #scene-create .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1340px;
+      }
+      #scene-create .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 16px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-create .dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
+      #scene-create .dot.r { background: #f85149; }
+      #scene-create .dot.y { background: #e3b341; }
+      #scene-create .dot.g { background: #3fb950; }
+      #scene-create .term-title {
+        margin-left: 14px; font-size: 20px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-create .term-body {
+        padding: 30px 40px 36px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 30px; line-height: 1.62; color: #c9d1d9;
+      }
+      #scene-create .cmdline { margin-bottom: 18px; font-size: 33px; }
+      #scene-create .prompt { color: #3fb950; margin-right: 14px; }
+      #scene-create .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-create .arg { color: #a5d6ff; }
+      #scene-create .row { display: flex; align-items: baseline; gap: 20px; }
+      #scene-create .idx { color: #8b949e; min-width: 84px; }
+      #scene-create .label { flex: 1; color: #c9d1d9; }
+      #scene-create .ok { color: #3fb950; font-weight: 700; }
+      #scene-create .done { margin-top: 22px; font-size: 32px; color: #3fb950; font-weight: 700; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-create .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-create .kicker", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-create .heading", { opacity: 0, y: 28, duration: 0.6, ease: "power3.out" }, 0.28);
+      tl.from("#scene-create .terminal", { opacity: 0, y: 36, duration: 0.6, ease: "power2.out" }, 0.5);
+      tl.from("#scene-create .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 0.85);
+      for (let i = 1; i <= 4; i++) {
+        tl.from("#scene-create .row[data-i='" + i + "']", { opacity: 0, x: -18, duration: 0.4, ease: "power2.out" }, 1.25 + (i - 1) * 0.55);
+      }
+      tl.from("#scene-create .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 3.7);
+      window.__timelines["scene-create"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-docheavy.html
+++ b/media/intro-video-en/compositions/scene-docheavy.html
@@ -1,0 +1,80 @@
+<template id="scene-docheavy-template">
+  <div data-composition-id="scene-docheavy" id="scene-docheavy" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">DOC-HEAVY PR MODE</div>
+          <div class="heading">Doc-centric PRs get <span class="hl">5-point consistency checks</span></div>
+          <div class="subnote">When a PR is detected as doc-heavy, the tech-writer verifies doc–implementation consistency via Grep / Read / Glob</div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">📝 doc-heavy detected<span class="bd">tech-writer reviewer · 5 categories</span></div>
+          <div class="cat" data-i="1"><span class="cname">Implementation Coverage</span><span class="cgloss">documented features exist in the code</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="2"><span class="cname">Enumeration Completeness</span><span class="cgloss">lists are exhaustive — no gaps or extras</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="3"><span class="cname">UX Flow Accuracy</span><span class="cgloss">described flows match reality</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="4"><span class="cname">Order-Emphasis Consistency</span><span class="cgloss">ordering &amp; emphasis stay aligned</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="5"><span class="cname">Screenshot Presence</span><span class="cgloss">screenshots included where needed</span><span class="ok">✓</span></div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-docheavy {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-docheavy .bg { position: absolute; inset: 0; }
+      #scene-docheavy .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 640px at 50% 4%, rgba(232,179,57,0.12), rgba(232,179,57,0) 66%);
+      }
+      #scene-docheavy .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 48px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-docheavy .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-docheavy .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-docheavy .heading .hl { color: #e8b339; }
+      #scene-docheavy .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-docheavy .panel {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        padding: 30px 38px; box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+      }
+      #scene-docheavy .panel-head {
+        font-size: 28px; color: #e6edf3; font-weight: 700; margin-bottom: 22px;
+        display: flex; align-items: baseline; gap: 16px;
+      }
+      #scene-docheavy .panel-head .bd {
+        font-size: 20px; color: #8b949e; font-weight: 500;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-docheavy .cat { display: flex; align-items: baseline; gap: 22px; padding: 12px 0; }
+      #scene-docheavy .cname {
+        font-size: 27px; font-weight: 700; color: #58a6ff; min-width: 460px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-docheavy .cgloss { flex: 1; font-size: 25px; color: #c9d1d9; }
+      #scene-docheavy .ok { color: #3fb950; font-weight: 700; font-size: 27px; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-docheavy .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-docheavy .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-docheavy .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-docheavy .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-docheavy .panel", { opacity: 0, y: 32, duration: 0.6, ease: "power2.out" }, 0.85);
+      tl.from("#scene-docheavy .panel-head", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 1.15);
+      tl.from("#scene-docheavy .cat", { opacity: 0, x: 24, duration: 0.42, ease: "power2.out", stagger: 0.18 }, 1.5);
+      window.__timelines["scene-docheavy"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/compositions/scene-goal.html
+++ b/media/intro-video-en/compositions/scene-goal.html
@@ -4,25 +4,25 @@
       <div class="glow" aria-hidden="true"></div>
       <div class="scene-content">
         <div class="head">
-          <div class="kicker">POWER USE — /goal</div>
-          <div class="heading">State the goal — <span class="hl">the workflow drives itself</span></div>
-          <div class="subnote">Pair with Claude Code's /goal to run the whole pipeline autonomously</div>
+          <div class="kicker">POWER USE — /rite:run</div>
+          <div class="heading">Hand it the Issue numbers — <span class="hl">the workflow drives itself</span></div>
+          <div class="subnote">rite's own orchestrator /rite:run runs multiple Issues from open to merge, no prompts</div>
         </div>
 
         <div class="terminal">
           <div class="term-head">
             <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-            <span class="term-title">claude code — /goal × rite</span>
+            <span class="term-title">claude code — /rite:run</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/goal</span> <span class="goal">Close Issue #1234 and set its status to Done</span></div>
-            <div class="cond">↳ Run pr:open → iterate → ready → merge → cleanup in sequence</div>
-            <div class="cond">↳ Don't forget to <span class="hl2">register follow-up Issues in GitHub Projects</span></div>
-            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:pr:open</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:pr:iterate <span class="anno">— converge review ⇄ fix</span></span><span class="ok">✓</span></div>
-            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:pr:ready</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:pr:merge</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:pr:cleanup</span><span class="ok">✓</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:run --merge</span> <span class="goal">1234</span></div>
+            <div class="cond">↳ Runs open → iterate → ready → merge → cleanup per Issue</div>
+            <div class="cond">↳ Stops only on failure, otherwise <span class="hl2">runs unattended to completion</span></div>
+            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:open</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:iterate <span class="anno">— converge review ⇄ fix</span></span><span class="ok">✓</span></div>
+            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:ready</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:merge</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:cleanup</span><span class="ok">✓</span></div>
             <div class="done">✅ Issue #1234 → Done</div>
           </div>
         </div>

--- a/media/intro-video-en/compositions/scene-goal.html
+++ b/media/intro-video-en/compositions/scene-goal.html
@@ -1,0 +1,108 @@
+<template id="scene-goal-template">
+  <div data-composition-id="scene-goal" id="scene-goal" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">POWER USE — /goal</div>
+          <div class="heading">State the goal — <span class="hl">the workflow drives itself</span></div>
+          <div class="subnote">Pair with Claude Code's /goal to run the whole pipeline autonomously</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — /goal × rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/goal</span> <span class="goal">Close Issue #1234 and set its status to Done</span></div>
+            <div class="cond">↳ Run pr:open → iterate → ready → merge → cleanup in sequence</div>
+            <div class="cond">↳ Don't forget to <span class="hl2">register follow-up Issues in GitHub Projects</span></div>
+            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:pr:open</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:pr:iterate <span class="anno">— converge review ⇄ fix</span></span><span class="ok">✓</span></div>
+            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:pr:ready</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:pr:merge</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:pr:cleanup</span><span class="ok">✓</span></div>
+            <div class="done">✅ Issue #1234 → Done</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-goal {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-goal .bg { position: absolute; inset: 0; }
+      #scene-goal .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 620px at 75% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 64%);
+      }
+      #scene-goal .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 34px; padding: 80px 150px; box-sizing: border-box;
+      }
+      #scene-goal .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-goal .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-goal .heading .hl { color: #e8b339; }
+      #scene-goal .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-goal .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1340px;
+      }
+      #scene-goal .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 14px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-goal .dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block; }
+      #scene-goal .dot.r { background: #f85149; }
+      #scene-goal .dot.y { background: #e3b341; }
+      #scene-goal .dot.g { background: #3fb950; }
+      #scene-goal .term-title {
+        margin-left: 13px; font-size: 19px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-goal .term-body {
+        padding: 24px 36px 28px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 27px; line-height: 1.5; color: #c9d1d9;
+      }
+      #scene-goal .cmdline { font-size: 29px; margin-bottom: 8px; }
+      #scene-goal .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-goal .cmd { color: #e8b339; font-weight: 700; }
+      #scene-goal .goal { color: #e6edf3; }
+      #scene-goal .cond { font-size: 23px; color: #8b949e; padding-left: 36px; }
+      #scene-goal .cond .hl2 { color: #58a6ff; }
+      #scene-goal .srow {
+        display: flex; justify-content: space-between; align-items: baseline;
+        max-width: 880px; margin-top: 4px;
+      }
+      #scene-goal .rcmd { color: #58a6ff; font-weight: 600; }
+      #scene-goal .rcmd .anno { color: #8b949e; font-weight: 400; }
+      #scene-goal .ok { color: #3fb950; font-weight: 700; }
+      #scene-goal .done { margin-top: 16px; font-size: 30px; color: #3fb950; font-weight: 700; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-goal .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-goal .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-goal .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-goal .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-goal .terminal", { opacity: 0, y: 34, duration: 0.6, ease: "power2.out" }, 0.7);
+      tl.from("#scene-goal .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 1.05);
+      tl.from("#scene-goal .cond", { opacity: 0, x: -12, duration: 0.4, ease: "power2.out", stagger: 0.2 }, 1.4);
+      for (let i = 1; i <= 5; i++) {
+        tl.from("#scene-goal .srow[data-i='" + i + "']", { opacity: 0, x: -16, duration: 0.4, ease: "power2.out" }, 2.05 + (i - 1) * 0.46);
+      }
+      tl.from("#scene-goal .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 4.5);
+      window.__timelines["scene-goal"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/hyperframes.json
+++ b/media/intro-video-en/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  }
+}

--- a/media/intro-video-en/index.html
+++ b/media/intro-video-en/index.html
@@ -17,7 +17,7 @@
       id="root"
       data-composition-id="main"
       data-start="0"
-      data-duration="104"
+      data-duration="114"
       data-width="1920"
       data-height="1080"
     >
@@ -29,16 +29,18 @@
            data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
       <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
            data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+      <div id="clip-docheavy" data-composition-id="scene-docheavy" data-composition-src="compositions/scene-docheavy.html"
+           data-start="46" data-duration="10.6" data-track-index="5" style="z-index: 5"></div>
       <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
-           data-start="46" data-duration="13.6" data-track-index="5" style="z-index: 5"></div>
+           data-start="56" data-duration="13.6" data-track-index="6" style="z-index: 6"></div>
       <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
-           data-start="59" data-duration="12.6" data-track-index="6" style="z-index: 6"></div>
+           data-start="69" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
       <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
-           data-start="71" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+           data-start="81" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
       <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
-           data-start="83" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+           data-start="93" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
       <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
-           data-start="95" data-duration="9"    data-track-index="9" style="z-index: 9"></div>
+           data-start="105" data-duration="9"   data-track-index="10" style="z-index: 10"></div>
     </div>
 
     <script>
@@ -49,13 +51,14 @@
       tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
       tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
       tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
-      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
-      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 59);
-      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 71);
-      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 83);
-      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 95);
+      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 56);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 69);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 81);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 93);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 105);
       // Final scene only: fade to black at the very end.
-      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 103.2);
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 113.2);
       window.__timelines["main"] = tl;
     </script>
   </body>

--- a/media/intro-video-en/index.html
+++ b/media/intro-video-en/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        margin: 0; width: 1920px; height: 1080px; overflow: hidden; background: #0e1117;
+      }
+      body { font-family: "Inter", "Noto Sans JP", sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="104"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="clip-1" data-composition-id="scene-1" data-composition-src="compositions/scene-1.html"
+           data-start="0"  data-duration="7.6"  data-track-index="1" style="z-index: 1"></div>
+      <div id="clip-create" data-composition-id="scene-create" data-composition-src="compositions/scene-create.html"
+           data-start="7"  data-duration="12.6" data-track-index="2" style="z-index: 2"></div>
+      <div id="clip-2" data-composition-id="scene-2" data-composition-src="compositions/scene-2.html"
+           data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
+      <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
+           data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+      <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
+           data-start="46" data-duration="13.6" data-track-index="5" style="z-index: 5"></div>
+      <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
+           data-start="59" data-duration="12.6" data-track-index="6" style="z-index: 6"></div>
+      <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
+           data-start="71" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+      <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
+           data-start="83" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+      <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
+           data-start="95" data-duration="9"    data-track-index="9" style="z-index: 9"></div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      // Scene 1 fades up from black; following scenes crossfade over the outgoing scene.
+      tl.from("#clip-1", { opacity: 0, duration: 0.6, ease: "sine.out" }, 0);
+      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
+      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
+      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 59);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 71);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 83);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 95);
+      // Final scene only: fade to black at the very end.
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 103.2);
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/media/intro-video-en/meta.json
+++ b/media/intro-video-en/meta.json
@@ -1,0 +1,5 @@
+{
+  "id": "rite-intro-video-en",
+  "name": "rite-intro-video-en",
+  "createdAt": "2026-06-19T01:10:20.205Z"
+}

--- a/media/intro-video-en/package.json
+++ b/media/intro-video-en/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "rite-intro-video-en",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "npx --yes hyperframes@0.6.112 preview",
+    "check": "npx --yes hyperframes@0.6.112 lint && npx --yes hyperframes@0.6.112 validate && npx --yes hyperframes@0.6.112 inspect",
+    "render": "npx --yes hyperframes@0.6.112 render",
+    "publish": "npx --yes hyperframes@0.6.112 publish"
+  }
+}

--- a/media/intro-video/AGENTS.md
+++ b/media/intro-video/AGENTS.md
@@ -1,0 +1,87 @@
+# HyperFrames Composition Project
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before writing or modifying compositions.** Skills encode framework-specific patterns (e.g., `window.__timelines` registration, `data-*` attribute semantics, shader-compatible CSS rules) that are NOT in generic web docs. Skipping them produces broken compositions.
+
+**Doing anything with HyperFrames?** Start at `/hyperframes` — it tells you what HyperFrames can do and which skill or workflow handles your intent (make a video, TTS / BGM, prep footage, author / animate, render, install blocks), and routes every "make me a video" request to the right workflow. Read it first, especially when there's no project context to orient you. The video workflows it routes to:
+
+- `/product-launch-video` — a **product** URL or brief / script → 60-90s product launch / SaaS / promo video.
+- `/website-to-video` — a **general** website / URL → a video _of_ the site (tour / showcase / social clip from captured visuals); a product **launch / promo** is `/product-launch-video`.
+- `/faceless-explainer` — arbitrary text (topic / article / notes), **no URL, no website capture** → 60-90s faceless explainer.
+- `/embedded-captions` — an existing talking-head video (MP4) → the same footage with captions / subtitles added (rail + embed, or pure-cinematic embed); the footage itself is untouched.
+- `/graphic-overlays` — an existing talking-head / interview / podcast video (MP4) → the same footage **packaged with designed graphic overlays** (kinetic titles, lower-thirds, data callouts, pull-quotes, side panels, pip) synced to the transcript; the clip plays unchanged underneath. (Plain captions/subtitles → `/embedded-captions`.)
+- `/pr-to-video` — a GitHub PR (URL / `owner/repo#N` / "this PR") → 30-90s code-change explainer (changelog / feature reveal / fix / refactor).
+- `/motion-graphics` — a short (typically under 10s) design-led **motion graphic**, motion-is-the-message, no narration: kinetic type, a stat / number count-up, a chart, a logo sting, a lower-third / overlay, or an animated tweet / headline / captured-page highlight; rendered to MP4 or a transparent overlay. Longer / narrated / custom → `/general-video`.
+- `/general-video` — fallback for any other video (title card, longer brand / sizzle reel, multi-scene montage, static loop, custom composition); the original hyperframes authoring flow, any length.
+
+**Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
+
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+
+> **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
+
+> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
+> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+
+## Commands
+
+```bash
+npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run check        # lint + validate + inspect
+npm run render       # render to MP4
+npm run publish      # publish and get a shareable link
+npx hyperframes lint --verbose  # include info-level findings
+npx hyperframes lint --json     # machine-readable output for CI
+npx hyperframes docs <topic> # reference docs in terminal
+```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
+> command — it will time out and the server will die, breaking the browser preview.
+
+## Documentation
+
+**For quick reference**, use the local CLI docs command (no network required):
+
+```bash
+npx hyperframes docs <topic>
+```
+
+Topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `examples`, `troubleshooting`
+
+**For full documentation**, discover pages via the machine-readable index — do NOT guess URLs:
+
+```
+https://hyperframes.heygen.com/llms.txt
+```
+
+## Project Structure
+
+- `index.html` — main composition (root timeline)
+- `compositions/` — sub-compositions referenced via `data-composition-src`
+- `meta.json` — project metadata (id, name)
+- `transcript.json` — whisper word-level transcript (if generated)
+
+## Linting — ALWAYS RUN AFTER CHANGES
+
+After creating or editing any `.html` composition, **always** run the full check before considering the task complete:
+
+```bash
+npm run check
+```
+
+Fix all errors before presenting the result. Inspect warnings should be reviewed before rendering.
+
+## Key Rules
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track
+5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
+6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches

--- a/media/intro-video/CLAUDE.md
+++ b/media/intro-video/CLAUDE.md
@@ -1,0 +1,87 @@
+# HyperFrames Composition Project
+
+## Skills — USE THESE FIRST
+
+**Always invoke the relevant skill before writing or modifying compositions.** Skills encode framework-specific patterns (e.g., `window.__timelines` registration, `data-*` attribute semantics, shader-compatible CSS rules) that are NOT in generic web docs. Skipping them produces broken compositions.
+
+**Doing anything with HyperFrames?** Start at `/hyperframes` — it tells you what HyperFrames can do and which skill or workflow handles your intent (make a video, TTS / BGM, prep footage, author / animate, render, install blocks), and routes every "make me a video" request to the right workflow. Read it first, especially when there's no project context to orient you. The video workflows it routes to:
+
+- `/product-launch-video` — a **product** URL or brief / script → 60-90s product launch / SaaS / promo video.
+- `/website-to-video` — a **general** website / URL → a video _of_ the site (tour / showcase / social clip from captured visuals); a product **launch / promo** is `/product-launch-video`.
+- `/faceless-explainer` — arbitrary text (topic / article / notes), **no URL, no website capture** → 60-90s faceless explainer.
+- `/embedded-captions` — an existing talking-head video (MP4) → the same footage with captions / subtitles added (rail + embed, or pure-cinematic embed); the footage itself is untouched.
+- `/graphic-overlays` — an existing talking-head / interview / podcast video (MP4) → the same footage **packaged with designed graphic overlays** (kinetic titles, lower-thirds, data callouts, pull-quotes, side panels, pip) synced to the transcript; the clip plays unchanged underneath. (Plain captions/subtitles → `/embedded-captions`.)
+- `/pr-to-video` — a GitHub PR (URL / `owner/repo#N` / "this PR") → 30-90s code-change explainer (changelog / feature reveal / fix / refactor).
+- `/motion-graphics` — a short (typically under 10s) design-led **motion graphic**, motion-is-the-message, no narration: kinetic type, a stat / number count-up, a chart, a logo sting, a lower-third / overlay, or an animated tweet / headline / captured-page highlight; rendered to MP4 or a transparent overlay. Longer / narrated / custom → `/general-video`.
+- `/general-video` — fallback for any other video (title card, longer brand / sizzle reel, multi-scene montage, static loop, custom composition); the original hyperframes authoring flow, any length.
+
+**Porting an existing composition?** `/remotion-to-hyperframes` translates a Remotion (React) composition into HyperFrames HTML — a source migration, separate from the creation workflows above.
+
+The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-creative`, `/hyperframes-cli`, `/hyperframes-media`, `/hyperframes-registry`) and the full capability map live inside `/hyperframes` — it is the single source of truth for which skill handles which intent.
+
+> **Tailwind v4 projects** (`hyperframes init --tailwind`): see `/hyperframes-core` → `references/tailwind.md`.
+
+> **Skills not available?** Ask the user to run `npx hyperframes skills` and restart their
+> agent session, or install manually: `npx skills add heygen-com/hyperframes`.
+
+## Commands
+
+```bash
+npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run check        # lint + validate + inspect
+npm run render       # render to MP4
+npm run publish      # publish and get a shareable link
+npx hyperframes lint --verbose  # include info-level findings
+npx hyperframes lint --json     # machine-readable output for CI
+npx hyperframes docs <topic> # reference docs in terminal
+```
+
+> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
+> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
+> command — it will time out and the server will die, breaking the browser preview.
+
+## Documentation
+
+**For quick reference**, use the local CLI docs command (no network required):
+
+```bash
+npx hyperframes docs <topic>
+```
+
+Topics: `data-attributes`, `gsap`, `compositions`, `rendering`, `examples`, `troubleshooting`
+
+**For full documentation**, discover pages via the machine-readable index — do NOT guess URLs:
+
+```
+https://hyperframes.heygen.com/llms.txt
+```
+
+## Project Structure
+
+- `index.html` — main composition (root timeline)
+- `compositions/` — sub-compositions referenced via `data-composition-src`
+- `meta.json` — project metadata (id, name)
+- `transcript.json` — whisper word-level transcript (if generated)
+
+## Linting — ALWAYS RUN AFTER CHANGES
+
+After creating or editing any `.html` composition, **always** run the full check before considering the task complete:
+
+```bash
+npm run check
+```
+
+Fix all errors before presenting the result. Inspect warnings should be reviewed before rendering.
+
+## Key Rules
+
+1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
+2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
+3. Timelines must be paused and registered on `window.__timelines`:
+   ```js
+   window.__timelines = window.__timelines || {};
+   window.__timelines["composition-id"] = gsap.timeline({ paused: true });
+   ```
+4. Videos use `muted` with a separate `<audio>` element for the audio track
+5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
+6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches

--- a/media/intro-video/DESIGN.md
+++ b/media/intro-video/DESIGN.md
@@ -1,0 +1,57 @@
+# DESIGN.md — Rite Workflow 紹介動画
+
+## Style Prompt
+
+開発者向けターミナルツールの世界観。深いインクブラックのキャンバスに、巻物（📜）と
+「儀式（rite）」を想起させる暖色のアンバー/ゴールドをアクセントに据える。GitHub Dark を
+基調にしたエンジニアリングらしい落ち着きと、コマンドが次々に成功していく小気味よい動きを
+両立させる。誇張のない、事実に忠実で端正なトーン。
+
+## Colors
+
+| Role | Hex | 用途 |
+|------|-----|------|
+| Canvas (背景) | `#0E1117` | 全シーン共通の背景 |
+| Surface (パネル) | `#161B22` | ターミナル/カードの面 |
+| Border | `#30363D` | 枠線・区切り |
+| Text primary | `#E6EDF3` | 見出し・本文 |
+| Text muted | `#8B949E` | サブ・補助テキスト |
+| Accent amber (儀式) | `#E8B339` | ブランド/強調/ロゴ |
+| Terminal green | `#3FB950` | 成功 ✓ / コマンド出力 OK |
+| Cyan link | `#58A6FF` | コマンド名・リンク・アクセント |
+
+### Severity（findings 表示用）
+
+| Level | Hex |
+|-------|-----|
+| CRITICAL | `#F85149` |
+| HIGH | `#FF9B50` |
+| MEDIUM | `#E3B341` |
+| OK / resolved | `#3FB950` |
+
+## Typography
+
+- 見出し・本文（欧文）: **Inter**
+- ターミナル/コマンド（等幅）: **JetBrains Mono**
+- 日本語: **Noto Sans JP**（フォント stack で欧文等幅の後段に置きフォールバック）
+- 数字カラムは `font-variant-numeric: tabular-nums`
+
+font stack 例:
+- 日本語見出し: `"Inter", "Noto Sans JP", sans-serif`
+- ターミナル内日本語ラベル: `"JetBrains Mono", "Noto Sans JP", monospace`
+
+## Motion
+
+- entrance のみ（exit はトランジションが兼ねる。最終シーンのみ fade out 可）
+- 最初の tween は 0.1–0.3s オフセット、1シーンに最低3種類の ease
+- シーン間はクロスフェード（全シーン同色背景なので 0.5–0.6s の opacity 重ねで自然に繋ぐ）
+- ターミナルのタイプ表示・進捗は決定論的（`SteppedEase`/幅クリップ。乱数・時刻不可）
+
+## What NOT to Do
+
+- 既定色 `#3b82f6` / `#333` / フォント `Roboto` を使わない（必ず上記パレット）
+- 濃色背景にフルスクリーン linear gradient を敷かない（H.264 バンディング。radial か solid+局所 glow）
+- ジャンプカット禁止（必ずトランジション）。シーン内の要素はすべて entrance を持つ
+- 誇張表現を書かない: レビュアーは「13人が常に並列」ではなく
+  「最大13種類から PR 内容に応じて動的選定」と事実どおりに表記する
+- `<br>` で強制改行しない（`max-width` で自然折返し。短い表示見出しの例外のみ可）

--- a/media/intro-video/PROVENANCE.md
+++ b/media/intro-video/PROVENANCE.md
@@ -1,0 +1,34 @@
+# intro-video — 来歴と取り扱い
+
+README.md の「Demo」節で参照している**日本語字幕版**紹介動画（約104秒）の HyperFrames ソース。
+
+## 来歴
+
+- もとは独立ディレクトリ `~/Projects/work/rite-intro-video/` で制作していたものを、Issue #1687 で本リポジトリ管理下（`media/intro-video/`）へ取り込んだ。
+- 取り込み時点ではソース内容を改変せず as-is でインポートし、別コミットで v0.7 仕様へ更新した。
+
+## ビルド / プレビュー
+
+```bash
+cd media/intro-video
+npm run check    # hyperframes lint && validate && inspect（HTML 妥当性の検証）
+npm run dev      # hyperframes preview（ブラウザでプレビュー）
+npm run render   # hyperframes render（MP4 を生成）
+```
+
+レンダリングには HyperFrames（`npx hyperframes`）+ headless Chromium + ffmpeg が必要。
+
+## コミットしないもの（`.gitignore` 済み）
+
+| 対象 | 理由 |
+|------|------|
+| `*.mp4`（`rite-intro.mp4` / `rite-intro-bgm*.mp4` 等） | `npm run render` で再生成可能なビルド成果物。README の再生動画は GitHub の添付（user-attachments）として別途アップロードする |
+| `*.mp3`（BGM） | 後述のライセンス制約のため |
+
+## BGM について
+
+- 楽曲: **BombinSound — Technology**（Pixabay, track ID `499581`）
+- 入手元: <https://pixabay.com/users/bombinsound-54782632/>
+- ライセンス: [Pixabay Content License](https://pixabay.com/service/terms/) — 商用利用可・帰属表示不要。**ただし「creative effort を加えず実質同形のまま単体（standalone）で配布すること」を禁止**している。
+- そのため**生の mp3 を本リポジトリにはコミットしない**（公開リポへ置くと単体ダウンロード可能となり standalone 配布に該当しうるため）。BGM 付きでレンダリングする場合は、上記 Pixabay ページから `bombinsound-technology-tech-technology-90-second-499581.mp3` を取得し、このディレクトリ直下に置くこと。
+- BGM を映像に合成した**動画そのもの（新たな創作物）**の配布は Pixabay ライセンス上問題ない。

--- a/media/intro-video/compositions/scene-1.html
+++ b/media/intro-video/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">Issue から PR まで、開発を“儀式”に変える</div>
         <div class="sub">Claude Code プラグイン</div>
-        <div class="badge">v0.6.2 · MIT</div>
+        <div class="badge">v0.7.0 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video/compositions/scene-1.html
+++ b/media/intro-video/compositions/scene-1.html
@@ -1,0 +1,107 @@
+<template id="scene-1-template">
+  <div data-composition-id="scene-1" id="scene-1" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="logo">
+          <span class="scroll">📜</span>
+          <span class="wordmark"><span class="rite">Rite</span> Workflow</span>
+        </div>
+        <div class="tagline">Issue から PR まで、開発を“儀式”に変える</div>
+        <div class="sub">Claude Code プラグイン</div>
+        <div class="badge">v0.6.2 · MIT</div>
+      </div>
+    </div>
+
+    <style>
+      #scene-1 {
+        width: 1920px;
+        height: 1080px;
+        position: relative;
+        overflow: hidden;
+        background: #0e1117;
+        font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-1 .bg {
+        position: absolute;
+        inset: 0;
+      }
+      #scene-1 .glow {
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(
+          ellipse 1300px 700px at 50% 8%,
+          rgba(232, 179, 57, 0.16),
+          rgba(232, 179, 57, 0) 68%
+        );
+      }
+      #scene-1 .scene-content {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 36px;
+        padding: 120px 160px;
+        box-sizing: border-box;
+        text-align: center;
+      }
+      #scene-1 .logo {
+        display: flex;
+        align-items: center;
+        gap: 28px;
+        font-size: 132px;
+        font-weight: 800;
+        letter-spacing: -2px;
+        line-height: 1;
+      }
+      #scene-1 .scroll {
+        font-size: 120px;
+      }
+      #scene-1 .wordmark {
+        color: #e6edf3;
+      }
+      #scene-1 .rite {
+        color: #e8b339;
+      }
+      #scene-1 .tagline {
+        font-size: 50px;
+        font-weight: 600;
+        color: #c9d1d9;
+        max-width: 1300px;
+      }
+      #scene-1 .sub {
+        font-size: 30px;
+        font-weight: 600;
+        color: #58a6ff;
+        padding: 10px 26px;
+        border: 1px solid #30363d;
+        border-radius: 999px;
+        background: #161b22;
+      }
+      #scene-1 .badge {
+        margin-top: 6px;
+        font-size: 22px;
+        font-weight: 500;
+        color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        letter-spacing: 1px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-1 .glow", { opacity: 0, scale: 1.15, duration: 1.2, ease: "power1.out", transformOrigin: "50% 8%" }, 0);
+      tl.from("#scene-1 .logo", { opacity: 0, scale: 0.82, duration: 0.8, ease: "power3.out" }, 0.2);
+      tl.from("#scene-1 .tagline", { opacity: 0, y: 44, duration: 0.6, ease: "power2.out" }, 0.6);
+      tl.from("#scene-1 .sub", { opacity: 0, y: 26, duration: 0.5, ease: "back.out(1.6)" }, 0.95);
+      tl.from("#scene-1 .badge", { opacity: 0, duration: 0.6, ease: "sine.out" }, 1.25);
+      window.__timelines["scene-1"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-2.html
+++ b/media/intro-video/compositions/scene-2.html
@@ -1,0 +1,99 @@
+<template id="scene-2-template">
+  <div data-composition-id="scene-2" id="scene-2" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 02 — OPEN</div>
+          <div class="heading">1コマンドで <span class="hl">Issue → Draft PR</span></div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:open 1234</span></div>
+            <div class="row" data-i="1"><span class="idx">[1/6]</span><span class="label">準備 — Issue #1234 を取得</span><span class="ok">✓</span></div>
+            <div class="row" data-i="2"><span class="idx">[2/6]</span><span class="label">ブランチ作成 — feat/issue-1234-add-auth</span><span class="ok">✓</span></div>
+            <div class="row" data-i="3"><span class="idx">[3/6]</span><span class="label">実装計画 — 変更ファイルと手順を分析</span><span class="ok">✓</span></div>
+            <div class="row" data-i="4"><span class="idx">[4/6]</span><span class="label">実装・テスト — Canon TDD サイクル</span><span class="ok">✓</span></div>
+            <div class="row" data-i="5"><span class="idx">[5/6]</span><span class="label">品質チェック — /rite:lint</span><span class="ok">✓</span></div>
+            <div class="row" data-i="6"><span class="idx">[6/6]</span><span class="label">Draft PR を作成</span><span class="ok">✓</span></div>
+            <div class="done">✅ Draft PR #5678 を作成しました</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-2 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-2 .bg { position: absolute; inset: 0; }
+      #scene-2 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 20% 0%, rgba(88,166,255,0.12), rgba(88,166,255,0) 65%);
+      }
+      #scene-2 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 44px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-2 .kicker {
+        font-size: 24px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 14px;
+      }
+      #scene-2 .heading { font-size: 66px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-2 .heading .hl { color: #58a6ff; }
+      #scene-2 .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1300px;
+      }
+      #scene-2 .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 16px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-2 .dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
+      #scene-2 .dot.r { background: #f85149; }
+      #scene-2 .dot.y { background: #e3b341; }
+      #scene-2 .dot.g { background: #3fb950; }
+      #scene-2 .term-title {
+        margin-left: 14px; font-size: 20px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-2 .term-body {
+        padding: 30px 40px 36px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 30px; line-height: 1.62; color: #c9d1d9;
+      }
+      #scene-2 .cmdline { margin-bottom: 18px; font-size: 33px; }
+      #scene-2 .prompt { color: #3fb950; margin-right: 14px; }
+      #scene-2 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-2 .row { display: flex; align-items: baseline; gap: 20px; }
+      #scene-2 .idx { color: #8b949e; min-width: 84px; }
+      #scene-2 .label { flex: 1; color: #c9d1d9; }
+      #scene-2 .ok { color: #3fb950; font-weight: 700; }
+      #scene-2 .done {
+        margin-top: 22px; font-size: 32px; color: #3fb950; font-weight: 700;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-2 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-2 .kicker", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-2 .heading", { opacity: 0, y: 28, duration: 0.6, ease: "power3.out" }, 0.28);
+      tl.from("#scene-2 .terminal", { opacity: 0, y: 36, duration: 0.6, ease: "power2.out" }, 0.5);
+      tl.from("#scene-2 .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 0.85);
+      for (let i = 1; i <= 6; i++) {
+        tl.from("#scene-2 .row[data-i='" + i + "']", { opacity: 0, x: -18, duration: 0.4, ease: "power2.out" }, 1.25 + (i - 1) * 0.52);
+      }
+      tl.from("#scene-2 .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 4.55);
+      window.__timelines["scene-2"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-2.html
+++ b/media/intro-video/compositions/scene-2.html
@@ -14,7 +14,7 @@
             <span class="term-title">claude code — rite</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:open 1234</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:open 1234</span></div>
             <div class="row" data-i="1"><span class="idx">[1/6]</span><span class="label">準備 — Issue #1234 を取得</span><span class="ok">✓</span></div>
             <div class="row" data-i="2"><span class="idx">[2/6]</span><span class="label">ブランチ作成 — feat/issue-1234-add-auth</span><span class="ok">✓</span></div>
             <div class="row" data-i="3"><span class="idx">[3/6]</span><span class="label">実装計画 — 変更ファイルと手順を分析</span><span class="ok">✓</span></div>

--- a/media/intro-video/compositions/scene-3.html
+++ b/media/intro-video/compositions/scene-3.html
@@ -7,7 +7,7 @@
           <div class="kicker">STEP 03 — REVIEW</div>
           <div class="heading">専門家が<span class="hl">“動的選定”</span>で並列レビュー</div>
           <div class="subnote">最大 13 種類のレビュアーから、PR の内容に応じて選定して同時にレビュー</div>
-          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:iterate 5678</span></div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:iterate 5678</span></div>
         </div>
 
         <div class="columns">

--- a/media/intro-video/compositions/scene-3.html
+++ b/media/intro-video/compositions/scene-3.html
@@ -1,0 +1,122 @@
+<template id="scene-3-template">
+  <div data-composition-id="scene-3" id="scene-3" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 03 — REVIEW</div>
+          <div class="heading">専門家が<span class="hl">“動的選定”</span>で並列レビュー</div>
+          <div class="subnote">最大 13 種類のレビュアーから、PR の内容に応じて選定して同時にレビュー</div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:pr:iterate 5678</span></div>
+        </div>
+
+        <div class="columns">
+          <div class="left">
+            <div class="chips">
+              <div class="chip">🔒 Security</div>
+              <div class="chip">⚡ Performance</div>
+              <div class="chip">🧪 Test</div>
+              <div class="chip">🔌 API</div>
+              <div class="chip">📊 Database</div>
+              <div class="chip">🎨 Frontend</div>
+              <div class="chip">⚠️ Error Handling</div>
+              <div class="chip">🔤 Type Design</div>
+              <div class="chip">🎯 Code Quality</div>
+              <div class="chip">📝 Tech Writer</div>
+              <div class="chip">📦 Dependencies</div>
+              <div class="chip">🐳 DevOps</div>
+              <div class="chip">💬 Prompt</div>
+            </div>
+          </div>
+          <div class="right">
+            <div class="panel">
+              <div class="panel-head">検出 <b>5 件</b><span class="bd">1 CRITICAL · 1 HIGH · 3 MEDIUM</span></div>
+              <div class="finding"><span class="sev c">CRITICAL</span><span class="ftxt">Security — SQL インジェクションの懸念</span></div>
+              <div class="finding"><span class="sev h">HIGH</span><span class="ftxt">Test — null 入力のエッジケース未カバー</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">Performance — ループ内の N+1 クエリ</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">API — レスポンス schema が未記載</span></div>
+              <div class="finding"><span class="sev m">MEDIUM</span><span class="ftxt">Type — any への安全でないキャスト</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-3 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-3 .bg { position: absolute; inset: 0; }
+      #scene-3 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 600px at 80% 0%, rgba(248,81,73,0.10), rgba(248,81,73,0) 64%);
+      }
+      #scene-3 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 40px; padding: 80px 130px; box-sizing: border-box;
+      }
+      #scene-3 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-3 .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-3 .heading .hl { color: #e8b339; }
+      #scene-3 .subnote { margin-top: 14px; font-size: 27px; color: #8b949e; }
+      #scene-3 .cmdline {
+        margin-top: 18px; font-size: 30px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-3 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-3 .columns { display: flex; gap: 48px; align-items: flex-start; }
+      #scene-3 .left { flex: 1; }
+      #scene-3 .chips { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-3 .chip {
+        font-size: 26px; font-weight: 600; color: #c9d1d9;
+        background: #161b22; border: 1px solid #30363d; border-left: 3px solid #3fb950;
+        border-radius: 10px; padding: 12px 20px;
+      }
+      #scene-3 .right { width: 700px; }
+      #scene-3 .panel {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        padding: 26px 30px; box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+      }
+      #scene-3 .panel-head {
+        font-size: 28px; color: #e6edf3; font-weight: 700; margin-bottom: 20px;
+        display: flex; align-items: baseline; gap: 14px;
+      }
+      #scene-3 .panel-head b { color: #f85149; }
+      #scene-3 .panel-head .bd {
+        font-size: 20px; color: #8b949e; font-weight: 500;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .finding { display: flex; align-items: center; gap: 18px; padding: 11px 0; }
+      #scene-3 .sev {
+        font-size: 18px; font-weight: 700; letter-spacing: 0.5px; min-width: 116px; text-align: center;
+        padding: 6px 0; border-radius: 7px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-3 .sev.c { color: #ffd7d4; background: rgba(248,81,73,0.18); border: 1px solid #f85149; }
+      #scene-3 .sev.h { color: #ffe0c2; background: rgba(255,155,80,0.16); border: 1px solid #ff9b50; }
+      #scene-3 .sev.m { color: #f4e2b0; background: rgba(227,179,65,0.14); border: 1px solid #e3b341; }
+      #scene-3 .ftxt { font-size: 24px; color: #c9d1d9; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-3 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-3 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-3 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-3 .subnote", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-3 .cmdline", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 0.7);
+      tl.from("#scene-3 .chip", { opacity: 0, scale: 0.8, y: 12, duration: 0.42, ease: "back.out(1.5)", stagger: 0.07 }, 1.0);
+      tl.from("#scene-3 .panel", { opacity: 0, x: 40, duration: 0.6, ease: "power3.out" }, 1.7);
+      tl.from("#scene-3 .finding", { opacity: 0, x: 24, duration: 0.4, ease: "power2.out", stagger: 0.13 }, 2.1);
+      window.__timelines["scene-3"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-4.html
+++ b/media/intro-video/compositions/scene-4.html
@@ -6,7 +6,7 @@
         <div class="head">
           <div class="kicker">STEP 03 — ITERATE</div>
           <div class="heading">指摘がゼロになるまで <span class="hl">自動修正</span></div>
-          <div class="subnote">/rite:pr:iterate が review ⇄ fix を mergeable まで繰り返す</div>
+          <div class="subnote">/rite:iterate が review ⇄ fix を mergeable まで繰り返す</div>
         </div>
 
         <div class="cycles">

--- a/media/intro-video/compositions/scene-4.html
+++ b/media/intro-video/compositions/scene-4.html
@@ -1,0 +1,120 @@
+<template id="scene-4-template">
+  <div data-composition-id="scene-4" id="scene-4" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 03 — ITERATE</div>
+          <div class="heading">指摘がゼロになるまで <span class="hl">自動修正</span></div>
+          <div class="subnote">/rite:pr:iterate が review ⇄ fix を mergeable まで繰り返す</div>
+        </div>
+
+        <div class="cycles">
+          <div class="cycle" id="cyc1">
+            <div class="clabel">Cycle 1</div>
+            <div class="flow">
+              <span class="pill review">🔄 review</span>
+              <span class="arrow">→</span>
+              <span class="pill warn">⚠️ 5 findings</span>
+              <span class="arrow">→</span>
+              <span class="pill fix">🔧 fix · push</span>
+            </div>
+          </div>
+          <div class="loopback" aria-hidden="true">⟳ もう一度レビュー</div>
+          <div class="cycle" id="cyc2">
+            <div class="clabel">Cycle 2</div>
+            <div class="flow">
+              <span class="pill review">🔄 review</span>
+              <span class="arrow">→</span>
+              <span class="pill ok">✅ 0 findings</span>
+              <span class="arrow">→</span>
+              <span class="pill merge">🎉 [review:mergeable]</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="counter">
+          <span class="big from">5</span><span class="to-arrow">→</span><span class="big to">0</span>
+          <span class="ctxt">findings</span>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-4 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-4 .bg { position: absolute; inset: 0; }
+      #scene-4 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 50% 6%, rgba(63,185,80,0.10), rgba(63,185,80,0) 66%);
+      }
+      #scene-4 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 46px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-4 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-4 .heading { font-size: 64px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-4 .heading .hl { color: #3fb950; }
+      #scene-4 .subnote {
+        margin-top: 14px; font-size: 26px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .cycles { display: flex; flex-direction: column; gap: 20px; }
+      #scene-4 .cycle {
+        background: #161b22; border: 1px solid #30363d; border-radius: 14px;
+        padding: 22px 30px; display: flex; align-items: center; gap: 30px;
+      }
+      #scene-4 .clabel {
+        font-size: 24px; font-weight: 700; color: #8b949e; min-width: 130px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .flow { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+      #scene-4 .pill {
+        font-size: 28px; font-weight: 700; padding: 12px 24px; border-radius: 999px;
+        border: 1px solid #30363d; background: #0d1117; color: #c9d1d9;
+      }
+      #scene-4 .pill.review { color: #58a6ff; border-color: #1f6feb; }
+      #scene-4 .pill.warn { color: #ff9b50; border-color: #ff9b50; }
+      #scene-4 .pill.fix { color: #e8b339; border-color: #e8b339; }
+      #scene-4 .pill.ok { color: #3fb950; border-color: #3fb950; }
+      #scene-4 .pill.merge { color: #3fb950; border-color: #3fb950; background: rgba(63,185,80,0.12); }
+      #scene-4 .arrow { font-size: 30px; color: #8b949e; }
+      #scene-4 .loopback {
+        font-size: 22px; color: #8b949e; padding-left: 160px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-4 .counter { display: flex; align-items: baseline; gap: 26px; margin-top: 8px; }
+      #scene-4 .big { font-size: 92px; font-weight: 900; letter-spacing: -2px; line-height: 1; }
+      #scene-4 .big.from { color: #f85149; }
+      #scene-4 .big.to { color: #3fb950; }
+      #scene-4 .to-arrow { font-size: 56px; color: #8b949e; }
+      #scene-4 .ctxt { font-size: 30px; color: #8b949e; align-self: center; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-4 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-4 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-4 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-4 .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-4 #cyc1", { opacity: 0, y: 28, duration: 0.55, ease: "power2.out" }, 0.85);
+      tl.from("#scene-4 #cyc1 .pill", { opacity: 0, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.16 }, 1.1);
+      tl.from("#scene-4 .loopback", { opacity: 0, x: -20, duration: 0.5, ease: "power2.out" }, 2.0);
+      tl.from("#scene-4 #cyc2", { opacity: 0, y: 28, duration: 0.55, ease: "power2.out" }, 2.4);
+      tl.from("#scene-4 #cyc2 .pill", { opacity: 0, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.16 }, 2.65);
+      tl.from("#scene-4 .counter .from", { opacity: 0, y: 20, duration: 0.5, ease: "power2.out" }, 3.5);
+      tl.from("#scene-4 .counter .to-arrow", { opacity: 0, duration: 0.4, ease: "sine.out" }, 3.8);
+      tl.from("#scene-4 .counter .to", { opacity: 0, scale: 0.6, duration: 0.6, ease: "back.out(2)" }, 4.0);
+      tl.from("#scene-4 .counter .ctxt", { opacity: 0, duration: 0.4, ease: "sine.out" }, 4.3);
+      window.__timelines["scene-4"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-5.html
+++ b/media/intro-video/compositions/scene-5.html
@@ -1,0 +1,104 @@
+<template id="scene-5-template">
+  <div data-composition-id="scene-5" id="scene-5" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">EXPERIENCE WIKI</div>
+          <div class="heading">プロジェクトが <span class="hl">学習して賢くなる</span></div>
+          <div class="subnote">レビュー・修正・Issue の知見を Wiki に自動蓄積（OKF v0.1 準拠）</div>
+        </div>
+
+        <div class="diagram">
+          <div class="cluster">
+            <div class="cluster-label">蓄積される経験則ページ</div>
+            <div class="nodes">
+              <div class="node">📄 security</div>
+              <div class="node">📄 error-handling</div>
+              <div class="node">📄 api</div>
+              <div class="node">📄 performance</div>
+              <div class="node">📄 database</div>
+            </div>
+          </div>
+
+          <div class="inject">
+            <div class="inj-arrow">⟶</div>
+            <div class="inj-label">自動注入</div>
+          </div>
+
+          <div class="next">
+            <div class="next-label">次の Issue 作成・レビュー時</div>
+            <div class="bubble">💡 外部 API のエラーは専用 fallback queue へ</div>
+            <div class="bubble">💡 token はハードコードせず環境変数へ</div>
+            <div class="bubble">💡 webhook の timeout は 30s に統一</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-5 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-5 .bg { position: absolute; inset: 0; }
+      #scene-5 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 650px at 50% 4%, rgba(88,166,255,0.11), rgba(88,166,255,0) 66%);
+      }
+      #scene-5 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 56px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-5 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-5 .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-5 .heading .hl { color: #58a6ff; }
+      #scene-5 .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-5 .diagram { display: flex; align-items: center; gap: 44px; }
+      #scene-5 .cluster {
+        flex: 1; background: #161b22; border: 1px solid #30363d; border-radius: 16px; padding: 28px 30px;
+      }
+      #scene-5 .cluster-label, #scene-5 .next-label {
+        font-size: 22px; color: #8b949e; font-weight: 600; margin-bottom: 20px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .nodes { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-5 .node {
+        font-size: 27px; font-weight: 600; color: #c9d1d9;
+        background: #0d1117; border: 1px solid #30363d; border-radius: 10px; padding: 14px 22px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .inject { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+      #scene-5 .inj-arrow { font-size: 64px; color: #e8b339; line-height: 1; }
+      #scene-5 .inj-label {
+        font-size: 22px; color: #e8b339; font-weight: 700;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-5 .next { flex: 1.05; display: flex; flex-direction: column; gap: 16px; }
+      #scene-5 .bubble {
+        font-size: 27px; color: #e6edf3; font-weight: 600;
+        background: rgba(88,166,255,0.10); border: 1px solid #1f6feb; border-radius: 12px; padding: 16px 24px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-5 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-5 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-5 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-5 .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-5 .cluster", { opacity: 0, x: -36, duration: 0.6, ease: "power3.out" }, 0.85);
+      tl.from("#scene-5 .node", { opacity: 0, scale: 0.82, duration: 0.4, ease: "back.out(1.5)", stagger: 0.1 }, 1.15);
+      tl.from("#scene-5 .inj-arrow", { opacity: 0, x: -24, duration: 0.5, ease: "power2.out" }, 1.9);
+      tl.from("#scene-5 .inj-label", { opacity: 0, duration: 0.4, ease: "sine.out" }, 2.15);
+      tl.from("#scene-5 .bubble", { opacity: 0, x: 34, duration: 0.5, ease: "power2.out", stagger: 0.18 }, 2.35);
+      window.__timelines["scene-5"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-6.html
+++ b/media/intro-video/compositions/scene-6.html
@@ -9,17 +9,17 @@
         </div>
 
         <div class="pipeline">
-          <span class="stage">issue:create</span>
+          <span class="stage">issue-create</span>
           <span class="sep">→</span>
-          <span class="stage">pr:open</span>
+          <span class="stage">open</span>
           <span class="sep">→</span>
-          <span class="stage">pr:iterate</span>
+          <span class="stage">iterate</span>
           <span class="sep">→</span>
-          <span class="stage">pr:ready</span>
+          <span class="stage">ready</span>
           <span class="sep">→</span>
-          <span class="stage">pr:merge</span>
+          <span class="stage">merge</span>
           <span class="sep">→</span>
-          <span class="stage">pr:cleanup</span>
+          <span class="stage">cleanup</span>
         </div>
 
         <div class="status">

--- a/media/intro-video/compositions/scene-6.html
+++ b/media/intro-video/compositions/scene-6.html
@@ -1,0 +1,99 @@
+<template id="scene-6-template">
+  <div data-composition-id="scene-6" id="scene-6" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">WORKFLOW</div>
+          <div class="heading">Issue から PR、マージまで <span class="hl">一気通貫</span></div>
+        </div>
+
+        <div class="pipeline">
+          <span class="stage">issue:create</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:open</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:iterate</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:ready</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:merge</span>
+          <span class="sep">→</span>
+          <span class="stage">pr:cleanup</span>
+        </div>
+
+        <div class="status">
+          <span class="st">Todo</span><span class="sa">→</span>
+          <span class="st">In Progress</span><span class="sa">→</span>
+          <span class="st">In Review</span><span class="sa">→</span>
+          <span class="st done">Done</span>
+        </div>
+
+        <div class="badges">
+          <div class="badge">🌐 Universal</div>
+          <div class="badge">🗂 GitHub Projects</div>
+          <div class="badge">🧪 Canon TDD</div>
+          <div class="badge">📚 Experience Wiki</div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-6 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-6 .bg { position: absolute; inset: 0; }
+      #scene-6 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1300px 650px at 50% 5%, rgba(232,179,57,0.12), rgba(232,179,57,0) 66%);
+      }
+      #scene-6 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center; align-items: center;
+        gap: 56px; padding: 90px 110px; box-sizing: border-box; text-align: center;
+      }
+      #scene-6 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 5px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-6 .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-6 .heading .hl { color: #e8b339; }
+      #scene-6 .pipeline {
+        display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: nowrap;
+      }
+      #scene-6 .stage {
+        font-size: 28px; font-weight: 700; color: #58a6ff;
+        background: #161b22; border: 1px solid #1f6feb; border-radius: 999px; padding: 14px 24px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; white-space: nowrap;
+      }
+      #scene-6 .sep { font-size: 28px; color: #8b949e; }
+      #scene-6 .status { display: flex; align-items: center; gap: 18px; }
+      #scene-6 .st {
+        font-size: 24px; font-weight: 600; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-6 .st.done { color: #3fb950; }
+      #scene-6 .sa { font-size: 22px; color: #768390; }
+      #scene-6 .badges { display: flex; gap: 22px; flex-wrap: wrap; justify-content: center; }
+      #scene-6 .badge {
+        font-size: 27px; font-weight: 700; color: #e6edf3;
+        background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px 26px;
+      }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-6 .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-6 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-6 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-6 .stage", { opacity: 0, y: 22, scale: 0.85, duration: 0.4, ease: "back.out(1.6)", stagger: 0.14 }, 0.8);
+      tl.from("#scene-6 .sep", { opacity: 0, duration: 0.3, ease: "sine.out", stagger: 0.14 }, 1.0);
+      tl.from("#scene-6 .status", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 2.0);
+      tl.from("#scene-6 .badge", { opacity: 0, y: 22, duration: 0.45, ease: "power2.out", stagger: 0.12 }, 2.35);
+      window.__timelines["scene-6"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-7.html
+++ b/media/intro-video/compositions/scene-7.html
@@ -1,0 +1,103 @@
+<template id="scene-7-template">
+  <div data-composition-id="scene-7" id="scene-7" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">GET STARTED</div>
+          <div class="heading">今すぐ試す</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">Claude Code</span>
+          </div>
+          <div class="term-body">
+            <div class="step-c">① マーケットプレイスを追加</div>
+            <div class="cmdline"><span class="prompt">/</span><span class="cmd">plugin marketplace add asakaguchi/cc-rite-workflow</span></div>
+            <div class="step-c">② プラグインをインストール</div>
+            <div class="cmdline"><span class="prompt">/</span><span class="cmd">plugin install rite@rite-marketplace</span></div>
+          </div>
+        </div>
+
+        <div class="outro">
+          <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
+          <div class="meta">v0.6.2 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="made">Made with 📜 rite</div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-7 {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-7 .bg { position: absolute; inset: 0; }
+      #scene-7 .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1300px 760px at 50% 50%, rgba(232,179,57,0.13), rgba(232,179,57,0) 64%);
+      }
+      #scene-7 .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center; align-items: center;
+        gap: 44px; padding: 90px 150px; box-sizing: border-box; text-align: center;
+      }
+      #scene-7 .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 5px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-7 .heading { font-size: 64px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-7 .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); width: 1180px; text-align: left;
+      }
+      #scene-7 .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 15px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-7 .dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block; }
+      #scene-7 .dot.r { background: #f85149; }
+      #scene-7 .dot.y { background: #e3b341; }
+      #scene-7 .dot.g { background: #3fb950; }
+      #scene-7 .term-title {
+        margin-left: 12px; font-size: 19px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-7 .term-body { padding: 28px 38px 32px; }
+      #scene-7 .step-c {
+        font-size: 23px; color: #8b949e; font-weight: 600; margin: 8px 0 10px;
+      }
+      #scene-7 .cmdline {
+        font-size: 31px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        margin-bottom: 18px;
+      }
+      #scene-7 .prompt { color: #3fb950; }
+      #scene-7 .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-7 .outro { display: flex; flex-direction: column; align-items: center; gap: 14px; }
+      #scene-7 .wordmark { font-size: 46px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-7 .wordmark .rite { color: #e8b339; }
+      #scene-7 .meta {
+        font-size: 23px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; letter-spacing: 0.5px;
+      }
+      #scene-7 .made { font-size: 22px; color: #6e7681; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-7 .glow", { opacity: 0, scale: 1.1, duration: 1.2, ease: "power1.out" }, 0);
+      tl.from("#scene-7 .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-7 .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-7 .terminal", { opacity: 0, y: 32, duration: 0.6, ease: "power2.out" }, 0.55);
+      tl.from("#scene-7 .term-body .step-c, #scene-7 .term-body .cmdline", { opacity: 0, x: -16, duration: 0.42, ease: "power2.out", stagger: 0.2 }, 0.95);
+      tl.from("#scene-7 .wordmark", { opacity: 0, scale: 0.9, duration: 0.55, ease: "back.out(1.5)" }, 2.0);
+      tl.from("#scene-7 .meta", { opacity: 0, y: 14, duration: 0.5, ease: "power2.out" }, 2.3);
+      tl.from("#scene-7 .made", { opacity: 0, duration: 0.5, ease: "sine.out" }, 2.55);
+      window.__timelines["scene-7"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-7.html
+++ b/media/intro-video/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.6.2 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.7.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>

--- a/media/intro-video/compositions/scene-create.html
+++ b/media/intro-video/compositions/scene-create.html
@@ -1,0 +1,96 @@
+<template id="scene-create-template">
+  <div data-composition-id="scene-create" id="scene-create" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 01 — CREATE</div>
+          <div class="heading">曖昧なアイデアを <span class="hl">実装可能な Issue</span> に</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue:create</span> <span class="arg">"ユーザー認証を追加"</span></div>
+            <div class="row" data-i="1"><span class="idx">[1/4]</span><span class="label">重複・親 Issue を検索 — 類似なし</span><span class="ok">✓</span></div>
+            <div class="row" data-i="2"><span class="idx">[2/4]</span><span class="label">仮定を表面化 — あなたにしか分からない点だけ確認</span><span class="ok">✓</span></div>
+            <div class="row" data-i="3"><span class="idx">[3/4]</span><span class="label">Implementation Contract を生成 — What / Why / Where</span><span class="ok">✓</span></div>
+            <div class="row" data-i="4"><span class="idx">[4/4]</span><span class="label">GitHub Projects に登録 — Todo</span><span class="ok">✓</span></div>
+            <div class="done">✅ Issue #1234 を作成しました</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-create {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-create .bg { position: absolute; inset: 0; }
+      #scene-create .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1100px 600px at 20% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 65%);
+      }
+      #scene-create .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 44px; padding: 96px 150px; box-sizing: border-box;
+      }
+      #scene-create .kicker {
+        font-size: 24px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 14px;
+      }
+      #scene-create .heading { font-size: 66px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-create .heading .hl { color: #e8b339; }
+      #scene-create .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1340px;
+      }
+      #scene-create .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 16px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-create .dot { width: 14px; height: 14px; border-radius: 50%; display: inline-block; }
+      #scene-create .dot.r { background: #f85149; }
+      #scene-create .dot.y { background: #e3b341; }
+      #scene-create .dot.g { background: #3fb950; }
+      #scene-create .term-title {
+        margin-left: 14px; font-size: 20px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-create .term-body {
+        padding: 30px 40px 36px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 30px; line-height: 1.62; color: #c9d1d9;
+      }
+      #scene-create .cmdline { margin-bottom: 18px; font-size: 33px; }
+      #scene-create .prompt { color: #3fb950; margin-right: 14px; }
+      #scene-create .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-create .arg { color: #a5d6ff; }
+      #scene-create .row { display: flex; align-items: baseline; gap: 20px; }
+      #scene-create .idx { color: #8b949e; min-width: 84px; }
+      #scene-create .label { flex: 1; color: #c9d1d9; }
+      #scene-create .ok { color: #3fb950; font-weight: 700; }
+      #scene-create .done { margin-top: 22px; font-size: 32px; color: #3fb950; font-weight: 700; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-create .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-create .kicker", { opacity: 0, y: 18, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-create .heading", { opacity: 0, y: 28, duration: 0.6, ease: "power3.out" }, 0.28);
+      tl.from("#scene-create .terminal", { opacity: 0, y: 36, duration: 0.6, ease: "power2.out" }, 0.5);
+      tl.from("#scene-create .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 0.85);
+      for (let i = 1; i <= 4; i++) {
+        tl.from("#scene-create .row[data-i='" + i + "']", { opacity: 0, x: -18, duration: 0.4, ease: "power2.out" }, 1.25 + (i - 1) * 0.55);
+      }
+      tl.from("#scene-create .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 3.7);
+      window.__timelines["scene-create"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-create.html
+++ b/media/intro-video/compositions/scene-create.html
@@ -14,7 +14,7 @@
             <span class="term-title">claude code — rite</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue:create</span> <span class="arg">"ユーザー認証を追加"</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:issue-create</span> <span class="arg">"ユーザー認証を追加"</span></div>
             <div class="row" data-i="1"><span class="idx">[1/4]</span><span class="label">重複・親 Issue を検索 — 類似なし</span><span class="ok">✓</span></div>
             <div class="row" data-i="2"><span class="idx">[2/4]</span><span class="label">仮定を表面化 — あなたにしか分からない点だけ確認</span><span class="ok">✓</span></div>
             <div class="row" data-i="3"><span class="idx">[3/4]</span><span class="label">Implementation Contract を生成 — What / Why / Where</span><span class="ok">✓</span></div>

--- a/media/intro-video/compositions/scene-docheavy.html
+++ b/media/intro-video/compositions/scene-docheavy.html
@@ -1,0 +1,80 @@
+<template id="scene-docheavy-template">
+  <div data-composition-id="scene-docheavy" id="scene-docheavy" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">DOC-HEAVY PR MODE</div>
+          <div class="heading">ドキュメント中心の PR は <span class="hl">整合性を5観点で検証</span></div>
+          <div class="subnote">PR が doc-heavy と判定されると、tech-writer が Grep / Read / Glob で実装との整合を検証</div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">📝 doc-heavy 検出<span class="bd">tech-writer reviewer · 5 categories</span></div>
+          <div class="cat" data-i="1"><span class="cname">Implementation Coverage</span><span class="cgloss">記載した機能が実装に存在するか</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="2"><span class="cname">Enumeration Completeness</span><span class="cgloss">列挙の網羅性（漏れ・余剰なし）</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="3"><span class="cname">UX Flow Accuracy</span><span class="cgloss">UX フロー記述の正確性</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="4"><span class="cname">Order-Emphasis Consistency</span><span class="cgloss">順序・強調の一貫性</span><span class="ok">✓</span></div>
+          <div class="cat" data-i="5"><span class="cname">Screenshot Presence</span><span class="cgloss">スクリーンショットの有無</span><span class="ok">✓</span></div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-docheavy {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-docheavy .bg { position: absolute; inset: 0; }
+      #scene-docheavy .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 640px at 50% 4%, rgba(232,179,57,0.12), rgba(232,179,57,0) 66%);
+      }
+      #scene-docheavy .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 48px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-docheavy .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-docheavy .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-docheavy .heading .hl { color: #e8b339; }
+      #scene-docheavy .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-docheavy .panel {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        padding: 30px 38px; box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+      }
+      #scene-docheavy .panel-head {
+        font-size: 28px; color: #e6edf3; font-weight: 700; margin-bottom: 22px;
+        display: flex; align-items: baseline; gap: 16px;
+      }
+      #scene-docheavy .panel-head .bd {
+        font-size: 20px; color: #8b949e; font-weight: 500;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-docheavy .cat { display: flex; align-items: baseline; gap: 22px; padding: 12px 0; }
+      #scene-docheavy .cname {
+        font-size: 27px; font-weight: 700; color: #58a6ff; min-width: 460px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-docheavy .cgloss { flex: 1; font-size: 25px; color: #c9d1d9; }
+      #scene-docheavy .ok { color: #3fb950; font-weight: 700; font-size: 27px; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-docheavy .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-docheavy .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-docheavy .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-docheavy .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-docheavy .panel", { opacity: 0, y: 32, duration: 0.6, ease: "power2.out" }, 0.85);
+      tl.from("#scene-docheavy .panel-head", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 1.15);
+      tl.from("#scene-docheavy .cat", { opacity: 0, x: 24, duration: 0.42, ease: "power2.out", stagger: 0.18 }, 1.5);
+      window.__timelines["scene-docheavy"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-goal.html
+++ b/media/intro-video/compositions/scene-goal.html
@@ -1,0 +1,108 @@
+<template id="scene-goal-template">
+  <div data-composition-id="scene-goal" id="scene-goal" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">POWER USE — /goal</div>
+          <div class="heading">ゴールを伝えれば、<span class="hl">ワークフローが自走</span></div>
+          <div class="subnote">Claude Code の /goal と組み合わせて、パイプライン全体を自律実行</div>
+        </div>
+
+        <div class="terminal">
+          <div class="term-head">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">claude code — /goal × rite</span>
+          </div>
+          <div class="term-body">
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/goal</span> <span class="goal">Issue #1234 を CLOSE し、ステータスを Done にする</span></div>
+            <div class="cond">↳ pr:open → iterate → ready → merge → cleanup を順次実行</div>
+            <div class="cond">↳ follow-up Issue は <span class="hl2">GitHub Projects への登録</span>を忘れない</div>
+            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:pr:open</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:pr:iterate <span class="anno">— review ⇄ fix を収束</span></span><span class="ok">✓</span></div>
+            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:pr:ready</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:pr:merge</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:pr:cleanup</span><span class="ok">✓</span></div>
+            <div class="done">✅ Issue #1234 → Done</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-goal {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-goal .bg { position: absolute; inset: 0; }
+      #scene-goal .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 620px at 75% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 64%);
+      }
+      #scene-goal .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 34px; padding: 80px 150px; box-sizing: border-box;
+      }
+      #scene-goal .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+      }
+      #scene-goal .heading { font-size: 60px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-goal .heading .hl { color: #e8b339; }
+      #scene-goal .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-goal .terminal {
+        background: #161b22; border: 1px solid #30363d; border-radius: 16px;
+        overflow: hidden; box-shadow: 0 24px 60px rgba(0,0,0,0.45); max-width: 1340px;
+      }
+      #scene-goal .term-head {
+        display: flex; align-items: center; gap: 10px;
+        padding: 14px 22px; background: #0d1117; border-bottom: 1px solid #30363d;
+      }
+      #scene-goal .dot { width: 13px; height: 13px; border-radius: 50%; display: inline-block; }
+      #scene-goal .dot.r { background: #f85149; }
+      #scene-goal .dot.y { background: #e3b341; }
+      #scene-goal .dot.g { background: #3fb950; }
+      #scene-goal .term-title {
+        margin-left: 13px; font-size: 19px; color: #8b949e;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-goal .term-body {
+        padding: 24px 36px 28px; font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+        font-size: 27px; line-height: 1.5; color: #c9d1d9;
+      }
+      #scene-goal .cmdline { font-size: 29px; margin-bottom: 8px; }
+      #scene-goal .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-goal .cmd { color: #e8b339; font-weight: 700; }
+      #scene-goal .goal { color: #e6edf3; }
+      #scene-goal .cond { font-size: 23px; color: #8b949e; padding-left: 36px; }
+      #scene-goal .cond .hl2 { color: #58a6ff; }
+      #scene-goal .srow {
+        display: flex; justify-content: space-between; align-items: baseline;
+        max-width: 880px; margin-top: 4px;
+      }
+      #scene-goal .rcmd { color: #58a6ff; font-weight: 600; }
+      #scene-goal .rcmd .anno { color: #8b949e; font-weight: 400; }
+      #scene-goal .ok { color: #3fb950; font-weight: 700; }
+      #scene-goal .done { margin-top: 16px; font-size: 30px; color: #3fb950; font-weight: 700; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-goal .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-goal .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-goal .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-goal .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-goal .terminal", { opacity: 0, y: 34, duration: 0.6, ease: "power2.out" }, 0.7);
+      tl.from("#scene-goal .cmdline", { opacity: 0, x: -14, duration: 0.4, ease: "power2.out" }, 1.05);
+      tl.from("#scene-goal .cond", { opacity: 0, x: -12, duration: 0.4, ease: "power2.out", stagger: 0.2 }, 1.4);
+      for (let i = 1; i <= 5; i++) {
+        tl.from("#scene-goal .srow[data-i='" + i + "']", { opacity: 0, x: -16, duration: 0.4, ease: "power2.out" }, 2.05 + (i - 1) * 0.46);
+      }
+      tl.from("#scene-goal .done", { opacity: 0, scale: 0.92, duration: 0.5, ease: "back.out(1.7)" }, 4.5);
+      window.__timelines["scene-goal"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/compositions/scene-goal.html
+++ b/media/intro-video/compositions/scene-goal.html
@@ -4,25 +4,25 @@
       <div class="glow" aria-hidden="true"></div>
       <div class="scene-content">
         <div class="head">
-          <div class="kicker">POWER USE — /goal</div>
-          <div class="heading">ゴールを伝えれば、<span class="hl">ワークフローが自走</span></div>
-          <div class="subnote">Claude Code の /goal と組み合わせて、パイプライン全体を自律実行</div>
+          <div class="kicker">POWER USE — /rite:run</div>
+          <div class="heading">Issue 番号を渡せば、<span class="hl">ワークフローが自走</span></div>
+          <div class="subnote">rite 自身のオーケストレータ /rite:run が複数 Issue を open→merge まで無確認で連続処理</div>
         </div>
 
         <div class="terminal">
           <div class="term-head">
             <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-            <span class="term-title">claude code — /goal × rite</span>
+            <span class="term-title">claude code — /rite:run</span>
           </div>
           <div class="term-body">
-            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/goal</span> <span class="goal">Issue #1234 を CLOSE し、ステータスを Done にする</span></div>
-            <div class="cond">↳ pr:open → iterate → ready → merge → cleanup を順次実行</div>
-            <div class="cond">↳ follow-up Issue は <span class="hl2">GitHub Projects への登録</span>を忘れない</div>
-            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:pr:open</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:pr:iterate <span class="anno">— review ⇄ fix を収束</span></span><span class="ok">✓</span></div>
-            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:pr:ready</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:pr:merge</span><span class="ok">✓</span></div>
-            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:pr:cleanup</span><span class="ok">✓</span></div>
+            <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:run --merge</span> <span class="goal">1234</span></div>
+            <div class="cond">↳ open → iterate → ready → merge → cleanup を Issue ごとに順次実行</div>
+            <div class="cond">↳ 失敗時のみ停止し、成功する限り <span class="hl2">無確認で連続実行</span></div>
+            <div class="srow" data-i="1"><span class="rcmd">▸ /rite:open</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="2"><span class="rcmd">▸ /rite:iterate <span class="anno">— review ⇄ fix を収束</span></span><span class="ok">✓</span></div>
+            <div class="srow" data-i="3"><span class="rcmd">▸ /rite:ready</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="4"><span class="rcmd">▸ /rite:merge</span><span class="ok">✓</span></div>
+            <div class="srow" data-i="5"><span class="rcmd">▸ /rite:cleanup</span><span class="ok">✓</span></div>
             <div class="done">✅ Issue #1234 → Done</div>
           </div>
         </div>

--- a/media/intro-video/hyperframes.json
+++ b/media/intro-video/hyperframes.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  }
+}

--- a/media/intro-video/index.html
+++ b/media/intro-video/index.html
@@ -17,7 +17,7 @@
       id="root"
       data-composition-id="main"
       data-start="0"
-      data-duration="104"
+      data-duration="114"
       data-width="1920"
       data-height="1080"
     >
@@ -29,16 +29,18 @@
            data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
       <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
            data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+      <div id="clip-docheavy" data-composition-id="scene-docheavy" data-composition-src="compositions/scene-docheavy.html"
+           data-start="46" data-duration="10.6" data-track-index="5" style="z-index: 5"></div>
       <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
-           data-start="46" data-duration="13.6" data-track-index="5" style="z-index: 5"></div>
+           data-start="56" data-duration="13.6" data-track-index="6" style="z-index: 6"></div>
       <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
-           data-start="59" data-duration="12.6" data-track-index="6" style="z-index: 6"></div>
+           data-start="69" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
       <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
-           data-start="71" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+           data-start="81" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
       <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
-           data-start="83" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+           data-start="93" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
       <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
-           data-start="95" data-duration="9"    data-track-index="9" style="z-index: 9"></div>
+           data-start="105" data-duration="9"   data-track-index="10" style="z-index: 10"></div>
     </div>
 
     <script>
@@ -49,13 +51,14 @@
       tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
       tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
       tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
-      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
-      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 59);
-      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 71);
-      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 83);
-      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 95);
+      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 56);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 69);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 81);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 93);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 105);
       // Final scene only: fade to black at the very end.
-      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 103.2);
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 113.2);
       window.__timelines["main"] = tl;
     </script>
   </body>

--- a/media/intro-video/index.html
+++ b/media/intro-video/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        margin: 0; width: 1920px; height: 1080px; overflow: hidden; background: #0e1117;
+      }
+      body { font-family: "Inter", "Noto Sans JP", sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="104"
+      data-width="1920"
+      data-height="1080"
+    >
+      <div id="clip-1" data-composition-id="scene-1" data-composition-src="compositions/scene-1.html"
+           data-start="0"  data-duration="7.6"  data-track-index="1" style="z-index: 1"></div>
+      <div id="clip-create" data-composition-id="scene-create" data-composition-src="compositions/scene-create.html"
+           data-start="7"  data-duration="12.6" data-track-index="2" style="z-index: 2"></div>
+      <div id="clip-2" data-composition-id="scene-2" data-composition-src="compositions/scene-2.html"
+           data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
+      <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
+           data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+      <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
+           data-start="46" data-duration="13.6" data-track-index="5" style="z-index: 5"></div>
+      <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
+           data-start="59" data-duration="12.6" data-track-index="6" style="z-index: 6"></div>
+      <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
+           data-start="71" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+      <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
+           data-start="83" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+      <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
+           data-start="95" data-duration="9"    data-track-index="9" style="z-index: 9"></div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      // Scene 1 fades up from black; following scenes crossfade over the outgoing scene.
+      tl.from("#clip-1", { opacity: 0, duration: 0.6, ease: "sine.out" }, 0);
+      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
+      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
+      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 59);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 71);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 83);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 95);
+      // Final scene only: fade to black at the very end.
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 103.2);
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/media/intro-video/meta.json
+++ b/media/intro-video/meta.json
@@ -1,0 +1,5 @@
+{
+  "id": "rite-intro-video",
+  "name": "rite-intro-video",
+  "createdAt": "2026-06-19T01:10:20.205Z"
+}

--- a/media/intro-video/package.json
+++ b/media/intro-video/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "rite-intro-video",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "npx --yes hyperframes@0.6.112 preview",
+    "check": "npx --yes hyperframes@0.6.112 lint && npx --yes hyperframes@0.6.112 validate && npx --yes hyperframes@0.6.112 inspect",
+    "render": "npx --yes hyperframes@0.6.112 render",
+    "publish": "npx --yes hyperframes@0.6.112 publish"
+  }
+}


### PR DESCRIPTION
## 概要

外部・git 管理外ディレクトリ（`~/Projects/work/rite-intro-video[-en]/`）に切り出されていた紹介動画の HyperFrames ソースを本リポジトリ管理下（`media/intro-video/`, `media/intro-video-en/`）へ取り込み、現行 v0.7.0 仕様へ更新する。外部化により動画更新の成果物が当リポ外に出て `/rite:run` 等で完結できなかった問題を解消する。

Closes #1687

## 変更内容

**(A) 取り込み**（as-is インポート）
- `media/intro-video/`・`media/intro-video-en/` へ source 一式を copy-in（compositions/, index.html, DESIGN.md, 各 config, CLAUDE.md, AGENTS.md）
- `.gitignore`: rendered MP4（`npm run render` で再生成可）と BGM mp3 を除外
- `PROVENANCE.md`（各プロジェクト）: 来歴・ビルド手順・BGM の出所/ライセンスを記載

**(B) v0.7 更新**
- コマンド名を v0.7 ハイフン記法へ（`issue:create`→`issue-create` / `pr:open`→`open` / `pr:iterate`→`iterate` / `pr:ready`→`ready` / `pr:merge`→`merge` / `pr:cleanup`→`cleanup`）
- バージョン表記 `v0.6.2`→`v0.7.0`（scene-1 バッジ / scene-7 outro meta）
- `scene-goal` をパワーユース `/goal` から rite 自身の `/rite:run --merge` 主導の自走デモへ差し替え
- v0.7 新機能シーン `scene-docheavy` を追加（Doc-Heavy PR Mode の5整合カテゴリ）
- `index.html`: scene-3 の後に scene-docheavy を挿入し timeline を再配置（総尺 104→114s）

**(C) README**
- `README.md` / `README.ja.md` の動画 URL を再レンダリングした v0.7 版（GitHub user-attachments）へ差し替え、尺記述「約100秒 / ~100-second」→「約115秒 / ~115-second」

## 検証

- 両プロジェクトで `npm run check`（hyperframes lint/validate/inspect）が **0 error・0 layout issue**
- `npm run render` で両版を実レンダリング成功（114秒, 1080p）。BGM 付き公開版を旧版と同じ音量（mean -20.3dB）で mux、CRF 20 で 6.5MB に圧縮し GitHub へアップロード済み
- コロン名前空間 0 / `v0.6.2` 0 / JA・EN 一致 / 誇張表現なし / `DESIGN.md` 無改変 / rendered MP4 は gitignore 済みで未コミット

## Definition of Done

- [x] 動画ソースを `media/` へ取り込み（git tracked、rendered MP4 除く）
- [x] クリーン状態から `npm run check` / `npm run render` 成功
- [x] 全コマンド名 v0.7 ハイフン記法・`v0.7.0` 統一
- [x] `scene-goal` が `/rite:run` 主役 / `scene-docheavy` 追加
- [x] JA/EN 対応・誇張表現なし・`DESIGN.md` 無改変
- [x] AC-9: README 動画 URL 差し替え（v0.7 版アップロード済み）

## 補足

- BGM（Pixabay BombinSound, Pixabay Content License）は standalone 再配布禁止のため mp3 を非コミットとし、取得手順を `PROVENANCE.md` に記載。映像へ合成した動画自体の配布は許諾内
- 外部 `~/Projects/work/rite-intro-video[-en]/` は SoT が本リポへ移ったため冗長（削除は当リポ外のため本 PR では変更しない）
