### PR TITLE
fix(skills): disable-model-invocation を user-invocable スキルから削除

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -301,7 +301,7 @@ name: <name>                        # ディレクトリ名と一致。起動は
 description: |
  狭く具体的な説明 + auto-activation 条件（汎用トリガ語を誘発語にしない）
 argument-hint: "<arg-hint>"         # 引数を取るスキルのみ（autocomplete 表示）
-# user-invocable: false             # 純 sub-skill / knowledge のみ（メニュー非表示）
+# user-invocable: false             # Skill ツール経由で呼ばれる純 sub-skill のみ（メニュー非表示。Read 専用の knowledge/coordinator は下記ポリシー表の第3区分を参照）
 ---
 
 # /rite:<name>

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -323,6 +323,7 @@ Skill documentation...
 |------|----|-------------|
 | user-invocable（`/rite:<name>` でユーザーが起動。orchestrator 到達の有無を問わない） | open / iterate / ready / merge / cleanup / lint / wiki-ingest / issue-create / wiki-init / learn / skill-suggest 等 | ナロー description のみ（`disable-model-invocation` は使用しない） |
 | 純 sub-skill（user は直接起動しない） | review / fix / pr-create / issue-implement | `user-invocable: false` |
+| Read 経由のみ到達する knowledge/coordinator（`/rite:<name>` を持たず、他スキルから `Read` で参照されるのみ） | reviewers | broad description の auto-activate 抑止目的で `disable-model-invocation: true` を許容（Skill ツール経由の invoke 自体が発生しないため、本節冒頭で述べたユーザー直叩き巻き添え遮断の問題は起きない） |
 
 **Skill Classification:**
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -301,7 +301,6 @@ name: <name>                        # ディレクトリ名と一致。起動は
 description: |
  狭く具体的な説明 + auto-activation 条件（汎用トリガ語を誘発語にしない）
 argument-hint: "<arg-hint>"         # 引数を取るスキルのみ（autocomplete 表示）
-# disable-model-invocation: true    # leaf user-only スキルのみ
 # user-invocable: false             # 純 sub-skill / knowledge のみ（メニュー非表示）
 ---
 
@@ -315,15 +314,14 @@ Skill documentation...
 | `name` | Yes | スキル識別子（= ディレクトリ名、`/rite:<name>` で起動） |
 | `description` | Yes | auto-activation 条件を含む狭い説明。汎用トリガ語（workflow / PR / review / commit / branch / next steps 等）を誘発語として書かない |
 | `argument-hint` | No | 引数を取るスキルの autocomplete 表示 |
-| `disable-model-invocation` | No | `true` = ユーザーのみ起動（leaf）。description をコンテキストから除外・auto 発火なし・**Skill ツール経由の programmatic 呼出も遮断** |
+| `disable-model-invocation` | **使用しない** | user-invocable スキルには使用しない方針。Claude Code CLI 側でユーザーが明示的にタイプしたスラッシュコマンドとモデル自身の Skill ツール呼び出しが同一経路を通り区別されない既知の挙動があり（[anthropics/claude-code#43660](https://github.com/anthropics/claude-code/issues/43660) 等）、`true` を付けるとユーザー直叩きも巻き添えで遮断されうる。auto-activate 抑止は narrow description のみで担保する |
 | `user-invocable` | No | `false` = メニュー非表示（純 sub-skill。orchestrator が Skill ツールで呼ぶ） |
 
 **frontmatter ポリシー（区分ごと）:**
 
 | 区分 | 例 | frontmatter |
 |------|----|-------------|
-| ユーザー起動 action（orchestrator からも到達） | open / iterate / ready / merge / cleanup / lint / wiki-ingest 等 | ナロー description のみ（`disable-model-invocation` は programmatic 呼出も遮断するため付けられない） |
-| leaf user-only（他スキルから呼ばれない） | issue-create / wiki-init / learn / skill-suggest 等 | `disable-model-invocation: true` |
+| user-invocable（`/rite:<name>` でユーザーが起動。orchestrator 到達の有無を問わない） | open / iterate / ready / merge / cleanup / lint / wiki-ingest / issue-create / wiki-init / learn / skill-suggest 等 | ナロー description のみ（`disable-model-invocation` は使用しない） |
 | 純 sub-skill（user は直接起動しない） | review / fix / pr-create / issue-implement | `user-invocable: false` |
 
 **Skill Classification:**

--- a/docs/skills-migration-v0.7-progress.md
+++ b/docs/skills-migration-v0.7-progress.md
@@ -228,6 +228,12 @@ go/no-go 判定後に**3スキルとも削除**する。`.spike-stop-marker.txt`
 - **orchestrator→sub-skill の呼び出し経路 = Skill ツール invoke**（sentinel+自然継続ではない）。spike #1 成功 + §B 遮断の両方が invoke 経路を裏付ける。→ §B frontmatter ポリシーを **lock**: orchestrator 到達スキルは `disable-model-invocation:true` 不可、narrow description で /goal 非干渉を担保。
 - **`CLAUDE_CODE_SESSION_ID` は skill Bash tool call で解決する**（`CLAUDE_SESSION_ID` 別名は不可）。継続 hook の session 照合・state 参照は `CLAUDE_CODE_SESSION_ID` を正とする。
 
+### Addendum: §B lock の前提の誤り（後日判明・spike 記録自体は保持）
+
+上記 §B lock は「spike-orch が自身の SKILL.md 本文の指示に従って Skill ツールを呼ぶ」経路のみを検証しており、「ユーザー自身が `/rite:xxx` と直接タイプした場合」は未検証だった。実際には Claude Code CLI 側で、ユーザーが明示的に入力したスラッシュコマンドとモデル自身が自律的に決定した Skill ツール呼び出しが**同一の Skill ツール経路**を通り、区別されない（upstream で複数回報告済みの既知の挙動: [anthropics/claude-code#43660](https://github.com/anthropics/claude-code/issues/43660) 等）。
+
+この見落としにより、「leaf スキル（他スキルから呼ばれない）なら `disable-model-invocation:true` は安全」という誤った結論のもと、issue-create 等 14 件の user-invocable leaf スキルに `disable-model-invocation: true` を付与していた。何らかの要因（画像添付等）でネイティブなスラッシュコマンド dispatch と認識されないケースでは、モデル側の Skill ツールフォールバックが発生し、`disable-model-invocation` ガードにユーザー起動そのものが阻まれるバグを生んでいた。是正内容は別途 Issue で対応し、frontmatter ポリシーを「`disable-model-invocation` は user-invocable スキルには使用しない」へ変更した。
+
 ### 残課題（任意の第2回スパイクで closeout・load-bearing は §D のみ）
 
 第1回は #2 の hook command path（`${CLAUDE_PLUGIN_ROOT}`）と #3 の injection 経路（`${CLAUDE_SKILL_DIR}`）を正しくテストしていない。両者は公式に「動く」とされるが skill 文脈の記述は最小限。**Read 参照ロードは相対リンクで確定済・Bash plugin file は既存機構で確定済**なので、唯一 load-bearing なのは **§D 継続 hook の path 解決**。第2回を実施する場合に備え spike-orch を下記へ修正済（round 2）:

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:getting-started で起動する。auto-activate しない。
   起動: /rite:getting-started
 argument-hint: ""
-disable-model-invocation: true
 ---
 
 # /rite:getting-started

--- a/plugins/rite/skills/investigate/SKILL.md
+++ b/plugins/rite/skills/investigate/SKILL.md
@@ -4,9 +4,9 @@ description: |
   コード構造を正確に調査し検証済みの結果を報告する (/rite:investigate)。grep で場所を特定 →
   Read で実コードを確認 → Codex(または代替検証)でクロスチェックする3段階検証により、推測による
   誤報告を防ぐ。関数呼び出し・ハッシュ・条件式・メソッドチェーン・クラス定義・設定値を網羅。
+  ユーザーが明示的に /rite:investigate で起動する。auto-activate しない。
   起動: /rite:investigate <調査対象の説明>
 argument-hint: "<調査対象の説明>"
-disable-model-invocation: true
 ---
 
 # /rite:investigate

--- a/plugins/rite/skills/issue-close/SKILL.md
+++ b/plugins/rite/skills/issue-close/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:issue-close で起動する。auto-activate しない。
   起動: /rite:issue-close <issue_number>
 argument-hint: "<issue_number>"
-disable-model-invocation: true
 ---
 
 # /rite:issue-close

--- a/plugins/rite/skills/issue-create/SKILL.md
+++ b/plugins/rite/skills/issue-create/SKILL.md
@@ -6,7 +6,6 @@ description: |
   ユーザーが明示的に /rite:issue-create で起動する。auto-activate しない。
   起動: /rite:issue-create <title or description>
 argument-hint: "<title or description>"
-disable-model-invocation: true
 ---
 
 # /rite:issue-create

--- a/plugins/rite/skills/issue-edit/SKILL.md
+++ b/plugins/rite/skills/issue-edit/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:issue-edit で起動する。auto-activate しない。
   起動: /rite:issue-edit <issue_number>
 argument-hint: "<issue_number>"
-disable-model-invocation: true
 ---
 
 # /rite:issue-edit

--- a/plugins/rite/skills/issue-update/SKILL.md
+++ b/plugins/rite/skills/issue-update/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:issue-update で起動する。auto-activate しない。
   起動: /rite:issue-update
 argument-hint: ""
-disable-model-invocation: true
 ---
 
 # /rite:issue-update

--- a/plugins/rite/skills/learn/SKILL.md
+++ b/plugins/rite/skills/learn/SKILL.md
@@ -6,7 +6,6 @@ description: |
   ユーザーが明示的に /rite:learn で起動する。auto-activate しない。
   起動: /rite:learn [issue_or_pr]
 argument-hint: "[issue_or_pr]"
-disable-model-invocation: true
 ---
 
 # /rite:learn

--- a/plugins/rite/skills/resume/SKILL.md
+++ b/plugins/rite/skills/resume/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:resume で起動する。auto-activate しない。
   起動: /rite:resume
 argument-hint: ""
-disable-model-invocation: true
 ---
 
 # /rite:resume

--- a/plugins/rite/skills/run/SKILL.md
+++ b/plugins/rite/skills/run/SKILL.md
@@ -6,7 +6,6 @@ description: |
   ユーザーが明示的に /rite:run で起動する meta-orchestrator。auto-activate しない。
   起動: /rite:run [--merge] <issue_number>...
 argument-hint: "[--merge] <issue_number>..."
-disable-model-invocation: true
 ---
 
 # /rite:run

--- a/plugins/rite/skills/skill-suggest/SKILL.md
+++ b/plugins/rite/skills/skill-suggest/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ユーザーが明示的に /rite:skill-suggest で起動する。auto-activate しない。
   起動: /rite:skill-suggest
 argument-hint: ""
-disable-model-invocation: true
 ---
 
 # /rite:skill-suggest

--- a/plugins/rite/skills/template-reset/SKILL.md
+++ b/plugins/rite/skills/template-reset/SKILL.md
@@ -5,7 +5,6 @@ description: |
   再生成する。ユーザーが明示的に /rite:template-reset で起動する。auto-activate しない。
   起動: /rite:template-reset [target]
 argument-hint: "[target]"
-disable-model-invocation: true
 ---
 
 # /rite:template-reset

--- a/plugins/rite/skills/wiki-init/SKILL.md
+++ b/plugins/rite/skills/wiki-init/SKILL.md
@@ -5,7 +5,6 @@ description: |
   ブランチ作成を行う。ユーザーが明示的に /rite:wiki-init で起動する。auto-activate しない。
   起動: /rite:wiki-init
 argument-hint: ""
-disable-model-invocation: true
 ---
 
 # /rite:wiki-init

--- a/plugins/rite/skills/wiki-query/SKILL.md
+++ b/plugins/rite/skills/wiki-query/SKILL.md
@@ -6,7 +6,6 @@ description: |
   auto-activate しない。
   起動: /rite:wiki-query <keywords>
 argument-hint: "<keywords>"
-disable-model-invocation: true
 ---
 
 # /rite:wiki-query

--- a/plugins/rite/skills/workflow/SKILL.md
+++ b/plugins/rite/skills/workflow/SKILL.md
@@ -3,8 +3,8 @@ name: workflow
 description: |
   rite ワークフロー全体のガイド (/rite:workflow) を表示する。現在の状態 (初期化状況・
   ブランチ・作業中 Issue) を検出し、ワークフロー全体図・コマンド一覧・次のステップを案内する。
+  ユーザーが明示的に /rite:workflow で起動する。auto-activate しない。
   起動: /rite:workflow
-disable-model-invocation: true
 ---
 
 # /rite:workflow


### PR DESCRIPTION
## Summary

`disable-model-invocation: true` が設定されている rite の user-invocable な leaf スキル 14 件で、ユーザーが直接 `/rite:xxx` スラッシュコマンドを叩いても正常に起動できるようにする。

Claude Code CLI 側で、ユーザーが明示的に入力したスラッシュコマンドとモデル自身の Skill ツール呼び出しが同一の Skill ツール経路を通り区別されない既知の挙動があり（[anthropics/claude-code#43660](https://github.com/anthropics/claude-code/issues/43660) 等）、`disable-model-invocation: true` を付与した user-invocable leaf スキルでは、何らかの要因（画像添付等）でネイティブなスラッシュコマンド dispatch と認識されない場合、モデル側の Skill ツールフォールバックがそのまま同フラグに阻まれ、ユーザー自身の直接起動が失敗する不具合があった。

## Related Issue

Closes #1693

## Changes

- 対象 14 スキル（issue-create / issue-update / issue-close / issue-edit / wiki-init / wiki-query / learn / skill-suggest / template-reset / getting-started / workflow / investigate / resume / run）の `SKILL.md` frontmatter から `disable-model-invocation: true` を削除
- `workflow` / `investigate` の `description` に不足していた非 auto-activate 文言（「ユーザーが明示的に `/rite:xxx` で起動する。auto-activate しない。」）を補強
- `docs/SPEC.md` の frontmatter ポリシー表・`disable-model-invocation` の説明文を「user-invocable スキルには使用しない」方針へ是正
- `docs/skills-migration-v0.7-progress.md` の §B lock 記録に、前提の誤りを説明する addendum を追記（既存の spike 記録は保持）
- `reviewers/SKILL.md`（non-user-invocable）および orchestrator 到達スキル（open/iterate/ready/merge/cleanup/lint/wiki-ingest/pr-create/issue-implement/review/fix）は無変更

## Known Issues

- lint コマンド未検出（`commands.lint: null`）のためプラグイン固有チェックのみ実施。全チェックは warning のみで、いずれも今回の変更と無関係の既存の技術的負債（drift check / comment-journal / backlink-format / comment-line-ref / wiki-growth / number-reference の各チェックで pre-existing findings を検出したが、本 PR のスコープ外のため対応しない）
- Issue #1693 の Definition of Done のうち、AC-1・AC-6・AC-7（および対応する T-05〜T-07）は fresh セッションでの手動確認が必要なため未検証。マージ後、fresh セッションで下記の回帰確認を推奨:
  - 対象スキル名を含まない一般的な依頼文で `issue-create` / `run` が誤って auto-invoke されないこと（AC-6）
  - 画像添付なしの通常テキストで `/rite:issue-create` / `/rite:run` が正常に起動すること（AC-7、非回帰）
  - 可能であれば画像添付ありのメッセージでの再現テスト（AC-1、upstream 側の再現条件が sporadic なため best-effort）

## Checklist

- [x] Code follows project conventions
- [x] No regression in existing functionality（diff は対象 14 ファイルの該当行削除のみ。reviewers・orchestrator 到達スキルは無変更）
- [ ] Documentation updated（SPEC.md・progress log は更新済み。AC-1/6/7 の fresh セッション確認は未実施）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
