### PR TITLE
fix(skills): ユーザー導線ガイドを v0.7 正典フローへ追随

### DIFF
--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -219,7 +219,7 @@ Wiki status line before exiting.
 Check if `rite-config.yml` exists:
 
 ```bash
-ls rite-config.yml 2>/dev/null || ls .claude/rite:config.yml 2>/dev/null
+ls rite-config.yml 2>/dev/null || ls .claude/rite-config.yml 2>/dev/null
 ```
 
 **If it exists:**
@@ -264,7 +264,8 @@ Option B: Create a new Issue
   1. Create an Issue with a description:
      /rite:issue-create Add user authentication
 
-  2. rite will automatically create the Issue and start working on it
+  2. Then start working on the created Issue:
+     /rite:open <issue number from step 1>
 
 What happens when you start an Issue:
   ✓ Creates a feature branch (e.g., feat/issue-42-description)
@@ -280,27 +281,24 @@ What happens when you start an Issue:
 │              Step 3: Complete and Submit                    │
 └─────────────────────────────────────────────────────────────┘
 
-After implementing your changes:
+/rite:open runs quality checks (/rite:lint) and creates a draft PR for you.
+After the draft PR is created:
 
-1. Run quality checks:
-   /rite:lint
+1. Run the review/fix loop until the PR is mergeable:
+   /rite:iterate <PR>
+   (Multi-reviewer analysis — code quality, security, tests, etc. —
+    with fixes applied automatically in a review ⇄ fix loop)
 
-2. Create a draft PR:
-   /rite:pr-create
-
-3. Review your changes:
-   /rite:review
-   (Multi-reviewer analysis: code quality, security, tests, etc.)
-
-4. If issues are found, fix them:
-   /rite:fix
-   (Then run /rite:review again)
-
-5. When ready for team review:
-   /rite:ready
+2. When ready for team review:
+   /rite:ready <PR>
    (Marks PR as "Ready for review")
 
-6. After PR is merged, the Issue is automatically closed
+3. Merge the PR:
+   /rite:merge <PR>
+
+4. Clean up after the merge:
+   /rite:cleanup <PR>
+   (Deletes the branch, closes the Issue, updates Projects status)
 ```
 
 > **Test-Driven Development (Canon TDD) is on by default.** During implementation
@@ -446,7 +444,7 @@ Now that you understand the basics:
 🚀 Try these workflows:
   - Start with a simple Issue to practice the flow
   - Use /rite:issue-update during work to save progress
-  - Experiment with /rite:review to see multi-reviewer analysis
+  - Experiment with /rite:iterate to see multi-reviewer analysis
 
 💡 Tips:
   - Work memory is automatically saved and restored
@@ -456,7 +454,7 @@ Now that you understand the basics:
 🔧 Advanced features:
   - Iteration tracking: enable `iteration` in rite-config.yml (auto-assign on /rite:open, --sprint / --backlog filters in /rite:issue-list)
   - Template customization: Edit template files in the plugin's templates/ directory
-  - Multi-agent PR reviews: Automatic in /rite:review
+  - Multi-agent PR reviews: Automatic in /rite:iterate
 
 Ready to start? Try:
   /rite:issue-list    (to view existing Issues)

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -297,7 +297,7 @@ After the draft PR is created:
    /rite:merge <PR>
 
 4. Clean up after the merge:
-   /rite:cleanup <PR>
+   /rite:cleanup
    (Deletes the branch, closes the Issue, updates Projects status)
 ```
 

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -271,7 +271,7 @@ What happens when you start an Issue:
   ✓ Creates a feature branch (e.g., feat/issue-42-description)
   ✓ Updates Issue status to "In Progress" (if Projects is configured)
   ✓ Initializes work memory for context tracking
-  ✓ Provides guidance for implementation
+  ✓ Implements changes, runs quality checks (/rite:lint), and opens a draft PR
 ```
 
 ### 3.4 Step 3: Complete and Submit

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -128,7 +128,7 @@ Stop here if not a valid repository.
 Quick Start (3 steps):
   1. Setup (one-time):   /rite:init
   2. Start an Issue:     /rite:issue-create → /rite:open <番号>
-  3. Complete & submit:  /rite:iterate <PR> → /rite:ready <PR> → /rite:merge <PR> → /rite:cleanup <PR>
+  3. Complete & submit:  /rite:iterate <pr> → /rite:ready <pr> → /rite:merge <pr> → /rite:cleanup
 
 詳細なフロー図とコマンド一覧は /rite:workflow で表示できます。
 ```
@@ -285,16 +285,16 @@ What happens when you start an Issue:
 After the draft PR is created:
 
 1. Run the review/fix loop until the PR is mergeable:
-   /rite:iterate <PR>
+   /rite:iterate <pr>
    (Multi-reviewer analysis — code quality, security, tests, etc. —
     with fixes applied automatically in a review ⇄ fix loop)
 
 2. When ready for team review:
-   /rite:ready <PR>
+   /rite:ready <pr>
    (Marks PR as "Ready for review")
 
 3. Merge the PR:
-   /rite:merge <PR>
+   /rite:merge <pr>
 
 4. Clean up after the merge:
    /rite:cleanup

--- a/plugins/rite/skills/workflow/SKILL.md
+++ b/plugins/rite/skills/workflow/SKILL.md
@@ -22,7 +22,7 @@ When this command is executed, run the following phases in order.
 Check whether `rite-config.yml` exists in the project root:
 
 ```bash
-ls rite-config.yml 2>/dev/null || ls .claude/rite:config.yml 2>/dev/null
+ls rite-config.yml 2>/dev/null || ls .claude/rite-config.yml 2>/dev/null
 ```
 
 **If it does not exist:**
@@ -68,40 +68,26 @@ Display the following diagram:
   /rite:issue-create (新規 Issue 作成)
         │                              Status: Todo
         ▼
-  /rite:open <番号> (ブランチ作成)
+  /rite:open <番号> (実装 → draft PR)
         │                              Status: In Progress
+        │  内部: ブランチ作成 → 実装計画 → 実装
+        │        → /rite:lint → draft PR 作成
+        │  （作業メモリ更新は /rite:issue-update）
         ▼
-  ┌─────────────────────┐
-  │     実装作業        │
-  │  └─ /rite:issue-update │ (作業メモリ更新)
-  └─────────────────────┘
+  /rite:iterate <PR> (レビュー/修正ループ)
+        │  内部: /rite:review ⇄ /rite:fix を
+        │        mergeable になるまで自律実行
+        ▼
+  /rite:ready <PR> (レビュー待ちに変更)
+        │                              Status: In Review
+        ▼
+  /rite:merge <PR> (squash マージ)
         │
         ▼
-  /rite:lint (品質チェック)
-        │
+  /rite:cleanup <PR> (後片付け)
+        │  ブランチ削除・Issue クローズ・Wiki 統合
         ▼
-  /rite:pr-create (ドラフト PR 作成)
-        │
-        ▼
-  /rite:review (セルフレビュー)
-        │
-        ▼
-  ┌───指摘あり？──┐
-  │               │
-  YES             NO
-  │               │
-  ▼               │
-  /rite:fix     │
-  (指摘対応)      │
-  │               │
-  └─→ /rite:review  │
-     (再レビュー)    │
-     └─→ (ループ)    │
-                     ▼
-              /rite:ready (レビュー待ちに変更)
-                     │                              Status: In Review
-                     ▼
-              PR マージ → Issue 自動クローズ       Status: Done
+  完了                                 Status: Done
 
 ┌─────────────────────────────────────────────────────────────┐
 │  Status 遷移: Todo → In Progress → In Review → Done         │
@@ -126,14 +112,16 @@ Display the following list:
 【Issue 管理】
   /rite:issue-list      Issue 一覧を表示
   /rite:issue-create    新規 Issue を作成
-  /rite:open     Issue の作業を開始（ブランチ作成）
+  /rite:open            Issue の作業を開始（実装 → draft PR）
   /rite:issue-update    作業メモリを更新
   /rite:issue-close     Issue の完了状態を確認
 
 【PR 管理】
-  /rite:pr-create       ドラフト PR を作成
-  /rite:ready        Ready for review に変更
-  /rite:review       マルチレビュアーレビュー
+  /rite:iterate         レビュー/修正ループ（review ⇄ fix を自律実行）
+  /rite:ready           Ready for review に変更
+  /rite:merge           PR を squash マージ
+  /rite:cleanup         マージ後クリーンアップ（ブランチ削除・Issue クローズ）
+  /rite:pr-create       ドラフト PR を作成（Issue なしの単発 PR 用）
 
 【ユーティリティ】
   /rite:lint            品質チェックを実行
@@ -163,10 +151,10 @@ Based on the state confirmed in Phase 1, suggest the next action.
   作業中の Issue: #{issue-number}
 
   【次のステップ】
-  1. 実装を続ける
+  1. 実装を続ける（/rite:open が lint → draft PR 作成まで実行します）
   2. /rite:issue-update で作業メモリを更新
-  3. 完了したら /rite:lint で品質チェック
-  4. /rite:pr-create でドラフト PR を作成
+  3. draft PR 作成後は /rite:iterate <PR> でレビュー/修正ループ
+  4. /rite:ready <PR> → /rite:merge <PR> → /rite:cleanup <PR> で完了
 ```
 
 > **multi-session 時の注意**: `multi_session.enabled: true` の場合、この作業は

--- a/plugins/rite/skills/workflow/SKILL.md
+++ b/plugins/rite/skills/workflow/SKILL.md
@@ -74,14 +74,14 @@ Display the following diagram:
         │        → /rite:lint → draft PR 作成
         │  （作業メモリ更新は /rite:issue-update）
         ▼
-  /rite:iterate <PR> (レビュー/修正ループ)
+  /rite:iterate <pr> (レビュー/修正ループ)
         │  内部: /rite:review ⇄ /rite:fix を
         │        mergeable になるまで自律実行
         ▼
-  /rite:ready <PR> (レビュー待ちに変更)
+  /rite:ready <pr> (レビュー待ちに変更)
         │                              Status: In Review
         ▼
-  /rite:merge <PR> (squash マージ)
+  /rite:merge <pr> (squash マージ)
         │
         ▼
   /rite:cleanup (後片付け)
@@ -153,8 +153,8 @@ Based on the state confirmed in Phase 1, suggest the next action.
   【次のステップ】
   1. 実装を続ける（/rite:open が lint → draft PR 作成まで実行します）
   2. /rite:issue-update で作業メモリを更新
-  3. draft PR 作成後は /rite:iterate <PR> でレビュー/修正ループ
-  4. /rite:ready <PR> → /rite:merge <PR> → /rite:cleanup で完了
+  3. draft PR 作成後は /rite:iterate <pr> でレビュー/修正ループ
+  4. /rite:ready <pr> → /rite:merge <pr> → /rite:cleanup で完了
 ```
 
 > **multi-session 時の注意**: `multi_session.enabled: true` の場合、この作業は

--- a/plugins/rite/skills/workflow/SKILL.md
+++ b/plugins/rite/skills/workflow/SKILL.md
@@ -84,7 +84,7 @@ Display the following diagram:
   /rite:merge <PR> (squash マージ)
         │
         ▼
-  /rite:cleanup <PR> (後片付け)
+  /rite:cleanup (後片付け)
         │  ブランチ削除・Issue クローズ・Wiki 統合
         ▼
   完了                                 Status: Done
@@ -154,7 +154,7 @@ Based on the state confirmed in Phase 1, suggest the next action.
   1. 実装を続ける（/rite:open が lint → draft PR 作成まで実行します）
   2. /rite:issue-update で作業メモリを更新
   3. draft PR 作成後は /rite:iterate <PR> でレビュー/修正ループ
-  4. /rite:ready <PR> → /rite:merge <PR> → /rite:cleanup <PR> で完了
+  4. /rite:ready <PR> → /rite:merge <PR> → /rite:cleanup で完了
 ```
 
 > **multi-session 時の注意**: `multi_session.enabled: true` の場合、この作業は


### PR DESCRIPTION
## Summary

ユーザー導線ドキュメント（`/rite:workflow` ガイド・`/rite:getting-started`）を v0.7 の正典フロー（open → iterate → ready → merge → cleanup）へ追随させ、初期化判定 fallback のコロン誤記パス `.claude/rite:config.yml` を修正する。

v0.7 のコマンド分割時にユーザー向け案内スキル 2 つの更新が漏れ、オンボーディング導線の最後（getting-started → workflow ガイド）で旧フラットフロー（pr-create → review → fix → ready）が案内されていた。コロン誤記は `.claude/` 配下に config を置くプロジェクトで初期化判定 fallback を永久に外す実害がある。

## Related Issue

Closes #1720

## Changes

- `plugins/rite/skills/workflow/SKILL.md`
  - Phase 1.1 の fallback パスを `.claude/rite-config.yml` に修正
  - Phase 2 フロー図を正典フロー（open → iterate → ready → merge → cleanup）へ更新
  - Phase 3 コマンド一覧へ iterate / merge / cleanup を追加、open の説明を「実装 → draft PR」へ更新、pr-create を単発 PR 用と明記
  - Phase 4.1 次ステップを新フローへ更新
- `plugins/rite/skills/getting-started/SKILL.md`
  - Phase 3.2 の fallback パス誤記を修正
  - Phase 3.3 Option B を実挙動（Issue 作成のみ、着手は `/rite:open`）に修正
  - Phase 3.4 を新フロー（iterate → ready → merge → cleanup）へ書き換え、Phase 3.1 Quick Start と整合
  - Phase 5 の `/rite:review` 直接起動を促す記述 2 箇所を `/rite:iterate` に修正

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — commands.test 未設定のため対象外。AC-1〜AC-4 は grep / 一時環境での fallback 動作テストで検証済み
- [x] Documentation updated (if applicable) — 本 PR 自体がドキュメント修正

## Known Issues

- `/rite:lint` の plugin checks で既存 warning 77 件（drift 1 / wiki-growth 1 / comment-journal 30 / comment-line-ref 16 / number-ref 29）を検出。いずれも本 PR の変更ファイル外の既存負債であり、リポジトリ改善 Issue 群（#1701〜#1720）の枠で別途対応する。

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
