### PR TITLE
chore(wiki): 過去 skip raw 231 件の frontmatter に ingest_status: skipped を back-fill

### DIFF
--- a/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
+++ b/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# wiki-backfill-skipped-frontmatter.sh
+#
+# One-time, idempotent back-fill of the `ingest_status: skipped` /
+# `skip_reason:` frontmatter onto historically-skipped raw sources
+# (Issue #1730).
+#
+# Background:
+#   Issue #1520 (Sub-3, PR #1540) moved the `ingest:skip` Source of Truth from
+#   `.rite/wiki/log.md` (a table) to each raw source's frontmatter
+#   (`ingest_status: skipped` + `skip_reason`). That PR only wired the
+#   *going-forward* mechanism — it did NOT back-fill the raw sources that had
+#   already been skipped before the migration. As a result, 231 raws remained in
+#   the state "`ingested: true`, not registered in any page's `sources.ref`, and
+#   without the skip frontmatter marker". `wiki-lint-skipped-refs.sh` scans
+#   frontmatter only, so those raws fell out of the skipped set and risked being
+#   miscounted as `missing_concept` (blocking) instead of `unregistered_raw`
+#   (informational) in wiki/lint.md ステップ 6.2.
+#
+#   log.md retains the human-facing `ingest:skip` change-log entries, so it is
+#   the authoritative source for each historically-skipped raw's `skip_reason`.
+#   This script reconciles that history back onto the entities.
+#
+# What it does (idempotent — safe to re-run):
+#   For each raw source under `.rite/wiki/raw/**/*.md` that is
+#     (1) `ingested: true`,
+#     (2) NOT already carrying an `ingest_status:` frontmatter key,
+#     (3) NOT registered in any page's `sources[].ref` (the "S" set — a
+#         page-contributing raw is genuinely NOT skipped, so it must be left
+#         untouched), and
+#     (4) recorded as `ingest:skip` in log.md (yielding a reason),
+#   insert `ingest_status: skipped` + `skip_reason: "<reason>"` immediately after
+#   the `ingested: true` line, matching the frontmatter shape ingest.md writes for
+#   new skips. A raw satisfying (1)-(3) but NOT (4) is reported (no reason to
+#   fabricate) and left untouched.
+#
+# The `skip_reason` value is emitted via `python3 json.dumps(..., ensure_ascii=
+# False)`. A JSON string literal is a valid YAML double-quoted scalar, so this is
+# a bullet-proof encoder for arbitrary reason prose (embedded `"`, `\`, `#`, `:`,
+# backticks) and matches the double-quoted style ingest.md already writes.
+#
+# Branch strategy:
+#   separate_branch — edits files in the `.rite/wiki-worktree` worktree (checked
+#                     out to `wiki.branch_name`); this script ensures the worktree
+#                     via wiki-worktree-setup.sh. Commit + push is left to
+#                     wiki-worktree-commit.sh (the caller runs it after this).
+#   same_branch     — edits `.rite/wiki/raw/**` in the current tree.
+#
+# This script performs frontmatter edits ONLY; it never commits. Pair with
+# `wiki-worktree-commit.sh` (separate_branch) or a normal commit (same_branch).
+#
+# Usage:
+#   bash wiki-backfill-skipped-frontmatter.sh [--dry-run] [--repo-root DIR]
+#
+# Options:
+#   --dry-run          Report what would change; write nothing. Exits 0.
+#   --repo-root DIR    Repository root (default: shared state root via
+#                      state-path-resolve.sh, falling back to git rev-parse).
+#   -h, --help         Show this help.
+#
+# Output (stdout): one structured summary line
+#   [wiki-backfill] backfilled=<N>; skipped_existing=<N>; page_registered=<N>; \
+#     no_reason=<N>; total_ingested=<N>; branch_strategy=<s>[; dry_run=1]
+#
+# Exit codes:
+#   0  Normal (including dry-run and "nothing to back-fill")
+#   1  Environment / config error (not a git repo, wiki disabled, wiki dir
+#      missing, python3 unavailable)
+#   2  Invocation error (unknown argument, repo-root cd failure)
+
+set -uo pipefail
+
+_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../control-char-neutralize.sh
+source "$_SCRIPT_DIR/../control-char-neutralize.sh"
+# shellcheck source=lib/wiki-config.sh
+source "$_SCRIPT_DIR/lib/wiki-config.sh"
+
+DRY_RUN=0
+REPO_ROOT=""
+
+usage() {
+  sed -n '2,70p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --repo-root) REPO_ROOT="${2:-}"; shift; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: not inside a git repository" >&2
+  exit 1
+fi
+
+# Resolve to the SHARED state root (main checkout) so `.rite/wiki-worktree`
+# resolves identically from a linked worktree session (mirrors
+# wiki-worktree-setup.sh). state-path-resolve.sh returns `git rev-parse
+# --show-toplevel` verbatim outside multi-session use.
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$("$_SCRIPT_DIR/../state-path-resolve.sh" 2>/dev/null)" || REPO_ROOT=""
+  [ -n "$REPO_ROOT" ] || REPO_ROOT="$(git rev-parse --show-toplevel)"
+fi
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root '$REPO_ROOT'" >&2; exit 2; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required (used to YAML-safe-encode skip_reason)" >&2
+  exit 1
+fi
+
+# ---- Wiki config -----------------------------------------------------------
+if [ ! -f rite-config.yml ]; then
+  echo "ERROR: rite-config.yml not found at repo root '$REPO_ROOT'" >&2
+  exit 1
+fi
+wiki_enabled=$(parse_wiki_scalar enabled)
+case "$wiki_enabled" in
+  true|yes|1) ;;
+  *) echo "[wiki-backfill] skipped: wiki feature disabled (wiki.enabled=$wiki_enabled)" >&2; exit 1 ;;
+esac
+branch_strategy=$(parse_wiki_scalar branch_strategy)
+[ -n "$branch_strategy" ] || branch_strategy="separate_branch"
+
+# ---- Resolve the wiki working directory (holds raw/, pages/, log.md) --------
+case "$branch_strategy" in
+  same_branch)
+    WIKI_DIR="$REPO_ROOT/.rite/wiki"
+    ;;
+  separate_branch)
+    wiki_branch=$(parse_wiki_scalar branch_name)
+    [ -n "$wiki_branch" ] || wiki_branch="wiki"
+    validate_wiki_branch_name "$wiki_branch" || exit 1
+    WIKI_DIR="$REPO_ROOT/.rite/wiki-worktree/.rite/wiki"
+    if [ ! -d "$WIKI_DIR" ]; then
+      # Ensure the worktree exists (idempotent). Non-fatal warnings tolerated.
+      bash "$_SCRIPT_DIR/wiki-worktree-setup.sh" >/dev/null 2>&1 || true
+    fi
+    ;;
+  *)
+    echo "ERROR: unknown wiki.branch_strategy '$branch_strategy' (expected separate_branch|same_branch)" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -d "$WIKI_DIR/raw" ]; then
+  echo "ERROR: wiki raw directory not found: $WIKI_DIR/raw" >&2
+  [ "$branch_strategy" = "separate_branch" ] && \
+    echo "  対処: bash $_SCRIPT_DIR/wiki-worktree-setup.sh で wiki worktree を用意してください" >&2
+  exit 1
+fi
+LOG_MD="$WIKI_DIR/log.md"
+if [ ! -f "$LOG_MD" ]; then
+  echo "ERROR: wiki log.md not found: $LOG_MD (skip_reason の一次情報源)" >&2
+  exit 1
+fi
+
+# ---- Build S: the set of raws registered in some page's sources[].ref -------
+# Match `ref: "raw/..."` (quoted) and `ref: raw/...` (bare). Keys are the
+# `raw/{type}/{filename}` refs; a raw in S is page-contributing => NOT skipped.
+declare -A IN_PAGES=()
+if [ -d "$WIKI_DIR/pages" ]; then
+  while IFS= read -r ref; do
+    [ -n "$ref" ] && IN_PAGES["$ref"]=1
+  done < <(
+    LC_ALL=C grep -rhoE 'ref:[[:space:]]*"?raw/[^"[:space:]]+' "$WIKI_DIR/pages" 2>/dev/null \
+      | sed -E 's/^ref:[[:space:]]*"?//'
+  )
+fi
+
+# ---- extract_skip_reason REF: emit the log.md `ingest:skip` reason for REF ---
+# log.md is a markdown table: | 日時 | アクション | 対象 | 詳細 |. The 詳細 (reason)
+# cell can itself contain markdown-escaped pipes (`\|`), so reason = fields
+# 5..NF-1 rejoined with `|`, then unescape `\|` -> `|`. Emits the first match.
+extract_skip_reason() {
+  local ref="$1"
+  awk -F'|' -v tgt="$ref" '
+    /ingest:skip/ {
+      a=$3; gsub(/^[ \t]+|[ \t]+$/, "", a)
+      t=$4; gsub(/^[ \t]+|[ \t]+$/, "", t)
+      if (a == "ingest:skip" && t == tgt) {
+        r=$5
+        for (i=6; i<NF; i++) r = r "|" $i
+        gsub(/^[ \t]+|[ \t]+$/, "", r)
+        gsub(/\\\|/, "|", r)
+        print r
+        exit
+      }
+    }
+  ' "$LOG_MD"
+}
+
+# ---- yaml_encode: STDIN reason text -> valid YAML double-quoted scalar -------
+# A JSON string literal is a valid YAML flow scalar; json.dumps handles all
+# escaping (`"`, `\`, control chars) and preserves non-ASCII verbatim.
+yaml_encode() {
+  python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read(), ensure_ascii=False))'
+}
+
+backfilled=0
+skipped_existing=0
+page_registered=0
+no_reason=0
+total_ingested=0
+
+# Iterate raws deterministically (sort) so dry-run / real runs align.
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  rel="raw/${file#"$WIKI_DIR"/raw/}"   # -> raw/{type}/{filename}
+
+  # Frontmatter must lead the file (line 1 == '---'). Read it once.
+  fm=$(awk 'NR==1 && /^---[[:space:]]*$/ {infm=1; next}
+            infm && /^---[[:space:]]*$/ {exit}
+            infm {print}' "$file")
+  # (1) ingested: true
+  printf '%s\n' "$fm" | grep -qE '^ingested:[[:space:]]*true[[:space:]]*$' || continue
+  total_ingested=$((total_ingested+1))
+  # (2) idempotency: already carries an ingest_status key -> leave as-is
+  if printf '%s\n' "$fm" | grep -qE '^ingest_status:[[:space:]]*'; then
+    skipped_existing=$((skipped_existing+1))
+    continue
+  fi
+  # (3) page-registered raws are genuinely not skipped -> leave untouched
+  if [ -n "${IN_PAGES[$rel]:-}" ]; then
+    page_registered=$((page_registered+1))
+    continue
+  fi
+  # (4) reason from log.md
+  reason=$(extract_skip_reason "$rel")
+  if [ -z "$reason" ]; then
+    no_reason=$((no_reason+1))
+    echo "WARNING: no ingest:skip entry in log.md for $rel — left untouched (reason は捏造しない)" >&2
+    continue
+  fi
+
+  reason_json=$(printf '%s' "$reason" | yaml_encode)
+  if [ -z "$reason_json" ]; then
+    no_reason=$((no_reason+1))
+    echo "WARNING: skip_reason の YAML エンコードに失敗しました: $rel — left untouched" >&2
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    backfilled=$((backfilled+1))
+    echo "[dry-run] would back-fill: $rel"
+    continue
+  fi
+
+  # Insert `ingest_status: skipped` + `skip_reason: <json>` after the
+  # `ingested: true` line, inside the frontmatter only (first occurrence).
+  # ENVIRON is used for the reason line so awk does NOT re-process its
+  # backslashes (awk -v would mangle the JSON escapes).
+  RITE_BF_REASON_LINE="skip_reason: $reason_json" \
+  awk '
+    BEGIN { infm=0; done=0 }
+    NR==1 && /^---[[:space:]]*$/ { infm=1; print; next }
+    infm && !done && /^---[[:space:]]*$/ { infm=0; print; next }
+    infm && !done && /^ingested:[[:space:]]*true[[:space:]]*$/ {
+      print
+      print "ingest_status: skipped"
+      print ENVIRON["RITE_BF_REASON_LINE"]
+      done=1
+      next
+    }
+    { print }
+  ' "$file" > "$file.bf.tmp" && mv "$file.bf.tmp" "$file" || {
+    rm -f "$file.bf.tmp"
+    echo "ERROR: frontmatter 書込に失敗しました: $rel" >&2
+    continue
+  }
+  backfilled=$((backfilled+1))
+done < <(LC_ALL=C find "$WIKI_DIR/raw" -type f -name '*.md' 2>/dev/null | LC_ALL=C sort)
+
+summary="[wiki-backfill] backfilled=$backfilled; skipped_existing=$skipped_existing; page_registered=$page_registered; no_reason=$no_reason; total_ingested=$total_ingested; branch_strategy=$branch_strategy"
+[ "$DRY_RUN" -eq 1 ] && summary="$summary; dry_run=1"
+echo "$summary"
+exit 0

--- a/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
+++ b/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
@@ -60,7 +60,11 @@
 #
 # Output (stdout): one structured summary line
 #   [wiki-backfill] backfilled=<N>; skipped_existing=<N>; page_registered=<N>; \
-#     no_reason=<N>; total_ingested=<N>; branch_strategy=<s>[; dry_run=1]
+#     no_reason=<N>; encode_failed=<N>; write_failed=<N>; total_ingested=<N>; \
+#     branch_strategy=<s>[; dry_run=1]
+#   The six per-raw counters partition total_ingested exactly, so a non-zero
+#   encode_failed / write_failed signals a partial run even though the exit code
+#   stays 0 (edits are per-file resilient).
 #
 # Exit codes:
 #   0  Normal (including dry-run and "nothing to back-fill")
@@ -78,15 +82,21 @@ source "$_SCRIPT_DIR/lib/wiki-config.sh"
 
 DRY_RUN=0
 REPO_ROOT=""
+REPO_ROOT_EXPLICIT=0
 
 usage() {
-  sed -n '2,70p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the header comment block (everything after the shebang up to the first
+  # non-comment line), stripping the leading "# ". Line-number-independent so the
+  # help text stays correct when the header grows/shrinks.
+  awk 'NR==1 { next }
+       /^#/ { sub(/^# ?/, ""); print; next }
+       { exit }' "${BASH_SOURCE[0]}"
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
-    --repo-root) REPO_ROOT="${2:-}"; shift; shift ;;
+    --repo-root) REPO_ROOT="${2:-}"; REPO_ROOT_EXPLICIT=1; shift; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -117,7 +127,7 @@ if [ ! -f rite-config.yml ]; then
   echo "ERROR: rite-config.yml not found at repo root '$REPO_ROOT'" >&2
   exit 1
 fi
-wiki_enabled=$(parse_wiki_scalar enabled)
+wiki_enabled=$(parse_wiki_scalar enabled | tr '[:upper:]' '[:lower:]')
 case "$wiki_enabled" in
   true|yes|1) ;;
   *) echo "[wiki-backfill] skipped: wiki feature disabled (wiki.enabled=$wiki_enabled)" >&2; exit 1 ;;
@@ -128,16 +138,31 @@ branch_strategy=$(parse_wiki_scalar branch_strategy)
 # ---- Resolve the wiki working directory (holds raw/, pages/, log.md) --------
 case "$branch_strategy" in
   same_branch)
-    WIKI_DIR="$REPO_ROOT/.rite/wiki"
+    # same_branch keeps the wiki in the CURRENT tree (the checked-out branch).
+    # From a linked worktree session the current tree is the session worktree, NOT
+    # the shared state root — so resolve it from `git rev-parse --show-toplevel`
+    # unless the caller pinned it with --repo-root.
+    if [ "$REPO_ROOT_EXPLICIT" -eq 1 ]; then
+      WIKI_DIR="$REPO_ROOT/.rite/wiki"
+    else
+      current_tree="$(git rev-parse --show-toplevel 2>/dev/null)" || current_tree="$REPO_ROOT"
+      WIKI_DIR="$current_tree/.rite/wiki"
+    fi
     ;;
   separate_branch)
     wiki_branch=$(parse_wiki_scalar branch_name)
     [ -n "$wiki_branch" ] || wiki_branch="wiki"
+    # Defense-in-depth early validation. The branch name is not otherwise consumed
+    # here (WIKI_DIR is a fixed path and worktree creation is delegated to
+    # wiki-worktree-setup.sh); validating up front fails fast on a malformed config.
     validate_wiki_branch_name "$wiki_branch" || exit 1
+    # separate_branch's worktree lives at the shared state root (main checkout).
     WIKI_DIR="$REPO_ROOT/.rite/wiki-worktree/.rite/wiki"
     if [ ! -d "$WIKI_DIR" ]; then
-      # Ensure the worktree exists (idempotent). Non-fatal warnings tolerated.
-      bash "$_SCRIPT_DIR/wiki-worktree-setup.sh" >/dev/null 2>&1 || true
+      # Ensure the worktree exists (idempotent). Non-fatal, but let setup's stderr
+      # through (only stdout is muted) so its exit-2/3 remediation hints survive —
+      # the WIKI_DIR-missing error below is otherwise the only signal the operator sees.
+      bash "$_SCRIPT_DIR/wiki-worktree-setup.sh" >/dev/null || true
     fi
     ;;
   *)
@@ -204,7 +229,23 @@ backfilled=0
 skipped_existing=0
 page_registered=0
 no_reason=0
+encode_failed=0
+write_failed=0
 total_ingested=0
+
+# The per-raw frontmatter write goes through an in-tree tempfile (`$file.bf.tmp`)
+# next to the target for an atomic rename. Because that tempfile lives inside the
+# wiki worktree, an interrupt between the redirect and the mv would orphan it, and
+# a later `git add -- .rite/wiki` (wiki-worktree-commit.sh) would stage the junk.
+# A signal-specific trap removes the in-flight tempfile on any exit path (sibling
+# canonical 4-line pattern). `_bf_tmp` is set just before each write and cleared
+# right after a successful mv, so on normal completion the trap is a no-op.
+_bf_tmp=""
+_rite_bf_cleanup() { [ -n "${_bf_tmp:-}" ] && rm -f "$_bf_tmp"; return 0; }
+trap 'rc=$?; _rite_bf_cleanup; exit $rc' EXIT
+trap '_rite_bf_cleanup; exit 130' INT
+trap '_rite_bf_cleanup; exit 143' TERM
+trap '_rite_bf_cleanup; exit 129' HUP
 
 # Iterate raws deterministically (sort) so dry-run / real runs align.
 while IFS= read -r file; do
@@ -235,10 +276,16 @@ while IFS= read -r file; do
     echo "WARNING: no ingest:skip entry in log.md for $rel — left untouched (reason は捏造しない)" >&2
     continue
   fi
+  # Neutralize C0 control chars + DEL (0x7f) so they never reach the frontmatter.
+  # `--c0-only` is deliberate: the default mode also strips 0x80-0x9f byte-wise,
+  # which would corrupt the reason's Japanese UTF-8 (its continuation bytes fall in
+  # that range). --c0-only is the documented "preserve UTF-8 body, JSON use" mode
+  # (control-char-neutralize.sh). This also makes the sourced helper non-dead.
+  reason=$(printf '%s' "$reason" | neutralize_ctrl --c0-only)
 
   reason_json=$(printf '%s' "$reason" | yaml_encode)
   if [ -z "$reason_json" ]; then
-    no_reason=$((no_reason+1))
+    encode_failed=$((encode_failed+1))
     echo "WARNING: skip_reason の YAML エンコードに失敗しました: $rel — left untouched" >&2
     continue
   fi
@@ -253,6 +300,7 @@ while IFS= read -r file; do
   # `ingested: true` line, inside the frontmatter only (first occurrence).
   # ENVIRON is used for the reason line so awk does NOT re-process its
   # backslashes (awk -v would mangle the JSON escapes).
+  _bf_tmp="$file.bf.tmp"
   RITE_BF_REASON_LINE="skip_reason: $reason_json" \
   awk '
     BEGIN { infm=0; done=0 }
@@ -266,15 +314,21 @@ while IFS= read -r file; do
       next
     }
     { print }
-  ' "$file" > "$file.bf.tmp" && mv "$file.bf.tmp" "$file" || {
-    rm -f "$file.bf.tmp"
+  ' "$file" > "$_bf_tmp" && mv "$_bf_tmp" "$file" && _bf_tmp="" || {
+    rm -f "$_bf_tmp"
+    _bf_tmp=""
+    write_failed=$((write_failed+1))
     echo "ERROR: frontmatter 書込に失敗しました: $rel" >&2
     continue
   }
   backfilled=$((backfilled+1))
 done < <(LC_ALL=C find "$WIKI_DIR/raw" -type f -name '*.md' 2>/dev/null | LC_ALL=C sort)
 
-summary="[wiki-backfill] backfilled=$backfilled; skipped_existing=$skipped_existing; page_registered=$page_registered; no_reason=$no_reason; total_ingested=$total_ingested; branch_strategy=$branch_strategy"
+# The counters partition total_ingested exactly:
+#   backfilled + skipped_existing + page_registered + no_reason + encode_failed + write_failed == total_ingested
+# encode_failed / write_failed surface partial failures the stderr WARNINGs also
+# report, so a caller inspecting only this summary line is not misled by exit 0.
+summary="[wiki-backfill] backfilled=$backfilled; skipped_existing=$skipped_existing; page_registered=$page_registered; no_reason=$no_reason; encode_failed=$encode_failed; write_failed=$write_failed; total_ingested=$total_ingested; branch_strategy=$branch_strategy"
 [ "$DRY_RUN" -eq 1 ] && summary="$summary; dry_run=1"
 echo "$summary"
 exit 0

--- a/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
+++ b/plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh
@@ -35,9 +35,10 @@
 #   fabricate) and left untouched.
 #
 # The `skip_reason` value is emitted via `python3 json.dumps(..., ensure_ascii=
-# False)`. A JSON string literal is a valid YAML double-quoted scalar, so this is
-# a bullet-proof encoder for arbitrary reason prose (embedded `"`, `\`, `#`, `:`,
-# backticks) and matches the double-quoted style ingest.md already writes.
+# False)` after neutralizing control codepoints (C0/DEL/C1 -> "?"; see yaml_encode).
+# With control chars removed, a JSON string literal is a valid YAML double-quoted
+# scalar, so this is a bullet-proof encoder for arbitrary reason prose (embedded
+# `"`, `\`, `#`, `:`, backticks) and matches the double-quoted style ingest.md writes.
 #
 # Branch strategy:
 #   separate_branch — edits files in the `.rite/wiki-worktree` worktree (checked
@@ -75,8 +76,6 @@
 set -uo pipefail
 
 _SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=../control-char-neutralize.sh
-source "$_SCRIPT_DIR/../control-char-neutralize.sh"
 # shellcheck source=lib/wiki-config.sh
 source "$_SCRIPT_DIR/lib/wiki-config.sh"
 
@@ -106,6 +105,12 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   echo "ERROR: not inside a git repository" >&2
   exit 1
 fi
+
+# Capture the invocation tree (the current worktree) BEFORE cd-ing to the shared
+# state root below. For same_branch the wiki lives in THIS tree, which from a
+# linked worktree session is the session worktree — resolving it after the cd
+# would always collapse to the state root and defeat the branch (F-02).
+INVOKE_TREE="$(git rev-parse --show-toplevel 2>/dev/null)" || INVOKE_TREE=""
 
 # Resolve to the SHARED state root (main checkout) so `.rite/wiki-worktree`
 # resolves identically from a linked worktree session (mirrors
@@ -139,14 +144,12 @@ branch_strategy=$(parse_wiki_scalar branch_strategy)
 case "$branch_strategy" in
   same_branch)
     # same_branch keeps the wiki in the CURRENT tree (the checked-out branch).
-    # From a linked worktree session the current tree is the session worktree, NOT
-    # the shared state root — so resolve it from `git rev-parse --show-toplevel`
-    # unless the caller pinned it with --repo-root.
+    # From a linked worktree session that is the session worktree captured in
+    # INVOKE_TREE (before the cd), NOT the shared state root. --repo-root overrides.
     if [ "$REPO_ROOT_EXPLICIT" -eq 1 ]; then
       WIKI_DIR="$REPO_ROOT/.rite/wiki"
     else
-      current_tree="$(git rev-parse --show-toplevel 2>/dev/null)" || current_tree="$REPO_ROOT"
-      WIKI_DIR="$current_tree/.rite/wiki"
+      WIKI_DIR="${INVOKE_TREE:-$REPO_ROOT}/.rite/wiki"
     fi
     ;;
   separate_branch)
@@ -219,10 +222,22 @@ extract_skip_reason() {
 }
 
 # ---- yaml_encode: STDIN reason text -> valid YAML double-quoted scalar -------
-# A JSON string literal is a valid YAML flow scalar; json.dumps handles all
-# escaping (`"`, `\`, control chars) and preserves non-ASCII verbatim.
+# Decode STDIN as UTF-8 (invalid bytes -> U+FFFD, locale-independent), replace all
+# control codepoints — C0 (<0x20), DEL (0x7f), and C1 (0x80-0x9f) — with "?", then
+# json.dumps. Neutralizing at the *codepoint* level (not byte-wise) closes the
+# 8-bit C1 / CSI (0x9b) path — which json.dumps would otherwise pass through
+# literally, breaking the "valid YAML c-printable scalar" invariant — while
+# leaving Japanese (U+3000+) untouched. A JSON string literal is then a valid YAML
+# double-quoted scalar, matching the double-quoted style ingest.md writes.
 yaml_encode() {
-  python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read(), ensure_ascii=False))'
+  python3 -c '
+import json, sys
+t = sys.stdin.buffer.read().decode("utf-8", "replace")
+def _san(c):
+    o = ord(c)
+    return "?" if (o < 0x20 or o == 0x7f or (0x80 <= o <= 0x9f)) else c
+sys.stdout.write(json.dumps("".join(_san(c) for c in t), ensure_ascii=False))
+'
 }
 
 backfilled=0
@@ -276,13 +291,8 @@ while IFS= read -r file; do
     echo "WARNING: no ingest:skip entry in log.md for $rel — left untouched (reason は捏造しない)" >&2
     continue
   fi
-  # Neutralize C0 control chars + DEL (0x7f) so they never reach the frontmatter.
-  # `--c0-only` is deliberate: the default mode also strips 0x80-0x9f byte-wise,
-  # which would corrupt the reason's Japanese UTF-8 (its continuation bytes fall in
-  # that range). --c0-only is the documented "preserve UTF-8 body, JSON use" mode
-  # (control-char-neutralize.sh). This also makes the sourced helper non-dead.
-  reason=$(printf '%s' "$reason" | neutralize_ctrl --c0-only)
-
+  # yaml_encode neutralizes control codepoints (C0/DEL/C1) itself, so no bash-side
+  # pre-pass is needed here.
   reason_json=$(printf '%s' "$reason" | yaml_encode)
   if [ -z "$reason_json" ]; then
     encode_failed=$((encode_failed+1))


### PR DESCRIPTION
## 概要

skip の Source of Truth は log.md（テーブル）から各 raw frontmatter の `ingest_status: skipped` へ移行済みだが、その移行は going-forward の仕組みのみで、移行以前に skip された過去 raw への back-fill が行われていなかった。結果 231 件の raw が「`ingested: true` かつ page `sources.ref` 未登録かつ skip マーカー無し」で残存し、`wiki-lint-skipped-refs.sh` の frontmatter 走査から漏れ、lint の 3-way 分類で `missing_concept`（ブロッキング）側へ落ちる潜在リスクがあった。

本 PR は back-fill スクリプトを追加し、231 件の frontmatter を wiki ブランチへ back-fill 済み。

Closes #1730

## 変更内容

- **追加**: `plugins/rite/hooks/scripts/wiki-backfill-skipped-frontmatter.sh`（一回性・冪等の back-fill スクリプト）
  - 対象を **R\S\K**（`ingested:true` / page `sources.ref` 未登録 / skip マーカー無し）に確定
  - **S-gate**: page 登録済 raw は「実際には skip でない」ため除外（誤マークを構造的に防止）
  - `skip_reason` は log.md の `ingest:skip` エントリから堅牢抽出（markdown エスケープ pipe `\|` を再構成・unescape）
  - YAML エンコードは `python3 json.dumps`（JSON 文字列 ⊂ YAML double-quoted scalar、既存 ingest.md の記法に一致）で任意プロ文字列を安全化
  - log.md に skip エントリの無い raw は reason を捏造せず untouched（本 backlog では該当 0 件）
  - 冪等（再実行で 0 件）・edit 専用（commit は `wiki-worktree-commit.sh` に委譲）・separate_branch / same_branch 両対応
- **wiki ブランチ**（本 PR diff には含まれない別 push）: 231 件の raw frontmatter に `ingest_status: skipped` + `skip_reason:` を追記

> **レビュー上の注意**: 実データの 231 件変更は separate_branch 戦略の `wiki` ブランチへコミット済みのため、本 develop PR の diff にはスクリプトのみが現れる。レビュー対象はスクリプトの正しさが中心。

## 検証

- dry-run 231 件が調査時の R\S\K 集合と**完全一致**（R=910, S=677, K=3, R\S\K=231 は Issue 計測値と一致）
- back-fill 後の全 231 件の frontmatter が **valid YAML**（`skip_reason` 値を JSON パースで round-trip 確認、double-quote / backslash / エスケープ pipe を含むエッジ 6 件も正常）
- **冪等性**: 再実行で `backfilled=0`
- **AC 検証**: back-fill 後 `wiki-lint-skipped-refs.sh` の `skipped_refs_count=234`、`missing_concept` 候補（R\S\K'）= **0**、`unregistered_raw` = 234（informational 計上）
- lint: 標準リンタ未設定のためスキップ、rite プラグイン固有チェックで新規スクリプトはクリーン（sh-cross-ref / hardcoded-line / orphan いずれも 0、comment 系 finding も新規ファイルに無し）

## チェックリスト

- [x] 231 件の back-fill 対象を log.md と突合して確定
- [x] back-fill スクリプトで frontmatter 追記（冪等）
- [x] wiki branch へ commit + push
- [x] wiki-lint 再実行で `unregistered_raw` 計上 + `missing_concept=0` を確認
