### PR TITLE
feat(init): /rite:init が safety セクションを rite-config.yml に書き出すようにする

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -502,7 +502,7 @@ followed by AskUserQuestion confirmation)
  - **User-customized value** (preserve): `project_number`, `owner`, `iteration` settings, `branch.base`, `language`, etc.
  - **Deprecated key** (remove): `project.name`, `commit.style`, `commit.enforce`, `commit.contextual`, `branch.release`, `branch.types`, `version`
  - **Missing section** (add with template defaults): `review.debate`, `review.fact_check`, `verification`, etc.
- - **Advanced section** (add as commented-out block): `parallel`, `metrics`, `safety`, `investigate`
+ - **Advanced section** (add as commented-out block): `parallel`, `metrics`, `investigate`
  - **Unknown key** (preserve with warning): user-added keys not present in the template
 5. **Preview and confirm** (Step 5)
  Display deprecated keys to be removed, sections to be added, and preserved existing settings; ask via `AskUserQuestion` to either apply or cancel.

--- a/plugins/rite/skills/init/SKILL.md
+++ b/plugins/rite/skills/init/SKILL.md
@@ -339,13 +339,13 @@ Compare current config against the template and classify each key:
 | **Missing section** — any active top-level section above the `--- Advanced ---` marker (github, iteration, branch, commands, verification, issue, review, etc. — **excluding `wiki:` and `multi_session:`**, which have dedicated rows below) | **Add** — insert the whole section from the template with default values |
 | **Missing sub-key** — a key newly added to the template *inside* a section the config already has (e.g., `review.fact_check.verify_internal_likelihood`) | **Add the missing key only** from the template default; **preserve** all existing sibling values (e.g., a customized `review.fact_check.max_claims`). No-op when the key already exists |
 | **`multi_session:` section** | **Back-add on --upgrade with `enabled: true`** (default-on). `multi_session:` is declared above the `--- Advanced ---` marker (active). When missing from an existing config, insert the template active block (`enabled: true` + `worktree_base`) so `--upgrade`-ed projects receive the same default-on behavior as new `/rite:init` generation. If a user's config already has a `multi_session:` block, it is preserved as a User-customized value (no overwrite — **including an explicit `enabled: false`**). Idempotent: no-op when the active section already exists |
-| **Advanced section** (parallel, metrics, safety, investigate) | **Add as comments** — insert commented-out with default values |
+| **Advanced section** (parallel, metrics, investigate) | **Add as comments** — insert commented-out with default values |
 | **`wiki:` section** | **Step 3/4 は扱わない**。wiki セクションの追加は **Phase 4.1.2 Step 2 (新規生成: template の Advanced 境界より上にある active block が自動コピーされる) および Phase 4.1.3 Step 6 item 7 (Upgrade path: 未存在時に active block として append。`current < latest` / `current >= latest` 両経路で実行) の専権**。template 側にはコメント形式の `# wiki:` ブロックは存在しない (active 位置に移動済み) ため、重複追加経路はない |
 | **Unknown key** (user-added keys not in template) | **Preserve with warning** — keep but display warning |
 
 **Unknown key 判定の scope**: Step 4 の "Unknown key" 判定 (user-added keys not in template) は、**template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。境界より下 (コメント形式の Advanced sections + 末尾コメント) は template 側で意図的に省略または注記のため存在する領域であり、ユーザー設定の classification 対象外。
 
-**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `language`, `wiki`, `multi_session`, `tdd`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
+**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `language`, `wiki`, `multi_session`, `tdd`, `safety`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
 
 **Active sub-keys covered on --upgrade** (drift anchor — the `init-upgrade-drift` test T-12 asserts, per section, this list ⊇ each template active section's **direct** sub-keys above the `--- Advanced ---` marker; Step 6 item 4 adds any missing sub-key while preserving existing siblings). Sections whose value is a scalar (`schema_version`, `language`) have no sub-keys and are omitted:
 
@@ -359,6 +359,7 @@ Compare current config against the template and classify each key:
 - `wiki`: `enabled`, `branch_strategy`, `branch_name`, `auto_ingest`, `auto_query`
 - `multi_session`: `enabled`, `worktree_base`
 - `tdd`: `enabled`
+- `safety`: `max_implementation_rounds`, `max_review_cycles`, `time_budget_minutes`, `auto_stop_on_repeated_failure`, `repeated_failure_threshold`
 
 **When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it (the same guard as the top-level list, one level down).
 

--- a/plugins/rite/templates/config/rite-config.yml
+++ b/plugins/rite/templates/config/rite-config.yml
@@ -160,6 +160,23 @@ multi_session:
 tdd:
   enabled: true   # true: implementation phase runs the Canon TDD cycle (default: true, opt-out)
 
+# Safety settings (fail-closed thresholds)
+# Hard limits that stop runaway autonomous loops (implementation rounds, review-fix
+# cycles, repeated failures). Declared ABOVE the `--- Advanced ---` marker (like
+# wiki / multi_session / tdd) so /rite:init new-generation emits it as an active
+# block — new projects can discover and tune the safety ceilings from the generated
+# config. Consumers read each value with an internal default, so a config that omits
+# `safety:` (or any single key) keeps the documented default behavior (backward
+# compatible). On --upgrade the section is back-added with these defaults; an
+# existing custom value is preserved. Values are UNCHANGED from the previous
+# Advanced (commented) block — only the position moved.
+safety:
+  max_implementation_rounds: 20   # implementation round hard limit per Issue (default: 20)
+  max_review_cycles: 5            # /rite:iterate review-fix loop circuit breaker per PR (default: 5)
+  time_budget_minutes: 120        # advisory time budget per Issue (not enforced by timer)
+  auto_stop_on_repeated_failure: true   # stop after repeated same-class failures
+  repeated_failure_threshold: 3   # consecutive same-class failures that trigger auto-stop
+
 # --- Advanced (below this line) ---
 # These sections are omitted during new generation (/rite:init).
 # They are added as comments during --upgrade.
@@ -184,14 +201,6 @@ pr_review:
 # metrics:
 #   enabled: true
 #   baseline_issues: 3
-
-# Safety settings (fail-closed thresholds)
-# safety:
-#   max_implementation_rounds: 20   # implementation round hard limit per Issue (default: 20)
-#   max_review_cycles: 5            # /rite:iterate review-fix loop circuit breaker per PR (default: 5)
-#   time_budget_minutes: 120
-#   auto_stop_on_repeated_failure: true
-#   repeated_failure_threshold: 3
 
 # Wiki settings are declared above the `--- Advanced ---` marker (active by default).
 # See docs/designs/experience-heuristics-persistence-layer.md for full specification.


### PR DESCRIPTION
## 概要

`safety` セクションはこれまで template の `--- Advanced ---` マーカーより下（コメントアウト）に置かれており、fresh `/rite:init` は Advanced 領域を省略するため、生成される `rite-config.yml` に安全装置（`max_implementation_rounds` 等）が一切現れませんでした。実装フェーズは内部 default で動作するものの、ユーザーは「安全上限が設定可能」であることを config から発見できず、調整の敷居が高い状態でした。

`wiki` / `multi_session` / `tdd` と同じく、`safety` を Advanced マーカーより**上の active ブロック**へ移動し、fresh init が既定値・説明コメント付きで書き出すようにします。

Closes #1704

## 変更内容

- **`plugins/rite/templates/config/rite-config.yml`**: `safety` セクションを `--- Advanced ---` マーカーより上へ active ブロックとして移動。既定値（`max_implementation_rounds: 20` / `max_review_cycles: 5` / `time_budget_minutes: 120` / `auto_stop_on_repeated_failure: true` / `repeated_failure_threshold: 3`）は**位置のみ移動で不変**。`wiki`/`tdd` に倣った説明コメントを付与
- **`plugins/rite/skills/init/SKILL.md`**: safety 昇格に伴う整合。(1) Advanced セクション分類一覧から `safety` を除外、(2) `--upgrade` の drift anchor（top-level sections）に `safety` を追加、(3) 同 sub-keys anchor に `safety` 行を追加。これは `init-upgrade-drift` テスト（T-10 / T-12）が template の active セクション／サブキーの列挙を要求するため必須
- **`docs/SPEC.md`**: `--upgrade` 分類の Advanced セクション一覧（`init/SKILL.md` のミラー）から `safety` を除外し整合

> `docs/SPEC.md` は Issue の named target 外ですが、`init/SKILL.md` の Advanced 分類を直接ミラーする記述で、変更しないと仕様書に矛盾が残るため整合目的で更新しています。

## 受入基準

- **AC-1**（fresh init での書き出し）: Advanced マーカーより上を抽出する init Step 2 の対象に `safety` が入るため、生成 config に既定値・コメント付きで含まれる。抽出シミュレーションで確認済み
- **AC-2**（後方互換）: 消費側（`issue-implement` / `iterate`）は `safety.*` を内部 default（`max_implementation_rounds`=20 / `max_review_cycles`=5）で読むため、`safety` 未記載の既存 config は従来どおり動作。消費側は非変更
- **AC-3**（テンプレート整合）: `init-upgrade-drift.test.sh` を含むテストスイート全体が pass

## テスト

- `init-upgrade-drift.test.sh`: 59 pass / 0 fail（safety 追加後）
- テストスイート全体（`run-tests.sh`）: 80/80 pass, 0 fail
- `rite-config.yml` の YAML 妥当性を `yq` で確認（`safety` ブロックが 5 キーとも正しくパース）
- 既定値が移動前後で不変であることを diff で確認

## チェックリスト

- [x] MUST 要件をすべて実装
- [x] 受入基準（AC-1〜AC-3）を検証
- [x] 既存機能の回帰なし（テストスイート 80/80 pass）
- [x] target files を変更し、non-target file（`skills/issue-implement/SKILL.md`）は未変更
- [x] プロジェクト規約に準拠

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
