### PR TITLE
fix(test): hooks テストの配線ギャップ修正とカバレッジ補完

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ echo "Results: $PASS passed, $FAIL failed"
 4. Clean up with `trap cleanup EXIT`
 5. Exit with code 1 if any test fails
 
-The test runner (`run-tests.sh`) automatically discovers all `*.test.sh` files and reports aggregate results.
+The test runner (`run-tests.sh`) automatically discovers all `*.test.sh` files in `plugins/rite/hooks/tests/` plus the `test-*.sh` files in `plugins/rite/hooks/scripts/tests/`, and reports aggregate results.
 
 ## Worktree Workflow
 

--- a/plugins/rite/hooks/tests/backlink-format-check.test.sh
+++ b/plugins/rite/hooks/tests/backlink-format-check.test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Tests for hooks/scripts/backlink-format-check.sh (Issue #1719)
+#
+# The checker flags two legacy `Downstream reference:` dialects that the
+# canonical colon form replaced:
+#   P1 — space-separated: "<path> Phase N.N" instead of "<path>:Phase N.N"
+#   P2 — parenthetical "(DRIFT-CHECK ANCHOR: ...)" qualifier
+# These tests pin that the canonical colon form stays clean while both legacy
+# dialects are still detected — the regression this lint exists to prevent.
+#
+# Convention: mktemp sandbox, no network, no gh, GNU/BSD portable. The checker
+# resolves targets under --repo-root, so no git repo is needed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../scripts/backlink-format-check.sh"
+
+echo "=== backlink-format-check.sh tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+
+SANDBOX="$(make_plain_sandbox)"
+cleanup() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+trap cleanup EXIT INT TERM HUP
+
+# --- Fixtures (paths relative to --repo-root sandbox) -------------------------
+# Canonical colon form — must stay clean.
+printf 'Some prose.\n<!-- Downstream reference: lint.md:Phase 8.3 -->\nMore prose.\n' \
+  > "$SANDBOX/clean.md"
+# P1 space-separated dialect — a space, not a colon, before "Phase".
+printf '<!-- Downstream reference: lint.md Phase 8.3 -->\n' \
+  > "$SANDBOX/ng-p1.md"
+# P2 parenthetical DRIFT-CHECK ANCHOR qualifier on a Downstream reference line.
+printf '<!-- Downstream reference: lint.md:Phase 8.3 (DRIFT-CHECK ANCHOR: foo) -->\n' \
+  > "$SANDBOX/ng-p2.md"
+
+run() { bash "$SCRIPT" --repo-root "$SANDBOX" "$@" >/dev/null 2>&1; echo $?; }
+
+# --- Invocation contract ------------------------------------------------------
+assert "--help exits 0" "0" "$(bash "$SCRIPT" --help >/dev/null 2>&1; echo $?)"
+assert "no targets exits 2 (invocation error)" "2" "$(run --quiet)"
+assert "unknown argument exits 2" "2" "$(run --bogus)"
+
+# --- Clean canonical form -----------------------------------------------------
+assert "canonical colon form is clean (exit 0)" "0" "$(run --quiet --target clean.md)"
+
+# --- Legacy dialect detection -------------------------------------------------
+assert "P1 space-separated dialect detected (exit 1)" "1" "$(run --quiet --target ng-p1.md)"
+assert "P2 parenthetical qualifier detected (exit 1)" "1" "$(run --quiet --target ng-p2.md)"
+
+# --- Finding output names the pattern -----------------------------------------
+p1_out="$(bash "$SCRIPT" --repo-root "$SANDBOX" --quiet --target ng-p1.md 2>/dev/null || true)"
+if printf '%s' "$p1_out" | grep -qF '[backlink-format][P1]'; then
+  pass "P1 finding is tagged [backlink-format][P1]"
+else
+  fail "P1 finding tag missing: $p1_out"
+fi
+p2_out="$(bash "$SCRIPT" --repo-root "$SANDBOX" --quiet --target ng-p2.md 2>/dev/null || true)"
+if printf '%s' "$p2_out" | grep -qF '[backlink-format][P2]'; then
+  pass "P2 finding is tagged [backlink-format][P2]"
+else
+  fail "P2 finding tag missing: $p2_out"
+fi
+
+print_summary "backlink-format-check.sh"

--- a/plugins/rite/hooks/tests/comment-line-ref-check.test.sh
+++ b/plugins/rite/hooks/tests/comment-line-ref-check.test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Tests for hooks/scripts/comment-line-ref-check.sh (Issue #1719)
+#
+# The checker flags hardcoded `<file>.<ext>:<NN>` line-number references that
+# live inside shell comments (these rot when the referenced file changes).
+# These tests pin both the positive detection and the exclusions the checker
+# deliberately makes (shebang, range `:N-M`, `# example:` whitelist, code
+# lines) so a future regex tweak cannot silently widen or narrow the scope.
+#
+# Convention: mktemp sandbox, no network, no gh, GNU/BSD portable. Targets are
+# resolved under --repo-root, so no git repo is needed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../scripts/comment-line-ref-check.sh"
+
+echo "=== comment-line-ref-check.sh tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+
+SANDBOX="$(make_plain_sandbox)"
+cleanup() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+trap cleanup EXIT INT TERM HUP
+
+# --- Fixtures (paths relative to --repo-root sandbox) -------------------------
+# NG: a filename:NN reference inside a shell comment.
+printf '#!/bin/bash\n# see wiki-config.sh:42 for the check\necho hi\n' \
+  > "$SANDBOX/ng.sh"
+# Clean: same filename but no :NN line number.
+printf '#!/bin/bash\n# see wiki-config.sh for the check\necho hi\n' \
+  > "$SANDBOX/clean.sh"
+# Excluded: range form :N-M (review-finding location, not a fragile line ref).
+printf '#!/bin/bash\n# Location: foo.sh:12-20\n' \
+  > "$SANDBOX/range.sh"
+# Excluded: `# example:` whitelist marker.
+printf '#!/bin/bash\n# example: foo.sh:42\n' \
+  > "$SANDBOX/example.sh"
+# Excluded: a code line (not a comment) referencing a file legitimately.
+printf '#!/bin/bash\ngrep -n pattern wiki-config.sh:42 || true\n' \
+  > "$SANDBOX/codeline.sh"
+
+run() { bash "$SCRIPT" --repo-root "$SANDBOX" "$@" >/dev/null 2>&1; echo $?; }
+
+# --- Invocation contract ------------------------------------------------------
+assert "--help exits 0" "0" "$(bash "$SCRIPT" --help >/dev/null 2>&1; echo $?)"
+assert "no targets exits 2 (invocation error)" "2" "$(run --quiet)"
+assert "unknown argument exits 2" "2" "$(run --bogus)"
+
+# --- Positive detection -------------------------------------------------------
+assert "comment line-number ref detected (exit 1)" "1" "$(run --quiet --target ng.sh)"
+
+# --- Exclusions (must stay clean, exit 0) -------------------------------------
+assert "no line number is clean" "0" "$(run --quiet --target clean.sh)"
+assert "range form :N-M is excluded" "0" "$(run --quiet --target range.sh)"
+assert "# example: whitelist is excluded" "0" "$(run --quiet --target example.sh)"
+assert "code line (non-comment) is excluded" "0" "$(run --quiet --target codeline.sh)"
+
+# --- Finding output shape -----------------------------------------------------
+ng_out="$(bash "$SCRIPT" --repo-root "$SANDBOX" --quiet --target ng.sh 2>/dev/null || true)"
+if printf '%s' "$ng_out" | grep -qF '[comment-line-ref]' && printf '%s' "$ng_out" | grep -qF 'wiki-config.sh:42'; then
+  pass "finding tags [comment-line-ref] and quotes the offending reference"
+else
+  fail "finding tag/reference missing: $ng_out"
+fi
+
+print_summary "comment-line-ref-check.sh"

--- a/plugins/rite/hooks/tests/review-schema-version-check.test.sh
+++ b/plugins/rite/hooks/tests/review-schema-version-check.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Tests for hooks/scripts/review-schema-version-check.sh (Issue #1719)
+#
+# The script detects schema_version drift in review-result JSON files. Its
+# accept list (1.0.0 / 1.0 / 1.1.0) is the canonical SoT from
+# review-result-schema.md; any other value — including a missing key, invalid
+# JSON, or a missing file — is drift (exit 1). These tests pin that contract
+# so a future accept-list edit or JSON-parse change cannot silently regress it.
+#
+# Convention (shared with the sibling suite): mktemp sandbox, no network, no gh,
+# GNU/BSD portable (jq only). --target resolves paths as-is, so a git repo is
+# not required.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../scripts/review-schema-version-check.sh"
+
+echo "=== review-schema-version-check.sh tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available — review-schema-version-check requires jq" >&2
+  exit 0
+fi
+
+SANDBOX="$(make_plain_sandbox)"
+cleanup() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+trap cleanup EXIT INT TERM HUP
+
+# --- Fixtures -----------------------------------------------------------------
+printf '{"schema_version":"1.1.0","findings":[]}\n' > "$SANDBOX/ok-110.json"
+printf '{"schema_version":"1.0","findings":[]}\n'   > "$SANDBOX/ok-10.json"
+printf '{"schema_version":"9.9.9","findings":[]}\n' > "$SANDBOX/drift-999.json"
+printf '{"findings":[]}\n'                           > "$SANDBOX/missing-version.json"
+printf 'not valid json {{{\n'                        > "$SANDBOX/invalid.json"
+
+run() { bash "$SCRIPT" "$@" >/dev/null 2>&1; echo $?; }
+
+# --- Invocation contract ------------------------------------------------------
+assert "--help exits 0" "0" "$(run --help)"
+assert "no targets exits 2 (invocation error)" "2" "$(run)"
+assert "unknown argument exits 2" "2" "$(run --bogus)"
+assert "--target without value exits 2" "2" "$(run --target)"
+
+# --- Accept list (clean) ------------------------------------------------------
+assert "accepted 1.1.0 exits 0" "0" "$(run --target "$SANDBOX/ok-110.json")"
+assert "accepted 1.0 (legacy alias) exits 0" "0" "$(run --target "$SANDBOX/ok-10.json")"
+
+# --- Drift (exit 1) -----------------------------------------------------------
+assert "unlisted version 9.9.9 is drift (exit 1)" "1" "$(run --quiet --target "$SANDBOX/drift-999.json")"
+assert "missing schema_version is drift (exit 1)" "1" "$(run --quiet --target "$SANDBOX/missing-version.json")"
+assert "invalid JSON is drift (exit 1)" "1" "$(run --quiet --target "$SANDBOX/invalid.json")"
+assert "missing file is drift (exit 1)" "1" "$(run --quiet --target "$SANDBOX/nonexistent.json")"
+
+# --- Mixed batch: one drift among clean targets → exit 1 ----------------------
+assert "one drift in a mixed batch fails the whole run" "1" \
+  "$(run --quiet --target "$SANDBOX/ok-110.json" --target "$SANDBOX/drift-999.json")"
+
+# --- Drift marker shape -------------------------------------------------------
+drift_stderr="$(bash "$SCRIPT" --target "$SANDBOX/drift-999.json" 2>&1 >/dev/null || true)"
+if printf '%s' "$drift_stderr" | grep -qE 'REVIEW_SCHEMA_VERSION_DRIFT=1; file=.*; schema_version=9\.9\.9'; then
+  pass "drift marker names the offending file and version"
+else
+  fail "drift marker missing/malformed: $drift_stderr"
+fi
+
+print_summary "review-schema-version-check.sh"

--- a/plugins/rite/hooks/tests/run-tests.sh
+++ b/plugins/rite/hooks/tests/run-tests.sh
@@ -19,8 +19,22 @@ PASSED=0
 FAILED=0
 FAILED_TESTS=()
 
-for test_file in "$SCRIPT_DIR"/*.test.sh; do
-  [ -f "$test_file" ] || continue
+# Discover test files from BOTH conventions/locations (Issue #1719):
+#   1. this dir's `*.test.sh` — the hook/entry-point suite
+#   2. the sibling `hooks/scripts/tests/test-*.sh` — the checker suite for
+#      hooks/scripts/ scripts. It uses a `test-*.sh` name in a separate
+#      directory, so the `*.test.sh` glob never reached it and those tests
+#      ran nowhere despite existing. Collecting both into one list keeps a
+#      single runner as the single source of test execution.
+test_files=()
+for f in "$SCRIPT_DIR"/*.test.sh; do
+  [ -f "$f" ] && test_files+=("$f")
+done
+for f in "$SCRIPT_DIR"/../scripts/tests/test-*.sh; do
+  [ -f "$f" ] && test_files+=("$f")
+done
+
+for test_file in "${test_files[@]}"; do
   test_name="$(basename "$test_file")"
   TOTAL=$((TOTAL + 1))
   echo "=== Running: $test_name ==="

--- a/plugins/rite/hooks/tests/session-ownership.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership.test.sh
@@ -296,9 +296,10 @@ echo ""
 # without RITE_DEBUG.
 echo "TC-CORRUPT-01: extract_session_id WARNING fires without RITE_DEBUG"
 unset RITE_DEBUG
-out_stdout=$(extract_session_id 'not-json-corrupt-{{{' 2>/tmp/rite-corrupt01-stderr)
-out_stderr=$(cat /tmp/rite-corrupt01-stderr 2>/dev/null)
-rm -f /tmp/rite-corrupt01-stderr
+# Capture stderr under the per-run TEST_DIR (mktemp -d, trap-cleaned) instead of
+# a fixed /tmp path — the latter collides across concurrent runs and needs manual rm.
+out_stdout=$(extract_session_id 'not-json-corrupt-{{{' 2>"$TEST_DIR/corrupt01-stderr")
+out_stderr=$(cat "$TEST_DIR/corrupt01-stderr" 2>/dev/null)
 if printf '%s' "$out_stderr" | grep -qE 'WARNING: extract_session_id: jq parse failed.*rc='; then
   pass "TC-CORRUPT-01 WARNING emitted with rc capture"
 else
@@ -316,9 +317,8 @@ unset RITE_DEBUG
 corrupt_state="$TEST_DIR/corrupt-state.json"
 mkdir -p "$TEST_DIR"
 printf '{ not valid json' > "$corrupt_state"
-out_stdout=$(get_state_session_id "$corrupt_state" 2>/tmp/rite-corrupt02-stderr)
-out_stderr=$(cat /tmp/rite-corrupt02-stderr 2>/dev/null)
-rm -f /tmp/rite-corrupt02-stderr
+out_stdout=$(get_state_session_id "$corrupt_state" 2>"$TEST_DIR/corrupt02-stderr")
+out_stderr=$(cat "$TEST_DIR/corrupt02-stderr" 2>/dev/null)
 if printf '%s' "$out_stderr" | grep -qE 'WARNING: get_state_session_id: jq parse failed.*rc='; then
   pass "TC-CORRUPT-02 WARNING emitted with rc capture"
 else

--- a/plugins/rite/hooks/tests/validate-state-root.test.sh
+++ b/plugins/rite/hooks/tests/validate-state-root.test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Security pin tests for hooks/_validate-state-root.sh (Issue #1719, AC-3)
+#
+# _validate-state-root.sh is the single source of truth for STATE_ROOT
+# validation across the state-read helpers. Its rejection rules (path
+# traversal `..`, shell metacharacters `$` / backtick, control characters)
+# are a defence-in-depth guard against a future caller passing an untrusted
+# path. Until now it only ran via the happy path of its callers; this test
+# exercises the rejection branches DIRECTLY so a regex loosening cannot
+# silently reopen the injection surface.
+#
+# Convention: no sandbox needed — the helper validates the argument string
+# only (no filesystem access). GNU/BSD portable.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../_validate-state-root.sh"
+
+echo "=== _validate-state-root.sh security pin tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+
+rc() { bash "$SCRIPT" "$@" >/dev/null 2>&1; echo $?; }
+
+# --- Accept: a normalized path with no traversal / metachar / control char ---
+assert "clean absolute path accepted (exit 0)" "0" "$(rc "/home/user/project/.rite/state")"
+assert "clean relative path accepted (exit 0)" "0" "$(rc "some/nested/state")"
+
+# --- Reject: empty ------------------------------------------------------------
+assert "empty STATE_ROOT rejected (exit 1)" "1" "$(rc "")"
+assert "missing argument rejected (exit 1)" "1" "$(rc)"
+
+# --- Reject: path traversal ---------------------------------------------------
+assert "parent traversal '..' rejected (exit 1)" "1" "$(rc "/home/user/../etc/state")"
+assert "leading '..' rejected (exit 1)" "1" "$(rc "../outside")"
+
+# --- Reject: shell metacharacters ---------------------------------------------
+assert "'\$' expansion metachar rejected (exit 1)" "1" "$(rc '/home/$USER/state')"
+assert "backtick command-substitution metachar rejected (exit 1)" "1" "$(rc '/home/`whoami`/state')"
+
+# --- Reject: control characters -----------------------------------------------
+assert "embedded newline rejected (exit 1)" "1" "$(rc "$(printf '/home/a\nb/state')")"
+assert "embedded tab rejected (exit 1)" "1" "$(rc "$(printf '/home/a\tb/state')")"
+
+# --- Rejection diagnostics reach stderr ---------------------------------------
+traversal_err="$(bash "$SCRIPT" "/home/user/../etc" 2>&1 >/dev/null || true)"
+if printf '%s' "$traversal_err" | grep -qE 'unsafe traversal or shell metacharacter'; then
+  pass "traversal rejection prints a descriptive ERROR to stderr"
+else
+  fail "traversal ERROR missing/malformed: $traversal_err"
+fi
+ctrl_err="$(bash "$SCRIPT" "$(printf '/home/a\nb')" 2>&1 >/dev/null || true)"
+if printf '%s' "$ctrl_err" | grep -qE 'control characters'; then
+  pass "control-char rejection prints a descriptive ERROR to stderr"
+else
+  fail "control-char ERROR missing/malformed: $ctrl_err"
+fi
+
+print_summary "_validate-state-root.sh"

--- a/plugins/rite/hooks/tests/wiki-config-branch-name.test.sh
+++ b/plugins/rite/hooks/tests/wiki-config-branch-name.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Security pin tests for validate_wiki_branch_name() in
+# hooks/scripts/lib/wiki-config.sh (Issue #1719, AC-3)
+#
+# validate_wiki_branch_name rejects branch names that would be unsafe as a git
+# ref or as the positional argument of `git -C ... add -- "$path"` (leading `-`
+# parsed as a flag, leading `.` colliding with hidden refs, `..` traversal, `//`
+# empty segment, out-of-alphabet chars). Its callers only ever reach it on the
+# happy path with `wiki` (or a valid custom name), so the rejection branches
+# were never exercised directly. This test sources the lib and calls the
+# function against malicious inputs so a validation regression is caught.
+#
+# Convention: source the lib and call the function in-process (it is a
+# source-only helper, not a standalone script). No sandbox / network.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+LIB="$SCRIPT_DIR/../scripts/lib/wiki-config.sh"
+
+echo "=== validate_wiki_branch_name() security pin tests ==="
+
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: $LIB not found" >&2
+  exit 1
+fi
+
+# shellcheck source=../scripts/lib/wiki-config.sh
+source "$LIB"
+
+if ! type validate_wiki_branch_name >/dev/null 2>&1; then
+  echo "ERROR: validate_wiki_branch_name not defined after sourcing $LIB" >&2
+  exit 1
+fi
+
+check() { validate_wiki_branch_name "$1" >/dev/null 2>&1; echo $?; }
+
+# --- Accept: valid ref names --------------------------------------------------
+assert "'wiki' (default) accepted" "0" "$(check "wiki")"
+assert "namespaced 'feature/wiki-notes' accepted" "0" "$(check "feature/wiki-notes")"
+assert "dot-in-middle 'wiki.backup' accepted" "0" "$(check "wiki.backup")"
+assert "underscore/dash/slash 'a_b-c/d' accepted" "0" "$(check "a_b-c/d")"
+
+# --- Reject: empty ------------------------------------------------------------
+assert "empty name rejected" "1" "$(check "")"
+
+# --- Reject: leading '-' (parsed as an option flag) ---------------------------
+assert "leading '-' rejected" "1" "$(check "-wiki")"
+
+# --- Reject: leading '.' (hidden-ref collision) -------------------------------
+assert "leading '.' rejected" "1" "$(check ".wiki")"
+
+# --- Reject: '..' traversal in refs/heads/<name> ------------------------------
+assert "'..' traversal rejected" "1" "$(check "wiki/../evil")"
+
+# --- Reject: '//' empty path segment ------------------------------------------
+assert "'//' empty segment rejected" "1" "$(check "wiki//branch")"
+
+# --- Reject: out-of-alphabet characters ---------------------------------------
+assert "space rejected" "1" "$(check "wiki branch")"
+assert "shell metachar '\$' rejected" "1" "$(check 'wiki$x')"
+assert "semicolon rejected" "1" "$(check "wiki;rm")"
+
+# --- Rejection diagnostics reach stderr ---------------------------------------
+reject_err="$(validate_wiki_branch_name "-wiki" 2>&1 >/dev/null || true)"
+if printf '%s' "$reject_err" | grep -qE "invalid wiki.branch_name"; then
+  pass "rejection prints a descriptive ERROR to stderr"
+else
+  fail "rejection ERROR missing/malformed: $reject_err"
+fi
+
+print_summary "validate_wiki_branch_name"

--- a/plugins/rite/hooks/tests/wiki-growth-check.test.sh
+++ b/plugins/rite/hooks/tests/wiki-growth-check.test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Tests for hooks/scripts/wiki-growth-check.sh (Issue #1719)
+#
+# The checker is a non-blocking lint that fires (exit 1) when the wiki branch
+# has stalled relative to merged PRs on the base branch. Its many skip paths
+# (exit 0) exist so it never blocks a flow on a misconfigured or wiki-disabled
+# repo. These tests pin the invocation contract, the config/branch skip gates,
+# and one gh-stubbed positive detection.
+#
+# Convention: mktemp sandbox, gh stubbed via PATH (no network), GNU/BSD
+# portable, commit.gpgsign disabled locally so fixtures commit under a global
+# signing config.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../scripts/wiki-growth-check.sh"
+
+echo "=== wiki-growth-check.sh tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+
+SANDBOXES=()
+cleanup() { local d; for d in "${SANDBOXES[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT INT TERM HUP
+
+# gh stub: emit a fixed merged-PR JSON array (GH_STUB_PRS, default []). Both the
+# growth-stall count query and the pr-raw correspondence query read this.
+STUB_DIR="$(mktemp -d)"; SANDBOXES+=("$STUB_DIR")
+cat > "$STUB_DIR/gh" <<'EOF'
+#!/bin/bash
+printf '%s\n' "${GH_STUB_PRS:-[]}"
+exit 0
+EOF
+chmod +x "$STUB_DIR/gh"
+
+# Build a git repo with rite-config.yml committed and (optionally) a wiki branch.
+#   $1 = wiki enabled? (true|false)   $2 = create wiki branch? (yes|no)
+# Echoes the repo path.
+make_wiki_repo() {
+  local enabled="$1" with_wiki="$2" repo
+  repo="$(mktemp -d)"; SANDBOXES+=("$repo")
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@test.local
+  git -C "$repo" config user.name test
+  git -C "$repo" config commit.gpgsign false
+  printf 'wiki:\n  enabled: %s\n  branch_name: wiki\nbranch:\n  base: develop\n' "$enabled" \
+    > "$repo/rite-config.yml"
+  git -C "$repo" add rite-config.yml
+  git -C "$repo" commit -q -m init
+  [ "$with_wiki" = "yes" ] && git -C "$repo" branch wiki
+  printf '%s' "$repo"
+}
+
+# --- Invocation contract ------------------------------------------------------
+assert "--help exits 0" "0" "$(bash "$SCRIPT" --help >/dev/null 2>&1; echo $?)"
+assert "unknown argument exits 2" "2" "$(bash "$SCRIPT" --repo-root "$STUB_DIR" --bogus >/dev/null 2>&1; echo $?)"
+
+# --- Skip gates (exit 0) ------------------------------------------------------
+empty_dir="$(mktemp -d)"; SANDBOXES+=("$empty_dir")
+assert "rite-config.yml absent → skip (exit 0)" "0" \
+  "$(bash "$SCRIPT" --repo-root "$empty_dir" --quiet >/dev/null 2>&1; echo $?)"
+
+disabled_repo="$(make_wiki_repo false yes)"
+assert "wiki.enabled=false → skip (exit 0)" "0" \
+  "$(bash "$SCRIPT" --repo-root "$disabled_repo" --quiet >/dev/null 2>&1; echo $?)"
+
+no_wiki_repo="$(make_wiki_repo true no)"
+assert "wiki branch absent → skip (exit 0)" "0" \
+  "$(PATH="$STUB_DIR:$PATH" bash "$SCRIPT" --repo-root "$no_wiki_repo" --quiet >/dev/null 2>&1; echo $?)"
+
+# --- Healthy: wiki branch present, zero merged PRs → exit 0 -------------------
+healthy_repo="$(make_wiki_repo true yes)"
+assert "no merged PRs since last wiki commit → healthy (exit 0)" "0" \
+  "$(PATH="$STUB_DIR:$PATH" GH_STUB_PRS='[]' bash "$SCRIPT" --repo-root "$healthy_repo" --quiet >/dev/null 2>&1; echo $?)"
+
+# --- Growth stall detected (exit 1) ------------------------------------------
+# threshold=1 with 1 merged PR trips the stall; pr-raw-threshold set high so the
+# correspondence check stays healthy and only the growth-stall finding counts.
+stall_repo="$(make_wiki_repo true yes)"
+assert "merged PRs >= threshold with stalled wiki → finding (exit 1)" "1" \
+  "$(PATH="$STUB_DIR:$PATH" GH_STUB_PRS='[{"number":1}]' bash "$SCRIPT" \
+      --repo-root "$stall_repo" --threshold 1 --pr-raw-threshold 999 --quiet >/dev/null 2>&1; echo $?)"
+
+# --- Findings line always emitted --------------------------------------------
+findings_out="$(PATH="$STUB_DIR:$PATH" GH_STUB_PRS='[]' bash "$SCRIPT" --repo-root "$healthy_repo" --quiet 2>/dev/null || true)"
+if printf '%s' "$findings_out" | grep -qE '==> Total wiki-growth-check findings: [0-9]+'; then
+  pass "always prints the findings summary line"
+else
+  fail "findings summary line missing: $findings_out"
+fi
+
+print_summary "wiki-growth-check.sh"

--- a/plugins/rite/hooks/tests/wiki-growth-check.test.sh
+++ b/plugins/rite/hooks/tests/wiki-growth-check.test.sh
@@ -25,6 +25,13 @@ if [ ! -f "$SCRIPT" ]; then
   echo "ERROR: $SCRIPT not found" >&2
   exit 1
 fi
+# The growth-stall path counts merged PRs via jq; without jq the script exits 0
+# (skip) and the exit-1 assertion below would FAIL rather than skip. Guard the
+# whole test the same way the sibling review-schema-version-check.test.sh does.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available — wiki-growth-check requires jq" >&2
+  exit 0
+fi
 
 SANDBOXES=()
 cleanup() { local d; for d in "${SANDBOXES[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
@@ -42,19 +49,29 @@ chmod +x "$STUB_DIR/gh"
 
 # Build a git repo with rite-config.yml committed and (optionally) a wiki branch.
 #   $1 = wiki enabled? (true|false)   $2 = create wiki branch? (yes|no)
-# Echoes the repo path.
+# Echoes the repo path. The caller MUST register the returned path in SANDBOXES
+# from the PARENT shell — this helper runs inside a $(...) command substitution,
+# so a `SANDBOXES+=` here would be lost with the subshell (the pitfall
+# _test-helpers.sh documents). Git steps are &&-chained and HEAD is asserted so a
+# broken fixture fails loudly instead of returning an empty repo that silently
+# passes the skip-path (exit 0) assertions.
 make_wiki_repo() {
   local enabled="$1" with_wiki="$2" repo
-  repo="$(mktemp -d)"; SANDBOXES+=("$repo")
-  git -C "$repo" init -q
-  git -C "$repo" config user.email t@test.local
-  git -C "$repo" config user.name test
-  git -C "$repo" config commit.gpgsign false
+  repo="$(mktemp -d)"
+  git -C "$repo" init -q \
+    && git -C "$repo" config user.email t@test.local \
+    && git -C "$repo" config user.name test \
+    && git -C "$repo" config commit.gpgsign false \
+    || { echo "FAIL: make_wiki_repo git init/config failed" >&2; exit 1; }
   printf 'wiki:\n  enabled: %s\n  branch_name: wiki\nbranch:\n  base: develop\n' "$enabled" \
     > "$repo/rite-config.yml"
-  git -C "$repo" add rite-config.yml
-  git -C "$repo" commit -q -m init
-  [ "$with_wiki" = "yes" ] && git -C "$repo" branch wiki
+  git -C "$repo" add rite-config.yml \
+    && git -C "$repo" commit -q -m init \
+    && git -C "$repo" rev-parse HEAD >/dev/null 2>&1 \
+    || { echo "FAIL: make_wiki_repo fixture commit failed" >&2; exit 1; }
+  if [ "$with_wiki" = "yes" ]; then
+    git -C "$repo" branch wiki || { echo "FAIL: make_wiki_repo wiki branch failed" >&2; exit 1; }
+  fi
   printf '%s' "$repo"
 }
 
@@ -67,23 +84,23 @@ empty_dir="$(mktemp -d)"; SANDBOXES+=("$empty_dir")
 assert "rite-config.yml absent → skip (exit 0)" "0" \
   "$(bash "$SCRIPT" --repo-root "$empty_dir" --quiet >/dev/null 2>&1; echo $?)"
 
-disabled_repo="$(make_wiki_repo false yes)"
+disabled_repo="$(make_wiki_repo false yes)"; SANDBOXES+=("$disabled_repo")
 assert "wiki.enabled=false → skip (exit 0)" "0" \
   "$(bash "$SCRIPT" --repo-root "$disabled_repo" --quiet >/dev/null 2>&1; echo $?)"
 
-no_wiki_repo="$(make_wiki_repo true no)"
+no_wiki_repo="$(make_wiki_repo true no)"; SANDBOXES+=("$no_wiki_repo")
 assert "wiki branch absent → skip (exit 0)" "0" \
   "$(PATH="$STUB_DIR:$PATH" bash "$SCRIPT" --repo-root "$no_wiki_repo" --quiet >/dev/null 2>&1; echo $?)"
 
 # --- Healthy: wiki branch present, zero merged PRs → exit 0 -------------------
-healthy_repo="$(make_wiki_repo true yes)"
+healthy_repo="$(make_wiki_repo true yes)"; SANDBOXES+=("$healthy_repo")
 assert "no merged PRs since last wiki commit → healthy (exit 0)" "0" \
   "$(PATH="$STUB_DIR:$PATH" GH_STUB_PRS='[]' bash "$SCRIPT" --repo-root "$healthy_repo" --quiet >/dev/null 2>&1; echo $?)"
 
 # --- Growth stall detected (exit 1) ------------------------------------------
 # threshold=1 with 1 merged PR trips the stall; pr-raw-threshold set high so the
 # correspondence check stays healthy and only the growth-stall finding counts.
-stall_repo="$(make_wiki_repo true yes)"
+stall_repo="$(make_wiki_repo true yes)"; SANDBOXES+=("$stall_repo")
 assert "merged PRs >= threshold with stalled wiki → finding (exit 1)" "1" \
   "$(PATH="$STUB_DIR:$PATH" GH_STUB_PRS='[{"number":1}]' bash "$SCRIPT" \
       --repo-root "$stall_repo" --threshold 1 --pr-raw-threshold 999 --quiet >/dev/null 2>&1; echo $?)"

--- a/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
+++ b/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
@@ -37,28 +37,43 @@ cleanup() {
 trap cleanup EXIT INT TERM HUP
 
 # Build a git repo with rite-config.yml (wiki enabled|disabled). Echoes the path.
+# The caller MUST register the returned path in SANDBOXES from the PARENT shell —
+# this helper runs inside a $(...) command substitution, so a `SANDBOXES+=` here
+# would be lost with the subshell (the pitfall _test-helpers.sh documents for
+# make_sandbox). Git steps are &&-chained and HEAD is asserted so a broken fixture
+# fails loudly instead of returning a half-built repo that silently passes the
+# skip-path tests.
 new_repo() {
   local enabled="$1" repo
-  repo="$(mktemp -d)"; SANDBOXES+=("$repo")
-  git -C "$repo" init -q
-  git -C "$repo" config user.email t@test.local
-  git -C "$repo" config user.name test
-  git -C "$repo" config commit.gpgsign false
+  repo="$(mktemp -d)"
+  git -C "$repo" init -q \
+    && git -C "$repo" config user.email t@test.local \
+    && git -C "$repo" config user.name test \
+    && git -C "$repo" config commit.gpgsign false \
+    || { echo "FAIL: new_repo git init/config failed" >&2; exit 1; }
   printf 'wiki:\n  enabled: %s\n  branch_name: wiki\n' "$enabled" > "$repo/rite-config.yml"
-  git -C "$repo" add rite-config.yml
-  git -C "$repo" commit -q -m init
+  git -C "$repo" add rite-config.yml \
+    && git -C "$repo" commit -q -m init \
+    && git -C "$repo" rev-parse HEAD >/dev/null 2>&1 \
+    || { echo "FAIL: new_repo fixture commit failed" >&2; exit 1; }
   printf '%s' "$repo"
 }
 
 # Add a `wiki` branch, a local bare "origin", and a wiki-worktree on it.
+# Called directly (not in $(...)) so `SANDBOXES+=` reaches the parent and `exit 1`
+# aborts the whole run. Git steps are &&-chained and origin/wiki is asserted so a
+# failed push cannot degrade the happy-path "advanced" check into an empty-string
+# comparison that passes without a real push.
 setup_wiki_worktree() {
   local repo="$1" bare
-  git -C "$repo" branch wiki
   bare="$(mktemp -d)"; SANDBOXES+=("$bare")
-  git -C "$bare" init -q --bare
-  git -C "$repo" remote add origin "$bare"
-  git -C "$repo" push -q origin wiki
-  git -C "$repo" worktree add -q "$repo/.rite/wiki-worktree" wiki
+  git -C "$repo" branch wiki \
+    && git -C "$bare" init -q --bare \
+    && git -C "$repo" remote add origin "$bare" \
+    && git -C "$repo" push -q origin wiki \
+    && git -C "$repo" worktree add -q "$repo/.rite/wiki-worktree" wiki \
+    && git -C "$repo" rev-parse origin/wiki >/dev/null 2>&1 \
+    || { echo "FAIL: setup_wiki_worktree failed (branch/bare/remote/push/worktree)" >&2; exit 1; }
 }
 
 # Drop an untracked page under the worktree's .rite/wiki tree.
@@ -72,20 +87,19 @@ run_in() { local repo="$1"; shift; ( cd "$repo" && bash "$SCRIPT" "$@" ) 2>/dev/
 rc_in()  { local repo="$1"; shift; ( cd "$repo" && bash "$SCRIPT" "$@" >/dev/null 2>&1 ); echo $?; }
 
 # --- Invocation contract (no repo needed) ------------------------------------
+# Reuse rc_in() rather than a raw `$(( cd ... ))` — the latter reads as an
+# arithmetic-expansion opener (shellcheck SC1102) and errors under POSIX sh.
 assert "--help exits 0" "0" "$(bash "$SCRIPT" --help >/dev/null 2>&1; echo $?)"
 plain="$(mktemp -d)"; SANDBOXES+=("$plain")
-assert "unknown option exits 1" "1" "$(( cd "$plain" && bash "$SCRIPT" --bogus ) >/dev/null 2>&1; echo $?)"
-assert "outside a git repo exits 1" "1" "$(( cd "$plain" && bash "$SCRIPT" ) >/dev/null 2>&1; echo $?)"
-# newline in --message is rejected before any git op (header smuggling guard).
-assert "--message with newline exits 1" "1" \
-  "$(( cd "$plain" && bash "$SCRIPT" --message "$(printf 'a\nb')" ) >/dev/null 2>&1; echo $?)"
+assert "unknown option exits 1" "1" "$(rc_in "$plain" --bogus)"
+assert "outside a git repo exits 1" "1" "$(rc_in "$plain")"
 
 # --- Config / worktree preconditions -----------------------------------------
 norc_repo="$(mktemp -d)"; SANDBOXES+=("$norc_repo")
 git -C "$norc_repo" init -q
 assert "rite-config.yml absent exits 1" "1" "$(rc_in "$norc_repo")"
 
-disabled_repo="$(new_repo false)"
+disabled_repo="$(new_repo false)"; SANDBOXES+=("$disabled_repo")
 assert "wiki disabled exits 2" "2" "$(rc_in "$disabled_repo")"
 # Capture stdout to a variable first: run_in exits 2 here, and `set -o pipefail`
 # would make `run_in | grep` report the pipeline as failed even on a grep match.
@@ -96,11 +110,11 @@ else
   fail "wiki-disabled reason line missing: $disabled_out"
 fi
 
-missing_wt_repo="$(new_repo true)"
+missing_wt_repo="$(new_repo true)"; SANDBOXES+=("$missing_wt_repo")
 assert "worktree missing exits 1" "1" "$(rc_in "$missing_wt_repo")"
 
 # --- No pending changes → no-op commit=0 -------------------------------------
-nopending_repo="$(new_repo true)"
+nopending_repo="$(new_repo true)"; SANDBOXES+=("$nopending_repo")
 setup_wiki_worktree "$nopending_repo"
 assert "no pending changes exits 0" "0" "$(rc_in "$nopending_repo")"
 nopending_out="$(run_in "$nopending_repo")"
@@ -110,8 +124,17 @@ else
   fail "no-pending status line missing: $nopending_out"
 fi
 
+# --- newline --message guard, isolated -----------------------------------
+# The header-smuggling guard fires BEFORE the git/worktree checks. Run against a
+# fully-built repo where a benign message reaches the no-pending exit 0, so the
+# benign=0 / newline=1 differential pins the guard specifically — a bare non-git
+# dir would give exit 1 on both (from the not-a-git-repo check) and not isolate it.
+assert "benign --message reaches no-pending (exit 0)" "0" "$(rc_in "$nopending_repo" --message "safe message")"
+assert "--message with newline is rejected by the guard (exit 1)" "1" \
+  "$(rc_in "$nopending_repo" --message "$(printf 'a\nb')")"
+
 # --- Dry-run: reports pending, performs no commit ----------------------------
-dryrun_repo="$(new_repo true)"
+dryrun_repo="$(new_repo true)"; SANDBOXES+=("$dryrun_repo")
 setup_wiki_worktree "$dryrun_repo"
 add_pending "$dryrun_repo"
 wiki_before_dry="$(git -C "$dryrun_repo" rev-parse wiki)"
@@ -125,7 +148,7 @@ else
 fi
 
 # --- Happy path: commit + push to LOCAL bare origin (AC-4) --------------------
-commit_repo="$(new_repo true)"
+commit_repo="$(new_repo true)"; SANDBOXES+=("$commit_repo")
 setup_wiki_worktree "$commit_repo"
 add_pending "$commit_repo"
 origin_before="$(git -C "$commit_repo" rev-parse origin/wiki)"

--- a/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
+++ b/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Tests for hooks/scripts/wiki-worktree-commit.sh (Issue #1719)
+#
+# The script stages + commits + pushes pending changes in the .rite/wiki-worktree
+# worktree. It has a git push side effect, so the happy-path test wires `origin`
+# to a LOCAL bare repo (AC-4): the push lands in that bare repo, never touching a
+# real remote or the network. The remaining cases pin the invocation contract and
+# the early-exit reasons (wiki-disabled / worktree-missing / no-pending / dry-run).
+#
+# Convention: mktemp sandbox, no gh, no network, GNU/BSD portable, commit.gpgsign
+# disabled locally so fixtures commit under a global signing config.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+SCRIPT="$SCRIPT_DIR/../scripts/wiki-worktree-commit.sh"
+
+echo "=== wiki-worktree-commit.sh tests ==="
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found" >&2
+  exit 1
+fi
+
+SANDBOXES=()
+cleanup() {
+  local d
+  for d in "${SANDBOXES[@]:-}"; do
+    # Detach any worktrees before rm so no stale admin entries leak into $HOME.
+    [ -n "$d" ] && [ -d "$d" ] && git -C "$d" worktree prune 2>/dev/null || true
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT INT TERM HUP
+
+# Build a git repo with rite-config.yml (wiki enabled|disabled). Echoes the path.
+new_repo() {
+  local enabled="$1" repo
+  repo="$(mktemp -d)"; SANDBOXES+=("$repo")
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@test.local
+  git -C "$repo" config user.name test
+  git -C "$repo" config commit.gpgsign false
+  printf 'wiki:\n  enabled: %s\n  branch_name: wiki\n' "$enabled" > "$repo/rite-config.yml"
+  git -C "$repo" add rite-config.yml
+  git -C "$repo" commit -q -m init
+  printf '%s' "$repo"
+}
+
+# Add a `wiki` branch, a local bare "origin", and a wiki-worktree on it.
+setup_wiki_worktree() {
+  local repo="$1" bare
+  git -C "$repo" branch wiki
+  bare="$(mktemp -d)"; SANDBOXES+=("$bare")
+  git -C "$bare" init -q --bare
+  git -C "$repo" remote add origin "$bare"
+  git -C "$repo" push -q origin wiki
+  git -C "$repo" worktree add -q "$repo/.rite/wiki-worktree" wiki
+}
+
+# Drop an untracked page under the worktree's .rite/wiki tree.
+add_pending() {
+  local repo="$1"
+  mkdir -p "$repo/.rite/wiki-worktree/.rite/wiki/pages"
+  printf '# test page\n' > "$repo/.rite/wiki-worktree/.rite/wiki/pages/test.md"
+}
+
+run_in() { local repo="$1"; shift; ( cd "$repo" && bash "$SCRIPT" "$@" ) 2>/dev/null; }
+rc_in()  { local repo="$1"; shift; ( cd "$repo" && bash "$SCRIPT" "$@" >/dev/null 2>&1 ); echo $?; }
+
+# --- Invocation contract (no repo needed) ------------------------------------
+assert "--help exits 0" "0" "$(bash "$SCRIPT" --help >/dev/null 2>&1; echo $?)"
+plain="$(mktemp -d)"; SANDBOXES+=("$plain")
+assert "unknown option exits 1" "1" "$(( cd "$plain" && bash "$SCRIPT" --bogus ) >/dev/null 2>&1; echo $?)"
+assert "outside a git repo exits 1" "1" "$(( cd "$plain" && bash "$SCRIPT" ) >/dev/null 2>&1; echo $?)"
+# newline in --message is rejected before any git op (header smuggling guard).
+assert "--message with newline exits 1" "1" \
+  "$(( cd "$plain" && bash "$SCRIPT" --message "$(printf 'a\nb')" ) >/dev/null 2>&1; echo $?)"
+
+# --- Config / worktree preconditions -----------------------------------------
+norc_repo="$(mktemp -d)"; SANDBOXES+=("$norc_repo")
+git -C "$norc_repo" init -q
+assert "rite-config.yml absent exits 1" "1" "$(rc_in "$norc_repo")"
+
+disabled_repo="$(new_repo false)"
+assert "wiki disabled exits 2" "2" "$(rc_in "$disabled_repo")"
+# Capture stdout to a variable first: run_in exits 2 here, and `set -o pipefail`
+# would make `run_in | grep` report the pipeline as failed even on a grep match.
+disabled_out="$(run_in "$disabled_repo")"
+if printf '%s' "$disabled_out" | grep -q 'reason=wiki-disabled'; then
+  pass "wiki disabled reports reason=wiki-disabled"
+else
+  fail "wiki-disabled reason line missing: $disabled_out"
+fi
+
+missing_wt_repo="$(new_repo true)"
+assert "worktree missing exits 1" "1" "$(rc_in "$missing_wt_repo")"
+
+# --- No pending changes → no-op commit=0 -------------------------------------
+nopending_repo="$(new_repo true)"
+setup_wiki_worktree "$nopending_repo"
+assert "no pending changes exits 0" "0" "$(rc_in "$nopending_repo")"
+nopending_out="$(run_in "$nopending_repo")"
+if printf '%s' "$nopending_out" | grep -q 'committed=0; branch=wiki; reason=no-pending'; then
+  pass "no pending reports committed=0; reason=no-pending"
+else
+  fail "no-pending status line missing: $nopending_out"
+fi
+
+# --- Dry-run: reports pending, performs no commit ----------------------------
+dryrun_repo="$(new_repo true)"
+setup_wiki_worktree "$dryrun_repo"
+add_pending "$dryrun_repo"
+wiki_before_dry="$(git -C "$dryrun_repo" rev-parse wiki)"
+dry_out="$(run_in "$dryrun_repo" --dry-run)"
+wiki_after_dry="$(git -C "$dryrun_repo" rev-parse wiki)"
+assert "dry-run does not advance the wiki branch" "$wiki_before_dry" "$wiki_after_dry"
+if printf '%s' "$dry_out" | grep -qE 'dry-run; branch=wiki'; then
+  pass "dry-run reports the dry-run status line"
+else
+  fail "dry-run status line missing: $dry_out"
+fi
+
+# --- Happy path: commit + push to LOCAL bare origin (AC-4) --------------------
+commit_repo="$(new_repo true)"
+setup_wiki_worktree "$commit_repo"
+add_pending "$commit_repo"
+origin_before="$(git -C "$commit_repo" rev-parse origin/wiki)"
+commit_out="$(run_in "$commit_repo")"
+if printf '%s' "$commit_out" | grep -qE 'committed=1; branch=wiki;.*push=ok'; then
+  pass "pending change is committed and pushed to the local bare origin (push=ok)"
+else
+  fail "expected committed=1 + push=ok; got: $commit_out"
+fi
+origin_after="$(git -C "$commit_repo" rev-parse origin/wiki)"
+assert "local bare origin/wiki advanced (push landed, no network)" \
+  "advanced" \
+  "$([ "$origin_before" != "$origin_after" ] && echo advanced || echo unchanged)"
+# The committed page is now tracked on the wiki branch.
+if git -C "$commit_repo" ls-tree -r --name-only wiki | grep -q '.rite/wiki/pages/test.md'; then
+  pass "committed page is tracked on the wiki branch"
+else
+  fail "committed page not found on wiki branch"
+fi
+
+print_summary "wiki-worktree-commit.sh"


### PR DESCRIPTION
## 概要

`run-tests.sh` は `hooks/tests/*.test.sh` のみを glob していたため、別ディレクトリ `hooks/scripts/tests/` の `test-*.sh` 4 件が「存在するのに実行されない」実効ゼロ状態だった。runner を両ディレクトリ探索に拡張し、単一 runner で全テストを実行できるようにしたうえで、未テストだったスクリプト群・セキュリティ拒否ロジックにテストを追加してカバレッジの空白を埋める。対象スクリプト本体は変更していない（テスト追加が目的）。

## Related Issue

Closes #1719

## Changes

- **配線ギャップ修正（AC-1）**: `run-tests.sh` を `hooks/tests/*.test.sh` に加え `hooks/scripts/tests/test-*.sh` も discover するよう拡張。孤立していた 4 テスト（bang-backtick / distributed-fix-drift / doc-heavy-patterns-drift / hardcoded-line-number）が単一 runner から実行されるようになり、全て pass することを確認
- **未テストスクリプトのテスト追加（AC-2）**: 5 スクリプトに新規テストを追加
  - `wiki-worktree-commit.test.sh`: **ローカル bare repo を origin** にして push 副作用をネットワーク非依存に閉じ込め（AC-4）。commit=1/push=ok/no-pending/dry-run/wiki-disabled/worktree-missing の各経路を pin
  - `wiki-growth-check.test.sh`: config gating・wiki branch 不在 skip に加え、gh stub で growth-stall 検出（exit 1）を検証
  - `backlink-format-check.test.sh` / `comment-line-ref-check.test.sh` / `review-schema-version-check.test.sh`: help / invocation error / clean / NG fixture を pin
- **セキュリティ pin テスト（AC-3）**: 従来 happy path 経由でしか実行されなかった拒否分岐を直接検証
  - `validate-state-root.test.sh`: `_validate-state-root.sh` のパストラバーサル（`..`）・シェルメタ文字（`$` / バッククォート）・制御文字の拒否
  - `wiki-config-branch-name.test.sh`: `validate_wiki_branch_name` の不正ブランチ名拒否
- **nit**: `session-ownership.test.sh` の固定 `/tmp` パス（TC-CORRUPT-01/02）を per-run `TEST_DIR`（`mktemp -d`・trap cleanup 済み）配下へ移し、並列実行時の衝突を解消
- **ドキュメント整合**: `CONTRIBUTING.md` の runner discovery 説明を 2 ディレクトリ探索に更新

## 検証

- runner 一括実行で **91/91 テストファイル green**（既存 80 + 配線 4 + 新規 7、AC-5）
- 新規テストは既存規約に準拠: `mktemp` サンドボックス / `gh` の PATH stub / ネットワーク不使用 / GNU・BSD 両対応 / `commit.gpgsign` 無効化 / `_test-helpers.sh` の共通ヘルパー再利用
- plugin 固有 lint チェック実行済み。検出された warning は全て develop 時点の既存・非ブロッキングで、本 PR の変更ファイルは新規 finding ゼロ

## Definition of Done

- [x] All MUST requirements implemented（push 副作用なし・既存規約準拠・単一コマンド実行 + 件数報告）
- [x] All Acceptance Criteria (AC-1〜5) verified
- [x] All test cases (T-01〜05) passing
- [x] No regression in existing functionality（既存 80 テスト pass 維持）
- [x] Target files modified, non-target files untouched（対象スクリプト本体は不変）
- [x] Code follows project conventions

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
