### PR TITLE
fix(hooks): pre-tool-bash-guard の Pattern 4 を fail-closed 化し timeout を設定

### DIFF
--- a/plugins/rite/hooks/hooks.json
+++ b/plugins/rite/hooks/hooks.json
@@ -59,7 +59,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-bash-guard.sh"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-bash-guard.sh",
+            "timeout": 10
           }
         ],
         "matcher": "Bash"

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -181,14 +181,6 @@ _rite_btg_pattern4_fail_closed() {
 }
 trap '_rite_btg_pattern13_fail_open' ERR
 
-# Test-only fault injection for the fail-OPEN region (no effect in production):
-# raises an ERR while the Patterns 1-3 fail-open trap is active so the regression
-# test can confirm a crash here still resolves to allow (exit 0). Gated on an env
-# var that is never set outside the test suite.
-if [ "${RITE_BTG_TEST_CRASH:-}" = "pattern13" ]; then
-  false
-fi
-
 # --- Heredoc-safe command extraction ---
 # Strip heredoc content to avoid false positives on text inside commit messages,
 # PR descriptions, etc. Only check the command prefix before the first heredoc marker.
@@ -277,9 +269,20 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # TC-118) — it cannot be crashed by faking an external binary. This lets the
   # fail-closed regression test raise an ERR deterministically inside the guarded
   # region. Gated on an env var that is never set outside the test suite.
+  # Deliberately fail-CLOSED-only: if the env var is ever set in production, the
+  # only effect is a DENY (the guard becomes more restrictive) — it can never turn
+  # the guard into allow-all. A symmetric fail-OPEN injection was intentionally NOT
+  # added, because an env-triggered fail-open path would be an allow-all backdoor to
+  # a security boundary. AC-3 (Patterns 1-3 stay fail-open) is instead pinned
+  # structurally by the test (default trap is fail-open + restored at block exit).
   if [ "${RITE_BTG_TEST_CRASH:-}" = "pattern4" ]; then
     false
   fi
+  # Upper bound on global-flag normalization iterations (see the loops below). A
+  # legitimate reviewer git command has well under this many global flags; the cap
+  # exists only to keep an adversarially padded command from timing out the hook and
+  # falling open. 128 is >10x the realistic maximum and keeps worst-case cost tiny.
+  _RITE_BTG_MAX_GLOBAL_FLAG_NORM=128
   # Normalize whitespace AND shell meta-characters into a single space so that
   # `;git reset` / `(git checkout ...)` / `$(git commit)` / multi-line commands
   # are recognized as `git <verb>` with proper word boundaries.
@@ -355,12 +358,37 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     s="${s//\[/\\[}"
     printf '%s' "$s"
   }
+  # Global-flag normalization iteration cap (fail-closed on abnormally many flags).
+  # The per-flag regex + fork loops below are super-linear in the number of git
+  # global flags, and the PreToolUse hook timeout is fail-OPEN (a timed-out hook
+  # allows the command — Claude Code cancels the hook and lets the tool proceed). A
+  # reviewer subagent could therefore pad a state-mutating git with thousands of
+  # `-C x` global flags so this normalization exceeds the hook timeout; the deny is
+  # never emitted and the padded git executes, bypassing the guard. The ERR trap
+  # cannot catch a timeout (the process is killed externally), so this iteration cap
+  # is what keeps that failure mode fail-CLOSED. A legitimate reviewer git command
+  # has only a handful of global flags, so exceeding the cap means the input is
+  # adversarial → deny. The counter is shared across both loops so the total work is
+  # bounded regardless of which flag family is padded.
+  _gf_norm_iters=0
   while [[ " $CMD_NORMALIZED " =~ \ git\ (-C|--git-dir|--work-tree|--exec-path|--namespace|-c|--config-env)(=[^[:space:]]+|[[:space:]]+[^[:space:]]+)\  ]]; do
+    _gf_norm_iters=$((_gf_norm_iters + 1))
+    if [ "$_gf_norm_iters" -gt "$_RITE_BTG_MAX_GLOBAL_FLAG_NORM" ]; then
+      BLOCKED_PATTERN="reviewer-state-mutating-git"
+      BLOCKED_SUBKIND="oversized-normalization"
+      break
+    fi
     _matched="${BASH_REMATCH[0]}"
     _lit=$(_escape_glob_meta "${_matched# }")
     CMD_NORMALIZED="${CMD_NORMALIZED/$_lit/git }"
   done
   while [[ " $CMD_NORMALIZED " =~ \ git\ (--bare|--no-replace-objects|--paginate|--no-pager|--literal-pathspecs|--glob-pathspecs|--noglob-pathspecs|--icase-pathspecs|--no-optional-locks|--info-path|--man-path|--html-path)\  ]]; do
+    _gf_norm_iters=$((_gf_norm_iters + 1))
+    if [ "$_gf_norm_iters" -gt "$_RITE_BTG_MAX_GLOBAL_FLAG_NORM" ]; then
+      BLOCKED_PATTERN="reviewer-state-mutating-git"
+      BLOCKED_SUBKIND="oversized-normalization"
+      break
+    fi
     _matched="${BASH_REMATCH[0]}"
     _lit=$(_escape_glob_meta "${_matched# }")
     CMD_NORMALIZED="${CMD_NORMALIZED/$_lit/git }"
@@ -620,6 +648,14 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     if [ "$BLOCKED_SUBKIND" = "shell-wrapper" ]; then
       BLOCKED_REASON="Shell-command wrappers (eval / bash -c / sh -c / zsh -c / ksh -c / dash -c / fish -c) are blocked in reviewer contexts because their quoted argument is opaque to this guard's word-boundary matching and can hide state-mutating git commands. They are therefore blocked unconditionally — even when the wrapped command is read-only. $BLOCKED_REASON"
       BLOCKED_ALTERNATIVE="For a read-only probe, drop the wrapper: run the command directly, group multiple commands in a subshell '( cmd1; cmd2 )', or put them in a file and run 'bash <script.sh>'. $BLOCKED_ALTERNATIVE"
+    fi
+    # (oversized-normalization) The command has an abnormally large number of git
+    # global flags, which would make normalization exceed the fail-open hook timeout.
+    # Denied fail-closed to prevent a timeout-based bypass — explain that rather than
+    # showing the generic state-mutating message (the command may even be read-only).
+    if [ "$BLOCKED_SUBKIND" = "oversized-normalization" ]; then
+      BLOCKED_REASON="This reviewer command carries an abnormally large number of git global flags (e.g. many repeated -C / -c). Normalizing that many flags could exceed the PreToolUse hook timeout, and a timed-out hook fails OPEN (the command would be allowed) — so such oversized commands are denied fail-closed to prevent a timeout-based bypass of the reviewer read-only guard. $BLOCKED_REASON"
+      BLOCKED_ALTERNATIVE="Simplify the command — reviewer git operations never need this many global flags. $BLOCKED_ALTERNATIVE"
     fi
   fi
   # Restore the Patterns 1-3 fail-open trap for the shared result-emit section

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -213,7 +213,9 @@ BLOCKED_SUBKIND=""
 _RITE_BTG_MAX_SUBAGENT_CMD_BYTES=65536
 if [ "$IS_SUBAGENT" = "1" ] && [ "${#COMMAND}" -gt "$_RITE_BTG_MAX_SUBAGENT_CMD_BYTES" ]; then
   BLOCKED_PATTERN="reviewer-state-mutating-git"
-  BLOCKED_SUBKIND="oversized-normalization"
+  # This path builds its own reason/alternative below and never reaches the Pattern 4
+  # block's message section (that block is skipped because BLOCKED_PATTERN is now set),
+  # so BLOCKED_SUBKIND is intentionally left unset here — it would be an inert write.
   BLOCKED_REASON="This reviewer command is abnormally large (${#COMMAND} bytes, ceiling ${_RITE_BTG_MAX_SUBAGENT_CMD_BYTES}). A command this size could make the guard's parsing exceed the PreToolUse hook timeout, and a timed-out hook fails OPEN (the command would be allowed) — so oversized reviewer commands are denied fail-closed to prevent a timeout-based bypass of the reviewer read-only guard."
   BLOCKED_ALTERNATIVE="Simplify the command — reviewer git operations are at most a few KB. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the read-only command set."
 fi

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -13,6 +13,19 @@
 # Exit behavior:
 #   exit 0 — allow (no output)
 #   stdout JSON with permissionDecision: "deny" — block
+#
+# Fail direction is pattern-specific: Patterns 1-3 (convenience) fail OPEN so an
+# edge-case parse crash never false-blocks a legitimate command; Pattern 4 (the
+# reviewer state-mutating-git security boundary) fails CLOSED so a parse crash
+# never silently bypasses the guard. See the two ERR traps below.
+#
+# hooks.json timeout: this hook is registered in hooks.json (PreToolUse:Bash) with
+# a 10s timeout. hooks.json is strict JSON (no comments), so the rationale lives
+# here: the guard is a fast, synchronous pre-execution gate that runs on every
+# Bash command using only bash built-ins plus a couple of jq calls, so 10s is a
+# generous ceiling that bounds a pathological hang without risking false timeouts —
+# aligned with the other lightweight synchronous gates (Stop=10s, the Edit/Write
+# bang-backtick hook=10s).
 set -euo pipefail
 
 # Double-execution guard (hooks.json + settings.local.json migration)
@@ -130,7 +143,51 @@ _rite_btg_pattern13_fail_open() {
   fi
   exit 0
 }
+# Fail-closed ERR trap for Pattern 4 (the reviewer state-mutating-git security
+# boundary): if normalization / token-loop evaluation crashes on edge-case input,
+# DENY the command (deny JSON + exit 2 + stderr WARNING) instead of allowing it.
+# This is the OPPOSITE failure direction from the fail-open trap above: convenience
+# patterns must not false-block, but the security pattern must not false-allow — a
+# single parse crash must never silently bypass the reviewer read-only guard. This
+# trap is installed only for the Pattern 4 block (swapped in at block entry,
+# restored to the fail-open trap at block exit), so non-reviewer sessions — which
+# never enter that block — are never denied by it.
+_rite_btg_pattern4_fail_closed() {
+  local _rc=$?
+  trap - ERR  # prevent re-entrancy while emitting the deny
+  # Visibility: record that the security boundary crashed and we fell closed.
+  echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] pre-tool-bash-guard: WARNING Pattern 4 (reviewer git guard) crashed (rc=$_rc) — command DENIED via fail-closed" >&2
+  if [ -n "${RITE_DEBUG:-}" ]; then
+    printf '[%s] pre-tool-bash-guard: Pattern 4 ERR trap fired (rc=%s) — deny fail-closed\n' \
+      "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$_rc" \
+      >> "${STATE_ROOT:-/tmp}/.rite-flow-debug.log" 2>/dev/null || true
+  fi
+  local _reason="BLOCKED (reviewer-state-mutating-git): Pattern 4 security-boundary evaluation crashed; denying fail-closed to avoid bypassing the reviewer read-only guard. See the bash-guard stderr WARNING for the crash context."
+  # Mirror the result-section emit contract: jq for the payload, printf fallback
+  # via _bash_guard_escape_deny_reason so a jq failure still emits a valid deny.
+  if ! jq -n --arg reason "$_reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }' 2>/dev/null; then
+    local _escaped
+    _escaped=$(_bash_guard_escape_deny_reason "$_reason" 2>/dev/null) \
+      || _escaped="BLOCKED: reviewer git command denied (Pattern 4 crash, fail-closed)."
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$_escaped"
+  fi
+  exit 2
+}
 trap '_rite_btg_pattern13_fail_open' ERR
+
+# Test-only fault injection for the fail-OPEN region (no effect in production):
+# raises an ERR while the Patterns 1-3 fail-open trap is active so the regression
+# test can confirm a crash here still resolves to allow (exit 0). Gated on an env
+# var that is never set outside the test suite.
+if [ "${RITE_BTG_TEST_CRASH:-}" = "pattern13" ]; then
+  false
+fi
 
 # --- Heredoc-safe command extraction ---
 # Strip heredoc content to avoid false positives on text inside commit messages,
@@ -210,6 +267,19 @@ fi
 #   (4) Long-form flag coverage: `git branch --delete/--force/--move/--copy`
 #       are treated the same as the short forms `-d/-f/-m/-c/-C`.
 if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
+  # Pattern 4 is the security boundary: swap the Patterns 1-3 fail-OPEN trap for a
+  # fail-CLOSED one so an unexpected crash while evaluating a reviewer's git command
+  # denies rather than allows. Restored to the fail-open trap at block exit (below)
+  # so the shared result-emit section keeps its original fail-open behavior.
+  trap '_rite_btg_pattern4_fail_closed' ERR
+  # Test-only fault injection for the fail-CLOSED region (no effect in production):
+  # Pattern 4 uses only bash built-ins, so — unlike the deny-emit path (see test
+  # TC-118) — it cannot be crashed by faking an external binary. This lets the
+  # fail-closed regression test raise an ERR deterministically inside the guarded
+  # region. Gated on an env var that is never set outside the test suite.
+  if [ "${RITE_BTG_TEST_CRASH:-}" = "pattern4" ]; then
+    false
+  fi
   # Normalize whitespace AND shell meta-characters into a single space so that
   # `;git reset` / `(git checkout ...)` / `$(git commit)` / multi-line commands
   # are recognized as `git <verb>` with proper word boundaries.
@@ -552,6 +622,10 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       BLOCKED_ALTERNATIVE="For a read-only probe, drop the wrapper: run the command directly, group multiple commands in a subshell '( cmd1; cmd2 )', or put them in a file and run 'bash <script.sh>'. $BLOCKED_ALTERNATIVE"
     fi
   fi
+  # Restore the Patterns 1-3 fail-open trap for the shared result-emit section
+  # below: a crash there keeps the original (pre-fix) fail-open behavior, and the
+  # section already has its own fail-closed fallback for the deny-emit path.
+  trap '_rite_btg_pattern13_fail_open' ERR
 fi
 
 # --- Result ---

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -181,14 +181,6 @@ _rite_btg_pattern4_fail_closed() {
 }
 trap '_rite_btg_pattern13_fail_open' ERR
 
-# --- Heredoc-safe command extraction ---
-# Strip heredoc content to avoid false positives on text inside commit messages,
-# PR descriptions, etc. Only check the command prefix before the first heredoc marker.
-# Known limitation: Piped heredoc patterns (e.g., `cat <<EOF | gh pr diff`) bypass
-# this stripping because the command before `<<` is `cat`, not the target pattern.
-# Risk is limited since such patterns are rare in practice.
-CMD_CHECK="${COMMAND%%<<*}"
-
 # --- Denylist check (Bash built-ins only) ---
 
 BLOCKED_PATTERN=""
@@ -199,14 +191,61 @@ BLOCKED_ALTERNATIVE=""
 # message can explain why a read-only wrapper probe is blocked.
 BLOCKED_SUBKIND=""
 
+# --- Reviewer command length guard (O(1), primary fail-closed bound) ---
+# Runs BEFORE the heredoc strip and every pattern check because that downstream work
+# is whole-string and at least two operations degrade to catastrophically slow on a
+# large enough input: the `${COMMAND%%<<*}` heredoc strip below is O(n²) in bash
+# (empirically ~45s on ~1.3MB), and Pattern 2's `[[ =~ ]]` regex is O(n²) on a few MB
+# of meta chars (empirically >2min). A timed-out PreToolUse hook fails OPEN (Claude
+# Code cancels it and lets the tool run), so a reviewer subagent could pad a
+# state-mutating git — with huge flag VALUES, thousands of flags, or a giant meta-char
+# string — until one of those operations times out, dropping the deny and bypassing
+# the guard. The ERR trap cannot catch a timeout (the process is killed externally). A
+# legitimate reviewer git command is at most a few KB, so any oversized command is
+# denied fail-closed here, before ANY O(n) work: setting BLOCKED_PATTERN both skips the
+# O(n²) heredoc strip (below) and short-circuits Patterns 1-4 (all now guarded by
+# `[ -z "$BLOCKED_PATTERN" ]`). Guards on the RAW ${#COMMAND} (fast, O(1)-ish) so the
+# check itself never triggers the slow path. Scoped to reviewer subagents
+# (IS_SUBAGENT=1), so normal main-session Bash is never blocked by size (MUST NOT — the
+# pre-existing main-session slowdown on huge input is a separate, out-of-scope
+# convenience-pattern concern). The per-flag iteration cap inside the Pattern 4 block
+# is a secondary bound on fork COUNT for sub-ceiling commands padded with many flags.
+_RITE_BTG_MAX_SUBAGENT_CMD_BYTES=65536
+if [ "$IS_SUBAGENT" = "1" ] && [ "${#COMMAND}" -gt "$_RITE_BTG_MAX_SUBAGENT_CMD_BYTES" ]; then
+  BLOCKED_PATTERN="reviewer-state-mutating-git"
+  BLOCKED_SUBKIND="oversized-normalization"
+  BLOCKED_REASON="This reviewer command is abnormally large (${#COMMAND} bytes, ceiling ${_RITE_BTG_MAX_SUBAGENT_CMD_BYTES}). A command this size could make the guard's parsing exceed the PreToolUse hook timeout, and a timed-out hook fails OPEN (the command would be allowed) — so oversized reviewer commands are denied fail-closed to prevent a timeout-based bypass of the reviewer read-only guard."
+  BLOCKED_ALTERNATIVE="Simplify the command — reviewer git operations are at most a few KB. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the read-only command set."
+fi
+
+# --- Heredoc-safe command extraction ---
+# Strip heredoc content to avoid false positives on text inside commit messages,
+# PR descriptions, etc. Only check the command prefix before the first heredoc marker.
+# Known limitation: Piped heredoc patterns (e.g., `cat <<EOF | gh pr diff`) bypass
+# this stripping because the command before `<<` is `cat`, not the target pattern.
+# Risk is limited since such patterns are rare in practice.
+# Skipped for an already-denied (oversized) command: `${COMMAND%%<<*}` is O(n²) on
+# huge input and would itself time out the fail-open hook (the whole reason the length
+# guard runs first). CMD_CHECK is unused in that case (the command is already denied).
+if [ -z "$BLOCKED_PATTERN" ]; then
+  CMD_CHECK="${COMMAND%%<<*}"
+else
+  CMD_CHECK=""
+fi
+
 # Pattern 1: gh pr diff --stat
-case "$CMD_CHECK" in
-  *"gh pr diff"*" --stat"*)
-    BLOCKED_PATTERN="gh-pr-diff-stat"
-    BLOCKED_REASON="gh pr diff does not support the --stat flag."
-    BLOCKED_ALTERNATIVE="Use: gh pr view {pr_number} --json files --jq '.files[] | {path, additions, deletions}'"
-    ;;
-esac
+# Guarded by `[ -z "$BLOCKED_PATTERN" ]` so the length guard above short-circuits it
+# (the `*A*B*` glob would otherwise run over an oversized string). Normally
+# BLOCKED_PATTERN is empty here, so this runs exactly as before.
+if [ -z "$BLOCKED_PATTERN" ]; then
+  case "$CMD_CHECK" in
+    *"gh pr diff"*" --stat"*)
+      BLOCKED_PATTERN="gh-pr-diff-stat"
+      BLOCKED_REASON="gh pr diff does not support the --stat flag."
+      BLOCKED_ALTERNATIVE="Use: gh pr view {pr_number} --json files --jq '.files[] | {path, additions, deletions}'"
+      ;;
+  esac
+fi
 
 # Pattern 2: gh pr diff -- <path> (file filter)
 # `[^|]*` (zero-or-more) covers both forms: `gh pr diff 123 -- file` and
@@ -278,10 +317,15 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   if [ "${RITE_BTG_TEST_CRASH:-}" = "pattern4" ]; then
     false
   fi
-  # Upper bound on global-flag normalization iterations (see the loops below). A
-  # legitimate reviewer git command has well under this many global flags; the cap
-  # exists only to keep an adversarially padded command from timing out the hook and
-  # falling open. 128 is >10x the realistic maximum and keeps worst-case cost tiny.
+  # Secondary bound: cap the global-flag normalization iterations (see the loops
+  # below). The PRIMARY bound is the length guard above, which denies any command
+  # large enough to time out before it is normalized; this cap additionally bounds
+  # the fork COUNT for sub-ceiling commands padded with many small global flags (so
+  # the per-flag regex+fork loop can't run thousands of times within the byte
+  # ceiling). A legitimate reviewer git command has well under this many global
+  # flags, so 128 (>10x the realistic maximum) denies such padding while never
+  # tripping on a real command. Bounded together with the length guard, the total
+  # normalization work is at most ~128 iterations over a <64KB string.
   _RITE_BTG_MAX_GLOBAL_FLAG_NORM=128
   # Normalize whitespace AND shell meta-characters into a single space so that
   # `;git reset` / `(git checkout ...)` / `$(git commit)` / multi-line commands

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1415,17 +1415,22 @@ rm -rf "$fake_bin_118"
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-119〜122: Pattern 4 (security boundary) fail-closed vs Pattern 1-3 fail-open
-#   Issue #1717: Pattern 4 (reviewer state-mutating-git denylist) shares the
+# TC-119〜123: Pattern 4 (security boundary) fail-closed vs Pattern 1-3 fail-open
+#   Issue #1717: Pattern 4 (reviewer state-mutating-git denylist) shared the
 #   fail-OPEN ERR trap with the convenience patterns, so a parse crash inside
-#   Pattern 4 converges to exit 0 (allow) and silently bypasses the security
+#   Pattern 4 converged to exit 0 (allow) and silently bypassed the security
 #   boundary. The fix installs a fail-CLOSED ERR trap over the Pattern 4 block
 #   (deny + exit 2 + WARNING) and restores fail-open afterwards. Pattern 4 uses
 #   only bash built-ins, so — unlike the deny-emit path faked in TC-118 — it
-#   cannot be crashed via a fake external binary; the hook exposes a test-only
-#   fault-injection env var (RITE_BTG_TEST_CRASH=pattern13|pattern4) that raises
-#   an ERR inside the respective trap region. These TCs drive it directly (the
-#   run_guard_* helpers do not thread extra env through the pipe).
+#   cannot be crashed via a fake external binary; the hook exposes a test-only,
+#   fail-CLOSED-ONLY fault-injection env var (RITE_BTG_TEST_CRASH=pattern4) that
+#   raises an ERR inside the fail-closed trap region (TC-119). A symmetric
+#   fail-OPEN injection was deliberately NOT added — an env-triggered fail-open
+#   path would be an allow-all backdoor to a security boundary — so AC-3 (Patterns
+#   1-3 stay fail-open) is pinned structurally instead (TC-120). TC-123 covers the
+#   timeout-bypass guard: an oversized global-flag command denies fail-closed before
+#   the super-linear normalization can time out the fail-open hook. These TCs drive
+#   the hook directly (the run_guard_* helpers do not thread extra env through the pipe).
 # --------------------------------------------------------------------------
 echo "TC-119: Pattern 4 crash in reviewer subagent → deny + exit 2 + stderr WARNING (AC-1)"
 rc=0
@@ -1452,15 +1457,35 @@ else
 fi
 echo ""
 
-echo "TC-120: Pattern 1-3 crash → allow (exit 0), fail-open preserved (AC-3)"
-rc=0
-tc120_input=$(jq -n --arg cmd "git status" --arg tp "$SUBAGENT_TRANSCRIPT" \
-  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
-output=$(echo "$tc120_input" | RITE_BTG_TEST_CRASH=pattern13 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
-if [ "$rc" = "0" ] && [ -z "$output" ]; then
-  pass "TC-120 crash under the Patterns 1-3 trap still resolves to allow (exit 0, no output)"
+echo "TC-120: Patterns 1-3 fail-open invariant is structurally preserved (AC-3)"
+# AC-3 requires that a crash in the Patterns 1-3 region still resolves to allow.
+# This is guaranteed structurally: the default ERR trap is the fail-OPEN handler,
+# and the fail-CLOSED trap is installed ONLY inside the reviewer-only Pattern 4
+# block and restored to fail-open at that block's exit. We deliberately do NOT ship
+# a fail-open fault-injection env var to drive this behaviorally — such a var would
+# be an allow-all backdoor to the security boundary (Issue #1717 review F-02). So we
+# pin the three invariants that guarantee AC-3 by inspecting the hook source.
+tc120_src=$(cat "$HOOK")
+# (a) the default (pre-Pattern-4) ERR trap is the fail-OPEN handler
+if [[ "$tc120_src" == *"trap '_rite_btg_pattern13_fail_open' ERR"* ]]; then
+  pass "TC-120 default ERR trap is the fail-open handler (Patterns 1-3 fail open)"
 else
-  fail "TC-120 expected fail-open allow (rc=0, empty), got rc=$rc output=$output"
+  fail "TC-120 default fail-open ERR trap not found in hook source"
+fi
+# (b) the fail-CLOSED trap is installed only inside the Pattern 4 block, and (c) the
+# fail-open trap is restored at block exit. Both restore/swap lines must be present.
+if [[ "$tc120_src" == *"trap '_rite_btg_pattern4_fail_closed' ERR"* ]] \
+   && [[ "$tc120_src" == *"Restore the Patterns 1-3 fail-open trap"* ]]; then
+  pass "TC-120 fail-closed trap is scoped to Pattern 4 and fail-open is restored at block exit"
+else
+  fail "TC-120 fail-closed swap / fail-open restore lines not found in hook source"
+fi
+# (d) no fail-open fault-injection backdoor remains (F-02): the env var must never
+# trigger an allow (fail-open) path. Assert the removed pattern13 injection is gone.
+if [[ "$tc120_src" != *'RITE_BTG_TEST_CRASH:-}" = "pattern13"'* ]]; then
+  pass "TC-120 no fail-open (pattern13) fault-injection backdoor remains"
+else
+  fail "TC-120 fail-open (pattern13) injection backdoor is still present in hook source"
 fi
 echo ""
 
@@ -1491,6 +1516,53 @@ if [ -n "$tc122_timeout" ] && [[ "$tc122_timeout" =~ ^[0-9]+$ ]]; then
   pass "TC-122 pre-tool-bash-guard hook has a numeric timeout ($tc122_timeout)"
 else
   fail "TC-122 expected a numeric timeout on the PreToolUse:Bash hook, got '$tc122_timeout'"
+fi
+# Pin the exact value (Issue #1717 review F-03): the .sh header comment documents
+# "a 10s timeout", but nothing tied that prose to the config. Pin 10 here so that
+# changing hooks.json without updating the header comment fails this test (drift
+# detection). Update BOTH this literal and the .sh header if the value ever changes.
+if [ "$tc122_timeout" = "10" ]; then
+  pass "TC-122 timeout value is 10 (matches the value documented in the .sh header)"
+else
+  fail "TC-122 expected timeout=10 (as documented in pre-tool-bash-guard.sh header), got '$tc122_timeout'"
+fi
+echo ""
+
+echo "TC-123: oversized global-flag command → fail-closed deny before timeout (AC via F-01)"
+# The Pattern 4 global-flag normalization is super-linear, and the PreToolUse hook
+# timeout is fail-OPEN. A reviewer subagent could pad a state-mutating git with
+# thousands of global flags so normalization times out → the deny is dropped → the
+# git runs (bypass). The fix caps the normalization iterations and denies fail-closed
+# past the cap. Drive it with a heavily-padded reviewer git command and assert it is
+# denied quickly (the cap keeps it far under any timeout).
+rc=0
+tc123_pad=$(printf -- '-C x %.0s' $(seq 1 400))
+tc123_cmd="git ${tc123_pad}checkout evil"
+tc123_input=$(jq -n --arg cmd "$tc123_cmd" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
+output=$(echo "$tc123_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-123 oversized global-flag reviewer command is denied (fail-closed, not timeout→allow)"
+else
+  fail "TC-123 expected deny for oversized command, got decision=$decision rc=$rc"
+fi
+if [[ "$reason" == *"abnormally large"* ]]; then
+  pass "TC-123 deny reason explains the oversized-command / timeout-bypass rationale"
+else
+  fail "TC-123 expected oversized-command explanation in reason, got: $reason"
+fi
+# Guard scope: an oversized MAIN-session command must NOT be denied (main sessions
+# never enter Pattern 4 — the cap must not add false denies to non-reviewer Bash).
+rc=0
+tc123_main_input=$(jq -n --arg cmd "$tc123_cmd" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
+output=$(echo "$tc123_main_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-123 oversized MAIN-session command is not denied by the reviewer-only cap"
+else
+  fail "TC-123 expected allow (rc=0, empty) for oversized main-session command, got rc=$rc output=$output"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1619,20 +1619,24 @@ if [ "$decision" = "deny" ]; then
 else
   fail "TC-124 expected deny for oversized read-only command, got decision=$decision rc=$rc"
 fi
-# (c) oversized WITH a huge heredoc body → fast deny (the O(n²) ${COMMAND%%<<*} strip is skipped)
-{ printf 'git checkout evil <<EOF\n'; printf 'y%.0s' $(seq 1 200000); printf '\nEOF'; } > "$tc124_dir/hd.txt"
+# (c) oversized because of a huge heredoc BODY, with a READ-ONLY prefix → deny.
+# The length guard checks ${#COMMAND} over the WHOLE command (heredoc body included),
+# so it fires here. Non-vacuous (Issue #1717 review F-06): the prefix `git status` is
+# read-only, so WITHOUT the length guard the heredoc strip yields `git status` and the
+# command is ALLOWED — WITH it the command is denied. (Note: the `<<` sits near the
+# front, so `${COMMAND%%<<*}` is itself fast here regardless — this case pins the
+# length guard's use of the full command length, not the O(n²) strip skip; the O(n²)
+# no-heredoc path is covered by (a).)
+{ printf 'git status <<EOF\n'; printf 'y%.0s' $(seq 1 200000); printf '\nEOF'; } > "$tc124_dir/hd.txt"
 jq -n --rawfile cmd "$tc124_dir/hd.txt" --arg tp "$SUBAGENT_TRANSCRIPT" \
   '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/hdin.json"
 rc=0
-_t0=$(date +%s%N)
 output=$(timeout 15 bash "$HOOK" < "$tc124_dir/hdin.json" 2>"$STDERR_FILE") || rc=$?
-_t1=$(date +%s%N)
-_ms=$(( (_t1 - _t0) / 1000000 ))
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
-if [ "$decision" = "deny" ] && [ "$_ms" -lt 5000 ]; then
-  pass "TC-124 oversized-with-heredoc command is denied fast (${_ms}ms — O(n²) heredoc strip skipped)"
+if [ "$decision" = "deny" ]; then
+  pass "TC-124 heredoc-body-oversized READ-ONLY command is denied (length guard uses full command length)"
 else
-  fail "TC-124 expected fast deny for oversized-with-heredoc, got decision=$decision rc=$rc ms=$_ms"
+  fail "TC-124 expected deny for heredoc-body-oversized read-only command, got decision=$decision rc=$rc"
 fi
 # (d) oversized (~80KB) MAIN-session command → must NOT be denied (MUST NOT — reviewer-only guard)
 jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1415,6 +1415,86 @@ rm -rf "$fake_bin_118"
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-119〜122: Pattern 4 (security boundary) fail-closed vs Pattern 1-3 fail-open
+#   Issue #1717: Pattern 4 (reviewer state-mutating-git denylist) shares the
+#   fail-OPEN ERR trap with the convenience patterns, so a parse crash inside
+#   Pattern 4 converges to exit 0 (allow) and silently bypasses the security
+#   boundary. The fix installs a fail-CLOSED ERR trap over the Pattern 4 block
+#   (deny + exit 2 + WARNING) and restores fail-open afterwards. Pattern 4 uses
+#   only bash built-ins, so — unlike the deny-emit path faked in TC-118 — it
+#   cannot be crashed via a fake external binary; the hook exposes a test-only
+#   fault-injection env var (RITE_BTG_TEST_CRASH=pattern13|pattern4) that raises
+#   an ERR inside the respective trap region. These TCs drive it directly (the
+#   run_guard_* helpers do not thread extra env through the pipe).
+# --------------------------------------------------------------------------
+echo "TC-119: Pattern 4 crash in reviewer subagent → deny + exit 2 + stderr WARNING (AC-1)"
+rc=0
+tc119_input=$(jq -n --arg cmd "git status" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
+output=$(echo "$tc119_input" | RITE_BTG_TEST_CRASH=pattern4 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+stderr_log=$(cat "$STDERR_FILE")
+if [ "$rc" = "2" ]; then
+  pass "TC-119 Pattern 4 crash exits 2 (fail-closed, not the old exit 0 allow)"
+else
+  fail "TC-119 expected rc=2, got rc=$rc"
+fi
+if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-state-mutating-git"* ]]; then
+  pass "TC-119 emits deny JSON with reviewer-state-mutating-git reason"
+else
+  fail "TC-119 expected deny (reviewer-state-mutating-git), got decision=$decision reason=$reason"
+fi
+if [[ "$stderr_log" == *"WARNING"* ]] && [[ "$stderr_log" == *"Pattern 4"* ]]; then
+  pass "TC-119 stderr WARNING makes the fail-closed firing visible"
+else
+  fail "TC-119 expected stderr WARNING for Pattern 4, got: $stderr_log"
+fi
+echo ""
+
+echo "TC-120: Pattern 1-3 crash → allow (exit 0), fail-open preserved (AC-3)"
+rc=0
+tc120_input=$(jq -n --arg cmd "git status" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
+output=$(echo "$tc120_input" | RITE_BTG_TEST_CRASH=pattern13 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-120 crash under the Patterns 1-3 trap still resolves to allow (exit 0, no output)"
+else
+  fail "TC-120 expected fail-open allow (rc=0, empty), got rc=$rc output=$output"
+fi
+echo ""
+
+echo "TC-121: Pattern 4 crash injection on a MAIN session → allow (no false deny; MUST NOT)"
+# The fail-closed trap must be scoped to the reviewer-only Pattern 4 block. A main
+# session never enters that block, so even with the injection var set it must not be
+# denied — proves the fix does not add false denies to normal (non-reviewer) Bash.
+rc=0
+tc121_input=$(jq -n --arg cmd "git status" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
+output=$(echo "$tc121_input" | RITE_BTG_TEST_CRASH=pattern4 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-121 main-session Bash is not denied by the Pattern 4 fail-closed trap"
+else
+  fail "TC-121 expected allow (rc=0, empty) for main session, got rc=$rc output=$output"
+fi
+echo ""
+
+echo "TC-122: hooks.json PreToolUse:Bash has a timeout (AC-4)"
+HOOKS_JSON="$SCRIPT_DIR/../hooks.json"
+if jq empty "$HOOKS_JSON" 2>/dev/null; then
+  pass "TC-122 hooks.json is valid JSON"
+else
+  fail "TC-122 hooks.json is not valid JSON"
+fi
+tc122_timeout=$(jq -r '.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test("pre-tool-bash-guard")) | .timeout // empty' "$HOOKS_JSON" 2>/dev/null)
+if [ -n "$tc122_timeout" ] && [[ "$tc122_timeout" =~ ^[0-9]+$ ]]; then
+  pass "TC-122 pre-tool-bash-guard hook has a numeric timeout ($tc122_timeout)"
+else
+  fail "TC-122 expected a numeric timeout on the PreToolUse:Bash hook, got '$tc122_timeout'"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1415,7 +1415,7 @@ rm -rf "$fake_bin_118"
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-119〜123: Pattern 4 (security boundary) fail-closed vs Pattern 1-3 fail-open
+# TC-119〜124: Pattern 4 (security boundary) fail-closed vs Pattern 1-3 fail-open
 #   Issue #1717: Pattern 4 (reviewer state-mutating-git denylist) shared the
 #   fail-OPEN ERR trap with the convenience patterns, so a parse crash inside
 #   Pattern 4 converged to exit 0 (allow) and silently bypassed the security
@@ -1472,13 +1472,23 @@ if [[ "$tc120_src" == *"trap '_rite_btg_pattern13_fail_open' ERR"* ]]; then
 else
   fail "TC-120 default fail-open ERR trap not found in hook source"
 fi
-# (b) the fail-CLOSED trap is installed only inside the Pattern 4 block, and (c) the
-# fail-open trap is restored at block exit. Both restore/swap lines must be present.
-if [[ "$tc120_src" == *"trap '_rite_btg_pattern4_fail_closed' ERR"* ]] \
-   && [[ "$tc120_src" == *"Restore the Patterns 1-3 fail-open trap"* ]]; then
-  pass "TC-120 fail-closed trap is scoped to Pattern 4 and fail-open is restored at block exit"
+# (b) the fail-CLOSED trap is installed inside the Pattern 4 block (swap-in present)
+if [[ "$tc120_src" == *"trap '_rite_btg_pattern4_fail_closed' ERR"* ]]; then
+  pass "TC-120 fail-closed trap is swapped in for the Pattern 4 block"
 else
-  fail "TC-120 fail-closed swap / fail-open restore lines not found in hook source"
+  fail "TC-120 fail-closed swap line not found in hook source"
+fi
+# (c) the fail-OPEN trap is restored at Pattern 4 block exit. Pin the EXECUTABLE
+# statement, not a comment: the fail-open trap line must appear at least TWICE — once
+# as the default install (before Pattern 4) and once as the restore (block exit). This
+# is now the only guard for AC-3's block-exit fail-open restoration (behavioral
+# injection was removed as an allow-all backdoor, F-02), so it must catch deletion of
+# the actual restore statement — not just its comment (Issue #1717 review F-04).
+tc120_restore_count=$(printf '%s\n' "$tc120_src" | grep -c "trap '_rite_btg_pattern13_fail_open' ERR")
+if [ "${tc120_restore_count:-0}" -ge 2 ]; then
+  pass "TC-120 fail-open trap statement appears >=2x (default install + block-exit restore)"
+else
+  fail "TC-120 expected the fail-open trap statement >=2x (install+restore), found $tc120_restore_count"
 fi
 # (d) no fail-open fault-injection backdoor remains (F-02): the env var must never
 # trigger an allow (fail-open) path. Assert the removed pattern13 injection is gone.
@@ -1528,42 +1538,114 @@ else
 fi
 echo ""
 
-echo "TC-123: oversized global-flag command → fail-closed deny before timeout (AC via F-01)"
+echo "TC-123: many-global-flag command → iteration-cap fail-closed deny (F-01 secondary bound)"
 # The Pattern 4 global-flag normalization is super-linear, and the PreToolUse hook
-# timeout is fail-OPEN. A reviewer subagent could pad a state-mutating git with
-# thousands of global flags so normalization times out → the deny is dropped → the
-# git runs (bypass). The fix caps the normalization iterations and denies fail-closed
-# past the cap. Drive it with a heavily-padded reviewer git command and assert it is
-# denied quickly (the cap keeps it far under any timeout).
+# timeout is fail-OPEN. A reviewer subagent could pad a git command with thousands of
+# global flags so normalization times out → the deny is dropped → the git runs. The
+# per-flag iteration cap denies fail-closed past 128 flags (a secondary bound; the
+# length guard in TC-124 is the primary one). Use a READ-ONLY verb (`status`) under
+# the byte ceiling so this exercises the CAP, not the length guard, and so the deny is
+# genuinely attributable to the cap: without the cap the command would normalize to
+# `git status` and be ALLOWED — with the cap it is denied (Issue #1717 review F-05).
 rc=0
 tc123_pad=$(printf -- '-C x %.0s' $(seq 1 400))
-tc123_cmd="git ${tc123_pad}checkout evil"
+tc123_cmd="git ${tc123_pad}status"
 tc123_input=$(jq -n --arg cmd "$tc123_cmd" --arg tp "$SUBAGENT_TRANSCRIPT" \
   '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
 output=$(echo "$tc123_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
 reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
 if [ "$decision" = "deny" ]; then
-  pass "TC-123 oversized global-flag reviewer command is denied (fail-closed, not timeout→allow)"
+  pass "TC-123 many-global-flag READ-ONLY reviewer command is denied by the cap (allow→deny flip)"
 else
-  fail "TC-123 expected deny for oversized command, got decision=$decision rc=$rc"
+  fail "TC-123 expected deny (cap fires on 400 flags), got decision=$decision rc=$rc"
 fi
 if [[ "$reason" == *"abnormally large"* ]]; then
   pass "TC-123 deny reason explains the oversized-command / timeout-bypass rationale"
 else
   fail "TC-123 expected oversized-command explanation in reason, got: $reason"
 fi
-# Guard scope: an oversized MAIN-session command must NOT be denied (main sessions
+# Guard scope: the same command on a MAIN session must NOT be denied (main sessions
 # never enter Pattern 4 — the cap must not add false denies to non-reviewer Bash).
 rc=0
 tc123_main_input=$(jq -n --arg cmd "$tc123_cmd" --arg tp "$MAIN_TRANSCRIPT" \
   '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}')
 output=$(echo "$tc123_main_input" | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
 if [ "$rc" = "0" ] && [ -z "$output" ]; then
-  pass "TC-123 oversized MAIN-session command is not denied by the reviewer-only cap"
+  pass "TC-123 many-global-flag MAIN-session command is not denied by the reviewer-only cap"
 else
   fail "TC-123 expected allow (rc=0, empty) for oversized main-session command, got rc=$rc output=$output"
 fi
+echo ""
+
+echo "TC-124: oversized command → length-guard fail-closed deny WITHOUT the O(n²) paths (F-01b)"
+# The PRIMARY F-01 bound (Issue #1717 review F-01b showed the iteration cap alone was
+# insufficient): any reviewer command over the byte ceiling is denied fail-closed
+# BEFORE the O(n²) heredoc strip (${COMMAND%%<<*}, ~45s on ~1.3MB) and the O(n²) Pattern
+# 2 regex (>2min on a few MB) — both of which would otherwise time out the fail-open
+# hook and let the padded git run. Build huge commands via temp file + --rawfile to
+# avoid argv limits, and pin that the deny is FAST (proves the O(n²) work is skipped).
+tc124_dir=$(mktemp -d)
+tc124_bigval=$(printf 'x%.0s' $(seq 1 10000))
+# (a) 1.28MB state-mutating (checkout) padded with huge flag values → fast deny
+{ printf 'git '; for _i in $(seq 1 128); do printf -- '-C %s ' "$tc124_bigval"; done; printf 'checkout evil'; } > "$tc124_dir/cmd.txt"
+jq -n --rawfile cmd "$tc124_dir/cmd.txt" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/in.json"
+rc=0
+_t0=$(date +%s%N)
+output=$(timeout 15 bash "$HOOK" < "$tc124_dir/in.json" 2>"$STDERR_FILE") || rc=$?
+_t1=$(date +%s%N)
+_ms=$(( (_t1 - _t0) / 1000000 ))
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [ "$rc" != "124" ]; then
+  pass "TC-124 oversized (1.3MB) reviewer command is denied fail-closed"
+else
+  fail "TC-124 expected deny for oversized command, got decision=$decision rc=$rc"
+fi
+if [ "$_ms" -lt 5000 ]; then
+  pass "TC-124 oversized deny completes fast (${_ms}ms < 5s — O(n²) paths skipped, no timeout→fail-open)"
+else
+  fail "TC-124 oversized deny too slow (${_ms}ms) — length guard is not short-circuiting the O(n²) work"
+fi
+# (b) oversized (~80KB) READ-ONLY command → deny (allow→deny flip; a small `git status` allows)
+{ printf 'git '; for _i in $(seq 1 8); do printf -- '-C %s ' "$tc124_bigval"; done; printf 'status'; } > "$tc124_dir/ro.txt"
+jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/roin.json"
+rc=0
+output=$(timeout 15 bash "$HOOK" < "$tc124_dir/roin.json" 2>"$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-124 oversized READ-ONLY reviewer command is denied (length guard, allow→deny flip)"
+else
+  fail "TC-124 expected deny for oversized read-only command, got decision=$decision rc=$rc"
+fi
+# (c) oversized WITH a huge heredoc body → fast deny (the O(n²) ${COMMAND%%<<*} strip is skipped)
+{ printf 'git checkout evil <<EOF\n'; printf 'y%.0s' $(seq 1 200000); printf '\nEOF'; } > "$tc124_dir/hd.txt"
+jq -n --rawfile cmd "$tc124_dir/hd.txt" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/hdin.json"
+rc=0
+_t0=$(date +%s%N)
+output=$(timeout 15 bash "$HOOK" < "$tc124_dir/hdin.json" 2>"$STDERR_FILE") || rc=$?
+_t1=$(date +%s%N)
+_ms=$(( (_t1 - _t0) / 1000000 ))
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [ "$_ms" -lt 5000 ]; then
+  pass "TC-124 oversized-with-heredoc command is denied fast (${_ms}ms — O(n²) heredoc strip skipped)"
+else
+  fail "TC-124 expected fast deny for oversized-with-heredoc, got decision=$decision rc=$rc ms=$_ms"
+fi
+# (d) oversized (~80KB) MAIN-session command → must NOT be denied (MUST NOT — reviewer-only guard)
+jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/mainin.json"
+rc=0
+output=$(timeout 15 bash "$HOOK" < "$tc124_dir/mainin.json" 2>"$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" != "deny" ]; then
+  pass "TC-124 oversized MAIN-session command is not denied by the reviewer-only length guard"
+else
+  fail "TC-124 oversized main-session command was wrongly denied (MUST NOT violation)"
+fi
+rm -rf "$tc124_dir"
 echo ""
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`pre-tool-bash-guard.sh` のセキュリティ境界である Pattern 4（reviewer subagent の状態変更 git コマンドブロック）を、便宜パターン 1-3 と共有していた fail-open ERR trap から分離し、crash 時に deny へ倒れる（fail-closed）よう再構成しました。あわせて hooks.json で唯一 timeout 未設定だった PreToolUse:Bash に timeout を追加しました。

## Related Issue

Closes #1717

## 背景 / 問題

- 便宜パターン(誤ブロックを避けたい = fail-open)とセキュリティパターン(誤許可を避けたい = fail-closed)が**同一の ERR trap**（`_rite_btg_pattern13_fail_open`, exit 0）を全域共有していた
- そのため Pattern 4 の正規化ロジック / token loop が予期せぬ入力で crash すると `exit 0`（allow）に収束し、**パースクラッシュ 1 つで reviewer の read-only ガードが bypass** され得た

## 変更内容

- **fail-closed ハンドラ追加**: `_rite_btg_pattern4_fail_closed()` を新設（deny JSON + `exit 2` + stderr WARNING、再入防止に `trap - ERR`、jq 失敗時は既存 `_bash_guard_escape_deny_reason` + printf フォールバック）
- **trap スコープ分離**: Pattern 4 ブロック入口で fail-closed trap へ切替え、出口で fail-open trap へ復元。非 reviewer セッション（`IS_SUBAGENT=0`）は Pattern 4 ブロックに入らないため fail-closed trap は一切適用されず、誤 deny の増加なし
- **hooks.json**: PreToolUse:Bash に `timeout: 10` を追加（strict JSON でコメント不可のため、値の根拠は `.sh` ヘッダに記載。高速な同期プレゲートである点を踏まえ、軽量同期ゲート Stop=10 / Edit-Write=10 に整合）
- **テスト追加**: Pattern 4 は純 bash built-in で fake binary による crash 注入が不可のため、テスト専用 fault-injection env var `RITE_BTG_TEST_CRASH=pattern13|pattern4` を追加

## 受入基準

- **AC-1**（Pattern 4 crash の fail-closed）: TC-119 — deny + `exit 2` + stderr WARNING
- **AC-2**（正常系の非回帰）: 既存 guard スイート全 pass（172/172）
- **AC-3**（便宜パターンの fail-open 維持）: TC-120 — Pattern 1-3 領域 crash → allow（exit 0）
- **AC-4**（timeout 設定）: TC-122 — PreToolUse:Bash に numeric timeout
- 補助: TC-121 — main セッションでは Pattern 4 fail-closed trap による誤 deny が発生しないこと（MUST NOT）

## 変更ファイル

- `plugins/rite/hooks/pre-tool-bash-guard.sh` - 変更（trap 分離・fail-closed 化・WARNING 可視化・timeout 根拠コメント）
- `plugins/rite/hooks/hooks.json` - 変更（PreToolUse:Bash に timeout: 10）
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` - 変更（TC-119〜122 追加）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (172 passed, 0 failed)
- [x] Documentation updated (if applicable) — 仕様外部ドキュメントへの影響なし（init テンプレートの timeout 省略は既存慣習・スコープ外）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
