### PR TITLE
refactor(hooks): per-call hook に非 rite 向け前段 early-exit と jq 集約を追加

### DIFF
--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -25,6 +25,34 @@ INPUT=$(cat) || INPUT=""
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 [ -n "$CWD" ] && [ -d "$CWD" ] || exit 0
 
+# Lightweight rite-project gate (subprocess-free early-exit).
+# Before spawning state-path-resolve.sh (git rev-parse ×2) and flow-state.sh
+# path below, cheaply check whether CWD is inside a rite project by walking up
+# for a rite marker using bash built-ins only — no git / helper subprocess. A
+# non-rite project has neither marker and exits here, so every Bash tool call in
+# projects that do not use rite pays only this walk instead of the resolver
+# spawns. The marker is `rite-config.yml` (a tracked file, so it is checked out
+# in multi_session worktrees where the .rite state dir lives only in the main
+# checkout) OR the `.rite` state dir (present in the main checkout). Whenever the
+# resolver would have found an active flow-state, one of these markers exists at
+# or above CWD, so the gate never skips real work. Parent-walk uses `${d%/*}`
+# (not dirname) to stay subprocess-free. Read-only: no marker is written
+# (Issue #1716 MUST NOT). A permission-denied ancestor makes `[ -e ]` false, but
+# that requires the repo root itself to be unreadable mid-workflow, where the
+# flow is already broken — the optimized path is the common non-rite one.
+_rite_gate_dir="$CWD"
+_rite_gate_found=0
+while : ; do
+  if [ -f "$_rite_gate_dir/rite-config.yml" ] || [ -d "$_rite_gate_dir/.rite" ]; then
+    _rite_gate_found=1
+    break
+  fi
+  [ "$_rite_gate_dir" = "/" ] && break
+  _rite_gate_dir="${_rite_gate_dir%/*}"
+  [ -n "$_rite_gate_dir" ] || _rite_gate_dir="/"
+done
+[ "$_rite_gate_found" = "1" ] || exit 0
+
 # Resolve state root (git root or CWD)
 # SCRIPT_DIR already set in preamble block above
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -37,9 +37,10 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
 # resolver would have found an active flow-state, one of these markers exists at
 # or above CWD, so the gate never skips real work. Parent-walk uses `${d%/*}`
 # (not dirname) to stay subprocess-free. Read-only: no marker is written
-# (Issue #1716 MUST NOT). A permission-denied ancestor makes `[ -e ]` false, but
-# that requires the repo root itself to be unreadable mid-workflow, where the
-# flow is already broken — the optimized path is the common non-rite one.
+# (Issue #1716 MUST NOT). A permission-denied ancestor makes the `[ -f ]` / `[ -d ]`
+# marker test false, but that requires the repo root itself to be unreadable
+# mid-workflow, where the flow is already broken — the optimized path is the
+# common non-rite one.
 _rite_gate_dir="$CWD"
 _rite_gate_found=0
 while : ; do
@@ -48,8 +49,15 @@ while : ; do
     break
   fi
   [ "$_rite_gate_dir" = "/" ] && break
-  _rite_gate_dir="${_rite_gate_dir%/*}"
-  [ -n "$_rite_gate_dir" ] || _rite_gate_dir="/"
+  _rite_gate_parent="${_rite_gate_dir%/*}"
+  # `${x%/*}` leaves a slashless segment unchanged — for a relative CWD (e.g.
+  # `a/b/c` reduced to `a`) there is no `/` to strip, so the value stops
+  # changing. Break on no-progress to avoid an infinite loop; an empty result
+  # means the segment sat directly under root, so continue from `/`. (The
+  # harness supplies an absolute .cwd in practice, but a relative one would
+  # otherwise spin forever here.)
+  [ "$_rite_gate_parent" = "$_rite_gate_dir" ] && break
+  _rite_gate_dir="${_rite_gate_parent:-/}"
 done
 [ "$_rite_gate_found" = "1" ] || exit 0
 

--- a/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
@@ -31,10 +31,14 @@ CHECK_SCRIPT="$SCRIPT_DIR/bang-backtick-check.sh"
 INPUT=$(cat 2>/dev/null) || INPUT=""
 [ -n "$INPUT" ] || exit 0
 
-# Extract tool_name and file_path. jq failures fall through to exit 0.
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
-FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
-CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+# Extract tool_name, file_path and cwd in a single jq spawn via @tsv (was three
+# separate jq invocations — Issue #1716 AC-4). Empty JSON fields become empty
+# columns, which the tab-split below reads back as empty strings, so the same
+# `|| exit 0` fall-throughs still apply. jq failure yields an empty line → all
+# three variables empty → the tool-name filter below exits 0.
+IFS=$'\t' read -r TOOL_NAME FILE_PATH CWD <<< "$(
+  printf '%s' "$INPUT" | jq -r '[.tool_name // "", .tool_input.file_path // "", .cwd // ""] | @tsv' 2>/dev/null
+)"
 
 # Filter on tool name. PostToolUse hooks.json uses matcher "Edit|Write" so
 # the harness already pre-filters, but this defense-in-depth check keeps
@@ -47,6 +51,20 @@ esac
 # Bail if no file_path captured (defensive — should never happen for the
 # tools above, but the JSON contract is upstream-controlled).
 [ -n "$FILE_PATH" ] || exit 0
+
+# Front-loaded scope pre-filter (Issue #1716): a rite plugin markdown target
+# always matches `*plugins/rite/*.md` (true for both absolute and repo-relative
+# file_path). Reject anything else with a bash-builtin glob *before* resolving
+# the repo root (git rev-parse) below, so non-rite projects and the vast
+# majority of edits never spawn git. This is a necessary-but-not-sufficient gate
+# — it never rejects an in-scope path (every path the precise per-directory glob
+# accepts contains `plugins/rite/` and ends in `.md`), and the precise glob
+# still runs afterward to reject candidates that merely happen to match (e.g. a
+# repo whose own checkout path contains `plugins/rite/`).
+case "$FILE_PATH" in
+  *plugins/rite/*.md) ;;
+  *) exit 0 ;;
+esac
 
 # Resolve repo root. Prefer the cwd reported by the harness (matches the
 # user's working tree even if the hook runs from a different cwd); fall

--- a/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
+++ b/plugins/rite/hooks/scripts/bang-backtick-edit-hook.sh
@@ -31,13 +31,16 @@ CHECK_SCRIPT="$SCRIPT_DIR/bang-backtick-check.sh"
 INPUT=$(cat 2>/dev/null) || INPUT=""
 [ -n "$INPUT" ] || exit 0
 
-# Extract tool_name, file_path and cwd in a single jq spawn via @tsv (was three
-# separate jq invocations — Issue #1716 AC-4). Empty JSON fields become empty
-# columns, which the tab-split below reads back as empty strings, so the same
-# `|| exit 0` fall-throughs still apply. jq failure yields an empty line → all
+# Extract tool_name, file_path and cwd in a single jq spawn (was three separate
+# jq invocations — Issue #1716 AC-4). Fields are joined on the unit separator
+# (\x1f, U+001F), not a tab: with `IFS=$'\t' read` a tab is IFS whitespace, so an
+# empty middle field (e.g. an event with no file_path) would collapse and
+# left-shift cwd into FILE_PATH. \x1f is non-whitespace, so `read` keeps empty
+# fields positional — the same convention the sibling post-tool-wm-sync.sh uses
+# and documents for exactly this hazard. jq failure yields an empty line → all
 # three variables empty → the tool-name filter below exits 0.
-IFS=$'\t' read -r TOOL_NAME FILE_PATH CWD <<< "$(
-  printf '%s' "$INPUT" | jq -r '[.tool_name // "", .tool_input.file_path // "", .cwd // ""] | @tsv' 2>/dev/null
+IFS=$'\x1f' read -r TOOL_NAME FILE_PATH CWD <<< "$(
+  printf '%s' "$INPUT" | jq -r '[.tool_name // "", .tool_input.file_path // "", .cwd // ""] | join("\u001f")' 2>/dev/null
 )"
 
 # Filter on tool name. PostToolUse hooks.json uses matcher "Edit|Write" so

--- a/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
@@ -269,6 +269,61 @@ else
 fi
 rm -f "$hook_stderr"
 
+# ----- TC-8: AC-4 — input extraction uses a single jq spawn -----------------
+# The three separate jq calls (tool_name / file_path / cwd) were aggregated into
+# one @tsv extraction. A `jq` PATH-shim counts invocations; an out-of-scope path
+# exits right after extraction (before the check script, which uses no jq), so
+# the total jq count is exactly the one extraction call.
+echo "TC-8: AC-4 — single jq spawn for input extraction"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+real_jq=$(command -v jq)
+jq_shim_dir=$(mktemp -d)
+cleanup_dirs+=("$jq_shim_dir")
+jq_count_file="$jq_shim_dir/count"
+cat > "$jq_shim_dir/jq" <<SHIM
+#!/bin/sh
+echo x >> "$jq_count_file"
+exec "$real_jq" "\$@"
+SHIM
+chmod +x "$jq_shim_dir/jq"
+# build_input runs BEFORE the shim is on PATH, so its jq is not counted.
+input=$(build_input "Edit" "$repo/other-plugin/commands/sample.md" "$repo")
+hook_rc=0
+printf '%s' "$input" | PATH="$jq_shim_dir:$PATH" bash "$HOOK" 2>/dev/null >/dev/null || hook_rc=$?
+jq_calls=$( [ -f "$jq_count_file" ] && wc -l < "$jq_count_file" | tr -d ' ' || echo 0 )
+if [ "$hook_rc" -eq 0 ] && [ "$jq_calls" -eq 1 ]; then
+  pass "TC-8 exactly 1 jq spawn for input extraction (AC-4)"
+else
+  fail "TC-8 expected 1 jq spawn, got $jq_calls (exit=$hook_rc)"
+fi
+
+# ----- TC-9: pre-filter front-loads before git rev-parse (non-scope path) ----
+# The cheap `*plugins/rite/*.md` glob must reject non-scope paths BEFORE the repo
+# root resolution, so a non-rite / out-of-scope edit spawns no git. A `git`
+# PATH-shim records invocations; an out-of-scope path must leave it untouched.
+echo "TC-9: non-scope path skips git rev-parse (front-loaded pre-filter)"
+repo=$(make_repo)
+cleanup_dirs+=("$repo")
+git_shim_dir=$(mktemp -d)
+cleanup_dirs+=("$git_shim_dir")
+git_count_file="$git_shim_dir/count"
+cat > "$git_shim_dir/git" <<SHIM
+#!/bin/sh
+echo x >> "$git_count_file"
+exit 0
+SHIM
+chmod +x "$git_shim_dir/git"
+input=$(build_input "Edit" "$repo/other-plugin/commands/sample.md" "$repo")
+hook_rc=0
+printf '%s' "$input" | PATH="$git_shim_dir:$PATH" bash "$HOOK" 2>/dev/null >/dev/null || hook_rc=$?
+git_calls=$( [ -f "$git_count_file" ] && wc -l < "$git_count_file" | tr -d ' ' || echo 0 )
+if [ "$hook_rc" -eq 0 ] && [ "$git_calls" -eq 0 ]; then
+  pass "TC-9 no git rev-parse for non-scope path (pre-filter front-loaded)"
+else
+  fail "TC-9 expected 0 git spawns for non-scope path, got $git_calls (exit=$hook_rc)"
+fi
+
 # ----- Summary --------------------------------------------------------------
 echo ""
 echo "==> $PASS PASS / $FAIL FAIL"

--- a/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-edit-hook.test.sh
@@ -271,9 +271,10 @@ rm -f "$hook_stderr"
 
 # ----- TC-8: AC-4 — input extraction uses a single jq spawn -----------------
 # The three separate jq calls (tool_name / file_path / cwd) were aggregated into
-# one @tsv extraction. A `jq` PATH-shim counts invocations; an out-of-scope path
-# exits right after extraction (before the check script, which uses no jq), so
-# the total jq count is exactly the one extraction call.
+# one single-jq extraction joined on the unit separator (\x1f). A `jq` PATH-shim
+# counts invocations; an out-of-scope path exits right after extraction (before
+# the check script, which uses no jq), so the total jq count is exactly the one
+# extraction call.
 echo "TC-8: AC-4 — single jq spawn for input extraction"
 repo=$(make_repo)
 cleanup_dirs+=("$repo")

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -502,6 +502,28 @@ else
 fi
 echo ""
 
+# --- TC-EARLYEXIT-3: relative CWD terminates the gate walk (no infinite loop) ---
+# The upward-walk ascends via `${dir%/*}`, which leaves a slashless segment
+# (a relative .cwd like `reldir`) unchanged. Without the no-progress guard the
+# gate spins forever. The harness supplies an absolute .cwd in practice, but this
+# pins the guard. Run under `timeout`; a hang exits 124. Skip when `timeout` is
+# unavailable (e.g. macOS without coreutils) rather than fail spuriously.
+echo "TC-EARLYEXIT-3: relative CWD terminates the gate walk (no infinite loop)"
+dir_ee3="$TEST_DIR/tc_earlyexit3"
+mkdir -p "$dir_ee3/reldir"
+if command -v timeout >/dev/null 2>&1; then
+  rc_ee3=0
+  ( cd "$dir_ee3" && echo '{"tool_name": "Bash", "cwd": "reldir"}' | timeout 5 bash "$HOOK" >/dev/null 2>&1 ) || rc_ee3=$?
+  if [ "$rc_ee3" -ne 124 ]; then
+    pass "TC-EARLYEXIT-3 gate terminated for relative CWD (exit code: $rc_ee3, not a 124 timeout)"
+  else
+    fail "TC-EARLYEXIT-3 hook hung on relative CWD (timeout 124 — infinite-loop regression)"
+  fi
+else
+  pass "TC-EARLYEXIT-3 skipped: timeout(1) unavailable, termination not exercised"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -442,6 +442,66 @@ else
 fi
 echo ""
 
+# --- TC-EARLYEXIT-1 (AC-1): non-rite project → no git rev-parse spawn, exit 0 ---
+# The lightweight rite-project gate must early-exit before state-path-resolve.sh
+# (git rev-parse ×2). A `git` PATH-shim records every invocation; a non-rite
+# sandbox (no rite-config.yml, no .rite/, none up to /) must exit 0 with the
+# shim never touched and no work memory created.
+echo "TC-EARLYEXIT-1 (AC-1): non-rite project early-exits with no git spawn"
+dir_ee1="$TEST_DIR/tc_earlyexit1"
+mkdir -p "$dir_ee1"
+shim_ee1="$TEST_DIR/tc_earlyexit1-shim"
+mkdir -p "$shim_ee1"
+git_log_ee1="$TEST_DIR/tc_earlyexit1-git.log"
+cat > "$shim_ee1/git" <<SHIM
+#!/bin/sh
+echo "GIT_CALLED \$*" >> "$git_log_ee1"
+exit 0
+SHIM
+chmod +x "$shim_ee1/git"
+rc_ee1=0
+echo "{\"tool_name\": \"Bash\", \"cwd\": \"$dir_ee1\"}" | PATH="$shim_ee1:$PATH" bash "$HOOK" 2>/dev/null || rc_ee1=$?
+if [ ! -f "$git_log_ee1" ]; then
+  pass "TC-EARLYEXIT-1 no git rev-parse spawned in non-rite project (exit code: $rc_ee1)"
+else
+  fail "TC-EARLYEXIT-1 git was spawned in non-rite project: $(cat "$git_log_ee1")"
+fi
+if [ "$rc_ee1" -eq 0 ] && [ ! -d "$dir_ee1/.rite-work-memory" ]; then
+  pass "TC-EARLYEXIT-1 exit 0 and no work memory created"
+else
+  fail "TC-EARLYEXIT-1 unexpected: rc=$rc_ee1, wm-dir=$([ -d "$dir_ee1/.rite-work-memory" ] && echo present || echo absent)"
+fi
+echo ""
+
+# --- TC-EARLYEXIT-2 (AC-3): worktree (rite-config.yml only, no .rite/) does NOT early-exit ---
+# A multi_session worktree checks out the tracked rite-config.yml but has no
+# .rite state dir (that lives in the main checkout). The gate must detect it via
+# rite-config.yml and proceed past the gate to the resolver — proven by the git
+# shim being invoked. Guards against a regression that keys detection on .rite/
+# alone (which would false-early-exit every worktree edit).
+echo "TC-EARLYEXIT-2 (AC-3): worktree with rite-config.yml only is not early-exited"
+dir_ee2="$TEST_DIR/tc_earlyexit2"
+mkdir -p "$dir_ee2"
+printf '# rite worktree sandbox config\n' > "$dir_ee2/rite-config.yml"
+# Intentionally do NOT create .rite/ — this is the worktree-specific condition.
+shim_ee2="$TEST_DIR/tc_earlyexit2-shim"
+mkdir -p "$shim_ee2"
+git_log_ee2="$TEST_DIR/tc_earlyexit2-git.log"
+cat > "$shim_ee2/git" <<SHIM
+#!/bin/sh
+echo "GIT_CALLED \$*" >> "$git_log_ee2"
+exit 0
+SHIM
+chmod +x "$shim_ee2/git"
+rc_ee2=0
+echo "{\"tool_name\": \"Bash\", \"cwd\": \"$dir_ee2\"}" | PATH="$shim_ee2:$PATH" bash "$HOOK" 2>/dev/null || rc_ee2=$?
+if [ -f "$git_log_ee2" ]; then
+  pass "TC-EARLYEXIT-2 gate passed via rite-config.yml (git rev-parse reached, exit code: $rc_ee2)"
+else
+  fail "TC-EARLYEXIT-2 gate wrongly early-exited a worktree (git never reached — .rite-only detection regression)"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -524,6 +524,35 @@ else
 fi
 echo ""
 
+# --- TC-EARLYEXIT-4: rite marker found at an ANCESTOR (multi-level upward walk) ---
+# The other early-exit TCs place the rite marker directly at CWD, so none of them
+# exercise the upward walk actually ascending. Here the marker (.rite) sits at the
+# sandbox root and CWD is several levels below it — the gate must walk up to find
+# it, proven by git being reached. Guards against a regression that narrows the
+# gate to a CWD-only check, which would still pass every other TC but break the
+# common "Bash invoked from a subdirectory of a rite project" case (WM sync would
+# silently stop).
+echo "TC-EARLYEXIT-4 (AC-1/AC-3): ancestor marker found via upward walk is not early-exited"
+dir_ee4="$TEST_DIR/tc_earlyexit4"
+mkdir -p "$dir_ee4/.rite" "$dir_ee4/sub/deep"
+shim_ee4="$TEST_DIR/tc_earlyexit4-shim"
+mkdir -p "$shim_ee4"
+git_log_ee4="$TEST_DIR/tc_earlyexit4-git.log"
+cat > "$shim_ee4/git" <<SHIM
+#!/bin/sh
+echo "GIT_CALLED \$*" >> "$git_log_ee4"
+exit 0
+SHIM
+chmod +x "$shim_ee4/git"
+rc_ee4=0
+echo "{\"tool_name\": \"Bash\", \"cwd\": \"$dir_ee4/sub/deep\"}" | PATH="$shim_ee4:$PATH" bash "$HOOK" 2>/dev/null || rc_ee4=$?
+if [ -f "$git_log_ee4" ]; then
+  pass "TC-EARLYEXIT-4 gate ascended to the ancestor .rite marker (git rev-parse reached, exit code: $rc_ee4)"
+else
+  fail "TC-EARLYEXIT-4 gate did not walk up to the ancestor marker (CWD-only detection regression)"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## 概要

rite を使っていないプロジェクトでも Bash / Edit 1 コールごとに per-call hook が
helper subprocess を spawn していたコストを削減する。軽量マーカーによる前段
early-exit と jq 呼び出しの集約を導入する。rite プロジェクト内の入出力・副作用は
不変（fully_compatible）。

## 関連 Issue

Closes #1716

## Changes

- **post-tool-wm-sync.sh**: `state-path-resolve.sh`（内部で `git rev-parse` ×2）と
  `flow-state.sh path` を起動する**前**に、subprocess を増やさない上方ディレクトリ
  走査（bash パラメータ展開 `${dir%/*}`）で rite マーカーを探索し、無ければ
  early-exit する。マーカーは worktree にも checkout される tracked な
  `rite-config.yml`、または `.rite` state dir（main checkout に存在）の OR。
  multi_session worktree（`.rite` は main のみ）でも `rite-config.yml` により
  誤って early-exit しない。読み取りのみ（マーカー書き込みは追加しない）。
- **bang-backtick-edit-hook.sh**: `tool_name` / `file_path` / `cwd` の jq 抽出 3 回を
  `@tsv` で 1 回に集約。さらに `git rev-parse` による repo root 解決の**前に**
  cheap glob pre-filter（`*plugins/rite/*.md`）を前段化し、非 scope の編集は git を
  spawn せず exit する。
- **tests/**: AC-1（非 rite → git 未 spawn）/ AC-3（worktree = `rite-config.yml`
  のみ → early-exit しない）/ AC-4（jq 1 回）/ pre-filter（非 scope → git 未 spawn）
  の回帰テストを追加。

## 受入基準

- **AC-1**（非 rite プロジェクトの early-exit）: gate + `TC-EARLYEXIT-1`（git 未 spawn + exit 0）
- **AC-2**（rite 挙動不変・全テスト pass）: 既存 hooks テスト **91/91 pass**（新規テスト含む）
- **AC-3**（worktree 非誤爆）: `rite-config.yml` を主マーカーにする設計 + `TC-EARLYEXIT-2`
- **AC-4**（jq 集約）: `@tsv` 化 + `TC-8`（jq 1 回）

## 横断確認

per-call hook は 3 つ（`pre-tool-bash-guard.sh` / `post-tool-wm-sync.sh` /
`bang-backtick-edit-hook.sh`）。`pre-tool-bash-guard.sh` は bash built-in のみで
`state-path-resolve` / `git rev-parse` を判定前に spawn しないため、同種の
「判定前 spawn」アンチパターンは持たず変更不要と確認した。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (hooks テストスイート 91/91)
- [x] Documentation updated (該当なし — 内部最適化で公開仕様変更なし)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
