### PR TITLE
fix(hooks): ロック機構を堅牢化（issue-claim CAS・PID再利用検出・eval前検証）

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1232,7 +1232,7 @@ Shared library script providing `mkdir`-based lock/unlock functionality. Used by
 
 **Stale Lock Detection:**
 
-If a lock's `mtime` exceeds the threshold (default: 120 seconds), the PID file is checked to verify process liveness. Liveness compares both the PID (`kill -0`) and a recorded process start-token, so an exited holder whose PID was later recycled by an unrelated process is still detected as gone. If the process has terminated (or its PID was reused), the lock is automatically released.
+If a lock's `mtime` exceeds the threshold (default: 120 seconds), the PID file is checked to verify process liveness. Liveness compares the PID (`kill -0`) and, when a start-token was recorded, a process start-token, so an exited holder whose PID was later recycled by an unrelated process is detected as gone. If the process has terminated (or, when a start-token was recorded, its PID was reused), the lock is automatically released. Locks written by older versions (no token file) or on platforms lacking a start-token source stay conservatively held (legacy PID-only behavior).
 
 ### Phase Transition Whitelist (retired)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1232,7 +1232,7 @@ Shared library script providing `mkdir`-based lock/unlock functionality. Used by
 
 **Stale Lock Detection:**
 
-If a lock's `mtime` exceeds the threshold (default: 120 seconds), the PID file is checked to verify process liveness. If the process has terminated, the lock is automatically released.
+If a lock's `mtime` exceeds the threshold (default: 120 seconds), the PID file is checked to verify process liveness. Liveness compares both the PID (`kill -0`) and a recorded process start-token, so an exited holder whose PID was later recycled by an unrelated process is still detected as gone. If the process has terminated (or its PID was reused), the lock is automatically released.
 
 ### Phase Transition Whitelist (retired)
 

--- a/docs/designs/multi-session-worktree.md
+++ b/docs/designs/multi-session-worktree.md
@@ -193,7 +193,7 @@ multi_session:
 
 | サブコマンド | stdout | exit code | 挙動 |
 |---|---|---|---|
-| `claim` | `claimed` / `own` / `other` | `0`（claimed/own/stale-steal）/ `10`（other=live）/ `1`（usage/env エラー） | free→noclobber 取得 / own→冪等 refresh / stale→flock 奪取 / **other(live)→取得せず rc 10**（呼び出し側が AskUserQuestion） |
+| `claim` | `claimed` / `own` / `other` | `0`（claimed/own/stale-steal）/ `10`（other=live または stale-steal の CAS 中止）/ `1`（usage/env エラー） | free→noclobber 取得 / own→冪等 refresh / stale→flock 内 CAS 再検証付き奪取（並行奪取の敗者・ロック内で live に転じた holder は奪取せず `other` rc 10）/ **other(live)→取得せず rc 10**（呼び出し側が AskUserQuestion） |
 | `release` | `released` / `skipped` | `0`（冪等。不在でも `released`）/ `1` | 自セッションの claim のみ削除。他セッション保持時は `skipped`（触らない） |
 | `check` | `own` / `free` / `other` / `stale` | `0` | 読み取りのみ。corrupt/空 holder は `stale`（再取得可能） |
 

--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -160,6 +160,40 @@ _atomic_claim_write() {
   return "$rc"
 }
 
+# Compare-and-swap steal of a stale claim. The out-of-lock `_classify` (cmd_claim)
+# only tells us the claim WAS stale a moment ago; two sessions can both see the
+# same stale holder and both reach here. flock serializes the mv but does not make
+# the decision exclusive, so a plain _atomic_claim_write lets BOTH win (double
+# steal). This function re-verifies UNDER the lock before overwriting: it steals
+# only when the on-disk holder is still `expected` (the stale holder we classified)
+# AND that holder has not revived to live. A concurrent stealer that already swapped
+# the record (holder changed) or a holder that came back to life aborts the steal.
+# Returns: 0 stole, 10 CAS mismatch / holder revived (caller reports "other"),
+#          1 environment/IO error.
+_atomic_claim_steal() {
+  local file="$1" json="$2" expected="$3" tmp rc=0 cur
+  tmp=$(mktemp "${file}.XXXXXX" 2>/dev/null) || return 1
+  printf '%s\n' "$json" > "$tmp" || { rm -f "$tmp"; return 1; }
+  if command -v flock >/dev/null 2>&1 && ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
+    (
+      exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1
+      cur=$(_claim_holder "$file")
+      [ "$cur" = "$expected" ] || exit 10   # another session swapped the claim under us
+      _holder_is_live "$cur" && exit 10      # the stale holder revived → do not steal
+      mv -f "$tmp" "$file"
+    ) || rc=$?
+  else
+    # No flock (minimal containers / macOS without util-linux): best-effort CAS.
+    cur=$(_claim_holder "$file")
+    if [ "$cur" != "$expected" ]; then rc=10
+    elif _holder_is_live "$cur"; then rc=10
+    else mv -f "$tmp" "$file" || rc=$?
+    fi
+  fi
+  [ "$rc" -eq 0 ] || rm -f "$tmp" 2>/dev/null || true
+  return "$rc"
+}
+
 _validate_issue() {
   case "$1" in
     ''|*[!0-9]*) echo "ERROR: --issue must be a positive integer (got: '${1:-}')" >&2; return 1 ;;
@@ -198,8 +232,19 @@ cmd_claim() {
       return 0
       ;;
     stale)
-      local prev; prev=$(_claim_holder "$file")
-      _atomic_claim_write "$file" "$json" || { echo "ERROR: failed to steal stale claim" >&2; return 1; }
+      local prev src=0; prev=$(_claim_holder "$file")
+      _atomic_claim_steal "$file" "$json" "$prev" || src=$?
+      if [ "$src" -eq 10 ]; then
+        # CAS aborted under the lock: a concurrent stealer already won, or the
+        # holder revived. Report "other" (rc 10) so the caller (open Step 1.6)
+        # raises an AskUserQuestion instead of double-stealing (AC-1).
+        echo "[issue-claim] issue #${issue} steal aborted under lock (concurrent stealer or holder revived); not stealing" >&2
+        echo "other"
+        return 10
+      elif [ "$src" -ne 0 ]; then
+        echo "ERROR: failed to steal stale claim" >&2
+        return 1
+      fi
       echo "[issue-claim] stole stale claim for issue #${issue} (previous holder: ${prev:-<corrupt>})" >&2
       echo "claimed"
       return 0

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -103,6 +103,7 @@ violations_c=$(grep -rnE 'head -c [0-9]+' "$HOOKS_DIR" --include='*.sh' \
   | grep -v 'neutralize_ctrl' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   | grep -v 'work-memory-lock.sh:.*lock_pid=' \
+  | grep -v 'work-memory-lock.sh:.*stored_token=' \
   || true)
 assert "TC-3: un-neutralized head -c emission sites" "" "$violations_c"
 if [ -n "$violations_c" ]; then

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -7,6 +7,8 @@
 #   AC-3: release removes only the OWN claim; another session's is untouched
 #   AC-4: release on an absent claim is idempotent (success)
 #   plus: free check, stale-steal, corrupt-claim → stale, live-other refusal (rc 10)
+#   Issue #1718: concurrent stale-STEAL CAS (TC-14, exactly one wins) + lone-steal
+#                non-regression (TC-15)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -120,5 +122,42 @@ assert "TC-13 env-absent claim holder resolved via file sid (SID_B)" \
 assert "TC-13 env-absent check own (resolver returned file sid SID_B == holder)" \
   "own" "$(env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID bash "$IC" check --issue 711)"
 
+echo "=== TC-14 (Issue #1718 AC-1): concurrent stale-STEAL → exactly one 'claimed' ==="
+# TC-11 covers concurrent claim of a FREE issue (noclobber). This covers the
+# separate stale-STEAL path: N sessions all classify the SAME stale claim as
+# reclaimable out-of-lock, then race to overwrite it. Without the in-lock CAS
+# (_atomic_claim_steal), flock only serializes the mv and BOTH would "steal"
+# (double-commit). The CAS re-verifies the holder under the lock so exactly one
+# wins; the losers see the holder already swapped and abort with "other" (rc 10).
+SID_STALE="cccccccc-9999-8888-7777-666666666666"
+mk_active "$SID_STALE" 950
+assert "TC-14 stale-holder claims first" "claimed" "$(claim "$SID_STALE" 950)"
+bash "$FS" deactivate --session "$SID_STALE" --next done >/dev/null 2>&1  # holder now inactive → stale
+assert "TC-14 precondition: holder classified stale" "stale" "$(check "$SID_A" 950)"
+rm -f "$ROOT"/stealout.* 2>/dev/null || true
+for i in 1 2 3 4 5; do mk_active "d000000$i-1111-2222-3333-444444444444" 950; done
+for i in 1 2 3 4 5; do
+  ( bash "$IC" claim --session "d000000$i-1111-2222-3333-444444444444" --issue 950 > "$ROOT/stealout.$i" 2>/dev/null ) &
+done
+wait
+_stolen=0; _other=0
+for i in 1 2 3 4 5; do
+  case "$(cat "$ROOT/stealout.$i" 2>/dev/null)" in
+    claimed) _stolen=$((_stolen+1)) ;;
+    other)   _other=$((_other+1)) ;;
+  esac
+done
+assert "TC-14 exactly one stole the stale claim (AC-1)" "1" "$_stolen"
+assert "TC-14 the other four aborted with 'other'" "4" "$_other"
+
+echo "=== TC-15 (Issue #1718 AC-2): single-session stale-steal is non-regressed ==="
+# The CAS path must still let a lone stealer succeed (holder unchanged == expected).
+SID_STALE2="eeeeeeee-1010-1010-1010-101010101010"
+mk_active "$SID_STALE2" 951
+claim "$SID_STALE2" 951 >/dev/null 2>&1
+bash "$FS" deactivate --session "$SID_STALE2" --next done >/dev/null 2>&1
+assert "TC-15 lone steal → claimed" "claimed" "$(claim "$SID_A" 951)"
+assert "TC-15 holder now A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-951.json")"
+
 print_summary "$(basename "$0")" \
-  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity; _resolve_current_session_id env-first (Issue #1530)."
+  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity; stale-steal CAS via _atomic_claim_steal (Issue #1718); _resolve_current_session_id env-first (Issue #1530)."

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -164,10 +164,13 @@ echo "=== TC-16 (Issue #1718 F-03): no-flock branch of _atomic_claim_steal steal
 # best-effort no-flock branch of _atomic_claim_steal never runs. Force it by invoking
 # issue-claim.sh with a PATH stub that omits flock, proving the flock-absent path still
 # steals a lone stale claim (the else/mv path). Concurrent exactly-one is intentionally
-# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. The
-# mismatch→10 / revive→10 branches only fire on a concurrent swap / revive race, which
-# is not deterministically reproducible via the CLI, so they stay covered by the flock
-# branch's TC-14 logic.
+# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. Of the
+# two abort branches, mismatch→10 (cur != expected) IS exercised by TC-14's losers: the
+# winner swaps the holder, so each loser aborts on the mismatch. revive→10 (a stale
+# holder that becomes live between the out-of-lock classify and the in-lock re-check)
+# requires a state transition that is not deterministically reproducible via the CLI and
+# is currently exercised by no test — it is a defensive TOCTOU guard, distinct from the
+# mismatch path that carries the actual double-steal guarantee.
 noflock_stub=$(mktemp -d)
 cleanup_dirs+=("$noflock_stub")
 for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv rm sed tr wc sleep; do

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -164,13 +164,15 @@ echo "=== TC-16 (Issue #1718 F-03): no-flock branch of _atomic_claim_steal steal
 # best-effort no-flock branch of _atomic_claim_steal never runs. Force it by invoking
 # issue-claim.sh with a PATH stub that omits flock, proving the flock-absent path still
 # steals a lone stale claim (the else/mv path). Concurrent exactly-one is intentionally
-# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. Of the
-# two abort branches, mismatch→10 (cur != expected) IS exercised by TC-14's losers: the
-# winner swaps the holder, so each loser aborts on the mismatch. revive→10 (a stale
-# holder that becomes live between the out-of-lock classify and the in-lock re-check)
-# requires a state transition that is not deterministically reproducible via the CLI and
-# is currently exercised by no test — it is a defensive TOCTOU guard, distinct from the
-# mismatch path that carries the actual double-steal guarantee.
+# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. On the
+# abort side, TC-14's four losers prove the two guards TOGETHER prevent a double steal,
+# but do NOT isolate which guard fires: because every contender is mk_active'd the winner
+# is live, so a loser can abort on EITHER mismatch→10 (cur != expected, the winner already
+# swapped the holder) OR revive→10 (_holder_is_live "$cur"). Mutation-removing just one of
+# the two guards leaves TC-14 green; only removing both turns it red. So neither guard is
+# isolated by any current test — pinning mismatch alone would need an on-disk holder that
+# is ≠ expected AND not live, which the CLI cannot deterministically produce (revive→10 is
+# likewise a defensive TOCTOU guard exercised by no test).
 noflock_stub=$(mktemp -d)
 cleanup_dirs+=("$noflock_stub")
 for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv rm sed tr wc sleep; do

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -8,7 +8,7 @@
 #   AC-4: release on an absent claim is idempotent (success)
 #   plus: free check, stale-steal, corrupt-claim → stale, live-other refusal (rc 10)
 #   Issue #1718: concurrent stale-STEAL CAS (TC-14, exactly one wins) + lone-steal
-#                non-regression (TC-15)
+#                non-regression (TC-15) + no-flock branch lone steal (TC-16, F-03)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -159,5 +159,35 @@ bash "$FS" deactivate --session "$SID_STALE2" --next done >/dev/null 2>&1
 assert "TC-15 lone steal → claimed" "claimed" "$(claim "$SID_A" 951)"
 assert "TC-15 holder now A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-951.json")"
 
+echo "=== TC-16 (Issue #1718 F-03): no-flock branch of _atomic_claim_steal steals a lone stale claim ==="
+# TC-14/15 always exercise the flock branch (flock is present on the test host), so the
+# best-effort no-flock branch of _atomic_claim_steal never runs. Force it by invoking
+# issue-claim.sh with a PATH stub that omits flock, proving the flock-absent path still
+# steals a lone stale claim (the else/mv path). Concurrent exactly-one is intentionally
+# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. The
+# mismatch→10 / revive→10 branches only fire on a concurrent swap / revive race, which
+# is not deterministically reproducible via the CLI, so they stay covered by the flock
+# branch's TC-14 logic.
+noflock_stub=$(mktemp -d)
+cleanup_dirs+=("$noflock_stub")
+for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv rm sed tr wc sleep; do
+  _p=$(command -v "$_c" 2>/dev/null) && ln -sf "$_p" "$noflock_stub/$_c"
+done
+run_noflock() { PATH="$noflock_stub" bash "$IC" "$@" 2>/dev/null; }
+SID_NF="ffffffff-1111-2222-3333-444444444444"
+mk_active "$SID_NF" 960
+# Sanity probe: the stub must be able to run a claim at all. A curated PATH can miss a
+# host-specific tool path — skip (not fail) rather than mis-attribute a setup gap to the
+# no-flock logic (the same platform-fragility guard TC-014 in work-memory-lock applies).
+if [ "$(run_noflock claim --session "$SID_NF" --issue 960)" != "claimed" ]; then
+  pass "TC-16 skipped: no-flock PATH stub could not run a claim on this host (env-specific setup)"
+else
+  bash "$FS" deactivate --session "$SID_NF" --next done >/dev/null 2>&1  # holder now stale
+  assert "TC-16 precondition: holder classified stale" "stale" "$(check "$SID_A" 960)"
+  # Steal via the flock-absent branch: lone stealer → cur==expected, holder dead → mv → claimed.
+  assert "TC-16 no-flock lone steal → claimed (F-03)" "claimed" "$(run_noflock claim --session "$SID_A" --issue 960)"
+  assert "TC-16 holder now A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-960.json")"
+fi
+
 print_summary "$(basename "$0")" \
-  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity; stale-steal CAS via _atomic_claim_steal (Issue #1718); _resolve_current_session_id env-first (Issue #1530)."
+  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity; stale-steal CAS via _atomic_claim_steal (Issue #1718, flock + no-flock branches); _resolve_current_session_id env-first (Issue #1530)."

--- a/plugins/rite/hooks/tests/work-memory-lock.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-lock.test.sh
@@ -262,9 +262,16 @@ lockdir="$TEST_DIR/tc014.lock"
 mkdir -p "$lockdir"
 echo "$$" > "$lockdir/pid"                                # PID $$ is alive...
 echo "STALE_TOKEN_OF_DEAD_HOLDER" > "$lockdir/pid_token"  # ...but this token is the dead holder's
+token_probe=$(_proc_start_token "$$")
 touch -t "$(date -u -d '5 minutes ago' +'%Y%m%d%H%M' 2>/dev/null || date -u -v-5M +'%Y%m%d%H%M')" "$lockdir" 2>/dev/null || true
 WM_LOCK_STALE_THRESHOLD=1
-if acquire_wm_lock "$lockdir" 2; then
+if [ -z "$token_probe" ]; then
+  # Reuse detection needs a usable current token to compare the stored one against.
+  # Without a start-token source the code degrades to the legacy PID-only conservative
+  # hold (covered by TC-010) — the same platform guard TC-015 applies, so keep them
+  # symmetric to avoid a false FAIL on such platforms.
+  pass "start-token unavailable on this platform → skip (legacy PID-only covered by TC-010)"
+elif acquire_wm_lock "$lockdir" 2; then
   pass "PID reuse detected via token mismatch → stale lock reclaimed"
   release_wm_lock "$lockdir"
 else

--- a/plugins/rite/hooks/tests/work-memory-lock.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-lock.test.sh
@@ -251,6 +251,79 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-014 (Issue #1718): PID reuse — alive PID but mismatched start-token → stale
+# --------------------------------------------------------------------------
+# Simulates the classic PID-reuse race: the original holder died and its PID was
+# recycled by an unrelated (live) process. `kill -0` alone would wrongly keep the
+# abandoned lock forever; the start-token stored by the dead holder no longer
+# matches the live process's token, so the lock must be reclaimed.
+echo "TC-014: PID reuse (alive PID, mismatched start-token) is treated as stale"
+lockdir="$TEST_DIR/tc014.lock"
+mkdir -p "$lockdir"
+echo "$$" > "$lockdir/pid"                                # PID $$ is alive...
+echo "STALE_TOKEN_OF_DEAD_HOLDER" > "$lockdir/pid_token"  # ...but this token is the dead holder's
+touch -t "$(date -u -d '5 minutes ago' +'%Y%m%d%H%M' 2>/dev/null || date -u -v-5M +'%Y%m%d%H%M')" "$lockdir" 2>/dev/null || true
+WM_LOCK_STALE_THRESHOLD=1
+if acquire_wm_lock "$lockdir" 2; then
+  pass "PID reuse detected via token mismatch → stale lock reclaimed"
+  release_wm_lock "$lockdir"
+else
+  fail "Should reclaim: alive PID with mismatched token means the original holder is gone"
+  rm -rf "$lockdir"
+fi
+WM_LOCK_STALE_THRESHOLD="$DEFAULT_WM_LOCK_STALE_THRESHOLD"
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-015 (Issue #1718): alive PID with MATCHING token is NOT reclaimed
+# --------------------------------------------------------------------------
+# Guards against a false positive: a genuinely-held lock (same live process, same
+# token) must survive even past the stale mtime threshold.
+echo "TC-015: alive PID with matching start-token is NOT reclaimed"
+lockdir="$TEST_DIR/tc015.lock"
+mkdir -p "$lockdir"
+echo "$$" > "$lockdir/pid"
+_proc_start_token "$$" > "$lockdir/pid_token"   # the REAL token of this live process
+token_probe=$(_proc_start_token "$$")
+touch -t "$(date -u -d '5 minutes ago' +'%Y%m%d%H%M' 2>/dev/null || date -u -v-5M +'%Y%m%d%H%M')" "$lockdir" 2>/dev/null || true
+WM_LOCK_STALE_THRESHOLD=1
+if [ -z "$token_probe" ]; then
+  # No /proc and no usable ps on this platform → token unverifiable; the code
+  # degrades to the legacy PID-only conservative hold, which TC-010 already covers.
+  pass "start-token unavailable on this platform → skip (legacy behavior covered by TC-010)"
+elif acquire_wm_lock "$lockdir" 2; then
+  fail "Should NOT reclaim: matching token means the same live process still holds it"
+  release_wm_lock "$lockdir"
+else
+  pass "Matching token → genuine live holder → lock preserved"
+  rm -rf "$lockdir"
+fi
+WM_LOCK_STALE_THRESHOLD="$DEFAULT_WM_LOCK_STALE_THRESHOLD"
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-016 (Issue #1718): acquire writes numeric pid + pid_token; release removes both
+# --------------------------------------------------------------------------
+echo "TC-016: acquire writes numeric pid + pid_token file; release removes both"
+lockdir="$TEST_DIR/tc016.lock"
+acquire_wm_lock "$lockdir"
+_ok=1
+{ [ -f "$lockdir/pid" ] && [[ "$(cat "$lockdir/pid")" =~ ^[0-9]+$ ]]; } || _ok=0
+[ -f "$lockdir/pid_token" ] || _ok=0
+if [ "$_ok" -eq 1 ]; then
+  pass "pid (numeric) + pid_token both written on acquire"
+else
+  fail "expected numeric pid and a pid_token file after acquire"
+fi
+release_wm_lock "$lockdir"
+if [ ! -f "$lockdir/pid" ] && [ ! -f "$lockdir/pid_token" ]; then
+  pass "release removed both pid and pid_token"
+else
+  fail "release left pid/pid_token behind"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/work-memory-lock.sh
+++ b/plugins/rite/hooks/work-memory-lock.sh
@@ -18,6 +18,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
 # Stale lock threshold in seconds (default: 120s for compact, 300s for issue)
 WM_LOCK_STALE_THRESHOLD="${WM_LOCK_STALE_THRESHOLD:-120}"
 
+# Process start-token: a value that changes when a PID is recycled by a new
+# process, so `kill -0` alone (which cannot tell the original holder from an
+# unrelated process that reused its PID) can be disambiguated. Linux uses the
+# monotonic starttime (field 22 of /proc/<pid>/stat, never reused within a boot);
+# BSD/macOS falls back to `ps -o lstart=` (absolute start time). Empty when
+# neither source is available — callers then degrade to the legacy PID-only check.
+_proc_start_token() {
+  local pid="$1" tok="" rest
+  if [ -r "/proc/$pid/stat" ]; then
+    # comm (field 2) is parenthesized and may contain spaces / ')', so strip
+    # through the LAST ') ' before counting: state becomes field 1, starttime 20.
+    rest=$(sed 's/.*) //' "/proc/$pid/stat" 2>/dev/null) || rest=""
+    [ -n "$rest" ] && tok=$(printf '%s\n' "$rest" | awk '{print $20}')
+  fi
+  if [ -z "$tok" ]; then
+    tok=$(ps -o lstart= -p "$pid" 2>/dev/null | tr -s ' ' '_')
+  fi
+  printf '%s' "$tok"
+}
+
+# Record the current process's PID + start-token into the lockdir. `pid` stays
+# purely numeric (backward compatible with readers / older versions); the token
+# lives in a separate `pid_token` file so its absence signals a legacy lock.
+_write_pid_record() {
+  local lockdir="$1"
+  echo $$ > "$lockdir/pid" 2>/dev/null || true
+  _proc_start_token "$$" > "$lockdir/pid_token" 2>/dev/null || true
+}
+
 acquire_wm_lock() {
   local lockdir="$1"
   local timeout="${2:-50}"  # 50 iterations * 100ms = 5 seconds
@@ -56,15 +85,32 @@ acquire_wm_lock() {
             local lock_pid
             lock_pid=$(head -c 20 "$lockdir/pid" 2>/dev/null) || lock_pid=""
             if [ -n "$lock_pid" ] && [[ "$lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
-              # Process still running — lock is not stale, give up
-              return 1
+              # PID is alive — but a dead holder's PID may have been RECYCLED by an
+              # unrelated process, in which case `kill -0` succeeds for the wrong
+              # process and we would wrongly keep an abandoned lock forever. Compare
+              # the recorded start-token against the live process's current token:
+              # a mismatch means PID reuse → the original holder is gone → stale.
+              if [ -f "$lockdir/pid_token" ]; then
+                local stored_token cur_token
+                stored_token=$(head -c 100 "$lockdir/pid_token" 2>/dev/null) || stored_token=""
+                cur_token=$(_proc_start_token "$lock_pid")
+                if [ -n "$stored_token" ] && [ -n "$cur_token" ] && [ "$stored_token" != "$cur_token" ]; then
+                  : # PID reused by a different process → fall through to reclaim
+                else
+                  return 1  # same live holder (or token unverifiable) — not stale
+                fi
+              else
+                # Legacy lock without a token file: reuse is undetectable, so stay
+                # conservative and treat the live PID as the genuine holder.
+                return 1
+              fi
             fi
           fi
-          # Stale lock — remove pid file and directory, then retry once
-          rm -f "$lockdir/pid" 2>/dev/null || true
+          # Stale lock — remove pid + token files and directory, then retry once
+          rm -f "$lockdir/pid" "$lockdir/pid_token" 2>/dev/null || true
           rmdir "$lockdir" 2>/dev/null || rm -rf "$lockdir" 2>/dev/null || true
           if mkdir "$lockdir" 2>/dev/null; then
-            echo $$ > "$lockdir/pid" 2>/dev/null || true
+            _write_pid_record "$lockdir"
             return 0
           fi
         fi
@@ -73,13 +119,13 @@ acquire_wm_lock() {
     fi
     sleep 0.1
   done
-  echo $$ > "$lockdir/pid" 2>/dev/null || true
+  _write_pid_record "$lockdir"
   return 0
 }
 
 release_wm_lock() {
   local lockdir="$1"
-  rm -f "$lockdir/pid" 2>/dev/null || true
+  rm -f "$lockdir/pid" "$lockdir/pid_token" 2>/dev/null || true
   rmdir "$lockdir" 2>/dev/null || rm -rf "$lockdir" 2>/dev/null || true
 }
 

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -151,6 +151,16 @@ if [ -z "$INPUT_JSON" ]; then
   exit 1
 fi
 
+# Validate JSON parseability before eval'ing extracted fields — symmetric with
+# projects-status-update.sh. `@sh` escaping already prevents injection, but a
+# malformed payload would otherwise reach `eval` with every field defaulted to
+# empty, silently producing a bogus issue instead of failing loud here.
+if ! printf '%s\n' "$INPUT_JSON" | jq -e . >/dev/null 2>&1; then
+  add_warning "Invalid JSON argument"
+  output_result "" 0 "" "" "failed"
+  exit 1
+fi
+
 # Extract all fields in a single jq invocation (1 subprocess instead of 13)
 eval "$(printf '%s\n' "$INPUT_JSON" | jq -r '
   @sh "TITLE=\(.issue.title // "")",

--- a/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
+++ b/plugins/rite/scripts/tests/create-issue-with-projects.test.sh
@@ -460,13 +460,19 @@ fi
 # --------------------------------------------------------------------------
 # TC-015: Invalid JSON argument → exit 1
 # --------------------------------------------------------------------------
-echo "TC-015: Invalid JSON argument → exit 1"
+echo "TC-015: Invalid JSON argument → eval 前に fail-fast (exit 1 + warning)"
 rc=0
 output=$(PATH="$MOCK_BIN_DIR:$PATH" bash "$TARGET" "NOT-VALID-JSON" 2>/dev/null) || rc=$?
-if [ $rc -ne 0 ]; then
-  pass "Invalid JSON → exit $rc"
+# eval 前 jq -e 検証ブランチ (AC-3) を固有に pin する。汎用の exit≠0 だけでは当該ブランチを
+# 削除しても下流の空フィールド/title-required 経路経由で exit 1 になり検出できないため、
+# projects-status-update.sh の同型ガード (TC-002) と対称に "Invalid JSON argument" warning と
+# project_registration=failed を assert する。
+if [ "$rc" -eq 1 ] \
+  && printf '%s\n' "$output" | jq -e '.warnings | map(select(. == "Invalid JSON argument")) | length == 1' >/dev/null \
+  && [ "$(printf '%s\n' "$output" | jq -r '.project_registration')" = "failed" ]; then
+  pass "Invalid JSON → eval 前 fail-fast (exit 1 + 'Invalid JSON argument' warning + project_registration=failed)"
 else
-  fail "Expected non-zero exit for invalid JSON"
+  fail "Expected exit 1 with 'Invalid JSON argument' warning and project_registration=failed, got rc=$rc output=$output"
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

ロック・排他機構の 3 つの既知の穴を塞ぐ堅牢化。いずれも「判定と反映の間にロックが跨っていない」「PID だけで生存判定している」「eval 前検証が姉妹スクリプトと非対称」という、現行方式（mkdir / noclobber / flock）を維持したまま閉じられる欠陥。

Closes #1718

## 変更内容

### 1. issue-claim.sh: stale-steal の compare-and-swap 化（AC-1 / AC-2）

stale-steal は `_classify` をロック**外**で行うため、2 セッションが同一 stale claim を両方 "stale" 判定→両方奪取できる TOCTOU の窓があった（flock は `mv` を直列化するだけで奪取の排他はしない）。

- 新規 `_atomic_claim_steal` を追加し、flock 取得**後**に holder を再読取して CAS 検証する。
- ロック内 holder が観測した stale holder（`expected`）と一致し、かつ live に転じていないときのみ奪取。
- 後着セッション（holder が swap 済み）や復活 holder は奪取を中止し `other`（rc 10）を返す → 呼び出し側が AskUserQuestion。
- 単独 stale 奪取（holder 不変）は従来どおり成功（非回帰）。

### 2. work-memory-lock.sh: PID 再利用レースの緩和

`kill -0 "$lock_pid"` は、holder が死んで PID が別プロセスに再利用された場合に「生存」と誤判定し、放棄されたロックを永久に stale 回収できなかった。

- プロセス開始トークン（Linux `/proc/<pid>/stat` starttime / BSD `ps -o lstart=`）を `pid_token` に併記。
- PID が生存でもトークン不一致なら「PID 再利用」とみなし stale 回収する。
- `pid` ファイルは数値のまま保持し token を別ファイルに置くことで、legacy lock（token 無し）は従来どおり保守的に「生存」扱いとし後方互換を維持。

### 3. create-issue-with-projects.sh: eval 前検証の対称化（AC-3）

eval 前の `jq -e .` パース検証を追加し、malformed JSON を eval に渡さず ERROR 停止する（projects-status-update.sh と同挙動）。

### 4. テスト追加（AC-1 / AC-4）

- `issue-claim.test.sh` TC-14: 5 セッション並行 stale 奪取 → 奪取成功は常に 1 プロセスのみ・残り 4 は `other`。TC-15: 単独奪取の非回帰。
- `work-memory-lock.test.sh` TC-14/15/16: PID 再利用（トークン不一致→stale）・トークン一致→非回収・acquire/release の pid_token 生成/削除。
- `diag-snippet-neutralize-parity.test.sh`: 新規 `head -c`（非 emission の `stored_token`）を既存の `lock_pid` と同様 allowlist に追加。

### 5. ドキュメント整合（drift 修正）

- `docs/designs/multi-session-worktree.md`: claim exit-code 表を CAS 挙動（rc 10 に stale-steal CAS 中止が加わる）に更新。
- `docs/SPEC.md`: stale lock 検出の説明に PID 再利用検出を追記。

## テスト計画

- `plugins/rite/hooks/tests/run-tests.sh` — **91/91 pass**（AC-4）。
- AC-1: TC-14 で並行奪取が常に 1 プロセスのみ成功することを検証。
- AC-2: TC-15 + 既存 TC-6 で単独奪取の非回帰を検証。
- AC-3: malformed JSON で eval 前に "Invalid JSON argument" で停止することを手動検証。

## チェックリスト

- [x] All MUST requirements implemented（FREE noclobber 経路不変・単独 stale 奪取成功・既存テスト全 pass）
- [x] All Acceptance Criteria (AC-1〜AC-4) verified
- [x] No regression in existing functionality（91/91 pass）
- [x] Target files modified, non-target files untouched（session-ownership.sh 未変更）
- [x] Code follows project conventions

## Non-target（変更していないファイル）

- `plugins/rite/hooks/session-ownership.sh`（構造的に所有権保証済みのため対象外）
