### PR TITLE
feat(pr-create): PR body に Decision Log / 計画逸脱ログの要約を還流

### DIFF
--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -730,22 +730,22 @@ When executed via an orchestrator's end-to-end flow (e.g. `/rite:open` ステッ
 
 **Optimization conditions (OR evaluation):** During end-to-end flow execution / 20 or more changed files / Over 30 tool invocations. 30 invocations is lightweight optimization for PR creation alone; 50 invocations (see `skills/open/SKILL.md` 等の上位 orchestrator) is full-scale mitigation.
 
-**Optimization content:** Changes -> file list and summary only (show top 3 files), Work memory -> progress summary only, Checklist -> mandatory items only, Implementation Notes (§3.2.2) -> capped per the same section's E2E cap rule. Applied automatically without user confirmation.
+**Optimization content:** Changes -> file list and summary only (show top 3 files), Work memory -> progress summary only, Checklist -> mandatory items only, Implementation Notes -> capped per §3.2.2's E2E optimization cap rule. Applied automatically without user confirmation.
 
-#### 3.2.2 Implementation Notes Summary (Decision Log / Plan Deviation)
+#### 3.2.2 Implementation Notes Summary (Plan Deviation / Decision Log)
 
 Before finalizing the PR body, gather two additional sources so reviewers start with the same unknowns the implementer had (rather than re-deriving them from the diff alone):
 
 1. **Work memory Plan Deviation Log** (`### 計画逸脱ログ` table — see [Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#plan-deviation-log-section)). Read the local work memory file or, if absent, the Issue comment sync. If the table shows only `_計画逸脱はありません_` (or the section/file is absent), treat this source as 0 items — do not error.
 2. **Issue body Section 9 Decision Log** (`## 9. Decision Log` — see [Issue Template Structure](../../templates/issue/template-structure.md)). Read the Issue body already retained in conversation context. If the section is absent or contains no `D-xx:` entries, treat this source as 0 items — do not error.
 
-**Summarization rule**: For each item found, generate one line: `{種別}: {1 行要約} — {理由}`, where `種別` is `逸脱` (from the Plan Deviation Log) or `判断` (from the Decision Log). Keep each line to a single sentence — this is a pointer for the reviewer, not a full transcript.
+**Summarization rule**: For each item found, generate one line: `{種別}: {1 行要約} — {理由}`, where `種別` is `Deviation` / `逸脱` (from the Plan Deviation Log) or `Decision` / `判断` (from the Decision Log), following the language determined in Phase 3.1 — use the English label in `en` mode and the Japanese label in `ja` mode, matching the heading's language switch below. Keep each line to a single sentence — this is a pointer for the reviewer, not a full transcript.
 
 **Zero-item rule (MUST)**: If both sources yield 0 items, omit the entire section — heading included. Never emit an empty heading or an empty bullet list.
 
 **Section heading**: Follow the language determined in Phase 3.1 — `## Implementation Notes` (English) or `## 実装中の判断・計画逸脱` (Japanese). Place the section between `## Changes` and `## Checklist` (see `templates/pr/generic.md`).
 
-**E2E optimization cap (Phase 3.2.1)**: When Phase 3.2.1's optimization conditions are met, cap the summary to the top 3 items — Plan Deviation items first, then Decision Log items, both in source order — and append a note stating how many were omitted (e.g. `(他 N 件省略)` / `(N more omitted)`).
+**E2E optimization cap**: When Phase 3.2.1's optimization conditions are met, cap the summary to the top 3 items — Plan Deviation items first, then Decision Log items, both in source order — and append a note stating how many were omitted (e.g. `(他 N 件省略)` / `(N more omitted)`).
 
 ### 3.3 Push to Remote
 

--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -722,7 +722,7 @@ Generate the PR body in **the same language determined in Phase 3.1**:
 | Boilerplate text | Description for `Closes #XX`, etc. |
 | Checklist items | `- [ ] Tests added` / `- [ ] テスト追加`, etc. |
 
-Information to include in the PR body: summary, related Issue (`Closes #{number}`), changes (from work memory or git diff), checklist. Generate all in the language determined in Phase 3.1.
+Information to include in the PR body: summary, related Issue (`Closes #{number}`), changes (from work memory or git diff), checklist, Implementation Notes summary (§3.2.2, when applicable). Generate all in the language determined in Phase 3.1.
 
 #### 3.2.1 Context Optimization During End-to-End Flow
 
@@ -730,7 +730,22 @@ When executed via an orchestrator's end-to-end flow (e.g. `/rite:open` ステッ
 
 **Optimization conditions (OR evaluation):** During end-to-end flow execution / 20 or more changed files / Over 30 tool invocations. 30 invocations is lightweight optimization for PR creation alone; 50 invocations (see `skills/open/SKILL.md` 等の上位 orchestrator) is full-scale mitigation.
 
-**Optimization content:** Changes -> file list and summary only (show top 3 files), Work memory -> progress summary only, Checklist -> mandatory items only. Applied automatically without user confirmation.
+**Optimization content:** Changes -> file list and summary only (show top 3 files), Work memory -> progress summary only, Checklist -> mandatory items only, Implementation Notes (§3.2.2) -> capped per the same section's E2E cap rule. Applied automatically without user confirmation.
+
+#### 3.2.2 Implementation Notes Summary (Decision Log / Plan Deviation)
+
+Before finalizing the PR body, gather two additional sources so reviewers start with the same unknowns the implementer had (rather than re-deriving them from the diff alone):
+
+1. **Work memory Plan Deviation Log** (`### 計画逸脱ログ` table — see [Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#plan-deviation-log-section)). Read the local work memory file or, if absent, the Issue comment sync. If the table shows only `_計画逸脱はありません_` (or the section/file is absent), treat this source as 0 items — do not error.
+2. **Issue body Section 9 Decision Log** (`## 9. Decision Log` — see [Issue Template Structure](../../templates/issue/template-structure.md)). Read the Issue body already retained in conversation context. If the section is absent or contains no `D-xx:` entries, treat this source as 0 items — do not error.
+
+**Summarization rule**: For each item found, generate one line: `{種別}: {1 行要約} — {理由}`, where `種別` is `逸脱` (from the Plan Deviation Log) or `判断` (from the Decision Log). Keep each line to a single sentence — this is a pointer for the reviewer, not a full transcript.
+
+**Zero-item rule (MUST)**: If both sources yield 0 items, omit the entire section — heading included. Never emit an empty heading or an empty bullet list.
+
+**Section heading**: Follow the language determined in Phase 3.1 — `## Implementation Notes` (English) or `## 実装中の判断・計画逸脱` (Japanese). Place the section between `## Changes` and `## Checklist` (see `templates/pr/generic.md`).
+
+**E2E optimization cap (Phase 3.2.1)**: When Phase 3.2.1's optimization conditions are met, cap the summary to the top 3 items — Plan Deviation items first, then Decision Log items, both in source order — and append a note stating how many were omitted (e.g. `(他 N 件省略)` / `(N more omitted)`).
 
 ### 3.3 Push to Remote
 

--- a/plugins/rite/templates/pr/generic.md
+++ b/plugins/rite/templates/pr/generic.md
@@ -10,6 +10,8 @@ Closes #{issue_number}
 
 -
 
+<!-- Optional: Implementation Notes / 実装中の判断・計画逸脱 — include only when the work memory Plan Deviation Log or the Issue's Section 9 Decision Log has entries; omit this section (heading included) otherwise. See skills/pr-create/SKILL.md Phase 3.2.2. -->
+
 ## Checklist
 
 - [ ] Code follows project conventions


### PR DESCRIPTION
## Summary

`/rite:pr-create` の PR body 生成（Phase 3.2）に、work memory の「計画逸脱ログ」と Issue body Section 9「Decision Log」を要約する手順（Phase 3.2.2）を追加した。実装中の判断・計画からの逸脱が PR 説明に還流されることで、レビュアーが diff だけからは分からない「なぜこの実装になったのか」という unknowns を PR 本文から把握できるようにする。両ソースとも 0 件の場合はセクション自体を省略する（本 PR 自身がその実例 — 計画逸脱・Decision Log ともに 0 件のため、このセクションは出力されていない）。

## Related Issue

Closes #1749

## Changes

- `plugins/rite/skills/pr-create/SKILL.md`: Phase 3.2 に新規サブセクション「3.2.2 Implementation Notes Summary」を追加（計画逸脱ログ + Decision Log の読取・要約・0 件時省略ルール）、Phase 3.2.1 の最適化対象一覧に本セクションの上限圧縮（top 3 + 省略件数）を追記
- `plugins/rite/templates/pr/generic.md`: Changes と Checklist の間に言語中立なプレースホルダーコメントを追加

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
