### PR TITLE
docs(templates): interview-perspectives.md の旧 Deep-Dive Interview 参照を現行ステップに更新

### DIFF
--- a/plugins/rite/templates/issue/interview-perspectives.md
+++ b/plugins/rite/templates/issue/interview-perspectives.md
@@ -1,6 +1,6 @@
 # Interview Perspectives Template
 
-This template defines the 6 interview perspectives used by the Deep-Dive Interview step in `skills/issue-create/SKILL.md` ステップ 1.
+This template defines the 6 interview perspectives originally used by the Deep-Dive Interview step (a former `create-interview` sub-skill). That sub-skill was retired in the flat-workflow refactor, and the current Assumption Surfacing procedure in `skills/issue-create/SKILL.md` ステップ 4.0 / 5.0 uses a different mechanism (3-way a/b/c classification + blind-spot pass) that does not reference this Perspective Scope Table. This file is currently not referenced by any active skill step (orphaned); see the tracking issue for its disposition.
 
 ## Perspective Scope Table
 


### PR DESCRIPTION
## Summary

`plugins/rite/templates/issue/interview-perspectives.md` 3 行目の説明文が、存在しない旧ステップ（旧 `create-interview` サブスキルの Deep-Dive Interview）を参照しているドキュメント drift を修正した。

## Related Issue

Closes #1750

## Changes

- `plugins/rite/templates/issue/interview-perspectives.md`: 3 行目の説明文を修正。`grep -rn "interview-perspectives" plugins/ docs/` で全参照元を確認した結果、機能的な参照は0件（`docs/SPEC.md` のディレクトリツリー表記のみ）であることが判明。旧 `create-interview` サブスキルは flat-workflow リファクタで廃止され、現行の仮定表面化（`issue-create/SKILL.md` ステップ 4.0/5.0）は「6 perspectives」ではなく別方式（3分類 a/b/c + 盲点列挙）のため、本ファイルは現在どの skill step からも参照されていない（orphan）ことを明記する記述に更新した。6 観点の内容・Perspective Scope Table 自体は変更していない。

## 参照元調査結果 (AC-2)

- `grep -rn "interview-perspectives" plugins/ docs/` の結果: `docs/SPEC.md:240` のディレクトリツリー表記のみ（機能的参照ゼロ）
- `issue-create/SKILL.md` のステップ 4.0/5.0（仮定表面化）は本テンプレートの「6 perspectives」「Perspective Scope Table」を一切参照していないことを確認
- **orphan 状態の扱い**: 本 Issue では説明文修正に留め、ファイルの削除・統合は行っていない（Non-goal / AC-2 の方針通り）。orphan の削除・統合要否は別 Issue での検討を推奨する

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
