### PR TITLE
docs(references): coding-principles.md と open 計画テンプレートの「参考実装」参照不整合を解消

### DIFF
--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -350,6 +350,11 @@ Issue body から「What / Why / Where / Acceptance Criteria」を抽出。
 ### 変更対象ファイル
 - {file_path_1}: {responsibility}
 
+### 参考実装
+| 参考ファイル | 参考理由 |
+|-------------|---------|
+| {reference_file_1} | {reason_1} |
+
 ### 実装ステップ
 1. {step_1}
 2. {step_2}
@@ -362,6 +367,8 @@ Issue body から「What / Why / Where / Acceptance Criteria」を抽出。
 ```
 
 **volatile-first 提示ルール**: `## 実装計画` の直後・`### 変更対象ファイル` の前に、ユーザーの判断で変わりやすい項目（データモデル変更・型/インターフェース定義・ユーザー可視挙動/UX）があれば「要判断ポイント」として箇条書きで列挙する。ステップ 3.4 の承認時にユーザーが本質的な判断へ注意を集中できるようにするため（出典: [A Field Guide to Fable: Finding Your Unknowns](https://x.com/trq212/status/2073100352921215386) — "lead with the decisions I'm most likely to tweak"）。**「実装ステップ」自体の並び順（= 実行順）は変更しない**（issue-implement 側の実行順序決定に影響を与えないため）。該当項目がない計画ではこのブロックを出力しない。
+
+**参考実装セクション**: `reference_discovery` 原則（[coding-principles.md](../rite-workflow/references/coding-principles.md)）のルール 4「発見した参照を実装計画に記録」に従い、ステップ 3.2 で発見した既存の参考実装（同ディレクトリの類似ファイル、命名パターンが一致するファイル等）を記録する。参考実装が見つからない場合（新規ディレクトリ、初めてのファイルパターン等）は、テーブルの代わりに `参考実装: なし（新規ディレクトリまたは初めてのファイルパターン）` の 1 行を出力する。
 
 ### 3.4 ユーザー確認
 

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -229,7 +229,7 @@ Issue の内容に矛盾があります:
 この計画で進めますか？
 ```
 
-**Note**: For the full plan template including the "参考実装" section, see [`skills/open/SKILL.md`](../../../skills/open/SKILL.md) ステップ 3 (実装計画)。
+**Note**: For the full plan template including the "参考実装" section, see [`skills/open/SKILL.md`](../../../skills/open/SKILL.md) ステップ 3.3 (実装計画生成)。
 
 ---
 


### PR DESCRIPTION
## Summary

`plugins/rite/skills/rite-workflow/references/coding-principles.md` 232 行目の Note が参照する `open/SKILL.md` ステップ 3.3 の実装計画テンプレートに、実際には「参考実装」セクションが存在しないというドキュメント drift を解消した。

## Related Issue

Closes #1751

## Changes

- `plugins/rite/skills/open/SKILL.md`: ステップ 3.3 の実装計画テンプレートに「### 参考実装」セクション（参考ファイル/参考理由テーブル + 空時の代替記法）を追加。`reference_discovery` 原則のルール4「発見した参照を実装計画に記録」の意図を実際のテンプレート出力に反映（**案A採用**）
- `plugins/rite/skills/rite-workflow/references/coding-principles.md`: 232 行目の Note の参照先を「ステップ 3」から「ステップ 3.3」へ精度向上

## 実装中の判断・計画逸脱

Decision: 案A（open/SKILL.md へ参考実装セクション追加）を採用 — reference_discovery 原則が求める「計画への記録」を実テンプレートに反映するため。副次的に、`plugins/rite/references/bottleneck-detection.md:69` が既に前提としていた「実装計画に参考実装セクションが含まれる」という pre-existing dangling reference もこの修正で解消される。

## 関連 Issue との非干渉確認 (AC-4)

#1747（volatile-first 提示順ルール）で追加された段落は、本PRで追加した「参考実装セクション」の説明文の直前に隣接する形で共存し、矛盾なく統合されていることを確認した。

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
