### PR TITLE
docs(open): 出典引用のSNS直リンクを内部参照中心の記法に寄せる

### DIFF
--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -366,7 +366,7 @@ Issue body から「What / Why / Where / Acceptance Criteria」を抽出。
 - {note_1}
 ```
 
-**volatile-first 提示ルール**: `## 実装計画` の直後・`### 変更対象ファイル` の前に、ユーザーの判断で変わりやすい項目（データモデル変更・型/インターフェース定義・ユーザー可視挙動/UX）があれば「要判断ポイント」として箇条書きで列挙する。ステップ 3.4 の承認時にユーザーが本質的な判断へ注意を集中できるようにするため（出典: [A Field Guide to Fable: Finding Your Unknowns](https://x.com/trq212/status/2073100352921215386) — "lead with the decisions I'm most likely to tweak"）。**「実装ステップ」自体の並び順（= 実行順）は変更しない**（issue-implement 側の実行順序決定に影響を与えないため）。該当項目がない計画ではこのブロックを出力しない。
+**volatile-first 提示ルール**: `## 実装計画` の直後・`### 変更対象ファイル` の前に、ユーザーの判断で変わりやすい項目（データモデル変更・型/インターフェース定義・ユーザー可視挙動/UX）があれば「要判断ポイント」として箇条書きで列挙する。ステップ 3.4 の承認時にユーザーが本質的な判断へ注意を集中できるようにするため（出典: Thariq (Anthropic) "A Field Guide to Fable: Finding Your Unknowns" (2026) — "lead with the decisions I'm most likely to tweak"）。**「実装ステップ」自体の並び順（= 実行順）は変更しない**（issue-implement 側の実行順序決定に影響を与えないため）。該当項目がない計画ではこのブロックを出力しない。
 
 **参考実装セクション**: `reference_discovery` 原則（[coding-principles.md](../rite-workflow/references/coding-principles.md)）のルール 4「発見した参照を実装計画に記録」に従い、ステップ 3.2 で発見した既存の参考実装（同ディレクトリの類似ファイル、命名パターンが一致するファイル等）を記録する。参考実装が見つからない場合（新規ディレクトリ、初めてのファイルパターン等）は、テーブルの代わりに `参考実装: なし（新規ディレクトリまたは初めてのファイルパターン）` の 1 行を出力する。
 


### PR DESCRIPTION
## 概要

`skills/open/SKILL.md` の volatile-first 提示ルールにあった出典引用を、認証必須のX/Twitter投稿への直リンクから、本リポジトリ既存の慣習である属人化引用形式に変更した。

Closes #1753

## 変更内容

- `plugins/rite/skills/open/SKILL.md:369`: 出典表記を Markdown リンク（x.com 直リンク）から `出典: Thariq (Anthropic) "A Field Guide to Fable: Finding Your Unknowns" (2026)` 形式に変更

## Checklist

- [x] Issue のチェックリスト項目を完了
- [x] ドキュメントのみの変更（コード動作への影響なし）

## Known Issues

- lint 未実行（rite-config.yml の commands.lint 未設定、package.json 等のプロジェクトファイルも不在のため自動検出不可）
