### PR TITLE
docs(references): coding-principles.md の実装計画Exampleをopen/SKILL.mdの実テンプレートに合わせる

### DIFF
--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -213,23 +213,30 @@ Issue の内容に矛盾があります:
 ## 実装計画
 
 ### 変更対象ファイル
-| ファイル | 変更内容 |
-|---------|---------|
-| src/auth.ts | 認証ロジックの追加 |
-| src/middleware.ts | 認証ミドルウェアの追加 |
+- src/auth.ts: 認証ロジックの追加
+- src/middleware.ts: 認証ミドルウェアの追加
 
-### 実装ステップ（依存グラフ）
+### 参考実装
+| 参考ファイル | 参考理由 |
+|-------------|---------|
+| src/session.ts | 同様の認証状態管理パターンを踏襲 |
 
-| Step | 内容 | depends_on | 並列グループ |
-|------|------|------------|-------------|
-| S1 | 認証ロジックの実装 | — | A |
-| S2 | ミドルウェアの統合 | S1 | B |
-| S3 | テストの追加 | S1, S2 | C |
+### 実装ステップ
+1. 認証ロジックの実装
+2. ミドルウェアの統合
+3. テストの追加
+
+### 受入基準マッピング
+- AC1 → step 1
+- AC2 → step 2
+
+### 注意点
+- 既存セッション管理との整合性に注意
 
 この計画で進めますか？
 ```
 
-**Note**: For the full plan template including the "参考実装" section, see [`skills/open/SKILL.md`](../../../skills/open/SKILL.md) ステップ 3.3 (実装計画生成)。
+**Note**: This example mirrors the actual plan template. See [`skills/open/SKILL.md`](../../../skills/open/SKILL.md) ステップ 3.3 (実装計画生成) for the canonical template definition.
 
 ---
 


### PR DESCRIPTION
## 概要

`plugins/rite/skills/rite-workflow/references/coding-principles.md` の inline_planning 原則にある実装計画 Example が、実際の `open/SKILL.md` ステップ3.3 テンプレート（プレーン番号リスト形式）と乖離していた（`depends_on`/並列グループ列を持つテーブル形式のままだった）ため、実テンプレートに合わせて更新した。

Closes #1754

## 変更内容

- `plugins/rite/skills/rite-workflow/references/coding-principles.md`: 実装計画 Example を `depends_on`/並列グループ列を持つテーブル形式からプレーン番号リスト形式に変更し、参考実装セクションの例も追加。存在しない「参考実装」セクションへの参照だった旧 Note を、実テンプレートを指す形に更新

## Checklist

- [x] Issue のチェックリスト項目を完了
- [x] ドキュメントのみの変更（コード動作への影響なし）

## Known Issues

- lint 未実行（rite-config.yml の commands.lint 未設定、package.json 等のプロジェクトファイルも不在のため自動検出不可）
