### PR TITLE
test(hooks): reviewer-registry-drift-check に数字入りslugの回帰テストを追加する

### DIFF
--- a/plugins/rite/hooks/tests/reviewer-registry-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-registry-drift-check.test.sh
@@ -24,6 +24,9 @@
 #   - Cross-component contract: the `==> Total reviewer-registry-drift
 #     findings: N` aggregate line (consumed by skills/lint/SKILL.md's
 #     extraction regex) is asserted verbatim without --quiet
+#   - Regression guard: a digit-bearing slug (web3) is correctly counted
+#     across all 3 sync points, guarding against AGENT_RE reverting to a
+#     digit-unaware pattern (Issue #1763)
 #
 # Portability note: fixture mutations use `awk` via the
 # read→transform→write→mv pattern instead of `sed -i`. BSD sed (macOS)

--- a/plugins/rite/hooks/tests/reviewer-registry-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/reviewer-registry-drift-check.test.sh
@@ -67,11 +67,14 @@ awk_inplace() {
   mv "$tmp" "$file"
 }
 
-# 12 種のダミー reviewer slug（checker の >= 10 抽出ガードを満たす数）
-FIXTURE_SLUGS=(alpha bravo charlie delta echo-x foxtrot golf hotel india juliett kilo lima)
+# 13 種のダミー reviewer slug（checker の >= 10 抽出ガードを満たす数）。
+# web3 は数字入り slug (Issue #1763): AGENT_RE が `[a-z][a-z-]*-reviewer[.]md` に
+# 巻き戻った場合、この 1 件だけが 3 集合 + I3 行フィルタから静かに脱落する
+# （TC-15 の回帰ガード対象）。
+FIXTURE_SLUGS=(alpha bravo charlie delta echo-x foxtrot golf hotel india juliett kilo lima web3)
 
 # Helper: create a sandbox holding a synchronized reviewer registry fixture
-# (12 agent files + reviewers/SKILL.md with both tables in sync) and echo its
+# (13 agent files + reviewers/SKILL.md with both tables in sync) and echo its
 # repo root path. Callers push the path onto cleanup_dirs and then mutate the
 # fixture to create the drift under test.
 make_registry_sandbox() {
@@ -465,6 +468,50 @@ if printf '%s\n' "$out" | grep -Fq "plugins/rite/agents"; then
   pass "TC-14b: names plugins/rite/agents as the missing sync point"
 else
   fail "TC-14b: expected output to name plugins/rite/agents"
+  echo "--- output ---"; printf '%s\n' "$out"; echo "--- end ---"
+fi
+
+# --- TC-15: numeric slug (web3) synced fixture → rc=0, correctly counted in
+# all 3 sync points (regression guard for AGENT_RE digit support, Issue #1763) ---
+# PR #1762 extended AGENT_RE from `[a-z][a-z-]*-reviewer[.]md` to
+# `[a-z][a-z0-9-]*-reviewer[.]md` so digit-bearing slugs (e.g. web3) are
+# extracted instead of silently dropping out of all 3 sets + the I3 row
+# filter. A plain rc=0 assertion on a fully-synced fixture would NOT catch a
+# regression here: if AGENT_RE reverted, web3-reviewer.md would simply be
+# excluded from every set, so the fixture would still trivially report rc=0
+# (in sync) for the wrong reason. Asserting the reported per-source counts
+# equal the full FIXTURE_SLUGS length (13) instead of 12 is what actually
+# distinguishes "correctly counted" from "silently dropped" — the log line
+# only prints its count with --quiet omitted, hence no --quiet here.
+echo ""
+echo "=== TC-15: numeric slug (web3) synced fixture → rc=0, counted in all 3 sync points ==="
+d=$(make_registry_sandbox)
+cleanup_dirs+=("$d")
+expected_count=${#FIXTURE_SLUGS[@]}
+rc=0
+out=$(bash "$CHECKER" --all --repo-root "$d" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "TC-15: numeric-slug fixture reports no drift"
+else
+  fail "TC-15: expected rc=0, got rc=$rc"
+  echo "--- output ---"; printf '%s\n' "$out"; echo "--- end ---"
+fi
+if printf '%s\n' "$out" | grep -qE "agents/ profiles[[:space:]]*: ${expected_count} reviewers"; then
+  pass "TC-15: agents/ profiles count includes web3-reviewer.md (not silently dropped by AGENT_RE)"
+else
+  fail "TC-15: expected agents/ profiles count to be ${expected_count} (web3 must not be excluded by a digit-unaware AGENT_RE)"
+  echo "--- output ---"; printf '%s\n' "$out"; echo "--- end ---"
+fi
+if printf '%s\n' "$out" | grep -qE "Available Reviewers table[[:space:]]*: ${expected_count} reviewers"; then
+  pass "TC-15: Available Reviewers table count includes web3-reviewer.md"
+else
+  fail "TC-15: expected Available Reviewers table count to be ${expected_count}"
+  echo "--- output ---"; printf '%s\n' "$out"; echo "--- end ---"
+fi
+if printf '%s\n' "$out" | grep -qE "Type Identifiers table[[:space:]]*: ${expected_count} reviewers"; then
+  pass "TC-15: Type Identifiers table count includes web3-reviewer.md"
+else
+  fail "TC-15: expected Type Identifiers table count to be ${expected_count}"
   echo "--- output ---"; printf '%s\n' "$out"; echo "--- end ---"
 fi
 


### PR DESCRIPTION
## Summary

`reviewer-registry-drift-check.test.sh` に数字入りslug（例: `web3-reviewer.md`）の回帰テストを追加する。PR #1762 で AGENT_RE を数字対応に拡張した修正が将来巻き戻されても検知できるようにする。

## Related Issue

Closes #1763

## Changes

- `FIXTURE_SLUGS` に `web3`（数字入りslug）を追加（12→13種）
- 新規 TC-15: 数字入りslugが登録済み・drift無しの正常系で、かつ `--quiet` 無しのログに出る3集計行（agents/ profiles・Available Reviewers table・Type Identifiers table）の件数が `FIXTURE_SLUGS` の全件数と一致することをassert
  - 単に rc=0 を確認するだけでは、AGENT_RE が数字非対応に巻き戻っても `web3-reviewer.md` が3集合すべてから丸ごと除外されて trivially rc=0 になるため検知できない。件数一致のassertにより「正しくカウントされた」ことと「静かに脱落した」ことを区別できるようにした
- 実機検証: AGENT_RE を一時的に旧正規表現（`[a-z][a-z-]*-reviewer[.]md`）へ戻して実行し、TC-15 の3assertが期待どおり FAIL（件数が12に減少）することを確認済み（プロダクションコードは無変更）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [ ] Documentation updated (if applicable) — テストファイルのみの変更のため対象ドキュメントなし

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
