### PR TITLE
refactor(hooks): 他 per-call hook の @tsv+IFS read field-shift hazard を横断確認・統一

### DIFF
--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -484,16 +484,20 @@ _reset_active_state() {
   # 3 field を single composite jq read で読む。3 read に分けると mid-write 中断などで
   # .phase だけ valid / .issue_number 以降が corrupt な partial-failure を WARNING の有無で
   # 区別できなくなり、reset reason の triage が不能になる経路ができる。
+  # IFS=$'\t' + @tsv collapses empty fields under POSIX whitespace rules: an empty
+  # issue_number shifts _branch's value into _issue, leaving _branch empty. The
+  # unit separator \x1f preserves empty fields safely (see post-compact.sh / the
+  # ACTIVE-fallback read below for the same convention).
   local _reset_jq_err _composite
   _reset_jq_err=$(mktemp 2>/dev/null) || _reset_jq_err=""
-  _composite=$(jq -r '[(.phase // ""), (.issue_number // "" | tostring), (.branch // "")] | @tsv' \
-    "$STATE_FILE" 2>"${_reset_jq_err:-/dev/null}") || _composite=$'\t\t'
+  _composite=$(jq -r '[(.phase // ""), (.issue_number // "" | tostring), (.branch // "")] | join("\u001f")' \
+    "$STATE_FILE" 2>"${_reset_jq_err:-/dev/null}") || _composite=$'\x1f\x1f'
   if [ -n "$_reset_jq_err" ] && [ -s "$_reset_jq_err" ]; then
     echo "rite: session-start: WARNING: _reset_active_state jq read failed (STATE_FILE may be corrupt)" >&2
     head -3 "$_reset_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   [ -n "$_reset_jq_err" ] && rm -f "$_reset_jq_err"
-  IFS=$'\t' read -r _phase _issue _branch <<< "$_composite"
+  IFS=$'\x1f' read -r _phase _issue _branch <<< "$_composite"
 
   # Session ownership check runs on the normal execution path, not just RITE_DEBUG.
   # Fail-safe: if the helper isn't sourced or returns non-zero, treat as "unknown"


### PR DESCRIPTION
## 概要

Issue #1716（PR #1737）で `bang-backtick-edit-hook.sh` の `@tsv` + `IFS=$'\t' read` を、空中間フィールドで後続フィールドが左シフトする field-shift hazard 回避のため unit separator (`\x1f`) 化した。同種パターンを持つ他 4 hook を横断確認し、必要な箇所を統一した。

Closes #1740

## 変更内容

4 hook の `@tsv` + `IFS` read パターンを確認した結果:

| Hook | 判定 | 対応 |
|------|------|------|
| `session-start.sh` (`_reset_active_state()`) | **hazard あり** | `join("")` + `IFS=$'\x1f' read` に統一 |
| `post-compact.sh` | 変更不要 | 既に `join("")` + `\x1f` read 済み |
| `pre-tool-bash-guard.sh` | 変更不要 | `@tsv` + `cut -fN` で、`cut` は連続する区切り文字を圧縮しないため hazard 対象外（実機検証済み） |
| `work-memory-update.sh` | 変更不要 | 3 フィールド全て空文字列になり得ない（sync_revision/loop_count は整数、pr_number は `"null"` 文字列） |

### session-start.sh の hazard 詳細

`_reset_active_state()` は `[.phase, .issue_number, .branch] | @tsv` を `IFS=$'\t' read -r _phase _issue _branch` で読んでいた。POSIX の IFS whitespace 規則により、tab を含む IFS では連続する区切り文字（`issue_number` が空文字列のときの `\t\t`）が 1 個に圧縮され、`_branch` の値が `_issue` にシフトし `_branch` が空になる。

実機検証:
```
$ echo '{"phase":"lint","issue_number":"","branch":"feat/issue-5-foo"}' | ...
修正前: phase=lint issue=[feat/issue-5-foo] branch=
修正後: phase=lint issue=[] branch=feat/issue-5-foo
```

## Checklist

- [x] 4 hook すべてで field-shift hazard の有無を確認・記録
- [x] hazard のある箇所を \x1f に統一（正常入力の挙動は不変）
- [x] 既存 hooks テストが全 pass

## 検証

- `session-start.test.sh`: 64 passed, 0 failed
- `pre-tool-bash-guard.test.sh`: 184 passed, 0 failed

## Known Issues

- `post-compact.test.sh`（17 failed）と `work-memory-update.test.sh`（一部 failed）は、本 PR で変更していないファイル（develop と byte-identical）に対する既存の環境依存失敗です。本セッションの `CLAUDE_CODE_SESSION_ID` 環境変数のリークが原因と推測され、本 Issue のスコープ外（field-shift hazard とは無関係）です。
