### PR TITLE
docs(rite-workflow): severity語彙3系統とschemaバージョン3系統のcrosswalkをSoT化する

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -419,6 +419,16 @@ Full schema reference lives in **[docs/CONFIGURATION.md](./CONFIGURATION.md)**, 
 
 **Migration**: `schema_version` (currently `2`) is bumped when breaking schema changes ship. `/rite:init --upgrade` performs a non-destructive merge for compatible upgrades; removed keys are silently ignored at runtime — see the [CHANGELOG](../CHANGELOG.md) for the current deprecation set (v0.4.0 removed `review.loop.severity_gating_cycle_threshold`, `review.loop.scope_lock_cycle_threshold`, and `safety.max_review_fix_loops`).
 
+### Schema Version Overview
+
+rite workflow has **3 independently-versioned schemas**. Each bumps on its own timeline when its own schema changes; a bump in one does not imply or require a bump in another — do not conflate them.
+
+| Schema | `schema_version` | Format | Defined At |
+|--------|-------------------|--------|------------|
+| `rite-config.yml` | `2` | integer | This section, above; template at `plugins/rite/templates/config/rite-config.yml` |
+| Flow state (per-session) | `3` | integer | [Multi-Session State Management](#multi-session-state-management) below; `plugins/rite/hooks/flow-state.sh` |
+| Review-result JSON | `1.1.0` | semver | [`review-result-schema.md` Schema Version (SoT)](../plugins/rite/references/review-result-schema.md#schema-version-sot) |
+
 ---
 
 ## Command Specifications

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -421,7 +421,7 @@ Full schema reference lives in **[docs/CONFIGURATION.md](./CONFIGURATION.md)**, 
 
 ### Schema Version Overview
 
-rite workflow has **3 independently-versioned schemas**. Each bumps on its own timeline when its own schema changes; a bump in one does not imply or require a bump in another — do not conflate them.
+rite workflow has **3 independently-versioned schemas that are commonly conflated** (their version numbers look similar and drift independently). Each bumps on its own timeline when its own schema changes; a bump in one does not imply or require a bump in another — do not conflate them. (Other artifacts also carry their own `schema_version` — e.g. the work-memory local file and the issue-claim JSON, both currently `1` — but their numbering is not easily confused with the 3 below, so they are out of scope for this table.)
 
 | Schema | `schema_version` | Format | Defined At |
 |--------|-------------------|--------|------------|

--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -460,3 +460,5 @@ Output using this format with evaluation (可/条件付き/要修正), findings 
 WHY が省略された findings は修正エージェントの判断精度を下げる。WHAT のみで WHY が自明な場合でも、影響範囲や既存コードとの比較を含めること。
 
 See [Severity Levels](../references/severity-levels.md) for common severity definitions and the [Severity × Scope Matrix](../references/severity-levels.md#severity--scope-matrix) for allowed/forbidden combinations.
+
+**Review Checklist 見出しとの関係**: 各 reviewer ファイルの `## Review Checklist` 見出し(`Critical (Must Fix)` / `Important (Should Fix)` / `Recommendations`)はレビュー観点を投資領域ごとに整理するためのものであり、finding 発行時の **重要度** 列(schema enum 5 値)そのものではない。見出し⇄enum の変換は再定義せず [`severity-levels.md` Severity 語彙 3 系統 Crosswalk](../references/severity-levels.md#severity-vocabulary-crosswalk) を参照すること。

--- a/plugins/rite/references/review-result-schema.md
+++ b/plugins/rite/references/review-result-schema.md
@@ -146,7 +146,7 @@
 | `Low-Medium`, `LOW-MEDIUM`, `LowMedium`, `low_medium`, `中低`, `軽中` | `LOW-MEDIUM` |
 | `Low`, `LOW`, `INFO`, `TRIVIAL`, `Nit`, `NIT`, `🔵`, `低`, `情報` | `LOW` |
 
-**運用ポリシーとの関係**: rite workflow の運用では reviewer agent (`plugins/rite/agents/*-reviewer.md`) は `Critical` / `Important` / `Minor` の 3 段階を使うことが多い。これは **運用レイヤ** の分類であり、**schema レイヤ** の 5 値 enum に対しては上記マッピング表を通じて: `Critical` → `CRITICAL`、`Important` → `HIGH`、`Minor` → `MEDIUM`、`Low-Medium` → `LOW-MEDIUM` のように正規化される。write 側 (`review.md` ステップ 6.1.a) は必ず schema enum 5 値で出力し、read 側 (`fix.md` ステップ 1.2 best-effort parser) が外部ツール由来の別名をここで正規化する。
+**運用ポリシーとの関係**: schema enum 5 値 / reviewer checklist 見出し / 運用 3 段の対応関係は [`severity-levels.md` Severity 語彙 3 系統 Crosswalk](./severity-levels.md#severity-vocabulary-crosswalk) を単一 SoT とする(本ファイルでは再定義しない)。write 側 (`review.md` ステップ 6.1.a) は必ず schema enum 5 値で出力し、read 側 (`fix.md` ステップ 1.2 best-effort parser) が外部ツール由来の別名を上記マッピング表で正規化する。
 
 **絵文字エイリアスの実運用検証状況**: 絵文字 (`🔴`/`🟠`/`🟡`/`🔵`) は将来の互換性のため列挙しているが、主要な外部ツールが絵文字を出力する事例は未検証。新しい外部レビューツールへの対応として絵文字エイリアスを追加した場合は、本表の下に注記を追加すること。
 

--- a/plugins/rite/references/severity-levels.md
+++ b/plugins/rite/references/severity-levels.md
@@ -14,6 +14,26 @@ This document defines the common severity levels and evaluation criteria used by
 
 **Note**: Each reviewer may provide domain-specific examples of what constitutes each severity level in their respective documentation.
 
+## Severity 語彙 3 系統 Crosswalk
+
+<a id="severity-vocabulary-crosswalk"></a>
+
+rite には severity を表す 3 つの正当な語彙が併存する。それぞれ用途が異なるため統一はせず、以下の表を単一 crosswalk SoT とする(`templates/issue/default.md` の Type Notation Policy と同じ crosswalk 方式)。
+
+| schema enum (5 値) | reviewer checklist 見出し | 運用 3 段 |
+|---|---|---|
+| `CRITICAL` | Critical (Must Fix) | Critical |
+| `HIGH` | Important (Should Fix) | Important |
+| `MEDIUM` | Recommendations | Minor |
+| `LOW-MEDIUM` | Recommendations | Minor |
+| `LOW` | Recommendations | Minor |
+
+- **schema enum (5 値)**: `findings[].severity` の JSON 出力値。上記 Severity Levels 表で正式定義され、`review-result-schema.md` の schema が受理する唯一の値域。
+- **reviewer checklist 見出し (3 値)**: 各 `agents/*-reviewer.md` の `## Review Checklist` セクション見出し(`### Critical (Must Fix)` / `### Important (Should Fix)` / `### Recommendations`)。レビュー観点を投資領域ごとに整理するための見出しであり、finding 発行時の enum 値そのものではない。`Recommendations` は MEDIUM/LOW-MEDIUM/LOW の 3 値を包含する。
+- **運用 3 段 (3 値)**: ドキュメント上の説明的表現(例: `review-result-schema.md` の外部ツール別名運用に関する記述)。reviewer が「Important」を出力した場合に読み手が enum 値へ変換するための日常語彙。
+
+**判断**: どちらか一方へ統一せず、3 系列を残し上表を単一 crosswalk SoT とする。**根拠**: 5 値 enum は JSON の型契約として、checklist 見出しはレビュー観点の整理として、運用 3 段は説明用の自然言語として、それぞれ異なる目的で存在しており、統一しても境界が別の場所(schema ⇄ 見出し ⇄ 説明文)に移動するだけ。非自明な対応は `Recommendations`/`Minor` が MEDIUM 以下 3 値をまとめて指す点のみ(他は大文字小文字・字面の差)。
+
 ## Observed Likelihood Axis
 
 Severity alone (impact axis) is insufficient. Every finding must also be classified along the **Observed Likelihood** axis — the degree to which the triggering condition can be demonstrated to exist in the codebase under review.


### PR DESCRIPTION
## 概要

severity 語彙 3 系統(schema enum 5 値 / reviewer checklist 見出し / 運用 3 段)と schema バージョン 3 系統(flow-state v3 / rite-config v2 / review-result v1.1.0)の対応関係を単一 SoT に集約し、誤マップ・取り違えの余地を減らす。

## 関連 Issue

Closes #1712

## 変更内容

- `plugins/rite/references/severity-levels.md`: severity 語彙 3 系統の crosswalk 表を新設(単一 SoT)
- `plugins/rite/references/review-result-schema.md`: 重複していた「運用ポリシーとの関係」説明を crosswalk への参照に置換
- `plugins/rite/agents/_reviewer-base.md`: Review Checklist 見出し⇄enum 変換の参照を明記
- `docs/SPEC.md`: schema バージョン 3 系統(現在値・定義位置)の一覧セクションを追加

schema/config の値自体は変更していない(Non-Target: `hooks/flow-state.sh`、`templates/config/rite-config.yml`)。

## チェックリスト

- [x] コーディング規約に準拠
- [x] `/rite:lint` 実行済み(問題なし)
- [x] ドキュメント更新(本 PR がドキュメント更新そのもの)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
