### PR TITLE
chore(hooks): rationale コメント形式ポインタを drift-check Pattern 4 の検証対象に含める

### DIFF
--- a/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/distributed-fix-drift-check.sh
@@ -15,7 +15,10 @@
 #      an eval-table `( `a` / `b` )` enumeration. Forward: an emit documented in
 #      neither. Reverse: a reason-table entry never emitted (stale doc).
 #   3. if-wrap drift            — `cat <<'EOF' > "$tmpfile"` not wrapped by `if !`
-#   4. anchor drift             — markdown `[text](path#anchor)` resolving to non-existent heading
+#   4. anchor drift             — markdown `[text](path#anchor)` OR comment-style
+#      `rationale: path#anchor` (`# rationale: ...` / `<!-- rationale: ... -->`,
+#      including cross-skill `../other-skill/references/...` pointers) resolving
+#      to a non-existent heading
 #   5. RETIRED — folded into Pattern 2 (see the Pattern 5 note below). `--pattern 5` is inert.
 #   6. review-result schema_version drift — `.rite/review-results/*.json` whose
 #      `.schema_version` is outside the accept list (delegates to
@@ -450,10 +453,41 @@ check_pattern_3() {
 }
 
 # ----- Pattern 4: anchor drift -----------------------------------------------
-# Extract [text](path#anchor) and verify the anchor exists in path's headings,
-# using GitHub's anchor conversion (github-slugger compatible):
+# Extract references to path#anchor and verify the anchor exists in path's
+# headings, using GitHub's anchor conversion (github-slugger compatible):
 # lowercase, strip non-word/non-space/non-hyphen, spaces->hyphens, collapse hyphens.
-# Implemented as inline perl in check_pattern_4 for batch processing efficiency.
+# Two independent reference forms are checked (both resolve to the same
+# invariant — anchor drift — so they share `_p4_check_anchor` and report under
+# the same Pattern 4):
+#   - markdown links: [text](path#anchor)
+#   - comment-style rationale pointers: `rationale: path#anchor`, found inside
+#     `# ...` / `<!-- ... -->` comments, including cross-skill
+#     `../other-skill/references/...` pointers (see coding-principles.md
+#     "スキル行数原則").
+# Implemented as inline perl in _p4_check_anchor for batch processing efficiency.
+
+_p4_check_anchor() {
+  local file="$1" file_dir="$2" target_path="$3" anchor="$4"
+  local abs_path
+  # Skip URL-style links and self-only anchors here (handled separately if needed)
+  case "$target_path" in
+    ""|http*|mailto:*) return 0 ;;
+    /*) abs_path="$REPO_ROOT$target_path" ;;
+    *)  abs_path="$file_dir/$target_path" ;;
+  esac
+  [ -f "$abs_path" ] || return 0
+  # Build heading anchor list
+  local headings
+  headings=$(grep -E '^#{1,6}[[:space:]]' "$abs_path" 2>/dev/null \
+    | sed -E 's/^#+[[:space:]]+//' \
+    | perl -CSD -Mutf8 -pe 'chomp; $_ = lc($_); s/[^\w\s-]//g; s/\s+/-/g; s/-{2,}/-/g; s/^-|-$//g; $_ .= "\n"')
+  # Skip files with no markdown headings (e.g. pure code files) to avoid
+  # false positives where every anchor would be reported as unresolved.
+  [ -z "$headings" ] && return 0
+  if ! grep -Fxq "$anchor" <<< "$headings"; then
+    report 4 "$file" 0 "anchor '#$anchor' not found in $target_path"
+  fi
+}
 
 check_pattern_4() {
   local file="$1"
@@ -466,27 +500,22 @@ check_pattern_4() {
     | { grep -oE '\([^)]*#[^)]+\)' || true; } \
     | sed -e 's/^(//' -e 's/)$//' \
     | while IFS= read -r ref; do
-        local target_path anchor abs_path
+        local target_path anchor
         target_path="${ref%%#*}"
         anchor="${ref#*#}"
-        # Skip URL-style links and self-only anchors here (handled separately if needed)
-        case "$target_path" in
-          ""|http*|mailto:*) continue ;;
-          /*) abs_path="$REPO_ROOT$target_path" ;;
-          *)  abs_path="$file_dir/$target_path" ;;
-        esac
-        [ -f "$abs_path" ] || continue
-        # Build heading anchor list
-        local headings
-        headings=$(grep -E '^#{1,6}[[:space:]]' "$abs_path" 2>/dev/null \
-          | sed -E 's/^#+[[:space:]]+//' \
-          | perl -CSD -Mutf8 -pe 'chomp; $_ = lc($_); s/[^\w\s-]//g; s/\s+/-/g; s/-{2,}/-/g; s/^-|-$//g; $_ .= "\n"')
-        # Skip files with no markdown headings (e.g. pure code files) to avoid
-        # false positives where every anchor would be reported as unresolved.
-        [ -z "$headings" ] && continue
-        if ! grep -Fxq "$anchor" <<< "$headings"; then
-          report 4 "$file" 0 "anchor '#$anchor' not found in $target_path"
-        fi
+        _p4_check_anchor "$file" "$file_dir" "$target_path" "$anchor"
+      done
+  # Extract comment-style `rationale: path#anchor` pointers (not markdown
+  # links, so not caught by the extraction above). Anchor is restricted to
+  # ASCII kebab-case, matching the convention actually in use.
+  { grep -oE 'rationale:[[:space:]]*[^[:space:])>]+#[A-Za-z0-9_-]+' "$file" 2>/dev/null || true; } \
+    | while IFS= read -r ref; do
+        local path_anchor target_path anchor
+        path_anchor="${ref#*rationale:}"
+        path_anchor="${path_anchor#"${path_anchor%%[![:space:]]*}"}"
+        target_path="${path_anchor%%#*}"
+        anchor="${path_anchor#*#}"
+        _p4_check_anchor "$file" "$file_dir" "$target_path" "$anchor"
       done
 }
 

--- a/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
+++ b/plugins/rite/hooks/scripts/tests/test-distributed-fix-drift-check.sh
@@ -255,6 +255,60 @@ out=$("$SCRIPT" --target "$CJK_BROKEN" 2>&1)
 p4_count=$(grep -c '^\[drift\]\[P4\]' <<< "$out")
 assert_ge "broken CJK anchor detected as drift" 1 "$p4_count"
 
+# --- Test 6b: comment-style rationale pointer anchor drift (Pattern 4) -------
+# `rationale: path#anchor` inside `# ...` / `<!-- ... -->` comments is not a
+# `[text](path#anchor)` markdown link, so it needs its own extraction path
+# (Issue #1775). Also covers the cross-skill `../other-skill/references/...`
+# pointer form.
+RATIONALE_DIR=$(mktemp -d)
+TMPFILES+=("$RATIONALE_DIR")
+mkdir -p "$RATIONALE_DIR/skill-a/references" "$RATIONALE_DIR/skill-b/references"
+RATIONALE_TARGET="$RATIONALE_DIR/skill-a/references/design-rationale.md"
+RATIONALE_CROSS_TARGET="$RATIONALE_DIR/skill-b/references/design-rationale.md"
+RATIONALE_CLEAN="$RATIONALE_DIR/skill-a/clean.md"
+RATIONALE_BROKEN="$RATIONALE_DIR/skill-a/broken.md"
+
+cat > "$RATIONALE_TARGET" <<'EOF'
+# Design Rationale
+
+## some-real-anchor
+Notes here.
+EOF
+
+cat > "$RATIONALE_CROSS_TARGET" <<'EOF'
+# Design Rationale (skill-b)
+
+## cross-skill-anchor
+Notes here.
+EOF
+
+cat > "$RATIONALE_CLEAN" <<'EOF'
+# Fixture
+
+# rationale: references/design-rationale.md#some-real-anchor
+echo hi
+
+<!-- rationale: references/design-rationale.md#some-real-anchor -->
+
+# rationale: ../skill-b/references/design-rationale.md#cross-skill-anchor
+EOF
+
+out=$("$SCRIPT" --target "$RATIONALE_CLEAN" 2>&1)
+p4_count=$(grep -c '^\[drift\]\[P4\]' <<< "$out")
+assert "comment-style rationale pointers resolve correctly (0 P4 drift)" "0" "$p4_count"
+
+cat > "$RATIONALE_BROKEN" <<'EOF'
+# Fixture
+
+# rationale: references/design-rationale.md#nonexistent-anchor
+
+<!-- rationale: references/design-rationale.md#also-nonexistent -->
+EOF
+
+out=$("$SCRIPT" --target "$RATIONALE_BROKEN" 2>&1)
+p4_count=$(grep -c '^\[drift\]\[P4\]' <<< "$out")
+assert "broken comment-style rationale anchor detected as drift (# and <!-- --> forms)" "2" "$p4_count"
+
 # --- Test 7: --pattern 2 filter outputs only P2 ------------------------------
 # Build a fixture that triggers BOTH Pattern-2 (reason-table drift) and
 # Pattern-3 (if-wrap drift). Without --pattern, the script would emit both


### PR DESCRIPTION
## 概要

`rationale: references/<file>.md#<anchor>` コメント形式ポインタ（`# rationale: ...` / `<!-- rationale: ... -->`、cross-skill `../other-skill/references/...` 参照を含む）が `distributed-fix-drift-check.sh` Pattern 4 (anchor drift) の機械検証対象外であることを実証し、検証対象に拡張した。

## 関連 Issue

Closes #1775

## Changes

- `check_pattern_4` のアンカー検証ロジックを `_p4_check_anchor` ヘルパーに共通化
- コメント形式ポインタ（`# rationale: ...` / `<!-- rationale: ... -->`、cross-skill 参照含む）を抽出する第2経路を追加し、既存の markdown-link 抽出と同じ `_p4_check_anchor` で検証
- `test-distributed-fix-drift-check.sh` に正常系・異常系のテストを追加（既存21 + 新規2 = 23件 PASS）
- 実リポジトリに対する `--all` 実行が回帰なく drift 0 のままであることを確認済み

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [ ] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
