### PR TITLE
fix(hooks): cleanup-work-memory.sh を schema_v2 multi-state aware に対応

### DIFF
--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -60,8 +60,19 @@ if [ "$CLOSE_MODE" = false ]; then
   # left the real per-session file behind with stale active:true/phase:cleanup
   # state after /rite:cleanup completed (#695). Fall back to the legacy shared
   # file only when session resolution itself fails (no .rite-session-id /
-  # session env var available).
-  RESOLVED_FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>/dev/null) || RESOLVED_FLOW_STATE=""
+  # session env var available) — surface that fallback with a WARNING so a
+  # corrupt/invalid session_id doesn't silently reproduce the same stale-state
+  # bug via a different trigger (schema_v2 environments have no legacy file,
+  # so a silent fallback here would make Step 1 a silent no-op).
+  _fs_err=$(mktemp 2>/dev/null) || _fs_err=""
+  if RESOLVED_FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>"${_fs_err:-/dev/null}"); then
+    :
+  else
+    echo "WARNING: cleanup-work-memory: flow-state.sh path resolution failed — falling back to legacy $(basename "$STATE_ROOT/.rite-flow-state") (session_id may be missing or invalid)" >&2
+    [ -n "$_fs_err" ] && [ -s "$_fs_err" ] && head -3 "$_fs_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+    RESOLVED_FLOW_STATE=""
+  fi
+  [ -n "$_fs_err" ] && rm -f "$_fs_err"
   FLOW_STATE="${RESOLVED_FLOW_STATE:-$STATE_ROOT/.rite-flow-state}"
 
   # Step 1: Reset flow-state to active:false BEFORE deleting files

--- a/plugins/rite/hooks/cleanup-work-memory.sh
+++ b/plugins/rite/hooks/cleanup-work-memory.sh
@@ -6,10 +6,13 @@
 # Usage:
 #   bash plugins/rite/hooks/cleanup-work-memory.sh [--issue <number>]
 #
-# Without --issue: reads issue number from .rite-flow-state, resets flow state
-#   to active:false, deletes ALL issue-*.md files and lockdirs (full cleanup).
+# Without --issue: resolves the current session's flow-state file via the
+#   canonical resolver (flow-state.sh path — schema_v2/v3 per-session file
+#   under .rite/sessions/, falling back to the legacy shared .rite-flow-state
+#   only when session resolution itself fails), resets it to active:false,
+#   deletes ALL issue-*.md files and lockdirs (full cleanup).
 # With --issue <number>: deletes only the specified issue's files (close mode).
-#   Does NOT reset .rite-flow-state (close.md handles its own state).
+#   Does NOT reset the flow-state file (close.md handles its own state).
 #
 # Exit codes:
 #   0: Success (files deleted or nothing to delete)
@@ -24,7 +27,6 @@ source "$SCRIPT_DIR/control-char-neutralize.sh"
 # Resolve repository root
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$(pwd)" 2>/dev/null) || STATE_ROOT="$(pwd)"
 
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
 WM_DIR="$STATE_ROOT/.rite-work-memory"
 
 # Parse arguments
@@ -52,7 +54,17 @@ failed_count=0
 
 # --- Full cleanup mode (no --issue) ---
 if [ "$CLOSE_MODE" = false ]; then
-  # Step 1: Reset .rite-flow-state to active:false BEFORE deleting files
+  # Resolve the current session's flow-state path via the canonical resolver
+  # (flow-state.sh path — schema_v2/v3 per-session file under .rite/sessions/).
+  # Resetting the legacy shared file directly (as this script previously did)
+  # left the real per-session file behind with stale active:true/phase:cleanup
+  # state after /rite:cleanup completed (#695). Fall back to the legacy shared
+  # file only when session resolution itself fails (no .rite-session-id /
+  # session env var available).
+  RESOLVED_FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>/dev/null) || RESOLVED_FLOW_STATE=""
+  FLOW_STATE="${RESOLVED_FLOW_STATE:-$STATE_ROOT/.rite-flow-state}"
+
+  # Step 1: Reset flow-state to active:false BEFORE deleting files
   # This prevents post-tool-wm-sync.sh from recreating files
   if [ -f "$FLOW_STATE" ]; then
     # Read issue number from flow state for logging. Capture jq stderr so a
@@ -65,14 +77,14 @@ if [ "$CLOSE_MODE" = false ]; then
     if [ "$_isn_rc" -ne 0 ]; then
       _isn_tag=""
       [ -z "$_isn_err" ] && _isn_tag=" stderr_capture=disabled"
-      echo "[rite] WARNING: cleanup-work-memory: .rite-flow-state の .issue_number 取得失敗 (rc=$_isn_rc — FLOW_STATE may be corrupt${_isn_tag})" >&2
+      echo "[rite] WARNING: cleanup-work-memory: $(basename "$FLOW_STATE") の .issue_number 取得失敗 (rc=$_isn_rc — FLOW_STATE may be corrupt${_isn_tag})" >&2
       [ -n "$_isn_err" ] && [ -s "$_isn_err" ] && head -3 "$_isn_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       ISSUE_NUMBER=""
     fi
     [ -n "$_isn_err" ] && rm -f "$_isn_err"
     # Validate issue number from flow state (non-numeric values would break --argjson)
     if [ -n "$ISSUE_NUMBER" ] && ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
-      echo "WARNING: .rite-flow-state の issue_number が数値でない: '$ISSUE_NUMBER'. 0 にフォールバック" >&2
+      echo "WARNING: $(basename "$FLOW_STATE") の issue_number が数値でない: '$ISSUE_NUMBER'. 0 にフォールバック" >&2
       ISSUE_NUMBER=""
     fi
 
@@ -100,18 +112,18 @@ if [ "$CLOSE_MODE" = false ]; then
           :
         else
           _mv_rc=$?
-          echo "WARNING: .rite-flow-state の更新に失敗しました (mv rc=$_mv_rc)" >&2
+          echo "WARNING: $(basename "$FLOW_STATE") の更新に失敗しました (mv rc=$_mv_rc)" >&2
           [ -n "$_mv_err" ] && [ -s "$_mv_err" ] && head -3 "$_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         fi
         [ -n "$_mv_err" ] && rm -f "$_mv_err"
       else
         _jq_rc=$?
-        echo "WARNING: .rite-flow-state のリセットに失敗しました (jq rc=$_jq_rc — missing in PATH / locale / parse error を区別)" >&2
+        echo "WARNING: $(basename "$FLOW_STATE") のリセットに失敗しました (jq rc=$_jq_rc — missing in PATH / locale / parse error を区別)" >&2
         [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       fi
       [ -n "$_jq_err" ] && rm -f "$_jq_err"
     else
-      echo "WARNING: .rite-flow-state TMP_STATE mktemp failed — flow-state reset skipped (subsequent cleanup steps will still run)" >&2
+      echo "WARNING: $(basename "$FLOW_STATE") TMP_STATE mktemp failed — flow-state reset skipped (subsequent cleanup steps will still run)" >&2
       echo "  hint: $(dirname "$FLOW_STATE") の permission / disk full / read-only を確認" >&2
     fi
   fi
@@ -120,11 +132,12 @@ if [ "$CLOSE_MODE" = false ]; then
   # Legacy shared path removal is retained for legacy migration residue.
   rm -f "$STATE_ROOT/.rite-compact-state" 2>/dev/null || true
   rm -rf "$STATE_ROOT/.rite-compact-state.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory" >&2
-  # Per-session compact-state: derive from the resolved flow-state
-  # path so full cleanup also reaps the current session's snapshot.
-  _cwm_flow_state=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>/dev/null) || _cwm_flow_state=""
-  if [ -n "$_cwm_flow_state" ]; then
-    _cwm_compact="${_cwm_flow_state%.flow-state}.compact-state"
+  # Per-session compact-state: derive from the already-resolved flow-state
+  # path (RESOLVED_FLOW_STATE, set above) so full cleanup also reaps the
+  # current session's snapshot. Empty when session resolution failed above —
+  # no per-session compact-state to derive in that case.
+  if [ -n "$RESOLVED_FLOW_STATE" ]; then
+    _cwm_compact="${RESOLVED_FLOW_STATE%.flow-state}.compact-state"
     rm -f "$_cwm_compact" 2>/dev/null || true
     rm -rf "$_cwm_compact.lockdir" 2>/dev/null || echo "[CONTEXT] LOCKDIR_CLEANUP_FAILED=1; from=cleanup_work_memory_per_session" >&2
   fi

--- a/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
@@ -110,13 +110,24 @@ echo "# wm 43" > "$dir002/.rite-work-memory/issue-43.md"
 ( cd "$dir002" && bash "$HOOK" >/dev/null 2>&1 ) || true
 
 # After successful run: compact-state and per-issue wm file removed.
-# (Step 1 flow-state reset is asserted indirectly through TC-001's WARNING
-# absence — the lack of warning means the mktemp/jq/mv chain succeeded.)
 if [ ! -f "$dir002/.rite-compact-state" ] \
    && [ ! -f "$dir002/.rite-work-memory/issue-43.md" ]; then
   pass "TC-002 happy path: Step 2/3 cleanup completed (compact-state + per-issue wm removed)"
 else
   fail "TC-002 happy path partial: compact-state present=$([ -f "$dir002/.rite-compact-state" ] && echo y || echo n), wm present=$([ -f "$dir002/.rite-work-memory/issue-43.md" ] && echo y || echo n)"
+fi
+
+# Directly verify the Step 1 reset outcome (the PR's core spec): the per-session
+# flow-state file must actually be reset to active:false. Without this, a
+# regression that no-ops the reset (e.g. #695's bug) would still pass every
+# other assertion in this file.
+tc002_session_file="$dir002/.rite/sessions/tc002-sid.flow-state"
+tc002_active=$(jq -r '.active' "$tc002_session_file" 2>/dev/null)
+tc002_phase=$(jq -r '.phase' "$tc002_session_file" 2>/dev/null)
+if [ "$tc002_active" = "false" ] && [ "$tc002_phase" = "completed" ]; then
+  pass "TC-002 happy path: per-session flow-state reset to active=false, phase=completed"
+else
+  fail "TC-002 happy path: per-session flow-state not reset (active=$tc002_active, phase=$tc002_phase)"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
@@ -256,6 +256,30 @@ else
 fi
 echo ""
 
+# ─── TC-resolver-fallback: session resolution failure surfaces WARNING and still resets legacy file ──────────
+# Regression guard for the resolver-failure branch added to fix #695: when no
+# .rite-session-id / session env var is available, flow-state.sh path fails,
+# and cleanup-work-memory.sh must (a) emit a WARNING (not silently swallow the
+# failure) and (b) still fall back to resetting the legacy .rite-flow-state
+# file. Without this guard, a regression that reverts the stderr capture +
+# WARNING (or drops the fallback reset) would not be caught by any other TC —
+# TC-001/002/003/008 all seed a valid .rite-session-id, so resolver always
+# succeeds in those paths.
+echo "TC-resolver-fallback: session resolution failure emits WARNING and resets legacy file"
+dir_resolver="$TEST_DIR/tc_resolver_fallback"
+mkdir -p "$dir_resolver/.rite-work-memory"
+echo '{"active":true,"issue_number":77,"phase":"cleanup"}' > "$dir_resolver/.rite-flow-state"
+out_resolver="$TEST_DIR/tc_resolver_fallback.out"
+( cd "$dir_resolver" && bash "$HOOK" >"$out_resolver" 2>&1 ) || true
+resolver_warning_seen=$(grep -c 'flow-state.sh path resolution failed' "$out_resolver" 2>/dev/null || true)
+resolver_active=$(jq -r '.active' "$dir_resolver/.rite-flow-state" 2>/dev/null)
+if [ "${resolver_warning_seen:-0}" -ge 1 ] && [ "$resolver_active" = "false" ]; then
+  pass "TC-resolver-fallback: WARNING emitted and legacy .rite-flow-state reset to active=false"
+else
+  fail "TC-resolver-fallback: warning_seen=${resolver_warning_seen:-0}, active=$resolver_active; got: $(head -10 "$out_resolver")"
+fi
+echo ""
+
 # ─── TC-full-cleanup-removes-per-session-compact: full cleanup removes the per-session compact-state ──────────
 # full-cleanup mode must reap the current session's per-session
 # compact-state (.rite/sessions/<sid>.compact-state), not just the legacy

--- a/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-work-memory.test.sh
@@ -16,11 +16,30 @@ TEST_DIR="$(mktemp -d)"
 PASS=0
 FAIL=0
 
+# Clean session-id env for standalone runs (same convention as flow-state.test.sh).
+# cleanup-work-memory.sh now resolves its flow-state file via flow-state.sh path,
+# which is env-first (CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID). Without this
+# unset, the dogfooding session's ambient session id would leak in and override
+# each test's seeded .rite-session-id, resolving to a path outside TEST_DIR and
+# silently no-op'ing the Step 1 flow-state reset under test.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 cleanup() { rm -rf "$TEST_DIR"; }
 trap cleanup EXIT
 
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# Seed a per-session flow-state file (schema_v2/v3 form) instead of the legacy
+# shared .rite-flow-state, matching what flow-state.sh path actually resolves
+# to at runtime. Sets .rite-session-id so the resolver picks this session
+# deterministically.
+seed_session_flow_state() {
+  local dir="$1" sid="$2" json="$3"
+  mkdir -p "$dir/.rite/sessions"
+  printf '%s' "$sid" > "$dir/.rite-session-id"
+  printf '%s' "$json" > "$dir/.rite/sessions/${sid}.flow-state"
+}
 
 echo "=== cleanup-work-memory.sh tests ==="
 echo ""
@@ -29,20 +48,23 @@ echo ""
 echo "TC-001: TMP_STATE mktemp failure does not abort Step 2/3 cleanup"
 dir001="$TEST_DIR/tc001"
 mkdir -p "$dir001/.rite-work-memory"
-# Seed flow-state, compact-state, and a per-issue work memory file
-echo '{"active":true,"issue_number":42,"phase":"completed","branch":"feat/issue-42-test"}' > "$dir001/.rite-flow-state"
+# Seed the per-session flow-state file (schema_v2/v3), compact-state, and a
+# per-issue work memory file
+seed_session_flow_state "$dir001" "tc001-sid" '{"active":true,"issue_number":42,"phase":"completed","branch":"feat/issue-42-test"}'
 echo '{"compact_state":"recovering","active_issue":42}' > "$dir001/.rite-compact-state"
 echo "# work memory for issue 42" > "$dir001/.rite-work-memory/issue-42.md"
 
 # Inject a mktemp shim that fails only when the target argument matches the
-# FLOW_STATE.tmp pattern. All other mktemp invocations (test helpers, child
+# FLOW_STATE.tmp pattern (matches both the legacy .rite-flow-state.tmp.* name
+# and the per-session .../sid.flow-state.tmp.* name — both end in
+# "flow-state.tmp."). All other mktemp invocations (test helpers, child
 # scripts) pass through to real mktemp.
 mkdir -p "$dir001/bin"
 cat > "$dir001/bin/mktemp" <<'EOF'
 #!/bin/bash
 for arg in "$@"; do
   case "$arg" in
-    *.rite-flow-state.tmp.*) exit 1 ;;
+    *flow-state.tmp.*) exit 1 ;;
   esac
 done
 exec /usr/bin/mktemp "$@"
@@ -81,7 +103,7 @@ echo ""
 echo "TC-002: happy path with working mktemp removes all three"
 dir002="$TEST_DIR/tc002"
 mkdir -p "$dir002/.rite-work-memory"
-echo '{"active":true,"issue_number":43,"phase":"completed"}' > "$dir002/.rite-flow-state"
+seed_session_flow_state "$dir002" "tc002-sid" '{"active":true,"issue_number":43,"phase":"completed"}'
 echo '{"compact_state":"recovering","active_issue":43}' > "$dir002/.rite-compact-state"
 echo "# wm 43" > "$dir002/.rite-work-memory/issue-43.md"
 
@@ -106,21 +128,23 @@ echo ""
 echo "TC-003: Step 1 mv mutation emits WARNING with real rc"
 dir003="$TEST_DIR/tc003"
 mkdir -p "$dir003/.rite-work-memory"
-echo '{"active":true,"issue_number":44,"phase":"completed","branch":"feat/issue-44"}' > "$dir003/.rite-flow-state"
+seed_session_flow_state "$dir003" "tc003-sid" '{"active":true,"issue_number":44,"phase":"completed","branch":"feat/issue-44"}'
 mkdir -p "$dir003/bin"
 cat > "$dir003/bin/mv" <<'MV_SHIM'
 #!/bin/bash
-# Fail only when targeting the flow-state file; let other mv calls succeed
+# Fail only when targeting the flow-state file (matches both the legacy
+# .rite-flow-state name and the per-session .../sid.flow-state name — both
+# end in "flow-state"); let other mv calls succeed
 for arg in "$@"; do
   case "$arg" in
-    *.rite-flow-state) exit 17 ;;
+    *flow-state) exit 17 ;;
   esac
 done
 exec /bin/mv "$@"
 MV_SHIM
 chmod +x "$dir003/bin/mv"
 stderr003=$(cd "$dir003" && PATH="$dir003/bin:$PATH" bash "$HOOK" 2>&1 >/dev/null || true)
-if printf '%s' "$stderr003" | grep -qE '\.rite-flow-state の更新に失敗しました \(mv rc=[1-9][0-9]*\)'; then
+if printf '%s' "$stderr003" | grep -qE 'flow-state の更新に失敗しました \(mv rc=[1-9][0-9]*\)'; then
   pass "TC-003: Step 1 mv WARNING carries real rc"
 else
   fail "TC-003: Step 1 mv WARNING missing or rc collapsed (a bash-! regression would emit rc=0). stderr: $stderr003"
@@ -209,10 +233,12 @@ echo ""
 echo "TC-008: corrupt FLOW_STATE surfaces jq rc in WARNING"
 dir008="$TEST_DIR/tc008"
 mkdir -p "$dir008/.rite-work-memory"
-printf 'not-valid-json{{' > "$dir008/.rite-flow-state"
+mkdir -p "$dir008/.rite/sessions"
+printf '%s' "tc008-sid" > "$dir008/.rite-session-id"
+printf 'not-valid-json{{' > "$dir008/.rite/sessions/tc008-sid.flow-state"
 out008="$TEST_DIR/tc008.out"
 ( cd "$dir008" && bash "$HOOK" >"$out008" 2>&1 ) || true
-if grep -qE 'cleanup-work-memory: \.rite-flow-state の \.issue_number 取得失敗 \(rc=[1-9]' "$out008"; then
+if grep -qE 'cleanup-work-memory: .*flow-state の \.issue_number 取得失敗 \(rc=[1-9]' "$out008"; then
   pass "TC-008 corrupt FLOW_STATE surfaces WARNING with real jq rc"
 else
   fail "TC-008 expected WARNING with rc on corrupt FLOW_STATE; got: $(head -10 "$out008")"
@@ -227,9 +253,7 @@ echo ""
 echo "TC-full-cleanup-removes-per-session-compact: full cleanup removes per-session compact-state"
 dir1371="$TEST_DIR/tc1371"
 sid1371="test-sid-tc1371"
-mkdir -p "$dir1371/.rite/sessions"
-printf '%s' "$sid1371" > "$dir1371/.rite-session-id"
-echo '{"active":true,"issue_number":1371,"phase":"completed"}' > "$dir1371/.rite-flow-state"
+seed_session_flow_state "$dir1371" "$sid1371" '{"active":true,"issue_number":1371,"phase":"completed"}'
 echo '{"compact_state":"recovering","active_issue":1371}' > "$dir1371/.rite-compact-state"
 cs1371_session="$dir1371/.rite/sessions/${sid1371}.compact-state"
 echo '{"compact_state":"recovering","active_issue":1371}' > "$cs1371_session"


### PR DESCRIPTION
## Summary

`cleanup-work-memory.sh` の full cleanup mode が legacy 共有ファイル (`.rite-flow-state`) を直書きしており、schema_v2/v3 のセッション別 flow-state ファイル (`.rite/sessions/{sid}.flow-state`) を無視していた。`/rite:cleanup` 完了後もセッション別ファイルが `active:true` / `phase:cleanup` のまま残存し、`/rite:recover` の誤判定や Stop hook の意図しない継続動作を招く実害を PR #1805 の実行中に実機再現した。

## Related Issue

Closes #695

## Changes

- `plugins/rite/hooks/cleanup-work-memory.sh`: FLOW_STATE 解決を `flow-state.sh path`（canonical resolver）経由に変更。解決失敗時のみ legacy `.rite-flow-state` にフォールバック。WARNING/ERROR メッセージも実際に操作したファイルの basename を反映するよう更新
- `plugins/rite/hooks/tests/cleanup-work-memory.test.sh`: TC-001/002/003/008 を per-session flow-state ファイル seed 方式に更新。`CLAUDE_CODE_SESSION_ID` の env leak（standalone 実行時にのみ顕在化していた既存の隠れた不安定性）を防ぐ `unset` も追加

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (run-tests.sh 経由 92/92、standalone 実行でも 11/11)
- [ ] Documentation updated (if applicable) — 該当ドキュメントは既存の記述が正確なままのため変更不要と判断

## Known Issues

- lint 未実行（外部 lint コマンド未検出。本プロジェクトは `commands.lint: null` を意図的に設定）。プラグイン固有チェック（Phase 3.5-3.20、20 項目）は全て実行しエラーなし（既存ファイルに起因する warning のみ）

## 横展開確認結果

`issue-comment-wm-sync.sh:58` にも同型のパターンを発見（`wm_comment_id` の read-only キャッシュ、致命的副作用なし）。#1807 として followup Issue 化した。

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)