### PR TITLE
fix(hooks): issue-comment-wm-sync.sh の wm_comment_id キャッシュを schema_v2 multi-state aware に対応

### DIFF
--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -55,7 +55,25 @@ PYTHON_SCRIPT="$SCRIPT_DIR/issue-comment-wm-update.py"
 # Resolve repository root for .rite-flow-state access
 CWD="${CWD:-$(pwd)}"
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
-FLOW_STATE="$STATE_ROOT/.rite-flow-state"
+
+# Resolve the current session's flow-state path via the canonical resolver
+# (flow-state.sh path — schema_v2/v3 per-session file under .rite/sessions/).
+# The legacy shared file (.rite-flow-state) does not exist in schema_v2/v3-only
+# environments, so caching against it always misses and forces a full gh api
+# comments scan on every call (#1807, same root cause as #695's
+# cleanup-work-memory.sh). Fall back to the legacy shared file only when
+# session resolution itself fails (no .rite-session-id / session env var
+# available) — surface that fallback with a WARNING for diagnosability.
+_fs_err=$(mktemp 2>/dev/null) || _fs_err=""
+if RESOLVED_FLOW_STATE=$(RITE_STATE_ROOT="$STATE_ROOT" "$SCRIPT_DIR/flow-state.sh" path 2>"${_fs_err:-/dev/null}"); then
+  :
+else
+  echo "WARNING: issue-comment-wm-sync: flow-state.sh path resolution failed — falling back to legacy $(basename "$STATE_ROOT/.rite-flow-state") (session_id may be missing or invalid)" >&2
+  [ -n "$_fs_err" ] && [ -s "$_fs_err" ] && head -3 "$_fs_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+  RESOLVED_FLOW_STATE=""
+fi
+[ -n "$_fs_err" ] && rm -f "$_fs_err"
+FLOW_STATE="${RESOLVED_FLOW_STATE:-$STATE_ROOT/.rite-flow-state}"
 
 # --- Get owner/repo ---
 # stderr を完全抑止すると、auth expiry / network outage / cwd outside repo の区別がつかず

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -130,10 +130,11 @@ out004=$(cd "$dir004" && bash -c "
   echo \"FLOW_STATE=\$FLOW_STATE\"
 " 2>&1)
 if printf '%s' "$out004" | grep -q 'WARNING: issue-comment-wm-sync: flow-state.sh path resolution failed' && \
+   printf '%s' "$out004" | grep -qE 'cannot resolve session_id' && \
    printf '%s' "$out004" | grep -qF "FLOW_STATE=$dir004/.rite-flow-state"; then
   pass "TC-004: resolver fallback emits WARNING and falls back to legacy path"
 else
-  fail "TC-004: expected WARNING + legacy fallback. got: $out004"
+  fail "TC-004: expected WARNING + legacy fallback (with diagnostic detail). got: $out004"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -18,6 +18,13 @@ TEST_DIR="$(mktemp -d)"
 PASS=0
 FAIL=0
 
+# Clean session-id env for standalone runs (same convention as
+# cleanup-work-memory.test.sh / flow-state.test.sh). The FLOW_STATE resolver
+# block under test (TC-003/TC-004) is env-first (CLAUDE_CODE_SESSION_ID /
+# CLAUDE_SESSION_ID); without this unset, the dogfooding session's ambient
+# session id would leak in and override each test's seeded .rite-session-id.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 cleanup() { rm -rf "$TEST_DIR"; }
 trap cleanup EXIT
 
@@ -26,6 +33,10 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
 extract_function() {
   awk '/^cache_comment_id\(\) \{/,/^\}$/' "$HOOK"
+}
+
+extract_resolver_block() {
+  awk '/^# Resolve repository root for/,/^FLOW_STATE=/' "$HOOK"
 }
 
 echo "=== issue-comment-wm-sync.sh tests ==="
@@ -75,6 +86,54 @@ if printf '%s' "$stderr002" | grep -qE 'cache_comment_id (mv|jq) failed'; then
   fail "TC-002: happy path emitted a failure WARNING — stderr: $stderr002"
 else
   pass "TC-002: happy path silent on stderr"
+fi
+echo ""
+
+# ─── TC-003: FLOW_STATE resolver → resolves to per-session file (#1807) ──
+# Regression guard for the fix to #1807: FLOW_STATE used to be hardcoded to
+# the legacy shared path ($STATE_ROOT/.rite-flow-state), which does not exist
+# in schema_v2/v3-only environments — every cache lookup missed and forced a
+# full gh api comments scan. When a session_id is resolvable, FLOW_STATE must
+# now point at the per-session file (.rite/sessions/{sid}.flow-state).
+echo "TC-003: FLOW_STATE resolver resolves to per-session file when session_id is available"
+dir003="$TEST_DIR/tc003"
+mkdir -p "$dir003"
+printf '%s' "tc003-sid" > "$dir003/.rite-session-id"
+resolver_block=$(extract_resolver_block)
+out003=$(cd "$dir003" && bash -c "
+  SCRIPT_DIR='$SCRIPT_DIR/..'
+  source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
+  CWD='$dir003'
+  $resolver_block
+  echo \"FLOW_STATE=\$FLOW_STATE\"
+" 2>&1)
+if printf '%s' "$out003" | grep -qF "FLOW_STATE=$dir003/.rite/sessions/tc003-sid.flow-state"; then
+  pass "TC-003: resolver resolved to per-session file"
+else
+  fail "TC-003: resolver did not resolve to expected per-session path. got: $out003"
+fi
+echo ""
+
+# ─── TC-004: FLOW_STATE resolver → falls back to legacy file with WARNING ──
+# Regression guard for the fallback branch: when session_id cannot be
+# resolved (no .rite-session-id / session env var), the resolver must emit a
+# WARNING (not silently swallow the failure) and still fall back to the
+# legacy shared path so callers keep a usable FLOW_STATE value.
+echo "TC-004: FLOW_STATE resolver falls back to legacy path with WARNING when session_id unresolvable"
+dir004="$TEST_DIR/tc004"
+mkdir -p "$dir004"
+out004=$(cd "$dir004" && bash -c "
+  SCRIPT_DIR='$SCRIPT_DIR/..'
+  source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
+  CWD='$dir004'
+  $resolver_block
+  echo \"FLOW_STATE=\$FLOW_STATE\"
+" 2>&1)
+if printf '%s' "$out004" | grep -q 'WARNING: issue-comment-wm-sync: flow-state.sh path resolution failed' && \
+   printf '%s' "$out004" | grep -qF "FLOW_STATE=$dir004/.rite-flow-state"; then
+  pass "TC-004: resolver fallback emits WARNING and falls back to legacy path"
+else
+  fail "TC-004: expected WARNING + legacy fallback. got: $out004"
 fi
 echo ""
 


### PR DESCRIPTION
## 概要

`issue-comment-wm-sync.sh` の `FLOW_STATE` 解決が legacy 共有ファイル (`.rite-flow-state`) への直書きになっており、schema_v2/v3 のセッション別 flow-state ファイル (`.rite/sessions/{sid}.flow-state`) を考慮していなかった。legacy ファイルが存在しない schema_v2/v3 専用環境では `wm_comment_id` キャッシュが常時ミスし、`cache_comment_id()` / `get_comment_id()` のたびに `gh api` の comments フルスキャンが発生していた（#695 で修正した `cleanup-work-memory.sh` と同型のパターン）。

## Related Issue

Closes #1807

## Changes

- `plugins/rite/hooks/issue-comment-wm-sync.sh`: `FLOW_STATE` の解決を `flow-state.sh path`（canonical resolver）経由に変更。解決失敗時のみ legacy ファイルにフォールバックし、WARNING を出す
- `plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh`: resolver 成功/フォールバックの両経路を検証する TC-003/TC-004 を追加（`#1808` の regression test パターンに倣う）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable) — 内部実装のみの変更で、ユーザー向け仕様変更なしと判断（ドキュメント影響調査済み、更新不要）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
