### PR TITLE
fix(hooks): flow-state.sh cmd_set の merge-preserve whitelist に wm_comment_id を追加

### DIFF
--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -313,7 +313,7 @@ cmd_set() {
      | (if $worktree != "" then .worktree = $worktree else . end)
      | (if $handoff != "" then .handoff = $handoff else . end)
      | (if $cycle != 0 then .cycle_count = $cycle else . end)
-     | (if $wmcid != "" then .wm_comment_id = ($wmcid | tonumber) else . end)') || return 1
+     | (if $wmcid != "" then .wm_comment_id = (try ($wmcid | tonumber) catch error("wm_comment_id not numeric (value=" + $wmcid + "): " + .)) else . end)') || return 1
   # `_atomic_write` の header コメント ("Callers MUST check rc") を遵守。現状は cmd_set の
   # 最終 statement のため set -e で rc が暗黙伝播するが、将来 `_atomic_write` の後に log 行を
   # 1 つ足す等の小修正で silent failure path が即復活する fragile pattern を避けるため、明示的

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -216,13 +216,16 @@ cmd_set() {
   # が常に「変化あり」と判定 → GitHub API spam (issue-comment-wm-sync 連発)。
   # 既存値が無い場合は空文字 → null として書き込み、wm-sync 側の `// "" | tostring` で
   # 空文字に縮退する (空 vs 非空 を別値として扱う wm-sync の diff guard と整合)。
+  # `cur_wm_comment_id` も同型: issue-comment-wm-sync.sh の cache_comment_id() が
+  # flow-state ファイルへ直接書き込む runtime-only field。lsp と同様に merge-preserve しないと
+  # 直後の他 skill の set 呼び出しで無警告に消える (#1810)。
   #
   # Single composite jq read: 6 つの独立 jq 呼び出しの silent fallback chain
   # では既存 state が corrupt JSON でも全フィールドが default に縮退して silent overwrite
   # される。1 回の composite jq + stderr capture に集約し、jq 失敗時に WARNING を stderr emit
   # して operator が corrupt overwrite を検出できるようにする。Unit separator () で field
   # を分割し、IFS で安全に split (whitespace collapse 防止)。
-  local cur_issue=0 cur_branch="" cur_pr=0 cur_parent=0 cur_active=true cur_err=0 cur_last_synced="" cur_worktree="" cur_cycle=0
+  local cur_issue=0 cur_branch="" cur_pr=0 cur_parent=0 cur_active=true cur_err=0 cur_last_synced="" cur_worktree="" cur_cycle=0 cur_wm_comment_id=""
   if [ -f "$path" ]; then
     local _cur_jq_err="" _cur_data _cur_rc=0
     _cur_jq_err=$(mktemp 2>/dev/null) || _cur_jq_err=""
@@ -236,13 +239,14 @@ cmd_set() {
                        (.error_count // 0 | tostring),
                        (.last_synced_phase // ""),
                        (.worktree // ""),
-                       (.cycle_count // 0 | tostring)] | join("")' "$path" 2>"${_cur_jq_err:-/dev/null}") || _cur_rc=$?
+                       (.cycle_count // 0 | tostring),
+                       (.wm_comment_id // "" | tostring)] | join("")' "$path" 2>"${_cur_jq_err:-/dev/null}") || _cur_rc=$?
     if [ "$_cur_rc" -ne 0 ]; then
       # basename only — multi-tenant 環境での絶対 path leakage を最小化 (cmd_get / cmd_set --if-exists と対称化)
       echo "WARNING: flow-state.sh cmd_set: existing state read failed for $(basename "$path") (may be corrupt; merged write will use defaults)" >&2
       _emit_jq_err_snippet "$_cur_jq_err"
     else
-      IFS=$'\x1f' read -r cur_issue cur_branch cur_pr cur_parent cur_active cur_err cur_last_synced cur_worktree cur_cycle <<< "$_cur_data"
+      IFS=$'\x1f' read -r cur_issue cur_branch cur_pr cur_parent cur_active cur_err cur_last_synced cur_worktree cur_cycle cur_wm_comment_id <<< "$_cur_data"
     fi
   fi
   [ -z "$issue" ] && issue=$cur_issue
@@ -300,7 +304,7 @@ cmd_set() {
     --arg next "$next" --argjson active "$active" \
     --argjson err "$err_count" --arg ts "$now" \
     --arg lsp "$cur_last_synced" --arg handoff "$handoff" --arg worktree "$worktree" \
-    --argjson cycle "$cycle_count" \
+    --argjson cycle "$cycle_count" --arg wmcid "$cur_wm_comment_id" \
     '{schema_version:$schema, session_id:$session, phase:$phase,
       issue_number:$issue, branch:$branch, pr_number:$pr,
       parent_issue_number:$parent, next_action:$next, active:$active,
@@ -308,7 +312,8 @@ cmd_set() {
      | (if $lsp != "" then .last_synced_phase = $lsp else . end)
      | (if $worktree != "" then .worktree = $worktree else . end)
      | (if $handoff != "" then .handoff = $handoff else . end)
-     | (if $cycle != 0 then .cycle_count = $cycle else . end)') || return 1
+     | (if $cycle != 0 then .cycle_count = $cycle else . end)
+     | (if $wmcid != "" then .wm_comment_id = ($wmcid | tonumber) else . end)') || return 1
   # `_atomic_write` の header コメント ("Callers MUST check rc") を遵守。現状は cmd_set の
   # 最終 statement のため set -e で rc が暗黙伝播するが、将来 `_atomic_write` の後に log 行を
   # 1 つ足す等の小修正で silent failure path が即復活する fragile pattern を避けるため、明示的

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -297,6 +297,13 @@ cmd_set() {
   # Stop hook が `consume-handoff` で読み取り + 削除し、prefix で reason を分岐して block する
   # (block 可否は handoff 非空かどうかで決まり、prefix は再注入する reason の選択にのみ影響する)。
   local now new; now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  # `_new_jq_err` capture (symmetric with the composite read's `_cur_jq_err`): the
+  # `tonumber` conversion below can fail on a corrupt on-disk `wm_comment_id`, and jq's
+  # own error text quotes the offending raw value. Without capturing stderr here it went
+  # straight to the terminal unneutralized, bypassing the `_emit_jq_err_snippet` control-char
+  # convention every other diagnostic site in this file uses (#1810 cycle 2 security finding).
+  local _new_jq_err="" _new_rc=0
+  _new_jq_err=$(mktemp 2>/dev/null) || _new_jq_err=""
   new=$(jq -n \
     --argjson schema "$SCHEMA_VERSION_V3" --arg session "$sid" \
     --arg phase "$phase" --argjson issue "$issue" --arg branch "$branch" \
@@ -313,7 +320,14 @@ cmd_set() {
      | (if $worktree != "" then .worktree = $worktree else . end)
      | (if $handoff != "" then .handoff = $handoff else . end)
      | (if $cycle != 0 then .cycle_count = $cycle else . end)
-     | (if $wmcid != "" then .wm_comment_id = (try ($wmcid | tonumber) catch error("wm_comment_id not numeric (value=" + $wmcid + "): " + .)) else . end)') || return 1
+     | (if $wmcid != "" then .wm_comment_id = ($wmcid | tonumber) else . end)' 2>"${_new_jq_err:-/dev/null}") || _new_rc=$?
+  if [ "$_new_rc" -ne 0 ]; then
+    echo "WARNING: flow-state.sh cmd_set: state write failed for $(basename "$path") (wm_comment_id not numeric, or other jq failure)" >&2
+    _emit_jq_err_snippet "$_new_jq_err"
+    [ -n "$_new_jq_err" ] && rm -f "$_new_jq_err"
+    return 1
+  fi
+  [ -n "$_new_jq_err" ] && rm -f "$_new_jq_err"
   # `_atomic_write` の header コメント ("Callers MUST check rc") を遵守。現状は cmd_set の
   # 最終 statement のため set -e で rc が暗黙伝播するが、将来 `_atomic_write` の後に log 行を
   # 1 つ足す等の小修正で silent failure path が即復活する fragile pattern を避けるため、明示的

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1178,6 +1178,15 @@ result=$(new_sandbox); d2="${result%|*}"; sid2="${result#*|}"
 sfile2="$d2/.rite/sessions/${sid2}.flow-state"
 (cd "$d2" && bash "$HOOK" set --phase branch --issue 1811 --branch "feat/1811" --pr 0 --next "n") >/dev/null
 assert "TC-28: backward compat → no wm_comment_id key when never written" "false" "$(jq -r 'has("wm_comment_id")' "$sfile2")"
+# write-time failure: a corrupted (non-numeric) wm_comment_id already on disk must make the
+# unrelated set fail loud (rc!=0) via tonumber, not silently succeed with a wiped/garbage value
+result=$(new_sandbox); d3="${result%|*}"; sid3="${result#*|}"
+sfile3="$d3/.rite/sessions/${sid3}.flow-state"
+(cd "$d3" && bash "$HOOK" set --phase init --issue 1812 --branch "" --pr 0 --next "n") >/dev/null
+jq '. + {wm_comment_id: "not-a-number"}' "$sfile3" > "$sfile3.tmp" && mv "$sfile3.tmp" "$sfile3"
+corrupt_set_rc=0
+(cd "$d3" && bash "$HOOK" set --phase branch --issue 1812 --branch "fix/issue-1812" --pr 0 --next "n2") >/dev/null 2>&1 || corrupt_set_rc=$?
+assert "TC-28: corrupt non-numeric wm_comment_id makes unrelated set fail (rc!=0)" "1" "$corrupt_set_rc"
 
 # --- T-01: AC-1 — distinct env CLAUDE_CODE_SESSION_ID → distinct per-session state files ---
 echo ""

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1156,6 +1156,29 @@ sfile2="$d2/.rite/sessions/${sid2}.flow-state"
 (cd "$d2" && bash "$HOOK" set --phase branch --issue 701 --branch "feat/701" --pr 0 --next "n") >/dev/null
 assert "TC-27: backward compat → no cycle_count key without --cycle-count" "false" "$(jq -r 'has("cycle_count")' "$sfile2")"
 
+# --- TC-28: wm_comment_id is merge-preserved across cmd_set (#1810) ---
+# wm_comment_id has NO --flag — it's written directly by issue-comment-wm-sync.sh's
+# cache_comment_id() via `jq '. + {wm_comment_id: ...}'`, mirroring how post-tool-wm-sync.sh
+# writes last_synced_phase. Repro: cache_comment_id writes the field, then any other skill's
+# ordinary phase-transition `set` (no wm_comment_id awareness) must NOT wipe it.
+echo ""
+echo "=== TC-28: wm_comment_id merge-preserve across ordinary phase-transition set ==="
+result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
+sfile="$d/.rite/sessions/${sid}.flow-state"
+(cd "$d" && bash "$HOOK" set --phase init --issue 1810 --branch "" --pr 0 --next "n") >/dev/null
+# simulate cache_comment_id() writing directly to the state file
+jq '. + {wm_comment_id: 999888}' "$sfile" > "$sfile.tmp" && mv "$sfile.tmp" "$sfile"
+assert "TC-28: wm_comment_id=999888 written directly" "999888" "$(jq -r '.wm_comment_id // "ABSENT"' "$sfile")"
+# an ordinary phase-transition set (no wm_comment_id flag exists) must preserve it
+(cd "$d" && bash "$HOOK" set --phase branch --issue 1810 --branch "fix/issue-1810" --pr 0 --next "n2") >/dev/null
+assert "TC-28: wm_comment_id preserved across unrelated phase-transition set" "999888" "$(jq -r '.wm_comment_id // "ABSENT"' "$sfile")"
+assert "TC-28: phase transition itself still applied" "branch" "$(jq -r '.phase' "$sfile")"
+# backward compat: a fresh session that never had wm_comment_id written has no such key
+result=$(new_sandbox); d2="${result%|*}"; sid2="${result#*|}"
+sfile2="$d2/.rite/sessions/${sid2}.flow-state"
+(cd "$d2" && bash "$HOOK" set --phase branch --issue 1811 --branch "feat/1811" --pr 0 --next "n") >/dev/null
+assert "TC-28: backward compat → no wm_comment_id key when never written" "false" "$(jq -r 'has("wm_comment_id")' "$sfile2")"
+
 # --- T-01: AC-1 — distinct env CLAUDE_CODE_SESSION_ID → distinct per-session state files ---
 echo ""
 echo "=== T-01: AC-1 concurrent sessions sharing one state root stay isolated by env ==="

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1187,6 +1187,21 @@ jq '. + {wm_comment_id: "not-a-number"}' "$sfile3" > "$sfile3.tmp" && mv "$sfile
 corrupt_set_rc=0
 (cd "$d3" && bash "$HOOK" set --phase branch --issue 1812 --branch "fix/issue-1812" --pr 0 --next "n2") >/dev/null 2>&1 || corrupt_set_rc=$?
 assert "TC-28: corrupt non-numeric wm_comment_id makes unrelated set fail (rc!=0)" "1" "$corrupt_set_rc"
+# security fix (cycle 2 #1810): the write-side jq stderr (which quotes the corrupt raw value)
+# must go through the same _emit_jq_err_snippet / neutralize_ctrl convention as the read side,
+# not straight to the terminal unneutralized. Same TC-23.2 pattern: inject an ESC byte and
+# assert it never reaches stderr raw.
+result=$(new_sandbox); d4="${result%|*}"; sid4="${result#*|}"
+sfile4="$d4/.rite/sessions/${sid4}.flow-state"
+(cd "$d4" && bash "$HOOK" set --phase init --issue 1813 --branch "" --pr 0 --next "n") >/dev/null
+esc=$(printf '\033')
+jq --arg v "${esc}[31mnot-a-number" '. + {wm_comment_id: $v}' "$sfile4" > "$sfile4.tmp" && mv "$sfile4.tmp" "$sfile4"
+corrupt_set_stderr=$( (cd "$d4" && bash "$HOOK" set --phase branch --issue 1813 --branch "fix/issue-1813" --pr 0 --next "n2") 2>&1 1>/dev/null || true )
+if printf '%s' "$corrupt_set_stderr" | LC_ALL=C grep -q "$esc"; then
+  fail "TC-28: corrupt wm_comment_id 由来の生 ESC が write エラー出力に残存 (control-char 中和が機能していない): '$(printf '%s' "$corrupt_set_stderr" | cat -v)'"
+else
+  pass "TC-28: corrupt wm_comment_id 由来の write エラー出力の生 ESC が中和されている"
+fi
 
 # --- T-01: AC-1 — distinct env CLAUDE_CODE_SESSION_ID → distinct per-session state files ---
 echo ""


### PR DESCRIPTION
## Summary

`flow-state.sh` の `cmd_set` が既存 JSON を `jq -n` で再構築する際、`issue-comment-wm-sync.sh` の `cache_comment_id()` が直接書き込む `wm_comment_id` フィールドが merge-preserve 対象に含まれておらず、直後の phase-transition set で無警告に消失していた問題を修正する。

## Related Issue

Closes #1810

## Changes

- `plugins/rite/hooks/flow-state.sh`: `cmd_set` の既存値読み取り（composite jq read）に `wm_comment_id` を追加し、`jq -n` 再構築時に `last_synced_phase` と同型の read-only preserve として merge-preserve する
- `plugins/rite/hooks/tests/flow-state.test.sh`: TC-28 を追加し、cache_comment_id 相当の直接書き込み → 無関係な phase-transition set の順で `wm_comment_id` が保持されることを検証（バックワード互換ケースも含む）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass（`flow-state.test.sh` 155 PASS / `issue-comment-wm-sync.test.sh` 5 PASS）
- [ ] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
