### PR TITLE
docs: 紹介動画に /rite:unknowns シーンを追加しv0.8.0表記へ更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@
 
 ## Demo
 
-Issue から PR まで、開発を“儀式”に変える — 約115秒で分かる紹介動画（日本語字幕）。
+Issue から PR まで、開発を“儀式”に変える — 約125秒で分かる紹介動画（日本語字幕）。
 
 https://github.com/user-attachments/assets/18160008-e329-4fdd-b170-fac925160e7a
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 
 Issue から PR まで、開発を“儀式”に変える — 約125秒で分かる紹介動画（日本語字幕）。
 
-https://github.com/user-attachments/assets/18160008-e329-4fdd-b170-fac925160e7a
+https://github.com/user-attachments/assets/900476d1-fbf0-4f8c-a3ef-3f286638568a
 
 ## なぜ "Rite" なのか
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 From Issue to PR — see Rite Workflow turn development into a *rite*. A ~125-second intro (English).
 
-https://github.com/user-attachments/assets/39d7aac7-5a4f-46b6-998f-9c061391af31
+https://github.com/user-attachments/assets/abc7455a-ed0a-40c9-964e-cee8c4262f35
 
 ## Why "Rite"?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Demo
 
-From Issue to PR — see Rite Workflow turn development into a *rite*. A ~115-second intro (English).
+From Issue to PR — see Rite Workflow turn development into a *rite*. A ~125-second intro (English).
 
 https://github.com/user-attachments/assets/39d7aac7-5a4f-46b6-998f-9c061391af31
 

--- a/media/intro-video-en/PROVENANCE.md
+++ b/media/intro-video-en/PROVENANCE.md
@@ -1,6 +1,6 @@
 # intro-video-en — Provenance and handling
 
-HyperFrames source for the **English** intro video (~104s) referenced in the "Demo" section of `README.md`.
+HyperFrames source for the **English** intro video (~125s) referenced in the "Demo" section of `README.md`.
 
 ## Provenance
 

--- a/media/intro-video-en/compositions/scene-1.html
+++ b/media/intro-video-en/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">From Issue to PR — turn development into a rite</div>
         <div class="sub">A Claude Code plugin</div>
-        <div class="badge">v0.7.0 · MIT</div>
+        <div class="badge">v0.8.0 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video-en/compositions/scene-7.html
+++ b/media/intro-video-en/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.7.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.8.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>

--- a/media/intro-video-en/compositions/scene-unknowns.html
+++ b/media/intro-video-en/compositions/scene-unknowns.html
@@ -1,0 +1,118 @@
+<template id="scene-unknowns-template">
+  <div data-composition-id="scene-unknowns" id="scene-unknowns" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 00 — EXPLORE <span class="new">NEW in v0.8</span></div>
+          <div class="heading">Surface <span class="hl">blind spots</span> before you build</div>
+          <div class="subnote">Shape a half-formed idea in a guided exploration session (optional, manual)</div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:unknowns</span> <span class="arg">"considering real-time notifications"</span></div>
+        </div>
+
+        <div class="diagram">
+          <div class="cluster">
+            <div class="cluster-label">mix exploration modes interactively</div>
+            <div class="modes">
+              <div class="mode">🕳 Blind-spot pass</div>
+              <div class="mode">💡 Brainstorming</div>
+              <div class="mode">🧪 Throwaway prototypes</div>
+              <div class="mode">🎤 Requirements interview</div>
+            </div>
+          </div>
+
+          <div class="inject">
+            <div class="inj-arrow">⟶</div>
+            <div class="inj-label">output</div>
+          </div>
+
+          <div class="next">
+            <div class="summary">📋 Exploration summary</div>
+            <div class="feed">feeds straight into /rite:issue-create</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-unknowns {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-unknowns .bg { position: absolute; inset: 0; }
+      #scene-unknowns .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 640px at 30% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 66%);
+      }
+      #scene-unknowns .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 48px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-unknowns .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+        display: flex; align-items: center; gap: 18px;
+      }
+      #scene-unknowns .new {
+        font-size: 18px; letter-spacing: 1px; color: #e8b339;
+        background: rgba(232,179,57,0.12); border: 1px solid #e8b339;
+        border-radius: 999px; padding: 4px 14px;
+      }
+      #scene-unknowns .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-unknowns .heading .hl { color: #e8b339; }
+      #scene-unknowns .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-unknowns .cmdline {
+        margin-top: 18px; font-size: 30px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-unknowns .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-unknowns .arg { color: #a5d6ff; }
+      #scene-unknowns .diagram { display: flex; align-items: center; gap: 44px; }
+      #scene-unknowns .cluster {
+        flex: 1.2; background: #161b22; border: 1px solid #30363d; border-radius: 16px; padding: 28px 30px;
+      }
+      #scene-unknowns .cluster-label {
+        font-size: 22px; color: #8b949e; font-weight: 600; margin-bottom: 20px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .modes { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-unknowns .mode {
+        font-size: 27px; font-weight: 600; color: #c9d1d9;
+        background: #0d1117; border: 1px solid #30363d; border-left: 3px solid #e8b339;
+        border-radius: 10px; padding: 14px 22px;
+      }
+      #scene-unknowns .inject { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+      #scene-unknowns .inj-arrow { font-size: 64px; color: #e8b339; line-height: 1; }
+      #scene-unknowns .inj-label {
+        font-size: 22px; color: #e8b339; font-weight: 700;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .next { flex: 1; display: flex; flex-direction: column; gap: 16px; }
+      #scene-unknowns .summary {
+        font-size: 32px; color: #e6edf3; font-weight: 700;
+        background: rgba(232,179,57,0.10); border: 1px solid #e8b339; border-radius: 12px; padding: 20px 26px;
+      }
+      #scene-unknowns .feed { font-size: 25px; color: #8b949e; padding-left: 6px; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-unknowns .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-unknowns .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-unknowns .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-unknowns .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-unknowns .cmdline", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 0.7);
+      tl.from("#scene-unknowns .cluster", { opacity: 0, x: -36, duration: 0.6, ease: "power3.out" }, 1.05);
+      tl.from("#scene-unknowns .mode", { opacity: 0, scale: 0.82, duration: 0.4, ease: "back.out(1.5)", stagger: 0.12 }, 1.35);
+      tl.from("#scene-unknowns .inj-arrow", { opacity: 0, x: -24, duration: 0.5, ease: "power2.out" }, 2.1);
+      tl.from("#scene-unknowns .inj-label", { opacity: 0, duration: 0.4, ease: "sine.out" }, 2.35);
+      tl.from("#scene-unknowns .summary", { opacity: 0, x: 34, duration: 0.5, ease: "power2.out" }, 2.55);
+      tl.from("#scene-unknowns .feed", { opacity: 0, y: 14, duration: 0.45, ease: "sine.out" }, 2.95);
+      window.__timelines["scene-unknowns"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video-en/index.html
+++ b/media/intro-video-en/index.html
@@ -17,30 +17,32 @@
       id="root"
       data-composition-id="main"
       data-start="0"
-      data-duration="114"
+      data-duration="125"
       data-width="1920"
       data-height="1080"
     >
       <div id="clip-1" data-composition-id="scene-1" data-composition-src="compositions/scene-1.html"
            data-start="0"  data-duration="7.6"  data-track-index="1" style="z-index: 1"></div>
+      <div id="clip-unknowns" data-composition-id="scene-unknowns" data-composition-src="compositions/scene-unknowns.html"
+           data-start="7"  data-duration="11.6" data-track-index="2" style="z-index: 2"></div>
       <div id="clip-create" data-composition-id="scene-create" data-composition-src="compositions/scene-create.html"
-           data-start="7"  data-duration="12.6" data-track-index="2" style="z-index: 2"></div>
+           data-start="18" data-duration="12.6" data-track-index="3" style="z-index: 3"></div>
       <div id="clip-2" data-composition-id="scene-2" data-composition-src="compositions/scene-2.html"
-           data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
+           data-start="30" data-duration="13.6" data-track-index="4" style="z-index: 4"></div>
       <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
-           data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+           data-start="43" data-duration="14.6" data-track-index="5" style="z-index: 5"></div>
       <div id="clip-docheavy" data-composition-id="scene-docheavy" data-composition-src="compositions/scene-docheavy.html"
-           data-start="46" data-duration="10.6" data-track-index="5" style="z-index: 5"></div>
+           data-start="57" data-duration="10.6" data-track-index="6" style="z-index: 6"></div>
       <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
-           data-start="56" data-duration="13.6" data-track-index="6" style="z-index: 6"></div>
+           data-start="67" data-duration="13.6" data-track-index="7" style="z-index: 7"></div>
       <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
-           data-start="69" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+           data-start="80" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
       <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
-           data-start="81" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+           data-start="92" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
       <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
-           data-start="93" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
+           data-start="104" data-duration="12.6" data-track-index="10" style="z-index: 10"></div>
       <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
-           data-start="105" data-duration="9"   data-track-index="10" style="z-index: 10"></div>
+           data-start="116" data-duration="9"   data-track-index="11" style="z-index: 11"></div>
     </div>
 
     <script>
@@ -48,17 +50,18 @@
       const tl = gsap.timeline({ paused: true });
       // Scene 1 fades up from black; following scenes crossfade over the outgoing scene.
       tl.from("#clip-1", { opacity: 0, duration: 0.6, ease: "sine.out" }, 0);
-      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
-      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
-      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
-      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
-      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 56);
-      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 69);
-      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 81);
-      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 93);
-      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 105);
+      tl.from("#clip-unknowns", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
+      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 18);
+      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 30);
+      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 43);
+      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 57);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 67);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 80);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 92);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 104);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 116);
       // Final scene only: fade to black at the very end.
-      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 113.2);
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 124.2);
       window.__timelines["main"] = tl;
     </script>
   </body>

--- a/media/intro-video/PROVENANCE.md
+++ b/media/intro-video/PROVENANCE.md
@@ -1,6 +1,6 @@
 # intro-video — 来歴と取り扱い
 
-README.md の「Demo」節で参照している**日本語字幕版**紹介動画（約104秒）の HyperFrames ソース。
+README.ja.md の「Demo」節で参照している**日本語字幕版**紹介動画（約125秒）の HyperFrames ソース。
 
 ## 来歴
 

--- a/media/intro-video/compositions/scene-1.html
+++ b/media/intro-video/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">Issue から PR まで、開発を“儀式”に変える</div>
         <div class="sub">Claude Code プラグイン</div>
-        <div class="badge">v0.7.0 · MIT</div>
+        <div class="badge">v0.8.0 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video/compositions/scene-7.html
+++ b/media/intro-video/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.7.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.8.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>

--- a/media/intro-video/compositions/scene-unknowns.html
+++ b/media/intro-video/compositions/scene-unknowns.html
@@ -1,0 +1,118 @@
+<template id="scene-unknowns-template">
+  <div data-composition-id="scene-unknowns" id="scene-unknowns" data-width="1920" data-height="1080">
+    <div class="bg">
+      <div class="glow" aria-hidden="true"></div>
+      <div class="scene-content">
+        <div class="head">
+          <div class="kicker">STEP 00 — EXPLORE <span class="new">NEW in v0.8</span></div>
+          <div class="heading">実装の前に、<span class="hl">盲点を探索</span></div>
+          <div class="subnote">構想段階のアイデアを対話セッションで固める（任意・手動起動）</div>
+          <div class="cmdline"><span class="prompt">$</span> <span class="cmd">/rite:unknowns</span> <span class="arg">"リアルタイム通知を検討したい"</span></div>
+        </div>
+
+        <div class="diagram">
+          <div class="cluster">
+            <div class="cluster-label">探索モードを対話で組み合わせ</div>
+            <div class="modes">
+              <div class="mode">🕳 盲点の洗い出し</div>
+              <div class="mode">💡 ブレインストーミング</div>
+              <div class="mode">🧪 使い捨てプロトタイプ</div>
+              <div class="mode">🎤 要件インタビュー</div>
+            </div>
+          </div>
+
+          <div class="inject">
+            <div class="inj-arrow">⟶</div>
+            <div class="inj-label">出力</div>
+          </div>
+
+          <div class="next">
+            <div class="summary">📋 探索サマリ</div>
+            <div class="feed">そのまま /rite:issue-create の入力に</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      #scene-unknowns {
+        width: 1920px; height: 1080px; position: relative; overflow: hidden;
+        background: #0e1117; font-family: "Inter", "Noto Sans JP", sans-serif;
+      }
+      #scene-unknowns .bg { position: absolute; inset: 0; }
+      #scene-unknowns .glow {
+        position: absolute; inset: 0;
+        background: radial-gradient(ellipse 1200px 640px at 30% 0%, rgba(232,179,57,0.13), rgba(232,179,57,0) 66%);
+      }
+      #scene-unknowns .scene-content {
+        position: relative; z-index: 1; width: 100%; height: 100%;
+        display: flex; flex-direction: column; justify-content: center;
+        gap: 48px; padding: 90px 150px; box-sizing: border-box;
+      }
+      #scene-unknowns .kicker {
+        font-size: 23px; font-weight: 700; letter-spacing: 4px; color: #e8b339;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace; margin-bottom: 12px;
+        display: flex; align-items: center; gap: 18px;
+      }
+      #scene-unknowns .new {
+        font-size: 18px; letter-spacing: 1px; color: #e8b339;
+        background: rgba(232,179,57,0.12); border: 1px solid #e8b339;
+        border-radius: 999px; padding: 4px 14px;
+      }
+      #scene-unknowns .heading { font-size: 62px; font-weight: 800; color: #e6edf3; letter-spacing: -1px; }
+      #scene-unknowns .heading .hl { color: #e8b339; }
+      #scene-unknowns .subnote { margin-top: 14px; font-size: 26px; color: #8b949e; }
+      #scene-unknowns .cmdline {
+        margin-top: 18px; font-size: 30px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .prompt { color: #3fb950; margin-right: 12px; }
+      #scene-unknowns .cmd { color: #58a6ff; font-weight: 600; }
+      #scene-unknowns .arg { color: #a5d6ff; }
+      #scene-unknowns .diagram { display: flex; align-items: center; gap: 44px; }
+      #scene-unknowns .cluster {
+        flex: 1.2; background: #161b22; border: 1px solid #30363d; border-radius: 16px; padding: 28px 30px;
+      }
+      #scene-unknowns .cluster-label {
+        font-size: 22px; color: #8b949e; font-weight: 600; margin-bottom: 20px;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .modes { display: flex; flex-wrap: wrap; gap: 16px; }
+      #scene-unknowns .mode {
+        font-size: 27px; font-weight: 600; color: #c9d1d9;
+        background: #0d1117; border: 1px solid #30363d; border-left: 3px solid #e8b339;
+        border-radius: 10px; padding: 14px 22px;
+      }
+      #scene-unknowns .inject { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+      #scene-unknowns .inj-arrow { font-size: 64px; color: #e8b339; line-height: 1; }
+      #scene-unknowns .inj-label {
+        font-size: 22px; color: #e8b339; font-weight: 700;
+        font-family: "JetBrains Mono", "Noto Sans JP", monospace;
+      }
+      #scene-unknowns .next { flex: 1; display: flex; flex-direction: column; gap: 16px; }
+      #scene-unknowns .summary {
+        font-size: 32px; color: #e6edf3; font-weight: 700;
+        background: rgba(232,179,57,0.10); border: 1px solid #e8b339; border-radius: 12px; padding: 20px 26px;
+      }
+      #scene-unknowns .feed { font-size: 25px; color: #8b949e; padding-left: 6px; }
+    </style>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#scene-unknowns .glow", { opacity: 0, duration: 1.0, ease: "power1.out" }, 0);
+      tl.from("#scene-unknowns .kicker", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.1);
+      tl.from("#scene-unknowns .heading", { opacity: 0, y: 26, duration: 0.6, ease: "power3.out" }, 0.25);
+      tl.from("#scene-unknowns .subnote", { opacity: 0, y: 16, duration: 0.5, ease: "power2.out" }, 0.5);
+      tl.from("#scene-unknowns .cmdline", { opacity: 0, x: -14, duration: 0.45, ease: "power2.out" }, 0.7);
+      tl.from("#scene-unknowns .cluster", { opacity: 0, x: -36, duration: 0.6, ease: "power3.out" }, 1.05);
+      tl.from("#scene-unknowns .mode", { opacity: 0, scale: 0.82, duration: 0.4, ease: "back.out(1.5)", stagger: 0.12 }, 1.35);
+      tl.from("#scene-unknowns .inj-arrow", { opacity: 0, x: -24, duration: 0.5, ease: "power2.out" }, 2.1);
+      tl.from("#scene-unknowns .inj-label", { opacity: 0, duration: 0.4, ease: "sine.out" }, 2.35);
+      tl.from("#scene-unknowns .summary", { opacity: 0, x: 34, duration: 0.5, ease: "power2.out" }, 2.55);
+      tl.from("#scene-unknowns .feed", { opacity: 0, y: 14, duration: 0.45, ease: "sine.out" }, 2.95);
+      window.__timelines["scene-unknowns"] = tl;
+    </script>
+  </div>
+</template>

--- a/media/intro-video/index.html
+++ b/media/intro-video/index.html
@@ -17,30 +17,32 @@
       id="root"
       data-composition-id="main"
       data-start="0"
-      data-duration="114"
+      data-duration="125"
       data-width="1920"
       data-height="1080"
     >
       <div id="clip-1" data-composition-id="scene-1" data-composition-src="compositions/scene-1.html"
            data-start="0"  data-duration="7.6"  data-track-index="1" style="z-index: 1"></div>
+      <div id="clip-unknowns" data-composition-id="scene-unknowns" data-composition-src="compositions/scene-unknowns.html"
+           data-start="7"  data-duration="11.6" data-track-index="2" style="z-index: 2"></div>
       <div id="clip-create" data-composition-id="scene-create" data-composition-src="compositions/scene-create.html"
-           data-start="7"  data-duration="12.6" data-track-index="2" style="z-index: 2"></div>
+           data-start="18" data-duration="12.6" data-track-index="3" style="z-index: 3"></div>
       <div id="clip-2" data-composition-id="scene-2" data-composition-src="compositions/scene-2.html"
-           data-start="19" data-duration="13.6" data-track-index="3" style="z-index: 3"></div>
+           data-start="30" data-duration="13.6" data-track-index="4" style="z-index: 4"></div>
       <div id="clip-3" data-composition-id="scene-3" data-composition-src="compositions/scene-3.html"
-           data-start="32" data-duration="14.6" data-track-index="4" style="z-index: 4"></div>
+           data-start="43" data-duration="14.6" data-track-index="5" style="z-index: 5"></div>
       <div id="clip-docheavy" data-composition-id="scene-docheavy" data-composition-src="compositions/scene-docheavy.html"
-           data-start="46" data-duration="10.6" data-track-index="5" style="z-index: 5"></div>
+           data-start="57" data-duration="10.6" data-track-index="6" style="z-index: 6"></div>
       <div id="clip-4" data-composition-id="scene-4" data-composition-src="compositions/scene-4.html"
-           data-start="56" data-duration="13.6" data-track-index="6" style="z-index: 6"></div>
+           data-start="67" data-duration="13.6" data-track-index="7" style="z-index: 7"></div>
       <div id="clip-5" data-composition-id="scene-5" data-composition-src="compositions/scene-5.html"
-           data-start="69" data-duration="12.6" data-track-index="7" style="z-index: 7"></div>
+           data-start="80" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
       <div id="clip-6" data-composition-id="scene-6" data-composition-src="compositions/scene-6.html"
-           data-start="81" data-duration="12.6" data-track-index="8" style="z-index: 8"></div>
+           data-start="92" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
       <div id="clip-goal" data-composition-id="scene-goal" data-composition-src="compositions/scene-goal.html"
-           data-start="93" data-duration="12.6" data-track-index="9" style="z-index: 9"></div>
+           data-start="104" data-duration="12.6" data-track-index="10" style="z-index: 10"></div>
       <div id="clip-7" data-composition-id="scene-7" data-composition-src="compositions/scene-7.html"
-           data-start="105" data-duration="9"   data-track-index="10" style="z-index: 10"></div>
+           data-start="116" data-duration="9"   data-track-index="11" style="z-index: 11"></div>
     </div>
 
     <script>
@@ -48,17 +50,18 @@
       const tl = gsap.timeline({ paused: true });
       // Scene 1 fades up from black; following scenes crossfade over the outgoing scene.
       tl.from("#clip-1", { opacity: 0, duration: 0.6, ease: "sine.out" }, 0);
-      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
-      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 19);
-      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 32);
-      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 46);
-      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 56);
-      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 69);
-      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 81);
-      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 93);
-      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 105);
+      tl.from("#clip-unknowns", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 7);
+      tl.from("#clip-create", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 18);
+      tl.from("#clip-2", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 30);
+      tl.from("#clip-3", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 43);
+      tl.from("#clip-docheavy", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 57);
+      tl.from("#clip-4", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 67);
+      tl.from("#clip-5", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 80);
+      tl.from("#clip-6", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 92);
+      tl.from("#clip-goal", { opacity: 0, duration: 0.6, ease: "sine.inOut" }, 104);
+      tl.from("#clip-7", { opacity: 0, duration: 0.7, ease: "power1.inOut" }, 116);
       // Final scene only: fade to black at the very end.
-      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 113.2);
+      tl.to("#clip-7", { opacity: 0, duration: 0.8, ease: "sine.in" }, 124.2);
       window.__timelines["main"] = tl;
     </script>
   </body>


### PR DESCRIPTION
## Summary

0.8.0 リリースに合わせ、README.md / README.ja.md の Demo 節で参照する紹介動画（日英）を develop 最新仕様へ更新した。`/rite:unknowns` の紹介シーン（STEP 00 — EXPLORE）を追加し、バージョン表記を v0.8.0 に更新、全体尺を約125秒とした。

## Related Issue

Closes #1814

## Changes

- `media/intro-video/compositions/scene-unknowns.html` / `media/intro-video-en/compositions/scene-unknowns.html`: 新規。`/rite:unknowns` 紹介シーン（日英）
- `media/intro-video/index.html` / `media/intro-video-en/index.html`: unknowns クリップ挿入、以降シーンを+11秒シフトして125秒化
- `media/intro-video/compositions/scene-1.html` / `scene-7.html`（日英）: バージョンバッジ v0.7.0 → v0.8.0
- `media/intro-video/PROVENANCE.md` / `media/intro-video-en/PROVENANCE.md`: 尺表記更新、日本語版の参照先誤記（README.md → README.ja.md）修正
- `README.md` / `README.ja.md`: Demo 節の尺表記を ~125 秒に更新、動画 URL を新 user-attachments へ差し替え

## Known Issues

- lint 未実行（lint コマンドが検出されませんでした。plugin 固有の品質チェック20種は実行しエラーなし）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — `npm run check`（hyperframes lint/validate/inspect）を日英両プロジェクトで実行、エラー0
- [x] Documentation updated (if applicable) — README の尺表記・動画URLとも更新済み

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
