### PR TITLE
fix(setup): Project 作成後に gh project link を冪等実行し初回 Issue 作成の Projects 登録失敗を解消

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -474,7 +474,8 @@ followed by AskUserQuestion confirmation)
 2. Present options:
  - Link to existing Projects
  - Create new Projects
-3. Auto-configure fields
+3. Link the Project to the repository (`gh project link`, idempotent, non-blocking on failure)
+4. Auto-configure fields
 
 #### Phase 4: Template Generation
 1. Check `.github/ISSUE_TEMPLATE/`

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -113,7 +113,7 @@ gh project create --owner {owner} --title "{repo-name}" --format json
 
 ### 3.3.5 Link Project to Repository (Both Paths)
 
-新規作成（3.3）・既存 Project 選択（3.2）のどちらのパスでも、Project 番号が確定したら必ず実行する。`gh project link` はリポジトリと Project を関連付け、`repository(owner:, name:) { projectV2(number:) }` ルートの GraphQL クエリ（Issue 作成 helper の Step 2.3 フィールド取得が使用）を解決可能にする。link しないままだと初回 `/rite:issue-create` が `project_registration: "partial"` で失敗する。
+新規作成（3.3）・既存 Project 選択（3.2）のどちらのパスでも、Project 番号が確定したら必ず実行する。`gh project link` はリポジトリと Project を関連付け、Issue 作成 helper のフィールド取得 GraphQL クエリ（`repository(owner:, name:) { projectV2(number:) }` ルート、[../../references/graphql-helpers.md](../../references/graphql-helpers.md) 参照）を解決可能にする。link しないままだと初回 `/rite:issue-create` が `project_registration: "partial"` で失敗する。
 
 ```bash
 # 冪等: 既にリンク済みでも成功する。失敗しても setup は続行する（non-blocking）

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -103,11 +103,27 @@ Select with AskUserQuestion:
 - 既存の Projects と連携する（リストから選択）
 - 新規 Projects を作成する
 
+どちらを選んでも、Project 番号確定後に 3.3.5（`gh project link`）を必ず実行する（既存 Project 選択時は 3.3 をスキップして 3.3.5 へ進む）。
+
 ### 3.3 If Creating New
 
 ```bash
 gh project create --owner {owner} --title "{repo-name}" --format json
 ```
+
+### 3.3.5 Link Project to Repository (Both Paths)
+
+新規作成（3.3）・既存 Project 選択（3.2）のどちらのパスでも、Project 番号が確定したら必ず実行する。`gh project link` はリポジトリと Project を関連付け、`repository(owner:, name:) { projectV2(number:) }` ルートの GraphQL クエリ（Issue 作成 helper の Step 2.3 フィールド取得が使用）を解決可能にする。link しないままだと初回 `/rite:issue-create` が `project_registration: "partial"` で失敗する。
+
+```bash
+# 冪等: 既にリンク済みでも成功する。失敗しても setup は続行する（non-blocking）
+if ! gh project link {project-number} --owner {owner} 2>&1; then
+  echo "WARNING: gh project link に失敗しました。Projects のフィールド設定が初回 Issue 作成時に partial になる可能性があります" >&2
+  echo "手動で以下を実行してください: gh project link {project-number} --owner {owner} --repo {owner}/{repo-name}" >&2
+fi
+```
+
+link 失敗（権限不足・API エラー等）は WARNING と上記の手動コマンド案内のみで、setup 全体は停止せず次の Phase へ続行する。
 
 ### 3.4 Verify and Configure Fields
 


### PR DESCRIPTION
## 概要

新規リポジトリで `/rite:setup` 完走直後の初回 `/rite:issue-create` が `project_registration: "partial"` になる問題を解消する。setup Phase 3.3 は `gh project create` でユーザーレベル Project を作成するだけでリポジトリと未リンクのため、Issue 作成 helper（`create-issue-with-projects.sh` Step 2.3）の repository ルート GraphQL クエリが Project を解決できず、Status / Priority / Complexity フィールドが未設定のままだった。

## 関連 Issue

Closes #1827

## 変更内容

- `plugins/rite/skills/setup/SKILL.md`
  - Phase 3.3 と 3.4 の間に **Phase 3.3.5 Link Project to Repository** を追加。`gh project link {project-number} --owner {owner}` を冪等実行し、失敗時は WARNING + 手動 link コマンド案内を出して setup を続行する（non-blocking）
  - Phase 3.2 に「既存 Project 選択時も 3.3.5 を必ず通る」誘導を 1 行追記（SHOULD 対応）
- `docs/SPEC.md`
  - setup Phase 3 の手順一覧に link ステップを追記（ドキュメント整合）

## 受入基準との対応

- AC-1（初回 Issue 作成成功）: Project 番号確定後に link を保証し repository ルートクエリを解決可能にする
- AC-2（冪等性）: `gh project link` はリンク済みでも成功し、失敗時も non-blocking で完走する
- AC-3（link 失敗時の継続）: WARNING + 手動コマンド案内を表示して後続 Phase へ続行する

## チェックリスト

- [x] MUST 要件（link 実行・冪等・non-blocking）実装済み
- [x] Non-Target ファイル（`create-issue-with-projects.sh` / `projects-status-update.sh`）は未変更
- [x] lint（plugin 固有チェック）: 新規指摘なし（既存警告のみ）
- [ ] テスト: `commands.test` 未設定のため未実行（T-01〜T-03 は手順記述で担保）
