### PR TITLE
fix(issue-create): ラベルを冪等に事前作成し helper 失敗時に result を surface する

### DIFF
--- a/plugins/rite/scripts/decompose-issues.sh
+++ b/plugins/rite/scripts/decompose-issues.sh
@@ -168,6 +168,15 @@ parent_body_file=$(spec_get '.parent.body_file')
 # select(length>0) drops empties — e.g. a trailing comma when labels_csv="").
 labels_json=$(printf '%s' "epic,${labels_csv}" | jq -R 'split(",") | map(select(length>0) | gsub("^\\s+|\\s+$"; ""))')
 
+# 各ラベルを冪等に事前作成する (`gh issue create --label X` は X 未存在時に fail するため。
+# skills/issue-create/SKILL.md ステップ 4.3 と同パターン)。親 labels (epic + labels_csv) は
+# sub-issue labels (labels_csv のみ) の上位集合のため、ここでの 1 回で Step 5.4 の分もカバーする。
+# 既存ラベル / 権限不足の失敗は無視して続行し、真の失敗は gh issue create 側で surface される。
+while IFS= read -r label; do
+  [ -z "$label" ] && continue
+  gh label create "$label" --description "auto-created by rite issue-create" --color "ededed" 2>/dev/null || true
+done < <(printf '%s\n' "$labels_json" | jq -r '.[]')
+
 parent_result=$(bash "$CREATE_SCRIPT" "$(build_payload "$parent_title" "$parent_body_file" "$labels_json" "XL")") || {
   echo "ERROR: 親 Issue 作成失敗" >&2
   exit 1

--- a/plugins/rite/skills/issue-create/SKILL.md
+++ b/plugins/rite/skills/issue-create/SKILL.md
@@ -240,6 +240,15 @@ ISSUE_BODY_EOF
 # {labels_csv} (例: "bug,fix") を JSON array に変換 (空 CSV は空配列)
 labels_json=$(printf '%s' "{labels_csv}" | jq -R 'split(",") | map(select(length>0) | gsub("^\\s+|\\s+$"; ""))')
 
+# 各ラベルを冪等に事前作成する (`gh issue create --label X` は X 未存在時に
+# `could not add label` で fail するため。skills/cleanup/SKILL.md ステップ 3 と同パターン)。
+# 既存ラベル / 権限不足の失敗は無視して続行し、真の失敗は gh issue create 側で
+# helper の $result (warnings) として surface される。空 labels_csv はループ 0 回で従来動作。
+while IFS= read -r label; do
+  [ -z "$label" ] && continue
+  gh label create "$label" --description "auto-created by rite issue-create" --color "ededed" 2>/dev/null || true
+done < <(printf '%s\n' "$labels_json" | jq -r '.[]')
+
 # args_json を入れ子 $() から分離して構築する (深い入れ子 quoting の malform 源を削減。
 # 単一 JSON 引数契約は不変)
 args_json=$(jq -n \
@@ -273,7 +282,15 @@ args_json=$(jq -n \
   }') || { echo "ERROR: args_json の jq 構築に失敗しました" >&2; exit 1; }
 
 result=$(bash {plugin_root}/scripts/create-issue-with-projects.sh "$args_json") || {
-  echo "ERROR: create-issue-with-projects.sh failed (exit $?)" >&2
+  rc=$?
+  echo "ERROR: create-issue-with-projects.sh failed (exit $rc)" >&2
+  # helper は失敗時も stdout JSON (warnings に原因を記録) を出力するため、捕捉済み $result を
+  # 破棄せず surface する (これが無いと gh の失敗理由がユーザーに一切見えない)
+  if [ -n "$result" ]; then
+    echo "  helper result:" >&2
+    printf '%s\n' "$result" | sed 's/^/    /' >&2
+    printf '%s\n' "$result" | jq -r '.warnings[]?' 2>/dev/null | sed 's/^/  ⚠️ /' >&2
+  fi
   exit 1
 }
 


### PR DESCRIPTION
## 概要

新規リポジトリ (GitHub デフォルトラベルのみ) で `/rite:issue-create` がラベル未存在を理由に失敗しないよう、labels の各ラベルを Issue 作成前に冪等作成する。あわせて helper (`create-issue-with-projects.sh`) 失敗時に、捕捉済み stdout JSON (`warnings` に原因が記録済み) を surface して原因を可視化する。

## 関連 Issue

Closes #1829

## 変更内容

- `plugins/rite/skills/issue-create/SKILL.md` (ステップ 4.3):
  - labels_json 構築直後に `gh label create X ... 2>/dev/null || true` の冪等事前作成ループを追加 (cleanup の既存パターンを踏襲。空 labels はループ 0 回で従来動作)
  - helper 失敗分岐で捕捉済み `$result` (JSON 全体 + `warnings` 抽出) を stderr に surface
- `plugins/rite/scripts/decompose-issues.sh`:
  - 親 Issue 作成前に同じ冪等事前作成ループを追加 (decompose 経由も同 helper で同じ失敗が起きることを確認。親 labels = `epic` + labels_csv は sub labels の上位集合のため、この 1 箇所で Sub-Issue 一括作成分もカバー)

## 実装中の判断・計画逸脱

- 判断: decompose 経由の同処置は `decompose-issues.sh` 側に配置 — Issue の In Scope 2「decompose 経由でも同じ失敗が起きるかの確認と、必要なら同処置」に該当。helper (`create-issue-with-projects.sh`) 本体は Non-Target のため不変
- 判断: 事前作成の失敗 (権限不足等) は `2>/dev/null || true` で無視 — 真の失敗は `gh issue create` 側で顕在化し、追加した `$result` surface で原因が見える (Issue 4.5 のエラー方針どおり)

## チェックリスト

- [x] AC-1: 未存在ラベルでの作成成功 (事前作成ループが helper 呼び出し前に実行される)
- [x] AC-2: 既存ラベルの冪等性 (`|| true` で既存時のエラーを無視、空 labels は前処理スキップ)
- [x] AC-3: 失敗時の原因可視化 (`$result` の JSON + warnings を stderr に表示)
- [x] `create-md-invocation-symmetry.test.sh` PASS 25/0 (単一 JSON 引数契約は不変)
- [x] `bash -n decompose-issues.sh` 構文チェック PASS
