### PR TITLE
fix(skills): multi_session の dirty main checkout ガードを open / cleanup に追加

### DIFF
--- a/plugins/rite/hooks/tests/base-update-classify.test.sh
+++ b/plugins/rite/hooks/tests/base-update-classify.test.sh
@@ -12,13 +12,13 @@
 #
 # 回帰 pin の背景 (Issue #1832 review cycles):
 # - TC-2: tree 全体比較はマージが追加したファイルを D と数え discardable を divergent に
-#   誤流出させた (cycle 2 F-01)。pathspec 限定後の正分類を pin
-# - TC-4: grep '^[^ ?]' は untracked (??) を素通りさせた (cycle 3 F-11)。混在 dirty の
+#   誤流出させた。pathspec 限定後の正分類を pin
+# - TC-4: grep '^[^ ?]' は untracked (??) を素通りさせた。混在 dirty の
 #   divergent 分類を pin
-# - TC-5: staged を含む dirty は working tree 比較で内容検証できない (cycle 2 F-08)
+# - TC-5: staged を含む dirty は working tree 比較で内容検証できない。divergent 分類を pin
 # - TC-6: 非 -z の --name-only は quotePath がファイル名を C-quote し、pathspec 不一致の
 #   git diff --quiet が exit 0 を返して相違変更が discardable に誤流出、破棄承認で
-#   データ喪失した (cycle 3 F-10)。非 ASCII 名の相違が divergent に落ちることを pin
+#   データ喪失した。非 ASCII 名の相違が divergent に落ちることを pin
 
 set -uo pipefail
 
@@ -52,9 +52,10 @@ classify() {
 # --- sandbox: origin + main clone ---
 ORIGIN="$TEST_DIR/origin.git"
 REPO="$TEST_DIR/repo"
-git init -q --bare -b main "$ORIGIN"
-git clone -q "$ORIGIN" "$REPO" 2>/dev/null
-cd "$REPO"
+git init -q --bare -b main "$ORIGIN" || { echo "FATAL: sandbox origin init 失敗"; exit 1; }
+git clone -q "$ORIGIN" "$REPO" 2>/dev/null || { echo "FATAL: sandbox clone 失敗"; exit 1; }
+# cd 失敗のまま続行すると後続の破壊的 git 操作 (add/commit/checkout/reset) が親 repo に向く
+cd "$REPO" || { echo "FATAL: sandbox cd 失敗"; exit 1; }
 git config user.email test@example.com
 git config user.name test
 git switch -qc main 2>/dev/null || true
@@ -97,7 +98,7 @@ r=$(classify)
 [ "$r" = "ff_failed_divergent" ] && pass "TC-3 ($r)" || fail "TC-3: expected ff_failed_divergent, got '$r'"
 git checkout -- :/
 
-# ─── TC-4: unstaged 同一 + untracked 混在 → divergent (F-11 回帰) ───
+# ─── TC-4: unstaged 同一 + untracked 混在 → divergent (untracked 混在の回帰 pin) ───
 echo "TC-4: identical unstaged + untracked mix -> divergent"
 echo "v2" > file.txt
 echo "brand-new" > untracked-new.txt
@@ -105,21 +106,22 @@ r=$(classify)
 [ "$r" = "ff_failed_divergent" ] && pass "TC-4 ($r)" || fail "TC-4: expected ff_failed_divergent, got '$r'"
 rm -f untracked-new.txt && git checkout -- :/
 
-# ─── TC-5: staged 変更を含む dirty → divergent (F-08 回帰) ───
+# ─── TC-5: staged 変更を含む dirty → divergent (staged の回帰 pin) ───
 echo "TC-5: staged change -> divergent"
 echo "STAGED-C" > file.txt && git add file.txt && echo "v2" > file.txt
 r=$(classify)
 [ "$r" = "ff_failed_divergent" ] && pass "TC-5 ($r)" || fail "TC-5: expected ff_failed_divergent, got '$r'"
 git reset -q --hard HEAD
 
-# ─── TC-6: 非 ASCII ファイル名の相違 → divergent (F-10 回帰、quotePath C-quote 経路) ───
+# ─── TC-6: 非 ASCII ファイル名の相違 → divergent (quotePath C-quote 経路の回帰 pin) ───
 echo "TC-6: non-ASCII filename divergent -> divergent (quotePath regression)"
 other="$TEST_DIR/other-jp"
 git clone -q "$ORIGIN" "$other" 2>/dev/null
 ( cd "$other" && git config user.email t@e.c && git config user.name t \
   && echo "jp1" > "設計.md" && git add -A && git commit -qm jp && git push -q origin main )
 git fetch -q origin main
-git merge -q --ff-only origin/main
+# setup の ff が失敗すると 設計.md が untracked になり、quotePath 経路を通らず偽 PASS する
+git merge -q --ff-only origin/main || { fail "TC-6 setup: ff-only merge 失敗"; }
 advance_origin "v3" ""
 echo "MY-DIFFERENT-DRAFT" > "設計.md"
 r=$(classify)
@@ -135,7 +137,7 @@ echo "TC-7: clean but behind -> ff_failed_clean"
 r=$(classify)
 [ "$r" = "ff_failed_clean" ] && pass "TC-7 ($r)" || fail "TC-7: expected ff_failed_clean, got '$r'"
 
-# ─── TC-8: subdir cwd から相違変更 → divergent (F-06 回帰、root 固定) ───
+# ─── TC-8: subdir cwd から相違変更 → divergent (root 固定 pathspec の回帰 pin) ───
 echo "TC-8: divergent from subdir cwd -> divergent (root-pinned pathspec)"
 echo "SUBDIR-LOCAL" > file.txt
 r=$(cd sub && bash "$CLASSIFY_SNIPPET" 2>/dev/null | sed -n 's/^\[CONTEXT\] BASE_UPDATE=//p' | head -1)

--- a/plugins/rite/hooks/tests/base-update-classify.test.sh
+++ b/plugins/rite/hooks/tests/base-update-classify.test.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# base-update-classify.test.sh
+#
+# cleanup/SKILL.md ステップ 4 の BASE_UPDATE 検証 block (retry break 後の成否検証) を
+# SKILL.md から literal 抽出して sandbox で実行し、4-way 分類 (ok / ff_failed_clean /
+# ff_failed_discardable / ff_failed_divergent) を pin する。
+#
+# 抽出実行方式の理由: 分類ロジックは SKILL.md 内の bash block テンプレートで、テストへ
+# コピーすると SKILL.md 側の修正がテストに反映されず drift する。抽出アンカー
+# (「# retry break 後の成否検証」〜 outer if の else) が壊れた場合はテスト自体が
+# fail するため、アンカー変更もテストが検出する。
+#
+# 回帰 pin の背景 (Issue #1832 review cycles):
+# - TC-2: tree 全体比較はマージが追加したファイルを D と数え discardable を divergent に
+#   誤流出させた (cycle 2 F-01)。pathspec 限定後の正分類を pin
+# - TC-4: grep '^[^ ?]' は untracked (??) を素通りさせた (cycle 3 F-11)。混在 dirty の
+#   divergent 分類を pin
+# - TC-5: staged を含む dirty は working tree 比較で内容検証できない (cycle 2 F-08)
+# - TC-6: 非 -z の --name-only は quotePath がファイル名を C-quote し、pathspec 不一致の
+#   git diff --quiet が exit 0 を返して相違変更が discardable に誤流出、破棄承認で
+#   データ喪失した (cycle 3 F-10)。非 ASCII 名の相違が divergent に落ちることを pin
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_MD="$SCRIPT_DIR/../../skills/cleanup/SKILL.md"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# --- SKILL.md から検証 block を抽出 ({base_branch} は main に置換) ---
+CLASSIFY_SNIPPET="$TEST_DIR/classify.sh"
+awk '/# retry break 後の成否検証/{f=1} f && /^else$/{exit} f{print}' "$SKILL_MD" \
+  | sed 's/{base_branch}/main/g' > "$CLASSIFY_SNIPPET"
+if ! grep -q 'BASE_UPDATE=ff_failed_discardable' "$CLASSIFY_SNIPPET"; then
+  echo "FAIL: SKILL.md からの検証 block 抽出に失敗しました (アンカーが変更された可能性)"
+  echo "  抽出結果: $(wc -l < "$CLASSIFY_SNIPPET") 行"
+  exit 1
+fi
+
+classify() {
+  # sandbox repo 内 (cwd) で抽出 block を実行し BASE_UPDATE marker 値を返す
+  bash "$CLASSIFY_SNIPPET" 2>/dev/null | sed -n 's/^\[CONTEXT\] BASE_UPDATE=//p' | head -1
+}
+
+# --- sandbox: origin + main clone ---
+ORIGIN="$TEST_DIR/origin.git"
+REPO="$TEST_DIR/repo"
+git init -q --bare -b main "$ORIGIN"
+git clone -q "$ORIGIN" "$REPO" 2>/dev/null
+cd "$REPO"
+git config user.email test@example.com
+git config user.name test
+git switch -qc main 2>/dev/null || true
+echo "v1" > file.txt
+mkdir sub && echo "s1" > sub/inner.txt
+git add -A && git commit -qm init && git push -qu origin main 2>/dev/null
+
+# origin を先行させる helper (別 clone 経由で file.txt 更新 + 新規ファイル追加)
+advance_origin() {
+  local content="$1" newfile="$2"
+  local other="$TEST_DIR/other-$RANDOM"
+  git clone -q "$ORIGIN" "$other" 2>/dev/null
+  ( cd "$other" && git config user.email t@e.c && git config user.name t \
+    && echo "$content" > file.txt \
+    && { [ -n "$newfile" ] && echo new > "$newfile" || true; } \
+    && git add -A && git commit -qm advance && git push -q origin main )
+  git fetch -q origin main
+}
+
+echo "=== BASE_UPDATE classify tests (SKILL.md 抽出実行) ==="
+echo ""
+
+# ─── TC-1: HEAD == origin → ok ───
+echo "TC-1: up-to-date -> ok"
+r=$(classify)
+[ "$r" = "ok" ] && pass "TC-1 ($r)" || fail "TC-1: expected ok, got '$r'"
+
+# ─── TC-2: unstaged tracked 変更が origin と同一 + マージが新規ファイル追加 → discardable ───
+echo "TC-2: unstaged identical (+ merge-added file) -> discardable"
+advance_origin "v2" "added-by-merge.txt"
+echo "v2" > file.txt
+r=$(classify)
+[ "$r" = "ff_failed_discardable" ] && pass "TC-2 ($r)" || fail "TC-2: expected ff_failed_discardable, got '$r'"
+git checkout -- :/
+
+# ─── TC-3: unstaged tracked 変更が origin と相違 → divergent ───
+echo "TC-3: unstaged different -> divergent"
+echo "LOCAL-EDIT" > file.txt
+r=$(classify)
+[ "$r" = "ff_failed_divergent" ] && pass "TC-3 ($r)" || fail "TC-3: expected ff_failed_divergent, got '$r'"
+git checkout -- :/
+
+# ─── TC-4: unstaged 同一 + untracked 混在 → divergent (F-11 回帰) ───
+echo "TC-4: identical unstaged + untracked mix -> divergent"
+echo "v2" > file.txt
+echo "brand-new" > untracked-new.txt
+r=$(classify)
+[ "$r" = "ff_failed_divergent" ] && pass "TC-4 ($r)" || fail "TC-4: expected ff_failed_divergent, got '$r'"
+rm -f untracked-new.txt && git checkout -- :/
+
+# ─── TC-5: staged 変更を含む dirty → divergent (F-08 回帰) ───
+echo "TC-5: staged change -> divergent"
+echo "STAGED-C" > file.txt && git add file.txt && echo "v2" > file.txt
+r=$(classify)
+[ "$r" = "ff_failed_divergent" ] && pass "TC-5 ($r)" || fail "TC-5: expected ff_failed_divergent, got '$r'"
+git reset -q --hard HEAD
+
+# ─── TC-6: 非 ASCII ファイル名の相違 → divergent (F-10 回帰、quotePath C-quote 経路) ───
+echo "TC-6: non-ASCII filename divergent -> divergent (quotePath regression)"
+other="$TEST_DIR/other-jp"
+git clone -q "$ORIGIN" "$other" 2>/dev/null
+( cd "$other" && git config user.email t@e.c && git config user.name t \
+  && echo "jp1" > "設計.md" && git add -A && git commit -qm jp && git push -q origin main )
+git fetch -q origin main
+git merge -q --ff-only origin/main
+advance_origin "v3" ""
+echo "MY-DIFFERENT-DRAFT" > "設計.md"
+r=$(classify)
+if [ "$r" = "ff_failed_divergent" ]; then
+  pass "TC-6 ($r)"
+else
+  fail "TC-6: expected ff_failed_divergent, got '$r' (quotePath 誤分類の再発 = 破棄承認でデータ喪失)"
+fi
+git checkout -- :/
+
+# ─── TC-7: clean だが履歴 behind (ff 失敗相当) → ff_failed_clean ───
+echo "TC-7: clean but behind -> ff_failed_clean"
+r=$(classify)
+[ "$r" = "ff_failed_clean" ] && pass "TC-7 ($r)" || fail "TC-7: expected ff_failed_clean, got '$r'"
+
+# ─── TC-8: subdir cwd から相違変更 → divergent (F-06 回帰、root 固定) ───
+echo "TC-8: divergent from subdir cwd -> divergent (root-pinned pathspec)"
+echo "SUBDIR-LOCAL" > file.txt
+r=$(cd sub && bash "$CLASSIFY_SNIPPET" 2>/dev/null | sed -n 's/^\[CONTEXT\] BASE_UPDATE=//p' | head -1)
+[ "$r" = "ff_failed_divergent" ] && pass "TC-8 ($r)" || fail "TC-8: expected ff_failed_divergent, got '$r'"
+git checkout -- :/
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -365,11 +365,38 @@ cur_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || cur_branch=""
 if [ "$cur_branch" = "{base_branch}" ]; then
   # index.lock 競合 3 回リトライ
   n=0; until git fetch origin {base_branch} 2>/dev/null && git merge --ff-only origin/{base_branch} 2>/dev/null; do n=$((n+1)); [ "$n" -ge 3 ] && { echo "WARNING: base 更新 (git fetch + git merge --ff-only origin/{base_branch}) が失敗しました (index.lock 競合 / fast-forward 不可 / コンフリクトの可能性)。git status で確認してください。" >&2; break; }; sleep 1; done
+  # retry break 後の成否検証 (Issue #1832): 失敗を silent に放置せず復旧分岐へ routing する。
+  # 典型例は「PR マージ済み内容と同じファイルの未コミット変更が残存し ff-only が上書き拒否する」ケース
+  if [ "$(git rev-parse HEAD 2>/dev/null)" = "$(git rev-parse origin/{base_branch} 2>/dev/null)" ]; then
+    echo "[CONTEXT] BASE_UPDATE=ok"
+  else
+    _bu_dirty=$(git status --porcelain 2>/dev/null) || _bu_dirty=""
+    if [ -z "$_bu_dirty" ]; then
+      echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
+    elif git diff --quiet "origin/{base_branch}" 2>/dev/null; then
+      # working tree の内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一
+      echo "[CONTEXT] BASE_UPDATE=ff_failed_discardable"
+      printf '%s\n' "$_bu_dirty"
+    else
+      echo "[CONTEXT] BASE_UPDATE=ff_failed_divergent"
+      printf '%s\n' "$_bu_dirty"
+    fi
+  fi
 else
   echo "WARNING: main checkout が '{base_branch}' ではなく '$cur_branch' 上にあるため base 更新を skip しました。" >&2
   echo "  復旧手順: 別の作業が無いことを確認のうえ 'git switch {base_branch}' で main checkout を base に戻してから再実行してください（rite は multi_session モードで main checkout のカレントブランチを切り替えません）。" >&2
+  echo "[CONTEXT] BASE_UPDATE=skipped_not_on_base"
 fi
 ```
+
+`BASE_UPDATE` marker で分岐する（Issue #1832。破棄・stash は必ずユーザー確認を挟み、無確認の破壊的操作をしない）:
+
+| `BASE_UPDATE` | アクション |
+|---|---|
+| `ok` / `skipped_not_on_base` | 従来どおり後続へ（`skipped_not_on_base` は既存 WARNING の可視化のみ） |
+| `ff_failed_clean` | 未コミット変更なしの ff 失敗（履歴 diverge / index.lock 恒常化等）。既存 WARNING どおり `git status` 確認を案内し、非ブロッキングで後続へ |
+| `ff_failed_discardable` | 未コミット変更が **origin/{base_branch} と diff 同一**（マージ済み内容の残存）。AskUserQuestion「diff 同一を確認済み。未コミット変更を破棄して base 更新を再実行 / そのまま続行（手動対応）」を表示。**承認後のみ** `git checkout -- .` で破棄し、上記 retry ループを 1 回再実行して `BASE_UPDATE=ok` を確認する |
+| `ff_failed_divergent` | 未コミット変更がマージ済み内容と**異なる**。stash 案内を表示して terminate（データ喪失なし）: `git stash push -u -m "rite-cleanup: manual-stash before base update (issue-{issue_number})"` を提示し、ユーザー実行後の `/rite:recover` 再開を案内する。自動 stash はしない |
 
 > **multi_session 無効（従来モード）の場合**: 従来どおり `git checkout {base_branch} && git fetch origin {base_branch} && git merge --ff-only origin/{base_branch}` を実行する（base branch 以外にいて未コミット変更があれば「stash して続行 / キャンセル」を確認。stash は `git stash push -m "rite-cleanup: auto-stash before cleanup"`）。fast-forward 不可 / コンフリクト時は `git status` で確認・解決後の再実行を案内し terminate。
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -373,25 +373,26 @@ if [ "$cur_branch" = "{base_branch}" ]; then
     _bu_dirty=$(git status --porcelain 2>/dev/null) || _bu_dirty=""
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
-    elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ?]'; then
-      # untracked (??) または staged 変更 (index status 列が非空白) を含む dirty は
-      # diff 同一性を機械判定できない — 下記比較は working tree しか見ないため、untracked は
-      # 比較対象外、staged 内容は未検証のまま「diff 同一」を主張することになる。
-      # 安全側の divergent へ倒す (stash 案内は -u で untracked も対象に含む)
+    elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ]'; then
+      # X 列 (index status、行頭 1 文字) が非空白 = staged 変更または untracked (??) を含む dirty。
+      # いずれも diff 同一性を機械判定できない — 下記比較は working tree しか見ないため、untracked
+      # は比較対象外、staged 内容は未検証のまま「diff 同一」を主張することになる。
+      # 安全側の divergent へ倒す (stash 案内は -u で untracked も対象に含む)。
+      # unstaged のみの変更 (X 列が空白: " M" / " D") だけが下の比較へ進む
       echo "[CONTEXT] BASE_UPDATE=ff_failed_divergent"
     else
       # unstaged の tracked 変更のみ: 比較を dirty パスに限定する。tree 全体比較 (pathspec なし)
       # はマージが追加/削除した無関係ファイルまで D として数え、diff 同一の残存変更を divergent に
       # 誤流出させる。pathspec は root 相対で出力されるため消費側も -C <root> で root 起点に固定
-      # する (cwd がサブディレクトリだと pathspec 不一致の空比較が discardable を偽装する)。
-      # 空リスト (name-only が失敗/空) も比較せず discardable にしない
-      # パスは改行区切りで保持し xargs 直前に NUL 区切りへ変換する (-z の NUL は command
-      # substitution が落とすため変数経由で使えない。改行入りファイル名は quotePath で C-quote
-      # され pathspec 不一致 → divergent の安全側に落ちる)
+      # し (--no-relative は diff.relative config の影響排除)、空リストは比較せず discardable に
+      # しない。比較 pipe は -z (NUL 区切り・quote なし) を xargs -0 へ直結する — 非 -z 出力は
+      # quotePath がファイル名を C-quote し、quote 済みリテラルの pathspec は実ファイルに不一致
+      # → git diff --quiet が exit 0 (差分なし扱い) を返して相違変更が discardable に誤流出する
+      # (NUL を command substitution の変数に入れると bash が落とすため、非空判定のみ別変数で行う)
       _bu_root=$(git rev-parse --show-toplevel 2>/dev/null) || _bu_root=""
       _bu_paths=$(git diff --name-only HEAD 2>/dev/null) || _bu_paths=""
       if [ -n "$_bu_root" ] && [ -n "$_bu_paths" ] && \
-         printf '%s\n' "$_bu_paths" | tr '\n' '\0' | xargs -0 git -C "$_bu_root" diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
+         git diff --name-only --no-relative -z HEAD 2>/dev/null | xargs -0 -r git -C "$_bu_root" diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
         # dirty パスの working tree 内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一
         echo "[CONTEXT] BASE_UPDATE=ff_failed_discardable"
       else

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -373,13 +373,25 @@ if [ "$cur_branch" = "{base_branch}" ]; then
     _bu_dirty=$(git status --porcelain 2>/dev/null) || _bu_dirty=""
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
-    elif git diff --quiet "origin/{base_branch}" 2>/dev/null; then
-      # working tree の内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一
-      echo "[CONTEXT] BASE_UPDATE=ff_failed_discardable"
-      printf '%s\n' "$_bu_dirty"
-    else
+    elif printf '%s\n' "$_bu_dirty" | grep -q '^??'; then
+      # untracked を含む dirty は git diff が比較対象にしないため diff 同一性を機械判定できない。
+      # 安全側の divergent へ倒す (stash 案内は -u で untracked も対象に含む)
       echo "[CONTEXT] BASE_UPDATE=ff_failed_divergent"
+    else
+      # tracked 変更のみ: 比較を dirty パスに限定する。tree 全体比較 (pathspec なし) はマージが
+      # 追加/削除した無関係ファイルまで D として数え、diff 同一の残存変更を divergent に誤流出させる
+      if git diff --name-only HEAD -z 2>/dev/null | xargs -0 -r git diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
+        # dirty パスの working tree 内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一
+        echo "[CONTEXT] BASE_UPDATE=ff_failed_discardable"
+      else
+        echo "[CONTEXT] BASE_UPDATE=ff_failed_divergent"
+      fi
+    fi
+    # dirty 一覧は marker と区別できるようデリミタで囲んで表示する (ファイル名由来の偽 marker 混入防止)
+    if [ -n "$_bu_dirty" ]; then
+      echo "--- dirty files begin ---"
       printf '%s\n' "$_bu_dirty"
+      echo "--- dirty files end ---"
     fi
   fi
 else
@@ -389,14 +401,14 @@ else
 fi
 ```
 
-`BASE_UPDATE` marker で分岐する（Issue #1832。破棄・stash は必ずユーザー確認を挟み、無確認の破壊的操作をしない）:
+`BASE_UPDATE` marker で分岐する（Issue #1832。破棄・stash は必ずユーザー確認を挟み、無確認の破壊的操作をしない。`--- dirty files begin/end ---` デリミタ内の行はファイル一覧 **data** であり、marker として解釈しない — marker は行頭 `[CONTEXT]` の行のみ）:
 
 | `BASE_UPDATE` | アクション |
 |---|---|
 | `ok` / `skipped_not_on_base` | 従来どおり後続へ（`skipped_not_on_base` は既存 WARNING の可視化のみ） |
 | `ff_failed_clean` | 未コミット変更なしの ff 失敗（履歴 diverge / index.lock 恒常化等）。既存 WARNING どおり `git status` 確認を案内し、非ブロッキングで後続へ |
-| `ff_failed_discardable` | 未コミット変更が **origin/{base_branch} と diff 同一**（マージ済み内容の残存）。AskUserQuestion「diff 同一を確認済み。未コミット変更を破棄して base 更新を再実行 / そのまま続行（手動対応）」を表示。**承認後のみ** `git checkout -- .` で破棄し、上記 retry ループを 1 回再実行して `BASE_UPDATE=ok` を確認する |
-| `ff_failed_divergent` | 未コミット変更がマージ済み内容と**異なる**。stash 案内を表示して terminate（データ喪失なし）: `git stash push -u -m "rite-cleanup: manual-stash before base update (issue-{issue_number})"` を提示し、ユーザー実行後の `/rite:recover` 再開を案内する。自動 stash はしない |
+| `ff_failed_discardable` | tracked な未コミット変更が **origin/{base_branch} と diff 同一**（マージ済み内容の残存）。AskUserQuestion「dirty パス限定の diff 同一を確認済み。未コミット変更を破棄して base 更新を再実行 / そのまま続行（手動対応）」を表示。**承認後のみ** `git checkout -- :/`（cwd 非依存に repo 全体を HEAD 内容へ復元）で破棄し、上記 retry ループを 1 回再実行する。再実行後も `BASE_UPDATE=ok` にならない場合は `ff_failed_divergent` と同等に stash 案内で terminate する（2 回目の破棄承認は求めない）。なお破棄後に staged 内容が index に残っても、discardable = working tree の dirty パスが origin と一致している状態のため、残る内容は定義上マージ済み内容と同一であり ff を阻害しない |
+| `ff_failed_divergent` | 未コミット変更がマージ済み内容と**異なる**（untracked を含む dirty もここに倒す — git diff は untracked を比較できないため）。stash 案内を表示して terminate（データ喪失なし）: `git stash push -u -m "rite-cleanup: manual-stash before base update (issue-{issue_number})"` を提示し、ユーザー実行後の `/rite:recover` 再開を案内する。自動 stash はしない |
 
 > **multi_session 無効（従来モード）の場合**: 従来どおり `git checkout {base_branch} && git fetch origin {base_branch} && git merge --ff-only origin/{base_branch}` を実行する（base branch 以外にいて未コミット変更があれば「stash して続行 / キャンセル」を確認。stash は `git stash push -m "rite-cleanup: auto-stash before cleanup"`）。fast-forward 不可 / コンフリクト時は `git status` で確認・解決後の再実行を案内し terminate。
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -373,14 +373,25 @@ if [ "$cur_branch" = "{base_branch}" ]; then
     _bu_dirty=$(git status --porcelain 2>/dev/null) || _bu_dirty=""
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
-    elif printf '%s\n' "$_bu_dirty" | grep -q '^??'; then
-      # untracked を含む dirty は git diff が比較対象にしないため diff 同一性を機械判定できない。
+    elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ?]'; then
+      # untracked (??) または staged 変更 (index status 列が非空白) を含む dirty は
+      # diff 同一性を機械判定できない — 下記比較は working tree しか見ないため、untracked は
+      # 比較対象外、staged 内容は未検証のまま「diff 同一」を主張することになる。
       # 安全側の divergent へ倒す (stash 案内は -u で untracked も対象に含む)
       echo "[CONTEXT] BASE_UPDATE=ff_failed_divergent"
     else
-      # tracked 変更のみ: 比較を dirty パスに限定する。tree 全体比較 (pathspec なし) はマージが
-      # 追加/削除した無関係ファイルまで D として数え、diff 同一の残存変更を divergent に誤流出させる
-      if git diff --name-only HEAD -z 2>/dev/null | xargs -0 -r git diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
+      # unstaged の tracked 変更のみ: 比較を dirty パスに限定する。tree 全体比較 (pathspec なし)
+      # はマージが追加/削除した無関係ファイルまで D として数え、diff 同一の残存変更を divergent に
+      # 誤流出させる。pathspec は root 相対で出力されるため消費側も -C <root> で root 起点に固定
+      # する (cwd がサブディレクトリだと pathspec 不一致の空比較が discardable を偽装する)。
+      # 空リスト (name-only が失敗/空) も比較せず discardable にしない
+      # パスは改行区切りで保持し xargs 直前に NUL 区切りへ変換する (-z の NUL は command
+      # substitution が落とすため変数経由で使えない。改行入りファイル名は quotePath で C-quote
+      # され pathspec 不一致 → divergent の安全側に落ちる)
+      _bu_root=$(git rev-parse --show-toplevel 2>/dev/null) || _bu_root=""
+      _bu_paths=$(git diff --name-only HEAD 2>/dev/null) || _bu_paths=""
+      if [ -n "$_bu_root" ] && [ -n "$_bu_paths" ] && \
+         printf '%s\n' "$_bu_paths" | tr '\n' '\0' | xargs -0 git -C "$_bu_root" diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
         # dirty パスの working tree 内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一
         echo "[CONTEXT] BASE_UPDATE=ff_failed_discardable"
       else
@@ -407,8 +418,8 @@ fi
 |---|---|
 | `ok` / `skipped_not_on_base` | 従来どおり後続へ（`skipped_not_on_base` は既存 WARNING の可視化のみ） |
 | `ff_failed_clean` | 未コミット変更なしの ff 失敗（履歴 diverge / index.lock 恒常化等）。既存 WARNING どおり `git status` 確認を案内し、非ブロッキングで後続へ |
-| `ff_failed_discardable` | tracked な未コミット変更が **origin/{base_branch} と diff 同一**（マージ済み内容の残存）。AskUserQuestion「dirty パス限定の diff 同一を確認済み。未コミット変更を破棄して base 更新を再実行 / そのまま続行（手動対応）」を表示。**承認後のみ** `git checkout -- :/`（cwd 非依存に repo 全体を HEAD 内容へ復元）で破棄し、上記 retry ループを 1 回再実行する。再実行後も `BASE_UPDATE=ok` にならない場合は `ff_failed_divergent` と同等に stash 案内で terminate する（2 回目の破棄承認は求めない）。なお破棄後に staged 内容が index に残っても、discardable = working tree の dirty パスが origin と一致している状態のため、残る内容は定義上マージ済み内容と同一であり ff を阻害しない |
-| `ff_failed_divergent` | 未コミット変更がマージ済み内容と**異なる**（untracked を含む dirty もここに倒す — git diff は untracked を比較できないため）。stash 案内を表示して terminate（データ喪失なし）: `git stash push -u -m "rite-cleanup: manual-stash before base update (issue-{issue_number})"` を提示し、ユーザー実行後の `/rite:recover` 再開を案内する。自動 stash はしない |
+| `ff_failed_discardable` | **unstaged の tracked 変更のみ**の dirty で、その全パスが **origin/{base_branch} と diff 同一**（マージ済み内容の残存）。AskUserQuestion「dirty パス限定の diff 同一を確認済み。未コミット変更を破棄して base 更新を再実行 / そのまま続行（手動対応）」を表示。**承認後のみ** `git checkout -- :/`（cwd 非依存に repo 全体を index 内容へ復元。discardable は staged なしを判定済みのため index == HEAD であり、HEAD 内容への復元と等価）で破棄し、上記 retry ループを 1 回再実行する。再実行後も `BASE_UPDATE=ok` にならない場合は `ff_failed_divergent` と同等に stash 案内で terminate する（2 回目の破棄承認は求めない） |
+| `ff_failed_divergent` | 未コミット変更がマージ済み内容と**異なる**か、diff 同一性を機械判定できない dirty（untracked は git diff が比較できず、staged 変更は working tree 比較で内容を検証できないため、いずれもここに倒す）。stash 案内を表示して terminate（データ喪失なし）: `git stash push -u -m "rite-cleanup: manual-stash before base update (issue-{issue_number})"` を提示し、ユーザー実行後の `/rite:recover` 再開を案内する。自動 stash はしない |
 
 > **multi_session 無効（従来モード）の場合**: 従来どおり `git checkout {base_branch} && git fetch origin {base_branch} && git merge --ff-only origin/{base_branch}` を実行する（base branch 以外にいて未コミット変更があれば「stash して続行 / キャンセル」を確認。stash は `git stash push -m "rite-cleanup: auto-stash before cleanup"`）。fast-forward 不可 / コンフリクト時は `git status` で確認・解決後の再実行を案内し terminate。
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -390,7 +390,7 @@ if [ "$cur_branch" = "{base_branch}" ]; then
       # → git diff --quiet が exit 0 (差分なし扱い) を返して相違変更が discardable に誤流出する
       # (NUL を command substitution の変数に入れると bash が落とすため、非空判定のみ別変数で行う)
       _bu_root=$(git rev-parse --show-toplevel 2>/dev/null) || _bu_root=""
-      _bu_paths=$(git diff --name-only HEAD 2>/dev/null) || _bu_paths=""
+      _bu_paths=$(git diff --name-only --no-relative HEAD 2>/dev/null) || _bu_paths=""
       if [ -n "$_bu_root" ] && [ -n "$_bu_paths" ] && \
          git diff --name-only --no-relative -z HEAD 2>/dev/null | xargs -0 -r git -C "$_bu_root" diff --quiet "origin/{base_branch}" -- 2>/dev/null; then
         # dirty パスの working tree 内容が origin/{base} と一致 = 未コミット変更はマージ済み内容と diff 同一

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -285,7 +285,7 @@ fi
 
 重なりあり時の AskUserQuestion（3 択）:
 
-- **搬送して続行**: worktree 作成 + 2.3-W 入場の後、重なった dirty ファイルを worktree へ搬送する（modified / untracked が対象。削除された Target File は搬送対象外として一覧にその旨を表示）。転送元ルートは 2.2-W の `[CONTEXT] MAIN_CHECKOUT_ROOT=` の値を使う（**cwd=worktree で `git rev-parse --show-toplevel` を再計算してはならない** — worktree root が返り、clean な base 版を搬送元に誤解決する）。各ファイルにつき `mkdir -p "$(dirname "{wt_path}/{relpath}")" && cp "{main_checkout_root}/{relpath}" "{wt_path}/{relpath}"` を実行する（`{relpath}` は porcelain 行のパス。rename 行 `R old -> new` は `->` 右側の new を使う）。main checkout 側の変更はそのまま残す（破棄しない）
+- **搬送して続行**: worktree 作成 + 2.3-W 入場の後、重なった dirty ファイルを worktree へ搬送する（modified / untracked が対象。削除された Target File は搬送対象外として一覧にその旨を表示）。転送元ルートは 2.2-W の `[CONTEXT] MAIN_CHECKOUT_ROOT=` の値を使う（**cwd=worktree で `git rev-parse --show-toplevel` を再計算してはならない** — worktree root が返り、clean な base 版を搬送元に誤解決する）。各ファイルにつき `mkdir -p "$(dirname "{wt_path}/{relpath}")" && cp "{main_checkout_root}/{relpath}" "{wt_path}/{relpath}"` を実行する（`{relpath}` は porcelain 行から抽出したパス: 行頭 3 文字の status 部（`XY␠`）を除き、`"` で囲まれた行は unquote し、rename 行 `R old -> new` は `->` 右側の new を使い、`?? dir/` に畳まれた untracked ディレクトリは `cp -r` で搬送する）。main checkout 側の変更はそのまま残す（破棄しない）
 - **そのまま続行**: 搬送せず worktree を作成する（未コミット変更は worktree に含まれないことを了解済みとして続行）
 - **中止**: workflow を終了し、main checkout を無変更で残す
 

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -224,6 +224,21 @@ wt_path="$repo_root/$wt_rel"
 branch="{branch_name}"
 base="{base_branch}"
 
+# dirty main checkout 検出 (Issue #1832): worktree は origin/{base} 起点で作られるため、
+# main checkout の未コミット変更は構造的に引き継がれない。作業対象と重なる変更が警告なく
+# worktree から欠落するのを防ぐ (git status 失敗時はガード skip = 従来挙動で続行)
+if _dirty_files=$(git -C "$repo_root" status --porcelain 2>/dev/null); then
+  if [ -n "$_dirty_files" ]; then
+    echo "[CONTEXT] MAIN_DIRTY=yes"
+    printf '%s\n' "$_dirty_files"
+  else
+    echo "[CONTEXT] MAIN_DIRTY=no"
+  fi
+else
+  echo "WARNING: git status の実行に失敗したため dirty main checkout ガードを skip します (従来挙動で続行)" >&2
+  echo "[CONTEXT] MAIN_DIRTY=unknown"
+fi
+
 # ref lock 競合対策の 3 回リトライ (references/git-worktree-patterns.md 参照)
 n=0; until git fetch origin "$base" 2>/dev/null; do n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 1; done
 
@@ -256,6 +271,21 @@ fi
 | `branch_only` | branch 存在・worktree なし → `git worktree add "{path}" "{branch}"`（`-b` なし） |
 | `create_new` | branch も worktree もなし → `git worktree add -b "{branch}" "{path}" "origin/{base_branch}"` |
 | `branch_other_worktree` | branch が**別の worktree** で checkout 中 → **中止**（他セッション作業中の可能性。`other=` のパスを表示。git が構造的に保証する二重着手ガード） |
+
+**dirty main checkout ガード（Issue #1832）**: 上記 bash block の `MAIN_DIRTY` marker で分岐する。`WT_CASE` が worktree を**新規作成する**場合（`branch_only` / `create_new`。`reuse` は既存 worktree 継続のため対象外）のみ、`git worktree add` を実行する**前に**評価する:
+
+| `MAIN_DIRTY` | アクション |
+|---|---|
+| `no` / `unknown` | ガードなしで従来どおり続行（`unknown` = git status 失敗、WARNING は bash block が emit 済み） |
+| `yes` | LLM が dirty ファイル一覧（bash block が出力した porcelain 行）と Issue 本文の **Target Files（Section 4.1 の表）/ 変更予定領域** を突合する。**重なりなし** → 従来どおり続行（確認なし）。**重なりあり** → 下記 AskUserQuestion を表示し、確認なしに `git worktree add` へ進まない |
+
+重なりあり時の AskUserQuestion（3 択）:
+
+- **搬送して続行**: worktree 作成 + 2.3-W 入場の後、重なった dirty ファイルを `cp` で worktree の同相対パスへ搬送する（modified / untracked が対象。削除された Target File は搬送対象外として一覧にその旨を表示）。main checkout 側の変更はそのまま残す（破棄しない）
+- **そのまま続行**: 搬送せず worktree を作成する（未コミット変更は worktree に含まれないことを了解済みとして続行）
+- **中止**: workflow を終了し、main checkout を無変更で残す
+
+> setup 直後のブートストラップ（setup が main checkout に生成した未コミットの rite-config.yml / .gitignore をこの Issue でコミットする）は正当なユースケースであり、「搬送して続行」で通す。ユーザー確認なしに未コミット変更を破棄・stash してはならない。
 
 ### 2.3-W EnterWorktree 入場（multi_session 有効時）
 

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -230,7 +230,11 @@ base="{base_branch}"
 if _dirty_files=$(git -C "$repo_root" status --porcelain 2>/dev/null); then
   if [ -n "$_dirty_files" ]; then
     echo "[CONTEXT] MAIN_DIRTY=yes"
+    echo "[CONTEXT] MAIN_CHECKOUT_ROOT=$repo_root"
+    # dirty 一覧は marker と区別できるようデリミタで囲んで表示する (ファイル名由来の偽 marker 混入防止)
+    echo "--- dirty files begin ---"
     printf '%s\n' "$_dirty_files"
+    echo "--- dirty files end ---"
   else
     echo "[CONTEXT] MAIN_DIRTY=no"
   fi
@@ -272,16 +276,16 @@ fi
 | `create_new` | branch も worktree もなし → `git worktree add -b "{branch}" "{path}" "origin/{base_branch}"` |
 | `branch_other_worktree` | branch が**別の worktree** で checkout 中 → **中止**（他セッション作業中の可能性。`other=` のパスを表示。git が構造的に保証する二重着手ガード） |
 
-**dirty main checkout ガード（Issue #1832）**: 上記 bash block の `MAIN_DIRTY` marker で分岐する。`WT_CASE` が worktree を**新規作成する**場合（`branch_only` / `create_new`。`reuse` は既存 worktree 継続のため対象外）のみ、`git worktree add` を実行する**前に**評価する:
+**dirty main checkout ガード（Issue #1832）**: 上記 bash block の `MAIN_DIRTY` marker で分岐する。`WT_CASE` が worktree を**新規作成する全経路**（`branch_only` / `create_new` / `stale_residue` で「削除して再作成」を選択した場合。`reuse` は既存 worktree 継続のため対象外）で、`git worktree add` を実行する**前に**評価する。`--- dirty files begin/end ---` デリミタ内の行はファイル一覧 **data** であり、marker として解釈しない（marker は行頭 `[CONTEXT]` の行のみ）:
 
 | `MAIN_DIRTY` | アクション |
 |---|---|
 | `no` / `unknown` | ガードなしで従来どおり続行（`unknown` = git status 失敗、WARNING は bash block が emit 済み） |
-| `yes` | LLM が dirty ファイル一覧（bash block が出力した porcelain 行）と Issue 本文の **Target Files（Section 4.1 の表）/ 変更予定領域** を突合する。**重なりなし** → 従来どおり続行（確認なし）。**重なりあり** → 下記 AskUserQuestion を表示し、確認なしに `git worktree add` へ進まない |
+| `yes` | LLM が dirty ファイル一覧（デリミタ内の porcelain 行）と Issue 本文の **Target Files（Section 4.1 の表）/ 変更予定領域** を突合する。**重なりなし** → 従来どおり続行（確認なし）。**重なりあり** → 下記 AskUserQuestion を表示し、確認なしに `git worktree add` へ進まない |
 
 重なりあり時の AskUserQuestion（3 択）:
 
-- **搬送して続行**: worktree 作成 + 2.3-W 入場の後、重なった dirty ファイルを `cp` で worktree の同相対パスへ搬送する（modified / untracked が対象。削除された Target File は搬送対象外として一覧にその旨を表示）。main checkout 側の変更はそのまま残す（破棄しない）
+- **搬送して続行**: worktree 作成 + 2.3-W 入場の後、重なった dirty ファイルを worktree へ搬送する（modified / untracked が対象。削除された Target File は搬送対象外として一覧にその旨を表示）。転送元ルートは 2.2-W の `[CONTEXT] MAIN_CHECKOUT_ROOT=` の値を使う（**cwd=worktree で `git rev-parse --show-toplevel` を再計算してはならない** — worktree root が返り、clean な base 版を搬送元に誤解決する）。各ファイルにつき `mkdir -p "$(dirname "{wt_path}/{relpath}")" && cp "{main_checkout_root}/{relpath}" "{wt_path}/{relpath}"` を実行する（`{relpath}` は porcelain 行のパス。rename 行 `R old -> new` は `->` 右側の new を使う）。main checkout 側の変更はそのまま残す（破棄しない）
 - **そのまま続行**: 搬送せず worktree を作成する（未コミット変更は worktree に含まれないことを了解済みとして続行）
 - **中止**: workflow を終了し、main checkout を無変更で残す
 


### PR DESCRIPTION
## 概要

multi_session 経路で main checkout に未コミット変更がある場合のガードを open / cleanup に追加する。

Closes #1832

## 変更内容

- **open 2.2-W**: worktree 作成前に `git status --porcelain` で dirty main checkout を検出 (`MAIN_DIRTY` marker)。未コミット変更が Issue の Target Files に重なる場合のみ AskUserQuestion（搬送して続行 / そのまま続行 / 中止）を表示し、確認なしに worktree 作成へ進まない。重ならない場合・clean 時は従来と完全一致
- **cleanup ステップ 4**: `git merge --ff-only` の 3 回リトライ全滅後に成否検証 (`BASE_UPDATE` marker) を追加。未コミット変更が origin/{base} と diff 同一なら破棄提案（承認後のみ実行）、異なれば stash 案内で terminate。無確認の破棄・stash はしない

## 検証

- bash block ロジックを sandbox で実測: MAIN_DIRTY yes/no、BASE_UPDATE の discardable→破棄→ok / divergent / clean→ok の全分岐を確認 (T-01〜T-05 相当)
- lint: skipped (commands 未設定)

## Known Issues

- なし
