### PR TITLE
chore(setup): plugin パス解決方式間のバージョン不一致を検出し警告する

### DIFF
--- a/plugins/rite/hooks/tests/plugin-path-mismatch-warn.test.sh
+++ b/plugins/rite/hooks/tests/plugin-path-mismatch-warn.test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# plugin-path-mismatch-warn.test.sh
+#
+# setup/SKILL.md 4.5.0 の hooks dir 検出 block を SKILL.md から literal 抽出して実行し、
+# plugin パス解決方式間 (direct key lookup vs 正準 one-liner) のバージョン不一致検出を pin する。
+# 抽出実行方式の理由は base-update-classify.test.sh と同じ (コピーは SKILL.md との drift を生む)。
+#
+# 背景 (Issue #1833): installed_plugins.json に複数の rite@* エントリがあると 2 方式が異なる
+# バージョンのパスを返し、1 セッション内で hooks と skills が別バージョンを参照する混在が
+# silent に進行した。4.5.0 に照合 WARNING を追加し、本テストがその発火条件を pin する。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_MD="$SCRIPT_DIR/../../skills/setup/SKILL.md"
+TEST_DIR="$(mktemp -d)" || { echo "FATAL: mktemp 失敗"; exit 1; }
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# --- SKILL.md から 4.5.0 の bash block を抽出 ---
+SNIPPET="$TEST_DIR/resolve.sh"
+awk '/^### 4\.5\.0 Resolve Hook Script Directory/{sect=1}
+     sect && /^```bash$/{fence=1; next}
+     sect && fence && /^```$/{exit}
+     sect && fence {print}' "$SKILL_MD" > "$SNIPPET"
+if ! grep -q 'MARKETPLACE:' "$SNIPPET" || ! grep -q 'CANON_PATH' "$SNIPPET"; then
+  echo "FAIL: SKILL.md からの 4.5.0 block 抽出に失敗しました (アンカーまたは照合ロジックが変更された可能性)"
+  echo "  抽出結果: $(wc -l < "$SNIPPET") 行"
+  exit 1
+fi
+
+# --- sandbox: fake HOME + fake install paths ---
+FAKE_HOME="$TEST_DIR/home"
+mkdir -p "$FAKE_HOME/.claude/plugins"
+INSTALL_A="$TEST_DIR/cache/rite/0.8.0"
+INSTALL_B="$TEST_DIR/cache/rite/0.8.1"
+mkdir -p "$INSTALL_A/hooks" "$INSTALL_B/hooks"
+touch "$INSTALL_A/hooks/pre-compact.sh" "$INSTALL_B/hooks/pre-compact.sh"
+
+# 実行 cwd は plugins/rite が存在しないディレクトリ (LOCAL 分岐を通らない)
+RUN_DIR="$TEST_DIR/proj"
+mkdir -p "$RUN_DIR"
+
+run_snippet() {
+  ( cd "$RUN_DIR" && HOME="$FAKE_HOME" bash "$SNIPPET" 2>"$TEST_DIR/err" )
+}
+
+echo "=== plugin-path mismatch warn tests (SKILL.md 4.5.0 抽出実行) ==="
+echo ""
+
+# ─── TC-1 (T-01/AC-1): 方式間不一致 → WARNING あり + 両パス表示、解決結果は direct key ───
+echo "TC-1: mismatch (rite@alpha 0.8.0 first, rite@rite-marketplace 0.8.1) -> WARNING"
+cat > "$FAKE_HOME/.claude/plugins/installed_plugins.json" <<JSON
+{
+  "plugins": {
+    "rite@alpha-marketplace": [{"installPath": "$INSTALL_A"}],
+    "rite@rite-marketplace": [{"installPath": "$INSTALL_B"}]
+  }
+}
+JSON
+out=$(run_snippet)
+err=$(cat "$TEST_DIR/err")
+if printf '%s' "$err" | grep -q '解決方式間で不一致' && \
+   printf '%s' "$err" | grep -qF "$INSTALL_A" && \
+   printf '%s' "$err" | grep -qF "$INSTALL_B" && \
+   [ "$out" = "MARKETPLACE:$INSTALL_B/hooks" ]; then
+  pass "TC-1: WARNING (両パス表示) + 解決は direct key 維持"
+else
+  fail "TC-1: expected WARNING with both paths + MARKETPLACE:$INSTALL_B/hooks, got out='$out' err_has_warn=$(printf '%s' "$err" | grep -c '不一致' || true)"
+fi
+
+# ─── TC-2 (T-02/AC-2): 一致 → WARNING なし ───
+echo "TC-2: single entry (agree) -> no WARNING"
+cat > "$FAKE_HOME/.claude/plugins/installed_plugins.json" <<JSON
+{
+  "plugins": {
+    "rite@rite-marketplace": [{"installPath": "$INSTALL_B"}]
+  }
+}
+JSON
+out=$(run_snippet)
+err=$(cat "$TEST_DIR/err")
+if ! printf '%s' "$err" | grep -q '不一致' && [ "$out" = "MARKETPLACE:$INSTALL_B/hooks" ]; then
+  pass "TC-2: WARNING なし + 従来どおり解決"
+else
+  fail "TC-2: expected no WARNING + MARKETPLACE, got out='$out' err='$err'"
+fi
+
+# ─── TC-3 (T-03/AC-3): installed_plugins.json 不在 → 従来どおり NOT_FOUND、警告なし ───
+echo "TC-3: no installed_plugins.json -> NOT_FOUND:NO_HOOKS, no WARNING"
+rm -f "$FAKE_HOME/.claude/plugins/installed_plugins.json"
+out=$(run_snippet)
+err=$(cat "$TEST_DIR/err")
+if [ "$out" = "NOT_FOUND:NO_HOOKS" ] && [ -z "$err" ]; then
+  pass "TC-3: 従来どおり NOT_FOUND (警告なし)"
+else
+  fail "TC-3: expected NOT_FOUND:NO_HOOKS silent, got out='$out' err='$err'"
+fi
+
+# ─── TC-4 (T-03/AC-3): ローカル開発 (plugins/rite あり) → LOCAL 解決、照合は走らない ───
+echo "TC-4: local dev -> LOCAL resolution, no probe"
+mkdir -p "$RUN_DIR/plugins/rite/hooks"
+touch "$RUN_DIR/plugins/rite/hooks/pre-compact.sh"
+out=$(run_snippet)
+err=$(cat "$TEST_DIR/err")
+if [ "$out" = "LOCAL:$RUN_DIR/plugins/rite/hooks" ] && [ -z "$err" ]; then
+  pass "TC-4: LOCAL 解決 (警告なし)"
+else
+  fail "TC-4: expected LOCAL:$RUN_DIR/plugins/rite/hooks silent, got out='$out' err='$err'"
+fi
+rm -rf "$RUN_DIR/plugins"
+
+# ─── TC-5: direct key 不在 (rite@* 別キーのみ) → WARNING なしで従来どおり NOT_FOUND ───
+echo "TC-5: direct key absent -> no spurious WARNING, NOT_FOUND"
+cat > "$FAKE_HOME/.claude/plugins/installed_plugins.json" <<JSON
+{
+  "plugins": {
+    "rite@alpha-marketplace": [{"installPath": "$INSTALL_A"}]
+  }
+}
+JSON
+out=$(run_snippet)
+err=$(cat "$TEST_DIR/err")
+if [ "$out" = "NOT_FOUND:NO_HOOKS" ] && ! printf '%s' "$err" | grep -q '不一致'; then
+  pass "TC-5: INSTALL_PATH 空のため照合せず従来どおり NOT_FOUND"
+else
+  fail "TC-5: expected NOT_FOUND:NO_HOOKS without WARNING, got out='$out' err='$err'"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/plugins/rite/references/plugin-path-resolution.md
+++ b/plugins/rite/references/plugin-path-resolution.md
@@ -119,7 +119,7 @@ Command files that need plugin path resolution should include the inline one-lin
 
 ## Relationship to setup.md Hook Path Resolution
 
-`setup.md` Phase 4.5.0 uses a similar but specialized detection for the `hooks/` subdirectory. This helper generalizes that pattern for the entire plugin root. The detection logic is intentionally consistent between the two.
+`setup.md` Phase 4.5.0 uses a similar but specialized detection for the `hooks/` subdirectory. This helper generalizes that pattern for the entire plugin root. The detection logic is intentionally consistent in approach (both look up `rite@*` entries in `installed_plugins.json`), though the two use **different jq shapes** that can diverge — see [Cross-Method Version Mismatch Check](#cross-method-version-mismatch-check-issue-1833) below for the divergence and its mitigation.
 
 ## Cross-Method Version Mismatch Check (Issue #1833)
 

--- a/plugins/rite/references/plugin-path-resolution.md
+++ b/plugins/rite/references/plugin-path-resolution.md
@@ -120,3 +120,18 @@ Command files that need plugin path resolution should include the inline one-lin
 ## Relationship to setup.md Hook Path Resolution
 
 `setup.md` Phase 4.5.0 uses a similar but specialized detection for the `hooks/` subdirectory. This helper generalizes that pattern for the entire plugin root. The detection logic is intentionally consistent between the two.
+
+## Cross-Method Version Mismatch Check (Issue #1833)
+
+The codebase contains **two jq lookup shapes** against `installed_plugins.json`:
+
+| Shape | Used by | jq filter |
+|-------|---------|-----------|
+| Canonical one-liner | this document (Priority 3) + all skill/hook call sites | `limit(1; .plugins \| to_entries[] \| select(.key \| startswith("rite@"))) \| .value[0].installPath` — first `rite@*` entry |
+| Direct key lookup | `setup.md` Phase 4.5.0 (hooks dir detection) | `.plugins["rite@rite-marketplace"][0].installPath` — exact key |
+
+When `installed_plugins.json` holds more than one `rite@*` entry (e.g., right after a marketplace cache update), the two shapes can return **different versions**, so hooks (resolved by 4.5.0) and skills/helpers (resolved by the one-liner) silently reference mixed plugin versions within one session. If sentinel formats / JSON schemas / marker conventions differ between those versions, the drift is very hard to trace.
+
+**Detection point**: `setup.md` Phase 4.5.0 runs both lookups and emits a WARNING with both paths when they differ. The resolved result stays the direct key lookup (no behavior change); the check itself is non-blocking — a jq failure in the canonical probe falls back to no warning. When `installed_plugins.json` is absent (local development), no probe runs and no warning appears.
+
+**Do NOT add further resolution shapes**: any new call site must use the canonical one-liner above. The direct key lookup in 4.5.0 is retained for backward compatibility and is the only sanctioned exception (paired with the mismatch check).

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -504,6 +504,21 @@ elif ! command -v jq >/dev/null 2>&1; then
 elif [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then
   INSTALL_PATH=$(jq -r '.plugins["rite@rite-marketplace"][0].installPath // empty' \
     "$HOME/.claude/plugins/installed_plugins.json")
+  # 解決方式間のバージョン照合: 本 block の direct key lookup と、他スキル・hook が使う正準
+  # one-liner (plugin-path-resolution.md の rite@* 先頭エントリ) は、installed_plugins.json に
+  # 複数の rite@* エントリがあると異なるバージョンのパスを返し、1 セッション内で hooks と
+  # skills が別バージョンを参照する混在が silent に進行する。照合失敗・不一致は non-blocking
+  # (解決結果は従来どおり direct key を採用し、解決フロー自体は退行させない)
+  CANON_PATH=$(jq -r 'limit(1; .plugins | to_entries[] | select(.key | startswith("rite@"))) | .value[0].installPath // empty' \
+    "$HOME/.claude/plugins/installed_plugins.json" 2>/dev/null) || CANON_PATH=""
+  if [ -n "$CANON_PATH" ] && [ -n "$INSTALL_PATH" ] && [ "$CANON_PATH" != "$INSTALL_PATH" ]; then
+    echo "WARNING: plugin パスの解決方式間で不一致を検出しました (バージョン混在の可能性)" >&2
+    echo "  direct key lookup (.plugins[\"rite@rite-marketplace\"][0]): $INSTALL_PATH" >&2
+    echo "  正準 one-liner (rite@* 先頭エントリ): $CANON_PATH" >&2
+    echo "  影響: hooks は前者、他スキル・hook の plugin_root 解決は後者を参照するため、バージョン間で" >&2
+    echo "        sentinel / スキーマ契約が変わると追跡困難な drift になります" >&2
+    echo "  対処: Claude Code を再起動して plugin キャッシュを更新し、/rite:setup を再実行してください" >&2
+  fi
   if [ -n "$INSTALL_PATH" ] && [ -f "$INSTALL_PATH/hooks/pre-compact.sh" ]; then
     echo "MARKETPLACE:$INSTALL_PATH/hooks"
   else


### PR DESCRIPTION
## 概要

plugin-path-resolution の解決方式間バージョン不一致を setup 実行時に検出し警告する。

Closes #1833

## 変更内容

- **setup 4.5.0**: MARKETPLACE 分岐に direct key lookup と正準 one-liner の照合を追加。不一致時は両パス・影響・対処を WARNING 表示（解決結果は従来どおり direct key = AC-3 非退行、照合失敗は non-blocking）
- **plugin-path-resolution.md**: 2 方式の対比表と照合の正準記述を追記。新しい解決方式の追加禁止を明記（MUST NOT 準拠）
- **テスト**: plugin-path-mismatch-warn.test.sh 新規（SKILL.md 4.5.0 block の抽出実行方式、5 TC — T-01/T-02/T-03 + direct key 不在の boundary）

## 検証

- fixture テスト 5/5 PASS (mismatch 警告 + 両パス表示 / 一致時無警告 / json 不在 / ローカル / direct key 不在)
- lint: skipped (commands 未設定)

## Known Issues

- なし
