### PR TITLE
chore(hooks): WM 同期経路の follow-up（awk fallback WARNING・shim テスト・signal trap retrofit・図更新）

### DIFF
--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -60,6 +60,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/control-char-neutralize.sh"
 PYTHON_SCRIPT="$SCRIPT_DIR/issue-comment-wm-update.py"
 
+# --- File-wide tmpfile trap 保護 ---
+# trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
+# (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
+# 対象は親シェルが直接 mktemp する tmpfile 全部。command substitution の subshell 内で mktemp
+# される関数 local (_err / _jq_err / _cid_mv_err / tmp) は親の trap から構造的に到達不能のため
+# 対象外 (通常経路は各関数の inline rm -f が清掃し、signal 時の残存は許容する)。
+# backup_file は失敗時 post-mortem 用に意図的に trap 対象外 (成功時のみ明示 rm)。
+_fs_err=""
+_pre_err=""
+tmpfile=""
+_init_err=""
+_verify_err=""
+_cb_err=""
+body_tmp=""
+updated_tmp=""
+py_err_tmp=""
+patch_err=""
+_rite_wm_sync_cleanup() {
+  rm -f "${_fs_err:-}" "${_pre_err:-}" "${tmpfile:-}" "${_init_err:-}" "${_verify_err:-}" \
+    "${_cb_err:-}" "${body_tmp:-}" "${updated_tmp:-}" "${py_err_tmp:-}" "${patch_err:-}"
+}
+trap 'rc=$?; _rite_wm_sync_cleanup; exit $rc' EXIT
+trap '_rite_wm_sync_cleanup; exit 130' INT
+trap '_rite_wm_sync_cleanup; exit 143' TERM
+trap '_rite_wm_sync_cleanup; exit 129' HUP
+
 # Resolve repository root for .rite-flow-state access
 CWD="${CWD:-$(pwd)}"
 STATE_ROOT=$("$SCRIPT_DIR/state-path-resolve.sh" "$CWD" 2>/dev/null) || STATE_ROOT="$CWD"
@@ -325,14 +351,13 @@ if [ "$MODE" = "init" ]; then
     exit 0
   fi
 
-  # set -e 配下で mktemp が /tmp full / inode 枯渇 / readonly fs で失敗すると、trap 設定前
-  # に abort する。明示 rc check で degrade させ、init mode を skip して上位で続行する。
-  tmpfile=""
+  # set -e 配下で mktemp が /tmp full / inode 枯渇 / readonly fs で失敗しても file-wide trap
+  # 設置済みのため orphan は残らない。明示 rc check で degrade させ、init mode を skip して
+  # 上位で続行する (cleanup は file-wide の _rite_wm_sync_cleanup に委譲)。
   if ! tmpfile=$(mktemp 2>/dev/null); then
     echo "[rite] WARNING: issue-comment-wm-sync: init mode mktemp failed (/tmp full or readonly?). Skipping comment creation." >&2
     exit 0
   fi
-  trap 'rm -f "$tmpfile"' EXIT
 
   cat <<INIT_EOF > "$tmpfile"
 ## 📜 rite 作業メモリ
@@ -445,28 +470,22 @@ COMMENT_ID=$(get_comment_id "$ISSUE" "$OWNER_REPO") || {
 }
 
 # Step 2: Get current body
-# /tmp 関連の failure (inode 枯渇 / readonly fs / quota) は set -e 配下で trap 設定前に
-# abort し orphan tempfile を残しうる。各 mktemp で rc を見て degrade させる。
-body_tmp=""
-updated_tmp=""
-py_err_tmp=""
+# /tmp 関連の failure (inode 枯渇 / readonly fs / quota) は各 mktemp で rc を見て degrade させる
+# (途中失敗時の先行 tmpfile は file-wide trap が清掃する)。
 if ! body_tmp=$(mktemp 2>/dev/null); then
   echo "[rite] WARNING: issue-comment-wm-sync: update mode body_tmp mktemp 失敗。skip." >&2
   exit 0
 fi
 if ! updated_tmp=$(mktemp 2>/dev/null); then
-  rm -f "$body_tmp"
   echo "[rite] WARNING: issue-comment-wm-sync: update mode updated_tmp mktemp 失敗。skip." >&2
   exit 0
 fi
 if ! py_err_tmp=$(mktemp 2>/dev/null); then
-  rm -f "$body_tmp" "$updated_tmp"
   echo "[rite] WARNING: issue-comment-wm-sync: update mode py_err_tmp mktemp 失敗。skip." >&2
   exit 0
 fi
 # Backup は失敗時の post-mortem 用。/tmp に蓄積した場合は `rm -f /tmp/rite-wm-backup-*` で手動清掃。
 backup_file="/tmp/rite-wm-backup-${ISSUE}-$(date +%s).md"
-trap 'rm -f "$body_tmp" "$updated_tmp" "$py_err_tmp"' EXIT
 
 # Capture gh stderr so that auth expiry / rate limit / 404 / network failure are
 # distinguishable in the operator log instead of collapsing into an empty body.

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -63,9 +63,11 @@ PYTHON_SCRIPT="$SCRIPT_DIR/issue-comment-wm-update.py"
 # --- File-wide tmpfile trap 保護 ---
 # trap + cleanup パターンの canonical 説明は references/bash-trap-patterns.md#signal-specific-trap-template 参照
 # (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
-# 対象は親シェルが直接 mktemp する tmpfile 全部。command substitution の subshell 内で mktemp
-# される関数 local (_err / _jq_err / _cid_mv_err / tmp) は親の trap から構造的に到達不能のため
-# 対象外 (通常経路は各関数の inline rm -f が清掃し、signal 時の残存は許容する)。
+# 対象は親シェル top-level で mktemp する tmpfile 全部。関数 local の tmpfile は対象外:
+# get_owner_repo / get_comment_id (_err) は command substitution subshell 経由のため親の trap
+# から構造的に到達不能。cache_comment_id (tmp / _jq_err / _cid_mv_err) は init mode で親シェル
+# から直接呼ばれる経路もあるが、いずれも通常経路は各関数の inline rm -f が清掃し、signal 時の
+# 残存は許容する。
 # backup_file は失敗時 post-mortem 用に意図的に trap 対象外 (成功時のみ明示 rm)。
 _fs_err=""
 _pre_err=""

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -193,6 +193,49 @@ else
 fi
 echo ""
 
+# ─── TC-007: init pre-check gh api 失敗 → non-blocking degrade (WARNING + 投稿続行) ──
+# pre-check の gh api 失敗は「存在不明」であり、ここで止めると replica が永遠に作られない
+# 恐れがあるため rc 付き WARNING を出して投稿続行に倒す契約。TC-005/006 は正常経路のみで
+# この degrade 経路は未検証だった (Issue #1844 D-05)。
+echo "TC-007: init pre-check gh api failure → WARNING + posting continues"
+dir007="$TEST_DIR/tc007"
+mkdir -p "$dir007/bin"
+echo '{"active":true,"issue_number":42}' > "$dir007/.rite-flow-state"
+GH_SHIM_MARKER7="$dir007/posted.marker"
+# pre-check (marker 不在) は gh api 失敗 (exit 1 + stderr)、投稿後の validation (marker 存在) は id を返す
+cat > "$dir007/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view") echo "testowner/testrepo"; exit 0 ;;
+  "api repos/testowner/testrepo/issues/42/comments")
+    if [ -f "$GH_SHIM_MARKER" ]; then echo "333"; exit 0; fi
+    echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
+  "issue comment") touch "$GH_SHIM_MARKER"; echo "https://github.com/testowner/testrepo/issues/42#issuecomment-3"; exit 0 ;;
+esac
+exit 0
+GH_SHIM
+chmod +x "$dir007/bin/gh"
+stderr007_file="$dir007/stderr.txt"
+out007=$(cd "$dir007" && PATH="$dir007/bin:$PATH" GH_SHIM_MARKER="$GH_SHIM_MARKER7" \
+  bash "$HOOK" init --issue 42 --branch "fix/issue-42-test" 2>"$stderr007_file") || true
+stderr007=$(cat "$stderr007_file" 2>/dev/null)
+if printf '%s' "$stderr007" | grep -qE 'init pre-check gh api 失敗 \(rc=1\)'; then
+  pass "TC-007: pre-check failure WARNING carries real rc (1)"
+else
+  fail "TC-007: pre-check WARNING missing or rc collapsed. stderr: $stderr007"
+fi
+if printf '%s' "$stderr007" | grep -qF 'HTTP 500: Internal Server Error'; then
+  pass "TC-007: captured gh stderr detail surfaced in WARNING"
+else
+  fail "TC-007: gh stderr detail not surfaced. stderr: $stderr007"
+fi
+if printf '%s' "$out007" | grep -qF "status=success" && [ -f "$GH_SHIM_MARKER7" ]; then
+  pass "TC-007: posting continued despite pre-check failure → status=success"
+else
+  fail "TC-007: expected post-through + status=success. out: $out007 marker=$([ -f "$GH_SHIM_MARKER7" ] && echo present || echo absent)"
+fi
+echo ""
+
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then
   exit 1

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -276,13 +276,19 @@ update_local_work_memory() {
   # File Structure 定義) のため、body 全置換するとフェーズ遷移のたびに追記内容が消える。
   # stock の先頭 `Phase:` / `Branch:` 行のみ最新値で再生成し、それ以外の自由記述内容を
   # verbatim で引き継ぐ (WM_BODY_TEXT はサマリー領域のみを対象とする契約)。
-  local detail_extra=""
+  local detail_extra="" _detail_awk_rc=0
   if [ -f "$local_wm" ]; then
     detail_extra=$(awk '
       /^## Detail$/ {found=1; next}
       found && !body && (/^Phase: / || /^Branch: / || /^[[:space:]]*$/) {next}
       found {body=1; print}
-    ' "$local_wm" 2>/dev/null) || detail_extra=""
+    ' "$local_wm" 2>/dev/null) || _detail_awk_rc=$?
+    # awk 失敗 (I/O error / 読み取り権限剥奪等) を silent fallback にすると、蓄積 Detail の
+    # 消失が「もともと空だった」と区別できない。non-blocking は維持しつつ WARNING で観測性を確保する。
+    if [ "$_detail_awk_rc" -ne 0 ]; then
+      echo "WARNING: detail_extra awk extraction failed (rc=$_detail_awk_rc) — accumulated Detail content will be dropped from the regenerated body" >&2
+      detail_extra=""
+    fi
   fi
 
   {

--- a/plugins/rite/skills/rite-workflow/references/work-memory-format.md
+++ b/plugins/rite/skills/rite-workflow/references/work-memory-format.md
@@ -264,8 +264,13 @@ loop_count: 0
 短い人間可読サマリー
 
 ## Detail
+Phase: implement
+Branch: feat/issue-721
+
 自由記述
 ```
+
+The stock `Phase:` / `Branch:` lines at the top of `## Detail` are regenerated with the latest values on every write (`work-memory-update.sh`); the free-form text after them is carried over verbatim.
 
 ### Frontmatter Fields
 


### PR DESCRIPTION
## 概要

PR #1838（Work Memory 同期経路の修復）のレビューで非ブロッキング推奨として記録された follow-up 4 件（Issue #1830 Decision Log D-04〜D-07）をまとめて対応する。

## 関連 Issue

Closes #1844

## 変更内容

- **D-04** `plugins/rite/hooks/work-memory-update.sh` — `detail_extra` awk 抽出失敗の silent fallback に rc 付き WARNING を追加。蓄積 Detail の消失と「もともと空だった」を区別可能にする（non-blocking は維持）
- **D-05** `plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh` — TC-007 を追加。init pre-check の gh api 失敗経路で「WARNING (rc 保持) + stderr 詳細の surface + 投稿続行 → status=success」の non-blocking degrade 契約を pin（既存 TC-005/006 は正常経路のみだった）
- **D-06** `plugins/rite/hooks/issue-comment-wm-sync.sh` — 親シェルが直接 mktemp する tmpfile 全 10 個（`_fs_err` / `_pre_err` / `tmpfile` / `_init_err` / `_verify_err` / `_cb_err` / `body_tmp` / `updated_tmp` / `py_err_tmp` / `patch_err`）を file-wide cleanup 関数 + 4 行 trap（EXIT/INT/TERM/HUP）で一括保護。file-wide EXIT trap を clobber していた mode 別 `trap ... EXIT` 2 箇所は撤去・統合。command substitution サブシェル内の関数 local tmpfile は親 trap の構造的射程外のため対象外（コメントで境界を明記、inline rm -f は維持）
- **D-07** `plugins/rite/skills/rite-workflow/references/work-memory-format.md` — local File Structure 図の `## Detail` に stock `Phase:`/`Branch:` 行を反映し、再生成/引き継ぎ挙動の 1 行説明を追加

## テスト

- `bash plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh` → 10 passed / 0 failed（既存 TC-001〜006 回帰なし + 新規 TC-007 3 assertion）

## チェックリスト

- [x] プロジェクト規約に準拠（bash-trap-patterns.md canonical 形式 / 既存 hook の Form A cleanup と同型）
- [x] テスト pass（hook テスト 10/10）
- [x] ドキュメント更新（work-memory-format.md — D-07 本体）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
