### PR TITLE
test(hooks): state-path-resolve 統一の観測面 4 種に回帰テストを追加

### DIFF
--- a/plugins/rite/hooks/tests/state-root-observers.test.sh
+++ b/plugins/rite/hooks/tests/state-root-observers.test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# state-root-observers.test.sh
+#
+# Pin the state-path-resolve based root resolution of the observation-surface
+# scripts unified in the review-result state-root change (Issue #1831,
+# regression tests deferred to Issue #1845):
+#
+#   TC-1..3  hooks/scripts/review-schema-version-check.sh --all (scan-root 解決)
+#   TC-4..5  hooks/review-skip-notification.sh              (表示パス解決)
+#   TC-6..7  hooks/scripts/distributed-fix-drift-check.sh Pattern 6
+#            (--repo-root を delegate へ伝搬しない契約)
+#
+# A regression back to `git rev-parse --show-toplevel` (or to forwarding
+# --repo-root into the Pattern 6 delegate) would split the writer root and the
+# reader root in a linked-worktree session: the scanner reads an empty
+# directory and drift detection silently no-ops. The sandbox mirrors the
+# plugin layout (hooks/ + hooks/scripts/) inside a real git repo with a linked
+# worktree, same as review-result-state-root.test.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_ROOT="$(cd "$HOOKS_DIR/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  # linked worktree を先に外さないと rm -rf 後の git 参照が残る
+  git -C "$TEST_DIR/repo" worktree remove --force "$TEST_DIR/repo/.rite/worktrees/issue-99" 2>/dev/null || true
+  rm -rf "$TEST_DIR"
+}
+trap 'rc=$?; cleanup; exit $rc' EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+echo "=== state-root-observers tests ==="
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available — review-schema-version-check requires jq" >&2
+  exit 0
+fi
+
+# --- sandbox: git repo + plugin layout + linked worktree ---
+REPO="$TEST_DIR/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+mkdir -p "$REPO/hooks/scripts"
+cp "$HOOKS_DIR/state-path-resolve.sh" "$REPO/hooks/"
+cp "$HOOKS_DIR/review-skip-notification.sh" "$REPO/hooks/"
+cp "$HOOKS_DIR/scripts/review-schema-version-check.sh" "$REPO/hooks/scripts/"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "init"
+git -C "$REPO" worktree add -q "$REPO/.rite/worktrees/issue-99" -b test-branch main
+WT="$REPO/.rite/worktrees/issue-99"
+
+# 期待パスは git / resolver が返す正規化済み root から導出する (macOS の /var → /private/var
+# symlink で literal $REPO との文字列比較が不一致になるため。sibling suite と同じ理由)
+MAIN_ROOT=$(git -C "$REPO" rev-parse --show-toplevel)
+RESOLVED_ROOT=$(cd "$WT" && bash "$MAIN_ROOT/hooks/state-path-resolve.sh")
+
+# drift fixture: state-root (main checkout) 側にのみ置く。worktree 側の
+# .rite/review-results/ は存在しない = --show-toplevel 回帰なら空 scan で rc=0 になる
+mkdir -p "$MAIN_ROOT/.rite/review-results"
+printf '{"schema_version":"9.9.9","findings":[]}\n' \
+  > "$MAIN_ROOT/.rite/review-results/99-20260101000000.json"
+
+# ─── TC-1: --all を worktree cwd から実行すると state-root の drift を検出する ───
+echo "TC-1: --all from worktree cwd scans the state root (drift detected)"
+rc=0
+(cd "$WT" && bash "$MAIN_ROOT/hooks/scripts/review-schema-version-check.sh" --all --quiet) >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "TC-1: state-root drift detected from worktree cwd (rc=1)"
+else
+  fail "TC-1: expected rc=1 (drift), got rc=$rc — --all scan root likely regressed to worktree toplevel"
+fi
+
+# ─── TC-2: --repo-root 明示指定は state-root 既定を上書きする ───
+echo "TC-2: explicit --repo-root overrides the state-root default"
+rc=0
+(cd "$WT" && bash "$MAIN_ROOT/hooks/scripts/review-schema-version-check.sh" --all --quiet --repo-root "$WT") >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "TC-2: --repo-root=\$WT scans the (empty) worktree dir → clean (rc=0)"
+else
+  fail "TC-2: expected rc=0 (explicit override wins), got rc=$rc"
+fi
+
+# ─── TC-3: 非 git cwd では従来どおり ERROR exit 2 (fail-fast 維持) ───
+echo "TC-3: non-git cwd still fail-fasts with exit 2"
+NOGIT="$TEST_DIR/nogit"
+mkdir -p "$NOGIT"
+rc=0
+(cd "$NOGIT" && bash "$MAIN_ROOT/hooks/scripts/review-schema-version-check.sh" --all --quiet) >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "TC-3: non-git cwd exits 2 (resolver did not convert it to silent success)"
+else
+  fail "TC-3: expected rc=2 (invocation error), got rc=$rc"
+fi
+
+# ─── TC-4: skip-notification の表示パスが state-root 絶対パスになる ───
+echo "TC-4: skip-notification displays the state-root absolute path from worktree cwd"
+notif_out=$( (cd "$WT" && bash "$MAIN_ROOT/hooks/review-skip-notification.sh" \
+  --post-comment-mode false --pr 99 --file-timestamp 20260101000000 --local-save-failed "") 2>&1 ) || true
+expected_line="ローカルファイル: ${RESOLVED_ROOT}/.rite/review-results/99-20260101000000.json"
+if printf '%s\n' "$notif_out" | grep -qF "$expected_line"; then
+  pass "TC-4: display path anchors to the resolved state root"
+else
+  fail "TC-4: expected '$expected_line' in output. got: $notif_out"
+fi
+if printf '%s\n' "$notif_out" | grep -qF "ローカルファイル: .rite/review-results/"; then
+  fail "TC-4: cwd-relative display path leaked (regression to pre-unification format)"
+else
+  pass "TC-4: no cwd-relative display path"
+fi
+
+# ─── TC-5: resolver 不在時は WARNING + cwd 相対へフォールバック ───
+echo "TC-5: skip-notification falls back to cwd-relative display when resolver is missing"
+NORES="$TEST_DIR/nores/hooks"
+mkdir -p "$NORES"
+cp "$HOOKS_DIR/review-skip-notification.sh" "$NORES/"
+# state-path-resolve.sh を意図的に置かない
+fallback_out=$( (cd "$TEST_DIR/nores" && bash "$NORES/review-skip-notification.sh" \
+  --post-comment-mode false --pr 99 --file-timestamp 20260101000000 --local-save-failed "") 2>&1 ) || true
+if printf '%s\n' "$fallback_out" | grep -q "WARNING: state-path-resolve.sh の解決に失敗"; then
+  pass "TC-5: fallback WARNING surfaced"
+else
+  fail "TC-5: fallback WARNING missing. got: $fallback_out"
+fi
+if printf '%s\n' "$fallback_out" | grep -qF "ローカルファイル: .rite/review-results/99-20260101000000.json"; then
+  pass "TC-5: cwd-relative display path used as fallback"
+else
+  fail "TC-5: cwd-relative fallback path missing. got: $fallback_out"
+fi
+
+# ─── TC-6: Pattern 6 は delegate に --repo-root を伝搬しない (--all のみ) ───
+echo "TC-6: Pattern 6 invokes the delegate with --all only (no --repo-root)"
+DRIFT_CHECKER="$PLUGIN_ROOT/hooks/scripts/distributed-fix-drift-check.sh"
+P6="$TEST_DIR/p6"
+mkdir -p "$P6/plugins/rite/hooks/scripts"
+git -C "$P6" init -q -b main
+ARGS_FILE="$P6/checker-args.txt"
+cat > "$P6/plugins/rite/hooks/scripts/review-schema-version-check.sh" <<SHIM
+#!/bin/bash
+printf '%s\n' "\$@" > "$ARGS_FILE"
+exit 0
+SHIM
+chmod +x "$P6/plugins/rite/hooks/scripts/review-schema-version-check.sh"
+rc=0
+bash "$DRIFT_CHECKER" --pattern 6 --repo-root "$P6" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ] && [ -f "$ARGS_FILE" ]; then
+  recorded=$(cat "$ARGS_FILE")
+  if [ "$recorded" = "--all" ]; then
+    pass "TC-6: delegate received exactly '--all'"
+  else
+    fail "TC-6: delegate args drifted (expected '--all', got '$recorded')"
+  fi
+  if grep -q -- "--repo-root" "$ARGS_FILE"; then
+    fail "TC-6: --repo-root propagated to the delegate (state-root bypass regression)"
+  else
+    pass "TC-6: --repo-root not propagated"
+  fi
+else
+  fail "TC-6: pattern 6 invocation failed (rc=$rc, args_file=$([ -f "$ARGS_FILE" ] && echo present || echo absent))"
+fi
+
+# ─── TC-7: delegate の drift stderr が Pattern 6 finding として report される ───
+echo "TC-7: delegate drift markers are parsed into Pattern 6 findings"
+P7="$TEST_DIR/p7"
+mkdir -p "$P7/plugins/rite/hooks/scripts"
+git -C "$P7" init -q -b main
+cat > "$P7/plugins/rite/hooks/scripts/review-schema-version-check.sh" <<'SHIM'
+#!/bin/bash
+echo "[CONTEXT] REVIEW_SCHEMA_VERSION_DRIFT=1; file=/shared/.rite/review-results/7-x.json; schema_version=9.9.9" >&2
+exit 1
+SHIM
+chmod +x "$P7/plugins/rite/hooks/scripts/review-schema-version-check.sh"
+rc=0
+out=$(bash "$DRIFT_CHECKER" --pattern 6 --repo-root "$P7" 2>/dev/null) || rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "TC-7: drift from delegate surfaces as checker rc=1"
+else
+  fail "TC-7: expected rc=1 (drift), got rc=$rc"
+fi
+if printf '%s\n' "$out" | grep -qF "schema_version='9.9.9' outside accept list"; then
+  pass "TC-7: Pattern 6 finding names the drifted version"
+else
+  fail "TC-7: Pattern 6 finding missing. output: $out"
+fi
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh
+++ b/plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Tests for scripts/migrate-review-state-to-1.1.sh
+# Usage: bash plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh
+#
+# Strategy: the migration script resolves its default REPO_ROOT via
+# hooks/state-path-resolve.sh (the same anchor as review-result-save.sh).
+# These tests pin the linked-worktree path (Issue #1831 の state-root 統一,
+# regression tests deferred to Issue #1845): a regression back to
+# `git rev-parse --show-toplevel` would resolve the worktree root, miss the
+# main-root JSON, and turn the migration into a silent no-op. The sandbox
+# mirrors the plugin layout (scripts/ + hooks/) inside a real git repo with a
+# linked worktree, following review-result-state-root.test.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$(cd "$SCRIPTS_DIR/../hooks" && pwd)"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+cleanup() {
+  git -C "$TEST_DIR/repo" worktree remove --force "$TEST_DIR/repo/.rite/worktrees/issue-99" 2>/dev/null || true
+  rm -rf "$TEST_DIR"
+}
+trap 'rc=$?; cleanup; exit $rc' EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 129' HUP
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+echo "=== migrate-review-state-to-1.1.sh tests ==="
+
+# --- sandbox: git repo + plugin layout (scripts/ + hooks/) + linked worktree ---
+REPO="$TEST_DIR/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+mkdir -p "$REPO/scripts" "$REPO/hooks"
+cp "$SCRIPTS_DIR/migrate-review-state-to-1.1.sh" "$REPO/scripts/"
+cp "$HOOKS_DIR/state-path-resolve.sh" "$REPO/hooks/"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "init"
+git -C "$REPO" worktree add -q "$REPO/.rite/worktrees/issue-99" -b test-branch main
+WT="$REPO/.rite/worktrees/issue-99"
+MAIN_ROOT=$(git -C "$REPO" rev-parse --show-toplevel)
+MIGRATE="$MAIN_ROOT/scripts/migrate-review-state-to-1.1.sh"
+
+# 1.0 fixture: state-root (main checkout) 側にのみ置く。worktree 側には置かない =
+# --show-toplevel 回帰なら空 dir scan で silent no-op になる
+mkdir -p "$MAIN_ROOT/.rite/review-results"
+json_10() {
+  cat <<'JSON'
+{
+  "schema_version": "1.0",
+  "pr_number": 42,
+  "findings": [
+    { "id": "F-01", "severity": "HIGH", "file": "src/a.ts", "line": 1,
+      "description": "x", "suggestion": "y", "status": "open" }
+  ]
+}
+JSON
+}
+json_10 > "$MAIN_ROOT/.rite/review-results/42-20260101000000.json"
+
+# ─── TC-1: --dry-run を worktree cwd から実行すると main-root の 1.0 JSON を検出する ───
+echo "TC-1: --dry-run from worktree cwd detects the main-root 1.0 JSON"
+rc=0
+dry_out=$( (cd "$WT" && bash "$MIGRATE" --dry-run) 2>&1 ) || rc=$?
+if [ "$rc" -eq 0 ] && printf '%s\n' "$dry_out" | grep -qF "would migrate ${MAIN_ROOT}/.rite/review-results/42-20260101000000.json"; then
+  pass "TC-1: dry-run resolved the state root and found the target"
+else
+  fail "TC-1: expected 'would migrate <main-root JSON>' (rc=$rc). got: $dry_out"
+fi
+# dry-run はファイルを変更しない
+ver=$(jq -r '.schema_version' "$MAIN_ROOT/.rite/review-results/42-20260101000000.json")
+if [ "$ver" = "1.0" ]; then
+  pass "TC-1: dry-run leaves the file unmodified"
+else
+  fail "TC-1: dry-run mutated the file (schema_version=$ver)"
+fi
+
+# ─── TC-2: apply を worktree cwd から実行すると main-root の JSON が migrate される ───
+echo "TC-2: apply from worktree cwd migrates the main-root JSON in place"
+rc=0
+(cd "$WT" && bash "$MIGRATE") >/dev/null 2>&1 || rc=$?
+ver=$(jq -r '.schema_version' "$MAIN_ROOT/.rite/review-results/42-20260101000000.json")
+scope=$(jq -r '.findings[0].scope // "missing"' "$MAIN_ROOT/.rite/review-results/42-20260101000000.json")
+if [ "$rc" -eq 0 ] && [ "$ver" = "1.1.0" ]; then
+  pass "TC-2: schema_version bumped to 1.1.0 on the state-root file"
+else
+  fail "TC-2: expected schema_version=1.1.0 (rc=$rc), got '$ver' — migration likely no-oped on the worktree root"
+fi
+if [ "$scope" = "current-pr" ]; then
+  pass "TC-2: HIGH finding backfilled with scope=current-pr"
+else
+  fail "TC-2: expected scope=current-pr, got '$scope'"
+fi
+# accepted-fingerprints 初期化も state-root 側に着地する
+if [ -f "$MAIN_ROOT/.rite/state/accepted-fingerprints-42.txt" ]; then
+  pass "TC-2: accepted-fingerprints state initialized under the state root"
+else
+  fail "TC-2: accepted-fingerprints-42.txt missing under $MAIN_ROOT/.rite/state/"
+fi
+
+# ─── TC-3: REPO_ROOT env 明示指定は state-root 既定を上書きする ───
+echo "TC-3: explicit REPO_ROOT env overrides the state-root default"
+json_10 > "$MAIN_ROOT/.rite/review-results/43-20260101000000.json"
+ALT="$TEST_DIR/alt"
+mkdir -p "$ALT"
+rc=0
+(cd "$WT" && REPO_ROOT="$ALT" bash "$MIGRATE") >/dev/null 2>&1 || rc=$?
+ver=$(jq -r '.schema_version' "$MAIN_ROOT/.rite/review-results/43-20260101000000.json")
+if [ "$rc" -eq 0 ] && [ "$ver" = "1.0" ]; then
+  pass "TC-3: REPO_ROOT=\$ALT left the state-root file untouched (override wins)"
+else
+  fail "TC-3: expected untouched schema_version=1.0 (rc=$rc), got '$ver'"
+fi
+
+# ─── TC-4: 非 git cwd + REPO_ROOT 未設定は従来どおり ERROR exit 1 ───
+echo "TC-4: non-git cwd without REPO_ROOT still fail-fasts with exit 1"
+NOGIT="$TEST_DIR/nogit"
+mkdir -p "$NOGIT"
+rc=0
+err_out=$( (cd "$NOGIT" && bash "$MIGRATE") 2>&1 ) || rc=$?
+if [ "$rc" -eq 1 ] && printf '%s\n' "$err_out" | grep -q "ERROR: REPO_ROOT could not be resolved"; then
+  pass "TC-4: non-git cwd exits 1 with the resolution ERROR"
+else
+  fail "TC-4: expected rc=1 + resolution ERROR, got rc=$rc: $err_out"
+fi
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh
+++ b/plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh
@@ -16,14 +16,16 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HOOKS_DIR="$(cd "$SCRIPTS_DIR/../hooks" && pwd)"
-TEST_DIR="$(mktemp -d)"
-PASS=0
-FAIL=0
 
+# jq gate は mktemp より前に置く (mktemp 後に trap 未設置のまま exit すると temp dir が orphan 残置される)
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required but not installed" >&2
   exit 1
 fi
+
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
 
 cleanup() {
   git -C "$TEST_DIR/repo" worktree remove --force "$TEST_DIR/repo/.rite/worktrees/issue-99" 2>/dev/null || true


### PR DESCRIPTION
## 概要

PR #1839（review-result 群の保存先を state-path-resolve 基準へ統一）で挙動が変わった観測面 script 4 種に、fixture ベースの回帰テストを追加する（Issue #1831 Decision Log D-02 の follow-up）。実挙動はレビュー時の sandbox 実測で検証済みだったが、テストが無く revert・退行の検知が実測に依存していた。

## 関連 Issue

Closes #1845

## 変更内容

- **新規** `plugins/rite/hooks/tests/state-root-observers.test.sh`（11 assertion）— linked worktree 付き git sandbox（`review-result-state-root.test.sh` と同型）で 3 観測面を pin:
  - `review-schema-version-check.sh --all`: worktree cwd から state-root の drift JSON を検出（`--show-toplevel` 回帰なら空 dir scan で silent no-op になる経路）/ `--repo-root` 明示指定の優先 / 非 git cwd の ERROR exit 2 維持
  - `review-skip-notification.sh`: 「ローカルファイル:」表示パスが state-root 絶対パスに解決される / resolver 不在時は WARNING + cwd 相対 fallback
  - `distributed-fix-drift-check.sh` Pattern 6: delegate に `--all` のみを渡し `--repo-root` を伝搬しない契約（arg 記録 shim）/ delegate の drift stderr が Pattern 6 finding として parse される統合経路
- **新規** `plugins/rite/scripts/tests/migrate-review-state-to-1.1.test.sh`（7 assertion）— worktree cwd からの `--dry-run` 検出 / apply の in-place migration（schema 1.1.0 化 + scope 補完 + accepted-fingerprints 初期化が state-root 側に着地）/ `REPO_ROOT` env 明示の優先 / 非 git cwd の ERROR exit 1 維持

runtime script は無変更（テストのみの追加）。

## テスト

- 新規: `state-root-observers.test.sh` → 11 passed / 0 failed、`migrate-review-state-to-1.1.test.sh` → 7 passed / 0 failed
- 回帰: `review-result-state-root.test.sh` 5/5、`review-schema-version-check.test.sh` 12/12、`distributed-fix-drift-check.test.sh` 22/22、`review-source-resolve.test.sh` 73/73

## チェックリスト

- [x] プロジェクト規約に準拠（既存 sandbox パターン踏襲、signal-specific trap cleanup）
- [x] テスト pass（新規 18 + 回帰 112）
- [x] ドキュメント更新（該当なし — テストのみの変更）

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
