### PR TITLE
fix(hooks): installPath セマンティクスの consumer 間不整合を修正

### DIFF
--- a/plugins/rite/hooks/hook-preamble.sh
+++ b/plugins/rite/hooks/hook-preamble.sh
@@ -38,7 +38,9 @@ _rite_resolve_hook_path() {
   [ -n "$current_install_path" ] || return 0
 
   # Compare: is SCRIPT_DIR different from the current version's hooks dir?
-  local current_hooks_dir="$current_install_path/plugins/rite/hooks"
+  # installPath IS the plugin root in marketplace installs (no plugins/rite/
+  # subdirectory beneath it) — see references/plugin-path-resolution.md.
+  local current_hooks_dir="$current_install_path/hooks"
   [ "$SCRIPT_DIR" != "$current_hooks_dir" ] || return 0
 
   # Validate resolved path stays within expected prefix (defense-in-depth)

--- a/plugins/rite/references/plugin-path-resolution.md
+++ b/plugins/rite/references/plugin-path-resolution.md
@@ -27,7 +27,7 @@ The plugin root is resolved using a 3-tier priority system:
 
 `installed_plugins.json`'s `installPath` field **is** the plugin root itself — it does **not** point to a parent directory containing a `plugins/rite/` subdirectory. Verified against a live marketplace install (`rite@rite-marketplace`, v0.8.1): `installPath` resolved to `~/.claude/plugins/cache/rite-marketplace/rite/0.8.1`, and `hooks/`, `skills/`, `scripts/`, `references/` exist directly under that path — there is no nested `plugins/rite/` directory.
 
-Every consumer of `installPath` must derive the hooks/skills/scripts dir as `$INSTALL_PATH/hooks` (etc.), never `$INSTALL_PATH/plugins/rite/hooks`. This matches Priority 3 above and `skills/setup/SKILL.md` Phase 4.5.0. `hooks/hook-preamble.sh` previously assumed the wrong (`plugins/rite/`-nested) layout, which made its version-redirect check silently never match (issue #1842).
+Every consumer of `installPath` must derive the hooks/skills/scripts dir as `$INSTALL_PATH/hooks` (etc.), never `$INSTALL_PATH/plugins/rite/hooks`. This matches Priority 3 above and `skills/setup/SKILL.md` Phase 4.5.0. `hooks/hook-preamble.sh` previously assumed the wrong (`plugins/rite/`-nested) layout, which made its version-redirect check silently never match.
 
 ## Inline One-Liner (for command files)
 

--- a/plugins/rite/references/plugin-path-resolution.md
+++ b/plugins/rite/references/plugin-path-resolution.md
@@ -23,6 +23,12 @@ The plugin root is resolved using a 3-tier priority system:
 | 2 (local dev) | `plugins/rite` directory check | Local development checkout | Always in local dev |
 | 3 (fallback) | `installed_plugins.json` lookup | Claude Code marketplace metadata | After marketplace install |
 
+## `installPath` Semantics
+
+`installed_plugins.json`'s `installPath` field **is** the plugin root itself — it does **not** point to a parent directory containing a `plugins/rite/` subdirectory. Verified against a live marketplace install (`rite@rite-marketplace`, v0.8.1): `installPath` resolved to `~/.claude/plugins/cache/rite-marketplace/rite/0.8.1`, and `hooks/`, `skills/`, `scripts/`, `references/` exist directly under that path — there is no nested `plugins/rite/` directory.
+
+Every consumer of `installPath` must derive the hooks/skills/scripts dir as `$INSTALL_PATH/hooks` (etc.), never `$INSTALL_PATH/plugins/rite/hooks`. This matches Priority 3 above and `skills/setup/SKILL.md` Phase 4.5.0. `hooks/hook-preamble.sh` previously assumed the wrong (`plugins/rite/`-nested) layout, which made its version-redirect check silently never match (issue #1842).
+
 ## Inline One-Liner (for command files)
 
 **Use this one-liner directly in command files** instead of referencing this document. This prevents Claude LLM from improvising its own resolution logic:


### PR DESCRIPTION
## 概要

`installed_plugins.json` の `installPath` が指す先の解釈が consumer 間で不整合になっていた問題を、実環境検証に基づき修正する。

## 関連 Issue

Closes #1842

## 変更内容

- 実環境検証: `rite@rite-marketplace` v0.8.1 の `installPath` を確認したところ、`hooks/`・`skills/`・`scripts/`・`references/` が直下に存在し、`plugins/rite/` という中間ディレクトリは存在しないことを確認（= `installPath` = plugin root が正しい解釈）
- `plugins/rite/hooks/hook-preamble.sh`: L41 の `$current_install_path/plugins/rite/hooks` を `$current_install_path/hooks` に修正。誤ったパス参照により `target_script` の存在チェックが常に false となり、version-redirect ロジックがサイレントに機能していなかった（dead code）
- `plugins/rite/references/plugin-path-resolution.md`: `installPath` セマンティクスを明記するセクションを追加し、実環境検証結果を根拠として記録
- プロジェクト全体を Grep で確認し、他の consumer（`setup/SKILL.md`、canonical one-liner を使う各 skill）には同種の誤りがないことを確認済み

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable) — commands.test 未設定のためテスト実行なし
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
