### PR TITLE
docs(references): plugin-path-resolution.md の setup.md 旧称参照を修正

### DIFF
--- a/plugins/rite/references/plugin-path-resolution.md
+++ b/plugins/rite/references/plugin-path-resolution.md
@@ -123,9 +123,9 @@ Command files that need plugin path resolution should include the inline one-lin
 
 **Important**: New command files should embed the one-liner directly rather than referencing this document with a link. Existing command files that still use the link-reference pattern (`per [Plugin Path Resolution](...)`) will be migrated incrementally to the inline one-liner in future Issues.
 
-## Relationship to setup.md Hook Path Resolution
+## Relationship to skills/setup/SKILL.md Hook Path Resolution
 
-`setup.md` Phase 4.5.0 uses a similar but specialized detection for the `hooks/` subdirectory. This helper generalizes that pattern for the entire plugin root. The detection logic is intentionally consistent in approach (both look up `rite@*` entries in `installed_plugins.json`), though the two use **different jq shapes** that can diverge — see [Cross-Method Version Mismatch Check](#cross-method-version-mismatch-check-issue-1833) below for the divergence and its mitigation.
+`skills/setup/SKILL.md` Phase 4.5.0 uses a similar but specialized detection for the `hooks/` subdirectory. This helper generalizes that pattern for the entire plugin root. The detection logic is intentionally consistent in approach (both look up `rite@*` entries in `installed_plugins.json`), though the two use **different jq shapes** that can diverge — see [Cross-Method Version Mismatch Check](#cross-method-version-mismatch-check-issue-1833) below for the divergence and its mitigation.
 
 ## Cross-Method Version Mismatch Check (Issue #1833)
 
@@ -134,10 +134,10 @@ The codebase contains **two jq lookup shapes** against `installed_plugins.json`:
 | Shape | Used by | jq filter |
 |-------|---------|-----------|
 | Canonical one-liner | this document (Priority 3) + all skill/hook call sites | `limit(1; .plugins \| to_entries[] \| select(.key \| startswith("rite@"))) \| .value[0].installPath` — first `rite@*` entry |
-| Direct key lookup | `setup.md` Phase 4.5.0 (hooks dir detection) | `.plugins["rite@rite-marketplace"][0].installPath` — exact key |
+| Direct key lookup | `skills/setup/SKILL.md` Phase 4.5.0 (hooks dir detection) | `.plugins["rite@rite-marketplace"][0].installPath` — exact key |
 
 When `installed_plugins.json` holds more than one `rite@*` entry (e.g., right after a marketplace cache update), the two shapes can return **different versions**, so hooks (resolved by 4.5.0) and skills/helpers (resolved by the one-liner) silently reference mixed plugin versions within one session. If sentinel formats / JSON schemas / marker conventions differ between those versions, the drift is very hard to trace.
 
-**Detection point**: `setup.md` Phase 4.5.0 runs both lookups and emits a WARNING with both paths when they differ. The resolved result stays the direct key lookup (no behavior change); the check itself is non-blocking — a jq failure in the canonical probe falls back to no warning. When `installed_plugins.json` is absent (local development), no probe runs and no warning appears.
+**Detection point**: `skills/setup/SKILL.md` Phase 4.5.0 runs both lookups and emits a WARNING with both paths when they differ. The resolved result stays the direct key lookup (no behavior change); the check itself is non-blocking — a jq failure in the canonical probe falls back to no warning. When `installed_plugins.json` is absent (local development), no probe runs and no warning appears.
 
 **Do NOT add further resolution shapes**: any new call site must use the canonical one-liner above. The direct key lookup in 4.5.0 is retained for backward compatibility and is the only sanctioned exception (paired with the mismatch check).


### PR DESCRIPTION
## 概要

`plugins/rite/references/plugin-path-resolution.md` 内の旧ファイル名 `setup.md` 参照（4箇所）を、v0.7 の commands→skills 移行後の正しいパス `skills/setup/SKILL.md` に統一する。

## 関連 Issue

Closes #1853

## 変更内容

- line 126: 見出し `## Relationship to setup.md Hook Path Resolution` → `## Relationship to skills/setup/SKILL.md Hook Path Resolution`
- line 128: 本文中の `` `setup.md` Phase 4.5.0 `` → `` `skills/setup/SKILL.md` Phase 4.5.0 ``
- line 137: テーブル内 `` `setup.md` Phase 4.5.0 (hooks dir detection) `` → `` `skills/setup/SKILL.md` Phase 4.5.0 (hooks dir detection) ``
- line 141: 本文中の `` `setup.md` Phase 4.5.0 `` → `` `skills/setup/SKILL.md` Phase 4.5.0 ``

line 30 の新設セクション（`installPath Semantics`）は既に正しい表記のため変更していない。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — 該当なし（ドキュメント修正のみ）
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
