### PR TITLE
fix(reviewers): reviewer subagent の parent working tree への Edit/Write を機械的に遮断

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -56,7 +56,7 @@ Reviewer subagents **may** use the following read-only commands for evidence gat
 
 Reviewer が **mutation testing / verification experiment** (例: 「ある line を `return 1` から `exit 1` に変えたら test が失敗するか」「helper を inline 展開したら sibling test が落ちるか」) を実行する必要がある場合、**parent repo の working tree / branch を絶対に変更してはならない**。正規経路は以下の **worktree-only mutation pattern** に限定される。
 
-**Rationale**: 過去に reviewer subagent が「mutation 検証」のために新規 named branch を作成し、`git checkout <test-branch>` → file 変更 → `git checkout develop` という遷移を行った結果、parent session の working tree が `develop` のクリーン状態に置き換わり、後続の `/rite:fix` が PR ブランチを見失う事故が起きた。prose レベルの「禁止」だけでは LLM agent は mutation 検証の必要性を過大評価して bypass する傾向があるため、**正規経路を明示**し、`hooks/pre-tool-bash-guard.sh` の structural enforcement と組み合わせて多層防御する。
+**Rationale**: 過去に reviewer subagent が「mutation 検証」のために新規 named branch を作成し、`git checkout <test-branch>` → file 変更 → `git checkout develop` という遷移を行った結果、parent session の working tree が `develop` のクリーン状態に置き換わり、後続の `/rite:fix` が PR ブランチを見失う事故が起きた。さらに rite 0.8.2 の実運用では、reviewer が実装ファイルを `Edit`/`Write` ツールで **parent working tree 上で直接変更**してテストを走らせ手動復元する事故も観測された (Issue #1860)。prose レベルの「禁止」だけでは LLM agent は mutation 検証の必要性を過大評価して bypass する傾向があるため、**正規経路を明示**し、structural enforcement と組み合わせて多層防御する。structural 層は 2 hook で構成される: `hooks/pre-tool-bash-guard.sh` (Pattern 4 — Bash 経由の state-changing git を block) と `hooks/pre-tool-edit-guard.sh` (Edit/Write/MultiEdit/NotebookEdit が parent working tree 配下を書き換えるのを block。隔離 worktree = `rite-review-mutation-*` / `rite-revert-test-*` 配下は許可)。
 
 **正規パターン (detached HEAD / 既存 branch)**:
 
@@ -86,13 +86,16 @@ cd -  # parent repo に戻る (HEAD 変更なし、stash なし)
 | `cp file file.bak` → file 変更 → test → `mv file.bak file` (parent working tree 内) | 同上 (parent working tree の file 変更自体が禁止 — `Edit`/`Write` tool レベル違反でもある) |
 | `git checkout HEAD~1 -- file` → test → `git checkout HEAD -- file` | `git show HEAD~1:file` で blob を取得し、worktree 内で適用 |
 
-**Invariant**: Reviewer subagent が exit する時点で **以下のすべて**が true であること。各 invariant は `skills/pr-review/SKILL.md` ステップ 5.0.A 経由で `post-review-state-verify.sh` により automatic check される (state vector は branch / stash count / branch list の 3 軸 — working tree の差分判定は `git status --porcelain` hash の cost が高く、本 PR では未 enforce):
+**`Edit`/`Write` ツールも隔離 worktree 配下に限る (Issue #1860)**: 上表は Bash/git 経路を挙げているが、mutation 実験でファイルを書き換える際は **`Edit` / `Write` / `MultiEdit` / `NotebookEdit` ツールも同様に、隔離 detached worktree (`/tmp/rite-review-mutation-*` / `rite-revert-test-*`) 配下のパスに対してのみ**発行してよい。parent working tree 配下 (repo 内かつ隔離領域外) のファイルをこれらのツールで書き換えることは、Bash の state-changing git と同格の READ-ONLY 違反であり、`hooks/pre-tool-edit-guard.sh` (PreToolUse) が **機械的に deny** する。正規経路は上記の worktree-only pattern で `cd "$mutation_dir"` した後に隔離配下のファイルを編集することであり、これは許可される。
+
+**Invariant**: Reviewer subagent が exit する時点で **以下のすべて**が true であること。各 invariant は `skills/pr-review/SKILL.md` ステップ 5.0.A 経由で `post-review-state-verify.sh` により automatic check される (state vector は branch / stash count / branch list / worktree の 4 軸。worktree 軸 = `git status --porcelain` hash は Issue #1860 で enforce に昇格 — Edit/Write in-place mutation や state-changing git が残す差分を検出する):
 
 1. `git branch --show-current` の値が reviewer 起動時と同一 (state vector axis 1: branch、`--original-branch` で check)
 2. `git stash list` の長さが reviewer 起動時と同一 (state vector axis 2: stash count、`--original-stash-count` で check)
 3. `git branch --list` の出力が reviewer 起動時と同一 (state vector axis 3: branch_list hash、`--original-branch-list-hash` で check — 新規 named branch leak 検出)
+4. `git status --porcelain` の hash が reviewer 起動時と同一 (state vector axis 4: worktree hash、`--original-worktree-hash` で check — Edit/Write in-place mutation / index 汚染の検出。Issue #1860)
 
-これらの invariant 違反は orchestrator 側 (`skills/pr-review/SKILL.md` ステップ 5.0.A post-review state verification) で post-condition check され、drift 検出時は WARNING を stderr に出力 + (branch drift のみ) automatic recovery (`git checkout <original_branch>`) を行う。stash/branch_list drift は内容を失うリスク回避のため auto-recover せず manual action を案内する。
+これらの invariant 違反は orchestrator 側 (`skills/pr-review/SKILL.md` ステップ 5.0.A post-review state verification) で post-condition check され、drift 検出時は WARNING を stderr に出力 + (branch drift のみ) automatic recovery (`git checkout <original_branch>`) を行う。stash/branch_list/worktree drift は内容を失うリスク回避のため auto-recover せず manual action を案内する。
 
 ## Reviewer Mindset
 

--- a/plugins/rite/hooks/hooks.json
+++ b/plugins/rite/hooks/hooks.json
@@ -64,6 +64,16 @@
           }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-edit-guard.sh",
+            "timeout": 10
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit"
       }
     ],
     "PostToolUse": [

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# rite workflow - Pre-Tool Edit Guard (PreToolUse hook)
+# Blocks reviewer subagents from mutating the parent working tree via the
+# Edit / Write / MultiEdit / NotebookEdit tools.
+#
+# Why this exists (Issue #1860):
+#   The sibling `pre-tool-bash-guard.sh` Pattern 4 only blocks state-mutating
+#   *git* commands issued through the Bash tool — it does nothing about a
+#   reviewer subagent that opens `Edit`/`Write` on a source file in the parent
+#   working tree (observed in production: a reviewer edited an implementation
+#   file in-place to run a mutation test, then hand-restored it). The prose ban
+#   in `agents/_reviewer-base.md` alone does not stop LLM agents. This hook is
+#   the structural enforcement layer for the Edit/Write side.
+#
+# Scope (all three must hold to deny):
+#   1. tool_name ∈ {Edit, Write, MultiEdit, NotebookEdit}
+#   2. subagent context (reviewer) — same 3-tier detection as pre-tool-bash-guard.sh
+#   3. target path is inside the parent repo working tree AND NOT inside a
+#      sanctioned reviewer isolation worktree (`rite-review-mutation-*` /
+#      `rite-revert-test-*` under $TMPDIR). The isolation allowlist is checked
+#      FIRST because a reviewer cd's into the mutation dir, so the repo-internal
+#      check would otherwise false-deny legitimate worktree-only mutation testing
+#      (AC-4). MultiEdit is included even though Issue #1860's Technical Notes
+#      list only {Edit, Write, NotebookEdit}: MultiEdit mutates files identically
+#      and omitting it would be a trivial bypass of a security boundary.
+#
+# Fail direction (mirrors pre-tool-bash-guard.sh Pattern 4):
+#   - A crash BEFORE scope (subagent + repo-internal + non-isolation) is confirmed
+#     fails OPEN (exit 0 = allow) so a main-session Edit is never false-blocked.
+#   - A crash AFTER scope is confirmed fails CLOSED (deny + exit 2) so a single
+#     parse crash never silently bypasses the reviewer read-only guard.
+#
+# Exit behavior:
+#   exit 0 — allow (no output)
+#   stdout JSON with permissionDecision: "deny" — block
+#
+# hooks.json timeout: registered as PreToolUse (matcher Edit|Write|MultiEdit|
+# NotebookEdit) with a 10s timeout — a fast synchronous gate using bash built-ins
+# plus a couple of jq calls, aligned with the sibling lightweight gates.
+set -euo pipefail
+
+# Double-execution guard (hooks.json + settings.local.json migration parity with
+# pre-tool-bash-guard.sh's _RITE_HOOK_RUNNING_PRETOOL, but a distinct var so the
+# two PreToolUse hooks never suppress each other).
+[ -z "${_RITE_HOOK_RUNNING_PRETOOL_EDIT:-}" ] || exit 0
+export _RITE_HOOK_RUNNING_PRETOOL_EDIT=1
+
+# Hook version resolution preamble (before INPUT=$(cat) to preserve stdin).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+
+# Fail-OPEN ERR trap (default): any unexpected crash before scope is confirmed
+# allows the tool rather than blocking it. Swapped to fail-CLOSED once the deny
+# scope is confirmed (below), mirroring pre-tool-bash-guard.sh Pattern 4.
+_rite_teg_fail_open() {
+  if [ -n "${RITE_DEBUG:-}" ]; then
+    printf '[%s] pre-tool-edit-guard: ERR trap fired before scope confirmed — allowed via fail-open\n' \
+      "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+      >> "${STATE_ROOT:-/tmp}/.rite-flow-debug.log" 2>/dev/null || true
+  fi
+  exit 0
+}
+_rite_teg_fail_closed() {
+  local _rc=$?
+  trap - ERR  # prevent re-entrancy while emitting the deny
+  echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] pre-tool-edit-guard: WARNING deny-emit crashed (rc=$_rc) — DENIED via fail-closed" >&2
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED (reviewer-edit-parent-tree): scope confirmed but deny-emit crashed; denying fail-closed to avoid bypassing the reviewer read-only guard."}}\n'
+  exit 2
+}
+trap '_rite_teg_fail_open' ERR
+
+# cat failure does not abort under set -e; || guard is defensive
+INPUT=$(cat) || INPUT=""
+
+# Only inspect the mutating file tools. Non-matching tools (the harness matcher
+# should already pre-filter, but this defense-in-depth check survives matcher drift).
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+# Extract target path (Edit/Write/MultiEdit use .tool_input.file_path;
+# NotebookEdit uses .tool_input.notebook_path) and cwd in a single jq spawn.
+JQ_OUT=$(echo "$INPUT" | jq -r '[((.tool_input.file_path // .tool_input.notebook_path) // ""), (.cwd // "")] | @tsv' 2>/dev/null) || JQ_OUT=$'\t'
+FILE_PATH=$(printf '%s' "$JQ_OUT" | cut -f1)
+CWD=$(printf '%s' "$JQ_OUT" | cut -f2)
+# No target path → cannot scope the write to the repo; allow (fail-open). A real
+# Edit/Write always carries a path, so this only trips on a malformed envelope.
+[ -n "$FILE_PATH" ] || exit 0
+
+# --- Reviewer subagent detection (3-tier) ---
+# CANONICAL COPY lives in pre-tool-bash-guard.sh (Pattern 4). Keep the two in
+# sync: this is an intentional defense-in-depth duplication (a shared lib used by
+# only two hooks would force a risky refactor of the heavily-pinned bash-guard).
+#   Tier 1 (primary):  transcript_path glob `*/subagents/*` — current Claude Code
+#                      convention routing subagent sessions under a subagents/ dir.
+#   Tier 2 (fallback): hook input JSON `subagent_type` / `agent_type` STRING field
+#                      (numeric/array/object rejected via `| strings`).
+#   Tier 3 (fallback): env vars CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE (presence-only).
+# Forward-compat caveat: presence-only fires on any non-empty string; if a future
+# SDK emits sentinel values like "main"/"none" on main-session hooks this would
+# false-positive — upgrade to an allow-list glob (e.g. `*-reviewer`) at that point.
+JQ_SA=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>/dev/null) || JQ_SA=$'\t\t'
+TRANSCRIPT_PATH=$(printf '%s' "$JQ_SA" | cut -f1)
+INPUT_SUBAGENT_TYPE=$(printf '%s' "$JQ_SA" | cut -f2)
+INPUT_AGENT_TYPE=$(printf '%s' "$JQ_SA" | cut -f3)
+IS_SUBAGENT=0
+case "$TRANSCRIPT_PATH" in
+  */subagents/*) IS_SUBAGENT=1 ;;
+esac
+if [ "$IS_SUBAGENT" = "0" ] && { [ -n "$INPUT_SUBAGENT_TYPE" ] || [ -n "$INPUT_AGENT_TYPE" ]; }; then
+  IS_SUBAGENT=1
+fi
+if [ "$IS_SUBAGENT" = "0" ] && { [ -n "${CLAUDE_SUBAGENT_TYPE:-}" ] || [ -n "${CLAUDE_AGENT_TYPE:-}" ]; }; then
+  IS_SUBAGENT=1
+fi
+# Main session (not a reviewer subagent) → never blocked. This is the primary
+# guarantee that /rite:open → implement.md Edit/Write is unaffected (AC-4).
+[ "$IS_SUBAGENT" = "1" ] || exit 0
+
+# --- Absolute path resolution (naive join; no symlink/`..` canonicalization) ---
+# A relative file_path is resolved against the tool's cwd. `..` escapes are not
+# normalized here: an adversarial `..`-laden path simply won't match the repo
+# prefix below and falls OPEN — the post-condition axis (post-review-state-verify.sh
+# worktree hash) still catches the resulting dirty tree (defense-in-depth).
+case "$FILE_PATH" in
+  /*) ABS_PATH="$FILE_PATH" ;;
+  *)  ABS_PATH="${CWD%/}/$FILE_PATH" ;;
+esac
+
+# --- Isolation allowlist (checked BEFORE repo-internal — AC-4 critical) ---
+# Reviewers legitimately cd into a detached mutation worktree created via
+# `mktemp -d -t rite-review-mutation-XXXXXX` / `rite-revert-test-*` under $TMPDIR
+# (see agents/_reviewer-base.md "Mutation experiments"). Because the reviewer cd's
+# INTO that dir, `git -C "$cwd" rev-parse --show-toplevel` returns the mutation
+# dir itself, so the repo-internal check below would false-deny a legitimate
+# in-worktree edit. Short-circuit to allow when the target is under a sanctioned
+# reviewer isolation prefix. (Namespace source of truth: the same prefixes swept
+# by hooks/scripts/pr-cycle-cleanup.sh Step 4.)
+case "$ABS_PATH" in
+  */rite-review-mutation-*|*/rite-revert-test-*) exit 0 ;;
+esac
+
+# --- Repo-internal check ---
+# Resolve the parent working tree root from the tool cwd. If git can't resolve a
+# toplevel (not a repo), we cannot confirm the write is repo-internal → allow
+# (fail-open; scope not confirmed).
+REPO_ROOT=$(git -C "${CWD:-.}" rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
+[ -n "$REPO_ROOT" ] || exit 0
+REPO_ROOT="${REPO_ROOT%/}"
+
+# Deny only when the absolute target path is under the repo root.
+case "$ABS_PATH" in
+  "$REPO_ROOT"/*) ;;   # inside the parent working tree → fall through to deny
+  *) exit 0 ;;         # outside the repo (e.g. /tmp scratch) → allow
+esac
+
+# --- Scope confirmed: subagent + repo-internal + non-isolation → DENY ---
+# Swap to the fail-CLOSED trap so any crash from here on denies rather than allows.
+trap '_rite_teg_fail_closed' ERR
+
+# Log block event (stderr, for effect measurement) — mirror bash-guard's format.
+PATH_SUMMARY="${ABS_PATH:0:120}"
+PATH_SUMMARY="${PATH_SUMMARY//\"/\\\"}"
+echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2
+
+_deny_reason="BLOCKED (reviewer-edit-parent-tree): Reviewer subagents must not mutate the parent working tree. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which is inside the repository working tree (${REPO_ROOT}). Reviewers are strictly read-only — inspect files with Read/Grep and compare historical content with 'git show <ref>:<file>'. If you need a mutation/verification experiment, do it in an isolated detached worktree under \$TMPDIR: 'git worktree add --detach \$(mktemp -d -t rite-review-mutation-XXXXXX) HEAD' and edit files THERE (paths under rite-review-mutation-* / rite-revert-test-* are allowed). See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement / Mutation experiments)."
+# jq is required to emit the permission payload; an intermittent jq failure would
+# silently downgrade the deny to allow, so the fail-CLOSED trap catches a crash
+# here and emits a static deny + exit 2.
+jq -n --arg reason "$_deny_reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -185,7 +185,7 @@ if [ -z "$TARGET_ROOT" ]; then
   #       axis (git status --porcelain ignores .git). This hook is the structural defense for the
   #       Edit/Write/MultiEdit/NotebookEdit path; deny git-internal writes there, allow only genuine
   #       non-repo scratch. (Reviewer .git writes via the Bash tool — e.g. `echo > .git/hooks/...`,
-  #       `ln -s` symlink redirection — are a broader gap tracked separately, out of Issue #1860's
+  #       `ln -s` symlink redirection — are a broader gap tracked in #1864, out of Issue #1860's
   #       Edit/Write scope; pre-tool-bash-guard.sh only blocks state-mutating git verbs today.)
   if [ "$(git -C "$_tdir" rev-parse --is-inside-git-dir 2>/dev/null)" = "true" ]; then
     _deny_kind="git-dir"

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -12,21 +12,24 @@
 #   in `agents/_reviewer-base.md` alone does not stop LLM agents. This hook is
 #   the structural enforcement layer for the Edit/Write side.
 #
-# Scope (all three must hold to deny):
+# Scope (all must hold to deny):
 #   1. tool_name ∈ {Edit, Write, MultiEdit, NotebookEdit}
 #   2. subagent context (reviewer) — same 3-tier detection as pre-tool-bash-guard.sh
-#   3. target path is inside the parent repo working tree AND NOT inside a
-#      sanctioned reviewer isolation worktree (`rite-review-mutation-*` /
-#      `rite-revert-test-*` under $TMPDIR). The isolation allowlist is checked
-#      FIRST because a reviewer cd's into the mutation dir, so the repo-internal
-#      check would otherwise false-deny legitimate worktree-only mutation testing
-#      (AC-4). MultiEdit is included even though Issue #1860's Technical Notes
-#      list only {Edit, Write, NotebookEdit}: MultiEdit mutates files identically
-#      and omitting it would be a trivial bypass of a security boundary.
+#   3. the target's OWN git worktree (resolved by walking the target path up to its
+#      nearest existing ancestor, then `git -C <ancestor> rev-parse`) is a real
+#      parent working tree — i.e. its toplevel is NOT a sanctioned reviewer isolation
+#      worktree (root named `rite-review-mutation-*` / `rite-revert-test-*`). Deciding
+#      isolation on the resolved worktree root (not the raw path string) is what closes
+#      the substring / `..` re-entry forgery found in review cycle 1. A write into a
+#      .git directory of a non-isolation worktree also denies (review cycle 2:
+#      .git/hooks/pre-commit etc. → main-session code execution). MultiEdit is included
+#      even though Issue #1860's Technical Notes list only {Edit, Write, NotebookEdit}:
+#      MultiEdit mutates files identically and omitting it would be a trivial bypass.
 #
 # Fail direction (mirrors pre-tool-bash-guard.sh Pattern 4):
-#   - A crash BEFORE scope (subagent + repo-internal + non-isolation) is confirmed
-#     fails OPEN (exit 0 = allow) so a main-session Edit is never false-blocked.
+#   - A crash BEFORE scope is confirmed (subagent + target resolved to a non-isolation
+#     worktree / its .git dir) fails OPEN (exit 0 = allow) so a main-session Edit and a
+#     genuine non-repo scratch write are never false-blocked.
 #   - A crash AFTER scope is confirmed fails CLOSED (deny + exit 2) so a single
 #     parse crash never silently bypasses the reviewer read-only guard.
 #
@@ -48,6 +51,11 @@ export _RITE_HOOK_RUNNING_PRETOOL_EDIT=1
 # Hook version resolution preamble (before INPUT=$(cat) to preserve stdin).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/hook-preamble.sh" 2>/dev/null || true
+# control-char-neutralize.sh provides neutralize_ctrl, used to sanitize the byte-oriented
+# RITE_DEBUG diagnostic snippet below (parity with pre-tool-bash-guard.sh, which sources it
+# for the same reason). Sourced without a guard: if the helper is missing (plugin broken) the
+# resulting exit is non-blocking under PreToolUse = allow, the same fail-open the sibling relies on.
+source "$SCRIPT_DIR/control-char-neutralize.sh"
 
 # Fail-OPEN ERR trap (default): any unexpected crash before scope is confirmed
 # allows the tool rather than blocking it. Swapped to fail-CLOSED once the deny
@@ -90,15 +98,16 @@ CWD=$(printf '%s' "$JQ_OUT" | cut -f2)
 [ -n "$FILE_PATH" ] || exit 0
 
 # --- Reviewer subagent detection (3-tier) ---
-# The detection LOGIC (the 3 tiers below) is the canonical copy from
-# pre-tool-bash-guard.sh (Pattern 4) and is kept in sync with it: an intentional
+# The detection LOGIC and the jq program below are the canonical copy from
+# pre-tool-bash-guard.sh (Pattern 4) and are kept in sync with it: an intentional
 # defense-in-depth duplication (a shared lib used by only two hooks would force a
-# risky refactor of the heavily-pinned bash-guard). Observability differs by design:
-# the sibling wraps this jq with a RITE_DEBUG stderr-capture because it is the first
-# jq to touch INPUT there; here two prior jq calls (tool_name, file/notebook path)
-# have already parsed the same INPUT, so a parse failure at this third jq is
-# unreachable — the `|| JQ_SA=$'\t\t'` fallback is a formality, not a live silent-bypass
-# path, and needs no debug logging.
+# risky refactor of the heavily-pinned bash-guard). The `|| JQ_SA=$'\t\t'` fallback is a
+# live silent-bypass path, NOT a formality: a valid-JSON envelope with a non-scalar
+# `.transcript_path` (array/object) makes jq's @tsv fail at runtime, and the fallback
+# then zeroes out Tier 1/2 → IS_SUBAGENT=0 → allow. So, exactly like the sibling, capture
+# this jq's stderr and surface it under RITE_DEBUG so a detection-path drop is observable.
+# (Do NOT add `| strings` to `.transcript_path` to swallow the error — that would diverge
+# the jq program from the canonical copy and break the "keep in sync" contract.)
 #   Tier 1 (primary):  transcript_path glob `*/subagents/*` — current Claude Code
 #                      convention routing subagent sessions under a subagents/ dir.
 #   Tier 2 (fallback): hook input JSON `subagent_type` / `agent_type` STRING field
@@ -107,7 +116,15 @@ CWD=$(printf '%s' "$JQ_OUT" | cut -f2)
 # Forward-compat caveat: presence-only fires on any non-empty string; if a future
 # SDK emits sentinel values like "main"/"none" on main-session hooks this would
 # false-positive — upgrade to an allow-list glob (e.g. `*-reviewer`) at that point.
-JQ_SA=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>/dev/null) || JQ_SA=$'\t\t'
+_jq_sa_err=$(mktemp 2>/dev/null) || _jq_sa_err=""
+JQ_SA=$(echo "$INPUT" | jq -r '[(.transcript_path // ""), (.subagent_type | strings // ""), (.agent_type | strings // "")] | @tsv' 2>"${_jq_sa_err:-/dev/null}") || JQ_SA=$'\t\t'
+if [ -n "${RITE_DEBUG:-}" ] && [ -n "$_jq_sa_err" ] && [ -s "$_jq_sa_err" ]; then
+  printf '[%s] pre-tool-edit-guard: subagent-detection jq stderr: %s\n' \
+    "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    "$(head -c 200 "$_jq_sa_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" \
+    >> "${STATE_ROOT:-/tmp}/.rite-flow-debug.log" 2>/dev/null || true
+fi
+[ -n "$_jq_sa_err" ] && rm -f "$_jq_sa_err"
 TRANSCRIPT_PATH=$(printf '%s' "$JQ_SA" | cut -f1)
 INPUT_SUBAGENT_TYPE=$(printf '%s' "$JQ_SA" | cut -f2)
 INPUT_AGENT_TYPE=$(printf '%s' "$JQ_SA" | cut -f3)
@@ -150,31 +167,53 @@ done
 [ -d "$_tdir" ] || _tdir="${CWD:-.}"
 # git -C chdir's to the resolved ancestor and reports the worktree toplevel that owns it.
 TARGET_ROOT=$(git -C "$_tdir" rev-parse --show-toplevel 2>/dev/null) || TARGET_ROOT=""
-# Target is not inside any git repo (e.g. /tmp scratch) → cannot be the parent working tree →
-# allow (fail-open; scope not confirmed).
-[ -n "$TARGET_ROOT" ] || exit 0
-TARGET_ROOT="${TARGET_ROOT%/}"
 
-# --- Isolation allowance: the target's OWN worktree is a sanctioned isolation worktree ---
-# Reviewers legitimately run mutation experiments in a detached worktree created via
-# `mktemp -d -t rite-review-mutation-XXXXXX` + `git worktree add --detach` (or the
-# `rite-revert-test-*` sibling namespace — same prefixes swept by pr-cycle-cleanup.sh Step 4).
-# Matching on TARGET_ROOT (the target's resolved worktree root), not the raw path, means only a
-# genuine isolation worktree is allowed — closing the substring / `..` re-entry bypass.
-case "$TARGET_ROOT" in
-  */rite-review-mutation-*|*/rite-revert-test-*) exit 0 ;;
-esac
+# `_deny_kind` stays empty for an allow; it is set to "parent-tree" or "git-dir" when the write
+# must be denied. Both deny kinds share the fail-CLOSED emit at the end of this block.
+_deny_kind=""
+if [ -z "$TARGET_ROOT" ]; then
+  # `--show-toplevel` is empty for two very different reasons, which MUST NOT be conflated:
+  #   (a) the ancestor is in NO git repo (genuine /tmp scratch) → allow (fail-open), or
+  #   (b) the target is INSIDE a .git directory — `rev-parse --show-toplevel` reports no work tree
+  #       there, so the old blanket `|| exit 0` allowed it (Issue #1860 review cycle 2). A reviewer
+  #       writing into .git (e.g. .git/hooks/pre-commit, or .git/config core.hooksPath / alias.*=!sh)
+  #       can execute arbitrary code in the non-sandboxed MAIN session on the next git operation —
+  #       strictly worse than a source-file edit, and invisible to the worktree-hash post-condition
+  #       axis (git status --porcelain ignores .git). This hook is the sole structural defense, so
+  #       deny git-internal writes; allow only genuine non-repo scratch.
+  if [ "$(git -C "$_tdir" rev-parse --is-inside-git-dir 2>/dev/null)" = "true" ]; then
+    _deny_kind="git-dir"
+  else
+    exit 0   # genuine non-repo scratch → allow (fail-open; scope not confirmed)
+  fi
+else
+  TARGET_ROOT="${TARGET_ROOT%/}"
+  # --- Isolation allowance: the target's OWN worktree is a sanctioned isolation worktree ---
+  # Reviewers legitimately run mutation experiments in a detached worktree created via
+  # `mktemp -d -t rite-review-mutation-XXXXXX` + `git worktree add --detach` (or the
+  # `rite-revert-test-*` sibling namespace — same prefixes swept by pr-cycle-cleanup.sh Step 4).
+  # Matching on TARGET_ROOT (the target's resolved worktree root), not the raw path, means only a
+  # genuine isolation worktree is allowed — closing the substring / `..` re-entry bypass.
+  case "$TARGET_ROOT" in
+    */rite-review-mutation-*|*/rite-revert-test-*) exit 0 ;;
+  esac
+  _deny_kind="parent-tree"
+fi
 
-# --- Scope confirmed: subagent + target inside a non-isolation (parent) working tree → DENY ---
+# --- Scope confirmed: subagent + write into a parent working tree OR its .git dir → DENY ---
 # Swap to the fail-CLOSED trap so any crash from here on denies rather than allows.
 trap '_rite_teg_fail_closed' ERR
 
 # Log block event (stderr, for effect measurement) — mirror bash-guard's format.
 PATH_SUMMARY="${ABS_PATH:0:120}"
 PATH_SUMMARY="${PATH_SUMMARY//\"/\\\"}"
-echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2
+echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED kind=$_deny_kind tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2
 
-_deny_reason="BLOCKED (reviewer-edit-parent-tree): Reviewer subagents must not mutate the parent working tree. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which resolves inside the repository working tree (${TARGET_ROOT}). Reviewers are strictly read-only — inspect files with Read/Grep and compare historical content with 'git show <ref>:<file>'. If you need a mutation/verification experiment, do it in an isolated detached worktree under \$TMPDIR: 'git worktree add --detach \$(mktemp -d -t rite-review-mutation-XXXXXX) HEAD' and edit files THERE (a real worktree whose root is named rite-review-mutation-* / rite-revert-test-* is allowed). See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement / Mutation experiments)."
+if [ "$_deny_kind" = "git-dir" ]; then
+  _deny_reason="BLOCKED (reviewer-edit-git-dir): Reviewer subagents must not write into a Git internal directory. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which is inside a .git directory. Writing there — .git/hooks/*, .git/config (core.hooksPath / alias / core.fsmonitor), etc. — can execute arbitrary code in the non-sandboxed main session on the next git operation. Reviewers are strictly read-only: inspect refs/blobs with 'git show', 'git cat-file', 'git rev-parse' instead. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement)."
+else
+  _deny_reason="BLOCKED (reviewer-edit-parent-tree): Reviewer subagents must not mutate the parent working tree. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which resolves inside the repository working tree (${TARGET_ROOT}). Reviewers are strictly read-only — inspect files with Read/Grep and compare historical content with 'git show <ref>:<file>'. If you need a mutation/verification experiment, do it in an isolated detached worktree under \$TMPDIR: 'git worktree add --detach \$(mktemp -d -t rite-review-mutation-XXXXXX) HEAD' and edit files THERE (a real worktree whose root is named rite-review-mutation-* / rite-revert-test-* is allowed). See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement / Mutation experiments)."
+fi
 # jq is required to emit the permission payload; an intermittent jq failure would
 # silently downgrade the deny to allow, so the fail-CLOSED trap catches a crash
 # here and emits a static deny + exit 2.

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -72,7 +72,10 @@ _rite_teg_fail_closed() {
   local _rc=$?
   trap - ERR  # prevent re-entrancy while emitting the deny
   echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] pre-tool-edit-guard: WARNING deny-emit crashed (rc=$_rc) — DENIED via fail-closed" >&2
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED (reviewer-edit-parent-tree): scope confirmed but deny-emit crashed; denying fail-closed to avoid bypassing the reviewer read-only guard."}}\n'
+  # Kind-neutral static reason: this trap fires for BOTH deny kinds (parent-tree and git-dir),
+  # so it must not hardcode either — a crashed git-dir deny (RCE vector) mislabeled as parent-tree
+  # would understate the block. Kept fully static (no interpolation) per the crash-handler contract.
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED (reviewer-edit): scope confirmed but deny-emit crashed; denying fail-closed to avoid bypassing the reviewer read-only guard."}}\n'
   exit 2
 }
 trap '_rite_teg_fail_open' ERR
@@ -179,8 +182,11 @@ if [ -z "$TARGET_ROOT" ]; then
   #       writing into .git (e.g. .git/hooks/pre-commit, or .git/config core.hooksPath / alias.*=!sh)
   #       can execute arbitrary code in the non-sandboxed MAIN session on the next git operation —
   #       strictly worse than a source-file edit, and invisible to the worktree-hash post-condition
-  #       axis (git status --porcelain ignores .git). This hook is the sole structural defense, so
-  #       deny git-internal writes; allow only genuine non-repo scratch.
+  #       axis (git status --porcelain ignores .git). This hook is the structural defense for the
+  #       Edit/Write/MultiEdit/NotebookEdit path; deny git-internal writes there, allow only genuine
+  #       non-repo scratch. (Reviewer .git writes via the Bash tool — e.g. `echo > .git/hooks/...`,
+  #       `ln -s` symlink redirection — are a broader gap tracked separately, out of Issue #1860's
+  #       Edit/Write scope; pre-tool-bash-guard.sh only blocks state-mutating git verbs today.)
   if [ "$(git -C "$_tdir" rev-parse --is-inside-git-dir 2>/dev/null)" = "true" ]; then
     _deny_kind="git-dir"
   else

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -90,9 +90,15 @@ CWD=$(printf '%s' "$JQ_OUT" | cut -f2)
 [ -n "$FILE_PATH" ] || exit 0
 
 # --- Reviewer subagent detection (3-tier) ---
-# CANONICAL COPY lives in pre-tool-bash-guard.sh (Pattern 4). Keep the two in
-# sync: this is an intentional defense-in-depth duplication (a shared lib used by
-# only two hooks would force a risky refactor of the heavily-pinned bash-guard).
+# The detection LOGIC (the 3 tiers below) is the canonical copy from
+# pre-tool-bash-guard.sh (Pattern 4) and is kept in sync with it: an intentional
+# defense-in-depth duplication (a shared lib used by only two hooks would force a
+# risky refactor of the heavily-pinned bash-guard). Observability differs by design:
+# the sibling wraps this jq with a RITE_DEBUG stderr-capture because it is the first
+# jq to touch INPUT there; here two prior jq calls (tool_name, file/notebook path)
+# have already parsed the same INPUT, so a parse failure at this third jq is
+# unreachable — the `|| JQ_SA=$'\t\t'` fallback is a formality, not a live silent-bypass
+# path, and needs no debug logging.
 #   Tier 1 (primary):  transcript_path glob `*/subagents/*` — current Claude Code
 #                      convention routing subagent sessions under a subagents/ dir.
 #   Tier 2 (fallback): hook input JSON `subagent_type` / `agent_type` STRING field
@@ -119,44 +125,47 @@ fi
 # guarantee that /rite:open → implement.md Edit/Write is unaffected (AC-4).
 [ "$IS_SUBAGENT" = "1" ] || exit 0
 
-# --- Absolute path resolution (naive join; no symlink/`..` canonicalization) ---
-# A relative file_path is resolved against the tool's cwd. `..` escapes are not
-# normalized here: an adversarial `..`-laden path simply won't match the repo
-# prefix below and falls OPEN — the post-condition axis (post-review-state-verify.sh
-# worktree hash) still catches the resulting dirty tree (defense-in-depth).
+# --- Absolute path resolution (join relative against cwd; do NOT collapse `..` lexically) ---
+# `..` is resolved PHYSICALLY by `git -C` / `[ -d ]` below, never by string munging. A lexical
+# collapse (or a raw substring match) would let a reviewer forge an isolation path —
+# `<repo>/rite-review-mutation-x/../plugins/rite/hooks.json` re-enters a tracked file, and
+# `<repo>/src/rite-review-mutation-hack.py` embeds the token in a filename — both empirically
+# bypassed the old substring allowlist (Issue #1860 review cycle 1).
 case "$FILE_PATH" in
   /*) ABS_PATH="$FILE_PATH" ;;
   *)  ABS_PATH="${CWD%/}/$FILE_PATH" ;;
 esac
 
-# --- Isolation allowlist (checked BEFORE repo-internal — AC-4 critical) ---
-# Reviewers legitimately cd into a detached mutation worktree created via
-# `mktemp -d -t rite-review-mutation-XXXXXX` / `rite-revert-test-*` under $TMPDIR
-# (see agents/_reviewer-base.md "Mutation experiments"). Because the reviewer cd's
-# INTO that dir, `git -C "$cwd" rev-parse --show-toplevel` returns the mutation
-# dir itself, so the repo-internal check below would false-deny a legitimate
-# in-worktree edit. Short-circuit to allow when the target is under a sanctioned
-# reviewer isolation prefix. (Namespace source of truth: the same prefixes swept
-# by hooks/scripts/pr-cycle-cleanup.sh Step 4.)
-case "$ABS_PATH" in
+# --- Resolve the git worktree that OWNS the target ---
+# The isolation allowance is defined by "the target lives inside a sanctioned reviewer isolation
+# worktree", NOT by "the path string contains the token". Resolve the target's own worktree by
+# walking up to its nearest EXISTING ancestor, then asking git. `[ -d ]` and `git -C` both chdir
+# and resolve `..` physically, so a path carrying a non-existent `..` segment lands on the real
+# parent repo (→ deny), not on a forged isolation dir. Walking to the nearest existing ancestor
+# also covers a brand-new file in a not-yet-created dir (the ancestor still resolves to the repo).
+_tdir=$(dirname "$ABS_PATH")
+while [ -n "$_tdir" ] && [ "$_tdir" != "/" ] && [ ! -d "$_tdir" ]; do
+  _tdir=$(dirname "$_tdir")
+done
+[ -d "$_tdir" ] || _tdir="${CWD:-.}"
+# git -C chdir's to the resolved ancestor and reports the worktree toplevel that owns it.
+TARGET_ROOT=$(git -C "$_tdir" rev-parse --show-toplevel 2>/dev/null) || TARGET_ROOT=""
+# Target is not inside any git repo (e.g. /tmp scratch) → cannot be the parent working tree →
+# allow (fail-open; scope not confirmed).
+[ -n "$TARGET_ROOT" ] || exit 0
+TARGET_ROOT="${TARGET_ROOT%/}"
+
+# --- Isolation allowance: the target's OWN worktree is a sanctioned isolation worktree ---
+# Reviewers legitimately run mutation experiments in a detached worktree created via
+# `mktemp -d -t rite-review-mutation-XXXXXX` + `git worktree add --detach` (or the
+# `rite-revert-test-*` sibling namespace — same prefixes swept by pr-cycle-cleanup.sh Step 4).
+# Matching on TARGET_ROOT (the target's resolved worktree root), not the raw path, means only a
+# genuine isolation worktree is allowed — closing the substring / `..` re-entry bypass.
+case "$TARGET_ROOT" in
   */rite-review-mutation-*|*/rite-revert-test-*) exit 0 ;;
 esac
 
-# --- Repo-internal check ---
-# Resolve the parent working tree root from the tool cwd. If git can't resolve a
-# toplevel (not a repo), we cannot confirm the write is repo-internal → allow
-# (fail-open; scope not confirmed).
-REPO_ROOT=$(git -C "${CWD:-.}" rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
-[ -n "$REPO_ROOT" ] || exit 0
-REPO_ROOT="${REPO_ROOT%/}"
-
-# Deny only when the absolute target path is under the repo root.
-case "$ABS_PATH" in
-  "$REPO_ROOT"/*) ;;   # inside the parent working tree → fall through to deny
-  *) exit 0 ;;         # outside the repo (e.g. /tmp scratch) → allow
-esac
-
-# --- Scope confirmed: subagent + repo-internal + non-isolation → DENY ---
+# --- Scope confirmed: subagent + target inside a non-isolation (parent) working tree → DENY ---
 # Swap to the fail-CLOSED trap so any crash from here on denies rather than allows.
 trap '_rite_teg_fail_closed' ERR
 
@@ -165,7 +174,7 @@ PATH_SUMMARY="${ABS_PATH:0:120}"
 PATH_SUMMARY="${PATH_SUMMARY//\"/\\\"}"
 echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2
 
-_deny_reason="BLOCKED (reviewer-edit-parent-tree): Reviewer subagents must not mutate the parent working tree. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which is inside the repository working tree (${REPO_ROOT}). Reviewers are strictly read-only — inspect files with Read/Grep and compare historical content with 'git show <ref>:<file>'. If you need a mutation/verification experiment, do it in an isolated detached worktree under \$TMPDIR: 'git worktree add --detach \$(mktemp -d -t rite-review-mutation-XXXXXX) HEAD' and edit files THERE (paths under rite-review-mutation-* / rite-revert-test-* are allowed). See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement / Mutation experiments)."
+_deny_reason="BLOCKED (reviewer-edit-parent-tree): Reviewer subagents must not mutate the parent working tree. The ${TOOL_NAME} tool targeted '${ABS_PATH}', which resolves inside the repository working tree (${TARGET_ROOT}). Reviewers are strictly read-only — inspect files with Read/Grep and compare historical content with 'git show <ref>:<file>'. If you need a mutation/verification experiment, do it in an isolated detached worktree under \$TMPDIR: 'git worktree add --detach \$(mktemp -d -t rite-review-mutation-XXXXXX) HEAD' and edit files THERE (a real worktree whose root is named rite-review-mutation-* / rite-revert-test-* is allowed). See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement / Mutation experiments)."
 # jq is required to emit the permission payload; an intermittent jq failure would
 # silently downgrade the deny to allow, so the fail-CLOSED trap catches a crash
 # here and emits a static deny + exit 2.

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -18,17 +18,24 @@
 #       --original-branch <name> \
 #       [--original-stash-count <N>] \
 #       [--original-branch-list-hash <hash>] \
+#       [--original-worktree-hash <hash>] \
 #       [--auto-recover true|false]
 #
 # Arguments:
 #   --original-branch <name>           Review 開始時の current branch 名 (required)
 #   --original-stash-count <N>         Review 開始時の `git stash list` 行数 (optional)
 #   --original-branch-list-hash <hash> Review 開始時の `git branch --list | sort | md5sum` (optional)
+#   --original-worktree-hash <hash>    Review 開始時の `git status --porcelain | md5sum` (optional、Issue #1860)
 #   --auto-recover                     drift 検出時に automatic recovery を行う (default: true)
 #
+# State vector axes (drift 検出の優先順): branch → stash → branch_list → worktree。
+# branch drift のみ auto-recover 対象 (exit 1 で block しうる)。stash / branch_list /
+# worktree drift は内容を失うリスク回避のため advisory (WARNING + 手動 triage、exit 0)。
+#
 # Exit codes:
-#   0 — no drift, or drift detected and successfully recovered
-#   1 — drift detected and recovery failed (manual intervention required)
+#   0 — no drift, or drift detected and (branch) successfully recovered,
+#       or advisory drift (stash / branch_list / worktree)
+#   1 — branch drift detected and recovery failed (manual intervention required)
 #   2 — invalid arguments
 #
 # Output:
@@ -36,12 +43,14 @@
 #   stdout: machine-readable JSON summary
 #     {"drift": false}
 #     {"drift": true, "type": "branch", "from": "...", "to": "...", "recovered": true}
+#     {"drift": true, "type": "worktree", "detail": "...", "recovered": false}
 
 set -uo pipefail  # 意図的に -e なし: drift detection 自体を fail とせず、結果を JSON で返す
 
 ORIGINAL_BRANCH=""
 ORIGINAL_STASH_COUNT=""
 ORIGINAL_BRANCH_LIST_HASH=""
+ORIGINAL_WORKTREE_HASH=""
 AUTO_RECOVER="true"
 
 # 各値付きフラグは `shift; shift` で消費する。値なしフラグが末尾に来た場合 ($#=1)、
@@ -60,6 +69,10 @@ while [ $# -gt 0 ]; do
       ;;
     --original-branch-list-hash)
       ORIGINAL_BRANCH_LIST_HASH="${2:-}"
+      shift; shift
+      ;;
+    --original-worktree-hash)
+      ORIGINAL_WORKTREE_HASH="${2:-}"
       shift; shift
       ;;
     --auto-recover)
@@ -117,6 +130,15 @@ if [ -n "$_hash_cmd" ]; then
 else
   current_branch_list_hash=""
 fi
+# Worktree axis (Issue #1860): `git status --porcelain` hash captures working-tree
+# + index drift (modified / staged / untracked) that the branch / stash /
+# branch_list axes cannot see — e.g. a reviewer editing a source file in place via
+# Edit/Write and hand-restoring it, or leaving a `.bak` untracked. Advisory only.
+if [ -n "$_hash_cmd" ]; then
+  current_worktree_hash=$(git status --porcelain 2>/dev/null | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
+else
+  current_worktree_hash=""
+fi
 
 # --- Drift detection ---
 drift_detected="false"
@@ -155,6 +177,18 @@ if [ "$drift_detected" = "false" ] \
   drift_detail="reviewer leaked named branch(es); compare 'git branch --list' before/after"
 fi
 
+# worktree_hash check (Issue #1860): 両側に hash 値がある場合のみ比較する。
+# 空文字列 (hash コマンド非利用 or hash 計算失敗) は比較不可として skip し silent
+# false-negative を防ぐ (branch_list check と同一ガード)。
+if [ "$drift_detected" = "false" ] \
+   && [ -n "$ORIGINAL_WORKTREE_HASH" ] \
+   && [ -n "$current_worktree_hash" ] \
+   && [ "$current_worktree_hash" != "$ORIGINAL_WORKTREE_HASH" ]; then
+  drift_detected="true"
+  drift_type="worktree"
+  drift_detail="reviewer mutated the working tree/index (Edit/Write or state-changing git); compare 'git status --porcelain' before/after"
+fi
+
 if [ "$drift_detected" = "false" ]; then
   printf '{"drift":false}\n'
   exit 0
@@ -164,7 +198,14 @@ fi
 echo "WARNING: Reviewer subagent caused parent session state drift" >&2
 echo "  type: $drift_type" >&2
 echo "  detail: $drift_detail" >&2
-echo "  context: pre-tool-bash-guard hook (Pattern 4) did not block this mutation — investigate transcript_path detection or hook registration" >&2
+# 一次防御 hook の名指しは drift 軸で出し分ける: worktree drift は Edit/Write または
+# state-changing git のどちらでも起こりうるため両 hook を、それ以外の軸は git 経路の
+# pre-tool-bash-guard.sh を指す (Issue #1860)。
+if [ "$drift_type" = "worktree" ]; then
+  echo "  context: pre-tool-edit-guard hook (Edit/Write/MultiEdit/NotebookEdit) and/or pre-tool-bash-guard hook (Pattern 4, state-changing git) did not block this mutation — investigate subagent detection (transcript_path) or hook registration" >&2
+else
+  echo "  context: pre-tool-bash-guard hook (Pattern 4) did not block this mutation — investigate transcript_path detection or hook registration" >&2
+fi
 
 recovered="false"
 recovery_error=""
@@ -195,6 +236,13 @@ if [ "$drift_type" = "branch_list" ]; then
   echo "  manual action: review 'git branch --list' for unexpected names matching reviewer experiment patterns" >&2
 fi
 
+# worktree drift は自動 recovery しない (reviewer が加えた変更を破棄すると PR ブランチの
+# 正当な作業まで巻き添えにするリスク。auto-recover は Issue #1860 の明示 non-goal)。
+if [ "$drift_type" = "worktree" ]; then
+  echo "  recovery: SKIPPED (working-tree drift is not auto-recovered — a blind revert could discard legitimate PR work)" >&2
+  echo "  manual action: run 'git status --porcelain' and 'git diff' to triage the drift; a reviewer subagent likely edited a file in place (Edit/Write) or ran a state-changing git command — restore intended state manually before /rite:fix consumes the diff" >&2
+fi
+
 # --- JSON summary ---
 # `drift_detail` / `drift_type` は他 hook script 由来の長文メッセージを内包する可能性があるため、
 # printf で JSON value に直接埋め込むのではなく jq で escape する。
@@ -203,8 +251,8 @@ jq -nc --arg t "$drift_type" --arg d "$drift_detail" --arg r "$recovered" \
   '{drift: true, type: $t, detail: $d, recovered: ($r == "true")}'
 
 # Exit code: recovered=true → 0、recovered=false → 1 (manual intervention required)
-if [ "$recovered" = "true" ] || [ "$drift_type" = "stash" ] || [ "$drift_type" = "branch_list" ]; then
-  # stash/branch_list は自動 recover しないが advisory として exit 0 (review flow を block しない)
+if [ "$recovered" = "true" ] || [ "$drift_type" = "stash" ] || [ "$drift_type" = "branch_list" ] || [ "$drift_type" = "worktree" ]; then
+  # stash/branch_list/worktree は自動 recover しないが advisory として exit 0 (review flow を block しない)
   exit 0
 fi
 exit 1

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -48,6 +48,7 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required but not installed" >&2
   exit 1
 fi
+REAL_JQ=$(command -v jq)   # absolute path, captured before any PATH-shim test shadows `jq`
 
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
@@ -250,6 +251,55 @@ out=$(jq -n --arg tp "$SUBAGENT_TRANSCRIPT" --arg cwd "$TEST_REPO" \
   '{tool_name: "Edit", tool_input: {}, cwd: $cwd, transcript_path: $tp}' \
   | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
 assert_allow "missing file_path fails open (cannot scope)" "$out" "$rc"
+echo ""
+
+# --------------------------------------------------------------------------
+# .git-internal writes → deny (Issue #1860 review cycle 2 — .git/hooks/pre-commit
+# etc. would give main-session code execution; git rev-parse --show-toplevel is empty
+# inside .git so the naive "empty → allow" branch used to let these through).
+# --------------------------------------------------------------------------
+assert_deny_gitdir() {
+  local label="$1" out="$2"
+  if [ "$(decision_of "$out")" = "deny" ] && [[ "$(reason_of "$out")" == *"reviewer-edit-git-dir"* ]]; then
+    pass "$label"
+  else
+    fail "$label — expected git-dir deny, got decision=$(decision_of "$out") reason=$(reason_of "$out")"
+  fi
+}
+
+echo "TC-GITDIR-hooks: subagent Write into .git/hooks/pre-commit → deny"
+out=$(run_edit_guard "Write" "$TEST_REPO/.git/hooks/pre-commit" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "write into .git/hooks blocked (RCE vector)" "$out"
+echo ""
+
+echo "TC-GITDIR-config: subagent Edit to .git/config → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/.git/config" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "write into .git/config blocked" "$out"
+echo ""
+
+# --------------------------------------------------------------------------
+# fail-closed: a crash in the deny-emit (jq -n) still DENIES (exit 2), never allows.
+# A PATH shim fails only `jq -n` (the deny payload) and passes every INPUT-parsing jq
+# through to the real jq, so scope is confirmed and only the final emit crashes.
+# --------------------------------------------------------------------------
+echo "TC-FAILCLOSED: deny-emit jq crash → fail-closed (deny + exit 2)"
+shimdir=$(mktemp -d)
+cat > "$shimdir/jq" <<SHIM
+#!/bin/bash
+for a in "\$@"; do [ "\$a" = "-n" ] && exit 1; done
+exec "$REAL_JQ" "\$@"
+SHIM
+chmod +x "$shimdir/jq"
+rc=0
+out=$(jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+  | PATH="$shimdir:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+if [ "$(decision_of "$out")" = "deny" ] && [ "$rc" = "2" ]; then
+  pass "deny-emit crash denies fail-closed (exit 2)"
+else
+  fail "expected deny + exit 2, got decision=$(decision_of "$out") rc=$rc"
+fi
+rm -rf "$shimdir"
 echo ""
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Tests for pre-tool-edit-guard.sh (PreToolUse hook, Issue #1860)
+# Usage: bash plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+#
+# Verifies AC-1 (reviewer subagent Edit/Write/MultiEdit/NotebookEdit to the parent
+# working tree is denied) and AC-4 (normal review and isolated-worktree mutation
+# testing are NOT false-denied).
+set -euo pipefail
+
+# Tier 3 (env var) subagent detection: a host env with these set would make the
+# main-session allow tests deny via Tier 3 and flake. Neutralize like the sibling
+# pre-tool-bash-guard.test.sh does.
+unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../pre-tool-edit-guard.sh"
+PASS=0
+FAIL=0
+STDERR_FILE=$(mktemp)
+
+# A real git repo so `git -C "$cwd" rev-parse --show-toplevel` resolves (the
+# repo-internal check). A sanctioned reviewer isolation dir sits OUTSIDE it.
+TEST_REPO=$(mktemp -d)
+ISO_MUT_DIR=$(mktemp -d -t rite-review-mutation-XXXXXX)
+ISO_REV_DIR=$(mktemp -d -t rite-revert-test-XXXXXX)
+OUTSIDE_DIR=$(mktemp -d)
+( cd "$TEST_REPO" && git init -q && git config user.email t@t && git config user.name t )
+
+cleanup() {
+  rm -f "$STDERR_FILE"
+  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR"
+}
+trap cleanup EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed" >&2
+  exit 1
+fi
+
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+SUBAGENT_TRANSCRIPT="/home/user/.claude/projects/proj/session-id/subagents/agent-abc123.jsonl"
+MAIN_TRANSCRIPT="/home/user/.claude/projects/proj/session-id/main.jsonl"
+
+# Build a PreToolUse envelope and pipe it to the hook.
+#   $1 tool_name  $2 file/notebook path  $3 cwd  $4 transcript_path
+# NotebookEdit populates tool_input.notebook_path; the rest use file_path.
+run_edit_guard() {
+  local tool_name="$1" path="$2" cwd="$3" transcript="$4"
+  local field="file_path"
+  [ "$tool_name" = "NotebookEdit" ] && field="notebook_path"
+  local rc=0 output
+  output=$(jq -n --arg tn "$tool_name" --arg p "$path" --arg cwd "$cwd" \
+    --arg tp "$transcript" --arg field "$field" \
+    '{tool_name: $tn, tool_input: {($field): $p}, cwd: $cwd, transcript_path: $tp}' \
+    | bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  echo "$output"
+  return $rc
+}
+
+decision_of() { echo "$1" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null; }
+reason_of()   { echo "$1" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null; }
+
+echo "=== pre-tool-edit-guard.sh tests ==="
+echo ""
+
+# --------------------------------------------------------------------------
+# (a) subagent Edit to a parent-working-tree file → deny
+# --------------------------------------------------------------------------
+echo "TC-A: subagent Edit to parent working tree → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/src/bets.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+if [ "$(decision_of "$out")" = "deny" ] && [[ "$(reason_of "$out")" == *"reviewer-edit-parent-tree"* ]]; then
+  pass "subagent Edit to repo file blocked"
+else
+  fail "Expected deny, got decision=$(decision_of "$out") reason=$(reason_of "$out")"
+fi
+if grep -q "edit-guard: BLOCKED" "$STDERR_FILE"; then
+  pass "stderr contains block log"
+else
+  fail "Expected stderr block log, got: $(cat "$STDERR_FILE")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (a2) subagent Edit with RELATIVE path (cwd=repo) → deny (relative join)
+# --------------------------------------------------------------------------
+echo "TC-A2: subagent Edit relative path under repo → deny"
+out=$(run_edit_guard "Edit" "src/bets.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+if [ "$(decision_of "$out")" = "deny" ]; then
+  pass "subagent Edit (relative) to repo file blocked"
+else
+  fail "Expected deny, got decision=$(decision_of "$out")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (b) subagent Edit under rite-review-mutation-* (reviewer cd'd in) → allow
+# --------------------------------------------------------------------------
+echo "TC-B: subagent Edit under rite-review-mutation-* isolation dir → allow"
+out=$(run_edit_guard "Edit" "some-file.sh" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  pass "isolated mutation-worktree edit allowed (AC-4)"
+else
+  fail "Expected allow (exit 0, no output), got rc=$rc out=$out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (e) subagent Edit under rite-revert-test-* → allow
+# --------------------------------------------------------------------------
+echo "TC-E: subagent Edit under rite-revert-test-* isolation dir → allow"
+out=$(run_edit_guard "Write" "$ISO_REV_DIR/probe.txt" "$ISO_REV_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  pass "isolated revert-test-worktree edit allowed (AC-4)"
+else
+  fail "Expected allow, got rc=$rc out=$out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (c) main-session Edit to parent tree → allow (primary AC-4 guarantee)
+# --------------------------------------------------------------------------
+echo "TC-C: main-session Edit to parent working tree → allow"
+out=$(run_edit_guard "Edit" "$TEST_REPO/src/bets.py" "$TEST_REPO" "$MAIN_TRANSCRIPT") && rc=0 || rc=$?
+if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  pass "main-session edit not blocked (implement.md Edit/Write unaffected)"
+else
+  fail "Expected allow, got rc=$rc out=$out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (d) tool parity: subagent Write / MultiEdit / NotebookEdit to parent tree → deny
+# --------------------------------------------------------------------------
+for tool in Write MultiEdit NotebookEdit; do
+  echo "TC-D-$tool: subagent $tool to parent working tree → deny"
+  path="$TEST_REPO/src/mod.py"
+  [ "$tool" = "NotebookEdit" ] && path="$TEST_REPO/nb.ipynb"
+  out=$(run_edit_guard "$tool" "$path" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+  if [ "$(decision_of "$out")" = "deny" ]; then
+    pass "$tool to repo file blocked"
+  else
+    fail "Expected deny for $tool, got decision=$(decision_of "$out")"
+  fi
+  echo ""
+done
+
+# --------------------------------------------------------------------------
+# (f) subagent Edit outside repo AND outside isolation → allow (not repo-internal)
+# --------------------------------------------------------------------------
+echo "TC-F: subagent Edit to /tmp scratch outside repo → allow"
+out=$(run_edit_guard "Edit" "$OUTSIDE_DIR/scratch.txt" "$OUTSIDE_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  pass "non-repo scratch edit allowed"
+else
+  fail "Expected allow, got rc=$rc out=$out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (g) non-matching tool (Bash) → allow (defense-in-depth against matcher drift)
+# --------------------------------------------------------------------------
+echo "TC-G: non-Edit tool (Bash) → allow (exit 0, no output)"
+out=$(jq -n --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Bash", tool_input: {command: "git status"}, cwd: "/tmp", transcript_path: $tp}' \
+  | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
+if [ "$rc" = "0" ] && [ -z "$out" ]; then
+  pass "Bash tool ignored by edit-guard"
+else
+  fail "Expected allow, got rc=$rc out=$out"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# (h) Tier 3 env-var subagent detection: main transcript but env set → deny
+# --------------------------------------------------------------------------
+echo "TC-H: env-var (Tier 3) subagent detection to parent tree → deny"
+out=$(CLAUDE_SUBAGENT_TYPE="code-quality-reviewer" jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+  | CLAUDE_SUBAGENT_TYPE="code-quality-reviewer" bash "$HOOK" 2>"$STDERR_FILE") || true
+if [ "$(decision_of "$out")" = "deny" ]; then
+  pass "Tier 3 env-var subagent detection blocks parent-tree edit"
+else
+  fail "Expected deny, got decision=$(decision_of "$out")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -3,14 +3,17 @@
 # Usage: bash plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
 #
 # Verifies AC-1 (reviewer subagent Edit/Write/MultiEdit/NotebookEdit to the parent
-# working tree is denied) and AC-4 (normal review and isolated-worktree mutation
-# testing are NOT false-denied).
+# working tree is denied — including token-in-filename / `..` re-entry forgery of the
+# isolation allowlist, Issue #1860 review cycle 1) and AC-4 (normal review and
+# isolated-worktree mutation testing are NOT false-denied).
 set -euo pipefail
 
-# Tier 3 (env var) subagent detection: a host env with these set would make the
-# main-session allow tests deny via Tier 3 and flake. Neutralize like the sibling
-# pre-tool-bash-guard.test.sh does.
-unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE
+# Neutralize env that would perturb detection / double-exec guards:
+# - CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE (Tier 3): a host value would make the
+#   main-session allow tests deny via Tier 3 and flake.
+# - _RITE_HOOK_RUNNING_PRETOOL_EDIT (double-exec guard): a host value would make every
+#   hook invocation exit 0 immediately, silently turning deny tests into false allows.
+unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE _RITE_HOOK_RUNNING_PRETOOL_EDIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../pre-tool-edit-guard.sh"
@@ -18,16 +21,25 @@ PASS=0
 FAIL=0
 STDERR_FILE=$(mktemp)
 
-# A real git repo so `git -C "$cwd" rev-parse --show-toplevel` resolves (the
-# repo-internal check). A sanctioned reviewer isolation dir sits OUTSIDE it.
+# A real git repo so `git -C ... rev-parse --show-toplevel` resolves the target's
+# worktree. Isolation dirs are REAL detached worktrees (not bare `mktemp -d`) so the
+# hook's isolation branch — which matches on the target's *worktree root* — is actually
+# exercised. A bare mktemp -d would resolve to "no repo" → allow via a different (fail-open)
+# path, giving a false-positive that survives even if the allowlist is deleted.
 TEST_REPO=$(mktemp -d)
-ISO_MUT_DIR=$(mktemp -d -t rite-review-mutation-XXXXXX)
-ISO_REV_DIR=$(mktemp -d -t rite-revert-test-XXXXXX)
-OUTSIDE_DIR=$(mktemp -d)
-( cd "$TEST_REPO" && git init -q && git config user.email t@t && git config user.name t )
+( cd "$TEST_REPO" && git init -q && git config user.email t@t && git config user.name t \
+    && git commit -q --allow-empty -m init )
+# Detached worktrees whose ROOT dir carries the sanctioned isolation prefixes.
+ISO_MUT_DIR=$(mktemp -u -t rite-review-mutation-XXXXXX)
+ISO_REV_DIR=$(mktemp -u -t rite-revert-test-XXXXXX)
+( cd "$TEST_REPO" && git worktree add --detach -q "$ISO_MUT_DIR" HEAD )
+( cd "$TEST_REPO" && git worktree add --detach -q "$ISO_REV_DIR" HEAD )
+OUTSIDE_DIR=$(mktemp -d)   # a plain, non-repo scratch dir
 
 cleanup() {
   rm -f "$STDERR_FILE"
+  ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_MUT_DIR" 2>/dev/null ) || true
+  ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_REV_DIR" 2>/dev/null ) || true
   rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR"
 }
 trap cleanup EXIT
@@ -62,6 +74,25 @@ run_edit_guard() {
 decision_of() { echo "$1" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null; }
 reason_of()   { echo "$1" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null; }
 
+# Assert deny with the expected pattern-name marker in the reason.
+assert_deny() {
+  local label="$1" out="$2"
+  if [ "$(decision_of "$out")" = "deny" ] && [[ "$(reason_of "$out")" == *"reviewer-edit-parent-tree"* ]]; then
+    pass "$label"
+  else
+    fail "$label — expected deny, got decision=$(decision_of "$out") reason=$(reason_of "$out")"
+  fi
+}
+# Assert allow (exit 0, no stdout).
+assert_allow() {
+  local label="$1" out="$2" rc="$3"
+  if [ "$rc" = "0" ] && [ -z "$out" ]; then
+    pass "$label"
+  else
+    fail "$label — expected allow (exit 0, empty), got rc=$rc out=$out"
+  fi
+}
+
 echo "=== pre-tool-edit-guard.sh tests ==="
 echo ""
 
@@ -70,52 +101,62 @@ echo ""
 # --------------------------------------------------------------------------
 echo "TC-A: subagent Edit to parent working tree → deny"
 out=$(run_edit_guard "Edit" "$TEST_REPO/src/bets.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
-if [ "$(decision_of "$out")" = "deny" ] && [[ "$(reason_of "$out")" == *"reviewer-edit-parent-tree"* ]]; then
-  pass "subagent Edit to repo file blocked"
-else
-  fail "Expected deny, got decision=$(decision_of "$out") reason=$(reason_of "$out")"
-fi
-if grep -q "edit-guard: BLOCKED" "$STDERR_FILE"; then
-  pass "stderr contains block log"
-else
-  fail "Expected stderr block log, got: $(cat "$STDERR_FILE")"
-fi
+assert_deny "subagent Edit to repo file blocked" "$out"
+if grep -q "edit-guard: BLOCKED" "$STDERR_FILE"; then pass "stderr contains block log"; else fail "stderr block log missing: $(cat "$STDERR_FILE")"; fi
 echo ""
 
-# --------------------------------------------------------------------------
 # (a2) subagent Edit with RELATIVE path (cwd=repo) → deny (relative join)
-# --------------------------------------------------------------------------
 echo "TC-A2: subagent Edit relative path under repo → deny"
 out=$(run_edit_guard "Edit" "src/bets.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
-if [ "$(decision_of "$out")" = "deny" ]; then
-  pass "subagent Edit (relative) to repo file blocked"
-else
-  fail "Expected deny, got decision=$(decision_of "$out")"
-fi
+assert_deny "subagent Edit (relative) to repo file blocked" "$out"
 echo ""
 
 # --------------------------------------------------------------------------
-# (b) subagent Edit under rite-review-mutation-* (reviewer cd'd in) → allow
+# BYPASS regression (Issue #1860 review cycle 1) — forged isolation paths → deny
 # --------------------------------------------------------------------------
-echo "TC-B: subagent Edit under rite-review-mutation-* isolation dir → allow"
+echo "TC-BYPASS-A: token embedded in a repo filename → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/src/rite-review-mutation-hack.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "token-in-filename does NOT grant isolation" "$out"
+echo ""
+
+echo "TC-BYPASS-B: '..' re-entry to a tracked repo file → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/rite-review-mutation-x/../src/tracked.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "dotdot re-entry does NOT grant isolation" "$out"
+echo ""
+
+echo "TC-BYPASS-B2: '..' via NON-existent segment → deny (physical resolution to real repo)"
+out=$(run_edit_guard "Edit" "$TEST_REPO/nonexistent-rite-review-mutation-x/../src/tracked.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "nonexistent-segment dotdot resolves to real repo → deny" "$out"
+echo ""
+
+echo "TC-BYPASS-C: revert-test token substring in a repo path → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/plugins/rite-revert-test-anything.md" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "revert-test substring does NOT grant isolation" "$out"
+echo ""
+
+echo "TC-NEWDIR: subagent Edit to a brand-new dir inside repo → deny (walk-up to repo)"
+out=$(run_edit_guard "Write" "$TEST_REPO/brand-new-dir/evil.py" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "new dir/file inside repo blocked" "$out"
+echo ""
+
+# --------------------------------------------------------------------------
+# (b) subagent Edit inside a REAL rite-review-mutation-* worktree → allow
+# --------------------------------------------------------------------------
+echo "TC-B: subagent Edit inside real rite-review-mutation-* worktree → allow"
 out=$(run_edit_guard "Edit" "some-file.sh" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
-if [ "$rc" = "0" ] && [ -z "$out" ]; then
-  pass "isolated mutation-worktree edit allowed (AC-4)"
-else
-  fail "Expected allow (exit 0, no output), got rc=$rc out=$out"
-fi
+assert_allow "isolated mutation-worktree edit allowed (AC-4)" "$out" "$rc"
 echo ""
 
-# --------------------------------------------------------------------------
-# (e) subagent Edit under rite-revert-test-* → allow
-# --------------------------------------------------------------------------
-echo "TC-E: subagent Edit under rite-revert-test-* isolation dir → allow"
+# (e) subagent Edit inside a REAL rite-revert-test-* worktree → allow
+echo "TC-E: subagent Edit inside real rite-revert-test-* worktree → allow"
 out=$(run_edit_guard "Write" "$ISO_REV_DIR/probe.txt" "$ISO_REV_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
-if [ "$rc" = "0" ] && [ -z "$out" ]; then
-  pass "isolated revert-test-worktree edit allowed (AC-4)"
-else
-  fail "Expected allow, got rc=$rc out=$out"
-fi
+assert_allow "isolated revert-test-worktree edit allowed (AC-4)" "$out" "$rc"
+echo ""
+
+# (residual) reviewer cd'd into isolation worktree but targets parent repo by abs path → deny
+echo "TC-RESIDUAL: cwd=isolation worktree, abs path INTO parent repo → deny"
+out=$(run_edit_guard "Edit" "$TEST_REPO/src/tracked.py" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "abs path escaping isolation into parent repo blocked" "$out"
 echo ""
 
 # --------------------------------------------------------------------------
@@ -123,11 +164,7 @@ echo ""
 # --------------------------------------------------------------------------
 echo "TC-C: main-session Edit to parent working tree → allow"
 out=$(run_edit_guard "Edit" "$TEST_REPO/src/bets.py" "$TEST_REPO" "$MAIN_TRANSCRIPT") && rc=0 || rc=$?
-if [ "$rc" = "0" ] && [ -z "$out" ]; then
-  pass "main-session edit not blocked (implement.md Edit/Write unaffected)"
-else
-  fail "Expected allow, got rc=$rc out=$out"
-fi
+assert_allow "main-session edit not blocked (implement.md Edit/Write unaffected)" "$out" "$rc"
 echo ""
 
 # --------------------------------------------------------------------------
@@ -138,52 +175,81 @@ for tool in Write MultiEdit NotebookEdit; do
   path="$TEST_REPO/src/mod.py"
   [ "$tool" = "NotebookEdit" ] && path="$TEST_REPO/nb.ipynb"
   out=$(run_edit_guard "$tool" "$path" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") || true
-  if [ "$(decision_of "$out")" = "deny" ]; then
-    pass "$tool to repo file blocked"
-  else
-    fail "Expected deny for $tool, got decision=$(decision_of "$out")"
-  fi
+  assert_deny "$tool to repo file blocked" "$out"
   echo ""
 done
 
 # --------------------------------------------------------------------------
-# (f) subagent Edit outside repo AND outside isolation → allow (not repo-internal)
+# (f) subagent Edit outside any repo → allow (target not in a repo)
 # --------------------------------------------------------------------------
-echo "TC-F: subagent Edit to /tmp scratch outside repo → allow"
+echo "TC-F: subagent Edit to /tmp scratch outside any repo → allow"
 out=$(run_edit_guard "Edit" "$OUTSIDE_DIR/scratch.txt" "$OUTSIDE_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
-if [ "$rc" = "0" ] && [ -z "$out" ]; then
-  pass "non-repo scratch edit allowed"
-else
-  fail "Expected allow, got rc=$rc out=$out"
-fi
+assert_allow "non-repo scratch edit allowed" "$out" "$rc"
+echo ""
+
+# (f2) cwd=repo but absolute target OUTSIDE the repo → allow (target not in repo)
+echo "TC-F2: cwd=repo, abs target outside repo → allow"
+out=$(run_edit_guard "Edit" "$OUTSIDE_DIR/scratch.txt" "$TEST_REPO" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+assert_allow "abs target outside repo allowed" "$out" "$rc"
 echo ""
 
 # --------------------------------------------------------------------------
 # (g) non-matching tool (Bash) → allow (defense-in-depth against matcher drift)
 # --------------------------------------------------------------------------
 echo "TC-G: non-Edit tool (Bash) → allow (exit 0, no output)"
-out=$(jq -n --arg tp "$SUBAGENT_TRANSCRIPT" \
-  '{tool_name: "Bash", tool_input: {command: "git status"}, cwd: "/tmp", transcript_path: $tp}' \
+out=$(jq -n --arg tp "$SUBAGENT_TRANSCRIPT" --arg cwd "$TEST_REPO" \
+  '{tool_name: "Bash", tool_input: {command: "git status"}, cwd: $cwd, transcript_path: $tp}' \
   | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
-if [ "$rc" = "0" ] && [ -z "$out" ]; then
-  pass "Bash tool ignored by edit-guard"
-else
-  fail "Expected allow, got rc=$rc out=$out"
-fi
+assert_allow "Bash tool ignored by edit-guard" "$out" "$rc"
+echo ""
+
+# --------------------------------------------------------------------------
+# Tier 2 detection (JSON subagent_type / agent_type) — main transcript, no env
+# --------------------------------------------------------------------------
+echo "TC-T2a: Tier 2 subagent_type field → deny parent-tree edit"
+out=$(jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp, subagent_type: "code-quality-reviewer"}' \
+  | bash "$HOOK" 2>"$STDERR_FILE") || true
+assert_deny "Tier 2 subagent_type blocks parent-tree edit" "$out"
+echo ""
+
+echo "TC-T2b: Tier 2 agent_type field → deny parent-tree edit"
+out=$(jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp, agent_type: "security-reviewer"}' \
+  | bash "$HOOK" 2>"$STDERR_FILE") || true
+assert_deny "Tier 2 agent_type blocks parent-tree edit" "$out"
+echo ""
+
+echo "TC-T2c: Tier 2 NON-string subagent_type (number) → does NOT fire (| strings), main-session → allow"
+out=$(jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
+  '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp, subagent_type: 123}' \
+  | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
+assert_allow "non-string subagent_type rejected via | strings (main-session allow)" "$out" "$rc"
 echo ""
 
 # --------------------------------------------------------------------------
 # (h) Tier 3 env-var subagent detection: main transcript but env set → deny
 # --------------------------------------------------------------------------
 echo "TC-H: env-var (Tier 3) subagent detection to parent tree → deny"
-out=$(CLAUDE_SUBAGENT_TYPE="code-quality-reviewer" jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
+out=$(jq -n --arg p "$TEST_REPO/src/x.py" --arg cwd "$TEST_REPO" --arg tp "$MAIN_TRANSCRIPT" \
   '{tool_name: "Edit", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
   | CLAUDE_SUBAGENT_TYPE="code-quality-reviewer" bash "$HOOK" 2>"$STDERR_FILE") || true
-if [ "$(decision_of "$out")" = "deny" ]; then
-  pass "Tier 3 env-var subagent detection blocks parent-tree edit"
-else
-  fail "Expected deny, got decision=$(decision_of "$out")"
-fi
+assert_deny "Tier 3 env-var subagent detection blocks parent-tree edit" "$out"
+echo ""
+
+# --------------------------------------------------------------------------
+# Malformed / missing input → fail-open (allow), never a spurious deny
+# --------------------------------------------------------------------------
+echo "TC-MALFORMED: non-JSON input → fail-open (allow)"
+out=$(printf 'not json at all' | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
+assert_allow "malformed input fails open" "$out" "$rc"
+echo ""
+
+echo "TC-NOPATH: Edit envelope with no file_path → fail-open (allow)"
+out=$(jq -n --arg tp "$SUBAGENT_TRANSCRIPT" --arg cwd "$TEST_REPO" \
+  '{tool_name: "Edit", tool_input: {}, cwd: $cwd, transcript_path: $tp}' \
+  | bash "$HOOK" 2>"$STDERR_FILE") && rc=0 || rc=$?
+assert_allow "missing file_path fails open (cannot scope)" "$out" "$rc"
 echo ""
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -35,12 +35,13 @@ ISO_REV_DIR=$(mktemp -u -t rite-revert-test-XXXXXX)
 ( cd "$TEST_REPO" && git worktree add --detach -q "$ISO_MUT_DIR" HEAD )
 ( cd "$TEST_REPO" && git worktree add --detach -q "$ISO_REV_DIR" HEAD )
 OUTSIDE_DIR=$(mktemp -d)   # a plain, non-repo scratch dir
+shimdir=""                 # set by TC-FAILCLOSED; cleaned here so an interrupt leaves no residue
 
 cleanup() {
   rm -f "$STDERR_FILE"
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_MUT_DIR" 2>/dev/null ) || true
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_REV_DIR" 2>/dev/null ) || true
-  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR"
+  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR" ${shimdir:+"$shimdir"}
 }
 trap cleanup EXIT
 

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -28,8 +28,8 @@
 #   1 — migration failed (atomic write or jq parse error on a file)
 
 # `-e` を意図的に省略する: 個別ファイルの jq parse 失敗で全体停止させず、
-# FAILED_FILES 配列に集約してから末尾で exit 1 する設計 (post-review-state-verify.sh:40
-# と同パターン)。pipefail は維持して pipeline 失敗を捕捉する。
+# FAILED_FILES 配列に集約してから末尾で exit 1 する設計 (post-review-state-verify.sh の
+# `set -uo pipefail` と同パターン)。pipefail は維持して pipeline 失敗を捕捉する。
 set -uo pipefail
 
 # --- Signal-specific trap setup ---

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1609,7 +1609,7 @@ Verification モードのレビュー指示テンプレート本文は [referenc
 ステップ 4.0.A で記録した `ORIG_BR` / `ORIG_SC` / `ORIG_BLH` / `ORIG_WTH` をリテラル substitute する (ステップ 4.0.A の大文字 shell 変数 → ステップ 5.0.A の小文字 placeholder への mapping: `$ORIG_BR → {orig_br}`, `$ORIG_SC → {orig_sc}`, `$ORIG_BLH → {orig_blh}`, `$ORIG_WTH → {orig_wth}`)。
 
 ```bash
-# {plugin_root} と {orig_br} / {orig_sc} / {orig_blh} (ステップ 4.0.A の出力値) をリテラル substitute する。
+# {plugin_root} と {orig_br} / {orig_sc} / {orig_blh} / {orig_wth} (ステップ 4.0.A の出力値) をリテラル substitute する。
 # Placeholder 残留 fail-fast gate: `{...}` 形状のまま渡ると verifier が silent false-positive cascade を
 # 起こすため早期 reject する。detached HEAD は ステップ 4.0.A で sentinel 変換済みのため常に非空で到達する。
 case "{orig_br}" in

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1300,9 +1300,11 @@ Reviewer subagent が READ-ONLY 契約を破って parent session の working tr
 一次防御は `plugins/rite/hooks/pre-tool-bash-guard.sh` Pattern 4 (subagent context で state-mutating git command を block する PreToolUse hook)。本 snapshot + ステップ 5.0.A verify は hook が edge case (transcript_path に `/subagents/` が含まれない subagent ルーティング等) で機能しなかった場合の **defense-in-depth post-condition gate**。
 
 ```bash
-# 3 変数 (ORIG_BR / ORIG_SC / ORIG_BLH) は ステップ 5.0.A の post-review-state-verify.sh 引数として
-# 再利用するため会話 context に保持する (Bash tool 間で shell 変数は引き継がれない)。
+# 4 変数 (ORIG_BR / ORIG_SC / ORIG_BLH / ORIG_WTH) は ステップ 5.0.A の post-review-state-verify.sh
+# 引数として再利用するため会話 context に保持する (Bash tool 間で shell 変数は引き継がれない)。
 # detached HEAD は `DETACHED:<short-hash>` sentinel に置換 (verifier 側で branch drift check を skip)。
+# ORIG_WTH は working tree / index の drift (Edit/Write in-place mutation や state-changing git) を
+# 捕捉する 4 軸目 (Issue #1860)。branch/stash/branch_list では見えない porcelain 差分を検出する。
 # rationale: references/design-rationale.md#state-snapshot-notes
 ORIG_BR=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$ORIG_BR" ]; then
@@ -1311,15 +1313,18 @@ fi
 ORIG_SC=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
 if command -v md5sum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | md5sum | awk '{print $1}')
+ ORIG_WTH=$(git status --porcelain 2>/dev/null | md5sum | awk '{print $1}')
 elif command -v shasum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | shasum | awk '{print $1}')
+ ORIG_WTH=$(git status --porcelain 2>/dev/null | shasum | awk '{print $1}')
 else
  ORIG_BLH="" # hash 計算不可 — branch_list drift check は skip 扱い (verifier 側で空文字列を skip)
+ ORIG_WTH="" # hash 計算不可 — worktree drift check は skip 扱い (verifier 側で空文字列を skip)
 fi
-echo "review_pre_state: branch=$ORIG_BR stash_count=$ORIG_SC branch_list_hash=$ORIG_BLH"
+echo "review_pre_state: branch=$ORIG_BR stash_count=$ORIG_SC branch_list_hash=$ORIG_BLH worktree_hash=$ORIG_WTH"
 ```
 
-LLM は出力 3 値 (`ORIG_BR`, `ORIG_SC`, `ORIG_BLH`) を ステップ 5.0.A の `post-review-state-verify.sh` 引数に literal substitute する。**Mapping for ステップ 5.0.A**: `$ORIG_BR → {orig_br}`, `$ORIG_SC → {orig_sc}`, `$ORIG_BLH → {orig_blh}` (大文字 shell 変数 → 小文字 placeholder)。
+LLM は出力 4 値 (`ORIG_BR`, `ORIG_SC`, `ORIG_BLH`, `ORIG_WTH`) を ステップ 5.0.A の `post-review-state-verify.sh` 引数に literal substitute する。**Mapping for ステップ 5.0.A**: `$ORIG_BR → {orig_br}`, `$ORIG_SC → {orig_sc}`, `$ORIG_BLH → {orig_blh}`, `$ORIG_WTH → {orig_wth}` (大文字 shell 変数 → 小文字 placeholder)。
 
 ### 4.0.W Wiki Query Injection (Conditional)
 
@@ -1599,9 +1604,9 @@ Verification モードのレビュー指示テンプレート本文は [referenc
 
 ### 5.0.A Post-Review State Verification
 
-ステップ 4 (parallel review execution) で起動した reviewer subagent が `pre-tool-bash-guard.sh` Pattern 4 を bypass し、parent session の working tree / branch / stash list を mutate しなかったことを post-condition で verify する。drift 検出時は WARNING を stderr に emit し、可能なら `git checkout` で automatic recovery を試みる。
+ステップ 4 (parallel review execution) で起動した reviewer subagent が `pre-tool-bash-guard.sh` Pattern 4 (state-changing git) / `pre-tool-edit-guard.sh` (Edit/Write/MultiEdit/NotebookEdit) を bypass し、parent session の working tree / branch / stash list を mutate しなかったことを post-condition で verify する。drift 検出時は WARNING を stderr に emit し、branch drift のみ `git checkout` で automatic recovery を試みる (worktree drift は auto-recover せず手動 triage を案内 — Issue #1860)。
 
-ステップ 4.0.A で記録した `ORIG_BR` / `ORIG_SC` / `ORIG_BLH` をリテラル substitute する (ステップ 4.0.A の大文字 shell 変数 → ステップ 5.0.A の小文字 placeholder への mapping: `$ORIG_BR → {orig_br}`, `$ORIG_SC → {orig_sc}`, `$ORIG_BLH → {orig_blh}`)。
+ステップ 4.0.A で記録した `ORIG_BR` / `ORIG_SC` / `ORIG_BLH` / `ORIG_WTH` をリテラル substitute する (ステップ 4.0.A の大文字 shell 変数 → ステップ 5.0.A の小文字 placeholder への mapping: `$ORIG_BR → {orig_br}`, `$ORIG_SC → {orig_sc}`, `$ORIG_BLH → {orig_blh}`, `$ORIG_WTH → {orig_wth}`)。
 
 ```bash
 # {plugin_root} と {orig_br} / {orig_sc} / {orig_blh} (ステップ 4.0.A の出力値) をリテラル substitute する。
@@ -1628,6 +1633,13 @@ case "{orig_blh}" in
  exit 1
  ;;
 esac
+case "{orig_wth}" in
+ "{"*"}")
+ echo "ERROR: ステップ 5.0.A の {orig_wth} placeholder が literal substitute されていません (値: '{orig_wth}')." >&2
+ echo "[CONTEXT] POST_REVIEW_VERIFY_FAILED=1; reason=orig_wth_placeholder_residue" >&2
+ exit 1
+ ;;
+esac
 
 # stdout (JSON line) のみ result_json に収集し、stderr の WARNING は
 # Bash tool 経由で会話 context に直接届く (2>&1 で混合させると JSON line を機械的に取り出せない)。
@@ -1635,6 +1647,7 @@ result_json=$(bash {plugin_root}/hooks/scripts/post-review-state-verify.sh \
  --original-branch "{orig_br}" \
  --original-stash-count "{orig_sc}" \
  --original-branch-list-hash "{orig_blh}" \
+ --original-worktree-hash "{orig_wth}" \
  --auto-recover true) || true
 printf '%s\n' "$result_json"
 ```
@@ -1646,6 +1659,7 @@ printf '%s\n' "$result_json"
 | `orig_br_placeholder_residue` | ステップ 5.0.A の `{orig_br}` placeholder が literal substitute されず `{...}` 形状のまま到達 (ステップ 4.0.A 未実行 / Bash tool 間変数の引き継ぎ失敗) |
 | `orig_sc_placeholder_residue` | ステップ 5.0.A の `{orig_sc}` placeholder が未 substitute (同上) |
 | `orig_blh_placeholder_residue` | ステップ 5.0.A の `{orig_blh}` placeholder が未 substitute (同上) |
+| `orig_wth_placeholder_residue` | ステップ 5.0.A の `{orig_wth}` placeholder が未 substitute (同上) |
 
 スクリプトは stderr に WARNING を emit (Bash tool が transcript に取り込む)、stdout に `{"drift":..., "type":..., "recovered":...}` JSON line を出力する。drift 検出時の処理は **non-blocking** (review flow は継続)、drift 結果は ステップ 5.4 完了レポートに reflect される。drift は WARNING として surface され、ユーザーが必要に応じて手動 triage する。
 


### PR DESCRIPTION
## 概要

reviewer subagent が parent working tree のソースファイルを `Edit`/`Write` で直接ミューテーションする READ-ONLY 違反を、hook で機械的に遮断する。あわせて post-review 検証に working tree dirty check 軸を追加し、事後にも drift を surface できるようにした。

これまでの防御層には 2 つの既知ギャップがあった:
1. `pre-tool-bash-guard.sh` Pattern 4 は **Bash 経由の state-changing git** のみを block し、`Edit`/`Write` ツールによるファイル変更は対象外だった
2. `post-review-state-verify.sh` の state vector は branch / stash / branch-list の 3 軸のみで、**working tree の内容 drift を検出しなかった**

prose 禁止（`_reviewer-base.md`）だけでは LLM agent の bypass を止められないことが実運用で実証されたため、structural enforcement を追加する。

## 関連 Issue

Closes #1860

## 変更内容

- **`hooks/pre-tool-edit-guard.sh`（新規）**: PreToolUse hook。`tool_name ∈ {Edit, Write, MultiEdit, NotebookEdit}` かつ subagent context かつ「repo 内 かつ 隔離領域外」の書き込みを deny する。subagent 検出は `pre-tool-bash-guard.sh` の 3-tier 検出（transcript_path / subagent_type / env）を複製（sync コメント付き）。（AC-1）
- **`hooks/hooks.json`**: PreToolUse に 2 個目のエントリを追加（matcher `Edit|Write|MultiEdit|NotebookEdit`）。
- **`hooks/scripts/post-review-state-verify.sh`**: 第 4 軸 `--original-worktree-hash`（`git status --porcelain` の hash）を追加。drift 検出時は WARNING + 手動 triage 案内を出し、**auto-recover しない**（advisory / exit 0）。（AC-2）
- **`skills/pr-review/SKILL.md`**: 4.0.A で `ORIG_WTH` を capture、5.0.A で placeholder 残留 gate + `--original-worktree-hash` 引数を追加。（AC-2）
- **`agents/_reviewer-base.md`**: mutation 節に「`Edit`/`Write`/`MultiEdit`/`NotebookEdit` も隔離 worktree 配下に限る」を明記し、state vector invariant を 3 軸 → 4 軸に更新。（AC-3）
- **`hooks/tests/pre-tool-edit-guard.test.sh`（新規）**: 12 ケースのテスト行列。

## 実装中の判断

- **判断: `MultiEdit` を対象ツールに含めた** — Issue Technical Notes は `{Edit, Write, NotebookEdit}` を挙げるが、MultiEdit も同様にファイルを変更するため、除外すると自明な bypass 経路が残る。security boundary として補正した。
- **判断: isolation allowlist を repo-internal 判定より先に評価** — reviewer は mutation worktree に `cd` してから編集するため、`git -C "$cwd" rev-parse --show-toplevel` が mutation dir 自身を返す。allowlist（`rite-review-mutation-*` / `rite-revert-test-*`）を先に短絡しないと、正当な worktree-only mutation testing を誤検出する（AC-4 の核）。
- **判断: fail 方向を Pattern 4 と対称化** — scope（subagent + repo 内 + 隔離外）確定**前**のクラッシュは fail-open（main セッションの Edit を誤 block しない）、確定**後**の deny emit クラッシュは fail-closed（deny + exit 2）。
- **判断: worktree dirty check は advisory** — auto-recover は Issue の明示 non-goal（盲目的 revert は PR の正当な作業を巻き添えにするリスク）。stash / branch_list 軸と同じ exit 契約に揃えた。

## テスト

- **新規テスト `pre-tool-edit-guard.test.sh`（12 ケース、全 pass）**: (a) subagent × parent tree → deny / (b) subagent × `rite-review-mutation-*` → allow / (c) main-session → allow / (d) `Write`/`MultiEdit`/`NotebookEdit` parity → deny / (e) `rite-revert-test-*` → allow / (f) repo 外 scratch → allow / (g) Bash tool は無視 / (h) Tier 3 env-var 検出。
- **hook 全スイート green**: `hooks/tests/run-tests.sh` → 97/97 passed（既存テストへの影響なし）。
- **post-review-state-verify.sh の worktree 軸を直接検証**: hash 一致 → drift なし / 不一致 → advisory drift (exit 0, WARNING) / 省略 → 従来どおり後方互換。
- **plugin-specific drift/contract チェック**: distributed-fix-drift / sentinel-contract / reviewer-registry-drift / hardcoded-line-number / sh-cross-ref / bash-heaviness / backlink-format / orphan-reference / doc-heavy-patterns-drift はすべて success。変更ファイルに新規 finding ゼロ。

## Notes（レビュー向け開示）

- `plugins/rite/scripts/migrate-review-state-to-1.1.sh:31` のコメントが `post-review-state-verify.sh:40` を参照しているが、本 PR の docstring 追加で当該パターン（`set -uo pipefail`）が行 47 へ移動した。これは repo 全体に既存する hardcoded-line-ref anti-pattern（16 件）の 1 つで、参照が示す設計パターン自体は今も有効。無関係ファイルへのスコープ外変更を避けるため本 PR では未修正とした（structural reference への一括移行は別 issue 相当）。

## チェックリスト

- [x] AC-1: reviewer subagent の Edit/Write を parent working tree に対して機械的に deny
- [x] AC-2: state vector に working tree dirty check（advisory / auto-recover なし）を追加
- [x] AC-3: `_reviewer-base.md` に Edit/Write ツールの隔離限定を明記
- [x] AC-4: 通常レビュー・隔離 worktree mutation testing を誤検出しない
- [x] テスト追加（12 ケース）+ hook 全スイート green（97/97）
