### PR TITLE
fix(reviewers): reviewer の Bash/symlink 経由 .git 書き込み経路を遮断

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -28,6 +28,7 @@ Any Bash invocation that matches the following patterns is forbidden inside a re
 | `git reflog expire` / `git reflog delete` | reflog 改変 | 代替なし — reviewer は実行禁止。`git reflog` の単純な display は read-only として許可 |
 | `git am` / `git apply` | patch 適用 (index 書き換え) | `git show <ref>` で patch 内容のみを参照する |
 | `git mv` / `git notes add/edit/append/remove` / `git config` / `git remote add/remove/set-url` | tracked file rename / notes 書き換え / local config / remote 編集 | 代替なし — reviewer は実行禁止 |
+| `> .git/…` / `>> .git/…` リダイレクト・`tee` / `cp` / `mv` / `ln` / `install` / `rsync` / `truncate` で `.git` ディレクトリ配下へ**書き込み** | `.git/hooks/*` / `.git/config` (`core.hooksPath` / `alias.*=!sh` 等) の書き換えは次の git 操作で非サンドボックスの main session で任意コード実行を招く (pre-tool-bash-guard.sh sub-block (H) が deny) | `.git` の**読み取り**は許可 — `cat .git/config` / `git config --list` / `git cat-file` / `git show <ref>:<file>` を使う。`.git` への書き込みは禁止 |
 
 ### Allowed Bash/Git commands
 

--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -28,7 +28,7 @@ Any Bash invocation that matches the following patterns is forbidden inside a re
 | `git reflog expire` / `git reflog delete` | reflog 改変 | 代替なし — reviewer は実行禁止。`git reflog` の単純な display は read-only として許可 |
 | `git am` / `git apply` | patch 適用 (index 書き換え) | `git show <ref>` で patch 内容のみを参照する |
 | `git mv` / `git notes add/edit/append/remove` / `git config` / `git remote add/remove/set-url` | tracked file rename / notes 書き換え / local config / remote 編集 | 代替なし — reviewer は実行禁止 |
-| `> .git/…` / `>> .git/…` リダイレクト・`tee` / `cp` / `mv` / `ln` / `install` / `rsync` / `truncate` で `.git` ディレクトリ配下へ**書き込み** | `.git/hooks/*` / `.git/config` (`core.hooksPath` / `alias.*=!sh` 等) の書き換えは次の git 操作で非サンドボックスの main session で任意コード実行を招く (pre-tool-bash-guard.sh sub-block (H) が deny) | `.git` の**読み取り**は許可 — `cat .git/config` / `git config --list` / `git cat-file` / `git show <ref>:<file>` を使う。`.git` への書き込みは禁止 |
+| `> .git/…` / `>> .git/…` リダイレクト・`tee` / `cp` / `mv` / `ln` / `install` / `rsync` / `truncate` / `dd of=` / `sponge` / `patch` 等で `.git` ディレクトリ配下へ**書き込み** | `.git/hooks/*` / `.git/config` (`core.hooksPath` / `alias.*=!sh` 等) の書き換えは次の git 操作で非サンドボックスの main session で任意コード実行を招く (pre-tool-bash-guard.sh sub-block (H) が deny)。verb 列挙は non-exhaustive (COMMON-SET) — 列挙外の write ツールも `.git` 書き込みは一律禁止 | `.git` の**読み取り**は許可 — `cat .git/config` / `git config --list` / `git cat-file` / `git show <ref>:<file>` / `dd if=.git/config` を使う。`.git` への書き込みは禁止 |
 
 ### Allowed Bash/Git commands
 

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -695,7 +695,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # --- (H) reviewer WRITE into a .git directory (shell redirect / file-mutating verb) ---
   # pre-tool-edit-guard.sh structurally blocks the Edit/Write/MultiEdit/NotebookEdit path into a
   # parent .git; this closes the sibling Bash-tool gap (Issue #1864 AC-1). A reviewer subagent can
-  # `echo pwned > <repo>/.git/hooks/pre-commit` (or via tee/cp/mv/ln/install/rsync/truncate/dd) to
+  # `echo pwned > <repo>/.git/hooks/pre-commit` (or via tee/cp/mv/ln/install/rsync/truncate/dd/sponge/patch) to
   # plant a hook or rewrite .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) — either
   # runs arbitrary code in the non-sandboxed MAIN session on the next git op, strictly worse than a
   # source edit and invisible to `git status`. This block runs INSIDE the Pattern-4 fail-CLOSED
@@ -718,6 +718,13 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #     quoting `> $'\x2egit/hooks/x'` (`\x2e`→`.`) — the `$`/`(`/`)` are collapsed to spaces by the
   #     meta-char normalization, so the path is not visible statically (ANSI-C escape decoding is a
   #     `$`-expansion, not plain quote-removal, so it is NOT dequoted below).
+  #   - GLOB-expanded write targets: `> .git*/config`, `> .gi?/config`, `cp x .git*/hooks/y` — the
+  #     `*`/`?`/`[` survive meta-char normalization, but the tokenizer below runs under `set -f`
+  #     (noglob), so the token stays LITERAL (`.git*/config`) and does not match the `.git`-component
+  #     globs. Catching this would mean un-noglobbing, which re-opens the hook-CWD pathname-expansion
+  #     DoS (→ timeout → fail-open) and the over-DENY this fix closes — and `.git*` is statically
+  #     indistinguishable from a legit `.git*`→`.github` expansion anyway. Same Layer-1-only class as
+  #     `$VAR`/`$(cmd)` above.
   #   - INTERPRETER-embedded writes: `python3 -c "open('.git/hooks/x','w')"`, `perl -e ...` — the
   #     write is inside an opaque quoted argument.
   #   - HEREDOC-body redirects: `cat <<EOF > .git/hooks/x` — CMD_CHECK cuts at `<<`, so a redirect

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -351,7 +351,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # literal `/git` segment — `> /srv/git/repo/.git/config` becomes `> /srv git/repo/.git/config`,
   # detaching `>` from the `.git` token so (H)'s adjacency test misses (silent allow of an RCE
   # write). (H) needs the path INTACT, so it tokenizes from this pre-munge snapshot instead of the
-  # verb-normalized CMD_NORMALIZED. `_gd_src` is initialized empty for `set -u` safety.
+  # verb-normalized CMD_NORMALIZED. (`set -u` safety at the (H) use site is via `${_gd_src:-}`.)
   _gd_src="$CMD_NORMALIZED"
   # Absolute-path / explicit-invocation bypass guard:
   # Pattern 4 全体は `*" git <verb> "*` glob に依存するため、`git` を直接呼び出さない
@@ -717,6 +717,13 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #     target after the marker is stripped (`cat > .git/hooks/x <<EOF` IS caught). Scanning raw
   #     $COMMAND to fix this would false-match `>.git` text inside heredoc/PR bodies and, under this
   #     fail-CLOSED region, turn those into spurious denies — so it is deliberately not done.
+  #   - FLAG-embedded write targets other than `dd of=`: a target glued to a flag rather than given
+  #     positionally — `install --target-directory=.git/hooks` / `install -t.git/hooks`, GNU
+  #     `cp --target-directory=.git/…` — is NOT parsed. Only the POSITIONAL destination of a
+  #     file-verb is matched (`install src .git/hooks/x` and `install -t .git/hooks src` with a
+  #     SPACE ARE caught). `dd of=` is the one flag-target special-cased, because `of=` is dd's
+  #     SOLE output form (dd has no positional destination); adding per-flag parsing for every verb
+  #     (`-t`/`--target-directory=`/…) is scope creep, so those stay Layer-1-only.
   #   Note: Layer 3 (post-review-state-verify.sh) does NOT backstop these — `.git` writes are
   #   invisible to `git status --porcelain`. A complete guarantee needs a different layer
   #   (filesystem permissions / sandbox), which is out of scope for this hook.
@@ -728,6 +735,12 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #   - cp/mv/ln/rsync/install fire even when the .git path is the SOURCE (`cp .git/config /tmp/x`),
   #     not only the destination — a read-copy a reviewer should do with `cat` instead; accepted to
   #     keep the matcher simple (an explicit `< .git/x` input redirect IS excluded as a read).
+  #   - The file-verb latch is set by a matching token ANYWHERE and persists across the (space-
+  #     collapsed) command, so it can over-DENY a later .git READ in the same command line — both a
+  #     cross-boundary read (`cp a b ; cat .git/config`) and a path ARG whose basename is a verb
+  #     (`grep x /tmp/cp .git/config` → `/tmp/cp` basename `cp` latches). This is fail-CLOSED (it
+  #     denies a read, never allows a write), rare, and recoverable via the deny message; accepted
+  #     rather than track command boundaries (which the meta-char collapse has already erased).
   if [ -z "$BLOCKED_PATTERN" ]; then
     # Tokenize from _gd_src (the PRE-`/git`-munge snapshot captured above), NOT CMD_NORMALIZED:
     # the `/git`→` git` invocation-normalization corrupts any redirect-target path with a literal
@@ -745,8 +758,14 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     for _gd_tok in $_gdw; do
       # strip one layer of surrounding quotes, then a leading `of=` (dd's write-target argument)
       # so `dd … of=.git/hooks/x` is detected while `dd if=.git/config …` (read source) is not.
+      # The quote strip is re-applied AFTER the `of=` strip because the quote can sit INSIDE the
+      # value (`of='.git/hooks/x'`): the first strip only removes the trailing quote (the token
+      # starts with `o`), leaving a stranded leading quote after `#of=` that would defeat the
+      # gitpath glob. Re-stripping normalizes `of='.git/x'` / `of=".git/x"` to `.git/x` (Issue #1864
+      # cycle-2 fix — value-quoted `of=` was a fail-open .git-write bypass).
       _gd_p="${_gd_tok#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
       _gd_p="${_gd_p#of=}"
+      _gd_p="${_gd_p#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
       _gd_is_gitpath=0
       case "$_gd_p" in
         .git|.git/*|*/.git|*/.git/*) _gd_is_gitpath=1 ;;

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -787,11 +787,15 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       if [ "$_gd_prev" = ">" ] && [ "$_gd_is_gitpath" = "1" ]; then
         BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
       fi
-      # File-mutating-verb vector: a write verb seen earlier + a .git path arg now. Resolve the
-      # verb to its bare form (basename + leading-`\` strip) so absolute-path / `\`-escaped
-      # invocations (`/usr/bin/tee`, `\cp`) match — mirroring the /git invocation-normalization the
-      # (A)-(G) verb globs get. `command cp` / `exec cp` already reach here as a bare `cp` token.
-      _gd_verb="${_gd_tok##*/}"; _gd_verb="${_gd_verb#\\}"
+      # File-mutating-verb vector: a write verb seen earlier + a .git path arg now. Resolve the verb
+      # to its bare form the SAME way the shell does before executing it: strip quotes and
+      # backslashes (POSIX quote-removal, mirroring the path dequoting above), THEN take the
+      # basename. Dequoting the verb token is required for the same reason as the path token —
+      # otherwise an obfuscated verb (`'tee'`, `t\ee`, `t"e"e`) evades the latch while the shell
+      # still runs it, re-opening the fail-open on the VERB axis (Issue #1864 cycle-5 fix). The
+      # basename after dequote catches absolute-path invocations (`/usr/bin/tee`); `command cp` /
+      # `exec cp` already reach here as a bare `cp` token.
+      _gd_verb="${_gd_tok//[\"\']/}"; _gd_verb="${_gd_verb//\\/}"; _gd_verb="${_gd_verb##*/}"
       case "$_gd_verb" in
         tee|cp|mv|ln|install|rsync|truncate|dd) _gd_fileverb=1 ;;
       esac

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -763,6 +763,24 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     while [[ "$_gdw" == *"  "* ]]; do _gdw="${_gdw//  / }"; done
     _gd_prev=""
     _gd_fileverb=0
+    # noglob for the tokenizer: `for _gd_tok in $_gdw` is UNQUOTED, so without `set -f` a reviewer
+    # command's glob metachars (`*`/`?`/`[`, which survive the meta-char collapse above — only
+    # ;&|(){}`$ are collapsed) undergo pathname expansion against the hook's CWD. Two fail modes:
+    # (a) FALSE-POSITIVE / over-DENY — a `*` expands to CWD entries; if a file named like a write-verb
+    #     (cp/tee/…) sits in CWD it latches _gd_fileverb, so a legit `.git` READ carrying a bare glob
+    #     (`cat .git/config *`) is wrongly denied. Violates AC-1 "read-only git/test not mis-detected".
+    # (b) TIMEOUT→FAIL-OPEN (RCE) — glob expansion happens AFTER the 64KB length guard, so the token
+    #     count is NOT bounded by it. `touch f{1..1000000}` then `echo x /bigdir/* > .git/hooks/pre-commit`
+    #     makes this loop iterate ~1M times (~9s measured, +glob readdir/sort) → the PreToolUse hook
+    #     times out → fails OPEN → the very `.git` write this block exists to deny then lands. The
+    #     sibling git-flag loop (~line 440) is iteration-capped for exactly this reason; noglob bounds
+    #     THIS loop's token count to the length-guarded input instead. `case` / `[[ == ]]` pattern
+    #     matching is unaffected by noglob, so the detection logic below is unchanged (Issue #1864
+    #     follow-up). Save/restore the prior noglob state (drift-safe; this hook leaves it off today).
+    #     The sibling `for tok in $WT_ARGS` loop (~line 608) shares the unquoted pattern but is
+    #     pre-existing (out of this fix's scope).
+    case $- in *f*) _gd_noglob_was_set=1 ;; *) _gd_noglob_was_set=0 ;; esac
+    set -f
     for _gd_tok in $_gdw; do
       # Dequote the token the way the SHELL does before opening the path, THEN strip a leading `of=`
       # (dd's write-target argument), so `dd … of=.git/hooks/x` is detected while `dd if=.git/config
@@ -809,6 +827,8 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       fi
       _gd_prev="$_gd_tok"
     done
+    # Restore the prior noglob state (only re-enable globbing if this hook had it on before).
+    [ "$_gd_noglob_was_set" = "1" ] || set +f
   fi
 
   if [ -n "$BLOCKED_PATTERN" ]; then

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -709,8 +709,10 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # argument (tee/cp/mv/ln/install/rsync/truncate), and `dd of=<path>`. The following are OUT OF
   # SCOPE for a static matcher and are covered by Layer 1 (the reviewer prompt / _reviewer-base.md
   # READ-ONLY contract) ONLY — NOT by this hook and NOT by Layer 3:
-  #   - Targets needing RUNTIME resolution: `> $VAR`, `> $(cmd)` (the `$`/`(`/`)` are collapsed to
-  #     spaces by the meta-char normalization, so the value/path is not visible statically).
+  #   - Targets needing RUNTIME resolution or `$`-EXPANSION: `> $VAR`, `> $(cmd)`, and ANSI-C
+  #     quoting `> $'\x2egit/hooks/x'` (`\x2e`→`.`) — the `$`/`(`/`)` are collapsed to spaces by the
+  #     meta-char normalization, so the path is not visible statically (ANSI-C escape decoding is a
+  #     `$`-expansion, not plain quote-removal, so it is NOT dequoted below).
   #   - INTERPRETER-embedded writes: `python3 -c "open('.git/hooks/x','w')"`, `perl -e ...` — the
   #     write is inside an opaque quoted argument.
   #   - HEREDOC-body redirects: `cat <<EOF > .git/hooks/x` — CMD_CHECK cuts at `<<`, so a redirect
@@ -757,17 +759,23 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     _gd_prev=""
     _gd_fileverb=0
     for _gd_tok in $_gdw; do
-      # Remove ALL quote chars from the token (mirroring the shell's own quote-removal), THEN strip
-      # a leading `of=` (dd's write-target argument), so `dd … of=.git/hooks/x` is detected while
-      # `dd if=.git/config …` (read source) is not. GLOBAL removal — not a fixed number of
-      # surrounding strips — is required because a quote can sit ANYWHERE and the shell strips every
-      # one before opening the path: surrounding (`of='.git/x'`), nested (`of=''.git/x''`), or
-      # INTERIOR between components (`of=.g'i't/hooks/x`, `> '.git'/hooks/x`). The gitpath check must
-      # see the same fully-dequoted path the shell writes to (Issue #1864 cycle-3 fix — interior /
-      # nested quotes were a fail-open .git-write bypass that a fixed surrounding-strip missed).
-      # Note: `_gd_prev` (redirect / `<` read-skip) and `_gd_verb` (file-verb latch) below use the
-      # RAW `_gd_tok`, so this dequoting affects ONLY the gitpath component match.
+      # Dequote the token the way the SHELL does before opening the path, THEN strip a leading `of=`
+      # (dd's write-target argument), so `dd … of=.git/hooks/x` is detected while `dd if=.git/config
+      # …` (read source) is not. POSIX quote-removal strips exactly THREE characters wherever they
+      # sit — `"`, `'`, and unquoted `\` — so ALL three are removed globally here. A fixed
+      # surrounding strip, or removing only the quotes, leaves an obfuscated write vector: quotes
+      # ANYWHERE (`of='.git/x'`, `of=''.git/x''`, `of=.g'i't/hooks/x`, `> '.git'/hooks/x`) and
+      # backslashes ANYWHERE (`> .g\it/hooks/x`, `> \.git/x`, `dd of=.g\it/…`) all still open the
+      # real `.git` for the shell. Backslash removal runs BEFORE the `of=` strip so `\of=.git/x`
+      # (escaped `o`) normalizes to `of=.git/x` first (Issue #1864 cycle-3/4 fix — interior/nested
+      # quotes and backslash-escaped path components were fail-open .git-write bypasses). Only the
+      # `.git` component match uses `_gd_p`; `_gd_prev` (redirect / `<` read-skip) and `_gd_verb`
+      # (file-verb latch) below use the RAW `_gd_tok`.
+      # Note: `$'…'` ANSI-C escape decoding (`$'\x2egit'` → `.git`) is NOT done — that is a
+      # `$`-triggered EXPANSION, already class-B out-of-scope (the `$` is collapsed to a space by
+      # the meta-char normalization above, same as `$VAR` / `$(cmd)`), covered by Layer 1.
       _gd_p="${_gd_tok//[\"\']/}"
+      _gd_p="${_gd_p//\\/}"
       _gd_p="${_gd_p#of=}"
       _gd_is_gitpath=0
       case "$_gd_p" in

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -705,10 +705,15 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #
   # SCOPE (deliberate — this is best-effort hardening, per AC-1 "可能な範囲で", NOT full closure):
   # a static bash matcher cannot decide "does this command write to .git" in general. This block
-  # matches only STATICALLY-IDENTIFIABLE write targets: a redirect operand (`>`/`>>`), a file-verb
-  # argument (tee/cp/mv/ln/install/rsync/truncate), and `dd of=<path>`. The following are OUT OF
-  # SCOPE for a static matcher and are covered by Layer 1 (the reviewer prompt / _reviewer-base.md
-  # READ-ONLY contract) ONLY — NOT by this hook and NOT by Layer 3:
+  # matches only STATICALLY-IDENTIFIABLE write targets: a redirect operand (`>`/`>>`), a positional
+  # argument of a common file-writing verb (tee/cp/mv/ln/install/rsync/truncate/sponge/patch), and
+  # `dd of=<path>`. The file-verb list is a COMMON-SET, deliberately NOT exhaustive — any write
+  # tool outside it (in-place editors `sed -i`/`perl -pi`/`ed`/`ex`/`gawk -i inplace`, and other
+  # exotic writers) is Layer-1-only, exactly like the interpreter class below. Enumerating every
+  # write-capable program is impossible for a static matcher, so the guarantee for the tail is the
+  # reviewer prompt, not this hook. The following are OUT OF SCOPE for a static matcher and are
+  # covered by Layer 1 (the reviewer prompt / _reviewer-base.md READ-ONLY contract) ONLY — NOT by
+  # this hook and NOT by Layer 3:
   #   - Targets needing RUNTIME resolution or `$`-EXPANSION: `> $VAR`, `> $(cmd)`, and ANSI-C
   #     quoting `> $'\x2egit/hooks/x'` (`\x2e`→`.`) — the `$`/`(`/`)` are collapsed to spaces by the
   #     meta-char normalization, so the path is not visible statically (ANSI-C escape decoding is a
@@ -797,7 +802,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       # `exec cp` already reach here as a bare `cp` token.
       _gd_verb="${_gd_tok//[\"\']/}"; _gd_verb="${_gd_verb//\\/}"; _gd_verb="${_gd_verb##*/}"
       case "$_gd_verb" in
-        tee|cp|mv|ln|install|rsync|truncate|dd) _gd_fileverb=1 ;;
+        tee|cp|mv|ln|install|rsync|truncate|dd|sponge|patch) _gd_fileverb=1 ;;
       esac
       if [ "$_gd_is_gitpath" = "1" ] && [ "$_gd_fileverb" = "1" ]; then
         BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
@@ -830,7 +835,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     # REPLACE (not prepend) the generic git-verb message — this is not a git command, and the
     # generic "State-changing git commands …" text would mislabel a plain `echo > .git/hooks/x`.
     if [ "$BLOCKED_SUBKIND" = "gitdir-write" ]; then
-      BLOCKED_REASON="Reviewer subagents must not WRITE into a Git internal (.git) directory. This command writes into a .git path via a shell redirect (> / >>) or a file-mutating command (tee / cp / mv / ln / install / rsync / truncate / dd of=). Planting or altering .git/hooks/* or .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) executes arbitrary code in the non-sandboxed main session on the next git operation — strictly worse than a source edit and invisible to 'git status'. The Edit/Write path is already blocked by pre-tool-edit-guard.sh; this closes the Bash-tool gap (Issue #1864)."
+      BLOCKED_REASON="Reviewer subagents must not WRITE into a Git internal (.git) directory. This command writes into a .git path via a shell redirect (> / >>) or a file-mutating command (tee / cp / mv / ln / install / rsync / truncate / dd of= / sponge / patch). Planting or altering .git/hooks/* or .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) executes arbitrary code in the non-sandboxed main session on the next git operation — strictly worse than a source edit and invisible to 'git status'. The Edit/Write path is already blocked by pre-tool-edit-guard.sh; this closes the Bash-tool gap (Issue #1864)."
       BLOCKED_ALTERNATIVE="Reviewers are strictly read-only — never write into .git. To INSPECT it, read instead: 'cat .git/config', 'git config --list', 'git cat-file -p <obj>', 'git show <ref>:<file>', 'git rev-parse'. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement)."
     fi
   fi

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -717,13 +717,14 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   #     target after the marker is stripped (`cat > .git/hooks/x <<EOF` IS caught). Scanning raw
   #     $COMMAND to fix this would false-match `>.git` text inside heredoc/PR bodies and, under this
   #     fail-CLOSED region, turn those into spurious denies — so it is deliberately not done.
-  #   - FLAG-embedded write targets other than `dd of=`: a target glued to a flag rather than given
-  #     positionally — `install --target-directory=.git/hooks` / `install -t.git/hooks`, GNU
-  #     `cp --target-directory=.git/…` — is NOT parsed. Only the POSITIONAL destination of a
-  #     file-verb is matched (`install src .git/hooks/x` and `install -t .git/hooks src` with a
-  #     SPACE ARE caught). `dd of=` is the one flag-target special-cased, because `of=` is dd's
-  #     SOLE output form (dd has no positional destination); adding per-flag parsing for every verb
-  #     (`-t`/`--target-directory=`/…) is scope creep, so those stay Layer-1-only.
+  #   - FLAG-embedded write targets other than `dd of=`: a target GLUED to a flag — `install
+  #     --target-directory=.git/hooks` / `install -t.git/hooks`, GNU `cp --target-directory=.git/…`
+  #     — is NOT parsed. Only a .git path that surfaces as its OWN token is matched, i.e. a
+  #     positional arg or a SPACE-separated flag argument (`install src .git/hooks/x` and
+  #     `install -t .git/hooks src` — the standalone `.git/hooks` token — ARE caught). `dd of=` is
+  #     the one glued-target special-cased, because `of=` is dd's SOLE output form (dd has no
+  #     positional destination); adding per-flag parsing for every verb (`-t`/`--target-directory=`
+  #     /…) is scope creep, so those stay Layer-1-only.
   #   Note: Layer 3 (post-review-state-verify.sh) does NOT backstop these — `.git` writes are
   #   invisible to `git status --porcelain`. A complete guarantee needs a different layer
   #   (filesystem permissions / sandbox), which is out of scope for this hook.
@@ -756,16 +757,18 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     _gd_prev=""
     _gd_fileverb=0
     for _gd_tok in $_gdw; do
-      # strip one layer of surrounding quotes, then a leading `of=` (dd's write-target argument)
-      # so `dd … of=.git/hooks/x` is detected while `dd if=.git/config …` (read source) is not.
-      # The quote strip is re-applied AFTER the `of=` strip because the quote can sit INSIDE the
-      # value (`of='.git/hooks/x'`): the first strip only removes the trailing quote (the token
-      # starts with `o`), leaving a stranded leading quote after `#of=` that would defeat the
-      # gitpath glob. Re-stripping normalizes `of='.git/x'` / `of=".git/x"` to `.git/x` (Issue #1864
-      # cycle-2 fix — value-quoted `of=` was a fail-open .git-write bypass).
-      _gd_p="${_gd_tok#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
+      # Remove ALL quote chars from the token (mirroring the shell's own quote-removal), THEN strip
+      # a leading `of=` (dd's write-target argument), so `dd … of=.git/hooks/x` is detected while
+      # `dd if=.git/config …` (read source) is not. GLOBAL removal — not a fixed number of
+      # surrounding strips — is required because a quote can sit ANYWHERE and the shell strips every
+      # one before opening the path: surrounding (`of='.git/x'`), nested (`of=''.git/x''`), or
+      # INTERIOR between components (`of=.g'i't/hooks/x`, `> '.git'/hooks/x`). The gitpath check must
+      # see the same fully-dequoted path the shell writes to (Issue #1864 cycle-3 fix — interior /
+      # nested quotes were a fail-open .git-write bypass that a fixed surrounding-strip missed).
+      # Note: `_gd_prev` (redirect / `<` read-skip) and `_gd_verb` (file-verb latch) below use the
+      # RAW `_gd_tok`, so this dequoting affects ONLY the gitpath component match.
+      _gd_p="${_gd_tok//[\"\']/}"
       _gd_p="${_gd_p#of=}"
-      _gd_p="${_gd_p#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
       _gd_is_gitpath=0
       case "$_gd_p" in
         .git|.git/*|*/.git|*/.git/*) _gd_is_gitpath=1 ;;

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -683,6 +683,66 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     fi
   fi
 
+  # --- (H) reviewer WRITE into a .git directory (shell redirect / file-mutating verb) ---
+  # pre-tool-edit-guard.sh structurally blocks the Edit/Write/MultiEdit/NotebookEdit path into a
+  # parent .git; this closes the sibling Bash-tool gap (Issue #1864 AC-1). A reviewer subagent can
+  # `echo pwned > <repo>/.git/hooks/pre-commit` (or via tee/cp/mv/ln/install/rsync/truncate) to
+  # plant a hook or rewrite .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) — either
+  # runs arbitrary code in the non-sandboxed MAIN session on the next git op, strictly worse than a
+  # source edit and invisible to `git status`. This block runs INSIDE the Pattern-4 fail-CLOSED
+  # trap region (before the restore below), so a crash here denies rather than allows. Only WRITES
+  # into a .git dir component are denied; READING .git (cat/ls/grep .git/config) stays allowed (no
+  # write operator/verb present).
+  #
+  # Scope & known limitations (shared with this guard's other patterns; documented, not bugs):
+  #   - Runs on CMD_CHECK (heredoc-stripped `${COMMAND%%<<*}`), so a redirect target AFTER a heredoc
+  #     marker — `cat <<EOF > .git/hooks/x` — is stripped with the heredoc and NOT caught (same
+  #     class as the pipe-heredoc note above); `cat > .git/hooks/x <<EOF` IS caught. Scanning raw
+  #     $COMMAND to fix this would false-match `>.git` text inside heredoc / PR bodies and — under
+  #     this fail-CLOSED region — turn those into spurious denies, so it is deliberately not done.
+  #   - A `>` or a .git path inside a quoted string (`echo "text > .git/x"`) can false-match. Rare
+  #     in a read-only reviewer command; the deny message explains the block so it is recoverable.
+  #   - `.git` is matched as a genuine path COMPONENT only (`(^|/).git(/|$)` via the case globs),
+  #     so a dir literally named `foo.git/` (e.g. a bare-repo clone) is NOT matched.
+  #   - `cp`/`mv`/`ln`/`rsync`/`install` fire even when the .git path is the SOURCE (`cp .git/config
+  #     /tmp/x`), not only the destination — a read-copy a reviewer should do with `cat` instead;
+  #     accepted to keep the matcher simple (an explicit `< .git/x` input redirect IS excluded).
+  #     `sed -i` / in-place editors are out of scope (Layer 3 post-condition gate covers them).
+  if [ -z "$BLOCKED_PATTERN" ]; then
+    # Reuse CMD_NORMALIZED (meta-chars ;&|(){}`$ already collapsed to spaces; the normalization
+    # does NOT strip `>`/`<`, so redirects survive) but surface `>>`/`>`/`<` as standalone tokens
+    # so `x>.git/y` and `x >> .git/y` both tokenize. Append order matters: `>>` before `>`.
+    _gdw=" $CMD_NORMALIZED "
+    _gdw="${_gdw//>>/ > }"
+    _gdw="${_gdw//>/ > }"
+    _gdw="${_gdw//</ < }"
+    while [[ "$_gdw" == *"  "* ]]; do _gdw="${_gdw//  / }"; done
+    _gd_prev=""
+    _gd_fileverb=0
+    for _gd_tok in $_gdw; do
+      # strip one layer of surrounding quotes for path inspection
+      _gd_p="${_gd_tok#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
+      _gd_is_gitpath=0
+      case "$_gd_p" in
+        .git|.git/*|*/.git|*/.git/*) _gd_is_gitpath=1 ;;
+      esac
+      # A .git path that is an INPUT redirect source (`… < .git/config`) is a READ → never a write.
+      if [ "$_gd_prev" = "<" ]; then _gd_prev="$_gd_tok"; continue; fi
+      # Redirect vector: the previous surfaced token was `>` and this token is a .git path.
+      if [ "$_gd_prev" = ">" ] && [ "$_gd_is_gitpath" = "1" ]; then
+        BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
+      fi
+      # File-mutating-verb vector: a write verb seen earlier + a .git path arg now.
+      case "$_gd_tok" in
+        tee|cp|mv|ln|install|rsync|truncate) _gd_fileverb=1 ;;
+      esac
+      if [ "$_gd_is_gitpath" = "1" ] && [ "$_gd_fileverb" = "1" ]; then
+        BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
+      fi
+      _gd_prev="$_gd_tok"
+    done
+  fi
+
   if [ -n "$BLOCKED_PATTERN" ]; then
     BLOCKED_REASON="Reviewer subagents must not mutate the working tree, index, or refs. State-changing git commands (checkout/reset/add/stash push/restore/commit/push/merge/rebase/cherry-pick/revert/tag -a -d -f/clean/gc/branch -D --delete/update-ref/symbolic-ref/am/apply/mv/notes/config/remote/bisect/filter-branch/replace/reflog expire/worktree remove/fetch --prune/--force/etc.) are forbidden inside reviewer contexts."
     BLOCKED_ALTERNATIVE="Use read-only alternatives: 'git show <ref>:<file>' to read a blob, 'git diff <ref> -- <file>' to compare, 'git worktree add <path> <ref>' to inspect a different ref in an isolated directory, 'git tag -l' / 'git stash list' / 'git reflog' / 'git branch --list' for display-only queries, or bare 'git fetch' (without --prune/--force) for ref sync. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement) for the full list. If this block fires on a main session (not a reviewer subagent), check whether CLAUDE_SUBAGENT_TYPE / CLAUDE_AGENT_TYPE env vars are accidentally set; recover with: unset CLAUDE_SUBAGENT_TYPE CLAUDE_AGENT_TYPE"
@@ -702,6 +762,13 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     if [ "$BLOCKED_SUBKIND" = "oversized-normalization" ]; then
       BLOCKED_REASON="This reviewer command carries an abnormally large number of git global flags (e.g. many repeated -C / -c). Normalizing that many flags could exceed the PreToolUse hook timeout, and a timed-out hook fails OPEN (the command would be allowed) — so such oversized commands are denied fail-closed to prevent a timeout-based bypass of the reviewer read-only guard. $BLOCKED_REASON"
       BLOCKED_ALTERNATIVE="Simplify the command — reviewer git operations never need this many global flags. $BLOCKED_ALTERNATIVE"
+    fi
+    # (gitdir-write) Reviewer writing into a .git directory via shell redirect / file-op (H).
+    # REPLACE (not prepend) the generic git-verb message — this is not a git command, and the
+    # generic "State-changing git commands …" text would mislabel a plain `echo > .git/hooks/x`.
+    if [ "$BLOCKED_SUBKIND" = "gitdir-write" ]; then
+      BLOCKED_REASON="Reviewer subagents must not WRITE into a Git internal (.git) directory. This command writes into a .git path via a shell redirect (> / >>) or a file-mutating command (tee / cp / mv / ln / install / rsync / truncate). Planting or altering .git/hooks/* or .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) executes arbitrary code in the non-sandboxed main session on the next git operation — strictly worse than a source edit and invisible to 'git status'. The Edit/Write path is already blocked by pre-tool-edit-guard.sh; this closes the Bash-tool gap (Issue #1864)."
+      BLOCKED_ALTERNATIVE="Reviewers are strictly read-only — never write into .git. To INSPECT it, read instead: 'cat .git/config', 'git config --list', 'git cat-file -p <obj>', 'git show <ref>:<file>', 'git rev-parse'. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement)."
     fi
   fi
   # Restore the Patterns 1-3 fail-open trap for the shared result-emit section

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -344,6 +344,15 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   CMD_NORMALIZED="${CMD_NORMALIZED//\}/ }"
   CMD_NORMALIZED="${CMD_NORMALIZED//\`/ }"
   CMD_NORMALIZED="${CMD_NORMALIZED//\$/ }"
+  # Snapshot for sub-block (H) .git-write detection, taken HERE — after meta-char collapse but
+  # BEFORE the `/git`→` git` path-corrupting substitution below (Issue #1864 fix). The `/git`
+  # munge (next block) exists to normalize git INVOCATION forms (`/usr/bin/git`, `\git`) for the
+  # (A)-(G) verb globs, but it also splits any redirect-target path whose ancestor contains a
+  # literal `/git` segment — `> /srv/git/repo/.git/config` becomes `> /srv git/repo/.git/config`,
+  # detaching `>` from the `.git` token so (H)'s adjacency test misses (silent allow of an RCE
+  # write). (H) needs the path INTACT, so it tokenizes from this pre-munge snapshot instead of the
+  # verb-normalized CMD_NORMALIZED. `_gd_src` is initialized empty for `set -u` safety.
+  _gd_src="$CMD_NORMALIZED"
   # Absolute-path / explicit-invocation bypass guard:
   # Pattern 4 全体は `*" git <verb> "*` glob に依存するため、`git` を直接呼び出さない
   # 形式 (絶対パス指定 `/usr/bin/git checkout`、`command git checkout`、`exec git checkout`、
@@ -686,33 +695,47 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # --- (H) reviewer WRITE into a .git directory (shell redirect / file-mutating verb) ---
   # pre-tool-edit-guard.sh structurally blocks the Edit/Write/MultiEdit/NotebookEdit path into a
   # parent .git; this closes the sibling Bash-tool gap (Issue #1864 AC-1). A reviewer subagent can
-  # `echo pwned > <repo>/.git/hooks/pre-commit` (or via tee/cp/mv/ln/install/rsync/truncate) to
+  # `echo pwned > <repo>/.git/hooks/pre-commit` (or via tee/cp/mv/ln/install/rsync/truncate/dd) to
   # plant a hook or rewrite .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) — either
   # runs arbitrary code in the non-sandboxed MAIN session on the next git op, strictly worse than a
   # source edit and invisible to `git status`. This block runs INSIDE the Pattern-4 fail-CLOSED
   # trap region (before the restore below), so a crash here denies rather than allows. Only WRITES
-  # into a .git dir component are denied; READING .git (cat/ls/grep .git/config) stays allowed (no
-  # write operator/verb present).
+  # into a .git dir component are denied; READING .git (cat/ls/grep .git/config, `dd if=.git/…`)
+  # stays allowed (no write operator/verb targeting .git).
   #
-  # Scope & known limitations (shared with this guard's other patterns; documented, not bugs):
-  #   - Runs on CMD_CHECK (heredoc-stripped `${COMMAND%%<<*}`), so a redirect target AFTER a heredoc
-  #     marker — `cat <<EOF > .git/hooks/x` — is stripped with the heredoc and NOT caught (same
-  #     class as the pipe-heredoc note above); `cat > .git/hooks/x <<EOF` IS caught. Scanning raw
-  #     $COMMAND to fix this would false-match `>.git` text inside heredoc / PR bodies and — under
-  #     this fail-CLOSED region — turn those into spurious denies, so it is deliberately not done.
+  # SCOPE (deliberate — this is best-effort hardening, per AC-1 "可能な範囲で", NOT full closure):
+  # a static bash matcher cannot decide "does this command write to .git" in general. This block
+  # matches only STATICALLY-IDENTIFIABLE write targets: a redirect operand (`>`/`>>`), a file-verb
+  # argument (tee/cp/mv/ln/install/rsync/truncate), and `dd of=<path>`. The following are OUT OF
+  # SCOPE for a static matcher and are covered by Layer 1 (the reviewer prompt / _reviewer-base.md
+  # READ-ONLY contract) ONLY — NOT by this hook and NOT by Layer 3:
+  #   - Targets needing RUNTIME resolution: `> $VAR`, `> $(cmd)` (the `$`/`(`/`)` are collapsed to
+  #     spaces by the meta-char normalization, so the value/path is not visible statically).
+  #   - INTERPRETER-embedded writes: `python3 -c "open('.git/hooks/x','w')"`, `perl -e ...` — the
+  #     write is inside an opaque quoted argument.
+  #   - HEREDOC-body redirects: `cat <<EOF > .git/hooks/x` — CMD_CHECK cuts at `<<`, so a redirect
+  #     target after the marker is stripped (`cat > .git/hooks/x <<EOF` IS caught). Scanning raw
+  #     $COMMAND to fix this would false-match `>.git` text inside heredoc/PR bodies and, under this
+  #     fail-CLOSED region, turn those into spurious denies — so it is deliberately not done.
+  #   Note: Layer 3 (post-review-state-verify.sh) does NOT backstop these — `.git` writes are
+  #   invisible to `git status --porcelain`. A complete guarantee needs a different layer
+  #   (filesystem permissions / sandbox), which is out of scope for this hook.
+  # Other documented traits (not gaps):
   #   - A `>` or a .git path inside a quoted string (`echo "text > .git/x"`) can false-match. Rare
   #     in a read-only reviewer command; the deny message explains the block so it is recoverable.
   #   - `.git` is matched as a genuine path COMPONENT only (`(^|/).git(/|$)` via the case globs),
   #     so a dir literally named `foo.git/` (e.g. a bare-repo clone) is NOT matched.
-  #   - `cp`/`mv`/`ln`/`rsync`/`install` fire even when the .git path is the SOURCE (`cp .git/config
-  #     /tmp/x`), not only the destination — a read-copy a reviewer should do with `cat` instead;
-  #     accepted to keep the matcher simple (an explicit `< .git/x` input redirect IS excluded).
-  #     `sed -i` / in-place editors are out of scope (Layer 3 post-condition gate covers them).
+  #   - cp/mv/ln/rsync/install fire even when the .git path is the SOURCE (`cp .git/config /tmp/x`),
+  #     not only the destination — a read-copy a reviewer should do with `cat` instead; accepted to
+  #     keep the matcher simple (an explicit `< .git/x` input redirect IS excluded as a read).
   if [ -z "$BLOCKED_PATTERN" ]; then
-    # Reuse CMD_NORMALIZED (meta-chars ;&|(){}`$ already collapsed to spaces; the normalization
-    # does NOT strip `>`/`<`, so redirects survive) but surface `>>`/`>`/`<` as standalone tokens
-    # so `x>.git/y` and `x >> .git/y` both tokenize. Append order matters: `>>` before `>`.
-    _gdw=" $CMD_NORMALIZED "
+    # Tokenize from _gd_src (the PRE-`/git`-munge snapshot captured above), NOT CMD_NORMALIZED:
+    # the `/git`→` git` invocation-normalization corrupts any redirect-target path with a literal
+    # `/git` ancestor (`/srv/git/…`, `~/github/…`), splitting `>` from the `.git` token (Issue #1864
+    # fix). Meta-chars ;&|(){}`$ are already collapsed to spaces in _gd_src; `>`/`<` survive.
+    # Surface `>>`/`>`/`<` as standalone tokens so `x>.git/y` and `x >> .git/y` both tokenize.
+    # Append order matters: `>>` before `>`.
+    _gdw=" ${_gd_src:-} "
     _gdw="${_gdw//>>/ > }"
     _gdw="${_gdw//>/ > }"
     _gdw="${_gdw//</ < }"
@@ -720,8 +743,10 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     _gd_prev=""
     _gd_fileverb=0
     for _gd_tok in $_gdw; do
-      # strip one layer of surrounding quotes for path inspection
+      # strip one layer of surrounding quotes, then a leading `of=` (dd's write-target argument)
+      # so `dd … of=.git/hooks/x` is detected while `dd if=.git/config …` (read source) is not.
       _gd_p="${_gd_tok#[\"\']}"; _gd_p="${_gd_p%[\"\']}"
+      _gd_p="${_gd_p#of=}"
       _gd_is_gitpath=0
       case "$_gd_p" in
         .git|.git/*|*/.git|*/.git/*) _gd_is_gitpath=1 ;;
@@ -732,9 +757,13 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       if [ "$_gd_prev" = ">" ] && [ "$_gd_is_gitpath" = "1" ]; then
         BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
       fi
-      # File-mutating-verb vector: a write verb seen earlier + a .git path arg now.
-      case "$_gd_tok" in
-        tee|cp|mv|ln|install|rsync|truncate) _gd_fileverb=1 ;;
+      # File-mutating-verb vector: a write verb seen earlier + a .git path arg now. Resolve the
+      # verb to its bare form (basename + leading-`\` strip) so absolute-path / `\`-escaped
+      # invocations (`/usr/bin/tee`, `\cp`) match — mirroring the /git invocation-normalization the
+      # (A)-(G) verb globs get. `command cp` / `exec cp` already reach here as a bare `cp` token.
+      _gd_verb="${_gd_tok##*/}"; _gd_verb="${_gd_verb#\\}"
+      case "$_gd_verb" in
+        tee|cp|mv|ln|install|rsync|truncate|dd) _gd_fileverb=1 ;;
       esac
       if [ "$_gd_is_gitpath" = "1" ] && [ "$_gd_fileverb" = "1" ]; then
         BLOCKED_PATTERN="reviewer-gitdir-write"; BLOCKED_SUBKIND="gitdir-write"; break
@@ -767,7 +796,7 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
     # REPLACE (not prepend) the generic git-verb message — this is not a git command, and the
     # generic "State-changing git commands …" text would mislabel a plain `echo > .git/hooks/x`.
     if [ "$BLOCKED_SUBKIND" = "gitdir-write" ]; then
-      BLOCKED_REASON="Reviewer subagents must not WRITE into a Git internal (.git) directory. This command writes into a .git path via a shell redirect (> / >>) or a file-mutating command (tee / cp / mv / ln / install / rsync / truncate). Planting or altering .git/hooks/* or .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) executes arbitrary code in the non-sandboxed main session on the next git operation — strictly worse than a source edit and invisible to 'git status'. The Edit/Write path is already blocked by pre-tool-edit-guard.sh; this closes the Bash-tool gap (Issue #1864)."
+      BLOCKED_REASON="Reviewer subagents must not WRITE into a Git internal (.git) directory. This command writes into a .git path via a shell redirect (> / >>) or a file-mutating command (tee / cp / mv / ln / install / rsync / truncate / dd of=). Planting or altering .git/hooks/* or .git/config (core.hooksPath / alias.*=!sh / core.fsmonitor) executes arbitrary code in the non-sandboxed main session on the next git operation — strictly worse than a source edit and invisible to 'git status'. The Edit/Write path is already blocked by pre-tool-edit-guard.sh; this closes the Bash-tool gap (Issue #1864)."
       BLOCKED_ALTERNATIVE="Reviewers are strictly read-only — never write into .git. To INSPECT it, read instead: 'cat .git/config', 'git config --list', 'git cat-file -p <obj>', 'git show <ref>:<file>', 'git rev-parse'. See plugins/rite/agents/_reviewer-base.md (READ-ONLY Enforcement)."
     fi
   fi

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -156,6 +156,27 @@ case "$FILE_PATH" in
   *)  ABS_PATH="${CWD%/}/$FILE_PATH" ;;
 esac
 
+# --- Physically resolve a FINAL-element symlink before isolation scoping (Issue #1864 AC-2) ---
+# The _tdir walk below resolves INTERMEDIATE dirs physically (via `[ -d ]` / `git -C`), but the
+# target's own final element is never dereferenced. A reviewer could drop a symlink inside its
+# sanctioned isolation worktree pointing at the parent repo's .git —
+# `ln -s <main>/.git/hooks/pre-commit <iso>/evil` (ln is a Bash-tool op, out of THIS hook's Edit
+# path) — then `Write file_path=<iso>/evil`: _tdir resolves to the isolation root → allowed, and
+# the write follows the link into the parent .git. Resolve the final symlink PHYSICALLY here so
+# such a target lands on the real parent .git (→ git-dir deny below) instead. `realpath` follows
+# every link and resolves `..` against the REAL directory tree, so it cannot be forged the way a
+# lexical `..` collapse could (the property the block below relies on). A legitimate symlink that
+# stays inside the isolation worktree still resolves to a path inside it → still allowed (no
+# regression). realpath failure (e.g. the link's target parent dir is missing) leaves ABS_PATH
+# unchanged and falls through to the _tdir walk — no worse than before this fix.
+#   Note (Issue #1864 AC-3): Claude Code's own Edit/Write tools REFUSE to write through a
+#   final-element symlink ("Refusing to write through symlink …"), verified empirically, so this
+#   is defense-in-depth — it does not rely on that (undocumented) harness behavior.
+if [ -L "$ABS_PATH" ]; then
+  _resolved=$(realpath "$ABS_PATH" 2>/dev/null) || _resolved=""
+  [ -n "$_resolved" ] && ABS_PATH="$_resolved"
+fi
+
 # --- Resolve the git worktree that OWNS the target ---
 # The isolation allowance is defined by "the target lives inside a sanctioned reviewer isolation
 # worktree", NOT by "the path string contains the token". Resolve the target's own worktree by
@@ -184,9 +205,8 @@ if [ -z "$TARGET_ROOT" ]; then
   #       strictly worse than a source-file edit, and invisible to the worktree-hash post-condition
   #       axis (git status --porcelain ignores .git). This hook is the structural defense for the
   #       Edit/Write/MultiEdit/NotebookEdit path; deny git-internal writes there, allow only genuine
-  #       non-repo scratch. (Reviewer .git writes via the Bash tool — e.g. `echo > .git/hooks/...`,
-  #       `ln -s` symlink redirection — are a broader gap tracked in #1864, out of Issue #1860's
-  #       Edit/Write scope; pre-tool-bash-guard.sh only blocks state-mutating git verbs today.)
+  #       non-repo scratch. (The sibling Bash-tool vector — `echo > .git/hooks/...`, `tee`/`cp`/`ln`
+  #       into .git — is closed by pre-tool-bash-guard.sh sub-block (H), Issue #1864 AC-1.)
   if [ "$(git -C "$_tdir" rev-parse --is-inside-git-dir 2>/dev/null)" = "true" ]; then
     _deny_kind="git-dir"
   else

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1749,6 +1749,24 @@ assert_subagent_deny_gitdir "cp into .g'i't/… (interior quote) blocked" "cp /t
 echo "TC-125v: subagent dd of= with NESTED quotes → deny"
 assert_subagent_deny_gitdir "dd of=''.git/…'' (nested quotes) blocked" "dd if=/tmp/evil of=''.git/hooks/pre-commit''"
 
+# --- backslash-escaped .git path components (Issue #1864 cycle-4 fix: backslash removal) ---
+# POSIX quote-removal strips `\` too; the shell resolves `.g\it`→`.git`, so the gitpath check must
+# strip backslashes as well as quotes to see the real target.
+echo "TC-125w1: subagent redirect into backslash-in-component .git → deny"
+assert_subagent_deny_gitdir "echo > .g\\it/… blocked" "echo pwned > .g\\it/hooks/pre-commit"
+
+echo "TC-125w2: subagent redirect into leading-backslash .git → deny"
+assert_subagent_deny_gitdir "echo > \\.git/… blocked" "echo pwned > \\.git/hooks/pre-commit"
+
+echo "TC-125w3: subagent dd of= with backslash component → deny"
+assert_subagent_deny_gitdir "dd of=.g\\it/… blocked" "dd if=/tmp/evil of=.g\\it/hooks/pre-commit"
+
+echo "TC-125w4: subagent tee with backslash component → deny"
+assert_subagent_deny_gitdir "tee .g\\it/… blocked" "echo x | tee .g\\it/hooks/pre-commit"
+
+echo "TC-125w5: subagent dd with backslash-escaped of= prefix → deny"
+assert_subagent_deny_gitdir "dd \\of=.git/… blocked" "dd if=/tmp/evil \\of=.git/hooks/pre-commit"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1653,6 +1653,88 @@ rm -rf "$tc124_dir"
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-125: reviewer WRITE into a .git directory (Issue #1864 AC-1, sub-block (H))
+# The Bash-tool sibling of pre-tool-edit-guard's .git protection: a reviewer must not
+# `echo pwned > .git/hooks/pre-commit` (RCE via next git op). Reading .git stays allowed.
+# --------------------------------------------------------------------------
+# --- Helper: deny assertion for the reviewer-gitdir-write pattern ---
+assert_subagent_deny_gitdir() {
+  local label="$1"
+  local cmd="$2"
+  local rc=0
+  local output
+  output=$(run_guard_with_transcript "Bash" "$cmd" "$SUBAGENT_TRANSCRIPT") || rc=$?
+  local decision reason
+  decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+  if [ "$decision" = "deny" ] && [[ "$reason" == *"reviewer-gitdir-write"* ]]; then
+    pass "$label"
+  else
+    fail "$label — expected deny (reviewer-gitdir-write), got decision=$decision reason=$reason"
+  fi
+}
+
+echo "TC-125a: subagent redirect into .git/hooks → deny"
+assert_subagent_deny_gitdir "echo > .git/hooks/pre-commit blocked" "echo pwned > .git/hooks/pre-commit"
+
+echo "TC-125b: subagent append (>>) into .git/hooks → deny"
+assert_subagent_deny_gitdir "echo >> .git/hooks/pre-commit blocked" "echo pwned >> .git/hooks/pre-commit"
+
+echo "TC-125c: subagent redirect (no space) into .git/config → deny"
+assert_subagent_deny_gitdir "echo >.git/config blocked" "echo x >.git/config"
+
+echo "TC-125d: subagent redirect into ABSOLUTE .git path → deny"
+assert_subagent_deny_gitdir "abs .git redirect blocked" "echo x > /tmp/repo/.git/hooks/pre-commit"
+
+echo "TC-125e: subagent redirect into ./.git → deny (leading ./)"
+assert_subagent_deny_gitdir "./.git redirect blocked" "echo x > ./.git/config"
+
+echo "TC-125f: subagent redirect with QUOTED .git target → deny"
+assert_subagent_deny_gitdir "quoted .git target blocked" "echo x > \".git/hooks/pre-commit\""
+
+echo "TC-125g: subagent redirect into .git after a meta-boundary (&&) → deny"
+assert_subagent_deny_gitdir "compound redirect into .git blocked" "cat foo && echo x > .git/config"
+
+echo "TC-125h: subagent tee into .git/hooks → deny"
+assert_subagent_deny_gitdir "tee into .git blocked" "echo x | tee .git/hooks/pre-commit"
+
+echo "TC-125i: subagent cp into .git/hooks → deny"
+assert_subagent_deny_gitdir "cp into .git blocked" "cp /tmp/evil .git/hooks/pre-commit"
+
+echo "TC-125j: subagent ln -s into .git/hooks → deny"
+assert_subagent_deny_gitdir "ln -s into .git blocked" "ln -s /tmp/evil .git/hooks/pre-commit"
+
+echo "TC-125k: subagent mv into .git → deny"
+assert_subagent_deny_gitdir "mv into .git blocked" "mv /tmp/evil .git/hooks/pre-commit"
+
+# --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
+echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
+assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"
+
+echo "TC-125-ALLOW-b: subagent LISTS .git/hooks (ls) → allow"
+assert_subagent_allow "ls .git/hooks/ allowed" "ls .git/hooks/"
+
+echo "TC-125-ALLOW-c: subagent greps .git/config → allow"
+assert_subagent_allow "grep .git/config allowed" "grep hooksPath .git/config"
+
+echo "TC-125-ALLOW-d: subagent legit isolation worktree setup → allow"
+assert_subagent_allow "git worktree add --detach (isolation) allowed" \
+  "git worktree add --detach /tmp/rite-review-mutation-abc HEAD"
+
+echo "TC-125-ALLOW-e: boundary — dir literally named 'foo.git/' is NOT the .git component → allow"
+assert_subagent_allow "redirect into myrepo.git/description NOT blocked" "echo x > myrepo.git/description"
+
+echo "TC-125-ALLOW-f: redirect into a NON-.git path → allow"
+assert_subagent_allow "redirect into /tmp/out.txt allowed" "echo x > /tmp/out.txt"
+
+echo "TC-125-ALLOW-g: .git as INPUT-redirect source (read) → allow"
+assert_subagent_allow "tee reading FROM .git via < allowed" "tee /tmp/x < .git/config"
+
+echo "TC-125-ALLOW-h: MAIN session redirect into .git → allow (reviewer-only guard)"
+assert_main_allow "main-session .git write not blocked by (H)" "echo x > .git/hooks/pre-commit"
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1785,6 +1785,16 @@ assert_subagent_deny_gitdir "c\\p into .git blocked" "c\\p /tmp/evil .git/hooks/
 echo "TC-125x5: subagent quoted verb 'dd' of=.git → deny"
 assert_subagent_deny_gitdir "'dd' of=.git blocked" "'dd' if=/tmp/evil of=.git/hooks/pre-commit"
 
+# --- additional positional file-writers (Issue #1864 cycle-5: sponge/patch, tee twins) ---
+echo "TC-125y1: subagent sponge into .git/hooks → deny"
+assert_subagent_deny_gitdir "sponge .git/hooks blocked" "echo pwned | sponge .git/hooks/pre-commit"
+
+echo "TC-125y2: subagent patch into .git/config → deny"
+assert_subagent_deny_gitdir "patch .git/config blocked" "patch .git/config"
+
+echo "TC-125y3: subagent quoted verb 'sponge' into .git → deny (verb dequote)"
+assert_subagent_deny_gitdir "'sponge' .git blocked" "echo x | 'sponge' .git/hooks/pre-commit"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1834,6 +1834,27 @@ echo "TC-125-ALLOW-h: MAIN session redirect into .git → allow (reviewer-only g
 assert_main_allow "main-session .git write not blocked by (H)" "echo x > .git/hooks/pre-commit"
 echo ""
 
+# --- noglob regression: the (H) tokenizer runs under `set -f`, so a reviewer command's bare glob
+# (`*`/`?`/`[`) is NOT pathname-expanded against the hook CWD (Issue #1864 follow-up). Without noglob
+# a `*` sitting BEFORE a `.git` READ path expands to CWD entries; a file named like a write-verb
+# (cp/tee/…) then latches the file-verb vector and the legit `.git` READ is wrongly DENIED (AC-1
+# false-positive; unbounded expansion could also time the hook out → fail-open). This pins the fix:
+# with `set -f` the `*` stays literal → allow. Runs from a temp CWD holding verb-named files so the
+# pre-fix (globbing) behavior would over-DENY (fail-on-revert).
+tc125_noglob_dir=$(mktemp -d)
+: > "$tc125_noglob_dir/cp"    # a file named like a write-verb — would latch _gd_fileverb if globbed
+: > "$tc125_noglob_dir/tee"
+_tc125_noglob_prev=$(pwd)
+if cd "$tc125_noglob_dir"; then
+  echo "TC-125-ALLOW-noglob: bare glob before a .git READ not polluted by CWD verb-files → allow (set -f)"
+  assert_subagent_allow "grep with bare glob + .git READ allowed under noglob" "grep hooksPath * .git/config"
+  cd "$_tc125_noglob_prev" || true
+else
+  fail "TC-125-ALLOW-noglob setup: cd into temp dir failed"
+fi
+rm -rf "$tc125_noglob_dir"
+echo ""
+
 # --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1727,6 +1727,13 @@ assert_subagent_deny_gitdir "\\cp into .git blocked" "\\cp /tmp/evil .git/hooks/
 echo "TC-125p: subagent dd of=.git/hooks → deny"
 assert_subagent_deny_gitdir "dd of=.git blocked" "dd if=/tmp/evil of=.git/hooks/pre-commit"
 
+# --- value-quoted dd of= (Issue #1864 cycle-2 fix: quote-strip-after-of= ordering) ---
+echo "TC-125q: subagent dd of='.git/…' (single-quoted value) → deny"
+assert_subagent_deny_gitdir "dd of='.git' (single-quoted) blocked" "dd if=/tmp/evil of='.git/hooks/pre-commit'"
+
+echo "TC-125r: subagent dd of=\".git/…\" (double-quoted value) → deny"
+assert_subagent_deny_gitdir "dd of=\".git\" (double-quoted) blocked" "dd if=/tmp/evil of=\".git/hooks/pre-commit\""
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"
@@ -1752,6 +1759,14 @@ assert_subagent_allow "tee reading FROM .git via < allowed" "tee /tmp/x < .git/c
 
 echo "TC-125-ALLOW-i: dd READING .git via if= (of= writes elsewhere) → allow"
 assert_subagent_allow "dd if=.git/config of=/tmp/x allowed (read source)" "dd if=.git/config of=/tmp/x"
+
+# Symmetric read-allow guard on /git-ancestor paths: the _gd_src snapshot fix must NOT over-block
+# a plain READ just because the path contains a `/git` segment (regression guard for the fix).
+echo "TC-125-ALLOW-j: read .git under /srv/git ancestor (cat) → allow"
+assert_subagent_allow "cat /srv/git/.../.git/config allowed" "cat /srv/git/proj/.git/config"
+
+echo "TC-125-ALLOW-k: read .git under ~/github ancestor (grep) → allow"
+assert_subagent_allow "grep /home/u/github/.../.git/config allowed" "grep hooksPath /home/u/github/proj/.git/config"
 
 echo "TC-125-ALLOW-h: MAIN session redirect into .git → allow (reviewer-only guard)"
 assert_main_allow "main-session .git write not blocked by (H)" "echo x > .git/hooks/pre-commit"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1707,6 +1707,26 @@ assert_subagent_deny_gitdir "ln -s into .git blocked" "ln -s /tmp/evil .git/hook
 echo "TC-125k: subagent mv into .git → deny"
 assert_subagent_deny_gitdir "mv into .git blocked" "mv /tmp/evil .git/hooks/pre-commit"
 
+# --- CRITICAL regression: repo under a `/git`-containing ancestor (Issue #1864 fix) ---
+# The `/git`→` git` invocation-normalization used to split these paths so `>` detached from the
+# `.git` token → silent allow (RCE). (H) now tokenizes from the pre-munge snapshot.
+echo "TC-125l: subagent redirect into .git under a /srv/git ancestor → deny (path not corrupted)"
+assert_subagent_deny_gitdir "redirect into /srv/git/.../.git blocked" "echo evil > /srv/git/proj/.git/config"
+
+echo "TC-125m: subagent append into .git under a ~/github ancestor → deny (path not corrupted)"
+assert_subagent_deny_gitdir "append into /home/u/github/.../.git blocked" "echo x >> /home/u/github/proj/.git/hooks/pre-commit"
+
+# --- fileverb absolute-path / backslash invocation (Issue #1864 fix) ---
+echo "TC-125n: subagent absolute-path tee into .git → deny"
+assert_subagent_deny_gitdir "/usr/bin/tee into .git blocked" "/usr/bin/tee .git/hooks/pre-commit"
+
+echo "TC-125o: subagent backslash-escaped cp into .git → deny"
+assert_subagent_deny_gitdir "\\cp into .git blocked" "\\cp /tmp/evil .git/hooks/pre-commit"
+
+# --- dd of=<gitpath> write vector (Issue #1864 fix) ---
+echo "TC-125p: subagent dd of=.git/hooks → deny"
+assert_subagent_deny_gitdir "dd of=.git blocked" "dd if=/tmp/evil of=.git/hooks/pre-commit"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"
@@ -1729,6 +1749,9 @@ assert_subagent_allow "redirect into /tmp/out.txt allowed" "echo x > /tmp/out.tx
 
 echo "TC-125-ALLOW-g: .git as INPUT-redirect source (read) → allow"
 assert_subagent_allow "tee reading FROM .git via < allowed" "tee /tmp/x < .git/config"
+
+echo "TC-125-ALLOW-i: dd READING .git via if= (of= writes elsewhere) → allow"
+assert_subagent_allow "dd if=.git/config of=/tmp/x allowed (read source)" "dd if=.git/config of=/tmp/x"
 
 echo "TC-125-ALLOW-h: MAIN session redirect into .git → allow (reviewer-only guard)"
 assert_main_allow "main-session .git write not blocked by (H)" "echo x > .git/hooks/pre-commit"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1767,6 +1767,24 @@ assert_subagent_deny_gitdir "tee .g\\it/… blocked" "echo x | tee .g\\it/hooks/
 echo "TC-125w5: subagent dd with backslash-escaped of= prefix → deny"
 assert_subagent_deny_gitdir "dd \\of=.git/… blocked" "dd if=/tmp/evil \\of=.git/hooks/pre-commit"
 
+# --- obfuscated file-verb NAME (Issue #1864 cycle-5 fix: dequote the verb token too) ---
+# The verb token is dequoted (quotes + backslashes) then basename'd, so a quoted/escaped verb name
+# still latches the file-verb vector — the shell runs `'tee'` / `t\ee` as `tee`.
+echo "TC-125x1: subagent backslash-in-verb tee into .git → deny"
+assert_subagent_deny_gitdir "t\\ee .git blocked" "t\\ee .git/hooks/pre-commit"
+
+echo "TC-125x2: subagent quoted verb 'tee' into .git → deny"
+assert_subagent_deny_gitdir "'tee' .git blocked" "'tee' .git/hooks/pre-commit"
+
+echo "TC-125x3: subagent interior-quoted verb t\"e\"e into .git → deny"
+assert_subagent_deny_gitdir "t\"e\"e .git blocked" "t\"e\"e .git/hooks/pre-commit"
+
+echo "TC-125x4: subagent backslash-in-verb cp into .git → deny"
+assert_subagent_deny_gitdir "c\\p into .git blocked" "c\\p /tmp/evil .git/hooks/pre-commit"
+
+echo "TC-125x5: subagent quoted verb 'dd' of=.git → deny"
+assert_subagent_deny_gitdir "'dd' of=.git blocked" "'dd' if=/tmp/evil of=.git/hooks/pre-commit"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1734,6 +1734,21 @@ assert_subagent_deny_gitdir "dd of='.git' (single-quoted) blocked" "dd if=/tmp/e
 echo "TC-125r: subagent dd of=\".git/…\" (double-quoted value) → deny"
 assert_subagent_deny_gitdir "dd of=\".git\" (double-quoted) blocked" "dd if=/tmp/evil of=\".git/hooks/pre-commit\""
 
+# --- interior / nested quotes (Issue #1864 cycle-3 fix: global quote removal) ---
+# A quote placed BETWEEN path components survives a fixed surrounding-strip but is removed by the
+# shell before opening the path — global `${tok//[\"\']/}` closes the whole class.
+echo "TC-125s: subagent dd of= with INTERIOR quote → deny"
+assert_subagent_deny_gitdir "dd of=.g'i't/… (interior quote) blocked" "dd if=/tmp/evil of=.g'i't/hooks/pre-commit"
+
+echo "TC-125t: subagent redirect into adjacent-quoted .git → deny"
+assert_subagent_deny_gitdir "echo > '.git'/… (adjacent quote) blocked" "echo x > '.git'/hooks/pre-commit"
+
+echo "TC-125u: subagent cp into interior-quoted .git → deny"
+assert_subagent_deny_gitdir "cp into .g'i't/… (interior quote) blocked" "cp /tmp/evil .g'i't/hooks/pre-commit"
+
+echo "TC-125v: subagent dd of= with NESTED quotes → deny"
+assert_subagent_deny_gitdir "dd of=''.git/…'' (nested quotes) blocked" "dd if=/tmp/evil of=''.git/hooks/pre-commit''"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"
@@ -1760,8 +1775,9 @@ assert_subagent_allow "tee reading FROM .git via < allowed" "tee /tmp/x < .git/c
 echo "TC-125-ALLOW-i: dd READING .git via if= (of= writes elsewhere) → allow"
 assert_subagent_allow "dd if=.git/config of=/tmp/x allowed (read source)" "dd if=.git/config of=/tmp/x"
 
-# Symmetric read-allow guard on /git-ancestor paths: the _gd_src snapshot fix must NOT over-block
-# a plain READ just because the path contains a `/git` segment (regression guard for the fix).
+# Over-broadening sentinel on /git-ancestor paths: a plain READ (cat/grep — no redirect, no file
+# verb) must stay allowed even when the path contains a `/git` segment. (The WRITE-side regression
+# guard for the _gd_src snapshot fix is TC-125l/m; these pin that reads never start being blocked.)
 echo "TC-125-ALLOW-j: read .git under /srv/git ancestor (cat) → allow"
 assert_subagent_allow "cat /srv/git/.../.git/config allowed" "cat /srv/git/proj/.git/config"
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1795,6 +1795,18 @@ assert_subagent_deny_gitdir "patch .git/config blocked" "patch .git/config"
 echo "TC-125y3: subagent quoted verb 'sponge' into .git → deny (verb dequote)"
 assert_subagent_deny_gitdir "'sponge' .git blocked" "echo x | 'sponge' .git/hooks/pre-commit"
 
+# --- file-verb blocklist completeness: install / rsync / truncate are IN the case list
+# (tee|cp|mv|ln|install|rsync|truncate|dd|sponge|patch) but lacked dedicated deny tests; pin them so
+# a future edit that drops one literal from the case is caught (Issue #1864 follow-up). ---
+echo "TC-125z1: subagent install into .git/hooks → deny"
+assert_subagent_deny_gitdir "install into .git blocked" "install -m755 /tmp/evil .git/hooks/pre-commit"
+
+echo "TC-125z2: subagent rsync into .git/hooks → deny"
+assert_subagent_deny_gitdir "rsync into .git blocked" "rsync /tmp/evil .git/hooks/pre-commit"
+
+echo "TC-125z3: subagent truncate .git/config → deny"
+assert_subagent_deny_gitdir "truncate .git/config blocked" "truncate -s 0 .git/config"
+
 # --- ALLOW cases: the AC's own false-positive gate ("read-only git / tests not mis-detected") ---
 echo "TC-125-ALLOW-a: subagent READS .git/config (cat) → allow"
 assert_subagent_allow "cat .git/config allowed (read, not write)" "cat .git/config"

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -279,6 +279,42 @@ assert_deny_gitdir "write into .git/config blocked" "$out"
 echo ""
 
 # --------------------------------------------------------------------------
+# Final-element symlink resolution (Issue #1864 AC-2): a symlink dropped INSIDE a
+# sanctioned isolation worktree that points at the parent repo's .git / working tree
+# is physically resolved (realpath) BEFORE the isolation decision, so it can no longer
+# dodge the guard by landing _tdir on the isolation root. AC-3 note: Claude Code's own
+# Edit/Write tools already refuse symlink writes, so this is defense-in-depth.
+# --------------------------------------------------------------------------
+echo "TC-SYMLINK-gitdir: isolation symlink → parent .git → deny (git-dir)"
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/evil-into-gitdir"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-into-gitdir" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "isolation symlink into parent .git resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-into-gitdir"
+echo ""
+
+echo "TC-SYMLINK-tree: isolation symlink → parent working tree → deny (parent-tree)"
+ln -s "$TEST_REPO/tracked.py" "$ISO_MUT_DIR/evil-into-tree"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-into-tree" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "isolation symlink into parent working tree resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-into-tree"
+echo ""
+
+echo "TC-SYMLINK-local: isolation-internal symlink → allow (no regression)"
+: > "$ISO_MUT_DIR/realfile.txt"
+ln -s "$ISO_MUT_DIR/realfile.txt" "$ISO_MUT_DIR/local-link"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/local-link" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+assert_allow "isolation-internal symlink still allowed" "$out" "$rc"
+rm -f "$ISO_MUT_DIR/local-link" "$ISO_MUT_DIR/realfile.txt"
+echo ""
+
+echo "TC-SYMLINK-main: MAIN-session write to symlink into parent .git → allow (IS_SUBAGENT=0)"
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/main-link"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/main-link" "$ISO_MUT_DIR" "$MAIN_TRANSCRIPT") && rc=0 || rc=$?
+assert_allow "main-session symlink write not blocked" "$out" "$rc"
+rm -f "$ISO_MUT_DIR/main-link"
+echo ""
+
+# --------------------------------------------------------------------------
 # fail-closed: a crash in the deny-emit (jq -n) still DENIES (exit 2), never allows.
 # A PATH shim fails only `jq -n` (the deny payload) and passes every INPUT-parsing jq
 # through to the real jq, so scope is confirmed and only the final emit crashes.


### PR DESCRIPTION
## 概要

reviewer subagent が **Edit/Write 以外の経路**で parent repo の `.git` ディレクトリを書き換え、main（非サンドボックス）session で任意コード実行を仕掛けられる残存ギャップを塞ぐ。#1863（Issue #1860）の cycle 2/3 レビューで security-reviewer が発見した follow-up。

`#1860`（PR #1863）で導入した `pre-tool-edit-guard.sh` は Edit/Write 経路の `.git` / parent working tree 書き込みを遮断済みだが、次の 2 経路が残っていた:

- **Bash tool 経由の `.git` 書き込み**: `pre-tool-bash-guard.sh` は state-mutating git 動詞のみ block し、`echo pwned > .git/hooks/pre-commit` のようなシェルリダイレクトは素通し
- **symlink 最終要素の canonicalize 漏れ**: 隔離 worktree 内に parent `.git` を指す symlink を張って Write すると isolation allow に倒れうる

## Changes

- `plugins/rite/hooks/pre-tool-bash-guard.sh` — **AC-1**: reviewer（fail-closed）領域内に sub-block (H) を追加。`>` / `>>` リダイレクト・`tee`/`cp`/`mv`/`ln`/`install`/`rsync`/`truncate` で `.git` ディレクトリ配下へ書き込む経路を deny。`.git` は `(^|/).git(/|$)` のパスコンポーネントとして判定（`foo.git/` を誤検出しない）。`.git` の読み取り（`cat`/`ls`/`grep`）・隔離 worktree 作成・`< .git/x` 入力リダイレクトの読み取り源は誤検出しない
- `plugins/rite/hooks/pre-tool-edit-guard.sh` — **AC-2**: 対象パスの最終要素が symlink の場合、isolation 判定の前に `realpath` で物理解決。隔離 worktree 内 symlink による parent `.git` 迂回を塞ぐ（中間ディレクトリ symlink は既存の `_tdir` walk が解決済み）
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` — **AC-4**: `.git` 書き込みの DENY 11 ケース + ALLOW 8 ケース（read-only git / 隔離 worktree 作成 / `foo.git/` 境界 / main session の非ブロック）を追加
- `plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh` — **AC-4**: symlink → parent `.git` / working tree の deny、隔離内部 symlink の allow（回帰なし）、main session の allow を追加
- `plugins/rite/agents/_reviewer-base.md` — READ-ONLY 表に `.git` 書き込み禁止行を追加（deny メッセージが参照するセクションを新ルールと整合）

## 実装中の判断・計画逸脱

- **判断 (AC-3)**: Claude Code の Write/Edit tool が open-truncate か temp+rename かを実機検証したところ、**両ツールとも最終要素が symlink の書き込みを outright 拒否**した（`"Refusing to write through symlink … Resolve the symlink and pass the real target path explicitly."`）。open-truncate でも temp+rename でもなく「拒否」のため、AC-2 が塞ぐ symlink 迂回は harness の Edit/Write tool 側で既に不成立。したがって **AC-2 は防御多層化（defense-in-depth）に格下げ** し、undocumented な harness 挙動に依存しない構造防御として実装した
- **判断 (AC-1 の精度 vs 単純さ)**: `cp`/`ln` 等の file-verb は SRC/DEST 位置を厳密に解析せず「verb + `.git` パス」で deny する（`cp .git/config /tmp`（read-source）も deny だが `cat` で代替可能）。redirect vector は精密。既知の制約（heredoc 後方の redirect target・quoted string 内 `>`）はコメントに明記。fail-closed 領域内に配置し、パース crash 時も deny に倒す

## Checklist

- [x] AC-1: Bash 経由 `.git` 書き込み経路を遮断（read-only git / テスト実行を誤検出しない）
- [x] AC-2: `pre-tool-edit-guard.sh` で symlink 最終要素を物理解決
- [x] AC-3: Write/Edit tool の symlink 挙動を実機確認（迂回不成立を裏付け）
- [x] AC-4: 両 hook に回帰テストを追加（bash-guard +19 / edit-guard +4）
- [x] hook テストスイート全 green（bash-guard 203 / edit-guard 31 / 全 97 スイート passed）
- [x] 変更ファイルに新規 lint finding なし

## 検証

```
plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh  → 203 passed, 0 failed
plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh  →  31 passed, 0 failed
plugins/rite/hooks/tests/run-tests.sh                 →  97/97 passed
```

> **注**: PreToolUse hook はセッション起動時にロードされるため、本 worktree の変更が実 hook として反映されるのは次セッションから。本 PR の検証はテストスイートで担保している。

Closes #1864
