### PR TITLE
fix(reviewers): pre-tool-bash-guard.sh :608 の worktree-add 引数ループを noglob 化

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -605,6 +605,21 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
       WT_POSITIONAL_COUNT=0
       WT_HAS_DETACH=0
       WT_NEW_BRANCH_FLAG=0
+      # noglob-scope the unquoted `$WT_ARGS` word-split loop (mirrors the (H) tokenizer at
+      # ~line 789, Issue #1866 follow-up to #1864). Without `set -f`, glob metachars (`*`/`?`/`[`)
+      # surviving the meta-char normalization undergo pathname expansion against the hook CWD,
+      # exposing two failure modes the sibling (H) loop already closed:
+      #   (a) OVER-DENY — a `*` that expands to a CWD entry named like a new-branch flag (e.g. a
+      #       file `-b`) makes a legit `git worktree add <path> <ref>` mis-detect as a branch-
+      #       creating form and get wrongly DENIED (violates AC-1 "read-only git not mis-detected").
+      #   (b) TIMEOUT→FAIL-OPEN — glob expansion is NOT bounded by the 64KB length guard, so a
+      #       large-dir glob makes this loop iterate unboundedly → the PreToolUse hook times out →
+      #       fails OPEN → the worktree-add branch-leak check it exists to enforce is bypassed.
+      # `case` pattern matching is unaffected by noglob (it is filename generation only), so the
+      # detection logic below is unchanged. Save/restore the prior noglob state (drift-safe; this
+      # hook leaves it off today). No `break` in the loop, so the restore after `done` always runs.
+      case $- in *f*) _wt_noglob_was_set=1 ;; *) _wt_noglob_was_set=0 ;; esac
+      set -f
       for tok in $WT_ARGS; do
         case "$tok" in
           --detach|--detach=*)
@@ -627,6 +642,8 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
             WT_POSITIONAL_COUNT=$((WT_POSITIONAL_COUNT + 1)) ;;
         esac
       done
+      # Restore the prior noglob state (only re-enable globbing if this hook had it on before).
+      [ "$_wt_noglob_was_set" = "1" ] || set +f
       # Deny logic:
       #   (a) new-branch flag present at any position → leak (regardless of --detach)
       #   (b) positional_count <= 1 AND no --detach → bare `add <path>`, auto-creates branch → leak

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1867,6 +1867,32 @@ fi
 rm -rf "$tc125_noglob_dir"
 echo ""
 
+# --- noglob regression for the `git worktree add` arg loop (Issue #1866, sibling of TC-125) ---
+# The `for tok in $WT_ARGS` loop (~line 608) that counts positional args / detects new-branch
+# flags now runs under `set -f`, so a glob metachar surviving in the worktree-add args is NOT
+# pathname-expanded against the hook CWD. Without noglob, a bare `*` in the args expands to CWD
+# entries; a file named exactly `-b` (the new-branch flag token) then latches WT_NEW_BRANCH_FLAG
+# and a legit `git worktree add <path> <existing-ref>` is wrongly DENIED (AC-1 over-DENY false
+# positive; an unbounded glob could also time the hook out → fail-open, bypassing the branch-leak
+# check). This pins the fix: with `set -f` the `*` stays a literal positional token → allow.
+#   Command shape note: the trailing `*` is a deliberately adversarial 4th token (git itself would
+#   reject a 3rd positional) — its only job is to be a glob that expands against the crafted CWD.
+#   The assertion is about the GUARD not over-denying due to CWD pollution, not about git accepting
+#   the command. Runs from a temp CWD holding a `-b` file so the pre-fix (globbing) path over-DENYs
+#   (fail-on-revert): verified empirically that the un-fixed loop returns deny for this input.
+tc126_noglob_dir=$(mktemp -d)
+: > "$tc126_noglob_dir/-b"    # a file named like the new-branch flag token — would set WT_NEW_BRANCH_FLAG if globbed
+_tc126_noglob_prev=$(pwd)
+if cd "$tc126_noglob_dir"; then
+  echo "TC-126-ALLOW-noglob: worktree-add args with a bare glob not polluted by CWD flag-file → allow (set -f)"
+  assert_subagent_allow "worktree add with bare glob + existing ref allowed under noglob" "git worktree add /tmp/wt develop *"
+  cd "$_tc126_noglob_prev" || true
+else
+  fail "TC-126-ALLOW-noglob setup: cd into temp dir failed"
+fi
+rm -rf "$tc126_noglob_dir"
+echo ""
+
 # --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

reviewer subagent 用の状態変更 git ガード `pre-tool-bash-guard.sh` において、`git worktree add` の引数を走査するループ `for tok in $WT_ARGS`（:608）を noglob スコープ（`set -f` / `set +f`、`case $- in *f*)` で直前状態を save/restore）で囲む。兄弟の gitdir-write tokenizer（:789 付近）が既に採用している unquote-glob 対策を、同じ欠陥を持つこのループにも適用する follow-up hardening。

## 背景

`$WT_ARGS` は unquote のまま `for` の単語分割に渡されるため、メタ文字正規化を生き延びた glob（`*` / `?` / `[`）が hook プロセスの CWD に対してパス名展開される。これにより 2 つの exposure が生じる:

- **over-DENY 誤検出**: CWD に `-b` のような new-branch フラグ名のファイルがあると、`*` が展開されて `-b` トークンが混入し、正当な `git worktree add <path> <既存ref>`（inspection 用の read-only 相当）が branch 作成形式と誤判定されて DENY される。reviewer の isolated inspection を妨げる。
- **timeout→fail-open**: glob 展開は 64KB 長さガードの後段で起きるためトークン数が上限で縛られず、大ディレクトリ glob でループが無制限反復し PreToolUse hook が timeout → fail-open する。本来ブロックすべき worktree-add branch-leak チェックが bypass される。

`case` / `[[ == ]]` のパターンマッチは noglob（`set -f`）の影響を受けない（filename generation のみが無効化される）ため、ループ内の検出ロジックは不変。

## 変更内容

- `plugins/rite/hooks/pre-tool-bash-guard.sh`: :608 の `for tok in $WT_ARGS` ループを `set -f` / `set +f` で囲み、直前の noglob 状態を `case $-` で保存・復元。ループに `break` がないため復元は常に実行される。
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`: over-DENY 回帰テスト TC-126 を追加。CWD に `-b` ファイルを置き、glob を含む `git worktree add` が誤検出されず ALLOW されることを固定。未修正コードでは DENY・修正後は ALLOW となる discriminating 性を実機で確認済み（fail-on-revert）。

## テスト

- `pre-tool-bash-guard.test.sh`: 235 passed / 0 failed（TC-126 含む）
- 全 hook テストスイート（`run-tests.sh`）: green（exit 0）

## Checklist

- [x] :608 のループを (H) と同型の noglob スコープで囲う
- [x] `case` / `[[ == ]]` が noglob 非影響のため判定ロジックが不変であることを確認
- [x] CWD に glob 展開ターゲットを置いた状態で正当な `git worktree add` が over-DENY されないことを回帰テストで固定
- [x] 全 hook テストスイート green

## 関連 Issue

Closes #1866
