### PR TITLE
fix(batch-run): batch/E2E 時に open 3.4・pr-review 3.3 の AskUserQuestion を機械判定で自動化

### DIFF
--- a/plugins/rite/skills/batch-run/SKILL.md
+++ b/plugins/rite/skills/batch-run/SKILL.md
@@ -460,7 +460,7 @@ echo "[CONTEXT] RUN_STOP; cursor=$cursor; done=$done_issues; remaining=$remainin
 - **session_id 解決不可は fail-loud**: 各 bash ブロックは `run-queue-{session_id}.json` を組む前に session_id を解決する。解決できない（`flow-state.sh path` が空を返す）場合は global 名 `run-queue.json` へフォールバックせず `exit 1` で停止する（フォールバックすると Issue #1859 の相互破壊バグを再導入するため）。停止した場合は環境の session_id 解決（`CLAUDE_CODE_SESSION_ID` env / `.rite-session-id`）を確認する
 - run-queue（`run-queue-{session_id}.json`）は停止時に残す。引数省略 `/rite:batch-run` で cursor から再開する（同一セッション内での再開を前提）
 - run は flow-state の `handoff` を使わないため、sub-skill 間（例: open 完了直後・iterate invoke 前）で turn が途切れた場合の構造ガードは持たない。これは `/rite:open` のステップ間遷移と同じ前提で、各 skill invoke 直前の continuation hint（HTML コメント）と flat step 構造で継続を促す
-- **前提**: 対象 Issue は事前に `/rite:open` 可能な状態（open かつ品質十分）であること。closed / 親 Issue / 品質 C-D の場合は open 内部の AskUserQuestion で自律フローが止まる（open 無変更の代償。完全な無人化は保証しない）
+- **前提**: 対象 Issue は事前に `/rite:open` 可能な状態（open かつ品質十分）であること。open ステップ 3.4 の実装計画承認は batch 実行中は run-queue 判定で自動承認され停止しない（#1861。宣言「完全自律（無確認）」と実挙動を一致させるための変更）。ただし closed / 親 Issue / 品質 C-D の入力品質ゲート（open 内部の AskUserQuestion）は batch でも従来どおり自律フローを止める（完全な無人化は保証しない）
 - `/rite:recover` が active batch 継続（設計判断節「recover.md からの active batch 継続」）を行う場合も、失敗時は即停止（サーキットブレーカーのみ例外）という本方針をそのまま適用する
 
 ---

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -459,9 +459,36 @@ Issue body から「What / Why / Where / Acceptance Criteria」を抽出。
 
 **参考実装セクション**: `reference_discovery` 原則（[coding-principles.md](../rite-workflow/references/coding-principles.md)）のルール 4「発見した参照を実装計画に記録」に従い、ステップ 3.2 で発見した既存の参考実装（同ディレクトリの類似ファイル、命名パターンが一致するファイル等）を記録する。参考実装が見つからない場合（新規ディレクトリ、初めてのファイルパターン等）は、テーブルの代わりに `参考実装: なし（新規ディレクトリまたは初めてのファイルパターン）` の 1 行を出力する。
 
-### 3.4 ユーザー確認
+### 3.4 計画承認（batch 時は自動承認 / standalone は AskUserQuestion）
 
-AskUserQuestion で「この計画で実装開始 / 計画を修正 / 中止」を選択。
+`/rite:batch-run` から駆動された batch 実行中かを run-queue で機械判定し、計画承認の要否を分岐する。batch 実行中（run-queue `active=true` かつ cursor が本 Issue を指す）は計画を**自動承認**して停止しない。standalone（直接 `/rite:open`）は従来どおり AskUserQuestion で確認する。
+
+> **Why（#1861）**: 旧仕様は本ステップを無条件 AskUserQuestion にしていたため、`/rite:batch-run` が宣言する「完全自律（無確認）」に反して Issue ごとに必ず 1 回停止していた。batch 時の自動承認で宣言と実挙動を一致させる。安全側の担保は batch-run のデフォルトモードが draft PR をレビュー待ちで残すこと・`--merge` が明示 opt-in であることに置く（本ステップでは停止しない）。batch 判定は iterate ステップ 6 の run-queue batch 判定と同型（`state-path-resolve.sh` / `flow-state.sh path` で session_id を導出 → `active` + cursor 一致）で、read-only。helper 失敗 / session_id 解決不可 / キュー不在のときは interactive（確認を出す）に fail-safe する。
+
+```bash
+state_root=$(bash {plugin_root}/hooks/state-path-resolve.sh)
+fs_path=$(bash {plugin_root}/hooks/flow-state.sh path)
+session_id=$(basename "$fs_path" .flow-state)
+queue_file="$state_root/.rite/state/run-queue-$session_id.json"
+plan_mode=interactive
+# session_id 解決不可（空）/ キュー不在 → 自セッションの batch キューを特定できないため
+# 安全側 interactive のまま（read-only なので fail-loud はせず確認を出す方に倒す）
+if [ -n "$session_id" ] && [ -f "$queue_file" ]; then
+  q_active=$(jq -r '.active // false' "$queue_file" 2>/dev/null)   # active 欠落の旧形式は false（安全側 = interactive）
+  q_cursor=$(jq -r '.cursor // 0' "$queue_file" 2>/dev/null)
+  q_total=$(jq -r '.issues | length' "$queue_file" 2>/dev/null)
+  q_issue=$(jq -r ".issues[$q_cursor] // empty" "$queue_file" 2>/dev/null)
+  if [ "$q_active" = "true" ] && [ "$q_cursor" -lt "${q_total:-0}" ] 2>/dev/null && [ "$q_issue" = "{issue_number}" ]; then
+    plan_mode=batch
+  fi
+fi
+echo "[CONTEXT] OPEN_PLAN_MODE=$plan_mode; issue={issue_number}"
+```
+
+| `OPEN_PLAN_MODE` | アクション |
+|---|---|
+| `batch` | 計画を**自動承認**（AskUserQuestion を出さない）。3.3 の計画（要判断ポイント含む）は記録として表示済みのまま、ステップ 3.5 へ直行する |
+| `interactive` | AskUserQuestion で「この計画で実装開始 / 計画を修正 / 中止」を選択（standalone。従来どおり。AC-4 回帰なし） |
 
 ### 3.5 Issue Body Checklist 更新
 

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -43,10 +43,13 @@ bash 4.0+ 必須 (ステップ 1.2.7 の `mapfile -t changed_file_paths < "$gh_f
 
 ## E2E Output Minimization
 
-`/rite:iterate` E2E flow から呼ばれた時、ステップ 4 (sub-agent execution) は **full execution**、ステップ 5-7 の **人間向け出力** のみ minimize する。minimize されるのは出力のみで、sub-agent parallel execution / PR コメント投稿 / recommendations AskUserQuestion 等の処理本体は standalone と同等に実行する (時間・context を理由にした sub-agent 省略 / parallel 直列化 / AskUserQuestion 省略は identity 違反)。
+`/rite:iterate` E2E flow から呼ばれた時、ステップ 4 (sub-agent execution) は **full execution**、ステップ 5-7 の **人間向け出力** のみ minimize する。minimize されるのは出力のみで、sub-agent parallel execution / PR コメント投稿 / recommendations AskUserQuestion 等の処理本体は standalone と同等に実行する (時間・context を理由にした sub-agent 省略 / parallel 直列化 は identity 違反)。
+
+**AskUserQuestion の扱いは 2 種を区別する（#1861）**: ステップ 7 の recommendations トリアージ（結果整合性 = 未解決指摘・スコープ外指摘の握り潰し防止）は E2E でも **skip 禁止**（省略は identity 違反）。一方 ステップ 3.3 の pre-flight レビュアー構成確認は E2E で **skip 可**（iterate の自律ループ設計に合わせ flow-state ベース判定で機械的に skip する。詳細はステップ 3.3）。いずれの場合も `起動 reviewer {count} 名` サマリ行・省略された reviewer 表示・ステップ 4 のフルレビュー実行は省略しない。
 
 | Phase | Standalone | E2E Flow |
 |-------|-----------|----------|
+| ステップ 3.3 (Confirm Reviewers) | `AskUserQuestion` で構成確認 | **`AskUserQuestion`（オプション選択）を skip**（pre-flight 確認のみ。flow-state ベース判定はステップ 3.3 参照）。`起動 reviewer {count} 名` サマリ行・省略された reviewer 表示は両経路で必須維持 |
 | ステップ 4 (Sub-Agent Execution) | Full execution | **Full execution** — sub-agents MUST run in parallel for every review cycle (including verification mode). No shortcut allowed. |
 | ステップ 5 (Consolidation) | Full findings table | Result pattern + summary counts only |
 | ステップ 6 (PR Comment) | Full comment + display | Post comment silently, output pattern only |
@@ -1194,8 +1197,41 @@ After the Security Expert conditional and any co-reviewer / sole-reviewer-guard 
 
 ### 3.3 Confirm Reviewers
 
+**E2E flow detection（#1861）**: `/rite:iterate` の review⇄fix ループから駆動された E2E 呼び出しでは、本ステップの pre-flight レビュアー構成確認 `AskUserQuestion`（末尾「オプション」の選択）を skip する。iterate は「mergeable まで自律的に回す」設計のため、cycle ごとに構成確認で停止するのは設計意図と矛盾する。判定は `skills/ready/SKILL.md` Phase 2.1 の `in_e2e_flow` と同型の flow-state ベース機械判定を用いる（iterate はステップ 1 で pr-review 呼び出し前に `phase=review` を、ステップ 3 で fix 呼び出し前に `phase=fix` を書くため、E2E 実行中は `phase ∈ {review, fix}` + `active=true` が成立する）。helper 失敗時は standalone（確認を出す）に fail-safe する:
 
-Confirm the reviewer configuration with `AskUserQuestion` (fallback: see ステップ 1.4 note):
+```bash
+if phase=$(bash {plugin_root}/hooks/flow-state.sh get --field phase --default ""); then
+  :
+else
+  rc=$?
+  echo "WARNING: flow-state.sh failed (rc=$rc) for --field phase in pr-review ステップ 3.3 — falling back to standalone confirmation" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=pr_review_step_3_3_phase; rc=$rc" >&2
+  phase=""
+fi
+if active=$(bash {plugin_root}/hooks/flow-state.sh get --field active --default ""); then
+  :
+else
+  rc=$?
+  echo "WARNING: flow-state.sh failed (rc=$rc) for --field active in pr-review ステップ 3.3 — falling back to standalone confirmation" >&2
+  echo "[CONTEXT] STATE_READ_FAILED=1; phase=pr_review_step_3_3_active; rc=$rc" >&2
+  active=""
+fi
+# whitelist は ready Phase 2.1 と同一（legacy phase5_* を含む）+ pr-review の live 値 review/fix。
+# --default "" が false/missing を "" に潰すため AND check は安全（NOT-style check は禁止）。
+if { [ "$phase" = "phase5_post_review" ] || [ "$phase" = "phase5_post_fix" ] || [ "$phase" = "review" ] || [ "$phase" = "fix" ]; } && [ "$active" = "true" ]; then
+  in_e2e_flow=true
+else
+  in_e2e_flow=false
+fi
+echo "[CONTEXT] PR_REVIEW_IN_E2E=$in_e2e_flow"
+```
+
+| `PR_REVIEW_IN_E2E` | アクション |
+|---|---|
+| `true` | E2E（iterate 経由）。**`AskUserQuestion`（下記「オプション」の選択）を skip** し、下記表示ブロック（`起動 reviewer {count} 名` サマリ行・選定・省略された reviewer）はそのまま出力してからステップ 4 のレビュー実行へ直行する（サマリ行は every-path 必須、省略表示の silent capping 禁止は E2E でも維持） |
+| `false` | standalone。下記構成を `AskUserQuestion` で確認する（従来どおり。AC-4 回帰なし。fallback: see ステップ 1.4 note） |
+
+standalone（`PR_REVIEW_IN_E2E=false`）ではレビュアー構成を `AskUserQuestion` で確認する。E2E（`true`）では末尾「オプション」の選択のみ skip し、以下の表示ブロックは両経路で出力する:
 
 ```
 以下のレビュアー構成でレビューを実行します:


### PR DESCRIPTION
## 概要

`/rite:batch-run` が宣言する「完全自律（無確認）」と、`/rite:open` ステップ 3.4（実装計画承認）・`/rite:pr-review` ステップ 3.3（レビュアー構成確認）の AskUserQuestion の矛盾を解消する。

- **open 3.4**: 旧仕様は無条件 AskUserQuestion のため、batch 実行中でも Issue ごとに必ず 1 回停止していた
- **pr-review 3.3**: E2E（iterate 経由）での skip 可否が未規定で、自律ループ内の扱いが未定義だった

宣言と実挙動を一致させる（案 a: batch/E2E 検出時の自動 skip を機械判定で正式仕様化）。

## 関連 Issue

Closes #1861

## 変更内容

- **`skills/open/SKILL.md` ステップ 3.4**: run-queue ベースの batch 検出（`iterate` ステップ 6 と同型の `state-path-resolve.sh` / `flow-state.sh path` → session_id 導出 → `active` + cursor 一致）を追加。`OPEN_PLAN_MODE=batch` のとき計画を自動承認（AskUserQuestion を出さない）。standalone は従来どおり確認。session_id 解決不可 / キュー不在は interactive に fail-safe（AC-1, AC-4）
- **`skills/pr-review/SKILL.md` ステップ 3.3**: `ready` Phase 2.1 の `in_e2e_flow` と同型の flow-state phase-whitelist 判定（`phase ∈ {review, fix}` + `active=true`）を追加。E2E 時は pre-flight のレビュアー構成確認 AskUserQuestion を skip（`起動 reviewer {count} 名` サマリ行・省略 reviewer 表示は両経路で維持）。helper 失敗時は standalone に fail-safe（AC-2, AC-4）
- **`skills/pr-review/SKILL.md` E2E Output Minimization**: 3.3 skip を表に明文化。「AskUserQuestion 省略は identity 違反」を、pre-flight 確認（3.3, skip 可）と結果整合性トリアージ（ステップ 7, skip 禁止）とで切り分けて改稿
- **`skills/batch-run/SKILL.md` 前提行**: 3.4 が batch で自動承認され停止しないことを反映（「open 無変更の代償」を削除）。入力品質ゲート（closed / 親 / 品質 C-D）は従来どおり停止する旨を明示（AC-3）

## 実装中の判断・計画逸脱

- 判断: batch 時 open 3.4 は **無条件で自動承認**（案 a 純正）を採用。要判断ポイント空時のみ自動承認する折衷案は batch の停止を非決定的にし LLM 判定に依存するため不採用（ユーザー承認済み）。安全弁は default モードの draft PR レビュー待ち・`--merge` の明示 opt-in
- 判断: open 3.4 と pr-review 3.3 で検出方式を使い分け。open は iterate を経由しないため phase では batch/standalone を区別できず run-queue が唯一の有効シグナル。pr-review は iterate が呼び出し前に `phase=review` を書くため flow-state phase-whitelist が成立（AC-2 の「flow-state ベース機械判定」要件に合致）
- 判断: pr-review 既存の会話コンテキスト E2E 判定（出力最小化用）は変更せず、flow-state 判定を 3.3 の権威的な機械ゲートとして追加。E2E Output Minimization にその切り分けを明記して二重メカニズムの曖昧さを排除

## 検証

- open 3.4 の batch 検出ロジックをライブなキュー（active=true, cursor→1861）で実地検証 → `OPEN_PLAN_MODE=batch` を確認
- pr-review 3.3 の flow-state 検出を実行し fail-safe（review/fix 以外は standalone）を確認
- iterate が pr-review 呼び出し前に `--phase review`、fix 呼び出し前に `--phase fix` を set することを確認（E2E 中 `phase ∈ {review, fix}` + `active=true` の成立を裏付け）
- `/rite:lint`: 変更 3 ファイルに新規 finding 0 件。既存 warning は全て未変更ファイルのみ（non-blocking）

## チェックリスト

- [x] open 3.4 batch 自動承認（AC-1）
- [x] pr-review 3.3 E2E skip の正式仕様化（AC-2）
- [x] batch-run.md 宣言・前提の実挙動整合（AC-3）
- [x] standalone 回帰なし・両検出 fail-safe（AC-4）
- [x] /rite:lint pass（変更ファイルに新規 finding なし）
