### PR TITLE
docs(worktree,open): sandbox環境でのSSH host alias経由git操作ブロックを文書化

### DIFF
--- a/plugins/rite/references/git-worktree-patterns.md
+++ b/plugins/rite/references/git-worktree-patterns.md
@@ -454,6 +454,25 @@ Two helper-driven patterns bracket the session-worktree lifecycle:
   the branch** (push-pending / unpushed work is preserved; branch cleanup stays the
   responsibility of the normal `cleanup` path).
 
+### SSH host alias 経由の `git push`/`fetch` が sandbox のネットワーク許可リストでブロックされる
+
+`origin` remote が `~/.ssh/config` の `Host` alias（例: `git@github.com-work:owner/repo.git`）
+経由の環境で、sandbox が有効なとき `git push` / `git fetch` の SSH 接続がブロックされることがある。
+
+**症状**: `socat[N] E CONNECT github.com-work:22: Bad Gateway` のようなエラーで SSH 接続が拒否
+され、`git push origin {branch}` / `git fetch origin {base}` が失敗する。`gh` CLI（HTTPS 経由で
+`api.github.com` を使う）は影響を受けないため、`gh issue view` 等の issue 操作は成功するのに
+push/fetch だけ失敗する非対称な挙動になる。
+
+**原因**: sandbox のネットワーク許可リストはドメイン名ベース（`github.com` / `*.github.com` 等）
+で構成される。`~/.ssh/config` の `Host` alias は実際の接続先ホスト名としては alias 名（例:
+`github.com-work`）になり、許可リストのいずれのパターンにも一致しない。
+
+**対処**: 上記はコマンド自体の失敗ではなく sandbox のネットワーク制限のため、当該 `git push` /
+`git fetch` コマンドのみ `dangerouslyDisableSandbox: true` で再実行してよい（ユーザー確認は不要
+— 既知の環境制約、Issue #1897）。sandbox のネットワーク許可リストはプラグイン外の環境設定のため、
+rite 側の設定変更では解消できない。SSH alias remote を使う任意のプロジェクトで同様に起こりうる。
+
 > **Canonical spec**: This file documents the operational *patterns*; the canonical
 > runtime specification for the session-worktree layer (lifecycle, claim, reap,
 > shared-state-root resolution, crash recovery) lives in

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -564,6 +564,8 @@ git push origin {branch_name}
 ```
 
 > `-u`（upstream 設定）は付けない。sandbox 有効環境で upstream tracking の `.git/config` 書込が拒否されるため（Issue #1894）。flow-state が `{branch_name}` を常時保持しているため upstream に依存する必要はない。
+>
+> `origin` が SSH host alias 経由（例: `git@github.com-work:...`）の環境で sandbox が有効な場合、`socat` の `Bad Gateway` エラーで push がネットワーク許可リストにブロックされることがある。この場合は当該コマンドのみ `dangerouslyDisableSandbox: true` で再実行してよい（詳細: [git-worktree-patterns.md](../../references/git-worktree-patterns.md#ssh-host-alias-経由の-git-pushfetch-が-sandbox-のネットワーク許可リストでブロックされる)、Issue #1897）。
 
 ### 6.2 PR 作成
 


### PR DESCRIPTION
## Summary

sandbox 有効環境で `origin` が SSH host alias（例: `git@github.com-work:...`）経由の場合、`git push` / `git fetch` が sandbox のネットワーク許可リストでブロックされる既知の制約を、rite プラグイン側のドキュメントとして記録する。

## Related Issue

Closes #1897

### 検出された問題（別 Issue として追跡）

- #1899: `gh repo view`（`--repo` 未指定）が SSH host alias remote のホストを解決できず内部スクリプトが失敗する
- #1900: `mktemp` の `/tmp` 直下ハードコードテンプレートが sandbox 環境で書き込み拒否される

## Changes

- `plugins/rite/references/git-worktree-patterns.md`: SSH host alias 経由の `git push`/`fetch` が sandbox のネットワーク許可リストでブロックされる件の症状・原因・対処（`dangerouslyDisableSandbox: true` での再実行）を正典として追記
- `plugins/rite/skills/open/SKILL.md`: push ステップに上記ドキュメントへのポインタを追加

コード変更は無し（ドキュメントのみ）。`CLAUDE.md`（cc-rite-workflow リポジトリのドッグフーディング注意事項）ではなく、rite プラグイン側の reference に置くことで、rite を使う任意のプロジェクトに適用されるようにした。

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable) — `commands.test` 未設定のためスキップ
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
