### PR TITLE
fix: mktemp の /tmp 直下ハードコードテンプレートが sandbox 環境で書き込み拒否される

### DIFF
--- a/plugins/rite/hooks/issue-body-safe-update.sh
+++ b/plugins/rite/hooks/issue-body-safe-update.sh
@@ -92,20 +92,20 @@ case "$MODE" in
     # but unguarded mktemp under `set -euo pipefail` would abort silently when
     # /tmp is exhausted. Surface mktemp failure as a normal fetch_failure_reason
     # so the caller can branch on it instead of getting a mute exit.
-    tmpfile_read=$(mktemp /tmp/rite-issue-body-read-XXXXXX) || {
+    tmpfile_read=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-read-XXXXXX") || {
       echo "${err_level}: issue-body-safe-update fetch: mktemp tmpfile_read failed (disk full / inode / permission?)" >&2
       echo "fetch_failure_reason=mktemp_failed"
       _emit_body_update_incident "issue_body_fetch_failed" "mktemp_failed" "1" "tmpfile_read mktemp failed"
       exit 0
     }
-    tmpfile_write=$(mktemp /tmp/rite-issue-body-write-XXXXXX) || {
+    tmpfile_write=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-write-XXXXXX") || {
       echo "${err_level}: issue-body-safe-update fetch: mktemp tmpfile_write failed" >&2
       echo "fetch_failure_reason=mktemp_failed"
       _emit_body_update_incident "issue_body_fetch_failed" "mktemp_failed" "1" "tmpfile_write mktemp failed"
       rm -f "$tmpfile_read"
       exit 0
     }
-    tmpfile_err=$(mktemp /tmp/rite-issue-body-err-XXXXXX) || {
+    tmpfile_err=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-err-XXXXXX") || {
       echo "${err_level}: issue-body-safe-update fetch: mktemp tmpfile_err failed" >&2
       echo "fetch_failure_reason=mktemp_failed"
       _emit_body_update_incident "issue_body_fetch_failed" "mktemp_failed" "1" "tmpfile_err mktemp failed"
@@ -213,7 +213,7 @@ case "$MODE" in
     # attributed in the WARNING rather than reported as "API failed, reason
     # unknown". The script is non-blocking, so mktemp failure degrades to
     # "no stderr capture" rather than aborting the caller's workflow.
-    apply_err=$(mktemp /tmp/rite-issue-body-apply-err-XXXXXX) || {
+    apply_err=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-apply-err-XXXXXX") || {
       echo "${err_level}: issue-body-safe-update apply: mktemp apply_err failed; stderr capture disabled" >&2
       _emit_body_update_incident "issue_body_fetch_failed" "mktemp_failed" "1" "apply_err mktemp failed"
       apply_err=""

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -253,12 +253,12 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     # permission) would vanish from the WARNING. Tag the failure so the WARNING
     # can distinguish "gh returned no stderr" from "we couldn't capture it".
     stderr_capture_disabled=0
-    pr_view_err=$(mktemp /tmp/rite-pc-pr-err-XXXXXX) || { pr_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for pr_view_err; gh pr view stderr will not be captured" >&2; }
-    repo_view_err=$(mktemp /tmp/rite-pc-repo-err-XXXXXX) || { repo_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for repo_view_err; gh repo view stderr will not be captured" >&2; }
-    jq_owner_err=$(mktemp /tmp/rite-pc-jq-owner-err-XXXXXX) || { jq_owner_err=""; stderr_capture_disabled=1; }
-    jq_name_err=$(mktemp /tmp/rite-pc-jq-name-err-XXXXXX) || { jq_name_err=""; stderr_capture_disabled=1; }
-    gql_err=$(mktemp /tmp/rite-pc-gql-err-XXXXXX) || { gql_err=""; stderr_capture_disabled=1; }
-    jq_err=$(mktemp /tmp/rite-pc-jq-err-XXXXXX) || { jq_err=""; stderr_capture_disabled=1; }
+    pr_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-pr-err-XXXXXX") || { pr_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for pr_view_err; gh pr view stderr will not be captured" >&2; }
+    repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-repo-err-XXXXXX") || { repo_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for repo_view_err; gh repo view stderr will not be captured" >&2; }
+    jq_owner_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-jq-owner-err-XXXXXX") || { jq_owner_err=""; stderr_capture_disabled=1; }
+    jq_name_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-jq-name-err-XXXXXX") || { jq_name_err=""; stderr_capture_disabled=1; }
+    gql_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-gql-err-XXXXXX") || { gql_err=""; stderr_capture_disabled=1; }
+    jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-jq-err-XXXXXX") || { jq_err=""; stderr_capture_disabled=1; }
 
     # Test STATE_ROOT existence up front and warn about state_root_inaccessible
     # directly. If we instead chained `cd ... 2>/dev/null && gh pr view ...`,
@@ -325,8 +325,8 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       # here would let broken Projects integration go unnoticed by the user.
       awk_pe_err=""
       awk_pn_err=""
-      awk_pe_err=$(mktemp /tmp/rite-pc-awk-pe-err-XXXXXX) || { awk_pe_err=""; stderr_capture_disabled=1; }
-      awk_pn_err=$(mktemp /tmp/rite-pc-awk-pn-err-XXXXXX) || { awk_pn_err=""; stderr_capture_disabled=1; }
+      awk_pe_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-awk-pe-err-XXXXXX") || { awk_pe_err=""; stderr_capture_disabled=1; }
+      awk_pn_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-awk-pn-err-XXXXXX") || { awk_pn_err=""; stderr_capture_disabled=1; }
       # awk rc を独立 capture することで「awk parse 失敗 (config file 不正)」と「Projects 無効
       # 設定」を区別する。両者が silent に同一視されると、permission denied や IO error で
       # Projects 整合性チェックが skip された事実が operator に届かない。
@@ -420,9 +420,9 @@ query($owner: String!, $repo: String!, $number: Int!) {
           # (引数 unsubstituted / type mismatch 等) が空文字列として projects-status-update.sh
           # へ silent 流入する経路を遮断する。command substitution は pipeline ではないため
           # `set -o pipefail` は内部 jq の rc を outer rc に伝播しない。
-          reconcile_err=$(mktemp /tmp/rite-pc-reconcile-err-XXXXXX) || reconcile_err=""
-          reconcile_parse_err=$(mktemp /tmp/rite-pc-reconcile-parse-err-XXXXXX) || reconcile_parse_err=""
-          reconcile_jq_err=$(mktemp /tmp/rite-pc-reconcile-jq-err-XXXXXX) || reconcile_jq_err=""
+          reconcile_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-reconcile-err-XXXXXX") || reconcile_err=""
+          reconcile_parse_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-reconcile-parse-err-XXXXXX") || reconcile_parse_err=""
+          reconcile_jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-reconcile-jq-err-XXXXXX") || reconcile_jq_err=""
           RECONCILE_RESULT=""
           RECONCILE_RC=0
           JQ_PAYLOAD=""

--- a/plugins/rite/hooks/post-tool-wm-sync.sh
+++ b/plugins/rite/hooks/post-tool-wm-sync.sh
@@ -242,7 +242,7 @@ case "$_phase" in
 
     # mktemp fallback uses $$ + $RANDOM to avoid TOCTOU collision when two
     # Claude Code sessions share a PID; pure $$ on /tmp is race-prone.
-    _changed_files_tmp=$(mktemp 2>/dev/null) || _changed_files_tmp="/tmp/rite-wm-sync-files.$$.${RANDOM}"
+    _changed_files_tmp=$(mktemp 2>/dev/null) || _changed_files_tmp="${TMPDIR:-/tmp}/rite-wm-sync-files.$$.${RANDOM}"
     _git_diff_err=$(mktemp 2>/dev/null) || _git_diff_err=""
     # State access uses STATE_ROOT (shared main checkout, via the `cd` above), but
     # the progress-table diff MUST run in the SESSION's working tree: under

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -149,7 +149,7 @@ trap '_rite_review_p61b_cleanup; exit 130' INT
 trap '_rite_review_p61b_cleanup; exit 143' TERM
 trap '_rite_review_p61b_cleanup; exit 129' HUP
 
-tmpfile_patched=$(mktemp /tmp/rite-review-p61b-comment-patched-XXXXXX.md) || {
+tmpfile_patched=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-comment-patched-XXXXXX.md") || {
   echo "ERROR: timestamp 置換用 tmpfile 作成失敗" >&2
   echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=tmpfile_write_failure" >&2
   exit 1
@@ -240,7 +240,7 @@ if [ "$original_markdown" != "$patched_markdown" ]; then
 fi
 
 # gh pr comment 投稿 (exit code 明示捕捉、silent failure 防止)。
-gh_err=$(mktemp /tmp/rite-review-p61b-gh-err-XXXXXX) || gh_err=""
+gh_err=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-gh-err-XXXXXX") || gh_err=""
 if gh pr comment "$PR_NUMBER" --body-file "$tmpfile_patched" 2>"${gh_err:-/dev/null}"; then
   if [ "$JSON_SAVED" = "false" ]; then
     echo "ℹ️ ローカルファイル保存は失敗しましたが、PR コメントへの投稿は成功しました。" >&2

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -147,7 +147,7 @@ fi
 json_path="${REVIEW_RESULTS_DIR}/${PR_NUMBER}-${file_timestamp}.json"
 
 # Create directory (失敗してもステップ 6 を fail させない)
-mkdir_err=$(mktemp /tmp/rite-review-p61a-mkdir-err-XXXXXX 2>/dev/null) || mkdir_err=""
+mkdir_err=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-mkdir-err-XXXXXX" 2>/dev/null) || mkdir_err=""
 if ! mkdir -p "$REVIEW_RESULTS_DIR" 2>"${mkdir_err:-/dev/null}"; then
   echo "WARNING: .rite/review-results/ ディレクトリの作成に失敗しました。会話コンテキストのみで続行します。" >&2
   [ -n "$mkdir_err" ] && [ -s "$mkdir_err" ] && head -5 "$mkdir_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
@@ -160,12 +160,12 @@ fi
 
 # mktemp stderr 退避 (失敗原因 disk full / permission / readonly を可視化)。
 # 退避 tempfile を作る mktemp 自体の失敗も silent 化しない。
-if ! mktemp_err=$(mktemp /tmp/rite-review-p61a-mktemp-err-XXXXXX 2>/dev/null); then
+if ! mktemp_err=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-mktemp-err-XXXXXX" 2>/dev/null); then
   echo "WARNING: mktemp stderr 退避用 tempfile の mktemp に失敗しました (meta エラー)。json_tmp 失敗時の stderr 詳細は失われます" >&2
   mktemp_err=""
 fi
 
-if ! json_tmp=$(mktemp /tmp/rite-review-p61a-json-XXXXXX.json 2>"${mktemp_err:-/dev/null}"); then
+if ! json_tmp=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-json-XXXXXX.json" 2>"${mktemp_err:-/dev/null}"); then
   echo "WARNING: JSON 一時ファイルの作成に失敗しました" >&2
   [ -n "$mktemp_err" ] && [ -s "$mktemp_err" ] && { echo "  詳細 (mktemp stderr):" >&2; head -5 "$mktemp_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2; }
   echo "  対処: /tmp の容量 / permission / readonly filesystem を確認してください" >&2
@@ -190,8 +190,8 @@ fi
 # Approach C: bash-internal jq timestamp injection。
 # caller が `"timestamp": "__RITE_TS_PLACEHOLDER_7f3a9b2c__"` を書き込み、ここで $iso_timestamp に
 # 置換する。JSON body / ファイル名 / [CONTEXT] emit の 3 値が helper 内で完全同期する。
-json_ts_injected=$(mktemp /tmp/rite-review-p61a-json-ts-XXXXXX.json 2>/dev/null) || json_ts_injected=""
-jq_ts_err=$(mktemp /tmp/rite-review-p61a-jq-ts-err-XXXXXX 2>/dev/null) || jq_ts_err=""
+json_ts_injected=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-json-ts-XXXXXX.json" 2>/dev/null) || json_ts_injected=""
+jq_ts_err=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-jq-ts-err-XXXXXX" 2>/dev/null) || jq_ts_err=""
 if [ -z "$json_ts_injected" ]; then
   echo "WARNING: timestamp 注入用 tempfile の mktemp に失敗しました" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=write_failure" >&2
@@ -221,7 +221,7 @@ fi
 # syntactically invalid JSON (literal substitute 漏れ含む) はそこで write_failure として既に fail する。
 # 下記 json_invalid は注入成功後に走る defense-in-depth backstop であり、syntactic invalidity 経由では
 # effectively unreachable (その経路の実発火 reason は write_failure)。
-jq_val_err_r=$(mktemp /tmp/rite-jq-val-err-r-XXXXXX 2>/dev/null) || jq_val_err_r=""
+jq_val_err_r=$(mktemp "${TMPDIR:-/tmp}/rite-jq-val-err-r-XXXXXX" 2>/dev/null) || jq_val_err_r=""
 if ! jq empty "$json_tmp" 2>"${jq_val_err_r:-/dev/null}"; then
   echo "WARNING: JSON 一時ファイルが syntactically invalid です (注入後に外部要因で破損した稀ケース。通常の literal substitute 漏れは upstream の write_failure で検出済)" >&2
   [ -n "${jq_val_err_r:-}" ] && [ -s "$jq_val_err_r" ] && head -3 "$jq_val_err_r" | neutralize_ctrl --keep-newline | sed 's/^/  jq: /' >&2
@@ -309,7 +309,7 @@ if [ -e "$json_path" ]; then
 fi
 
 # mv stderr 退避 (cross-FS / perm / TOCTOU / path-too-long を区別可能に)。
-if ! mv_err=$(mktemp /tmp/rite-review-p61a-mv-err-XXXXXX); then
+if ! mv_err=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61a-mv-err-XXXXXX"); then
   echo "WARNING: mv stderr 退避用 tempfile の mktemp に失敗しました。mv 失敗時の stderr は失われます" >&2
   echo "[CONTEXT] LOCAL_SAVE_FAILED=1; reason=mktemp_failure_mv_err" >&2
   mv_err=""

--- a/plugins/rite/hooks/scripts/gitignore-health-check.sh
+++ b/plugins/rite/hooks/scripts/gitignore-health-check.sh
@@ -180,7 +180,7 @@ if [ "$VERIFY_NEGATION" -eq 1 ]; then
   # >>> DRIFT-CHECK ANCHOR: same_branch add_dry_run rc capture (verify-negation copy) <<<
   # Keep one-for-one with the same_branch case copy below (mktemp stderr capture +
   # if-wrapper rc capture). Wiki 経験則 patterns/high「canonical 実装と一字一句同期」.
-  add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
+  add_dry_err=$(mktemp "${TMPDIR:-/tmp}/rite-gitignore-adddry-XXXXXX" 2>/dev/null) || add_dry_err=""
   add_dry_out=""
   add_dry_rc=0
   if add_dry_out=$(git add --dry-run -- "$negation_probe" 2>"${add_dry_err:-/dev/null}"); then
@@ -351,7 +351,7 @@ esac
 # the canonical way to ask git "is this path ignored by the current .gitignore?"
 # without polluting the working tree.
 probe_path=".rite/wiki/raw/.rite-lint-probe"
-check_ignore_err=$(mktemp /tmp/rite-gitignore-check-XXXXXX 2>/dev/null) || check_ignore_err=""
+check_ignore_err=$(mktemp "${TMPDIR:-/tmp}/rite-gitignore-check-XXXXXX" 2>/dev/null) || check_ignore_err=""
 if [ -z "$check_ignore_err" ]; then
   echo "WARNING: gitignore-health-check: mktemp failed — check-ignore stderr won't be surfaced" >&2
 fi
@@ -435,7 +435,7 @@ case "$branch_strategy" in
     # capture structure one-for-one with that copy — Wiki 経験則 patterns/high
     # 「canonical 実装と一字一句同期」. (wiki/init.md ステップ 1.3.4 holds no
     # inline copy; it delegates here via `gitignore-health-check.sh --verify-negation`.)
-    add_dry_err=$(mktemp /tmp/rite-gitignore-adddry-XXXXXX 2>/dev/null) || add_dry_err=""
+    add_dry_err=$(mktemp "${TMPDIR:-/tmp}/rite-gitignore-adddry-XXXXXX" 2>/dev/null) || add_dry_err=""
     add_dry_out=""
     add_dry_rc=0
     if add_dry_out=$(git add --dry-run -- "$negation_probe" 2>"${add_dry_err:-/dev/null}"); then

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -138,7 +138,7 @@ verify_worktree_branch() {
  _vwb_outer_hup=$(trap -p HUP)
 
  trap 'rm -f "${rev_parse_err:-}"' EXIT INT TERM HUP
- rev_parse_err=$(mktemp "/tmp/rite-${tempfile_tag}-revparse-err-XXXXXX" 2>/dev/null) || rev_parse_err=""
+ rev_parse_err=$(mktemp "${TMPDIR:-/tmp}/rite-${tempfile_tag}-revparse-err-XXXXXX" 2>/dev/null) || rev_parse_err=""
 
  # Save caller's errexit so we can restore exactly.
  local _vwb_errexit=0
@@ -226,19 +226,19 @@ worktree_commit_push() {
 
  # mktemp failures are surfaced to stderr (not silently swallowed) so
  # operators can see when stderr capture is degraded to /dev/null.
- if ! add_err=$(mktemp /tmp/rite-wtgit-add-err-XXXXXX 2>/dev/null); then
+ if ! add_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-add-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: mktemp for worktree_commit_push add stderr capture failed — diagnostics will be lost" >&2
  add_err=""
  fi
- if ! diff_err=$(mktemp /tmp/rite-wtgit-diff-err-XXXXXX 2>/dev/null); then
+ if ! diff_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-diff-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: mktemp for worktree_commit_push diff stderr capture failed — diagnostics will be lost" >&2
  diff_err=""
  fi
- if ! commit_err=$(mktemp /tmp/rite-wtgit-commit-err-XXXXXX 2>/dev/null); then
+ if ! commit_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-commit-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: mktemp for worktree_commit_push commit stderr capture failed — diagnostics will be lost" >&2
  commit_err=""
  fi
- if ! push_err=$(mktemp /tmp/rite-wtgit-push-err-XXXXXX 2>/dev/null); then
+ if ! push_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-push-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: mktemp for worktree_commit_push push stderr capture failed — diagnostics will be lost" >&2
  push_err=""
  fi
@@ -303,7 +303,7 @@ worktree_commit_push() {
  # Extend internal trap to cover head_err so SIGINT / SIGTERM / SIGHUP during
  # the post-commit rev-parse cannot leak the tempfile. Must be set BEFORE mktemp.
  trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}" "${head_err:-}"' EXIT INT TERM HUP
- head_err=$(mktemp /tmp/rite-wtgit-head-err-XXXXXX 2>/dev/null) || head_err=""
+ head_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-head-err-XXXXXX" 2>/dev/null) || head_err=""
  if head_sha=$(git -C "$worktree" rev-parse HEAD 2>"${head_err:-/dev/null}"); then
  :
  else

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -178,7 +178,7 @@ trap '_rite_pr_cycle_cleanup; exit 129' HUP
 # branch itself can be deleted (a branch checked out in a worktree cannot
 # be deleted with `git branch -D`).
 # -----------------------------------------------------------------------
-wt_list_err=$(mktemp /tmp/rite-pr-cycle-cleanup-wt-err-XXXXXX 2>/dev/null) || wt_list_err=""
+wt_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-wt-err-XXXXXX" 2>/dev/null) || wt_list_err=""
 if wt_list=$(git worktree list --porcelain 2>"${wt_list_err:-/dev/null}"); then
   # Parse porcelain output: pair each `worktree <path>` with its `branch refs/heads/<name>`
   current_path=""
@@ -235,7 +235,7 @@ fi
 # Prune any dangling worktree metadata to keep `git worktree list` clean.
 # AC-3 (異常終了経路) の核心ロジックのため、失敗を silent に握り潰さず errors カウンタに加算する。
 if [ "$DRY_RUN" = "0" ]; then
-  prune_err=$(mktemp /tmp/rite-pr-cycle-cleanup-prune-err-XXXXXX 2>/dev/null) || prune_err=""
+  prune_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-prune-err-XXXXXX" 2>/dev/null) || prune_err=""
   # bash の `if ! cmd; then rc=$?` は `!` 演算子が exit status を反転させるため
   # then ブロック内の `$?` は常に 0 になる仕様。`if cmd; then :; else rc=$?; fi` 形式で
   # 元コマンドの非ゼロ exit code を正しく取得する (兄弟スクリプト wt_list / ref と統一)。
@@ -256,7 +256,7 @@ fi
 # `git for-each-ref` is used instead of `git branch --list` because it
 # emits the bare ref name without leading whitespace/asterisks.
 # -----------------------------------------------------------------------
-ref_err=$(mktemp /tmp/rite-pr-cycle-cleanup-ref-err-XXXXXX 2>/dev/null) || ref_err=""
+ref_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-ref-err-XXXXXX" 2>/dev/null) || ref_err=""
 if branches=$(git for-each-ref --format='%(refname:short)' refs/heads/ 2>"${ref_err:-/dev/null}"); then
   while IFS= read -r br; do
     [ -z "$br" ] && continue
@@ -396,8 +396,8 @@ _reap_mutation_worktree() {
 
 workdir_tmp_base="${TMPDIR:-/tmp}"
 workdir_tmp_base="${workdir_tmp_base%/}"  # strip trailing slash
-workdir_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-err-XXXXXX 2>/dev/null) || workdir_find_err=""
-workdir_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-workdir-out-XXXXXX 2>/dev/null) || workdir_find_out=""
+workdir_find_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-workdir-err-XXXXXX" 2>/dev/null) || workdir_find_err=""
+workdir_find_out=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-workdir-out-XXXXXX" 2>/dev/null) || workdir_find_out=""
 reap_orphan_dirs "orphan workdir" "$workdir_tmp_base" 'rite-pr-create-*' \
   _reap_workdir "$workdir_find_out" "$workdir_find_err"
 
@@ -435,16 +435,16 @@ reap_orphan_dirs "orphan workdir" "$workdir_tmp_base" 'rite-pr-create-*' \
 # -----------------------------------------------------------------------
 mutation_tmp_base="${TMPDIR:-/tmp}"
 mutation_tmp_base="${mutation_tmp_base%/}"  # strip trailing slash
-mutation_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-err-XXXXXX 2>/dev/null) || mutation_find_err=""
-mutation_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-mutation-out-XXXXXX 2>/dev/null) || mutation_find_out=""
+mutation_find_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-mutation-err-XXXXXX" 2>/dev/null) || mutation_find_err=""
+mutation_find_out=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-mutation-out-XXXXXX" 2>/dev/null) || mutation_find_out=""
 # mutation_reaped_any は reaper (_reap_mutation_worktree) が成功時に 1 を立てるグローバル。
 # 走査前に 0 で初期化し、回収が 1 件でも成功したら下記 post-loop prune を起動する。
 mutation_reaped_any=0
 reap_orphan_dirs "orphan mutation worktree" "$mutation_tmp_base" 'rite-review-mutation-*' \
   _reap_mutation_worktree "$mutation_find_out" "$mutation_find_err"
 # 同じ reviewer-tmp 名前空間の `rite-revert-test-*` も同一 reaper / counter で回収する。
-revert_find_err=$(mktemp /tmp/rite-pr-cycle-cleanup-revert-err-XXXXXX 2>/dev/null) || revert_find_err=""
-revert_find_out=$(mktemp /tmp/rite-pr-cycle-cleanup-revert-out-XXXXXX 2>/dev/null) || revert_find_out=""
+revert_find_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-revert-err-XXXXXX" 2>/dev/null) || revert_find_err=""
+revert_find_out=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-revert-out-XXXXXX" 2>/dev/null) || revert_find_out=""
 reap_orphan_dirs "orphan revert-test worktree" "$mutation_tmp_base" 'rite-revert-test-*' \
   _reap_mutation_worktree "$revert_find_out" "$revert_find_err"
 # rm -rf fallback で残った stale worktree メタデータを掃除する (remove --force 経路では不要だが冪等)
@@ -479,7 +479,7 @@ manifest_path="$repo_root/$TMP_ARTIFACT_MANIFEST"
 # compare could let the guard miss. Resolve once so the compare holds.
 _repo_canon=$( cd -- "$repo_root" 2>/dev/null && pwd -P ) || _repo_canon="$repo_root"
 if [ -f "$manifest_path" ]; then
-  manifest_keep=$(mktemp /tmp/rite-pr-cycle-cleanup-manifest-keep-XXXXXX 2>/dev/null) || manifest_keep=""
+  manifest_keep=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-manifest-keep-XXXXXX" 2>/dev/null) || manifest_keep=""
   if [ -z "$manifest_keep" ]; then
     echo "WARNING: manifest reap 用の一時ファイル mktemp に失敗しました。今回の manifest 回収をスキップします" >&2
     errors=$((errors + 1))

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -152,7 +152,7 @@ trap '_rite_board_drift_cleanup; exit 143' TERM
 trap '_rite_board_drift_cleanup; exit 129' HUP
 
 # --- Repo info ---
-repo_view_err=$(mktemp /tmp/rite-board-drift-repo-err-XXXXXX) || repo_view_err=""
+repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-repo-err-XXXXXX") || repo_view_err=""
 if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
   echo "ERROR: gh repo view failed" >&2
   if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
@@ -169,8 +169,8 @@ if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
 fi
 
 # --- Scan recently-updated CLOSED Issues (single GraphQL page) ---
-gql_err=$(mktemp /tmp/rite-board-drift-gql-err-XXXXXX) || gql_err=""
-jq_err=$(mktemp /tmp/rite-board-drift-jq-err-XXXXXX) || jq_err=""
+gql_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-gql-err-XXXXXX") || gql_err=""
+jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-jq-err-XXXXXX") || jq_err=""
 
 # jq emits one TSV line per drifted Issue: number<TAB>status<TAB>title
 # Drift = stateReason COMPLETED AND on board (projectItem for $pn) AND Status != "Done".
@@ -230,7 +230,7 @@ if [ -n "$DRIFT_TSV" ]; then
 
     reconcile_suffix=""
     if [ "$RECONCILE" = "true" ]; then
-      reconcile_err=$(mktemp /tmp/rite-board-drift-reconcile-err-XXXXXX) || reconcile_err=""
+      reconcile_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-reconcile-err-XXXXXX") || reconcile_err=""
       reconcile_json=$(bash "$PLUGIN_ROOT/scripts/projects-status-update.sh" "$(jq -n \
         --argjson issue "$issue_number" --arg owner "$REPO_OWNER" --arg repo "$REPO_NAME" \
         --argjson project_number "$PROJECT_NUMBER" --arg status "Done" \

--- a/plugins/rite/hooks/scripts/wiki-growth-check.sh
+++ b/plugins/rite/hooks/scripts/wiki-growth-check.sh
@@ -183,7 +183,7 @@ wiki_branch=$(printf '%s\n' "$wiki_section" | awk '/^[[:space:]]+branch_name:/ {
 # git log の stderr を tempfile に退避し、permission/repo corruption 等の
 # 失敗を「branch not found」と誤報告する経路を排除する
 last_wiki=""
-git_log_err=$(mktemp /tmp/rite-wiki-growth-git-err-XXXXXX 2>/dev/null) || git_log_err=""
+git_log_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-growth-git-err-XXXXXX" 2>/dev/null) || git_log_err=""
 if [ -z "$git_log_err" ]; then
   echo "WARNING: mktemp が失敗しました — git log 失敗時の stderr 詳細が surface できません" >&2
 fi
@@ -240,7 +240,7 @@ fi
 
 # `merged:>YYYY-MM-DD` — gh search interprets full ISO 8601 timestamps too
 # gh pr list の stderr を tempfile に退避し、auth error / network error / rate limit を可視化する
-gh_pr_list_err=$(mktemp /tmp/rite-wiki-growth-gh-err-XXXXXX 2>/dev/null) || gh_pr_list_err=""
+gh_pr_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-growth-gh-err-XXXXXX" 2>/dev/null) || gh_pr_list_err=""
 if [ -z "$gh_pr_list_err" ]; then
   echo "WARNING: mktemp が失敗しました — gh pr list 失敗時の stderr 詳細が surface できません" >&2
 fi
@@ -266,7 +266,7 @@ fi
 gh_pr_list_err=""
 
 # jq stderr を tempfile に退避し、parse error 等を surface する
-jq_err=$(mktemp /tmp/rite-wiki-growth-jq-err-XXXXXX 2>/dev/null) || jq_err=""
+jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-growth-jq-err-XXXXXX" 2>/dev/null) || jq_err=""
 if [ -z "$jq_err" ]; then
   echo "WARNING: mktemp が失敗しました — jq 失敗時の stderr 詳細が surface できません" >&2
 fi
@@ -325,7 +325,7 @@ check_pr_raw_correspondence() {
   # Get the last `threshold` merged PRs (reuse existing threshold for the window size)
   local recent_prs_json recent_pr_numbers
   local gh_pr_err
-  gh_pr_err=$(mktemp /tmp/rite-wiki-growth-pr-err-XXXXXX 2>/dev/null) || gh_pr_err=""
+  gh_pr_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-growth-pr-err-XXXXXX" 2>/dev/null) || gh_pr_err=""
   recent_prs_json=$(gh pr list \
     --state merged \
     --base "$base_branch" \
@@ -339,7 +339,7 @@ check_pr_raw_correspondence() {
   [ -n "$gh_pr_err" ] && rm -f "$gh_pr_err"
 
   local jq_pr_err
-  jq_pr_err=$(mktemp /tmp/rite-wiki-growth-jq-err-XXXXXX 2>/dev/null) || jq_pr_err=""
+  jq_pr_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-growth-jq-err-XXXXXX" 2>/dev/null) || jq_pr_err=""
   recent_pr_numbers=$(printf '%s' "$recent_prs_json" | jq -r '.[].number' 2>"${jq_pr_err:-/dev/null}") || {
     echo "WARNING: wiki-growth-check: pr-raw-correspondence: jq parse failed, skipping" >&2
     [ -n "$jq_pr_err" ] && [ -s "$jq_pr_err" ] && head -3 "$jq_pr_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2

--- a/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-ingest-commit.sh
@@ -231,7 +231,7 @@ if [[ -d ".rite/wiki/raw" ]]; then
  # without a WARNING here, mktemp failure (full /tmp / inode exhaustion)
  # silently degrades awk stderr capture to /dev/null and operators can no
  # longer see why files are being treated as pending.
- if ! fm_err=$(mktemp /tmp/rite-wic-fm-err-XXXXXX 2>/dev/null); then
+ if ! fm_err=$(mktemp "${TMPDIR:-/tmp}/rite-wic-fm-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: wiki-ingest-commit: fm_err mktemp failed — frontmatter parse errors will not be surfaced" >&2
  echo " hint: /tmp permission / disk space / inode exhaustion を確認" >&2
  fm_err=""
@@ -288,7 +288,7 @@ if [[ "$branch_strategy" == "same_branch" ]]; then
  # failure, pre-commit hook reject, permission denied) collapse into a single
  # opaque "ERROR" line with no root cause, breaking parity with the
  # separate_branch path's dump_git_err diagnostics.
- _sb_git_err=$(mktemp /tmp/rite-wic-sb-git-err-XXXXXX 2>/dev/null) || _sb_git_err=""
+ _sb_git_err=$(mktemp "${TMPDIR:-/tmp}/rite-wic-sb-git-err-XXXXXX" 2>/dev/null) || _sb_git_err=""
  _sb_dump() {
   local label="$1"
   if [ -n "$_sb_git_err" ] && [ -s "$_sb_git_err" ]; then
@@ -504,7 +504,7 @@ if ! git show-ref --verify --quiet "refs/heads/${wiki_branch}"; then
  # scope-limited mini-trap so SIGINT / SIGTERM / SIGHUP all remove ref_err.
  ref_err=""
  trap 'rm -f "${ref_err:-}"' EXIT INT TERM HUP
- ref_err=$(mktemp /tmp/rite-wic-ref-err-XXXXXX 2>/dev/null || echo "")
+ ref_err=$(mktemp "${TMPDIR:-/tmp}/rite-wic-ref-err-XXXXXX" 2>/dev/null || echo "")
  if [[ -n "$ref_err" ]]; then
  git show-ref --verify "refs/heads/${wiki_branch}" >/dev/null 2>"$ref_err" || true
  fi
@@ -537,7 +537,7 @@ fi
 # Same class of bug as the ref_err leak fixed in cycle 3 LOW #3 (lines
 # 269-270, 282-283). stage_dir is created at this line but the main
 # cleanup_body trap is not installed until line ~400. A signal arriving
-# between mktemp and trap install would orphan /tmp/rite-wiki-stage-XXXXXX.
+# between mktemp and trap install would orphan ${TMPDIR:-/tmp}/rite-wiki-stage-XXXXXX.
 # Install a scope-limited mini-trap immediately after mktemp and disarm it
 # right before the main trap is installed, so the orphan race window is
 # closed without double-cleanup with cleanup_body.
@@ -547,7 +547,7 @@ fi
 # message with no context — emit an explicit ERROR first.
 stage_dir=""
 trap 'rm -rf "${stage_dir:-}" 2>/dev/null || true' EXIT INT TERM HUP
-if ! stage_dir=$(mktemp -d /tmp/rite-wiki-stage-XXXXXX 2>/dev/null); then
+if ! stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-stage-XXXXXX" 2>/dev/null); then
  echo "ERROR: failed to create staging directory under /tmp" >&2
  echo " hint: check /tmp permission / disk space / inode exhaustion / read-only filesystem" >&2
  trap - EXIT INT TERM HUP
@@ -712,7 +712,7 @@ done
 # diagnosable only by re-running the script without this wrapper. Emit an
 # explicit WARNING so the operator understands why git stderr disappears,
 # and set git_err="" so the no-op path is obvious from the warning trail.
-if ! git_err=$(mktemp /tmp/rite-wic-git-err-XXXXXX 2>/dev/null); then
+if ! git_err=$(mktemp "${TMPDIR:-/tmp}/rite-wic-git-err-XXXXXX" 2>/dev/null); then
  echo "WARNING: mktemp failed for git stderr capture — git error details will be suppressed" >&2
  echo " hint: check /tmp permission / disk space / inode exhaustion" >&2
  echo " impact: dump_git_err and surface_git_warnings will be no-op for this run" >&2
@@ -791,7 +791,7 @@ done
 # at a worktree problem (permission, inode), so route the diag to stderr when
 # RITE_DEBUG=1 instead of dropping it entirely.
 if [ -n "${RITE_DEBUG:-}" ]; then
- _find_err=$(mktemp /tmp/rite-wiki-ingest-find-err-XXXXXX 2>/dev/null) || _find_err=""
+ _find_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-ingest-find-err-XXXXXX" 2>/dev/null) || _find_err=""
  find .rite/wiki/raw -type d -empty -delete 2>"${_find_err:-/dev/null}" || true
  if [ -n "$_find_err" ] && [ -s "$_find_err" ]; then
  sed 's/^/[rite][debug] find -delete: /' "$_find_err" >&2 || true

--- a/plugins/rite/hooks/scripts/wiki-lint-orphans.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-orphans.sh
@@ -145,7 +145,7 @@ _emit_skipped() {
 # sibling helpers と同じ規約)。読出失敗は legitimate absence / IO error を区別せず
 # index_unreadable に一本化する (index_read_ok=false の単一経路に集約する。
 # 孤児検出は index.md が無ければ全ページ orphan 誤検出になるため、いずれの失敗でも skip が正解)。
-index_err=$(mktemp /tmp/rite-wiki-lint-orphans-err-XXXXXX 2>/dev/null) || {
+index_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-lint-orphans-err-XXXXXX" 2>/dev/null) || {
   echo "WARNING: stderr 退避 tempfile (index_err) の mktemp に失敗しました。index.md 読出の詳細エラー情報は失われます" >&2
   echo "  対処: /tmp の容量 / permission / inode 枯渇を確認してください" >&2
   index_err=""

--- a/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh
@@ -161,7 +161,7 @@ _rite_log_read_impact_advice() {
   echo "  影響: skipped_refs を空として継続するため、skip 済み raw が誤って missing_concept に計上される可能性あり" >&2
 }
 
-log_err=$(mktemp /tmp/rite-wiki-lint-p60-err-XXXXXX 2>/dev/null) || {
+log_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-lint-p60-err-XXXXXX" 2>/dev/null) || {
   echo "WARNING: stderr 退避 tempfile (log_err) の mktemp に失敗しました。raw 走査の詳細エラー情報は失われます" >&2
   echo "  対処: /tmp の容量 / permission / inode 枯渇を確認してください" >&2
   echo "  影響: stderr pattern match が実行不能になり io_error 側に倒れ、false positive note が常に表示される regression が起き得ます" >&2

--- a/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
+++ b/plugins/rite/hooks/scripts/wiki-lint-source-refs.sh
@@ -201,7 +201,7 @@ page_err_mktemp_failed=0  # accumulator (失敗件数)
 while IFS= read -r page; do
   [ -z "$page" ] && continue  # blank line guard
 
-  page_err=$(mktemp /tmp/rite-lint-page-err-XXXXXX 2>/dev/null) || { page_err=""; page_err_mktemp_failed=$((page_err_mktemp_failed + 1)); }
+  page_err=$(mktemp "${TMPDIR:-/tmp}/rite-lint-page-err-XXXXXX" 2>/dev/null) || { page_err=""; page_err_mktemp_failed=$((page_err_mktemp_failed + 1)); }
 
   # branch_strategy ごとに 2 経路:
   #   separate_branch: git show (worktree には存在しない、ref から読取)
@@ -224,7 +224,7 @@ while IFS= read -r page; do
     # frontmatter YAML list から sources[].ref を抽出。
     # awk diag mktemp で sources_seen / extracted のカウントを stderr 経由で per-page 可視化
     # (「sources: 節は検出したが ref が 0 件」という YAML 破損を可視化)
-    awk_diag=$(mktemp /tmp/rite-lint-p62-awk-diag-XXXXXX 2>/dev/null) || awk_diag=""
+    awk_diag=$(mktemp "${TMPDIR:-/tmp}/rite-lint-p62-awk-diag-XXXXXX" 2>/dev/null) || awk_diag=""
     if [ -z "$awk_diag" ]; then
       awk_diag_mktemp_failed=$((awk_diag_mktemp_failed + 1))
     fi
@@ -317,7 +317,7 @@ fi
 # sort -u で重複排除 (ステップ 6.0 awk/sort と対称に pipefail + stderr 捕捉)
 if [ -n "$all_source_refs" ]; then
   set -o pipefail
-  sort_err=$(mktemp /tmp/rite-lint-p62-sort-err-XXXXXX 2>/dev/null) || {
+  sort_err=$(mktemp "${TMPDIR:-/tmp}/rite-lint-p62-sort-err-XXXXXX" 2>/dev/null) || {
     echo "WARNING: stderr 退避 tempfile (sort_err) の mktemp に失敗しました。sort/awk pipeline の詳細エラー情報は失われます" >&2
     echo "  対処: /tmp の容量 / permission / inode 枯渇を確認してください" >&2
     echo "  影響: pipeline 失敗時の根本原因 (sort バイナリ異常 / OOM / SIGPIPE 等) が不可視になり、all_source_refs が io_error 降格しても理由が追えません" >&2

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -226,7 +226,7 @@ esac
 # silent miss し、`reason=no-pending` で skip してしまう経路が生じる。
 lsf_err=""
 trap 'rm -f "${lsf_err:-}"' EXIT INT TERM HUP
-lsf_err=$(mktemp /tmp/rite-wwc-lsf-err-XXXXXX 2>/dev/null) || lsf_err=""
+lsf_err=$(mktemp "${TMPDIR:-/tmp}/rite-wwc-lsf-err-XXXXXX" 2>/dev/null) || lsf_err=""
 set +e
 untracked=$(git -C "$worktree_path" ls-files --others --exclude-standard -- "$wiki_rel" 2>"${lsf_err:-/dev/null}")
 lsf_rc=$?

--- a/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-setup.sh
@@ -171,7 +171,7 @@ abs_target="${repo_root}/${target_path}"
 # 握り潰さない (cycle 2 MEDIUM F-11 fix)。
 wt_list_err=""
 trap 'rm -f "${wt_list_err:-}"' EXIT INT TERM HUP
-wt_list_err=$(mktemp /tmp/rite-wts-list-err-XXXXXX 2>/dev/null) || wt_list_err=""
+wt_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-wts-list-err-XXXXXX" 2>/dev/null) || wt_list_err=""
 
 existing_line=""
 existing_branch=""
@@ -263,7 +263,7 @@ if [ -e "$target_path" ] && ! git -C "$target_path" rev-parse --is-inside-work-t
   # this file (trap armed before mktemp, disarmed after rm -f).
   prune_err=""
   trap 'rm -f "${prune_err:-}"' EXIT INT TERM HUP
-  prune_err=$(mktemp /tmp/rite-wts-prune-err-XXXXXX 2>/dev/null) || prune_err=""
+  prune_err=$(mktemp "${TMPDIR:-/tmp}/rite-wts-prune-err-XXXXXX" 2>/dev/null) || prune_err=""
   if ! git worktree prune 2>"${prune_err:-/dev/null}"; then
     echo "WARNING: git worktree prune に失敗しました (stale metadata が残存する可能性があります)" >&2
     [ -n "$prune_err" ] && [ -s "$prune_err" ] && head -3 "$prune_err" | neutralize_ctrl --keep-newline | sed 's/^/  git: /' >&2
@@ -284,7 +284,7 @@ add_err=""
 trap 'rm -f "${add_err:-}"' EXIT INT TERM HUP
 # mktemp 失敗 (read-only /tmp / inode 枯渇 / permission denied) を silent に握り潰さず
 # WARNING で可視化する (wiki-ingest-commit.sh:559-564 の対称パターン)。
-if ! add_err=$(mktemp /tmp/rite-wts-err-XXXXXX 2>/dev/null); then
+if ! add_err=$(mktemp "${TMPDIR:-/tmp}/rite-wts-err-XXXXXX" 2>/dev/null); then
   echo "WARNING: mktemp for add_err failed — git worktree add stderr will not be captured for diagnostics" >&2
   echo "  hint: /tmp permission / disk space / inode exhaustion を確認してください" >&2
   add_err=""

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -13,9 +13,9 @@
 # *wholesale* failure):
 #   T-11 → Step 1: `git worktree remove --force` failure (locked worktree)
 #   T-12 → Step 2: `git branch -D` failure (read-only refs/heads)
-#   T-13 → Step 3: `rm -rf` failure (read-only orphan-workdir parent)
+#   T-13 → Step 3: `rm -rf` failure (read-only orphan-workdir itself)
 #   T-16 → Step 4: `git worktree remove --force || rm -rf` failure (read-only
-#                  mutation-worktree parent) — extends the symmetry to the
+#                  mutation-worktree itself) — extends the symmetry to the
 #                  mutation-worktree reap added in Step 4
 #
 # Step 4 mutation worktree reaping — path-based sweep of orphan
@@ -435,23 +435,39 @@ cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
 # T-10: find wholesale 失敗が silent でない
-# Given: TMPDIR が存在しないパスを指し、Step 3 の find が wholesale 失敗する
+# Given: TMPDIR は実在するが read 権限のない (0300: write+execute のみ) ディレクトリを指す
 # When: Cleanup runs
 # Then: find 失敗は WARNING + errors++ で surface され status=failed になる
 #       (process substitution の rc 非伝播による silent no-op 化を防ぐ回帰テスト)
-# TMPDIR override はこの 1 実行に限定する。cleanup script の mktemp は /tmp 直書きのため
-# bogus TMPDIR の影響を受けず、find の base 走査のみが失敗する。
+# 0300 は mktemp によるファイル作成 (write+execute で足りる) を許可しつつ find の readdir
+# (read が必要) だけを失敗させ、mktemp の走査出力先確保と find の wholesale 失敗を分離する。
+# mktemp が TMPDIR を尊重するようになった (Issue #1900) ため、旧来の「存在しないパス」技法
+# では mktemp 自身も失敗し別の WARNING (走査の出力先 mktemp に失敗) に化けてしまう。
+# root は DAC 権限チェックをバイパスするため本テストはスキップする。
 # -----------------------------------------------------------------------
 echo "T-10: find wholesale 失敗が silent でない"
-TEST_REPO=$(make_temp_repo)
-t10_output=$( cd "$TEST_REPO" && TMPDIR=/nonexistent/rite-pr-cleanup-does-not-exist bash "$CLEANUP" 2>&1 )
-if echo "$t10_output" | grep -q 'status=failed' \
-   && echo "$t10_output" | grep -q 'find による orphan workdir 走査が失敗'; then
-  pass "T-10: find 失敗が WARNING + status=failed で surface される (silent 化しない)"
+if [ "$IS_ROOT" = "1" ]; then
+  skip "T-10: root では perms がバイパスされ強制失敗にならないためスキップ"
 else
-  fail "T-10: status=failed と find WARNING を期待。Output: $t10_output"
+  T10_NOREAD_BASE=$(mktemp -d /tmp/rite-pr-cleanup-noread-XXXXXX) || T10_NOREAD_BASE=""
+  if [ -z "$T10_NOREAD_BASE" ]; then
+    fail "T-10: mktemp -d による no-read base 作成に失敗"
+  else
+    TEST_REPOS+=("$T10_NOREAD_BASE")
+    chmod 0300 "$T10_NOREAD_BASE"
+    TEST_REPO=$(make_temp_repo)
+    t10_output=$( cd "$TEST_REPO" && TMPDIR="$T10_NOREAD_BASE" bash "$CLEANUP" 2>&1 )
+    chmod 0700 "$T10_NOREAD_BASE"
+    if echo "$t10_output" | grep -q 'status=failed' \
+       && echo "$t10_output" | grep -q 'find による orphan workdir 走査が失敗'; then
+      pass "T-10: find 失敗が WARNING + status=failed で surface される (silent 化しない)"
+    else
+      fail "T-10: status=failed と find WARNING を期待。Output: $t10_output"
+    fi
+    rm -rf "$T10_NOREAD_BASE" 2>/dev/null || true
+    cleanup_temp_repo "$TEST_REPO"
+  fi
 fi
-cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
 # T-11: Step 1 per-item worktree removal failure -> status=failed
@@ -517,15 +533,20 @@ fi
 
 # -----------------------------------------------------------------------
 # T-13: Step 3 per-item orphan workdir reap failure -> status=failed
-# Given: an aged matching `rite-pr-create-*` workdir whose PARENT dir is read-only
-#        (chmod 0500), so `rm -rf` cannot rmdir the workdir
-# When: cleanup runs with TMPDIR pointed at that locked base
+# Given: an aged matching `rite-pr-create-*` workdir that itself lacks write
+#        permission (chmod 0500) and contains a file, so `rm -rf` cannot
+#        unlink the file inside it
+# When: cleanup runs with TMPDIR pointed at the (fully writable) base
+#       directory containing that workdir
 # Then: WARNING "failed to reap orphan workdir" + errors++ -> status=failed, and
 #       the workdir survives. (T-10 covers the find *wholesale* failure; this is
 #       the symmetric Step 3 gap: the per-item rm failure.)
-# A dedicated locked base (not the shared WORKDIR_SCAN_TMP) is used so the 0500
-# chmod never blocks the other tests; the cleanup script's err-file mktemp uses
-# explicit /tmp paths, so only the find/rm base is affected by the TMPDIR override.
+# The base directory itself stays fully writable (mktemp -d default 0700) so
+# the cleanup script's own mktemp (workdir_find_err/out) and find succeed
+# normally — only the victim workdir's OWN permission blocks its removal.
+# Chmod'ing the shared *base* to 0500 (as an earlier version of this test did)
+# would now also break the script's own TMPDIR-respecting mktemp (Issue #1900),
+# masking this per-item rm failure behind the wholesale mktemp-failure branch.
 # -----------------------------------------------------------------------
 echo "T-13: Step 3 orphan workdir rm 失敗で status=failed"
 if [ "$IS_ROOT" = "1" ]; then
@@ -545,16 +566,17 @@ else
   else
     TEST_REPOS+=("$LOCKED_BASE")
     mkdir -p "$LOCKED_BASE/rite-pr-create-victim"
+    echo "blocked" > "$LOCKED_BASE/rite-pr-create-victim/blocked.txt"
     touch -t 202001010000 "$LOCKED_BASE/rite-pr-create-victim"
-    chmod 0500 "$LOCKED_BASE"
+    chmod 0500 "$LOCKED_BASE/rite-pr-create-victim"
     TEST_REPO=$(make_temp_repo)
     t13_output=$( cd "$TEST_REPO" && TMPDIR="$LOCKED_BASE" bash "$CLEANUP" 2>&1 )
     # Restore write permission so the survival check and cleanup can proceed.
-    chmod 0700 "$LOCKED_BASE"
+    chmod 0700 "$LOCKED_BASE/rite-pr-create-victim"
     if echo "$t13_output" | grep -q 'status=failed' \
        && echo "$t13_output" | grep -q 'failed to reap orphan workdir' \
        && [ -d "$LOCKED_BASE/rite-pr-create-victim" ]; then
-      pass "T-13: read-only 親での orphan workdir rm 失敗が WARNING + status=failed で surface"
+      pass "T-13: read-only workdir 自身での rm 失敗が WARNING + status=failed で surface"
     else
       fail "T-13: status=failed と reap WARNING を期待。victim=$([ -d "$LOCKED_BASE/rite-pr-create-victim" ] && echo present || echo gone). Output: $t13_output"
     fi
@@ -620,20 +642,22 @@ cleanup_temp_repo "$TEST_REPO"
 # -----------------------------------------------------------------------
 # T-16: Step 4 per-item mutation worktree reap failure -> status=failed
 # Given: an aged registered detached `rite-review-mutation-*` worktree (as in T-14)
-#        whose PARENT dir is read-only (chmod 0500), so neither
-#        `git worktree remove --force` nor the `rm -rf` fallback can rmdir it
-# When: cleanup runs with TMPDIR pointed at that locked base
+#        that itself lacks write permission (chmod 0500), so neither
+#        `git worktree remove --force` nor the `rm -rf` fallback can delete
+#        its contents (the `.git` file / checked-out files inside it)
+# When: cleanup runs with TMPDIR pointed at the (fully writable) base
+#       directory containing that worktree
 # Then: WARNING "failed to reap orphan mutation worktree" + errors++ -> status=failed,
 #       mutation_worktrees=0 (nothing reaped), and the worktree directory survives.
-#       Note: `git worktree remove --force` deletes the worktree *contents* before
-#       its final rmdir is blocked by the read-only parent, so what survives is a
-#       contents-removed husk (same mechanism T-11's docblock warns about) — the
-#       assertion checks directory *presence* (`-d`), not intactness. This is the
-#       Step 4 analogue of T-13's Step 3 gap: Step 1/2/3 pin per-item delete
-#       failures (T-11/T-12/T-13); Step 4's mutation reap was the missing
+#       This is the Step 4 analogue of T-13's Step 3 gap: Step 1/2/3 pin per-item
+#       delete failures (T-11/T-12/T-13); Step 4's mutation reap was the missing
 #       symmetric case.
-# Mirrors T-13's dedicated locked base + TMPDIR override so the 0500 chmod never
-# blocks other tests (the script's err-file mktemp uses explicit /tmp paths).
+# The base directory itself stays fully writable (mktemp -d default 0700) so
+# the cleanup script's own mktemp (mutation_find_err/out) and find succeed
+# normally — only the victim worktree's OWN permission blocks its removal.
+# Chmod'ing the shared *base* to 0500 (as an earlier version of this test did)
+# would now also break the script's own TMPDIR-respecting mktemp (Issue #1900),
+# masking this per-item reap failure behind the wholesale mktemp-failure branch.
 # -----------------------------------------------------------------------
 echo "T-16: Step 4 mutation worktree reap 失敗で status=failed"
 if [ "$IS_ROOT" = "1" ]; then
@@ -651,15 +675,15 @@ else
     # Register the detached mutation worktree inside the base BEFORE locking it.
     ( cd "$TEST_REPO" && git worktree add --detach -q "$LOCKED_BASE/rite-review-mutation-victim" HEAD )
     touch -t 202001010000 "$LOCKED_BASE/rite-review-mutation-victim"
-    chmod 0500 "$LOCKED_BASE"
+    chmod 0500 "$LOCKED_BASE/rite-review-mutation-victim"
     t16_output=$( cd "$TEST_REPO" && TMPDIR="$LOCKED_BASE" bash "$CLEANUP" 2>&1 )
     # Restore write permission so the survival check and cleanup can proceed.
-    chmod 0700 "$LOCKED_BASE"
+    chmod 0700 "$LOCKED_BASE/rite-review-mutation-victim"
     if echo "$t16_output" | grep -q 'status=failed' \
        && echo "$t16_output" | grep -q 'mutation_worktrees=0' \
        && echo "$t16_output" | grep -q 'failed to reap orphan mutation worktree' \
        && [ -d "$LOCKED_BASE/rite-review-mutation-victim" ]; then
-      pass "T-16: read-only 親での mutation worktree reap 失敗が WARNING + status=failed (mutation_worktrees=0) で surface"
+      pass "T-16: read-only worktree 自身での reap 失敗が WARNING + status=failed (mutation_worktrees=0) で surface"
     else
       fail "T-16: status=failed と reap WARNING を期待。victim=$([ -d "$LOCKED_BASE/rite-review-mutation-victim" ] && echo present || echo gone). Output: $t16_output"
     fi

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -251,7 +251,7 @@ if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
   # IO errors don't get conflated with "no match". The old `2>/dev/null || ...=""`
   # pattern silently treated all of those as "section absent" — leading the
   # Wiki enable check to misfire.
-  _yaml_err=$(mktemp /tmp/rite-wiki-trigger-yaml-err-XXXXXX 2>/dev/null) || _yaml_err=""
+  _yaml_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-trigger-yaml-err-XXXXXX" 2>/dev/null) || _yaml_err=""
   # Fail closed on parse failure (exit 2 = treat as Wiki disabled). A lenient
   # fallback that continued staging would let a corrupted config quietly leak
   # raw sources to develop even when the user set wiki.enabled: false on purpose

--- a/plugins/rite/hooks/wiki-query-inject.sh
+++ b/plugins/rite/hooks/wiki-query-inject.sh
@@ -172,7 +172,7 @@ esac
 # before falling through.
 wiki_section=""
 if [[ -f "$STATE_ROOT/rite-config.yml" ]]; then
-  if ! _yaml_err=$(mktemp /tmp/rite-wiki-query-yaml-err-XXXXXX); then
+  if ! _yaml_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-query-yaml-err-XXXXXX"); then
     echo "WARNING: mktemp failed for YAML stderr capture; falling back to /dev/null" >&2
     echo "  対処: /tmp の permission / read-only / inode 枯渇を確認してください" >&2
     _yaml_err=""
@@ -225,7 +225,7 @@ _extract_yaml_value() {
 #   - exit >=2: awk runtime error (EPIPE / OOM / binary corruption) — must NOT
 #     be silently conflated with "not found", otherwise a real parse failure
 #     would degrade to the same silent-swallow pattern F-02 was meant to fix.
-if ! _awk_err=$(mktemp /tmp/rite-wiki-query-awk-err-XXXXXX); then
+if ! _awk_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-query-awk-err-XXXXXX"); then
   echo "WARNING: mktemp failed for awk stderr capture; falling back to /dev/null" >&2
   _awk_err=""
 fi
@@ -293,7 +293,7 @@ if [[ "$branch_strategy" == "separate_branch" ]]; then
   # to a tempfile so legitimate IO errors (permission denied / object corrupt
   # / submodule drift) surface as a WARNING with diagnostic detail, matching
   # the F-22 "silent-swallow to surface" policy applied elsewhere.
-  if ! _index_err=$(mktemp /tmp/rite-wiki-query-index-err-XXXXXX); then
+  if ! _index_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-query-index-err-XXXXXX"); then
     echo "WARNING: mktemp failed for index.md stderr capture; falling back to /dev/null" >&2
     _index_err=""
   fi
@@ -498,7 +498,7 @@ while IFS=$'\x1f' read -r score title path domain summary updated confidence; do
       # exactly one WARNING instead of one per loop iteration under /tmp
       # pressure.
       if [ -z "${_git_show_err:-}" ] && [ "${_git_show_err_failed:-0}" -eq 0 ]; then
-        if ! _git_show_err=$(mktemp /tmp/rite-wiki-query-gitshow-err-XXXXXX); then
+        if ! _git_show_err=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-query-gitshow-err-XXXXXX"); then
           echo "WARNING: mktemp failed for git show stderr capture; falling back to /dev/null for the rest of this run" >&2
           _git_show_err=""
           _git_show_err_failed=1

--- a/plugins/rite/scripts/review-findings-maps.sh
+++ b/plugins/rite/scripts/review-findings-maps.sh
@@ -162,7 +162,7 @@ if [ "$auto_demote_low" = "true" ]; then
   norm_demoted_low_count=$(jq '[.findings[]? | select(.severity == "LOW" and .scope == "current-pr")] | length' "$review_source_path" 2>/dev/null || echo 0)
 fi
 if [ "${norm_defaulted_count:-0}" -gt 0 ] || [ "${norm_corrected_count:-0}" -gt 0 ] || [ "${norm_demoted_low_count:-0}" -gt 0 ]; then
-  if norm_tmp=$(mktemp /tmp/rite-fix-normalized-XXXXXX 2>/dev/null); then
+  if norm_tmp=$(mktemp "${TMPDIR:-/tmp}/rite-fix-normalized-XXXXXX" 2>/dev/null); then
     # auto_demote_low jq filter: bash 変数を jq 引数で渡し、jq 内で動的判定
     if jq --arg demote_low "$auto_demote_low" '
       .findings |= map(
@@ -212,7 +212,7 @@ fi
 # jq バイナリ異常 / OOM / TOCTOU (別プロセスが file を rm / truncate) で silent に空文字になる。
 # 重複警告が silent skip し、severity_map 構築が無音で空になる regression を防ぐため、
 # if-else で exit code を独立 capture する。
-jq_err=$(mktemp /tmp/rite-fix-jq-err-XXXXXX 2>/dev/null) || jq_err=""
+jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-jq-err-XXXXXX" 2>/dev/null) || jq_err=""
 
 # line フィールドの nullable sentinel 正規化
 # review-result-schema.md L92 で line は `integer | null` (null が行非依存指摘の sentinel) に変更。

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -166,7 +166,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
     echo "[CONTEXT] REVIEW_SOURCE_MISSING=1; reason=explicit_file_not_found" >&2
     review_source="fallback"
     review_source_path=""
-  elif jq_val_err_p0=$(mktemp /tmp/rite-jq-val-err-p0-XXXXXX 2>/dev/null) || true; ! jq empty "$review_file_path" 2>"${jq_val_err_p0:-/dev/null}"; then
+  elif jq_val_err_p0=$(mktemp "${TMPDIR:-/tmp}/rite-jq-val-err-p0-XXXXXX" 2>/dev/null) || true; ! jq empty "$review_file_path" 2>"${jq_val_err_p0:-/dev/null}"; then
     echo "エラー: --review-file で指定されたファイルが有効な JSON ではありません: $review_file_path" >&2
     [ -n "${jq_val_err_p0:-}" ] && [ -s "$jq_val_err_p0" ] && head -3 "$jq_val_err_p0" | sed 's/^/  /' >&2
     echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=explicit_file_parse" >&2
@@ -245,7 +245,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
         # [CONTEXT] REVIEW_SOURCE_STALE=1 を emit して observability は維持する。
         # jq バイナリ異常 / I/O エラーと「.commit_sha フィールド不在 (legacy schema)」を区別する。
         # `2>/dev/null || echo ""` の素朴な実装はこの 2 ケースを silent に融合させ、stale detection を silent 無効化してしまう。
-        json_commit_sha_err=$(mktemp /tmp/rite-fix-p0-commit-sha-err-XXXXXX 2>/dev/null) || json_commit_sha_err=""
+        json_commit_sha_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-p0-commit-sha-err-XXXXXX" 2>/dev/null) || json_commit_sha_err=""
         if json_commit_sha=$(jq -r '.commit_sha // empty' "$review_file_path" 2>"${json_commit_sha_err:-/dev/null}"); then
           : # jq 成功 (空 or 非空)
         else
@@ -380,7 +380,7 @@ if [ -z "$review_source" ]; then
     # 構造: bash の 「!」否定 pipeline では then 節内 $? が常に 0 になるため、SoT と同じ
     # `if cmd; then :; else rc=$?; fi` 形式を採用する。mktemp の native stderr は SoT (norm_tmp) と
     # 揃えて `2>/dev/null` で抑制する (本ファイル内の他 mktemp capture site と同じ pattern)。
-    if find_err=$(mktemp /tmp/rite-fix-find-err-XXXXXX 2>/dev/null); then
+    if find_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-find-err-XXXXXX" 2>/dev/null); then
       : # mktemp 成功 — find_err は valid path
     else
       mktemp_find_err_rc=$?
@@ -439,7 +439,7 @@ if [ -z "$review_source" ]; then
     fi
     if [ -z "$review_source" ] && [ -n "$latest_file" ] && [ -f "$latest_file" ]; then
       # canonical jq validation (see common-error-handling.md#jq-required-fields-snippet-canonical)
-      jq_val_err_p2=$(mktemp /tmp/rite-jq-val-err-p2-XXXXXX 2>/dev/null) || jq_val_err_p2=""
+      jq_val_err_p2=$(mktemp "${TMPDIR:-/tmp}/rite-jq-val-err-p2-XXXXXX" 2>/dev/null) || jq_val_err_p2=""
       if ! jq empty "$latest_file" 2>"${jq_val_err_p2:-/dev/null}"; then
         echo "WARNING: $latest_file は有効な JSON ではありません。Priority 3 (PR コメント) に routing します。" >&2
         [ -n "${jq_val_err_p2:-}" ] && [ -s "$jq_val_err_p2" ] && head -3 "$jq_val_err_p2" | sed 's/^/  /' >&2
@@ -454,7 +454,7 @@ if [ -z "$review_source" ]; then
         # mv の stderr を tempfile に退避し、失敗時に原因を可視化する。
         corrupt_epoch=$(date +%s 2>/dev/null || printf '%s-%04x' "unknown" "$((RANDOM & 0xffff))")
         corrupt_suffix=".corrupt-${corrupt_epoch}"
-        mv_err=$(mktemp /tmp/rite-fix-corrupt-mv-err-XXXXXX 2>/dev/null) || mv_err=""
+        mv_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-corrupt-mv-err-XXXXXX" 2>/dev/null) || mv_err=""
         if mv "$latest_file" "${latest_file}${corrupt_suffix}" 2>"${mv_err:-/dev/null}"; then
           echo "  corrupted file をリネームしました: ${latest_file}${corrupt_suffix}" >&2
           echo "  対処: 内容を確認後、手動で削除するか新しい review を生成してください" >&2
@@ -481,7 +481,7 @@ if [ -z "$review_source" ]; then
         echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=local_file_schema_required_fields_missing" >&2
         corrupt_epoch=$(date +%s 2>/dev/null || printf '%s-%04x' "unknown" "$((RANDOM & 0xffff))")
         corrupt_suffix=".corrupt-${corrupt_epoch}"
-        mv_err=$(mktemp /tmp/rite-fix-corrupt-mv-err-XXXXXX 2>/dev/null) || mv_err=""
+        mv_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-corrupt-mv-err-XXXXXX" 2>/dev/null) || mv_err=""
         if mv "$latest_file" "${latest_file}${corrupt_suffix}" 2>"${mv_err:-/dev/null}"; then
           echo "  schema-invalid file をリネームしました: ${latest_file}${corrupt_suffix}" >&2
         else
@@ -551,7 +551,7 @@ if [ -z "$review_source" ]; then
             # (PR コメント) に routing する (Priority 2 の他の失敗経路と同じ扱い)。
             # 古い local file には fallback しない (Priority 2 schema doc の設計判断と整合)。
             # jq IO エラーを silent 化しない。
-            json_commit_sha_err=$(mktemp /tmp/rite-fix-p2-commit-sha-err-XXXXXX 2>/dev/null) || json_commit_sha_err=""
+            json_commit_sha_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-p2-commit-sha-err-XXXXXX" 2>/dev/null) || json_commit_sha_err=""
             if json_commit_sha=$(jq -r '.commit_sha // empty' "$latest_file" 2>"${json_commit_sha_err:-/dev/null}"); then
               :
             else

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -132,7 +132,7 @@ trap '_rite_watchdog_cleanup; exit 129' HUP
 # --- Repo info ---
 # gh repo view stderr is captured into a dedicated tempfile (repo_view_err) so
 # the discrimination matches the 2-site contract declared above.
-repo_view_err=$(mktemp /tmp/rite-watchdog-repo-err-XXXXXX) || repo_view_err=""
+repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-repo-err-XXXXXX") || repo_view_err=""
 if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
   echo "ERROR: gh repo view failed" >&2
   if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
@@ -153,7 +153,7 @@ if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
 fi
 
 # --- Scan OPEN, non-draft PRs ---
-pr_list_err=$(mktemp /tmp/rite-watchdog-pr-list-err-XXXXXX) || pr_list_err=""
+pr_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-pr-list-err-XXXXXX") || pr_list_err=""
 if ! PR_LIST=$(gh pr list --state open --limit "$LIMIT" --json number,isDraft,body,headRefName 2>"${pr_list_err:-/dev/null}"); then
   echo "ERROR: gh pr list failed" >&2
   if [ -n "$pr_list_err" ] && [ -s "$pr_list_err" ]; then
@@ -208,8 +208,8 @@ while IFS= read -r pr_entry; do
 
   # Query Issue's current Status in the Project. Capture gh and jq stderr into
   # independent tempfiles so a failed pipeline can be triaged by side (gh vs jq).
-  gql_err=$(mktemp /tmp/rite-watchdog-gql-err-XXXXXX) || gql_err=""
-  jq_err=$(mktemp /tmp/rite-watchdog-jq-err-XXXXXX) || jq_err=""
+  gql_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-gql-err-XXXXXX") || gql_err=""
+  jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-jq-err-XXXXXX") || jq_err=""
   # Inner `set -o pipefail` mirrors the outer setting; making it explicit keeps
   # the inheritance contract obvious when this block is run in a sub-shell.
   if ! current_status=$(set -o pipefail; gh api graphql -f query='
@@ -256,7 +256,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
     if [ "$RECONCILE" = "true" ]; then
       # stderr を tempfile に退避して失敗時の原因 (auth / rate limit / partial failure) を可視化する。
       # silent suppress (2>/dev/null) では RECONCILE_FAILURES non-zero 時に user が失敗原因を triage できない。
-      reconcile_err=$(mktemp /tmp/rite-watchdog-reconcile-err-XXXXXX) || reconcile_err=""
+      reconcile_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-reconcile-err-XXXXXX") || reconcile_err=""
       reconcile_json=$(bash "$PLUGIN_ROOT/scripts/projects-status-update.sh" "$(jq -n \
         --argjson issue "$issue_number" --arg owner "$REPO_OWNER" --arg repo "$REPO_NAME" \
         --argjson project_number "$PROJECT_NUMBER" --arg status "In Review" \


### PR DESCRIPTION
## 概要

sandbox 有効環境では書き込み許可ディレクトリが `$TMPDIR`（例: `/tmp/claude-1000/...`）に限定されるが、多数のスクリプトが `mktemp` に `/tmp/rite-xxx-XXXXXX` のような `/tmp` 直下ハードコードテンプレートを渡しており、`$TMPDIR` を無視するため書き込み拒否される。

Issue 本文は例として `hooks/issue-body-safe-update.sh` と `hooks/scripts/projects-board-drift-check.sh` の2ファイルを挙げているが、本文中の「等」の記述とタイトルが指す問題自体はパターン全体（本番コード21ファイル）に及んでいたため、systemic な修正としてスコープを広げた。既存の canonical helper（`_mktemp-stderr-guard.sh`）が既に使っている `mktemp "${TMPDIR:-/tmp}/rite-xxx-XXXXXX"` 形式（GNU/BSD 両対応のポータブル形式）に統一している。

## スコープに関する重要な注記

- **`--merge` で起動されたが、この PR は draft のまま止めている**。Issue 本文は2ファイルを指していたが実際の変更は21ファイル（+テスト1ファイル）に及ぶ、core hooks/scripts への広範な変更のため、merge は坂口さんの明示確認を経てから行うことを推奨する。
- `wiki-ingest-trigger.sh` の `--content-file` path-containment 検証（`$PWD` 配下 または `/tmp/rite-*` のみ許可）には**触れていない**。これは `--content-file` を介して他スクリプトへ渡すファイルの経路であり、本 Issue の mktemp 呼び出し先とは独立した別のセキュリティ境界のため。
- テストファイル自体（`hooks/tests/_test-helpers.sh` の `make_sandbox` 等）にも同じ `/tmp` 直下ハードコードパターンが残っている。意図的にスコープ外としたため、フォローアップ Issue を別途起票することを推奨する。
- `pr-cycle-cleanup.test.sh` の T-10/T-13/T-16 は、mktemp が `TMPDIR` を尊重するようになったことで従来の「TMPDIR に存在しないパス/読み取り専用の親ディレクトリ」という分離技法が意図した失敗経路ではなく別の mktemp-failure 警告に化けて回帰したため、分離技法を更新した（詳細はコミットメッセージ参照）。

## 検証

変更した21ファイルに対応する全テストファイル（26ファイル）を実行し、全て成功を確認した。

- `post-compact.test.sh`（15 passed, 17 failed）と `post-tool-wm-sync.test.sh`（16 passed, 12 failed）には失敗が残るが、修正前（HEAD~1）のコードで同じテストを実行して同一の失敗数であることを確認済み。**本 PR の変更とは無関係の既存failure**（詳細は各テストログ参照）。
- `pr-cycle-cleanup.test.sh` は当初3件回帰していたが、分離技法の更新により 30 passed / 0 failed。
- その他全テストファイルは 0 failed。

## 開発フロー上の注記

sandbox 環境で git の `unlink` 操作（`git stash` / `git checkout` 等が内部で使う）が "read-only filesystem" エラーでブロックされる事象を確認した（`sed -i` / Edit tool の rename-over 方式は影響を受けない）。この制約により、当初想定していたセッション worktree フロー（2.2-W）ではなく `git switch -c` でブランチを作成した。

refs #1900