### PR TITLE
fix(tests): テストハーネスの mktemp /tmp 直下ハードコードを TMPDIR 化

### DIFF
--- a/plugins/rite/hooks/tests/_resolve-cross-session-guard.test.sh
+++ b/plugins/rite/hooks/tests/_resolve-cross-session-guard.test.sh
@@ -72,7 +72,7 @@ OTHER_SID="22222222-2222-2222-2222-222222222222"
 # `SBX=$(make_sandbox); cleanup_dirs+=("$SBX")`.
 mktemp_legacy() {
   local f
-  f=$(mktemp /tmp/rite-cross-session-test-XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  f=$(mktemp "${TMPDIR:-/tmp}/rite-cross-session-test-XXXXXX") || { echo "ERROR: mktemp failed" >&2; exit 1; }
   echo "$f"
 }
 

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -321,8 +321,8 @@ make_sandbox() {
     [ "$soft_fail" -eq 1 ] && return 1
     exit 1
   }
-  sandbox_err=$(mktemp /tmp/rite-sandbox-err-XXXXXX 2>/dev/null) || {
-    echo "WARNING: make_sandbox: mktemp /tmp/rite-sandbox-err-XXXXXX failed; diagnostic capture disabled (git stderr will not be surfaced on failure)" >&2
+  sandbox_err=$(mktemp "${TMPDIR:-/tmp}/rite-sandbox-err-XXXXXX" 2>/dev/null) || {
+    echo "WARNING: make_sandbox: mktemp "${TMPDIR:-/tmp}/rite-sandbox-err-XXXXXX" failed; diagnostic capture disabled (git stderr will not be surfaced on failure)" >&2
     sandbox_err="/dev/null"
   }
 

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -322,7 +322,7 @@ make_sandbox() {
     exit 1
   }
   sandbox_err=$(mktemp "${TMPDIR:-/tmp}/rite-sandbox-err-XXXXXX" 2>/dev/null) || {
-    echo "WARNING: make_sandbox: mktemp "${TMPDIR:-/tmp}/rite-sandbox-err-XXXXXX" failed; diagnostic capture disabled (git stderr will not be surfaced on failure)" >&2
+    echo "WARNING: make_sandbox: mktemp ${TMPDIR:-/tmp}/rite-sandbox-err-XXXXXX failed; diagnostic capture disabled (git stderr will not be surfaced on failure)" >&2
     sandbox_err="/dev/null"
   }
 

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -247,7 +247,7 @@ EOF
 # 挙動を一致させるため、probe を sandbox dir 配下に作成する。
 # Why: mktemp 失敗時の stderr を一時的に capture することで、TMPDIR が別 fs を指す / inode 枯渇 /
 # permission denied 等の root cause を fail message から確認可能にする (silent な原因隠蔽を防ぐ)。
-_dac_probe_err=$(mktemp /tmp/rite-dac-probe-err-XXXXXX 2>/dev/null) || _dac_probe_err=""
+_dac_probe_err=$(mktemp "${TMPDIR:-/tmp}/rite-dac-probe-err-XXXXXX" 2>/dev/null) || _dac_probe_err=""
 if ! _dac_probe_parent=$(mktemp -d "$d/_dac_probe.XXXXXX" 2>"${_dac_probe_err:-/dev/null}"); then
   _dac_probe_diag=""
   [ -n "$_dac_probe_err" ] && [ -s "$_dac_probe_err" ] && _dac_probe_diag=" ($(head -1 "$_dac_probe_err"))"
@@ -808,7 +808,7 @@ echo "=== TC-H4: consume-handoff on file without handoff → empty + rc 0, WARNI
 # stderr を capture して WARNING 非発火を negative-assert する。
 result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 (cd "$d" && bash "$HOOK" set --phase review --issue 1168 --branch b --pr 99 --next n)
-_tch4_stderr=$(mktemp /tmp/rite-tch4-stderr-XXXXXX 2>/dev/null) || _tch4_stderr="/dev/null"
+_tch4_stderr=$(mktemp "${TMPDIR:-/tmp}/rite-tch4-stderr-XXXXXX" 2>/dev/null) || _tch4_stderr="/dev/null"
 out=$( (cd "$d" && bash "$HOOK" consume-handoff 2>"$_tch4_stderr"); echo "__RC=$?" )
 rc=$(printf '%s' "$out" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
 val="${out%__RC=*}"; val="${val%$'\n'}"
@@ -846,7 +846,7 @@ result=$(new_sandbox); d="${result%|*}"; sid="${result#*|}"
 state_file="$d/.rite/sessions/${sid}.flow-state"
 # DAC probe (同 TC-8b-e/g): root / fakeroot / CAP_DAC_OVERRIDE 環境では chmod 0555 が無効化され
 # write-failure path を強制できないため、実機 write probe で強制可能性を検出し silent false-pass を防ぐ。
-_dac_probe_err=$(mktemp /tmp/rite-dac-probe-err-XXXXXX 2>/dev/null) || _dac_probe_err=""
+_dac_probe_err=$(mktemp "${TMPDIR:-/tmp}/rite-dac-probe-err-XXXXXX" 2>/dev/null) || _dac_probe_err=""
 if ! _dac_probe_parent=$(mktemp -d "$d/_dac_probe.XXXXXX" 2>"${_dac_probe_err:-/dev/null}"); then
   _dac_probe_diag=""
   [ -n "$_dac_probe_err" ] && [ -s "$_dac_probe_err" ] && _dac_probe_diag=" ($(head -1 "$_dac_probe_err"))"
@@ -867,7 +867,7 @@ else
     # trap save/restore (TC-8b-e/g と同形): hard-fail / signal kill で sessions dir が readonly のまま
     # 残ると後続 test が clean state を得られないため restore を保証する。
     _tch6_saved_trap=$(trap -p EXIT INT TERM HUP)
-    _tch6_stderr=$(mktemp /tmp/rite-tch6-stderr-XXXXXX 2>/dev/null) || _tch6_stderr="/dev/null"
+    _tch6_stderr=$(mktemp "${TMPDIR:-/tmp}/rite-tch6-stderr-XXXXXX" 2>/dev/null) || _tch6_stderr="/dev/null"
     _tch6_test_cleanup() {
       chmod +w "$d/.rite/sessions" 2>/dev/null || true
       [ "${_tch6_stderr:-/dev/null}" != "/dev/null" ] && rm -f "$_tch6_stderr"
@@ -909,7 +909,7 @@ state_file="$d/.rite/sessions/${sid}.flow-state"
 # 正規 set で sessions dir + valid file を作ってから corrupt JSON で上書き (実際の FS corruption を模倣)
 (cd "$d" && bash "$HOOK" set --phase fix --issue 1170 --branch b --pr 99 --next n --handoff "/rite:pr-review 99")
 printf '{ this is not valid json' > "$state_file"
-_tch7_stderr=$(mktemp /tmp/rite-tch7-stderr-XXXXXX 2>/dev/null) || _tch7_stderr="/dev/null"
+_tch7_stderr=$(mktemp "${TMPDIR:-/tmp}/rite-tch7-stderr-XXXXXX" 2>/dev/null) || _tch7_stderr="/dev/null"
 out=$( (cd "$d" && bash "$HOOK" consume-handoff 2>"$_tch7_stderr"); echo "__RC=$?" )
 rc=$(printf '%s' "$out" | sed -n 's/.*__RC=\([0-9]*\).*/\1/p')
 val="${out%__RC=*}"; val="${val%$'\n'}"

--- a/plugins/rite/hooks/tests/gitignore-health-check-verify-negation.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-health-check-verify-negation.test.sh
@@ -53,7 +53,7 @@ write_broken_gitignore() {
 
 mk_errfile() {
   local f
-  f=$(mktemp /tmp/rite-vn-err-XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  f=$(mktemp "${TMPDIR:-/tmp}/rite-vn-err-XXXXXX") || { echo "ERROR: mktemp failed" >&2; exit 1; }
   err_files+=("$f")
   printf '%s' "$f"
 }

--- a/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
+++ b/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
@@ -274,7 +274,9 @@ cat > "$mock_bin6/mktemp" <<'EOF'
 #!/bin/bash
 for arg in "$@"; do
   case "$arg" in
-    /tmp/rite-issue-body-apply-err-*) exit 1 ;;
+    # 本番は ${TMPDIR:-/tmp}/rite-issue-body-apply-err-XXXXXX を渡すため、
+    # sandbox (TMPDIR 設定) 環境でも intercept できるよう両形にマッチさせる
+    /tmp/rite-issue-body-apply-err-*|"${TMPDIR:-/tmp}"/rite-issue-body-apply-err-*) exit 1 ;;
   esac
 done
 exec /usr/bin/mktemp "$@"
@@ -448,7 +450,7 @@ rm -rf "$mock_bin10"
 # accidentally tightens the regex to `[0-9]+` matching anywhere would let
 # `10abc` slip through and produce arithmetic-eval errors downstream.
 for invalid_val in "10abc" " 5 " "5e3"; do
-  mock_bin_25g=$(mktemp -d /tmp/rite-mock-bin-25g.XXXXXX)
+  mock_bin_25g=$(mktemp -d "${TMPDIR:-/tmp}/rite-mock-bin-25g.XXXXXX")
   cat > "$mock_bin_25g/gh" <<'GHEOF'
 #!/bin/sh
 exit 0

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -412,7 +412,9 @@ cat > "$recon_dir/bin/mktemp" <<'EOF'
 #!/bin/bash
 for arg in "$@"; do
   case "$arg" in
-    /tmp/rite-pc-pr-err-*) exit 1 ;;
+    # 本番は ${TMPDIR:-/tmp}/rite-pc-pr-err-XXXXXX を渡すため、
+    # sandbox (TMPDIR 設定) 環境でも intercept できるよう両形にマッチさせる
+    /tmp/rite-pc-pr-err-*|"${TMPDIR:-/tmp}"/rite-pc-pr-err-*) exit 1 ;;
   esac
 done
 exec /usr/bin/mktemp "$@"

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -66,7 +66,7 @@ trap '_cleanup_all_test_repos; exit 129' HUP
 # The workdir tests (T-06+) populate this directory explicitly. `mktemp -d
 # /tmp/...` and make_temp_repo both use explicit /tmp paths, so they are
 # unaffected by the TMPDIR export below.
-WORKDIR_SCAN_TMP=$(mktemp -d /tmp/rite-pr-cleanup-tmpdir-XXXXXX)
+WORKDIR_SCAN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-tmpdir-XXXXXX")
 TEST_REPOS+=("$WORKDIR_SCAN_TMP")
 export TMPDIR="$WORKDIR_SCAN_TMP"
 
@@ -107,7 +107,7 @@ if [ "$(id -u)" = "0" ]; then IS_ROOT=1; fi
 # Returns the absolute path on stdout.
 make_temp_repo() {
   local tmp
-  tmp=$(mktemp -d /tmp/rite-pr-cleanup-test-XXXXXX)
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-test-XXXXXX")
   TEST_REPOS+=("$tmp")
   (
     cd "$tmp"
@@ -449,7 +449,7 @@ echo "T-10: find wholesale 失敗が silent でない"
 if [ "$IS_ROOT" = "1" ]; then
   skip "T-10: root では perms がバイパスされ強制失敗にならないためスキップ"
 else
-  T10_NOREAD_BASE=$(mktemp -d /tmp/rite-pr-cleanup-noread-XXXXXX) || T10_NOREAD_BASE=""
+  T10_NOREAD_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-noread-XXXXXX") || T10_NOREAD_BASE=""
   if [ -z "$T10_NOREAD_BASE" ]; then
     fail "T-10: mktemp -d による no-read base 作成に失敗"
   else
@@ -560,7 +560,7 @@ else
   # letting `mkdir -p "$LOCKED_BASE/..."` target the filesystem root
   # (`/rite-pr-create-victim`). Matches the sibling `|| var=""` convention in
   # pr-cycle-cleanup.sh.
-  LOCKED_BASE=$(mktemp -d /tmp/rite-pr-cleanup-locked-XXXXXX) || LOCKED_BASE=""
+  LOCKED_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-locked-XXXXXX") || LOCKED_BASE=""
   if [ -z "$LOCKED_BASE" ]; then
     fail "T-13: mktemp -d による locked base 作成に失敗"
   else
@@ -666,7 +666,7 @@ else
   # `|| LOCKED_BASE=""` — see T-13's note: a plain `VAR=$(cmd)` propagates the
   # command-substitution exit status under `set -e`, so the `||` keeps a failed
   # mktemp from aborting the suite and lets the guard fail this test instead.
-  LOCKED_BASE=$(mktemp -d /tmp/rite-pr-cleanup-mut-locked-XXXXXX) || LOCKED_BASE=""
+  LOCKED_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-mut-locked-XXXXXX") || LOCKED_BASE=""
   if [ -z "$LOCKED_BASE" ]; then
     fail "T-16: mktemp -d による locked base 作成に失敗"
   else

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -63,10 +63,12 @@ trap '_cleanup_all_test_repos; exit 129' HUP
 # scans an empty, test-owned directory instead of the developer's real /tmp.
 # Without this, a real /tmp/rite-pr-create-* orphan on the host would make T-05
 # (noop assertion) flaky and could even delete a developer's in-flight workdir.
-# The workdir tests (T-06+) populate this directory explicitly. `mktemp -d
-# /tmp/...` and make_temp_repo both use explicit /tmp paths, so they are
-# unaffected by the TMPDIR export below.
-WORKDIR_SCAN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-tmpdir-XXXXXX")
+# The workdir tests (T-06+) populate this directory explicitly. make_temp_repo
+# and the standalone base mktemp calls use HOST_TMPDIR (captured BEFORE the
+# export below) so test repos stay OUTSIDE the scan directory — preserving the
+# isolation invariant while remaining sandbox-compatible (host tmp namespace).
+HOST_TMPDIR="${TMPDIR:-/tmp}"
+WORKDIR_SCAN_TMP=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-tmpdir-XXXXXX")
 TEST_REPOS+=("$WORKDIR_SCAN_TMP")
 export TMPDIR="$WORKDIR_SCAN_TMP"
 
@@ -107,7 +109,7 @@ if [ "$(id -u)" = "0" ]; then IS_ROOT=1; fi
 # Returns the absolute path on stdout.
 make_temp_repo() {
   local tmp
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-test-XXXXXX")
+  tmp=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-test-XXXXXX")
   TEST_REPOS+=("$tmp")
   (
     cd "$tmp"
@@ -449,7 +451,7 @@ echo "T-10: find wholesale 失敗が silent でない"
 if [ "$IS_ROOT" = "1" ]; then
   skip "T-10: root では perms がバイパスされ強制失敗にならないためスキップ"
 else
-  T10_NOREAD_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-noread-XXXXXX") || T10_NOREAD_BASE=""
+  T10_NOREAD_BASE=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-noread-XXXXXX") || T10_NOREAD_BASE=""
   if [ -z "$T10_NOREAD_BASE" ]; then
     fail "T-10: mktemp -d による no-read base 作成に失敗"
   else
@@ -560,7 +562,7 @@ else
   # letting `mkdir -p "$LOCKED_BASE/..."` target the filesystem root
   # (`/rite-pr-create-victim`). Matches the sibling `|| var=""` convention in
   # pr-cycle-cleanup.sh.
-  LOCKED_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-locked-XXXXXX") || LOCKED_BASE=""
+  LOCKED_BASE=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-locked-XXXXXX") || LOCKED_BASE=""
   if [ -z "$LOCKED_BASE" ]; then
     fail "T-13: mktemp -d による locked base 作成に失敗"
   else
@@ -666,7 +668,7 @@ else
   # `|| LOCKED_BASE=""` — see T-13's note: a plain `VAR=$(cmd)` propagates the
   # command-substitution exit status under `set -e`, so the `||` keeps a failed
   # mktemp from aborting the suite and lets the guard fail this test instead.
-  LOCKED_BASE=$(mktemp -d "${TMPDIR:-/tmp}/rite-pr-cleanup-mut-locked-XXXXXX") || LOCKED_BASE=""
+  LOCKED_BASE=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-mut-locked-XXXXXX") || LOCKED_BASE=""
   if [ -z "$LOCKED_BASE" ]; then
     fail "T-16: mktemp -d による locked base 作成に失敗"
   else

--- a/plugins/rite/hooks/tests/scope-enum-check.test.sh
+++ b/plugins/rite/hooks/tests/scope-enum-check.test.sh
@@ -145,7 +145,7 @@ cat > "$T3_DIR/.rite/review-results/300-20260101000000.json" <<'EOF'
 EOF
 
 # Capture stderr for diagnostic purposes (F-14)
-T3_STDERR=$(mktemp /tmp/rite-scope-enum-t3-stderr-XXXXXX) || { fail "T-3 stderr tmpfile mktemp failed"; T3_STDERR=""; }
+T3_STDERR=$(mktemp "${TMPDIR:-/tmp}/rite-scope-enum-t3-stderr-XXXXXX") || { fail "T-3 stderr tmpfile mktemp failed"; T3_STDERR=""; }
 T3_RC=0
 if [ -n "$T3_STDERR" ]; then
   REPO_ROOT="$T3_DIR" bash "$MIGRATE_SCRIPT" >/dev/null 2>"$T3_STDERR"

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -705,30 +705,39 @@ trap '_rite_issue518_cleanup; cleanup' EXIT
 # TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (正常系 / fix)
 # --------------------------------------------------------------------------
 # pr/pr-review.md / pr/fix.md / issue/close.md は wiki-ingest-trigger.sh を
-# 呼ぶときに tmpfile=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-content-XXXXXX") でファイル生成する必要がある。
+# 呼ぶときに tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX) でファイル生成する必要がある。
 # この TC は /tmp/rite-* prefix でのファイルが正常に受容され、fix が正しく動作することを保証する。
+# NOTE: content-file の /tmp/rite-* literal は被テスト hook の path-containment allowlist
+# ($PWD/* | /tmp/rite-* | /private/tmp/rite-*) に一致させる load-bearing fixture であり、
+# ${TMPDIR:-/tmp} 化してはならない (TMPDIR≠/tmp の環境で hook が正しく拒否し偽 FAIL する)。
+# /tmp 直下が書込不可な sandbox 環境では本 TC は検証不能のため明示 skip する。
 echo "TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (regression)"
-dir36a="$TEST_DIR/tc36a"
-mkdir -p "$dir36a"
-cat > "$dir36a/rite-config.yml" <<'EOF'
+if _probe36a=$(mktemp /tmp/rite-probe-XXXXXX 2>/dev/null); then
+  rm -f "$_probe36a"
+  dir36a="$TEST_DIR/tc36a"
+  mkdir -p "$dir36a"
+  cat > "$dir36a/rite-config.yml" <<'EOF'
 wiki:
   enabled: true
 EOF
-# Create content-file using /tmp/rite-* prefix (pr-review.md / fix.md / close.md と同パターン)
-tmp_in_rite=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-content-XXXXXX")
-_rite_issue518_tmps+=("$tmp_in_rite")
-echo "review body" > "$tmp_in_rite"
-( cd "$dir36a" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_in_rite" > out.log 2>err.log ) && rc=0 || rc=$?
-if [ $rc -eq 0 ]; then
-  # review F-06: tr -d [:space:] は stdout 多行時に path を連結してしまう。先頭行のみ取る
-  target_path36a=$(head -1 "$dir36a/out.log" | tr -d '[:space:]')
-  if [ -n "$target_path36a" ] && [ -f "$dir36a/$target_path36a" ]; then
-    pass "/tmp/rite-* prefix content-file → exit 0 + raw file created"
+  # Create content-file using /tmp/rite-* prefix (pr-review.md / fix.md / close.md と同パターン)
+  tmp_in_rite=$(mktemp /tmp/rite-wiki-content-XXXXXX)
+  _rite_issue518_tmps+=("$tmp_in_rite")
+  echo "review body" > "$tmp_in_rite"
+  ( cd "$dir36a" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_in_rite" > out.log 2>err.log ) && rc=0 || rc=$?
+  if [ $rc -eq 0 ]; then
+    # review F-06: tr -d [:space:] は stdout 多行時に path を連結してしまう。先頭行のみ取る
+    target_path36a=$(head -1 "$dir36a/out.log" | tr -d '[:space:]')
+    if [ -n "$target_path36a" ] && [ -f "$dir36a/$target_path36a" ]; then
+      pass "/tmp/rite-* prefix content-file → exit 0 + raw file created"
+    else
+      fail "/tmp/rite-* prefix → rc=0 but output file not found (path='$target_path36a')"
+    fi
   else
-    fail "/tmp/rite-* prefix → rc=0 but output file not found (path='$target_path36a')"
+    fail "Expected rc=0 for /tmp/rite-* prefix, got rc=$rc, stderr=$(cat "$dir36a/err.log")"
   fi
 else
-  fail "Expected rc=0 for /tmp/rite-* prefix, got rc=$rc, stderr=$(cat "$dir36a/err.log")"
+  echo "  SKIP: TC-036a — /tmp 直下が書込不可 (sandbox 環境) のため /tmp/rite-* prefix 受容を検証できません"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -705,7 +705,7 @@ trap '_rite_issue518_cleanup; cleanup' EXIT
 # TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (正常系 / fix)
 # --------------------------------------------------------------------------
 # pr/pr-review.md / pr/fix.md / issue/close.md は wiki-ingest-trigger.sh を
-# 呼ぶときに tmpfile=$(mktemp /tmp/rite-wiki-content-XXXXXX) でファイル生成する必要がある。
+# 呼ぶときに tmpfile=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-content-XXXXXX") でファイル生成する必要がある。
 # この TC は /tmp/rite-* prefix でのファイルが正常に受容され、fix が正しく動作することを保証する。
 echo "TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (regression)"
 dir36a="$TEST_DIR/tc36a"
@@ -715,7 +715,7 @@ wiki:
   enabled: true
 EOF
 # Create content-file using /tmp/rite-* prefix (pr-review.md / fix.md / close.md と同パターン)
-tmp_in_rite=$(mktemp /tmp/rite-wiki-content-XXXXXX)
+tmp_in_rite=$(mktemp "${TMPDIR:-/tmp}/rite-wiki-content-XXXXXX")
 _rite_issue518_tmps+=("$tmp_in_rite")
 echo "review body" > "$tmp_in_rite"
 ( cd "$dir36a" && bash "$HOOK" --type reviews --source-ref pr-518 --content-file "$tmp_in_rite" > out.log 2>err.log ) && rc=0 || rc=$?
@@ -901,7 +901,7 @@ echo ""
 # --------------------------------------------------------------------------
 
 echo "[TC-043] chmod 000 rite-config.yml → sed extraction fail → exit 2"
-dir43=$(mktemp -d /tmp/rite-wiki-test-tc043-XXXXXX)
+dir43=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc043-XXXXXX")
 cat > "$dir43/rite-config.yml" <<EOF
 wiki:
   enabled: true
@@ -923,7 +923,7 @@ rm -rf "$dir43"
 echo ""
 
 echo "[TC-044] binary garbage in wiki section → awk fail → exit 2"
-dir44=$(mktemp -d /tmp/rite-wiki-test-tc044-XXXXXX)
+dir44=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc044-XXXXXX")
 # NUL byte handling differs by platform, so this case may pass-through the
 # tr/sed pipeline. Either outcome is acceptable as long as raw is not silently
 # created when the parser bails: that is the invariant the assertion enforces.
@@ -950,7 +950,7 @@ rm -rf "$dir44"
 echo ""
 
 echo "[TC-045] wiki.enabled normalization happy path (negative control)"
-dir45=$(mktemp -d /tmp/rite-wiki-test-tc045-XXXXXX)
+dir45=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc045-XXXXXX")
 # Negative control: ensure the strict guards above don't accidentally break
 # the success path. A regression here would mean the safe-default became
 # fail-closed for valid configs too.
@@ -974,7 +974,7 @@ echo "[TC-046] wiki.enabled: TRUE (uppercase) → normalize lowercase → exit 0
 # Without `tr '[:upper:]' '[:lower:]'` the uppercase value would land in the
 # typo-reject arm and exit 2; the TC pins that the normalization step survives
 # future refactors.
-dir46=$(mktemp -d /tmp/rite-wiki-test-tc046-XXXXXX)
+dir46=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc046-XXXXXX")
 cat > "$dir46/rite-config.yml" <<EOF
 wiki:
   enabled: TRUE
@@ -992,7 +992,7 @@ echo ""
 echo "[TC-047] wiki.enabled: False (MixedCase) → normalize lowercase → exit 2"
 # Symmetric to TC-046 for the false path. A regression that drops the
 # normalize step would let MixedCase typos bypass the disable guard.
-dir47=$(mktemp -d /tmp/rite-wiki-test-tc047-XXXXXX)
+dir47=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc047-XXXXXX")
 cat > "$dir47/rite-config.yml" <<EOF
 wiki:
   enabled: False
@@ -1011,7 +1011,7 @@ echo "[TC-048] wiki.enabled: tru (typo) → exit 2 + recognised-boolean WARNING"
 # The typo-reject arm (`*)` in the case statement) is the security-net for
 # silent typo-induced enable. Without this TC, future refactors could weaken
 # the arm to no-op and the safety net would vanish silently.
-dir48=$(mktemp -d /tmp/rite-wiki-test-tc048-XXXXXX)
+dir48=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-test-tc048-XXXXXX")
 cat > "$dir48/rite-config.yml" <<EOF
 wiki:
   enabled: tru

--- a/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-source-refs.test.sh
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 mk_tmp() {
   local f
-  f=$(mktemp /tmp/rite-wlsr-XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  f=$(mktemp "${TMPDIR:-/tmp}/rite-wlsr-XXXXXX") || { echo "ERROR: mktemp failed" >&2; exit 1; }
   tmp_files+=("$f")
   printf '%s' "$f"
 }

--- a/plugins/rite/hooks/tests/wiki-query-inject.test.sh
+++ b/plugins/rite/hooks/tests/wiki-query-inject.test.sh
@@ -13,7 +13,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/../wiki-query-inject.sh"
-TEST_DIR=$(mktemp -d /tmp/rite-wiki-query-test-XXXXXX)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-wiki-query-test-XXXXXX")
 trap 'rm -rf "$TEST_DIR"' EXIT
 
 PASS=0

--- a/plugins/rite/scripts/tests/review-findings-maps.test.sh
+++ b/plugins/rite/scripts/tests/review-findings-maps.test.sh
@@ -123,7 +123,7 @@ if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]
     norm_demoted_low_count=$(jq '[.findings[]? | select(.severity == "LOW" and .scope == "current-pr")] | length' "$review_source_path" 2>/dev/null || echo 0)
   fi
   if [ "${norm_defaulted_count:-0}" -gt 0 ] || [ "${norm_corrected_count:-0}" -gt 0 ] || [ "${norm_demoted_low_count:-0}" -gt 0 ]; then
-    if norm_tmp=$(mktemp /tmp/rite-fix-normalized-XXXXXX 2>/dev/null); then
+    if norm_tmp=$(mktemp "${TMPDIR:-/tmp}/rite-fix-normalized-XXXXXX" 2>/dev/null); then
       if jq --arg demote_low "$auto_demote_low" '
         .findings |= map(
           (if has("scope") then . else .scope = (
@@ -164,7 +164,7 @@ if [ "$review_source" = "local_file" ] || [ "$review_source" = "explicit_file" ]
     fi
   fi
 
-  jq_err=$(mktemp /tmp/rite-fix-jq-err-XXXXXX 2>/dev/null) || jq_err=""
+  jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-fix-jq-err-XXXXXX" 2>/dev/null) || jq_err=""
 
   if duplicate_keys=$(jq -r '[.findings[] | (.file + ":" + (if .line == null or .line == 0 then "anchor" else (.line | tostring) end))] | group_by(.) | map(select(length > 1) | .[0]) | .[]' "$review_source_path" 2>"${jq_err:-/dev/null}"); then
     if [ -n "$duplicate_keys" ]; then
@@ -362,15 +362,15 @@ fi
 # TC-9: normalization tempfile が leak しない (script 終了時 trap 削除契約)
 # --------------------------------------------------------------------------
 echo "TC-9: norm_tmp leak なし"
-# 共有 /tmp glob の count delta は並列実行時に他プロセスの同 glob tempfile 生成/削除で
+# 共有 tmp glob の count delta は並列実行時に他プロセスの同 glob tempfile 生成/削除で
 # 両方向に flaky 化する。helper の mktemp template は
-# /tmp/rite-fix-normalized-XXXXXX の絶対 path 固定で TMPDIR 隔離が効かないため、
-# before/after の path 集合差分 (after にのみ存在する path) で leak を判定する。
-before_paths=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
+# ${TMPDIR:-/tmp}/rite-fix-normalized-XXXXXX で、本テストと同じ TMPDIR 名前空間に
+# 生成されるため、before/after の path 集合差分 (after にのみ存在する path) で leak を判定する。
+before_paths=$(ls "${TMPDIR:-/tmp}"/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
 repo=$(make_sandbox tc9 default)
 write_fixture "$repo/review.json" v10_missing_scope
 run_helper "$repo" local_file "$repo/review.json"
-after_paths=$(ls /tmp/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
+after_paths=$(ls "${TMPDIR:-/tmp}"/rite-fix-normalized-* 2>/dev/null | LC_ALL=C sort || true)
 leaked_paths=$(LC_ALL=C comm -13 <(printf '%s\n' "$before_paths") <(printf '%s\n' "$after_paths"))
 if [ -z "$leaked_paths" ]; then
   pass "handed_off_norm_tmp が trap EXIT で削除される (leak なし)"


### PR DESCRIPTION
## 概要

sandbox 有効環境では書き込み許可が `$TMPDIR` に限定され `/tmp` 直下は読み込み専用のため、テストハーネス自身の `mktemp /tmp/rite-*` ハードコードでテストスイートが起動不能・中断死していた。ハーネスの mktemp 実呼び出しを `${TMPDIR:-/tmp}` 形式に統一する。

## 関連 Issue

Closes #1903

## 変更内容

- mktemp 実呼び出し 28 箇所 / 11 ファイル（`hooks/tests/` 9 + `scripts/tests/` 1 + `_test-helpers.sh`）を `mktemp [-d] "${TMPDIR:-/tmp}/rite-*"` 化
- mock mktemp の intercept pattern 2 箇所（`issue-body-safe-update.test.sh` / `post-compact.test.sh`）に TMPDIR arm を追加（本番スクリプトは #1902 で TMPDIR 化済みのため、sandbox では旧 pattern が本番の渡すパスに一致せず mock が素通りしていた）
- `review-findings-maps.test.sh` の leak 判定 glob を TMPDIR 化し、stale コメント（「TMPDIR 隔離が効かない」）を実態に更新
- fixture 文字列・assertion 内の `/tmp` リテラル（テストデータ）は意図的に対象外

## 検証

- **sandbox 内**（本 Issue の主訴）: 変更前は `issue-body-safe-update.test.sh` が TC-25g で中断死（summary 未到達）→ 変更後 54/0 完走。flow-state 157/0、scope-enum 11/0、review-findings-maps 19/0、wiki-query 5/0 ほか完走
- **非 sandbox**（CI 相当、TMPDIR 未設定）: 全変換は `${TMPDIR:-/tmp}` = `/tmp` に縮退し挙動不変。issue-body 54/0 / wiki-ingest-trigger 56/0 / pr-cycle-cleanup 30/0 で回帰なし（post-compact の 15/17 は未変更ツリーでも同一の既存環境依存）

## 補足（cross-PR 依存）

`wiki-ingest-trigger.test.sh` の TC-036a（`/tmp/rite-*` prefix 受容の regression テスト）は、sandbox 内では PR #1909（#1904 の allowlist に `$TMPDIR/rite-*` arm を追加）とセットで green になる。非 sandbox では本 PR 単独で従来どおり green。

## チェックリスト

- [x] 変更は Issue のスコープ内（テストハーネスのみ、本番コード無変更）
- [x] 既存テストが通過（sandbox 内 / 非 sandbox の両方で検証）
- [x] fixture・assertion のテストデータは無変更
