### PR TITLE
fix: gh repo view が SSH host alias remote のホストを解決できず内部スクリプトが失敗する

### DIFF
--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -120,7 +120,11 @@ get_owner_repo() {
   # git-remote parse first: works even when `origin` is an SSH Host alias
   # unrecognized by gh's host allowlist (#1899). Falls through to
   # `gh repo view` below only when no origin remote is configured at all.
-  _git_line=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_line=""
+  # Anchored to `cd "$STATE_ROOT"` (same as post-compact.sh) so this resolves
+  # the intended repo rather than whatever git repo the ambient process cwd
+  # happens to sit in — `cd` here is subshell-scoped via the `$(...)` this
+  # function is always called through, so it cannot affect the caller's cwd.
+  _git_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_line=""
   if [ -n "$_git_line" ]; then
     IFS=$'\t' read -r _git_owner _git_repo <<< "$_git_line"
     if [ -n "$_git_owner" ] && [ -n "$_git_repo" ]; then

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -133,7 +133,10 @@ get_owner_repo() {
     fi
   fi
   _err=$(mktemp 2>/dev/null) || _err=""
-  _out=$(gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>"${_err:-/dev/null}") || _rc=$?
+  # cd "$STATE_ROOT" here too (same as the git-remote fast path above and
+  # post-compact.sh's fallback) — without it, this fallback could resolve a
+  # different repo than the fast path when cwd != STATE_ROOT.
+  _out=$(cd "$STATE_ROOT" 2>/dev/null && gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>"${_err:-/dev/null}") || _rc=$?
   if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
     if [ -n "$_err" ] && [ -s "$_err" ]; then
       echo "[rite] WARNING: issue-comment-wm-sync: gh repo view failed (rc=$_rc)" >&2

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -116,18 +116,21 @@ FLOW_STATE="${RESOLVED_FLOW_STATE:-$STATE_ROOT/.rite-flow-state}"
 # 「owner/repo 取得不能 = Issue comment 経路の機能停止」が silent に発生する。stderr を
 # tempfile capture して、失敗時に WARNING で根本原因を expose する。
 get_owner_repo() {
-  local _err _rc=0 _out _git_line _git_owner _git_repo
+  local _err _rc=0 _out _git_err _git_or_line _git_owner _git_repo
   # git-remote parse first: works even when `origin` is an SSH Host alias
   # unrecognized by gh's host allowlist (#1899). Falls through to
-  # `gh repo view` below only when no origin remote is configured at all.
+  # `gh repo view` below whenever the parse fails (no origin remote,
+  # unparseable URL, charset-rejected).
   # Anchored to `cd "$STATE_ROOT"` (same as post-compact.sh) so this resolves
   # the intended repo rather than whatever git repo the ambient process cwd
   # happens to sit in — `cd` here is subshell-scoped via the `$(...)` this
   # function is always called through, so it cannot affect the caller's cwd.
-  _git_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_line=""
-  if [ -n "$_git_line" ]; then
-    IFS=$'\t' read -r _git_owner _git_repo <<< "$_git_line"
+  _git_err=$(mktemp 2>/dev/null) || _git_err=""
+  _git_or_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>"${_git_err:-/dev/null}") || _git_or_line=""
+  if [ -n "$_git_or_line" ]; then
+    IFS=$'\t' read -r _git_owner _git_repo <<< "$_git_or_line"
     if [ -n "$_git_owner" ] && [ -n "$_git_repo" ]; then
+      [ -n "$_git_err" ] && rm -f "$_git_err"
       printf '%s/%s' "$_git_owner" "$_git_repo"
       return
     fi
@@ -146,9 +149,16 @@ get_owner_repo() {
     if [ -n "$_err" ] && [ -s "$_err" ]; then
       head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
+    # Both resolution paths failed at this point — also surface why the
+    # git-remote fast path bailed, or this WARNING would show only the
+    # fallback's side of a two-sided failure.
+    if [ -n "$_git_err" ] && [ -s "$_git_err" ]; then
+      head -3 "$_git_err" | neutralize_ctrl --keep-newline | sed 's/^/  git-remote: /' >&2
+    fi
     _out=""
   fi
   [ -n "$_err" ] && rm -f "$_err"
+  [ -n "$_git_err" ] && rm -f "$_git_err"
   printf '%s' "$_out"
 }
 

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -116,7 +116,18 @@ FLOW_STATE="${RESOLVED_FLOW_STATE:-$STATE_ROOT/.rite-flow-state}"
 # 「owner/repo 取得不能 = Issue comment 経路の機能停止」が silent に発生する。stderr を
 # tempfile capture して、失敗時に WARNING で根本原因を expose する。
 get_owner_repo() {
-  local _err _rc=0 _out
+  local _err _rc=0 _out _git_line _git_owner _git_repo
+  # git-remote parse first: works even when `origin` is an SSH Host alias
+  # unrecognized by gh's host allowlist (#1899). Falls through to
+  # `gh repo view` below only when no origin remote is configured at all.
+  _git_line=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_line=""
+  if [ -n "$_git_line" ]; then
+    IFS=$'\t' read -r _git_owner _git_repo <<< "$_git_line"
+    if [ -n "$_git_owner" ] && [ -n "$_git_repo" ]; then
+      printf '%s/%s' "$_git_owner" "$_git_repo"
+      return
+    fi
+  fi
   _err=$(mktemp 2>/dev/null) || _err=""
   _out=$(gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>"${_err:-/dev/null}") || _rc=$?
   if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
@@ -414,7 +425,10 @@ INIT_EOF
   _init_err=""
   _init_err=$(mktemp 2>/dev/null) || _init_err=""
   _init_rc=0
-  result=$(gh issue comment "$ISSUE" --body-file "$tmpfile" 2>"${_init_err:-/dev/null}") || _init_rc=$?
+  # --repo を明示: shorthand の `gh issue comment` は内部で `gh repo view` と同じ
+  # host-allowlist 解決を行うため、明示しないと origin が SSH Host alias のとき
+  # OWNER_REPO が解決済みでもここで再び失敗する (#1899)。
+  result=$(gh issue comment "$ISSUE" --repo "$OWNER_REPO" --body-file "$tmpfile" 2>"${_init_err:-/dev/null}") || _init_rc=$?
   if [ "$_init_rc" -ne 0 ]; then
     echo "[rite] WARNING: issue-comment-wm-sync: gh issue comment 作成失敗 (rc=$_init_rc)" >&2
     [ -n "$_init_err" ] && [ -s "$_init_err" ] && head -3 "$_init_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2

--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -138,8 +138,12 @@ get_owner_repo() {
   # different repo than the fast path when cwd != STATE_ROOT.
   _out=$(cd "$STATE_ROOT" 2>/dev/null && gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>"${_err:-/dev/null}") || _rc=$?
   if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
+    # WARNING header is unconditional — gh repo view's own stderr may be
+    # empty (e.g. `cd "$STATE_ROOT"` itself failed, short-circuiting before
+    # gh ever ran), which must not suppress the header itself, only the
+    # optional detail lines below it.
+    echo "[rite] WARNING: issue-comment-wm-sync: gh repo view failed (rc=$_rc)" >&2
     if [ -n "$_err" ] && [ -s "$_err" ]; then
-      echo "[rite] WARNING: issue-comment-wm-sync: gh repo view failed (rc=$_rc)" >&2
       head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     _out=""

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -269,6 +269,50 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       exit 0
     fi
 
+    # Resolve REPO_OWNER/REPO_NAME before the `gh pr view` call below so it can
+    # pass `--repo` explicitly. `gh pr view` is a shorthand command that
+    # resolves the target repo from `origin` the same way `gh repo view`
+    # does — under an SSH Host alias origin this fails with the exact error
+    # #1899 fixes elsewhere, gating this whole reconciliation block shut
+    # before PR_IS_DRAFT can even be determined.
+    #
+    # git-remote parse first: works even when `origin` is an SSH Host alias
+    # unrecognized by gh's host allowlist. Falls through to the existing
+    # `gh repo view` + stderr-attribution path only when no origin remote is
+    # configured at all. Both paths run inside `cd "$STATE_ROOT"` so the
+    # resolved repo always matches what `gh api graphql` below operates on —
+    # a bare git-remote call in the ambient process cwd would silently
+    # resolve a different repository when cwd != STATE_ROOT, bypassing the
+    # auth/network cascade guard further down.
+    REPO_OWNER=""
+    REPO_NAME=""
+    _git_or_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+    if [ -n "$_git_or_line" ]; then
+      IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
+    fi
+    if [ -n "$REPO_OWNER" ] && [ -n "$REPO_NAME" ]; then
+      REPO_INFO="git:${REPO_OWNER}/${REPO_NAME}"
+    else
+      # Capture gh repo view stderr so failures get attributed to auth/network/
+      # permission rather than misclassified as missing data. This pattern is
+      # paired with watchdog-status-mismatch; if those two sites diverge in error
+      # capture, the same root cause produces asymmetric WARNING details and
+      # becomes harder to diagnose.
+      if REPO_INFO=$(cd "$STATE_ROOT" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
+        :
+      else
+        repo_rc=$?
+        repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+        REPO_INFO=""
+      fi
+      # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
+      # is corrupt or a field is null) gets attributed in the WARNING details.
+      REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>"${jq_owner_err:-/dev/null}") || REPO_OWNER=""
+      REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>"${jq_name_err:-/dev/null}") || REPO_NAME=""
+    fi
+    _pc_repo_flag=()
+    [ -n "$REPO_OWNER" ] && [ -n "$REPO_NAME" ] && _pc_repo_flag=(--repo "$REPO_OWNER/$REPO_NAME")
+
     # `cd ... && gh ... 2>FILE` attaches the redirect to gh only — a TOCTOU
     # cd failure (dir removed between the `-d` check above and the cd) leaks no
     # stderr and gets misclassified as a gh failure. Capture cd stderr to a
@@ -279,7 +323,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       "post-compact" \
       "pr-cd-err" \
       "TOCTOU cd failure must be distinguished from gh pr view failure inside the same subshell") || _pr_cd_err=""
-    if PR_IS_DRAFT=$(cd "$STATE_ROOT" 2>"${_pr_cd_err:-/dev/null}" && gh pr view "$PR" --json isDraft --jq '.isDraft // null' 2>"${pr_view_err:-/dev/null}"); then
+    if PR_IS_DRAFT=$(cd "$STATE_ROOT" 2>"${_pr_cd_err:-/dev/null}" && gh pr view "$PR" "${_pc_repo_flag[@]}" --json isDraft --jq '.isDraft // null' 2>"${pr_view_err:-/dev/null}"); then
       :
     else
       pr_rc=$?
@@ -305,38 +349,12 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     [ -n "$_pr_cd_err" ] && rm -f "$_pr_cd_err"
 
     if [ "$PR_IS_DRAFT" = "false" ]; then
-      # git-remote parse first: works even when `origin` is an SSH Host alias
-      # unrecognized by gh's host allowlist (#1899). Falls through to the
-      # existing `gh repo view` + stderr-attribution path only when no origin
-      # remote is configured at all. REPO_INFO is only ever checked for
-      # emptiness downstream (never parsed as JSON again), so a non-empty
-      # sentinel is sufficient to signal "already resolved" past that gate.
-      REPO_OWNER=""
-      REPO_NAME=""
-      _git_or_line=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
-      if [ -n "$_git_or_line" ]; then
-        IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
-      fi
-      if [ -n "$REPO_OWNER" ] && [ -n "$REPO_NAME" ]; then
-        REPO_INFO="git:${REPO_OWNER}/${REPO_NAME}"
-      else
-        # Capture gh repo view stderr so failures get attributed to auth/network/
-        # permission rather than misclassified as missing data. This pattern is
-        # paired with watchdog-status-mismatch; if those two sites diverge in error
-        # capture, the same root cause produces asymmetric WARNING details and
-        # becomes harder to diagnose.
-        if REPO_INFO=$(cd "$STATE_ROOT" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
-          :
-        else
-          repo_rc=$?
-          repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
-          REPO_INFO=""
-        fi
-        # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
-        # is corrupt or a field is null) gets attributed in the WARNING details.
-        REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>"${jq_owner_err:-/dev/null}") || REPO_OWNER=""
-        REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>"${jq_name_err:-/dev/null}") || REPO_NAME=""
-      fi
+      # REPO_OWNER / REPO_NAME / REPO_INFO are already resolved above (before
+      # the `gh pr view` call) so that call could pass `--repo` explicitly.
+      # REPO_INFO is only ever checked for emptiness downstream (never parsed
+      # as JSON again), so the git-remote success path's non-JSON
+      # "git:owner/repo" sentinel is sufficient to signal "already resolved".
+      #
       # Capture awk stderr for rite-config.yml parsing. A silent empty fallback
       # here would let broken Projects integration go unnoticed by the user.
       awk_pe_err=""

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -223,6 +223,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     set -o pipefail
     pr_view_err=""
     repo_view_err=""
+    git_remote_err=""
     jq_owner_err=""
     jq_name_err=""
     gql_err=""
@@ -237,7 +238,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       # the redirect would let that diagnostic leak into triage and
       # mask real cleanup failures. The guard keeps the cleanup silent
       # regardless.
-      for f in "${pr_view_err:-}" "${repo_view_err:-}" \
+      for f in "${pr_view_err:-}" "${repo_view_err:-}" "${git_remote_err:-}" \
                "${jq_owner_err:-}" "${jq_name_err:-}" \
                "${gql_err:-}" "${jq_err:-}" "${reconcile_err:-}" \
                "${reconcile_jq_err:-}" "${reconcile_parse_err:-}"; do
@@ -255,6 +256,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     stderr_capture_disabled=0
     pr_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-pr-err-XXXXXX") || { pr_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for pr_view_err; gh pr view stderr will not be captured" >&2; }
     repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-repo-err-XXXXXX") || { repo_view_err=""; stderr_capture_disabled=1; echo "[rite] WARNING: post-compact: mktemp failed for repo_view_err; gh repo view stderr will not be captured" >&2; }
+    git_remote_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-git-remote-err-XXXXXX") || { git_remote_err=""; stderr_capture_disabled=1; }
     jq_owner_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-jq-owner-err-XXXXXX") || { jq_owner_err=""; stderr_capture_disabled=1; }
     jq_name_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-jq-name-err-XXXXXX") || { jq_name_err=""; stderr_capture_disabled=1; }
     gql_err=$(mktemp "${TMPDIR:-/tmp}/rite-pc-gql-err-XXXXXX") || { gql_err=""; stderr_capture_disabled=1; }
@@ -278,15 +280,17 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     #
     # git-remote parse first: works even when `origin` is an SSH Host alias
     # unrecognized by gh's host allowlist. Falls through to the existing
-    # `gh repo view` + stderr-attribution path only when no origin remote is
-    # configured at all. Both paths run inside `cd "$STATE_ROOT"` so the
+    # `gh repo view` + stderr-attribution path whenever the parse fails
+    # (no origin remote, unparseable URL, charset-rejected) — its stderr is
+    # captured so a two-sided failure can be attributed on both sides.
+    # Both paths run inside `cd "$STATE_ROOT"` so the
     # resolved repo always matches what `gh api graphql` below operates on —
     # a bare git-remote call in the ambient process cwd would silently
     # resolve a different repository when cwd != STATE_ROOT, bypassing the
     # auth/network cascade guard further down.
     REPO_OWNER=""
     REPO_NAME=""
-    _git_or_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+    _git_or_line=$(cd "$STATE_ROOT" 2>/dev/null && bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>"${git_remote_err:-/dev/null}") || _git_or_line=""
     if [ -n "$_git_or_line" ]; then
       IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
     fi
@@ -298,13 +302,23 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       # paired with watchdog-status-mismatch; if those two sites diverge in error
       # capture, the same root cause produces asymmetric WARNING details and
       # becomes harder to diagnose.
-      if REPO_INFO=$(cd "$STATE_ROOT" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
+      #
+      # cd stderr is captured separately (same TOCTOU discrimination as the
+      # `gh pr view` subshell below): a cd failure here would otherwise leave
+      # repo_view_err empty and get misattributed to gh.
+      _ri_cd_err=$(bash "$SCRIPT_DIR/_mktemp-stderr-guard.sh" \
+        "post-compact" \
+        "repo-cd-err" \
+        "TOCTOU cd failure must be distinguished from gh repo view failure inside the same subshell") || _ri_cd_err=""
+      if REPO_INFO=$(cd "$STATE_ROOT" 2>"${_ri_cd_err:-/dev/null}" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
         :
       else
         repo_rc=$?
         repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+        ri_cd_err_oneline=$(head -c 200 "${_ri_cd_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
         REPO_INFO=""
       fi
+      [ -n "$_ri_cd_err" ] && rm -f "$_ri_cd_err"
       # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
       # is corrupt or a field is null) gets attributed in the WARNING details.
       REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>"${jq_owner_err:-/dev/null}") || REPO_OWNER=""
@@ -404,7 +418,16 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
         [ -n "${jq_owner_err:-}" ] && [ -s "$jq_owner_err" ] && jq_owner_err_oneline=$(head -c 200 "$jq_owner_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
         [ -n "${jq_name_err:-}" ] && [ -s "$jq_name_err" ] && jq_name_err_oneline=$(head -c 200 "$jq_name_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
         if [ -z "$REPO_INFO" ]; then
-          echo "[rite] WARNING: post-compact: Issue #$ISSUE — gh repo view failed (rc=${repo_rc:-NA}, stderr=${repo_err_oneline:-NA}); PR Status reconciliation could not run (post_compact_gh_repo_view_failed)" >&2
+          # git-remote fast path's stderr rides along: when BOTH resolution
+          # paths failed, showing only gh's side would hide why the fast path
+          # bailed (the side most likely to matter under an alias origin).
+          git_remote_err_oneline=""
+          [ -n "${git_remote_err:-}" ] && [ -s "$git_remote_err" ] && git_remote_err_oneline=$(head -c 200 "$git_remote_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)
+          if [ -n "${ri_cd_err_oneline:-}" ]; then
+            echo "[rite] WARNING: post-compact: Issue #$ISSUE — cd STATE_ROOT failed inside gh repo view subshell (rc=${repo_rc:-NA}, stderr=$ri_cd_err_oneline); TOCTOU race between -d check and cd (state_root_toctou_race)" >&2
+          else
+            echo "[rite] WARNING: post-compact: Issue #$ISSUE — gh repo view failed (rc=${repo_rc:-NA}, stderr=${repo_err_oneline:-NA}, git_remote_stderr=${git_remote_err_oneline:-NA}); PR Status reconciliation could not run (post_compact_gh_repo_view_failed)" >&2
+          fi
         else
           echo "[rite] WARNING: post-compact: Issue #$ISSUE — gh repo view returned null fields (owner=$REPO_OWNER name=$REPO_NAME jq_owner_stderr=$jq_owner_err_oneline jq_name_stderr=$jq_name_err_oneline); PR Status reconciliation could not run (post_compact_gh_repo_view_returned_null)" >&2
         fi

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -305,22 +305,38 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
     [ -n "$_pr_cd_err" ] && rm -f "$_pr_cd_err"
 
     if [ "$PR_IS_DRAFT" = "false" ]; then
-      # Capture gh repo view stderr so failures get attributed to auth/network/
-      # permission rather than misclassified as missing data. This pattern is
-      # paired with watchdog-status-mismatch; if those two sites diverge in error
-      # capture, the same root cause produces asymmetric WARNING details and
-      # becomes harder to diagnose.
-      if REPO_INFO=$(cd "$STATE_ROOT" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
-        :
-      else
-        repo_rc=$?
-        repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
-        REPO_INFO=""
+      # git-remote parse first: works even when `origin` is an SSH Host alias
+      # unrecognized by gh's host allowlist (#1899). Falls through to the
+      # existing `gh repo view` + stderr-attribution path only when no origin
+      # remote is configured at all. REPO_INFO is only ever checked for
+      # emptiness downstream (never parsed as JSON again), so a non-empty
+      # sentinel is sufficient to signal "already resolved" past that gate.
+      REPO_OWNER=""
+      REPO_NAME=""
+      _git_or_line=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+      if [ -n "$_git_or_line" ]; then
+        IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
       fi
-      # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
-      # is corrupt or a field is null) gets attributed in the WARNING details.
-      REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>"${jq_owner_err:-/dev/null}") || REPO_OWNER=""
-      REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>"${jq_name_err:-/dev/null}") || REPO_NAME=""
+      if [ -n "$REPO_OWNER" ] && [ -n "$REPO_NAME" ]; then
+        REPO_INFO="git:${REPO_OWNER}/${REPO_NAME}"
+      else
+        # Capture gh repo view stderr so failures get attributed to auth/network/
+        # permission rather than misclassified as missing data. This pattern is
+        # paired with watchdog-status-mismatch; if those two sites diverge in error
+        # capture, the same root cause produces asymmetric WARNING details and
+        # becomes harder to diagnose.
+        if REPO_INFO=$(cd "$STATE_ROOT" && gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
+          :
+        else
+          repo_rc=$?
+          repo_err_oneline=$(head -c 200 "${repo_view_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl --c0-only)
+          REPO_INFO=""
+        fi
+        # Capture jq stderr separately so JSON parse failure (gh succeeded but JSON
+        # is corrupt or a field is null) gets attributed in the WARNING details.
+        REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>"${jq_owner_err:-/dev/null}") || REPO_OWNER=""
+        REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>"${jq_name_err:-/dev/null}") || REPO_NAME=""
+      fi
       # Capture awk stderr for rite-config.yml parsing. A silent empty fallback
       # here would let broken Projects integration go unnoticed by the user.
       awk_pe_err=""

--- a/plugins/rite/hooks/post-compact.sh
+++ b/plugins/rite/hooks/post-compact.sh
@@ -323,7 +323,7 @@ if [ "${PR:-0}" != "0" ] && [ "${PR:-0}" != "null" ] && [ -n "${PR:-}" ]; then
       "post-compact" \
       "pr-cd-err" \
       "TOCTOU cd failure must be distinguished from gh pr view failure inside the same subshell") || _pr_cd_err=""
-    if PR_IS_DRAFT=$(cd "$STATE_ROOT" 2>"${_pr_cd_err:-/dev/null}" && gh pr view "$PR" "${_pc_repo_flag[@]}" --json isDraft --jq '.isDraft // null' 2>"${pr_view_err:-/dev/null}"); then
+    if PR_IS_DRAFT=$(cd "$STATE_ROOT" 2>"${_pr_cd_err:-/dev/null}" && gh pr view "$PR" "${_pc_repo_flag[@]+"${_pc_repo_flag[@]}"}" --json isDraft --jq '.isDraft // null' 2>"${pr_view_err:-/dev/null}"); then
       :
     else
       pr_rc=$?

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -22,23 +22,12 @@
 # expected to fall back to `gh repo view` in that case, not treat it as fatal.
 
 resolve_owner_repo() {
-  local url path redacted_url
+  local url path
   url=$(git config --get remote.origin.url 2>/dev/null)
   if [ -z "$url" ]; then
     echo "ERROR: git-remote: no URL configured for remote 'origin'" >&2
     return 1
   fi
-  # A protocol-style origin can embed credentials (`https://TOKEN@host/...`,
-  # a real pattern for PAT-authenticated remotes). Redact before ever putting
-  # the URL in an ERROR message below — those callers currently all redirect
-  # this script's stderr to /dev/null, but that's an artifact of today's
-  # call sites, not a guarantee this function can rely on.
-  redacted_url="$url"
-  case "$url" in
-    *://*@*)
-      redacted_url="${url%%://*}://[redacted]@${url#*://*@}"
-      ;;
-  esac
   case "$url" in
     *://*)
       # protocol-style: scheme://[user@]host[:port]/owner/repo[.git]
@@ -56,12 +45,12 @@ resolve_owner_repo() {
   case "$path" in
     */*)
       if [ -z "${path%%/*}" ] || [ -z "${path#*/}" ]; then
-        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $redacted_url" >&2
+        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $url" >&2
         return 1
       fi
       ;;
     *)
-      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $redacted_url" >&2
+      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $url" >&2
       return 1
       ;;
   esac

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -10,9 +10,9 @@
 # host allowlist entirely: the host segment is discarded regardless of
 # what it says, so an unrecognized alias can never break this path.
 #
-# Usage (standalone only — this file is source-only for functions but the
-# resolver itself is invoked as a subprocess, not sourced, so it cannot
-# perturb a caller's `set -euo pipefail` / trap regime):
+# Usage (standalone subprocess only — callers never source this file;
+# running the resolver as its own process means it cannot perturb a
+# caller's `set -euo pipefail` / trap regime):
 #   line=$(bash lib/git-remote.sh resolve-owner-repo) || fall back
 #   IFS=$'\t' read -r owner repo <<< "$line"
 #
@@ -42,15 +42,19 @@ resolve_owner_repo() {
       ;;
   esac
   path="${path%.git}"
+  # The origin URL itself is deliberately NOT echoed in the ERROR messages
+  # below: protocol-style origins can embed credentials
+  # (https://TOKEN@host/...), and callers may surface this stderr in their
+  # own diagnostics. Inspect with: git config --get remote.origin.url
   case "$path" in
     */*)
       if [ -z "${path%%/*}" ] || [ -z "${path#*/}" ]; then
-        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $url" >&2
+        echo "ERROR: git-remote: owner or repo segment is empty in the origin URL path" >&2
         return 1
       fi
       ;;
     *)
-      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $url" >&2
+      echo "ERROR: git-remote: origin URL does not contain an owner/repo path" >&2
       return 1
       ;;
   esac

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -1,0 +1,69 @@
+# rite workflow - Git remote owner/repo resolution
+#
+# Responsibility: resolve "owner" and "repo" from the `origin` remote URL
+# without depending on `gh` recognizing the remote's host. `gh repo view`
+# fails with "none of the git remotes configured for this repository point
+# to a known GitHub host" when `origin` uses an SSH Host alias set up in
+# ~/.ssh/config (e.g. `git@github.com-work:owner/repo.git`) — even though
+# the alias resolves fine for plain git operations and `gh` is otherwise
+# authenticated (#1899). Parsing the remote URL directly sidesteps gh's
+# host allowlist entirely: the host segment is discarded regardless of
+# what it says, so an unrecognized alias can never break this path.
+#
+# Usage (standalone only — this file is source-only for functions but the
+# resolver itself is invoked as a subprocess, not sourced, so it cannot
+# perturb a caller's `set -euo pipefail` / trap regime):
+#   line=$(bash lib/git-remote.sh resolve-owner-repo) || fall back
+#   IFS=$'\t' read -r owner repo <<< "$line"
+#
+# Output contract: on success, stdout is exactly one line "owner<TAB>repo"
+# and exit is 0. On failure (no origin remote, or URL doesn't parse to an
+# owner/repo path), stderr gets one ERROR line and exit is 1 — callers are
+# expected to fall back to `gh repo view` in that case, not treat it as fatal.
+
+resolve_owner_repo() {
+  local url path
+  url=$(git config --get remote.origin.url 2>/dev/null)
+  if [ -z "$url" ]; then
+    echo "ERROR: git-remote: no URL configured for remote 'origin'" >&2
+    return 1
+  fi
+  case "$url" in
+    *://*)
+      # protocol-style: scheme://[user@]host[:port]/owner/repo[.git]
+      path="${url#*://}"
+      path="${path#*@}"
+      path="${path#*/}"
+      ;;
+    *)
+      # scp-like: [user@]host:owner/repo[.git] (the alias case — host is
+      # whatever ~/.ssh/config maps it to, e.g. github.com-work)
+      path="${url#*:}"
+      ;;
+  esac
+  path="${path%.git}"
+  case "$path" in
+    */*) : ;;
+    *)
+      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $url" >&2
+      return 1
+      ;;
+  esac
+  printf '%s\t%s\n' "${path%%/*}" "${path#*/}"
+}
+
+# -----------------------------------------------------------------------
+# Standalone CLI dispatch. Sourcing this file is a no-op here (the guard is
+# false); running it as `bash lib/git-remote.sh <subcommand>` dispatches.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    resolve-owner-repo)
+      resolve_owner_repo
+      exit $?
+      ;;
+    *)
+      echo "ERROR: git-remote.sh: unknown subcommand '${1:-}' (expected: resolve-owner-repo)" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -54,7 +54,20 @@ resolve_owner_repo() {
       return 1
       ;;
   esac
-  printf '%s\t%s\n' "${path%%/*}" "${path#*/}"
+  local owner="${path%%/*}" repo="${path#*/}"
+  # Reject charset outside GitHub's owner/repo alphabet and, critically, any
+  # embedded `/` left in $repo (a 3+ segment origin path, e.g.
+  # `host:a/b/c.git`). Callers pass this value straight into `gh ... --repo`,
+  # which re-parses `[HOST/]OWNER/REPO` — an unrejected extra segment would
+  # make gh treat the first segment as a HOST, redirecting the call to a
+  # different GitHub instance chosen by whatever `origin` happens to contain.
+  case "$owner$repo" in
+    *[!A-Za-z0-9._-]*)
+      echo "ERROR: git-remote: owner/repo contains characters outside the allowed set: $owner/$repo" >&2
+      return 1
+      ;;
+  esac
+  printf '%s\t%s\n' "$owner" "$repo"
 }
 
 # -----------------------------------------------------------------------

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -43,7 +43,12 @@ resolve_owner_repo() {
   esac
   path="${path%.git}"
   case "$path" in
-    */*) : ;;
+    */*)
+      if [ -z "${path%%/*}" ] || [ -z "${path#*/}" ]; then
+        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $url" >&2
+        return 1
+      fi
+      ;;
     *)
       echo "ERROR: git-remote: could not parse owner/repo from origin URL: $url" >&2
       return 1

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -22,12 +22,23 @@
 # expected to fall back to `gh repo view` in that case, not treat it as fatal.
 
 resolve_owner_repo() {
-  local url path
+  local url path redacted_url
   url=$(git config --get remote.origin.url 2>/dev/null)
   if [ -z "$url" ]; then
     echo "ERROR: git-remote: no URL configured for remote 'origin'" >&2
     return 1
   fi
+  # A protocol-style origin can embed credentials (`https://TOKEN@host/...`,
+  # a real pattern for PAT-authenticated remotes). Redact before ever putting
+  # the URL in an ERROR message below — those callers currently all redirect
+  # this script's stderr to /dev/null, but that's an artifact of today's
+  # call sites, not a guarantee this function can rely on.
+  redacted_url="$url"
+  case "$url" in
+    *://*@*)
+      redacted_url="${url%%://*}://[redacted]@${url#*://*@}"
+      ;;
+  esac
   case "$url" in
     *://*)
       # protocol-style: scheme://[user@]host[:port]/owner/repo[.git]
@@ -45,12 +56,12 @@ resolve_owner_repo() {
   case "$path" in
     */*)
       if [ -z "${path%%/*}" ] || [ -z "${path#*/}" ]; then
-        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $url" >&2
+        echo "ERROR: git-remote: parsed owner or repo is empty from origin URL: $redacted_url" >&2
         return 1
       fi
       ;;
     *)
-      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $url" >&2
+      echo "ERROR: git-remote: could not parse owner/repo from origin URL: $redacted_url" >&2
       return 1
       ;;
   esac

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -140,11 +140,12 @@ fi
 
 # --- Trap setup: tempfile orphan 防止 (EXIT/INT/TERM/HUP), same idiom as watchdog ---
 repo_view_err=""
+git_remote_err=""
 gql_err=""
 jq_err=""
 reconcile_err=""
 _rite_board_drift_cleanup() {
-  rm -f "${repo_view_err:-}" "${gql_err:-}" "${jq_err:-}" "${reconcile_err:-}"
+  rm -f "${repo_view_err:-}" "${git_remote_err:-}" "${gql_err:-}" "${jq_err:-}" "${reconcile_err:-}"
 }
 trap 'rc=$?; _rite_board_drift_cleanup; exit $rc' EXIT
 trap '_rite_board_drift_cleanup; exit 130' INT
@@ -154,10 +155,13 @@ trap '_rite_board_drift_cleanup; exit 129' HUP
 # --- Repo info ---
 # git-remote parse first: works even when `origin` is an SSH Host alias
 # unrecognized by gh's host allowlist (#1899). Falls through to
-# `gh repo view` only when no origin remote is configured at all.
+# `gh repo view` whenever the parse fails (no origin remote, unparseable
+# URL, charset-rejected) — its stderr is captured so a two-sided failure
+# can be attributed on both sides.
 REPO_OWNER=""
 REPO_NAME=""
-_git_or_line=$(bash "$SCRIPT_DIR/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+git_remote_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-git-remote-err-XXXXXX") || git_remote_err=""
+_git_or_line=$(bash "$SCRIPT_DIR/lib/git-remote.sh" resolve-owner-repo 2>"${git_remote_err:-/dev/null}") || _git_or_line=""
 if [ -n "$_git_or_line" ]; then
   IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
 fi
@@ -167,6 +171,9 @@ if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
     echo "ERROR: gh repo view failed" >&2
     if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
       head -5 "$repo_view_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+    fi
+    if [ -n "$git_remote_err" ] && [ -s "$git_remote_err" ]; then
+      head -3 "$git_remote_err" | neutralize_ctrl --keep-newline | sed 's/^/  git-remote: /' >&2
     fi
     echo "  対処: gh auth status / network 接続を確認してください" >&2
     exit 2

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -152,20 +152,31 @@ trap '_rite_board_drift_cleanup; exit 143' TERM
 trap '_rite_board_drift_cleanup; exit 129' HUP
 
 # --- Repo info ---
-repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-repo-err-XXXXXX") || repo_view_err=""
-if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
-  echo "ERROR: gh repo view failed" >&2
-  if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
-    head -5 "$repo_view_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
-  fi
-  echo "  対処: gh auth status / network 接続を確認してください" >&2
-  exit 2
+# git-remote parse first: works even when `origin` is an SSH Host alias
+# unrecognized by gh's host allowlist (#1899). Falls through to
+# `gh repo view` only when no origin remote is configured at all.
+REPO_OWNER=""
+REPO_NAME=""
+_git_or_line=$(bash "$SCRIPT_DIR/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+if [ -n "$_git_or_line" ]; then
+  IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
 fi
-REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>/dev/null) || REPO_OWNER=""
-REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>/dev/null) || REPO_NAME=""
 if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
-  echo "ERROR: failed to parse owner/name from gh repo view (owner='$REPO_OWNER' name='$REPO_NAME')" >&2
-  exit 2
+  repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-repo-err-XXXXXX") || repo_view_err=""
+  if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
+    echo "ERROR: gh repo view failed" >&2
+    if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
+      head -5 "$repo_view_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+    fi
+    echo "  対処: gh auth status / network 接続を確認してください" >&2
+    exit 2
+  fi
+  REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>/dev/null) || REPO_OWNER=""
+  REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>/dev/null) || REPO_NAME=""
+  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
+    echo "ERROR: failed to parse owner/name from gh repo view (owner='$REPO_OWNER' name='$REPO_NAME')" >&2
+    exit 2
+  fi
 fi
 
 # --- Scan recently-updated CLOSED Issues (single GraphQL page) ---

--- a/plugins/rite/hooks/tests/git-remote-resolve.test.sh
+++ b/plugins/rite/hooks/tests/git-remote-resolve.test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Tests for resolve_owner_repo() in hooks/scripts/lib/git-remote.sh (#1899)
+#
+# `gh repo view` (used without --repo by issue-comment-wm-sync.sh,
+# projects-board-drift-check.sh, watchdog-status-mismatch.sh, post-compact.sh)
+# fails when `origin` is an SSH Host alias unrecognized by gh's host allowlist
+# (e.g. `git@github.com-work:owner/repo.git`, configured in ~/.ssh/config).
+# resolve_owner_repo() sidesteps that entirely by parsing the remote URL
+# directly — the host segment is discarded regardless of what it says, so an
+# unrecognized alias can never break this path. This test exercises the URL
+# formats the parser must handle plus its two failure modes (no origin
+# remote / not a git repository at all), since callers rely on a clean
+# non-zero exit to know when to fall back to `gh repo view`.
+#
+# Convention: standalone subcommand (`bash lib/git-remote.sh resolve-owner-repo`),
+# not sourced — mirrors ensure-session-worktree.test.sh's invocation style for
+# the sibling lib/worktree-git.sh standalone subcommand.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+LIB="$SCRIPT_DIR/../scripts/lib/git-remote.sh"
+
+echo "=== resolve_owner_repo() (lib/git-remote.sh resolve-owner-repo) ==="
+
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: $LIB not found" >&2
+  exit 1
+fi
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+resolve_in() {
+  local dir="$1"
+  ( cd "$dir" && bash "$LIB" resolve-owner-repo )
+}
+
+# --- Accept: URL formats resolve_owner_repo must parse (owner/repo regardless
+#     of host string — this is the whole point: the alias case must parse
+#     identically to the canonical github.com case) --------------------------
+declare -A urls=(
+  ["scp-like SSH Host alias (the #1899 repro case)"]="git@github.com-work:asakaguchi/cc-rite-workflow.git"
+  ["scp-like SSH canonical host"]="git@github.com:asakaguchi/cc-rite-workflow.git"
+  ["https with .git suffix"]="https://github.com/asakaguchi/cc-rite-workflow.git"
+  ["https without .git suffix"]="https://github.com/asakaguchi/cc-rite-workflow"
+  ["ssh:// with explicit user"]="ssh://git@github.com/asakaguchi/cc-rite-workflow.git"
+  ["ssh:// with explicit port"]="ssh://git@github.com:22/asakaguchi/cc-rite-workflow.git"
+  ["https on a GitHub Enterprise host"]="https://github.mycompany.com/org/repo.git"
+)
+
+sbx=$(make_sandbox) && cleanup_dirs+=("$sbx") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+
+for label in "${!urls[@]}"; do
+  url="${urls[$label]}"
+  ( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "$url" ) >/dev/null 2>&1
+  out=$(resolve_in "$sbx") ; rc=$?
+  assert "$label: exit 0" "0" "$rc"
+  assert "$label: parses to asakaguchi/cc-rite-workflow or org/repo" "1" \
+    "$(printf '%s' "$out" | awk -F'\t' 'NF==2 && $1!="" && $2!="" {print 1; exit} {print 0}')"
+done
+
+# Spot-check one exact value end-to-end (owner and repo both correct, not just non-empty).
+( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "git@github.com-work:asakaguchi/cc-rite-workflow.git" ) >/dev/null 2>&1
+out=$(resolve_in "$sbx")
+assert "alias case: exact owner<TAB>repo value" "$(printf 'asakaguchi\tcc-rite-workflow')" "$out"
+
+# --- Reject: git repo with no origin remote configured ----------------------
+sbx_noremote=$(make_sandbox) && cleanup_dirs+=("$sbx_noremote") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_noremote" && git remote remove origin >/dev/null 2>&1 ) >/dev/null 2>&1
+out=$(resolve_in "$sbx_noremote" 2>/dev/null); rc=$?
+assert "no origin remote: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "no origin remote: empty stdout" "" "$out"
+
+# --- Reject: not a git repository at all (mirrors the bare `mkdir .git`
+#     fixture pattern used by post-compact.test.sh's _setup_recon_env — the
+#     4-site fallback design depends on this failing cleanly so it falls
+#     through to the existing gh repo view path in those test fixtures) -----
+fake_dir=$(make_plain_sandbox) && cleanup_dirs+=("$fake_dir") || { echo "ERROR: make_plain_sandbox failed, aborting" >&2; exit 1; }
+mkdir -p "$fake_dir/.git"
+out=$(resolve_in "$fake_dir" 2>/dev/null); rc=$?
+assert "bare mkdir .git (non-repo): non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "bare mkdir .git (non-repo): empty stdout" "" "$out"
+
+# --- Unknown subcommand: exit 2, not silently ignored -----------------------
+out=$(bash "$LIB" bogus-subcommand 2>&1); rc=$?
+assert "unknown subcommand: exit 2" "2" "$rc"
+
+print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/git-remote-resolve.test.sh
+++ b/plugins/rite/hooks/tests/git-remote-resolve.test.sh
@@ -105,6 +105,23 @@ out=$(resolve_in "$sbx" 2>/dev/null); rc=$?
 assert "empty repo segment: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
 assert "empty repo segment: empty stdout" "" "$out"
 
+# --- Reject: 3+ segment origin path leaks an embedded `/` into $repo --------
+# This is the charset check's whole reason for existing (git-remote.sh:58-63):
+# callers pass the result straight into `gh ... --repo`, which re-parses
+# `[HOST/]OWNER/REPO` — an unrejected extra segment here would let `gh`
+# treat "a" as a HOST instead of the owner, silently redirecting the call to
+# a different GitHub instance.
+( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "git@github.com-work:a/b/c.git" ) >/dev/null 2>&1
+out=$(resolve_in "$sbx" 2>/dev/null); rc=$?
+assert "3+ segment origin (embedded / in repo): non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "3+ segment origin (embedded / in repo): empty stdout" "" "$out"
+
+# --- Reject: disallowed character (outside [A-Za-z0-9._-]) in owner/repo ----
+( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "https://github.com/ow;ner/repo.git" ) >/dev/null 2>&1
+out=$(resolve_in "$sbx" 2>/dev/null); rc=$?
+assert "disallowed char in owner segment: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "disallowed char in owner segment: empty stdout" "" "$out"
+
 # --- Reject: not a git repository at all (mirrors the bare `mkdir .git`
 #     fixture pattern used by post-compact.test.sh's _setup_recon_env — the
 #     4-site fallback design depends on this failing cleanly so it falls

--- a/plugins/rite/hooks/tests/git-remote-resolve.test.sh
+++ b/plugins/rite/hooks/tests/git-remote-resolve.test.sh
@@ -47,7 +47,11 @@ resolve_in() {
 
 # --- Accept: URL formats resolve_owner_repo must parse (owner/repo regardless
 #     of host string — this is the whole point: the alias case must parse
-#     identically to the canonical github.com case) --------------------------
+#     identically to the canonical github.com case). Each case asserts the
+#     exact "owner<TAB>repo" value, not just "2 non-empty fields" — a parser
+#     regression that leaks the host/port into the owner field (e.g. the
+#     protocol-style branch stripping `:port` instead of the host) would
+#     still produce 2 non-empty fields and slip past a structural-only check.
 declare -A urls=(
   ["scp-like SSH Host alias (the #1899 repro case)"]="git@github.com-work:asakaguchi/cc-rite-workflow.git"
   ["scp-like SSH canonical host"]="git@github.com:asakaguchi/cc-rite-workflow.git"
@@ -57,6 +61,15 @@ declare -A urls=(
   ["ssh:// with explicit port"]="ssh://git@github.com:22/asakaguchi/cc-rite-workflow.git"
   ["https on a GitHub Enterprise host"]="https://github.mycompany.com/org/repo.git"
 )
+declare -A expected=(
+  ["scp-like SSH Host alias (the #1899 repro case)"]="asakaguchi/cc-rite-workflow"
+  ["scp-like SSH canonical host"]="asakaguchi/cc-rite-workflow"
+  ["https with .git suffix"]="asakaguchi/cc-rite-workflow"
+  ["https without .git suffix"]="asakaguchi/cc-rite-workflow"
+  ["ssh:// with explicit user"]="asakaguchi/cc-rite-workflow"
+  ["ssh:// with explicit port"]="asakaguchi/cc-rite-workflow"
+  ["https on a GitHub Enterprise host"]="org/repo"
+)
 
 sbx=$(make_sandbox) && cleanup_dirs+=("$sbx") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
 
@@ -65,8 +78,8 @@ for label in "${!urls[@]}"; do
   ( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "$url" ) >/dev/null 2>&1
   out=$(resolve_in "$sbx") ; rc=$?
   assert "$label: exit 0" "0" "$rc"
-  assert "$label: parses to asakaguchi/cc-rite-workflow or org/repo" "1" \
-    "$(printf '%s' "$out" | awk -F'\t' 'NF==2 && $1!="" && $2!="" {print 1; exit} {print 0}')"
+  owner_repo=$(printf '%s' "$out" | awk -F'\t' 'NF==2 {print $1 "/" $2; exit}')
+  assert "$label: parses to exact ${expected[$label]}" "${expected[$label]}" "$owner_repo"
 done
 
 # Spot-check one exact value end-to-end (owner and repo both correct, not just non-empty).

--- a/plugins/rite/hooks/tests/git-remote-resolve.test.sh
+++ b/plugins/rite/hooks/tests/git-remote-resolve.test.sh
@@ -94,6 +94,17 @@ out=$(resolve_in "$sbx_noremote" 2>/dev/null); rc=$?
 assert "no origin remote: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
 assert "no origin remote: empty stdout" "" "$out"
 
+# --- Reject: owner or repo segment parses to empty (degenerate URL) ---------
+( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "git@github.com-work:/onlyrepo.git" ) >/dev/null 2>&1
+out=$(resolve_in "$sbx" 2>/dev/null); rc=$?
+assert "empty owner segment: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "empty owner segment: empty stdout" "" "$out"
+
+( cd "$sbx" && git remote remove origin >/dev/null 2>&1; git remote add origin "https://github.com/onlyowner/" ) >/dev/null 2>&1
+out=$(resolve_in "$sbx" 2>/dev/null); rc=$?
+assert "empty repo segment: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "empty repo segment: empty stdout" "" "$out"
+
 # --- Reject: not a git repository at all (mirrors the bare `mkdir .git`
 #     fixture pattern used by post-compact.test.sh's _setup_recon_env — the
 #     4-site fallback design depends on this failing cleanly so it falls

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -268,6 +268,17 @@ echo "TC-008: get_owner_repo() fast path resolves via SSH Host alias origin, byp
 dir008="$TEST_DIR/tc008"
 mkdir -p "$dir008/bin"
 ( cd "$dir008" && git init -q && git remote add origin "git@github.com-work:o8/r8.git" )
+# Decoy repo with a DIFFERENT origin, used as the process cwd below. The
+# invocation deliberately runs with cwd != STATE_ROOT so the exact-value
+# assertion also guards the `cd "$STATE_ROOT"` anchor (the cycle-2 CRITICAL
+# invariant): if the anchor is dropped, the fast path resolves the ambient
+# cwd's repo (decoy/wrong) instead of STATE_ROOT's (o8/r8) and this fails.
+# Running from inside STATE_ROOT would make the anchor a no-op and let an
+# anchor regression pass silently (post-compact's TC-RECON-09 discriminates
+# the same invariant for its sibling site).
+dir008_decoy="$TEST_DIR/tc008-decoy"
+mkdir -p "$dir008_decoy"
+( cd "$dir008_decoy" && git init -q && git remote add origin "git@github.com-work:decoy/wrong.git" )
 cat > "$dir008/bin/gh" <<'GH_SHIM'
 #!/bin/bash
 case "$1 $2" in
@@ -276,7 +287,7 @@ esac
 exit 0
 GH_SHIM
 chmod +x "$dir008/bin/gh"
-out008=$(cd "$dir008" && PATH="$dir008/bin:$PATH" bash -c "
+out008=$(cd "$dir008_decoy" && PATH="$dir008/bin:$PATH" bash -c "
   SCRIPT_DIR='$SCRIPT_DIR/..'
   STATE_ROOT='$dir008'
   source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
@@ -284,7 +295,7 @@ out008=$(cd "$dir008" && PATH="$dir008/bin:$PATH" bash -c "
   get_owner_repo
 ")
 if [ "$out008" = "o8/r8" ]; then
-  pass "TC-008: fast path resolved o8/r8 from alias origin, bypassing broken gh repo view"
+  pass "TC-008: fast path resolved o8/r8 from STATE_ROOT's alias origin (not the ambient cwd's decoy/wrong)"
 else
   fail "TC-008: expected 'o8/r8', got '$out008'"
 fi

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -175,7 +175,10 @@ dir006="$TEST_DIR/tc006"
 mkdir -p "$dir006/bin"
 echo '{"active":true,"issue_number":42}' > "$dir006/.rite-flow-state"
 GH_SHIM_MARKER6="$dir006/posted.marker"
-# pre-check は空を返し、投稿後の validation は id を返す (marker 存在で切替)
+# pre-check は空を返し、投稿後の validation は id を返す (marker 存在で切替)。
+# "issue comment" は --repo の厳密一致を要求する (#1899 の実修正そのもの):
+# --repo が退行して shorthand に戻ると SSH Host alias origin で再び失敗するが、
+# サブコマンド名だけ見る shim ではその退行を検知できない (mutation で実証済み)。
 cat > "$dir006/bin/gh" <<'GH_SHIM'
 #!/bin/bash
 case "$1 $2" in
@@ -183,7 +186,12 @@ case "$1 $2" in
   "api repos/testowner/testrepo/issues/42/comments")
     if [ -f "$GH_SHIM_MARKER" ]; then echo "222"; fi
     exit 0 ;;
-  "issue comment") touch "$GH_SHIM_MARKER"; echo "https://github.com/testowner/testrepo/issues/42#issuecomment-2"; exit 0 ;;
+  "issue comment")
+    if ! printf '%s\n' "$*" | grep -qE -- '--repo testowner/testrepo( |$)'; then
+      echo "MOCK ASSERTION FAILED: expected --repo testowner/testrepo, got: $*" >&2
+      exit 1
+    fi
+    touch "$GH_SHIM_MARKER"; echo "https://github.com/testowner/testrepo/issues/42#issuecomment-2"; exit 0 ;;
 esac
 exit 0
 GH_SHIM
@@ -206,7 +214,8 @@ dir007="$TEST_DIR/tc007"
 mkdir -p "$dir007/bin"
 echo '{"active":true,"issue_number":42}' > "$dir007/.rite-flow-state"
 GH_SHIM_MARKER7="$dir007/posted.marker"
-# pre-check (marker 不在) は gh api 失敗 (exit 1 + stderr)、投稿後の validation (marker 存在) は id を返す
+# pre-check (marker 不在) は gh api 失敗 (exit 1 + stderr)、投稿後の validation (marker 存在) は id を返す。
+# "issue comment" の --repo 厳密一致は TC-006 shim と同じ理由 (#1899 退行検知)。
 cat > "$dir007/bin/gh" <<'GH_SHIM'
 #!/bin/bash
 case "$1 $2" in
@@ -214,7 +223,12 @@ case "$1 $2" in
   "api repos/testowner/testrepo/issues/42/comments")
     if [ -f "$GH_SHIM_MARKER" ]; then echo "333"; exit 0; fi
     echo "HTTP 500: Internal Server Error" >&2; exit 1 ;;
-  "issue comment") touch "$GH_SHIM_MARKER"; echo "https://github.com/testowner/testrepo/issues/42#issuecomment-3"; exit 0 ;;
+  "issue comment")
+    if ! printf '%s\n' "$*" | grep -qE -- '--repo testowner/testrepo( |$)'; then
+      echo "MOCK ASSERTION FAILED: expected --repo testowner/testrepo, got: $*" >&2
+      exit 1
+    fi
+    touch "$GH_SHIM_MARKER"; echo "https://github.com/testowner/testrepo/issues/42#issuecomment-3"; exit 0 ;;
 esac
 exit 0
 GH_SHIM

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -39,6 +39,10 @@ extract_resolver_block() {
   awk '/^# Resolve repository root for/,/^FLOW_STATE=/' "$HOOK"
 }
 
+extract_get_owner_repo() {
+  awk '/^get_owner_repo\(\) \{/,/^\}$/' "$HOOK"
+}
+
 echo "=== issue-comment-wm-sync.sh tests ==="
 echo ""
 
@@ -233,6 +237,92 @@ if printf '%s' "$out007" | grep -qF "status=success" && [ -f "$GH_SHIM_MARKER7" 
   pass "TC-007: posting continued despite pre-check failure → status=success"
 else
   fail "TC-007: expected post-through + status=success. out: $out007 marker=$([ -f "$GH_SHIM_MARKER7" ] && echo present || echo absent)"
+fi
+echo ""
+
+# ─── TC-008/009/010: get_owner_repo() (#1899) ────────────────────────────
+# get_owner_repo() had zero caller-level or function-level coverage before
+# this PR despite being the exact function cycle 2's review independently
+# found a CRITICAL cwd-anchoring bug in. These 3 cases exercise the fast
+# path's success case, its fall-through to the gh repo view fallback, and
+# the both-fail WARNING path (a regression guard for the empty-stderr
+# WARNING-header suppression bug fixed in this same PR: a `gh repo view`
+# failure with empty stderr used to suppress the WARNING header itself).
+func_get_owner_repo=$(extract_get_owner_repo)
+
+echo "TC-008: get_owner_repo() fast path resolves via SSH Host alias origin, bypassing broken gh repo view"
+dir008="$TEST_DIR/tc008"
+mkdir -p "$dir008/bin"
+( cd "$dir008" && git init -q && git remote add origin "git@github.com-work:o8/r8.git" )
+cat > "$dir008/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view") echo "should not be called — git-remote should resolve first" >&2; exit 1 ;;
+esac
+exit 0
+GH_SHIM
+chmod +x "$dir008/bin/gh"
+out008=$(cd "$dir008" && PATH="$dir008/bin:$PATH" bash -c "
+  SCRIPT_DIR='$SCRIPT_DIR/..'
+  STATE_ROOT='$dir008'
+  source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
+  $func_get_owner_repo
+  get_owner_repo
+")
+if [ "$out008" = "o8/r8" ]; then
+  pass "TC-008: fast path resolved o8/r8 from alias origin, bypassing broken gh repo view"
+else
+  fail "TC-008: expected 'o8/r8', got '$out008'"
+fi
+echo ""
+
+echo "TC-009: get_owner_repo() falls back to gh repo view when git-remote can't resolve"
+dir009="$TEST_DIR/tc009"
+mkdir -p "$dir009/bin" "$dir009/.git"
+cat > "$dir009/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view") echo "o9/r9"; exit 0 ;;
+esac
+exit 0
+GH_SHIM
+chmod +x "$dir009/bin/gh"
+out009=$(cd "$dir009" && PATH="$dir009/bin:$PATH" bash -c "
+  SCRIPT_DIR='$SCRIPT_DIR/..'
+  STATE_ROOT='$dir009'
+  source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
+  $func_get_owner_repo
+  get_owner_repo
+")
+if [ "$out009" = "o9/r9" ]; then
+  pass "TC-009: fast path failure falls through to gh repo view fallback (o9/r9)"
+else
+  fail "TC-009: expected 'o9/r9', got '$out009'"
+fi
+echo ""
+
+echo "TC-010: get_owner_repo() both fast path and fallback fail → WARNING header always emitted"
+dir010="$TEST_DIR/tc010"
+mkdir -p "$dir010/bin" "$dir010/.git"
+cat > "$dir010/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view") exit 1 ;;
+esac
+exit 1
+GH_SHIM
+chmod +x "$dir010/bin/gh"
+stderr010=$(cd "$dir010" && PATH="$dir010/bin:$PATH" bash -c "
+  SCRIPT_DIR='$SCRIPT_DIR/..'
+  STATE_ROOT='$dir010'
+  source \"\$SCRIPT_DIR/control-char-neutralize.sh\"
+  $func_get_owner_repo
+  get_owner_repo
+" 2>&1 >/dev/null)
+if printf '%s' "$stderr010" | grep -qE 'WARNING: issue-comment-wm-sync: gh repo view failed'; then
+  pass "TC-010: WARNING header emitted even when gh repo view fails with empty stderr"
+else
+  fail "TC-010: WARNING header missing when gh repo view fails silently. stderr: $stderr010"
 fi
 echo ""
 

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -292,7 +292,7 @@ _setup_recon_env() {
   mkdir -p "$dir/bin"
   if [ -n "$git_remote_url" ]; then
     # Real git repo (not the `mkdir -p .git` non-repo stub below) so
-    # resolve_owner_repo() can actually parse `origin` — used by TC-RECON-08
+    # resolve_owner_repo() can actually parse `origin` — used by TC-RECON-09
     # to exercise the git-remote fast path's *success* case at the caller
     # level, instead of always falling through to the gh repo view mock.
     ( cd "$dir" && git init -q && git remote add origin "$git_remote_url" )
@@ -358,12 +358,30 @@ EOF
       # `repo view` is deliberately broken — if git-remote resolution didn't
       # actually run (or silently fell through to this fallback), the
       # reconciliation block would surface post_compact_gh_repo_view_failed.
+      # `pr view` / `api graphql` additionally assert the *correct* resolved
+      # value (o/r, from the host-alias origin below) is what's actually
+      # passed through — without this, a regression that drops the
+      # `cd "$STATE_ROOT"` anchor (this dogfood repo's own ambient origin
+      # happens to also resolve successfully, just to the wrong repo) would
+      # silently pass this fixture. See MOCK ASSERTION FAILED handling below.
       cat > "$dir/bin/gh" <<'EOF'
 #!/bin/bash
 case "$1 $2" in
-  "pr view") echo "false" ;;
+  "pr view")
+    if ! printf '%s\n' "$*" | grep -q -- '--repo o/r'; then
+      echo "MOCK ASSERTION FAILED: expected --repo o/r, got: $*" >&2
+      exit 1
+    fi
+    echo "false"
+    ;;
   "repo view") echo "auth required (should not be called — git-remote should resolve first)" >&2; exit 1 ;;
-  "api graphql") echo '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"project":{"number":1},"fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"In Review"}]}}]}}}}}' ;;
+  "api graphql")
+    if ! { printf '%s\n' "$*" | grep -q -- '-f owner=o' && printf '%s\n' "$*" | grep -q -- '-f repo=r'; }; then
+      echo "MOCK ASSERTION FAILED: expected -f owner=o -f repo=r, got: $*" >&2
+      exit 1
+    fi
+    echo '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"project":{"number":1},"fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"In Review"}]}}]}}}}}'
+    ;;
   *) exit 0 ;;
 esac
 EOF
@@ -519,6 +537,11 @@ if grep -qE 'post_compact_gh_repo_view_failed' "$recon_stderr"; then
   fail "git-remote fast path did not bypass the broken gh repo view fallback: $(head -c 500 "$recon_stderr" | tr '\n' ' ')"
 else
   pass "git-remote fast path bypasses broken gh repo view (real #1899 scenario, caller-level)"
+fi
+if grep -qE 'MOCK ASSERTION FAILED' "$recon_stderr"; then
+  fail "git-remote fast path resolved the WRONG repo (not o/r from the alias origin): $(head -c 500 "$recon_stderr" | tr '\n' ' ')"
+else
+  pass "git-remote fast path resolved the exact owner/repo from the alias origin (o/r), not just any repo"
 fi
 
 # TC-CONFIG-PARSE: post-compact.sh が rite-config.yml の awk parse 失敗を silent skip ではなく

--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -287,9 +287,18 @@ echo ""
 # ──────────────────────────────────────────────────────────────────────────
 
 _setup_recon_env() {
-  local label="$1" gh_behavior="$2" reconcile_result="${3:-updated}"
+  local label="$1" gh_behavior="$2" reconcile_result="${3:-updated}" git_remote_url="${4:-}"
   local dir="$TEST_DIR/recon-$label"
-  mkdir -p "$dir/.git" "$dir/bin"
+  mkdir -p "$dir/bin"
+  if [ -n "$git_remote_url" ]; then
+    # Real git repo (not the `mkdir -p .git` non-repo stub below) so
+    # resolve_owner_repo() can actually parse `origin` — used by TC-RECON-08
+    # to exercise the git-remote fast path's *success* case at the caller
+    # level, instead of always falling through to the gh repo view mock.
+    ( cd "$dir" && git init -q && git remote add origin "$git_remote_url" )
+  else
+    mkdir -p "$dir/.git"
+  fi
   # flow-state with pr_number=42 → reconciliation block enters
   write_per_session_state "$dir" \
     '{"active": true, "issue_number": 42, "phase": "ready", "next_action": "Ready", "loop_count": 0, "pr_number": 42, "branch": "feat/issue-42-recon"}'
@@ -340,6 +349,20 @@ EOF
 case "$1 $2" in
   "pr view") echo "false" ;;
   "repo view") echo '{"owner":{"login":"o"},"name":"r"}' ;;
+  "api graphql") echo '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"project":{"number":1},"fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"In Review"}]}}]}}}}}' ;;
+  *) exit 0 ;;
+esac
+EOF
+      ;;
+    git_remote_bypass)
+      # `repo view` is deliberately broken — if git-remote resolution didn't
+      # actually run (or silently fell through to this fallback), the
+      # reconciliation block would surface post_compact_gh_repo_view_failed.
+      cat > "$dir/bin/gh" <<'EOF'
+#!/bin/bash
+case "$1 $2" in
+  "pr view") echo "false" ;;
+  "repo view") echo "auth required (should not be called — git-remote should resolve first)" >&2; exit 1 ;;
   "api graphql") echo '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"project":{"number":1},"fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"In Review"}]}}]}}}}}' ;;
   *) exit 0 ;;
 esac
@@ -480,6 +503,22 @@ if grep -qE 'post_compact_gh_repo_view_failed' "$recon_stderr"; then
   pass "TC-RECON-07 WARNING is attributed via post_compact_gh_repo_view_failed token"
 else
   fail "TC-RECON-07 WARNING emitted but not attributed via post_compact_gh_repo_view_failed token: $(head -c 500 "$recon_stderr")"
+fi
+
+# TC-RECON-09: SSH Host alias origin → git-remote fast path bypasses a broken
+# gh repo view (the actual #1899 scenario). Every fixture above uses a fake
+# `mkdir -p .git` non-repo, so all of them fail to parse via git-remote and
+# fall through to (and exercise) the gh repo view fallback — none exercises
+# the git-remote fast path's *success* case at the caller level.
+echo "TC-RECON-09: SSH Host alias origin → git-remote fast path bypasses broken gh repo view"
+recon_dir=$(_setup_recon_env "git-remote-success" "git_remote_bypass" "updated" "git@github.com-work:o/r.git")
+recon_stderr="$(mktemp "$TEST_DIR/recon-git-remote-success-stderr.XXXXXX")"
+echo "{\"cwd\": \"$recon_dir\", \"source\": \"auto\"}" \
+  | env PATH="$recon_dir/bin:$PATH" bash "$HOOK" >/dev/null 2>"$recon_stderr" || true
+if grep -qE 'post_compact_gh_repo_view_failed' "$recon_stderr"; then
+  fail "git-remote fast path did not bypass the broken gh repo view fallback: $(head -c 500 "$recon_stderr" | tr '\n' ' ')"
+else
+  pass "git-remote fast path bypasses broken gh repo view (real #1899 scenario, caller-level)"
 fi
 
 # TC-CONFIG-PARSE: post-compact.sh が rite-config.yml の awk parse 失敗を silent skip ではなく

--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -244,6 +244,57 @@ fi
 assert_file_contains "$DRIFT_SH" 'projectItems\(first: [1-9]' "GraphQL projectItems page size is positive (guards first: 0 break)"
 
 echo ""
+echo "[T-8] Behavioral: git-remote fast path resolves SSH alias origin, owner/repo threaded into graphql (#1899)"
+# Real git repo + SSH Host alias origin + deliberately-broken `gh repo view` +
+# enabled:true config (bypassing the T-6 no-op gates so the repo-resolution
+# block is actually reached). The graphql shim requires the exact resolved
+# owner/repo — a regression to the gh repo view shorthand or a wrong-repo
+# resolution fails loudly instead of passing silently.
+T8_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-board-drift-t8-XXXXXX")
+# T-7 の trap を上書きするため、その cleanup 対象 ($tmpd) も引き継ぐ
+trap 'rm -rf "${tmpd:-}" "$T8_DIR"' EXIT
+mkdir -p "$T8_DIR/repo/bin"
+( cd "$T8_DIR/repo" && git init -q && git remote add origin "git@github.com-work:o/r.git" ) >/dev/null 2>&1
+cat > "$T8_DIR/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$T8_DIR/repo/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view")
+    echo "should not be called - git-remote fast path must resolve first" >&2
+    exit 1 ;;
+  "api graphql")
+    if ! { printf '%s\n' "$*" | grep -qE -- ' owner=o( |$)' && printf '%s\n' "$*" | grep -qE -- ' repo=r( |$)'; }; then
+      echo "MOCK ASSERTION FAILED: expected -f owner=o -f repo=r, got: $*" >&2
+      exit 1
+    fi
+    echo '{"data":{"repository":{"issues":{"nodes":[]}}}}' ;;
+  *) exit 0 ;;
+esac
+GH_SHIM
+chmod +x "$T8_DIR/repo/bin/gh"
+set +e
+t8_out=$(cd "$T8_DIR/repo" && PATH="$T8_DIR/repo/bin:$PATH" bash "$DRIFT_SH" --quiet 2>"$T8_DIR/stderr.txt")
+t8_rc=$?
+set -e
+if [ "$t8_rc" -eq 0 ] && printf '%s' "$t8_out" | grep -q 'Total projects-board-drift findings: 0'; then
+  PASS=$((PASS + 1)); echo "  ✓ run succeeds via git-remote fast path (exit 0, 0 findings)"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-8: expected exit 0 + 0-findings summary, got rc=$t8_rc; stderr: $(head -c 300 "$T8_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ run failed (exit $t8_rc)" >&2
+fi
+if grep -qE 'MOCK ASSERTION FAILED|gh repo view failed' "$T8_DIR/stderr.txt" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); FAILURES+=("T-8: wrong owner/repo value or fallback to gh repo view: $(head -c 300 "$T8_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ wrong owner/repo value or gh repo view fallback was hit" >&2
+else
+  PASS=$((PASS + 1)); echo "  ✓ exact owner=o repo=r threaded to graphql, gh repo view never consulted"
+fi
+
+echo ""
 echo "==============================="
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
@@ -120,6 +120,57 @@ assert_file_contains "$WATCHDOG_SH" 'In Progress' \
   "Script checks Status == 'In Progress'"
 
 echo ""
+echo "[T-9f] Behavioral: git-remote fast path resolves SSH alias origin, --repo threaded into gh pr list (#1899)"
+# Real git repo + SSH Host alias origin + deliberately-broken `gh repo view`:
+# the run only succeeds if the git-remote fast path resolved owner/repo AND
+# `gh pr list` received the exact resolved value via --repo. The shim fails
+# loudly (MOCK ASSERTION FAILED) on a wrong/missing --repo — so a regression
+# back to the shorthand (the #1899 bug) or to a wrong-repo resolution turns
+# into a hard test failure instead of passing silently.
+T9F_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-watchdog-t9f-XXXXXX")
+trap 'rm -rf "$T9F_DIR"' EXIT
+mkdir -p "$T9F_DIR/repo/bin"
+( cd "$T9F_DIR/repo" && git init -q && git remote add origin "git@github.com-work:o/r.git" ) >/dev/null 2>&1
+cat > "$T9F_DIR/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$T9F_DIR/repo/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "repo view")
+    echo "should not be called - git-remote fast path must resolve first" >&2
+    exit 1 ;;
+  "pr list")
+    if ! printf '%s\n' "$*" | grep -qE -- '--repo o/r( |$)'; then
+      echo "MOCK ASSERTION FAILED: expected --repo o/r, got: $*" >&2
+      exit 1
+    fi
+    echo "[]" ;;
+  *) exit 0 ;;
+esac
+GH_SHIM
+chmod +x "$T9F_DIR/repo/bin/gh"
+set +e
+t9f_out=$(cd "$T9F_DIR/repo" && PATH="$T9F_DIR/repo/bin:$PATH" bash "$WATCHDOG_SH" --dry-run --quiet 2>"$T9F_DIR/stderr.txt")
+t9f_rc=$?
+set -e
+if [ "$t9f_rc" -eq 0 ]; then
+  PASS=$((PASS + 1)); echo "  ✓ run succeeds via git-remote fast path (exit 0)"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-9f: expected exit 0, got $t9f_rc; stderr: $(head -c 300 "$T9F_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ run failed (exit $t9f_rc)" >&2
+fi
+if grep -qE 'MOCK ASSERTION FAILED|gh repo view failed' "$T9F_DIR/stderr.txt" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); FAILURES+=("T-9f: wrong --repo value or fallback to gh repo view: $(head -c 300 "$T9F_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ wrong --repo value or gh repo view fallback was hit" >&2
+else
+  PASS=$((PASS + 1)); echo "  ✓ exact --repo o/r threaded to gh pr list, gh repo view never consulted"
+fi
+
+echo ""
 echo "==============================="
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -130,31 +130,41 @@ trap '_rite_watchdog_cleanup; exit 143' TERM
 trap '_rite_watchdog_cleanup; exit 129' HUP
 
 # --- Repo info ---
-# gh repo view stderr is captured into a dedicated tempfile (repo_view_err) so
-# the discrimination matches the 2-site contract declared above.
-repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-repo-err-XXXXXX") || repo_view_err=""
-if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
-  echo "ERROR: gh repo view failed" >&2
-  if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
-    head -5 "$repo_view_err" | sed 's/^/  /' >&2
-  fi
-  echo "  対処: gh auth status / network 接続を確認してください" >&2
-  exit 1
+# git-remote parse first: works even when `origin` is an SSH Host alias
+# unrecognized by gh's host allowlist (#1899). Falls through to
+# `gh repo view` (stderr captured to repo_view_err per the 2-site contract
+# declared above) only when no origin remote is configured at all.
+REPO_OWNER=""
+REPO_NAME=""
+_git_or_line=$(bash "$PLUGIN_ROOT/hooks/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+if [ -n "$_git_or_line" ]; then
+  IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
 fi
-# cycle 8 C7-F02 対応: jq の `// empty` fallback + 明示 fail で `set -euo pipefail` 下の silent abort を防ぐ。
-# `// empty` を付けない素朴な `jq -r '.owner.login'` は auth-scope 縮退時に `null` 文字列を代入するか
-# jq exit 5 で診断情報を破棄する。空文字列で fail-fast し、stderr に root cause を出力する。
-REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>/dev/null) || REPO_OWNER=""
-REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>/dev/null) || REPO_NAME=""
 if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
-  echo "ERROR: failed to parse owner/name from gh repo view (owner='$REPO_OWNER' name='$REPO_NAME')" >&2
-  echo "  対処: gh auth refresh で scope を更新するか、PAT の repo permission を確認してください" >&2
-  exit 1
+  repo_view_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-repo-err-XXXXXX") || repo_view_err=""
+  if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
+    echo "ERROR: gh repo view failed" >&2
+    if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
+      head -5 "$repo_view_err" | sed 's/^/  /' >&2
+    fi
+    echo "  対処: gh auth status / network 接続を確認してください" >&2
+    exit 1
+  fi
+  # cycle 8 C7-F02 対応: jq の `// empty` fallback + 明示 fail で `set -euo pipefail` 下の silent abort を防ぐ。
+  # `// empty` を付けない素朴な `jq -r '.owner.login'` は auth-scope 縮退時に `null` 文字列を代入するか
+  # jq exit 5 で診断情報を破棄する。空文字列で fail-fast し、stderr に root cause を出力する。
+  REPO_OWNER=$(printf '%s' "$REPO_INFO" | jq -r '.owner.login // empty' 2>/dev/null) || REPO_OWNER=""
+  REPO_NAME=$(printf '%s' "$REPO_INFO" | jq -r '.name // empty' 2>/dev/null) || REPO_NAME=""
+  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
+    echo "ERROR: failed to parse owner/name from gh repo view (owner='$REPO_OWNER' name='$REPO_NAME')" >&2
+    echo "  対処: gh auth refresh で scope を更新するか、PAT の repo permission を確認してください" >&2
+    exit 1
+  fi
 fi
 
 # --- Scan OPEN, non-draft PRs ---
 pr_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-pr-list-err-XXXXXX") || pr_list_err=""
-if ! PR_LIST=$(gh pr list --state open --limit "$LIMIT" --json number,isDraft,body,headRefName 2>"${pr_list_err:-/dev/null}"); then
+if ! PR_LIST=$(gh pr list --repo "$REPO_OWNER/$REPO_NAME" --state open --limit "$LIMIT" --json number,isDraft,body,headRefName 2>"${pr_list_err:-/dev/null}"); then
   echo "ERROR: gh pr list failed" >&2
   if [ -n "$pr_list_err" ] && [ -s "$pr_list_err" ]; then
     head -5 "$pr_list_err" | sed 's/^/  /' >&2

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -117,12 +117,13 @@ fi
 # gh repo view と gh pr list は別 tempfile (repo_view_err / pr_list_err) に分けて capture し、
 # 前者の non-fatal warning が後者の redirect で truncate されないようにする。
 repo_view_err=""
+git_remote_err=""
 pr_list_err=""
 gql_err=""
 jq_err=""
 reconcile_err=""
 _rite_watchdog_cleanup() {
-  rm -f "${repo_view_err:-}" "${pr_list_err:-}" "${gql_err:-}" "${jq_err:-}" "${reconcile_err:-}"
+  rm -f "${repo_view_err:-}" "${git_remote_err:-}" "${pr_list_err:-}" "${gql_err:-}" "${jq_err:-}" "${reconcile_err:-}"
 }
 trap 'rc=$?; _rite_watchdog_cleanup; exit $rc' EXIT
 trap '_rite_watchdog_cleanup; exit 130' INT
@@ -133,10 +134,13 @@ trap '_rite_watchdog_cleanup; exit 129' HUP
 # git-remote parse first: works even when `origin` is an SSH Host alias
 # unrecognized by gh's host allowlist (#1899). Falls through to
 # `gh repo view` (stderr captured to repo_view_err per the 2-site contract
-# declared above) only when no origin remote is configured at all.
+# declared above) whenever the parse fails (no origin remote, unparseable
+# URL, charset-rejected) — its stderr is captured so a two-sided failure
+# can be attributed on both sides.
 REPO_OWNER=""
 REPO_NAME=""
-_git_or_line=$(bash "$PLUGIN_ROOT/hooks/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+git_remote_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-git-remote-err-XXXXXX") || git_remote_err=""
+_git_or_line=$(bash "$PLUGIN_ROOT/hooks/scripts/lib/git-remote.sh" resolve-owner-repo 2>"${git_remote_err:-/dev/null}") || _git_or_line=""
 if [ -n "$_git_or_line" ]; then
   IFS=$'\t' read -r REPO_OWNER REPO_NAME <<< "$_git_or_line"
 fi
@@ -146,6 +150,9 @@ if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
     echo "ERROR: gh repo view failed" >&2
     if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
       head -5 "$repo_view_err" | sed 's/^/  /' >&2
+    fi
+    if [ -n "$git_remote_err" ] && [ -s "$git_remote_err" ]; then
+      head -3 "$git_remote_err" | sed 's/^/  git-remote: /' >&2
     fi
     echo "  対処: gh auth status / network 接続を確認してください" >&2
     exit 1


### PR DESCRIPTION
## Summary

`origin` remote が `~/.ssh/config` の Host alias 経由（例: `git@github.com-work:owner/repo.git`）の環境で、`gh repo view`（`--repo` 未指定）がホストを解決できず `none of the git remotes configured for this repository point to a known GitHub host` で失敗するバグを修正する。

owner/repo を `gh repo view` に頼らず git remote の URL から直接パースする `resolve_owner_repo()`（`hooks/scripts/lib/git-remote.sh`）を追加し、host 文字列に一切依存しない解決を第一経路にした。`gh repo view` は origin remote 自体が未設定のときのみのフォールバックとして残し、既存の auth/network 失敗の診断パスは維持している。

Closes #1899

## Changes

- `plugins/rite/hooks/scripts/lib/git-remote.sh`（新規）: `resolve_owner_repo()` — git remote URL（scp-like / https:// / ssh://、ポート付きも含む）から owner/repo をパースするスタンドアロン subcommand。`worktree-git.sh` の `ensure-session-worktree` と同じ standalone dispatch パターン。
- `plugins/rite/hooks/issue-comment-wm-sync.sh`: `get_owner_repo()` で git-remote 解決を優先。`gh issue comment` にも `--repo` を明示（shorthand コマンドが内部で同じ host 解決を行うため）。
- `plugins/rite/hooks/scripts/projects-board-drift-check.sh`: repo info 取得で git-remote 解決を優先、失敗時のみ `gh repo view` にフォールバック。
- `plugins/rite/scripts/watchdog-status-mismatch.sh`: 同上。`gh pr list` にも `--repo` を明示。
- `plugins/rite/hooks/post-compact.sh`: 同上（`watchdog-status-mismatch.sh` との 2-site エラー捕捉契約を維持）。
- `plugins/rite/hooks/tests/git-remote-resolve.test.sh`（新規）: `resolve_owner_repo()` の URL 形式カバレッジ（SSH alias / 標準 SSH / https / ポート付き ssh:// 等）と 2 つの失敗モード（origin 未設定 / git リポジトリでない）。

## Verification

- 新規テスト `git-remote-resolve.test.sh`: 20/20 pass
- 既存テスト（`issue-comment-wm-sync` / `projects-board-drift-check` / `watchdog-status-mismatch` / `post-compact`）: 修正前後で出力が完全一致（回帰なし）
- 実地再現: 本 PR のブランチ自体が SSH host alias 経由の origin で作業しており、`issue-comment-wm-sync.sh init` / `projects-board-drift-check.sh` を実行して owner/repo 解決の成功を確認済み

## Implementation Notes

- Deviation: 修正対象を Issue 本文が名指しした2ファイルに加え、同一パターンを持つ2ファイル（`watchdog-status-mismatch.sh` / `post-compact.sh`、コード内コメントで "2-site set" と明記されペアであることが判明）にも拡大した — 理由: 同じバグを見つけて2箇所だけ直すのは片手落ちであり、コメントが明示するペア関係を放置すると非対称な修正になるため。
- Deviation: `gh repo view` を git-remote 解決に完全置換せず、フォールバックとして残した — 理由: 既存テスト（auth 失敗シナリオ等）が `gh repo view` の失敗パスを検証しており、置換すると失敗トリガーの意味が変わってテストが機能しなくなるため。
- Decision: SKILL.md のプロンプト手順内に残る同型パターン（LLM 実行時コマンド）と `create-issue-with-projects.sh` の同型バグは別 Issue #1912 に切り出した — 理由: コミット済みスクリプトと LLM が都度読む手順書は対応方法が異なりうり、本 PR のスコープ（Issue #1899 が指す「内部スクリプト」）を超えるため。

## Checklist

- [x] 変更内容を確認した
- [x] 既存テストが通ることを確認した（新規テスト含む）
- [ ] `/rite:pr-review` でセルフレビュー
