### PR TITLE
fix(skills,scripts): SKILL.md 手順内・内部スクリプトの owner/repo 解決を SSH host alias 対応にする

### DIFF
--- a/plugins/rite/references/gh-cli-patterns.md
+++ b/plugins/rite/references/gh-cli-patterns.md
@@ -633,6 +633,38 @@ jq -n --rawfile body "$updated_tmp" '{"body": $body}' \
 
 ---
 
+## Owner/Repo Resolution (SSH Host Alias Safe)
+
+`gh repo view` / `gh issue create` など **`--repo`/`-R` 未指定の gh コマンド**は、origin remote が
+SSH host alias（例: `git@github.com-work:owner/repo.git`）のとき
+`none of the git remotes configured for this repository point to a known GitHub host` で失敗する。
+`{owner}` / `{repo}` プレースホルダの解決には、remote URL を直接パースする
+`hooks/scripts/lib/git-remote.sh`（#1899 で導入。host 名に依存しない）を優先し、
+`gh repo view` は fallback に回すこと。
+
+```bash
+# ✅ SAFE: git-remote.sh 優先で owner/repo を解決（SSH host alias 環境でも動く）
+# 出力契約: 成功時 "owner<TAB>repo" の 1 行。失敗時は空 → gh repo view に fallback
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
+
+# 🚫 PROHIBITED: gh repo view 単独での owner/repo 解決（SSH host alias 環境で失敗する）
+# owner=$(gh repo view --json owner --jq '.owner.login')
+# WHY: gh は remote URL の host 部（github.com-work 等）を GitHub host として解決できない
+```
+
+解決した `$owner/$repo` があれば、repo コンテキスト依存の gh コマンドにも明示指定できる
+（`gh issue view N -R "$owner/$repo"` / `gh repo view "$owner/$repo" --json id,url` 等 —
+明示指定なら alias 環境でも動く）。内部スクリプトでの実装例:
+`scripts/watchdog-status-mismatch.sh`（git-remote.sh → gh repo view の 2 段 fallback + 診断 stderr）。
+
+---
+
 ## Extended References
 
 For error pattern catalog, see: [`gh-cli-error-catalog.md`](./gh-cli-error-catalog.md)

--- a/plugins/rite/references/gh-cli-patterns.md
+++ b/plugins/rite/references/gh-cli-patterns.md
@@ -646,8 +646,8 @@ SSH host alias（例: `git@github.com-work:owner/repo.git`）のとき
 # ✅ SAFE: git-remote.sh 優先で owner/repo を解決（SSH host alias 環境でも動く）
 # 出力契約: 成功時 "owner<TAB>repo" の 1 行。失敗時は空 → gh repo view に fallback
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/scripts/create-issue-with-projects.sh
+++ b/plugins/rite/scripts/create-issue-with-projects.sh
@@ -56,6 +56,9 @@
 # Exit 0 = success or non-blocking failure. Exit 1 = fatal error.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+
 # --- Centralized tmpfile management ---
 # All temporary files live under TMPDIR_WORK; a single EXIT trap cleans them all.
 TMPDIR_WORK=$(mktemp -d)
@@ -195,7 +198,23 @@ if [ -n "$BODY_FILE" ] && [ ! -f "$BODY_FILE" ]; then
 fi
 
 # --- Phase 1: Create Issue ---
+# SSH host alias remote (git@github.com-work:owner/repo.git 等) では --repo 未指定の
+# gh issue create がホスト解決に失敗するため、git-remote.sh で owner/repo を解決して
+# 明示指定する。解決失敗時は従来どおり --repo なしで gh のデフォルト解決に委ねる。
+REPO_SLUG=""
+_git_or_line=$(bash "$PLUGIN_ROOT/hooks/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || _git_or_line=""
+if [ -n "$_git_or_line" ]; then
+  _ro=""; _rn=""
+  IFS=$'\t' read -r _ro _rn <<< "$_git_or_line"
+  if [ -n "$_ro" ] && [ -n "$_rn" ]; then
+    REPO_SLUG="$_ro/$_rn"
+  fi
+fi
+
 GH_ARGS=("issue" "create" "--title" "$TITLE")
+if [ -n "$REPO_SLUG" ]; then
+  GH_ARGS+=("--repo" "$REPO_SLUG")
+fi
 
 if [ -n "$BODY_FILE" ] && [ -s "$BODY_FILE" ]; then
   GH_ARGS+=("--body-file" "$BODY_FILE")

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -77,7 +77,15 @@ PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャ
 ### 1.4 リポジトリ情報取得
 
 ```bash
-gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'
+# SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
+# (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 ```
 
 ---
@@ -168,7 +176,7 @@ incomplete=$(printf '%s\n' "$comment_body" | sed -n '/### 進捗/,/### /p' \
 | `{projects_enabled}` | `rite-config.yml` → `github.projects.enabled` (boolean) | `true` |
 | `{project_number}` | `rite-config.yml` → `github.projects.project_number` | `6` |
 | `{owner}` | `rite-config.yml` → `github.projects.owner` | `asakaguchi` |
-| `{repo}` | ステップ 1.4 で取得した `gh repo view --json owner,name` の `.name` | `cc-rite-workflow` |
+| `{repo}` | ステップ 1.4 で取得した `$repo`（git-remote.sh 優先 + gh repo view fallback） | `cc-rite-workflow` |
 
 **Issue 本文テンプレート** (cleanup-specific、各タスクごとに以下の形式で生成):
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -80,8 +80,8 @@ PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャ
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
 # (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -92,11 +92,15 @@ Extract the Issue number from the current branch and retrieve work memory:
 # ブランチ名から Issue 番号を抽出
 issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
 
-# リポジトリ情報を取得（1回で owner と repo を両方取得）
-# 注: echo ... | jq -r はスタンドアロン jq コマンドに依存（GitHub CLI の --jq オプションとは別）
-owner_repo=$(gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}')
-owner=$(echo "$owner_repo" | jq -r '.owner')
-repo=$(echo "$owner_repo" | jq -r '.repo')
+# リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
+# canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 # 作業メモリを取得
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
@@ -313,14 +317,18 @@ echo "[CONTEXT] REMAINING_ARGS=$remaining_args" >&2
 
 After ステップ 1.0 has extracted `{pr_number}` (and optionally `{target_comment_id}`), retrieve repository information:
 
-- **Within end-to-end flow**: `{owner}` and `{repo}` are already available from ステップ 0.2. Reuse them — no additional `gh repo view` call needed.
+- **Within end-to-end flow**: `{owner}` and `{repo}` are already available from ステップ 0.2. Reuse them — no additional owner/repo resolution needed.
 - **Standalone execution**: ステップ 0 was not executed. Retrieve them here:
 
 ```bash
 # ステップ 0.2 と同一パターン（スタンドアロン実行時のみ使用。e2e フローでは ステップ 0.2 の値を再利用）
-owner_repo=$(gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}')
-owner=$(echo "$owner_repo" | jq -r '.owner')
-repo=$(echo "$owner_repo" | jq -r '.repo')
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 ```
 
 When PR number is specified as an argument:

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -95,8 +95,8 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 # リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
 # canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')
@@ -323,8 +323,8 @@ After ステップ 1.0 has extracted `{pr_number}` (and optionally `{target_comm
 ```bash
 # ステップ 0.2 と同一パターン（スタンドアロン実行時のみ使用。e2e フローでは ステップ 0.2 の値を再利用）
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -105,6 +105,13 @@ Stop here if not authenticated.
 gh repo view --json owner,name
 ```
 
+> **Note (SSH host alias remote)**: origin が `git@github.com-work:owner/repo.git` のような
+> SSH host alias の場合、GitHub リポジトリであってもこのコマンドは
+> `none of the git remotes configured for this repository point to a known GitHub host` で失敗する。
+> その場合は `git remote get-url origin` で owner/repo を確認できれば GitHub リポジトリとして扱ってよい
+> （rite の各スキルは `git-remote.sh` による remote URL 直接パースで owner/repo を解決するため動作する。
+> canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）。
+
 **If not a GitHub repository:**
 
 ```
@@ -331,9 +338,13 @@ Common Issues and Solutions:
 1. "gh: command not found"
    Solution: Install gh CLI (see Prerequisites section above)
 
-2. "Could not resolve to a Repository"
+2. "Could not resolve to a Repository" /
+   "none of the git remotes configured for this repository point to a known GitHub host"
    Solution: Ensure you're in a Git repository that's pushed to GitHub
    Check with: gh repo view
+   Note: origin が SSH host alias（git@github.com-work: 等）の場合、gh repo view は
+   GitHub リポジトリでも失敗する。git remote get-url origin で確認すること
+   （rite の実行手順は git-remote.sh 優先の解決で alias 環境でも動作する）
 
 3. "Projects not found" during /rite:setup
    Solution: Projects is optional. Choose "Skip Projects integration"

--- a/plugins/rite/skills/issue-create/SKILL.md
+++ b/plugins/rite/skills/issue-create/SKILL.md
@@ -40,8 +40,8 @@ argument-hint: "<title or description>"
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
 # (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/issue-create/SKILL.md
+++ b/plugins/rite/skills/issue-create/SKILL.md
@@ -24,7 +24,7 @@ argument-hint: "<title or description>"
 
 | Placeholder | Source |
 |-------------|--------|
-| `{owner}`, `{repo}` | `gh repo view --json owner,name` |
+| `{owner}`, `{repo}` | ステップ 1.1（git-remote.sh 優先 + `gh repo view` fallback。SSH host alias 対応） |
 | `{project_number}` | `rite-config.yml` の `github.projects.project_number` |
 | `{field_name_status}`, `{field_name_priority}`, `{field_name_complexity}` | `rite-config.yml` の `github.projects.fields.{status,priority,complexity}.name`（任意。未設定は空文字 = helper 内蔵の英日エイリアスで解決） |
 | `{language}` | `rite-config.yml` の `language`（`ja` / `en` / `auto`、未設定 `auto`） |
@@ -37,7 +37,15 @@ argument-hint: "<title or description>"
 ### 1.1 リポジトリと Project 設定取得
 
 ```bash
-gh repo view --json owner,name
+# SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
+# (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 ```
 
 Project 番号は `rite-config.yml` の `github.projects.project_number` を最優先。未設定なら `gh api graphql` でリポジトリの `projectsV2(first:10)` を取得して最も関連するものを選択。Project が見つからない場合は warning + Projects 追加を skip。
@@ -523,7 +531,7 @@ Decompose path も完了レポートの最終 2 行は `<!-- skill return signal
 
 ## Error Handling
 
-- `gh repo view` 失敗 → エラー、認証確認を案内
+- owner/repo 解決失敗（git-remote.sh + `gh repo view` fallback とも失敗）→ エラー、認証・remote 設定確認を案内
 - Projects 未設定 → warning、Projects 追加を skip
 - Issue 作成失敗 → AskUserQuestion で「再試行 / 手動作成 / 中止」
 - 親-子リンク失敗 → warning、後で手動リンクを案内

--- a/plugins/rite/skills/lint/SKILL.md
+++ b/plugins/rite/skills/lint/SKILL.md
@@ -95,9 +95,15 @@ Extract the Issue number from the current branch and retrieve work memory:
 # ブランチ名から Issue 番号を抽出
 issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
 
-# リポジトリ情報を取得
-owner=$(gh repo view --json owner --jq '.owner.login')
-repo=$(gh repo view --json name --jq '.name')
+# リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
+# canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 # 作業メモリを取得
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments \

--- a/plugins/rite/skills/lint/SKILL.md
+++ b/plugins/rite/skills/lint/SKILL.md
@@ -98,8 +98,8 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 # リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
 # canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -34,7 +34,7 @@ Issue を起点に「準備 → ブランチ → 計画 → 実装 → lint → 
 | `{branch_name}` | ステップ 2 で生成 |
 | `{pr_number}` | ステップ 6 の `[pr:created:N]` から抽出 |
 | `{plugin_root}` | [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) |
-| `{owner}` / `{repo}` | ステップ 2.4(A) 専用: `gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'` |
+| `{owner}` / `{repo}` | ステップ 2.4(A) 専用: `{plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo`（SSH host alias 対応。fallback: `gh repo view --json owner,name`。canonical: [gh-cli-patterns.md](../../references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)） |
 | `{project_number}` | ステップ 2.4(A) 専用: `rite-config.yml` → `github.projects.project_number` |
 
 > **Note**: 上記 2 行（ステップ 2.4(A) 専用と注記したもの）を除き、`{owner}` / `{repo}` / `{project_number}` / `{parent_issue_number}` 等は下流 sub-skill (`rite:issue-implement` / `rite:pr-create` / Projects integration script 経由) が `rite-config.yml` / `gh` から個別に取得するため、本コマンド body 内で直接 substitute する経路は持たない (responsibility を sub-skill に委譲)。

--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -93,8 +93,8 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
 # (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -90,8 +90,15 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 **Fallback (local file missing/corrupt)**: If the local file does not exist or is corrupt, fall back to the Issue comment API:
 
 ```bash
-owner=$(gh repo view --json owner --jq '.owner.login')
-repo=$(gh repo view --json name --jq '.name')
+# SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
+# (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
   --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | .body'

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -114,7 +114,7 @@ bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
 
 **Placeholder legend:**
 - `{pr_number}`: PR number (obtained from argument or `gh pr view` result)
-- `{owner}`, `{repo}`: Repository information (obtained via `gh repo view --json owner,name`)
+- `{owner}`, `{repo}`: Repository information (obtained via `{plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo`, fallback `gh repo view --json owner,name` — SSH host alias safe; canonical: [gh-cli-patterns.md](../../references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe))
 - `{post_comment_mode}`: Final decision whether to post PR comment (`true`/`false`), computed in ステップ 1.0 from flags + config
 - Other `{variable}` formats: Values obtained from command execution results or previous phases
 

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -65,8 +65,15 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 **Fallback (local file missing/corrupt)**:
 
 ```bash
-# リポジトリ情報を取得
-gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'
+# リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
+# canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 # Issue comment から作業メモリを読み込む（backup）
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments \

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -68,8 +68,8 @@ issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[
 # リポジトリ情報を取得（SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback。
 # canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/rite-workflow/references/session-detection.md
+++ b/plugins/rite/skills/rite-workflow/references/session-detection.md
@@ -25,8 +25,8 @@ Example: `feat/issue-288-checkpoint-removal` → Issue #288
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
 # (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/skills/rite-workflow/references/session-detection.md
+++ b/plugins/rite/skills/rite-workflow/references/session-detection.md
@@ -18,10 +18,19 @@ Example: `feat/issue-288-checkpoint-removal` → Issue #288
 
 ### 3. Work Memory Retrieval
 
+> `{plugin_root}` は [Plugin Path Resolution](../../../references/plugin-path-resolution.md) で解決する。
+
 ```bash
-# First, get {owner} and {repo} (execute before variable expansion):
-gh repo view --json owner,name --jq '{owner: .owner.login, repo: .name}'
-# → {"owner":"asakaguchi","repo":"cc-rite-workflow"}
+# First, get {owner} and {repo} (execute before variable expansion).
+# SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
+# (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 # Use the retrieved values to search for work memory:
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments \

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -75,13 +75,15 @@ and exit.
 
 ### 1.4 Retrieve Repository Information
 
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) — 下記 snippet の `git-remote.sh` 呼び出しで使用する（未解決のまま実行すると git-remote.sh 経路が silent に失敗し、SSH host alias 環境で fallback の `gh repo view` も失敗する）。
+
 ```bash
 # owner/repo は SSH host alias 環境でも解決できる git-remote.sh を優先し、
 # id/url は解決済み repo を明示指定した gh repo view で取得する（明示指定なら alias 環境でも動く。
 # canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 if [ -n "$owner" ] && [ -n "$repo" ]; then
   gh repo view "$owner/$repo" --json owner,name,id,url
 else
@@ -252,7 +254,7 @@ If the user selects "set up later", proceed to Phase 4 with `iteration.enabled: 
 
 ### 4.1 Generate rite-config.yml
 
-> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1. This resolved path is used by 4.1.1 (template schema_version read), 4.1.2 (template-based generation), and 4.1.3 (upgrade).
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1. This resolved path is used by 1.4 (repository information retrieval — 通常は 1.4 到達時点で解決済み), 4.1.1 (template schema_version read), 4.1.2 (template-based generation), and 4.1.3 (upgrade).
 
 #### 4.1.1 Check for Existing Configuration
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -76,7 +76,17 @@ and exit.
 ### 1.4 Retrieve Repository Information
 
 ```bash
-gh repo view --json owner,name,id,url
+# owner/repo は SSH host alias 環境でも解決できる git-remote.sh を優先し、
+# id/url は解決済み repo を明示指定した gh repo view で取得する（明示指定なら alias 環境でも動く。
+# canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+if [ -n "$owner" ] && [ -n "$repo" ]; then
+  gh repo view "$owner/$repo" --json owner,name,id,url
+else
+  gh repo view --json owner,name,id,url
+fi
 ```
 
 If not a Git repository or not a GitHub repository, show:

--- a/plugins/rite/templates/README.md
+++ b/plugins/rite/templates/README.md
@@ -137,8 +137,8 @@ Commands use these methods to replace variables (`{plugin_root}` is resolved per
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
 # (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
-owner=$(printf '%s' "$owner_repo" | cut -f1)
-repo=$(printf '%s' "$owner_repo" | cut -f2)
+owner=""; repo=""
+[ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
 [ -n "$owner" ] && [ -n "$repo" ] || {
   owner=$(gh repo view --json owner --jq '.owner.login')
   repo=$(gh repo view --json name --jq '.name')

--- a/plugins/rite/templates/README.md
+++ b/plugins/rite/templates/README.md
@@ -15,9 +15,9 @@ Variables use the following formats:
 
 | Variable | Description | Source | Example |
 |----------|-------------|--------|---------|
-| `{owner}` | Repository owner (user or organization) | `gh repo view --json owner --jq '.owner.login'` | `asakaguchi` |
-| `{repo}` | Repository name | `gh repo view --json name --jq '.name'` | `cc-rite-workflow` |
-| `{default_branch}` | Repository default branch | `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'` | `main` or `develop` |
+| `{owner}` | Repository owner (user or organization) | `git-remote.sh resolve-owner-repo` (fallback: `gh repo view --json owner --jq '.owner.login'`) | `asakaguchi` |
+| `{repo}` | Repository name | `git-remote.sh resolve-owner-repo` (fallback: `gh repo view --json name --jq '.name'`) | `cc-rite-workflow` |
+| `{default_branch}` | Repository default branch | `gh repo view "$owner/$repo" --json defaultBranchRef --jq '.defaultBranchRef.name'`（`$owner/$repo` は上記 2 行で解決済みの値。明示指定なら SSH host alias 環境でも動く） | `main` or `develop` |
 
 ### Issue Information
 
@@ -129,12 +129,20 @@ Variables are replaced at runtime by the command that reads the template:
 
 ### Replacement Implementation
 
-Commands use these methods to replace variables:
+Commands use these methods to replace variables (`{plugin_root}` is resolved per
+[Plugin Path Resolution](../references/plugin-path-resolution.md)):
 
 ```bash
 # Example: Replace {owner} and {repo}
-owner=$(gh repo view --json owner --jq '.owner.login')
-repo=$(gh repo view --json name --jq '.name')
+# SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
+# (canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)
+owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
+owner=$(printf '%s' "$owner_repo" | cut -f1)
+repo=$(printf '%s' "$owner_repo" | cut -f2)
+[ -n "$owner" ] && [ -n "$repo" ] || {
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+}
 
 # Read template and replace
 sed -e "s/{owner}/$owner/g" \


### PR DESCRIPTION
## 概要

origin remote が SSH host alias（例: `git@github.com-work:owner/repo.git`）の環境では、`--repo` 未指定の `gh repo view` / `gh issue create` がホストを解決できず失敗する。内部スクリプト 4 箇所は修正済みだったが、LLM が実行時に読む SKILL.md 手順書の bash 例と `create-issue-with-projects.sh` に同パターンが残っていたため、canonical パターン（`git-remote.sh resolve-owner-repo` 優先 + `gh repo view` fallback）へ統一する。

## 関連 Issue

Closes #1912

### 検出された問題（別 Issue として追跡）

- #1914: `issue-body-safe-update.sh` の `gh issue view/edit` が SSH host alias 環境で失敗する（本セッションで実地再現）
- #1915: `worktree-git-nff-retry.test.sh` が sandbox 環境で環境依存失敗する（develop 基準でも同一再現の既存失敗）
- #1916: SKILL.md 手順内の repo コンテキスト依存 gh コマンド全般（`gh pr create` / `gh issue view` 等）への `-R` 明示指定の伝播

## 変更内容

主な変更（全 14 ファイル、+167/-34）:

- `plugins/rite/references/gh-cli-patterns.md`: canonical「Owner/Repo Resolution (SSH Host Alias Safe)」節を新設。git-remote.sh 優先 + gh repo view fallback を単一の正典とし、解決値の `-R` 明示指定の一般則も記載
- `plugins/rite/scripts/create-issue-with-projects.sh`: git-remote.sh で owner/repo を解決し `gh issue create` に `--repo` を明示指定（解決失敗時は従来挙動に fallback）
- 実行スニペット置換（10 ファイル）: `lint` / `ready` / `pr-create` / `cleanup` / `setup` / `issue-create` / `fix`（2 箇所）/ `getting-started` / `rite-workflow/references/session-detection.md` / `templates/README.md`

補足:

- `setup/SKILL.md` は id/url も必要なため「git-remote.sh で owner/repo 解決 → `gh repo view "$owner/$repo" --json ...` の明示指定」の 2 段構成
- `getting-started/SKILL.md` はオンボーディングガイドのため、検証コマンドは維持しつつ SSH host alias 環境での偽陰性（GitHub リポジトリなのに失敗）の注記とトラブルシューティング項を追記
- 表・prose の参照行（`open` / `cleanup` / `issue-create` / `pr-review` / `fix` の placeholder legend 等）を追従更新
- fix/SKILL.md の旧スニペットが持っていたスタンドアロン jq 依存は置換により解消

## 検証

- `create-issue-with-projects.sh`: 本 PR の follow-up Issue 起票（#1914〜#1916）を修正版スクリプト自身で実行し、SSH host alias 環境での動作を実地確認（旧版は同環境で失敗することも対照確認済み）
- `bash -n` 構文チェック / `check-no-direct-gh-issue-create.sh --all` 通過
- `hooks/tests/run-tests.sh`: 94/95 通過（唯一の失敗 `worktree-git-nff-retry.test.sh` は develop 基準でも同一再現の既存の環境依存失敗 → #1915 として追跡）
- `/rite:lint`: `[lint:success]`（plugin 内部チェック 15 種。警告 4 件はいずれも本 PR の変更ファイル外の既存 finding）
- canonical 節への anchor 参照 12 ファイルの整合を確認

## チェックリスト

- [x] 実装完了（Issue の実装ステップ 5 項目すべて）
- [x] テスト実行（run-tests.sh 94/95、失敗 1 件は既存・#1915 で追跡）
- [x] ドキュメント更新（canonical 節・表・prose の追従）
- [x] セルフレビュー準備完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)
