### PR TITLE
fix(hooks): issue-body-safe-update.sh の gh 呼び出しに --repo を明示指定

### DIFF
--- a/plugins/rite/hooks/issue-body-safe-update.sh
+++ b/plugins/rite/hooks/issue-body-safe-update.sh
@@ -51,6 +51,57 @@ _emit_body_update_incident() {
   echo "WARNING: issue-body-safe-update: Issue #${ISSUE:-unknown} ${MODE:-unknown} ${incident_type} (reason=$reason rc=$rc stderr=$stderr_snippet)" >&2
 }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Owner/repo resolution ---
+# Without an explicit --repo, `gh issue view` / `gh issue edit` infer the target
+# repo from the git remotes and fail with "none of the git remotes configured for
+# this repository point to a known GitHub host" when `origin` is an SSH Host alias
+# (e.g. git@github.com-work:owner/repo.git). gh expands such aliases by reading
+# ~/.ssh/config, so the failure surfaces specifically where that read is denied —
+# notably the sandboxed workflow environment, where every body update degraded to
+# fetch_failure_reason=gh_view_failed (#1914). Resolving owner/repo ourselves and
+# passing it explicitly bypasses gh's host inference entirely.
+#
+# Both paths are best-effort: when neither yields an owner/repo the caller keeps
+# the previous behaviour (no --repo flag) rather than failing, per this script's
+# non-blocking contract. The double failure is still surfaced as a WARNING so a
+# genuinely unresolvable environment stays diagnosable instead of silently
+# reverting to the broken path.
+get_owner_repo() {
+  local _err _rc=0 _out _git_err _git_or_line _git_owner _git_repo
+  # git-remote parse first: works even when `origin` is an SSH Host alias that
+  # gh's host allowlist rejects (#1899). Falls through to `gh repo view` when the
+  # parse fails (no origin remote, unparseable URL).
+  _git_err=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-remote-err-XXXXXX" 2>/dev/null) || _git_err=""
+  _git_or_line=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>"${_git_err:-/dev/null}") || _git_or_line=""
+  if [ -n "$_git_or_line" ]; then
+    IFS=$'\t' read -r _git_owner _git_repo <<< "$_git_or_line"
+    if [ -n "$_git_owner" ] && [ -n "$_git_repo" ]; then
+      [ -n "$_git_err" ] && rm -f "$_git_err"
+      printf '%s/%s' "$_git_owner" "$_git_repo"
+      return
+    fi
+  fi
+  _err=$(mktemp "${TMPDIR:-/tmp}/rite-issue-body-ghrepo-err-XXXXXX" 2>/dev/null) || _err=""
+  _out=$(gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>"${_err:-/dev/null}") || _rc=$?
+  if [ "$_rc" -ne 0 ] || [ -z "$_out" ]; then
+    echo "${err_level:-WARNING}: issue-body-safe-update: owner/repo を解決できません (gh repo view rc=$_rc)。--repo なしで続行します（SSH host alias 環境では gh 呼び出しが失敗する可能性があります）" >&2
+    if [ -n "$_err" ] && [ -s "$_err" ]; then
+      head -3 "$_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+    fi
+    # Surface why the git-remote fast path bailed too, or this WARNING would show
+    # only the fallback's side of a two-sided failure.
+    if [ -n "$_git_err" ] && [ -s "$_git_err" ]; then
+      head -3 "$_git_err" | neutralize_ctrl --keep-newline | sed 's/^/  git-remote: /' >&2
+    fi
+    _out=""
+  fi
+  [ -n "$_err" ] && rm -f "$_err"
+  [ -n "$_git_err" ] && rm -f "$_git_err"
+  printf '%s' "$_out"
+}
+
 # --- Argument parsing ---
 MODE="${1:-}"
 shift 2>/dev/null || true
@@ -86,6 +137,15 @@ fi
 # for future severity differentiation but currently has no behavioral effect.
 err_level="WARNING"
 
+# Resolved once ahead of the mode dispatch: fetch and apply each issue exactly one
+# gh call needing the flag, and resolution is identical for either mode. Empty
+# array = pre-#1914 behaviour, so an unresolvable repo degrades instead of failing.
+GH_REPO_ARGS=()
+OWNER_REPO=$(get_owner_repo)
+if [ -n "$OWNER_REPO" ]; then
+  GH_REPO_ARGS=(--repo "$OWNER_REPO")
+fi
+
 case "$MODE" in
   fetch)
     # The script's non-blocking contract requires exit 0 on transient failure,
@@ -118,7 +178,7 @@ case "$MODE" in
     # status). Use the else-branch to preserve gh's real exit code so the WARNING
     # details accurately attribute auth / rate-limit / 404 failures.
     rc=0
-    if gh issue view "$ISSUE" --json body --jq '.body' >"$tmpfile_read" 2>"$tmpfile_err"; then
+    if gh issue view "$ISSUE" "${GH_REPO_ARGS[@]+"${GH_REPO_ARGS[@]}"}" --json body --jq '.body' >"$tmpfile_read" 2>"$tmpfile_err"; then
       :
     else
       rc=$?
@@ -220,7 +280,7 @@ case "$MODE" in
     }
     trap 'rm -f "$apply_err" 2>/dev/null || true' EXIT
     rc=0
-    if gh issue edit "$ISSUE" --body-file "$TMPFILE_WRITE" 2>"${apply_err:-/dev/null}"; then
+    if gh issue edit "$ISSUE" "${GH_REPO_ARGS[@]+"${GH_REPO_ARGS[@]}"}" --body-file "$TMPFILE_WRITE" 2>"${apply_err:-/dev/null}"; then
       :
     else
       rc=$?

--- a/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
+++ b/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
@@ -511,15 +511,45 @@ fi
 printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
 rm -f "$mock_log7"
 
-# Degrade path: with no resolvable origin remote AND `gh repo view` failing,
-# neither resolution path yields an owner/repo. The script must fall back to the
-# pre-#1914 invocation shape rather than aborting — and must say so, because a
-# silent fallback is indistinguishable from the bug this fix removes.
+# The remaining two tiers both need a directory whose `git config --get
+# remote.origin.url` is empty, so git-remote.sh fails and resolution falls
+# through. `git init` makes that state explicit instead of relying on $TMPDIR
+# happening to sit outside a repository — a precondition that silently dropped
+# three assertions when it did not hold. GIT_CONFIG_* are neutralised at
+# invocation time so a stray global remote.origin.url cannot leak in.
 norepo_dir=$(mktemp -d)
-if git -C "$norepo_dir" rev-parse --git-dir >/dev/null 2>&1; then
-  echo "  (TC-31 skipped: \$TMPDIR sits inside a git repo, so an unresolvable remote cannot be simulated)"
+git init -q "$norepo_dir"
+
+# Tier 2: git-remote.sh fails but `gh repo view` resolves. Without a test here,
+# deleting the entire fallback branch keeps the suite green — the flag simply
+# stops appearing and no assertion notices.
+cat > "$mock_bin7/gh" <<'MOCK_REPO_VIEW_OK'
+#!/bin/bash
+echo "gh $*" >> "${MOCK_LOG:-/dev/null}"
+case "$1 $2" in
+  "repo view") echo "fallbackowner/fallbackrepo" ;;
+  "issue view") echo "body content" ;;
+esac
+exit 0
+MOCK_REPO_VIEW_OK
+chmod +x "$mock_bin7/gh"
+mock_log7=$(mktemp)
+rc=0
+out=$(cd "$norepo_dir" && PATH="$mock_bin7:$PATH" MOCK_LOG="$mock_log7" \
+  GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash "$TARGET" fetch --issue 999 2>&1) || rc=$?
+assert_exit "TC-32 gh repo view fallback → exit 0" 0 "$rc"
+if grep -qE 'issue view 999 --repo fallbackowner/fallbackrepo --json body' "$mock_log7"; then
+  pass "TC-32b gh repo view fallback supplies --repo when git-remote resolution fails"
 else
-  cat > "$mock_bin7/gh" <<'MOCK_NO_REPO'
+  fail "TC-32b fallback tier did not reach the gh call — the whole fallback branch can be deleted undetected: $(cat "$mock_log7")"
+fi
+printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
+rm -f "$mock_log7"
+
+# Tier 3 (degrade): neither path yields an owner/repo. The script must fall back
+# to the pre-#1914 invocation shape rather than aborting — and must say so,
+# because a silent fallback is indistinguishable from the bug this fix removes.
+cat > "$mock_bin7/gh" <<'MOCK_NO_REPO'
 #!/bin/bash
 echo "gh $*" >> "${MOCK_LOG:-/dev/null}"
 case "$1 $2" in
@@ -528,24 +558,24 @@ case "$1 $2" in
 esac
 exit 0
 MOCK_NO_REPO
-  chmod +x "$mock_bin7/gh"
-  mock_log7=$(mktemp)
-  rc=0
-  out=$(cd "$norepo_dir" && PATH="$mock_bin7:$PATH" MOCK_LOG="$mock_log7" bash "$TARGET" fetch --issue 999 2>&1) || rc=$?
-  assert_exit "TC-31 unresolvable repo → exit 0 (non-blocking degrade)" 0 "$rc"
-  if grep -qE 'issue view 999 --json body' "$mock_log7"; then
-    pass "TC-31b unresolvable repo degrades to a --repo-less gh invocation"
-  else
-    fail "TC-31b expected a --repo-less 'issue view' invocation: $(cat "$mock_log7")"
-  fi
-  if printf '%s' "$out" | grep -q 'owner/repo を解決できません'; then
-    pass "TC-31c unresolvable repo surfaces a WARNING instead of degrading silently"
-  else
-    fail "TC-31c missing owner/repo resolution WARNING: $out"
-  fi
-  printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
-  rm -f "$mock_log7"
+chmod +x "$mock_bin7/gh"
+mock_log7=$(mktemp)
+rc=0
+out=$(cd "$norepo_dir" && PATH="$mock_bin7:$PATH" MOCK_LOG="$mock_log7" \
+  GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash "$TARGET" fetch --issue 999 2>&1) || rc=$?
+assert_exit "TC-31 unresolvable repo → exit 0 (non-blocking degrade)" 0 "$rc"
+if grep -qE 'issue view 999 --json body' "$mock_log7"; then
+  pass "TC-31b unresolvable repo degrades to a --repo-less gh invocation"
+else
+  fail "TC-31b expected a --repo-less 'issue view' invocation: $(cat "$mock_log7")"
 fi
+if printf '%s' "$out" | grep -q 'owner/repo を解決できません'; then
+  pass "TC-31c unresolvable repo surfaces a WARNING instead of degrading silently"
+else
+  fail "TC-31c missing owner/repo resolution WARNING: $out"
+fi
+printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
+rm -f "$mock_log7"
 rm -rf "$mock_bin7" "$norepo_dir"
 
 print_summary "$(basename "$0")" "If you weaken or remove the 50% shrinkage guard / empty-write rejection / missing-args check / gh-edit error capture / _emit_body_update_incident fallback in issue-body-safe-update.sh, body truncation or silent auth-failure regressions become invisible. Dropping the explicit --repo flag likewise re-breaks every body update under an SSH host alias (#1914). Keep the guards intact and update the test if the guards intentionally change."

--- a/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
+++ b/plugins/rite/hooks/tests/issue-body-safe-update.test.sh
@@ -115,10 +115,20 @@ printf 'b%.0s' $(seq 1 250) > "$tmp_write"
 rc=0
 out=$(PATH="$mock_bin:$PATH" MOCK_LOG="$mock_log" bash "$TARGET" apply --issue 999 --tmpfile-read "$tmp_read" --tmpfile-write "$tmp_write" --original-length 200 2>&1) || rc=$?
 assert_exit "TC-14 apply happy-path → exit 0" 0 "$rc"
-if grep -q 'issue edit 999 --body-file' "$mock_log"; then
+# The `--repo` flag sits between the issue number and --body-file since #1914, so
+# this must not re-tighten into an adjacency match on 'issue edit 999 --body-file'.
+if grep -qE 'issue edit 999 .*--body-file' "$mock_log"; then
   pass "TC-15 apply called gh issue edit with --body-file"
 else
   fail "TC-15 mock gh log missing 'issue edit ... --body-file': $(cat "$mock_log")"
+fi
+# Without an explicit --repo, gh infers the repo from git remotes and fails when
+# `origin` is an SSH Host alias it cannot expand (#1914). The test process runs
+# inside this repo, so git-remote resolution succeeds and the flag must be present.
+if grep -qE 'issue edit 999 --repo [^ ]+/[^ ]+ --body-file' "$mock_log"; then
+  pass "TC-15b apply passes --repo owner/repo explicitly (SSH host alias safety)"
+else
+  fail "TC-15b mock gh log missing '--repo owner/repo' — gh would fall back to remote inference: $(cat "$mock_log")"
 fi
 [ ! -f "$tmp_read" ] && pass "TC-16 apply happy-path cleaned tmpfile-read" || fail "TC-16 tmpfile-read leak"
 [ ! -f "$tmp_write" ] && pass "TC-17 apply happy-path cleaned tmpfile-write" || fail "TC-17 tmpfile-write leak"
@@ -472,4 +482,70 @@ GHEOF
   rm -rf "$mock_bin_25g"
 done
 
-print_summary "$(basename "$0")" "If you weaken or remove the 50% shrinkage guard / empty-write rejection / missing-args check / gh-edit error capture / _emit_body_update_incident fallback in issue-body-safe-update.sh, body truncation or silent auth-failure regressions become invisible. Keep the guards intact and update the test if the guards intentionally change."
+echo ""
+echo "=== Phase 16: owner/repo resolution → explicit --repo, with degrade fallback (#1914) ==="
+# fetch mode must carry the same --repo flag as apply: the SSH-host-alias failure
+# hit `gh issue view` first, and fixing only one mode leaves the checklist-update
+# path (implement 5.1.1.1) broken while apply looks healthy.
+mock_bin7=$(mktemp -d)
+mock_log7=$(mktemp)
+cat > "$mock_bin7/gh" <<'MOCK_FETCH_OK'
+#!/bin/bash
+echo "gh $*" >> "${MOCK_LOG:-/dev/null}"
+case "$1 $2" in
+  "issue view") echo "body content" ;;
+esac
+exit 0
+MOCK_FETCH_OK
+chmod +x "$mock_bin7/gh"
+rc=0
+out=$(PATH="$mock_bin7:$PATH" MOCK_LOG="$mock_log7" bash "$TARGET" fetch --issue 999 2>&1) || rc=$?
+assert_exit "TC-30 fetch with resolvable repo → exit 0" 0 "$rc"
+if grep -qE 'issue view 999 --repo [^ ]+/[^ ]+ --json body' "$mock_log7"; then
+  pass "TC-30b fetch passes --repo owner/repo explicitly"
+else
+  fail "TC-30b fetch missing '--repo owner/repo' — gh falls back to remote inference: $(cat "$mock_log7")"
+fi
+# fetch deliberately persists tmpfile_read / tmpfile_write for Step 2/3, so this
+# test owns their cleanup.
+printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
+rm -f "$mock_log7"
+
+# Degrade path: with no resolvable origin remote AND `gh repo view` failing,
+# neither resolution path yields an owner/repo. The script must fall back to the
+# pre-#1914 invocation shape rather than aborting — and must say so, because a
+# silent fallback is indistinguishable from the bug this fix removes.
+norepo_dir=$(mktemp -d)
+if git -C "$norepo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "  (TC-31 skipped: \$TMPDIR sits inside a git repo, so an unresolvable remote cannot be simulated)"
+else
+  cat > "$mock_bin7/gh" <<'MOCK_NO_REPO'
+#!/bin/bash
+echo "gh $*" >> "${MOCK_LOG:-/dev/null}"
+case "$1 $2" in
+  "repo view") echo "none of the git remotes configured for this repository point to a known GitHub host" >&2; exit 1 ;;
+  "issue view") echo "body content" ;;
+esac
+exit 0
+MOCK_NO_REPO
+  chmod +x "$mock_bin7/gh"
+  mock_log7=$(mktemp)
+  rc=0
+  out=$(cd "$norepo_dir" && PATH="$mock_bin7:$PATH" MOCK_LOG="$mock_log7" bash "$TARGET" fetch --issue 999 2>&1) || rc=$?
+  assert_exit "TC-31 unresolvable repo → exit 0 (non-blocking degrade)" 0 "$rc"
+  if grep -qE 'issue view 999 --json body' "$mock_log7"; then
+    pass "TC-31b unresolvable repo degrades to a --repo-less gh invocation"
+  else
+    fail "TC-31b expected a --repo-less 'issue view' invocation: $(cat "$mock_log7")"
+  fi
+  if printf '%s' "$out" | grep -q 'owner/repo を解決できません'; then
+    pass "TC-31c unresolvable repo surfaces a WARNING instead of degrading silently"
+  else
+    fail "TC-31c missing owner/repo resolution WARNING: $out"
+  fi
+  printf '%s\n' "$out" | sed -n 's/^tmpfile_[a-z]*=//p' | xargs -r rm -f
+  rm -f "$mock_log7"
+fi
+rm -rf "$mock_bin7" "$norepo_dir"
+
+print_summary "$(basename "$0")" "If you weaken or remove the 50% shrinkage guard / empty-write rejection / missing-args check / gh-edit error capture / _emit_body_update_incident fallback in issue-body-safe-update.sh, body truncation or silent auth-failure regressions become invisible. Dropping the explicit --repo flag likewise re-breaks every body update under an SSH host alias (#1914). Keep the guards intact and update the test if the guards intentionally change."


### PR DESCRIPTION
## 概要

`hooks/issue-body-safe-update.sh` の `gh issue view` / `gh issue edit` が `--repo` 未指定で
リポジトリを git remote から推論しており、origin が SSH host alias の環境で失敗していた。
owner/repo を自前で解決して `--repo` に明示指定し、gh の host 推論を回避する。

## 関連 Issue

Closes #1914

### 実装中に検出した別問題（別 Issue として追跡）

- #1920: sandbox 環境で `git add .` が dotfile マスクにより hard fail する

## 変更内容

- `plugins/rite/hooks/issue-body-safe-update.sh`
  - `get_owner_repo()` を追加（`git-remote.sh resolve-owner-repo` を優先し、失敗時に `gh repo view` へ fallback）
  - mode dispatch の前で 1 回だけ解決し `GH_REPO_ARGS` を構築。fetch / apply の両モードが同じ結果を使う
  - 両解決経路が失敗した場合は `--repo` なしの従来動作へ degrade し、その旨を WARNING で表面化する
- `plugins/rite/hooks/tests/issue-body-safe-update.test.sh`
  - TC-15 のアサーションを `--repo` 挿入後の引数列に追従
  - TC-15b（apply が `--repo owner/repo` を渡す）を追加
  - Phase 16 を追加: TC-30/30b（fetch も `--repo` を渡す）、TC-31/31b/31c（解決不可時の degrade と WARNING）

## 実装中の判断・計画逸脱

- 判断: 再現条件は Issue 記述より狭く **sandbox 有効時のみ**だと実地で確定した — sandbox の read deny リストに `~/.ssh` が含まれ、gh が Host alias 定義を読めないことが直接原因。sandbox 外では gh が alias を解決するため成功する。修正方針（`--repo` 明示）は両条件で正しいため変更なし
- 判断: フラグは `-R` ではなく `--repo` を採用 — 同じ `hooks/` 配下で同一バグクラスを修正済みの `issue-comment-wm-sync.sh` と表記を揃えるため（機能は同一）
- 判断: owner/repo 解決を `STATE_ROOT` 等にアンカーせず ambient cwd のままにした — 本スクリプトは state root の概念を持たず、既存の `gh issue view` も ambient cwd 依存だったため、新しい依存を持ち込まない最小差分とした
- 逸脱: 既存テスト TC-15 のアサーションを変更した — `--repo` が引数列に挿入されることで隣接マッチ `issue edit 999 --body-file` が成立しなくなるため。意図した挙動変更に対する追従であり、ガードの緩和ではない（`--repo` 自体の存在は TC-15b で新たに固定した）

## 検証

- `issue-body-safe-update.test.sh`: 60 件 pass / 0 fail
- hooks テストスイート全体: 96 件中 95 件 pass。唯一の失敗 `worktree-git-nff-retry.test.sh` は既知の別 Issue #1915（sandbox 環境依存）で、本変更とは無関係
- 実地検証: sandbox 有効下で本 PR の Issue body 更新（fetch → apply）を修正後スクリプトで実行し、両モードとも成功することを確認。修正前は同条件で `fetch_failure_reason=gh_view_failed` になる

## チェックリスト

- [x] 実装完了
- [x] テスト追加・更新
- [x] 実地での再現と修正の確認
- [ ] ドキュメント更新（不要 — スクリプトの CLI 契約は不変で、参照する文書に陳腐化なし）
