### PR TITLE
docs(setup,skills): sandbox 環境の worktree state 書込拒否（#1896）の案内を setup と全 worktree 入場経路に伝播する

### DIFF
--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -436,8 +436,10 @@ Operating rules (important):
 
   • Sandboxed environments: after entering a session worktree, state writes to
     the main checkout (.rite/sessions/, etc.) can be rejected as read-only.
-    See references/git-worktree-patterns.md's "#1896" section for the fix
-    (/rite:setup surfaces the same guidance when it detects this applies).
+    See ../../references/git-worktree-patterns.md, section "worktree cwd から
+    main checkout 配下への書き込みが sandbox の write 許可リストでブロックされる"
+    (Issue #1896), for the fix (/rite:setup surfaces the same guidance when it
+    detects this applies).
 
 Note: multi_session is a SEPARATE axis from parallel.mode: "worktree".
   - parallel  → multiple sub-agents within ONE session (.worktrees/{issue}/{task})

--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -434,6 +434,11 @@ Operating rules (important):
     suffices (/rite:setup adds an entry only when not already covered;
     /rite:lint warns if it is not ignored while multi_session is enabled).
 
+  • Sandboxed environments: after entering a session worktree, state writes to
+    the main checkout (.rite/sessions/, etc.) can be rejected as read-only.
+    See references/git-worktree-patterns.md's "#1896" section for the fix
+    (/rite:setup surfaces the same guidance when it detects this applies).
+
 Note: multi_session is a SEPARATE axis from parallel.mode: "worktree".
   - parallel  → multiple sub-agents within ONE session (.worktrees/{issue}/{task})
   - multi_session → whole-session isolation across terminals (.rite/worktrees/issue-{N})

--- a/plugins/rite/skills/recover/SKILL.md
+++ b/plugins/rite/skills/recover/SKILL.md
@@ -176,6 +176,8 @@ bash {plugin_root}/hooks/scripts/lib/worktree-git.sh ensure-session-worktree --i
 
 > **caller-local marker `skip` について**: `review` / `fix` の入場ゲートは PR の `headRefName` が issue ブランチ（`issue-N` 命名）でないとき、helper を呼ばず caller 自身が `[CONTEXT] WT_ENSURE=skip` を emit する（session worktree の対象外＝従来どおり単一ツリーで続行する no-op）。`skip` は helper の出力 case ではなく **caller 固有拡張**であり、`disabled` / `already_in` と同じく no-op として扱う。recover は引数 / branch / 候補列挙で issue を確定してから本 helper を呼ぶため、recover 経路で `skip` は emit されない。
 
+> **sandbox 有効環境での state 書込拒否（#1896）**: `reenter` / `reconstructed` で worktree に入場した直後、後続フェーズの `flow-state.sh set` 等 main checkout 配下への state 書込が「読み込み専用ファイルシステムです」で失敗することがある（sandbox の write 許可リストが cwd 依存の相対パスのため）。対処は [git-worktree-patterns.md](../../references/git-worktree-patterns.md#worktree-cwd-から-main-checkout-配下への書き込みが-sandbox-の-write-許可リストでブロックされる) を参照。
+
 **EnterWorktree が失敗した場合**（`reenter` / `reconstructed` 経路の `EnterWorktree(path)` がエラー）: open Step 2.3-W と同じ切り分けを行い、**silent に新規セッション扱いしない**。
 
 - **harness の git 誤判定**（`.git` が存在し `git -C "{path}" rev-parse` は成功するのに、起動コンテキストが `Is a git repository: false` で EnterWorktree が「not in a git repository」エラーを返す）→ **推奨**。診断とともに「**リポジトリ root から Claude Code を再起動**し、`/rite:recover {issue_number}` を再実行すれば、登録済み worktree が `WT_ENSURE=reenter` で再入場される」と案内する。worktree は保持済みのため破壊しない。

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -475,7 +475,7 @@ After Phase 4.7.1/4.7.2/4.7.4 returns control to Step 7, display a Wiki status l
 - Else if `wiki_status == "skipped_disabled"` → `Wiki: スキップ（無効）`
 - Else if `wiki_status == "failed"` → `Wiki: 失敗`
 
-After displaying the status line, exit. (`--upgrade` skips Phases 1-3 and the Phase 5 full completion report, so only the Wiki status is reported — there is no merge conflict with Phase 5 because `--upgrade` does not enter the new-install path.)
+Before exiting, execute [Phase 4.8: Sandbox Write-Allowlist 事前案内](#phase-48-sandbox-write-allowlist-事前案内multi_session-有効時1896) (non-blocking, self-gated by its own multi_session + sandbox check — safe to invoke unconditionally). Then display the status line and exit. (`--upgrade` skips Phases 1-3 and the Phase 5 full completion report, so only the Wiki status (and, when applicable, the Phase 4.8 guidance) is reported — there is no merge conflict with Phase 5 because `--upgrade` does not enter the new-install path.)
 
 If the user cancels: Display "アップグレードをキャンセルしました" and exit.
 
@@ -1073,7 +1073,7 @@ echo "wiki_enabled=$wiki_enabled"
 **When `wiki_enabled=false`**:
 - Display `Wiki が無効化されています（wiki.enabled: false）。Phase 4.7 をスキップします。`
 - Set `wiki_status=skipped_disabled` (remember in LLM context)
-- **Skip the rest of Phase 4.7** and proceed to the next step (new-install: Phase 5 full completion report / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit)
+- **Skip the rest of Phase 4.7** and proceed to the next step (new-install: Phase 4.8, then Phase 5 full completion report / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit)
 
 **When `wiki_enabled=true`**: Display `Wiki の自動初期化を開始します...` and proceed to 4.7.2.
 
@@ -1114,7 +1114,7 @@ fi
 **When `WIKI_INITIALIZED=true`**:
 - Display `Wiki は既に初期化されています（検知: {detection}）。スキップします。` (substitute `{detection}` with the matched branch name or file path)
 - Set `wiki_status=already_initialized` (remember in LLM context)
-- **Skip the rest of Phase 4.7** and proceed to the next step (new-install: Phase 5 / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit). Do NOT invoke Skill (preserves existing Wiki content per AC-2)
+- **Skip the rest of Phase 4.7** and proceed to the next step (new-install: Phase 4.8, then Phase 5 / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit). Do NOT invoke Skill (preserves existing Wiki content per AC-2)
 
 **When `WIKI_INITIALIZED=false`**: Proceed to 4.7.3.
 
@@ -1167,7 +1167,7 @@ Then:
 - Display `⚠️ Wiki の初期化に失敗しました。/rite:setup 全体は成功扱いで続行します。手動で /rite:wiki-init を実行してください。` (warning only — do NOT exit)
 - Set `wiki_status=failed` (remember in LLM context)
 
-**→ Proceed to the next step (new-install: Phase 5 full completion report / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit). Non-blocking regardless of outcome.**
+**→ Proceed to the next step (new-install: Phase 4.8, then Phase 5 full completion report / `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit). Non-blocking regardless of outcome.**
 
 ---
 
@@ -1195,6 +1195,8 @@ bash {plugin_root}/hooks/state-path-resolve.sh
 ```
 
 settings ファイルへの自動書き込みは行わない（案内のみ、MUST NOT）。
+
+**→ Proceed to Phase 5 (new-install) — this Phase is only reached via the new-install exit points in Phase 4.7 (§4.7.1/4.7.2/4.7.4); `--upgrade` invokes this Phase directly from Step 7b and then exits without a Phase 5 report.**
 
 ## Phase 5: Completion Report
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -1177,10 +1177,10 @@ Then:
 
 判定は Claude 自身の実行コンテキスト（system prompt に記述された sandbox の write 許可リスト）を読んで行う。bash コマンドでは検出できない（sandbox の有無はセッションの起動設定であり、ファイルから読み取れる状態ではないため）。
 
-該当する場合、まずリポジトリルートの絶対パスを取得する:
+該当する場合、まず main checkout root の絶対パスを取得する。`git rev-parse --show-toplevel` は現在の worktree の toplevel を返すため、setup がセッション worktree cwd から実行された場合（例: EnterWorktree 後の `/rite:setup --upgrade` 手動実行）に worktree パスを誤って返す（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh) が同じ理由でこのパターンを避けている）。代わりに `state-path-resolve.sh` で main checkout root を解決する:
 
 ```bash
-git rev-parse --show-toplevel
+bash {plugin_root}/hooks/state-path-resolve.sh
 ```
 
 その値を `{repo_root}` として、以下を表示する（本文の複製ではなく [git-worktree-patterns.md](../../references/git-worktree-patterns.md#worktree-cwd-から-main-checkout-配下への書き込みが-sandbox-の-write-許可リストでブロックされる) への 1 行ポインタ + 対象パスの実例のみ）:

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -1171,6 +1171,31 @@ Then:
 
 ---
 
+## Phase 4.8: Sandbox Write-Allowlist 事前案内（multi_session 有効時、#1896）
+
+`multi_session.enabled: true`（Phase 4.1 で決定済み。新規生成・back-add いずれの経路でも既定 ON）**かつ** Claude 自身の Bash tool 定義（sandbox セクション）が filesystem write 制限を伴う sandbox で動作していることを示している場合のみ、以下を表示する。いずれか一方でも該当しない場合（`multi_session.enabled: false`、または sandbox 無効／write 制限なし）は本節を完全に silent skip する（案内・warning 共に一切出さない — AC-3）。
+
+判定は Claude 自身の実行コンテキスト（system prompt に記述された sandbox の write 許可リスト）を読んで行う。bash コマンドでは検出できない（sandbox の有無はセッションの起動設定であり、ファイルから読み取れる状態ではないため）。
+
+該当する場合、まずリポジトリルートの絶対パスを取得する:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+その値を `{repo_root}` として、以下を表示する（本文の複製ではなく [git-worktree-patterns.md](../../references/git-worktree-patterns.md#worktree-cwd-から-main-checkout-配下への書き込みが-sandbox-の-write-許可リストでブロックされる) への 1 行ポインタ + 対象パスの実例のみ）:
+
+```
+ℹ️ sandbox 環境かつ multi_session が有効です。EnterWorktree でセッション worktree へ入場後、
+   main checkout 配下（.rite/sessions/ 等）への state 書込が「読み込み専用ファイルシステムです」
+   で拒否されることがあります。
+   恒久対処: sandbox の write 許可リストへ main checkout root の絶対パスを追加してください
+     （例: {repo_root} を settings の sandbox.filesystem.write.allowWithinDeny 等に追加）
+   詳細: git-worktree-patterns.md の #1896 対処節を参照
+```
+
+settings ファイルへの自動書き込みは行わない（案内のみ、MUST NOT）。
+
 ## Phase 5: Completion Report
 
 ### Display Configuration Summary

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -1183,7 +1183,7 @@ Then:
 bash {plugin_root}/hooks/state-path-resolve.sh
 ```
 
-その値を `{repo_root}` として、以下を表示する（本文の複製ではなく [git-worktree-patterns.md](../../references/git-worktree-patterns.md#worktree-cwd-から-main-checkout-配下への書き込みが-sandbox-の-write-許可リストでブロックされる) への 1 行ポインタ + 対象パスの実例のみ）:
+その値を `{repo_root}` として、以下を表示する（原因や恒久対処の詳細本文は複製せず、要約 + [git-worktree-patterns.md](../../references/git-worktree-patterns.md#worktree-cwd-から-main-checkout-配下への書き込みが-sandbox-の-write-許可リストでブロックされる) への 1 行ポインタ + 対象パスの実例に留める）:
 
 ```
 ℹ️ sandbox 環境かつ multi_session が有効です。EnterWorktree でセッション worktree へ入場後、

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -1189,8 +1189,8 @@ git rev-parse --show-toplevel
 ℹ️ sandbox 環境かつ multi_session が有効です。EnterWorktree でセッション worktree へ入場後、
    main checkout 配下（.rite/sessions/ 等）への state 書込が「読み込み専用ファイルシステムです」
    で拒否されることがあります。
-   恒久対処: sandbox の write 許可リストへ main checkout root の絶対パスを追加してください
-     （例: {repo_root} を settings の sandbox.filesystem.write.allowWithinDeny 等に追加）
+   恒久対処: /sandbox コマンド、または settings の sandbox 設定で、write 許可リストへ
+     main checkout root の絶対パス（{repo_root}）を追加してください
    詳細: git-worktree-patterns.md の #1896 対処節を参照
 ```
 


### PR DESCRIPTION
## Summary

sandbox 有効環境で `EnterWorktree` によりセッション worktree へ入場した後、main checkout 配下（state root）への state 書込が「読み込み専用ファイルシステムです」で拒否される既知問題（#1896）について、ユーザーがエラーに遭遇する前に恒久対処を知れるよう、案内を `/rite:setup` と全 worktree 入場経路に伝播する。

## Related Issue

Closes #1922

## Changes

- `plugins/rite/skills/setup/SKILL.md`: Phase 4.8 として、multi_session 有効 + sandbox 有効（Claude 自身の Bash tool 定義から判定）を条件に、main checkout root 絶対パスを sandbox write 許可リストへ追加する恒久策を事前案内するステップを追加
- `plugins/rite/skills/getting-started/SKILL.md`: multi_session FAQ の運用ルール箇条書きに、git-worktree-patterns.md の #1896 対処節への 1 行ポインタを追加
- `plugins/rite/skills/recover/SKILL.md`: Phase 3.1.5 WT_ENSURE 分岐表（全 worktree 入場経路が参照する SoT）の直後に、#1896 対処節への 1 行ポインタを追加し、`/rite:recover` 経由の入場（クラッシュ後セッション）でも案内に到達できるようにした

## 実装中の判断・計画逸脱

Decision: `skills/open/SKILL.md` Step 2.3-W の既存 note は変更不要と判断 — 確認したところ既に SoT（git-worktree-patterns.md）への 1 行ポインタ形式になっており、本文複製は存在しなかったため。

## Checklist

- [x] Code follows project conventions
- [x] 案内は SoT（git-worktree-patterns.md）への 1 行ポインタ形式（本文複製なし）
- [x] settings ファイルへの自動書き込みは行っていない（案内のみ）
