### PR TITLE
fix(tests): post-compact.test.sh の ambient session-id 環境変数漏洩を遮断し sandbox で実行可能にする

### DIFF
--- a/plugins/rite/hooks/tests/post-compact.test.sh
+++ b/plugins/rite/hooks/tests/post-compact.test.sh
@@ -3,6 +3,17 @@
 # Usage: bash plugins/rite/hooks/tests/post-compact.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1911): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into every `bash "$HOOK"` invocation
+# below and silently overrides the file-based per-session fixtures written by
+# write_per_session_state(), making the hook resolve a nonexistent (or wrong)
+# flow-state file and exit with empty output. Unsetting both here forces every
+# invocation to resolve session_id from the fixture's `.rite-session-id` file,
+# matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../post-compact.sh"
 TEST_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

`post-compact.test.sh` が sandbox 有効環境で 15 passed / 17 failed となっていた。Issue 本文では gh/network 依存の未 mock 化が原因と推測されていたが、実際の根本原因は異なっていた: テストランナー自身（実行中の Claude Code セッション）が持つ `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` 環境変数が各 `bash "$HOOK"` 呼び出しに漏洩し、`flow-state.sh path` の session_id 解決優先順位（env var > `.rite-session-id` ファイル、Issue #1530 で導入）によって、`write_per_session_state()` が書いたファイルベースの fixture が無視され、hook が実在しない（または無関係な）flow-state ファイルを参照して空出力のまま終了していた。

`env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID` を付けて実行すると 34/34 全成功することを実機で確認し、根本原因を実証した。

## Related Issue

Closes #1911

## Changes

- `plugins/rite/hooks/tests/post-compact.test.sh`: スクリプト冒頭で `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` を `unset` し、全テストケースがファイルベースの `.rite-session-id` fixture を確実に参照するようにした。既存の `gh` CLI mock（PATH-injected shim）は変更不要（既に正しく機能している）

## 実装中の判断・計画逸脱

Decision: Issue 本文の想定原因（gh/network 依存の mock 化未実施）とは異なる根本原因（ambient session-id 環境変数の漏洩）を特定した。`bash -x` によるトレースで `flow-state.sh path` が期待と異なるセッションIDに解決されていることを確認し、環境変数を unset するだけで全テストが成功することを実証した。gh CLI の追加 mock 化は不要と判断し、スコープを縮小した。

Decision: TC-LEGACY-FALLBACK 内に既存する `env -u CLAUDE_CODE_SESSION_ID -u CLAUDE_SESSION_ID` は本修正により冗長になるが、diff 最小化のため変更しなかった（無害な冗長性であり、削除は本 Issue のスコープ外）。

## Checklist

- [x] Code follows project conventions
- [x] 修正後、実機でテストを再実行し 34/34 assertion 成功を確認（env prefix 不要な直接実行で）
- [x] 根本原因（gh/network ではなく ambient session-id 漏洩）を実証的に特定
