### PR TITLE
fix(tests): hooks/tests 全体で ambient session-id 環境変数漏洩の hermeticity 監査を実施する

### DIFF
--- a/plugins/rite/hooks/tests/cleanup-on-session-end.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-on-session-end.test.sh
@@ -34,6 +34,16 @@
 # Usage: bash plugins/rite/hooks/tests/cleanup-on-session-end.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into every `bash "$HOOK"` invocation
+# below and silently overrides the file-based per-session fixtures, making the
+# hook resolve a nonexistent (or wrong) flow-state file. Unsetting both here
+# forces every invocation to resolve session_id from the fixture's
+# `.rite-session-id` file, matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOKS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 HOOK="$HOOKS_DIR/session-end.sh"

--- a/plugins/rite/hooks/tests/crash-resume.test.sh
+++ b/plugins/rite/hooks/tests/crash-resume.test.sh
@@ -25,6 +25,17 @@
 # Usage: bash plugins/rite/hooks/tests/crash-resume.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into the `$STATE_READ get --field ...`
+# calls (no `--session` passed) below and silently overrides the file-based
+# per-session fixtures, making the read resolve a nonexistent (or wrong)
+# flow-state file. Unsetting both here forces every invocation to resolve
+# session_id from the fixture's `.rite-session-id` file, matching the intended
+# test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../flow-state.sh"
 STATE_READ="$SCRIPT_DIR/../flow-state.sh"

--- a/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
@@ -3,6 +3,16 @@
 # Usage: bash plugins/rite/hooks/tests/post-tool-wm-sync.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into every `bash "$HOOK"` invocation
+# below and silently overrides the file-based per-session fixtures, making the
+# hook resolve a nonexistent (or wrong) flow-state file. Unsetting both here
+# forces every invocation to resolve session_id from the fixture's
+# `.rite-session-id` file, matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../post-tool-wm-sync.sh"
 TEST_DIR="$(mktemp -d)"

--- a/plugins/rite/hooks/tests/pre-compact.test.sh
+++ b/plugins/rite/hooks/tests/pre-compact.test.sh
@@ -3,6 +3,20 @@
 # Usage: bash plugins/rite/hooks/tests/pre-compact.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into most `bash "$HOOK"` invocations
+# below (only one call site had an inline `env -u` guard) and silently
+# overrides the file-based per-session fixtures, making the hook resolve a
+# nonexistent (or wrong) flow-state file — in the worst case crashing the
+# suite outright under `set -euo pipefail`. Unsetting both here forces every
+# invocation to resolve session_id from the fixture's `.rite-session-id` file,
+# matching the intended test isolation. (The pre-existing inline `env -u`
+# guard further down stays as defense in depth; it's redundant but harmless
+# with this file-wide unset in place.)
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../pre-compact.sh"
 TEST_DIR="$(mktemp -d)"

--- a/plugins/rite/hooks/tests/session-end.test.sh
+++ b/plugins/rite/hooks/tests/session-end.test.sh
@@ -3,6 +3,16 @@
 # Usage: bash plugins/rite/hooks/tests/session-end.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into every `bash "$HOOK"` invocation
+# below and silently overrides the file-based per-session fixtures, making the
+# hook resolve a nonexistent (or wrong) flow-state file. Unsetting both here
+# forces every invocation to resolve session_id from the fixture's
+# `.rite-session-id` file, matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK="$SCRIPT_DIR/../session-end.sh"
 TEST_DIR="$(mktemp -d)"

--- a/plugins/rite/hooks/tests/session-ownership-regression.test.sh
+++ b/plugins/rite/hooks/tests/session-ownership-regression.test.sh
@@ -21,6 +21,17 @@
 # Usage: bash plugins/rite/hooks/tests/session-ownership-regression.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into calls that deliberately omit
+# `--session` (notably TC-session-id-auto-read, which verifies file-based
+# resolution) and into `session-start.sh` invocations below, silently
+# overriding the file-based per-session fixtures. Unsetting both here forces
+# every such invocation to resolve session_id from the fixture's
+# `.rite-session-id` file, matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK_DIR="$SCRIPT_DIR/.."
 HOOK="$HOOK_DIR/flow-state.sh"

--- a/plugins/rite/hooks/tests/work-memory-update.test.sh
+++ b/plugins/rite/hooks/tests/work-memory-update.test.sh
@@ -22,6 +22,17 @@
 # Usage: bash plugins/rite/hooks/tests/work-memory-update.test.sh
 set -euo pipefail
 
+# Hermeticity guard (Issue #1929): flow-state.sh path resolves session_id with
+# priority env CLAUDE_CODE_SESSION_ID > env CLAUDE_SESSION_ID > .rite-session-id
+# file (Issue #1530). When this test suite runs inside a live Claude Code
+# session, that session's own id leaks into the `flow-state.sh get --field ...`
+# call inside work-memory-update.sh's run_update() helper (no `--session`
+# passed) and silently overrides the file-based per-session fixtures, making
+# the read resolve a nonexistent (or wrong) flow-state file. Unsetting both
+# here forces every invocation to resolve session_id from the fixture's
+# `.rite-session-id` file, matching the intended test isolation.
+unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HELPER="$SCRIPT_DIR/../work-memory-update.sh"


### PR DESCRIPTION
## 概要

`hooks/tests/*.test.sh`（全95ファイル）を対象に、ambient `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` 環境変数漏洩の hermeticity 悉皆監査を実施し、影響のあった7ファイルに guard を追加した。

## 関連 Issue

Closes #1929

## 背景

PR #1928（Issue #1911）では `post-compact.test.sh` のみを対象に、テストランナー自身（実行中の Claude Code セッション）が持つ `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` が各 `bash "$HOOK"` 呼び出しに漏洩し、`flow-state.sh` の session_id 解決優先順位（env var > `.rite-session-id` ファイル）によってテストのファイルベース fixture が無視される問題を修正した。同レビューで他ファイルにも同一パターンが潜在している可能性が指摘され、本 Issue で全体監査を行った。

## 変更内容

静的解析（session_id 解決チェーンに触れる hook 呼び出しの洗い出し）と実機検証（ambient env 設定状態 vs unset 状態の挙動比較）で全95ファイルを監査し、以下7ファイルの冒頭に `unset CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID`（`post-compact.test.sh` 等で確立済みの blessed pattern）を追加した:

- `session-end.test.sh`（20/14 → 34/0）
- `cleanup-on-session-end.test.sh`（4/4 → 8/0）
- `crash-resume.test.sh`（6/1 → 7/0）
- `session-ownership-regression.test.sh`（5/3 → 8/0）
- `post-tool-wm-sync.test.sh`（16/12 → 28/0）
- `work-memory-update.test.sh`（9/4 → 13/0）
- `pre-compact.test.sh`（unguarded 10箇所中9箇所。ambient env 下では `set -euo pipefail` によりテストスイート自体がクラッシュしていた）

Issue 起票時点で「部分ガード・未検証」と推測されていた `issue-claim.test.sh` / `wiki-ingest-lock.test.sh` は、実機検証の結果、`--session` を省略する全呼出に既存の inline `env -u` ガードが漏れなく掛かっており、修正不要と判明した。

残る86ファイルは session_id 解決チェーンに触れる hook 呼び出しを持たない（純粋な static/grep チェック、または全呼出が `--session` 明示指定）ため対象外。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (all 7 modified files verified with 0 failures under both ambient-set and ambient-unset conditions)
- [ ] Documentation updated (if applicable) — テストファイルのみの変更のためドキュメント更新は不要と判断

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
