### PR TITLE
fix(sandbox): 書き込みブロック用マウントを git status の untracked から除外

### DIFF
--- a/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
+++ b/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
@@ -1,0 +1,73 @@
+# rite workflow - git status filtered for sandbox write-block ghost mounts
+#
+# Responsibility: wrap `git status --porcelain -z` and drop untracked (`??`)
+# entries whose path is actually a Bash tool sandbox write-block bind mount
+# (a persistent character-device /dev/null mount placed over a real path
+# such as .bashrc or .claude/agents to block writes there), not a genuine
+# untracked file. These mounts are invisible to the harness's own git-status
+# snapshot but visible from inside the Bash tool, so they show up as
+# spurious `??` entries in every `git status --porcelain` call made from a
+# sandboxed Bash command even though nothing in the working tree actually
+# changed (#1936). Detection is mechanism-based (`test -c`), never a
+# filename allowlist, so it survives whatever set of paths a given sandbox
+# config happens to block.
+#
+# Scope: only `??` (untracked) entries are ever dropped, and only when the
+# path is a character device. Every other status code (staged / unstaged /
+# unmerged / renamed / copied) passes through unchanged — this is a
+# display-layer filter, not a substitute for real conflict or dirty-state
+# detection.
+#
+# -z is used on the read side (not the traditional non-`-z` porcelain v1)
+# so paths with special characters parse unambiguously via NUL delimiters
+# instead of relying on quote-escaping; the output is re-rendered as plain
+# porcelain v1 text (newline-separated) so existing callers that already
+# expect `git status --porcelain` output need no changes beyond swapping
+# the command.
+#
+# Usage (standalone subprocess only — this file is not meant to be
+# sourced):
+#   dirty=$(bash lib/git-status-filtered.sh 2>/dev/null)
+#
+# Output contract: on success, stdout is porcelain v1 text ("XY path" /
+# "XY orig -> new" lines, newline-separated, empty when clean) and exit is
+# 0. On failure (not a git repository, or git itself errors), stderr gets
+# one WARNING line and exit is non-zero — callers must not treat empty
+# stdout as "no changes" without checking the exit code, since that would
+# silently mask a genuine detection failure as a clean tree.
+
+set -uo pipefail
+
+tmp_out=$(mktemp) && tmp_err=$(mktemp) || {
+  echo "WARNING: git-status-filtered: mktemp failed" >&2
+  exit 1
+}
+trap 'rm -f "$tmp_out" "$tmp_err"' EXIT
+
+if ! git status --porcelain -z >"$tmp_out" 2>"$tmp_err"; then
+  echo "WARNING: git-status-filtered: 'git status --porcelain -z' failed (not a git repository, or git itself errored): $(cat "$tmp_err" 2>/dev/null)" >&2
+  exit 1
+fi
+
+result=""
+while IFS= read -r -d '' entry; do
+  [ -z "$entry" ] && continue
+  code="${entry:0:2}"
+  path="${entry:3}"
+  case "${code:0:1}" in
+    R | C)
+      # Rename/copy: -z emits the new path (with status) first, then the
+      # bare original path as the next NUL-terminated field.
+      IFS= read -r -d '' orig_path || orig_path=""
+      result+="$code $orig_path -> $path"$'\n'
+      ;;
+    *)
+      if [ "$code" = "??" ] && [ -c "$path" ]; then
+        continue # sandbox write-block ghost mount — drop
+      fi
+      result+="$code $path"$'\n'
+      ;;
+  esac
+done <"$tmp_out"
+
+printf '%s' "$result"

--- a/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
+++ b/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
@@ -26,8 +26,11 @@
 # the command.
 #
 # Usage (standalone subprocess only — this file is not meant to be
-# sourced):
-#   dirty=$(bash lib/git-status-filtered.sh 2>/dev/null)
+# sourced). Do not redirect stderr to /dev/null on the call site — that
+# discards this script's own diagnostic WARNING (see Output contract
+# below) and, combined with a caller that also skips the exit-code check,
+# recreates the exact silent-failure bug this script exists to prevent:
+#   dirty=$(bash lib/git-status-filtered.sh) || dirty="<non-empty fallback, e.g. treat as dirty>"
 #
 # Output contract: on success, stdout is porcelain v1 text ("XY path" /
 # "XY orig -> new" lines, newline-separated, empty when clean) and exit is

--- a/plugins/rite/hooks/tests/base-update-classify.test.sh
+++ b/plugins/rite/hooks/tests/base-update-classify.test.sh
@@ -24,6 +24,10 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_MD="$SCRIPT_DIR/../../skills/cleanup/SKILL.md"
+# tests/ -> hooks/ -> rite (2 up), same resolution as _test-helpers.sh's
+# _helpers_resolve_plugin_root. Needed because the extracted classify block
+# now calls lib/git-status-filtered.sh via the {plugin_root} placeholder (#1936).
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TEST_DIR="$(mktemp -d)"
 PASS=0
 FAIL=0
@@ -37,7 +41,7 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 # --- SKILL.md から検証 block を抽出 ({base_branch} は main に置換) ---
 CLASSIFY_SNIPPET="$TEST_DIR/classify.sh"
 awk '/# retry break 後の成否検証/{f=1} f && /^else$/{exit} f{print}' "$SKILL_MD" \
-  | sed 's/{base_branch}/main/g' > "$CLASSIFY_SNIPPET"
+  | sed -e 's/{base_branch}/main/g' -e "s|{plugin_root}|$PLUGIN_ROOT|g" > "$CLASSIFY_SNIPPET"
 if ! grep -q 'BASE_UPDATE=ff_failed_discardable' "$CLASSIFY_SNIPPET"; then
   echo "FAIL: SKILL.md からの検証 block 抽出に失敗しました (アンカーが変更された可能性)"
   echo "  抽出結果: $(wc -l < "$CLASSIFY_SNIPPET") 行"

--- a/plugins/rite/hooks/tests/base-update-classify.test.sh
+++ b/plugins/rite/hooks/tests/base-update-classify.test.sh
@@ -19,6 +19,10 @@
 # - TC-6: 非 -z の --name-only は quotePath がファイル名を C-quote し、pathspec 不一致の
 #   git diff --quiet が exit 0 を返して相違変更が discardable に誤流出、破棄承認で
 #   データ喪失した。非 ASCII 名の相違が divergent に落ちることを pin
+# - TC-9 (#1936, T-05): sandbox の書き込みブロック用 character device マウントが
+#   untracked (`??`) として誤検出され ff_failed_divergent に誤流出しないことを pin。
+#   dirty 判定が lib/git-status-filtered.sh 経由になったことで、ゴーストマウントのみ・
+#   HEAD が origin と同一の状態では ok に分類される
 
 set -uo pipefail
 
@@ -147,6 +151,16 @@ echo "SUBDIR-LOCAL" > file.txt
 r=$(cd sub && bash "$CLASSIFY_SNIPPET" 2>/dev/null | sed -n 's/^\[CONTEXT\] BASE_UPDATE=//p' | head -1)
 [ "$r" = "ff_failed_divergent" ] && pass "TC-8 ($r)" || fail "TC-8: expected ff_failed_divergent, got '$r'"
 git checkout -- :/
+
+# ─── TC-9: sandbox ゴーストマウント (character device) のみ + HEAD == origin → ok (T-05, #1936) ───
+# mknod は root/CAP_MKNOD 必須で本環境では使えないため、/dev/null への symlink で
+# character device を模す (test -c は symlink を辿るため実マウントと等価)。
+echo "TC-9: sandbox ghost-mount only (up-to-date) -> ok"
+git fetch -q origin main && git merge -q --ff-only origin/main
+ln -s /dev/null ghost_devnull
+r=$(classify)
+[ "$r" = "ok" ] && pass "TC-9 ($r)" || fail "TC-9: expected ok, got '$r' (#1936 sandbox ghost mount regression)"
+rm -f ghost_devnull && git checkout -- :/
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/base-update-classify.test.sh
+++ b/plugins/rite/hooks/tests/base-update-classify.test.sh
@@ -23,6 +23,11 @@
 #   untracked (`??`) として誤検出され ff_failed_divergent に誤流出しないことを pin。
 #   dirty 判定が lib/git-status-filtered.sh 経由になったことで、ゴーストマウントのみ・
 #   HEAD が origin と同一の状態では ok に分類される
+# - TC-10 (#1937 cross-validation): lib/git-status-filtered.sh 自体が失敗した場合
+#   （mktemp 枯渇等、旧来の `git status --porcelain` には無かった新規失敗モード）、
+#   `_bu_dirty` の空文字列フォールバックにより ff_failed_clean へ silent に倒れず
+#   ff_failed_divergent（安全側）に分類されることを pin。stub plugin_root で
+#   helper を強制失敗させて検証する
 
 set -uo pipefail
 
@@ -161,6 +166,26 @@ ln -s /dev/null ghost_devnull
 r=$(classify)
 [ "$r" = "ok" ] && pass "TC-9 ($r)" || fail "TC-9: expected ok, got '$r' (#1936 sandbox ghost mount regression)"
 rm -f ghost_devnull && git checkout -- :/
+
+# ─── TC-10: lib/git-status-filtered.sh 自体の失敗時 → divergent (fail-safe, PR #1937 cross-validation) ───
+echo "TC-10: git-status-filtered.sh helper failure -> divergent (fail-safe, not silently clean)"
+advance_origin "v4" ""
+stub_root="$TEST_DIR/stub-plugin-root"
+mkdir -p "$stub_root/hooks/scripts/lib"
+cat > "$stub_root/hooks/scripts/lib/git-status-filtered.sh" << 'STUB_EOF'
+echo "WARNING: git-status-filtered: simulated failure (test stub)" >&2
+exit 1
+STUB_EOF
+CLASSIFY_SNIPPET_FAIL="$TEST_DIR/classify-fail.sh"
+awk '/# retry break 後の成否検証/{f=1} f && /^else$/{exit} f{print}' "$SKILL_MD" \
+  | sed -e 's/{base_branch}/main/g' -e "s|{plugin_root}|$stub_root|g" > "$CLASSIFY_SNIPPET_FAIL"
+r=$(bash "$CLASSIFY_SNIPPET_FAIL" 2>/dev/null | sed -n 's/^\[CONTEXT\] BASE_UPDATE=//p' | head -1)
+if [ "$r" = "ff_failed_divergent" ]; then
+  pass "TC-10 ($r)"
+else
+  fail "TC-10: expected ff_failed_divergent (fail-safe), got '$r' (helper failure must not be silently treated as clean)"
+fi
+git checkout -- :/
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/git-status-filtered.test.sh
+++ b/plugins/rite/hooks/tests/git-status-filtered.test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Tests for lib/git-status-filtered.sh (#1936)
+#
+# The Bash tool sandbox blocks writes to certain paths (.bashrc,
+# .claude/agents, .gitconfig, etc.) by bind-mounting /dev/null over them.
+# These mounts are persistent character-device files, invisible to the
+# harness's own git-status snapshot but visible from inside the Bash tool,
+# so they show up as spurious `??` (untracked) entries in every
+# `git status --porcelain` a sandboxed Bash command runs — even though
+# nothing in the working tree actually changed. lib/git-status-filtered.sh
+# strips exactly those entries (untracked + character device, detected via
+# `test -c`, never a filename allowlist) while passing every other status
+# code through unchanged.
+#
+# mknod requires root/CAP_MKNOD and is unavailable in this (and most CI)
+# environments, so tests simulate a "character device at this path" with a
+# symlink to /dev/null (`ln -s /dev/null <path>`) instead of a real device
+# node. `test -c` follows symlinks (like stat, not lstat), so this is
+# behaviorally identical to the real sandbox mount for the one property the
+# script inspects, and `git status --porcelain` reports it as an ordinary
+# `??` entry exactly like the genuine ghost mount.
+#
+# Convention: standalone subprocess (`bash lib/git-status-filtered.sh`),
+# not sourced — mirrors git-remote-resolve.test.sh's invocation style for
+# the sibling lib/git-remote.sh standalone subcommand.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+LIB="$SCRIPT_DIR/../scripts/lib/git-status-filtered.sh"
+
+echo "=== git-status-filtered.sh (untracked character-device ghost mount filter) ==="
+
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: $LIB not found" >&2
+  exit 1
+fi
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+run_in() {
+  local dir="$1"
+  ( cd "$dir" && bash "$LIB" )
+}
+
+# --- T-01 (AC-1): character device untracked-only tree filters to empty --
+sbx1=$(make_sandbox) && cleanup_dirs+=("$sbx1") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx1" && ln -s /dev/null ghost_devnull ) >/dev/null 2>&1
+out=$(run_in "$sbx1"); rc=$?
+assert "T-01: exit 0" "0" "$rc"
+assert "T-01: output empty (ghost entry dropped)" "" "$out"
+
+# --- T-02 (AC-1 + AC-2): real untracked file survives, ghost is dropped ---
+sbx2=$(make_sandbox) && cleanup_dirs+=("$sbx2") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx2" && ln -s /dev/null ghost_devnull && echo new > real_untracked.txt ) >/dev/null 2>&1
+out=$(run_in "$sbx2"); rc=$?
+assert "T-02: exit 0" "0" "$rc"
+assert "T-02: real untracked file present" "?? real_untracked.txt" "$out"
+case "$out" in
+  *ghost_devnull*) fail "T-02: ghost entry must not appear in output" ;;
+  *) pass "T-02: ghost entry absent from output" ;;
+esac
+
+# --- T-03 (AC-3): staged / unstaged / unmerged entries pass through as-is -
+sbx3=$(make_sandbox) && cleanup_dirs+=("$sbx3") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+base_branch=$( cd "$sbx3" && git branch --show-current )
+(
+  cd "$sbx3" || exit 1
+  echo modified >> a
+  echo staged > staged.txt
+  git add staged.txt
+) >/dev/null 2>&1
+out=$(run_in "$sbx3")
+case "$out" in
+  *"A  staged.txt"*) pass "T-03: staged (A ) entry passes through" ;;
+  *) fail "T-03: staged (A ) entry passes through (got: $out)" ;;
+esac
+case "$out" in
+  *" M a"*) pass "T-03: unstaged ( M) entry passes through" ;;
+  *) fail "T-03: unstaged ( M) entry passes through (got: $out)" ;;
+esac
+
+# unmerged (UU): diverge on a branch, then merge to force a conflict on "a"
+sbx3u=$(make_sandbox) && cleanup_dirs+=("$sbx3u") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+base3u=$( cd "$sbx3u" && git branch --show-current )
+(
+  cd "$sbx3u" || exit 1
+  git checkout -q -b conflict-side
+  echo side > a
+  git -c user.email=t@test.local -c user.name=test commit -q -am side
+  git checkout -q "$base3u"
+  echo main > a
+  git -c user.email=t@test.local -c user.name=test commit -q -am main
+  git merge conflict-side >/dev/null 2>&1
+) >/dev/null 2>&1
+out=$(run_in "$sbx3u")
+case "$out" in
+  *"UU a"*) pass "T-03: unmerged (UU) entry passes through" ;;
+  *) fail "T-03: unmerged (UU) entry passes through (got: $out)" ;;
+esac
+
+# --- Rename pass-through: -z's two-field rename record reassembles as "R  old -> new"
+sbx_ren=$(make_sandbox) && cleanup_dirs+=("$sbx_ren") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_ren" && git mv a b ) >/dev/null 2>&1
+out=$(run_in "$sbx_ren")
+assert "rename: reassembled as 'R  a -> b'" "R  a -> b" "$out"
+
+# --- Clean tree: no entries at all -> empty output, exit 0 ------------------
+sbx_clean=$(make_sandbox) && cleanup_dirs+=("$sbx_clean") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+out=$(run_in "$sbx_clean"); rc=$?
+assert "clean tree: exit 0" "0" "$rc"
+assert "clean tree: empty output" "" "$out"
+
+# --- Failure path: not a git repository -> non-zero exit, WARNING on stderr,
+#     empty stdout (script must not silently report a "clean" tree) --------
+plain=$(make_plain_sandbox) && cleanup_dirs+=("$plain") || { echo "ERROR: make_plain_sandbox failed, aborting" >&2; exit 1; }
+err_capture=$(mktemp) || { echo "ERROR: mktemp failed, aborting" >&2; exit 1; }
+out=$( cd "$plain" && bash "$LIB" 2>"$err_capture" )
+rc=$?
+err=$(cat "$err_capture" 2>/dev/null); rm -f "$err_capture"
+assert "not-a-repo: non-zero exit" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+assert "not-a-repo: empty stdout" "" "$out"
+case "$err" in
+  *"WARNING: git-status-filtered"*) pass "not-a-repo: WARNING emitted on stderr" ;;
+  *) fail "not-a-repo: WARNING emitted on stderr (got: $err)" ;;
+esac
+
+print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
+++ b/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# sandbox-ghost-dirty-integration.test.sh (#1936, T-04 / T-06)
+#
+# Pins that the exact dirty-detection lines embedded in cleanup/SKILL.md
+# Step 4-W and recover/SKILL.md Phase 3.2 — extracted literally from the
+# SKILL.md files, not reimplemented — resolve to "not dirty" when the only
+# `??` entries in the tree are sandbox write-block ghost mounts, and still
+# resolve to "dirty" for a genuine untracked file (no false-negative
+# regression). T-05 (cleanup Step 4 BASE_UPDATE=ok under the same ghost-only
+# condition) is covered by base-update-classify.test.sh's dedicated case.
+#
+# mknod requires root/CAP_MKNOD (unavailable here and in most CI), so a
+# symlink to /dev/null simulates the ghost mount: `test -c` follows
+# symlinks (like stat, not lstat), so a symlink target of /dev/null is
+# indistinguishable from the real character-device bind mount for the one
+# property lib/git-status-filtered.sh inspects, and `git status --porcelain`
+# reports it as an ordinary `??` entry exactly like the genuine ghost mount.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+CLEANUP_MD="$PLUGIN_ROOT/skills/cleanup/SKILL.md"
+RECOVER_MD="$PLUGIN_ROOT/skills/recover/SKILL.md"
+
+echo "=== sandbox ghost-mount dirty-check integration (cleanup Step 4-W / recover) ==="
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# --- Extract the exact dirty-detection line from each SKILL.md, literally,
+#     so drift in the source file (not just this test) is caught -----------
+CLEANUP_LINE=$(grep -m1 '^\s*dirty=\$(bash {plugin_root}' "$CLEANUP_MD")
+if [ -z "$CLEANUP_LINE" ]; then
+  echo "ERROR: cleanup/SKILL.md からの dirty= 行抽出に失敗しました（アンカーが変更された可能性）" >&2
+  exit 1
+fi
+CLEANUP_LINE=${CLEANUP_LINE//\{plugin_root\}/$PLUGIN_ROOT}
+
+RECOVER_LINE=$(grep -m1 'git_has_uncommitted=\$(bash {plugin_root}' "$RECOVER_MD")
+if [ -z "$RECOVER_LINE" ]; then
+  echo "ERROR: recover/SKILL.md からの git_has_uncommitted= 行抽出に失敗しました（アンカーが変更された可能性）" >&2
+  exit 1
+fi
+RECOVER_LINE=${RECOVER_LINE//\{plugin_root\}/$PLUGIN_ROOT}
+
+run_cleanup_dirty() {
+  # Mirrors the SKILL.md line's own variable name ("dirty") so the extracted
+  # text runs unmodified; echoes it out for the test to capture.
+  ( cd "$1" && eval "$CLEANUP_LINE" && printf '%s' "$dirty" )
+}
+
+run_recover_uncommitted() {
+  ( cd "$1" && eval "$RECOVER_LINE" && printf '%s' "$git_has_uncommitted" )
+}
+
+# --- T-04: cleanup Step 4-W dirty line, ghost-only tree -> empty (not dirty)
+sbx_t04=$(make_sandbox) && cleanup_dirs+=("$sbx_t04") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_t04" && ln -s /dev/null ghost_devnull ) >/dev/null 2>&1
+out=$(run_cleanup_dirty "$sbx_t04")
+assert "T-04: cleanup Step 4-W dirty= is empty with ghost-only tree" "" "$out"
+
+# --- T-04 regression guard: a genuine untracked file must still register --
+sbx_t04b=$(make_sandbox) && cleanup_dirs+=("$sbx_t04b") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_t04b" && echo x > real.txt ) >/dev/null 2>&1
+out=$(run_cleanup_dirty "$sbx_t04b")
+assert "T-04 regression guard: real untracked file still reported dirty" "?? real.txt" "$out"
+
+# --- T-06: recover git_has_uncommitted, ghost-only tree -> empty ("なし") -
+sbx_t06=$(make_sandbox) && cleanup_dirs+=("$sbx_t06") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_t06" && ln -s /dev/null ghost_devnull ) >/dev/null 2>&1
+out=$(run_recover_uncommitted "$sbx_t06")
+assert "T-06: recover git_has_uncommitted is empty with ghost-only tree" "" "$out"
+
+# --- T-06 regression guard: a genuine unstaged change must still register -
+sbx_t06b=$(make_sandbox) && cleanup_dirs+=("$sbx_t06b") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+( cd "$sbx_t06b" && echo modified >> a ) >/dev/null 2>&1
+out=$(run_recover_uncommitted "$sbx_t06b")
+assert "T-06 regression guard: real unstaged change still reported uncommitted" " M a" "$out"
+
+print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
+++ b/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
@@ -111,6 +111,12 @@ STUB_EOF
 
 CLEANUP_LINE_FAIL=$(grep -m1 '^\s*dirty=\$(bash {plugin_root}' "$CLEANUP_MD")
 CLEANUP_LINE_FAIL=${CLEANUP_LINE_FAIL//\{plugin_root\}/$stub_root}
+BU_DIRTY_LINE_FAIL=$(grep -m1 '_bu_dirty=\$(bash {plugin_root}' "$CLEANUP_MD")
+if [ -z "$BU_DIRTY_LINE_FAIL" ]; then
+  echo "ERROR: cleanup/SKILL.md からの _bu_dirty= 行抽出に失敗しました（アンカーが変更された可能性）" >&2
+  exit 1
+fi
+BU_DIRTY_LINE_FAIL=${BU_DIRTY_LINE_FAIL//\{plugin_root\}/$stub_root}
 RECOVER_LINE_FAIL=$(grep -m1 'git_has_uncommitted=\$(bash {plugin_root}' "$RECOVER_MD")
 RECOVER_LINE_FAIL=${RECOVER_LINE_FAIL//\{plugin_root\}/$stub_root}
 
@@ -129,6 +135,23 @@ err_out=$( cd "$sbx_fail" && eval "$CLEANUP_LINE_FAIL" 2>&1 1>/dev/null )
 case "$err_out" in
   *"git-status-filtered: simulated failure"*) pass "fail-safe: cleanup Step 4-W surfaces the helper's own stderr on failure ($err_out)" ;;
   *) fail "fail-safe: cleanup Step 4-W must surface the helper's own stderr on failure (got: $err_out)" ;;
+esac
+
+# --- cleanup Step 4 (_bu_dirty, base-update classify): same fail-safe /
+#     stderr-visibility pin as Step 4-W above, for the third call site that
+#     had its own `2>/dev/null` removed in cycle 3 (test-reviewer escalation:
+#     TC-10 in base-update-classify.test.sh only pins the classification
+#     outcome, not stderr visibility for this specific line) --------------
+out=$( cd "$sbx_fail" && eval "$BU_DIRTY_LINE_FAIL" && printf '%s' "$_bu_dirty" )
+case "$out" in
+  "") fail "fail-safe: cleanup Step 4 _bu_dirty= must not be empty when the helper fails (got empty — silent clean masking a detection failure)" ;;
+  *) pass "fail-safe: cleanup Step 4 _bu_dirty= is non-empty when the helper fails ($out)" ;;
+esac
+
+err_out=$( cd "$sbx_fail" && eval "$BU_DIRTY_LINE_FAIL" 2>&1 1>/dev/null )
+case "$err_out" in
+  *"git-status-filtered: simulated failure"*) pass "fail-safe: cleanup Step 4 surfaces the helper's own stderr on failure ($err_out)" ;;
+  *) fail "fail-safe: cleanup Step 4 must surface the helper's own stderr on failure (got: $err_out)" ;;
 esac
 
 out=$( cd "$sbx_fail" && eval "$RECOVER_LINE_FAIL" && printf '%s' "$git_has_uncommitted" )

--- a/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
+++ b/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
@@ -15,6 +15,16 @@
 # indistinguishable from the real character-device bind mount for the one
 # property lib/git-status-filtered.sh inspects, and `git status --porcelain`
 # reports it as an ordinary `??` entry exactly like the genuine ghost mount.
+#
+# Fail-safe pin (cross-validation escalation, PR #1937): when
+# lib/git-status-filtered.sh itself fails (e.g. mktemp exhaustion — a
+# failure mode the helper introduces that plain `git status --porcelain`
+# never had), both extracted lines must fall back to a non-empty "assume
+# dirty/uncommitted" sentinel rather than silently reporting clean. A stub
+# replacing the helper (via a fake plugin_root) simulates this failure.
+# The same stub also pins that issue-update/SKILL.md Phase 3.2 Step 1
+# (changed_files=) emits a visible WARNING on helper failure instead of
+# silently producing an empty file list with no signal.
 
 set -uo pipefail
 
@@ -25,6 +35,7 @@ source "$SCRIPT_DIR/_test-helpers.sh"
 PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
 CLEANUP_MD="$PLUGIN_ROOT/skills/cleanup/SKILL.md"
 RECOVER_MD="$PLUGIN_ROOT/skills/recover/SKILL.md"
+ISSUE_UPDATE_MD="$PLUGIN_ROOT/skills/issue-update/SKILL.md"
 
 echo "=== sandbox ghost-mount dirty-check integration (cleanup Step 4-W / recover) ==="
 
@@ -86,5 +97,50 @@ sbx_t06b=$(make_sandbox) && cleanup_dirs+=("$sbx_t06b") || { echo "ERROR: make_s
 ( cd "$sbx_t06b" && echo modified >> a ) >/dev/null 2>&1
 out=$(run_recover_uncommitted "$sbx_t06b")
 assert "T-06 regression guard: real unstaged change still reported uncommitted" " M a" "$out"
+
+# --- Fail-safe: when lib/git-status-filtered.sh itself fails, the extracted
+#     lines must NOT silently report clean (cross-validation escalation,
+#     PR #1937). A stub plugin_root replaces the real helper with one that
+#     always fails, and the same production lines are re-extracted against it.
+stub_root=$(mktemp -d) && cleanup_dirs+=("$stub_root") || { echo "ERROR: mktemp -d failed for stub_root, aborting" >&2; exit 1; }
+mkdir -p "$stub_root/hooks/scripts/lib"
+cat > "$stub_root/hooks/scripts/lib/git-status-filtered.sh" << 'STUB_EOF'
+echo "WARNING: git-status-filtered: simulated failure (test stub)" >&2
+exit 1
+STUB_EOF
+
+CLEANUP_LINE_FAIL=$(grep -m1 '^\s*dirty=\$(bash {plugin_root}' "$CLEANUP_MD")
+CLEANUP_LINE_FAIL=${CLEANUP_LINE_FAIL//\{plugin_root\}/$stub_root}
+RECOVER_LINE_FAIL=$(grep -m1 'git_has_uncommitted=\$(bash {plugin_root}' "$RECOVER_MD")
+RECOVER_LINE_FAIL=${RECOVER_LINE_FAIL//\{plugin_root\}/$stub_root}
+
+sbx_fail=$(make_sandbox) && cleanup_dirs+=("$sbx_fail") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+
+out=$( cd "$sbx_fail" && eval "$CLEANUP_LINE_FAIL" && printf '%s' "$dirty" )
+case "$out" in
+  "") fail "fail-safe: cleanup Step 4-W dirty= must not be empty when the helper fails (got empty — silent clean masking a detection failure)" ;;
+  *) pass "fail-safe: cleanup Step 4-W dirty= is non-empty when the helper fails ($out)" ;;
+esac
+
+out=$( cd "$sbx_fail" && eval "$RECOVER_LINE_FAIL" && printf '%s' "$git_has_uncommitted" )
+case "$out" in
+  "") fail "fail-safe: recover git_has_uncommitted must not be empty when the helper fails (got empty — silent 'なし' masking a detection failure)" ;;
+  *) pass "fail-safe: recover git_has_uncommitted is non-empty when the helper fails ($out)" ;;
+esac
+
+# --- issue-update Phase 3.2 Step 1: helper failure must emit a visible
+#     WARNING (not silently produce an empty file list with no signal) ---
+ISSUE_UPDATE_LINE_FAIL=$(grep -m1 '^changed_files=\$(bash {plugin_root}' "$ISSUE_UPDATE_MD")
+if [ -z "$ISSUE_UPDATE_LINE_FAIL" ]; then
+  echo "ERROR: issue-update/SKILL.md からの changed_files= 行抽出に失敗しました（アンカーが変更された可能性）" >&2
+  exit 1
+fi
+ISSUE_UPDATE_LINE_FAIL=${ISSUE_UPDATE_LINE_FAIL//\{plugin_root\}/$stub_root}
+
+err_out=$( cd "$sbx_fail" && eval "$ISSUE_UPDATE_LINE_FAIL" 2>&1 1>/dev/null )
+case "$err_out" in
+  *"git-status-filtered.sh failed while collecting changed files"*) pass "issue-update: WARNING emitted when the helper fails ($err_out)" ;;
+  *) fail "issue-update: WARNING must be emitted when the helper fails (got: $err_out)" ;;
+esac
 
 print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
+++ b/plugins/rite/hooks/tests/sandbox-ghost-dirty-integration.test.sh
@@ -122,10 +122,25 @@ case "$out" in
   *) pass "fail-safe: cleanup Step 4-W dirty= is non-empty when the helper fails ($out)" ;;
 esac
 
+# --- stderr visibility (PR #1937 cycle 2, error-handling escalation): the
+#     helper's own diagnostic WARNING (e.g. "mktemp failed") must reach
+#     stderr, not be discarded by a `2>/dev/null` on the call site ---------
+err_out=$( cd "$sbx_fail" && eval "$CLEANUP_LINE_FAIL" 2>&1 1>/dev/null )
+case "$err_out" in
+  *"git-status-filtered: simulated failure"*) pass "fail-safe: cleanup Step 4-W surfaces the helper's own stderr on failure ($err_out)" ;;
+  *) fail "fail-safe: cleanup Step 4-W must surface the helper's own stderr on failure (got: $err_out)" ;;
+esac
+
 out=$( cd "$sbx_fail" && eval "$RECOVER_LINE_FAIL" && printf '%s' "$git_has_uncommitted" )
 case "$out" in
   "") fail "fail-safe: recover git_has_uncommitted must not be empty when the helper fails (got empty — silent 'なし' masking a detection failure)" ;;
   *) pass "fail-safe: recover git_has_uncommitted is non-empty when the helper fails ($out)" ;;
+esac
+
+err_out=$( cd "$sbx_fail" && eval "$RECOVER_LINE_FAIL" 2>&1 1>/dev/null )
+case "$err_out" in
+  *"git-status-filtered: simulated failure"*) pass "fail-safe: recover surfaces the helper's own stderr on failure ($err_out)" ;;
+  *) fail "fail-safe: recover must surface the helper's own stderr on failure (got: $err_out)" ;;
 esac
 
 # --- issue-update Phase 3.2 Step 1: helper failure must emit a visible

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -335,7 +335,7 @@ cleanup_wt=${detect#CLEANUP_WT=}; cleanup_wt=${cleanup_wt%%;*}
 flow_wt=${detect##*worktree=}
 case "$cleanup_wt" in
   in_worktree|in_worktree_unrecorded)
-    dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || dirty="?? (dirty-check failed — assume dirty for safety)"
+    dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh) || dirty="?? (dirty-check failed — assume dirty for safety)"
     echo "[CONTEXT] CLEANUP_WT=$cleanup_wt; worktree=$flow_wt; dirty=$([ -n "$dirty" ] && echo yes || echo no); main_root=$main_root"
     # dirty 一覧は marker と区別できるようデリミタで囲んで表示する（ファイル名由来の偽 marker 混入防止。Step 4 と同一パターン）
     if [ -n "$dirty" ]; then
@@ -423,7 +423,7 @@ if [ "$cur_branch" = "{base_branch}" ]; then
   if [ "$_head_rc" -eq 0 ] && [ "$_base_rc" -eq 0 ] && [ -n "$_head_rev" ] && [ "$_head_rev" = "$_base_rev" ]; then
     echo "[CONTEXT] BASE_UPDATE=ok"
   else
-    _bu_dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || _bu_dirty="?? (dirty-check failed — assume dirty for safety)"
+    _bu_dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh) || _bu_dirty="?? (dirty-check failed — assume dirty for safety)"
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
     elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ]'; then

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -335,7 +335,7 @@ cleanup_wt=${detect#CLEANUP_WT=}; cleanup_wt=${cleanup_wt%%;*}
 flow_wt=${detect##*worktree=}
 case "$cleanup_wt" in
   in_worktree|in_worktree_unrecorded)
-    dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null)
+    dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || dirty="?? (dirty-check failed — assume dirty for safety)"
     echo "[CONTEXT] CLEANUP_WT=$cleanup_wt; worktree=$flow_wt; dirty=$([ -n "$dirty" ] && echo yes || echo no); main_root=$main_root"
     # dirty 一覧は marker と区別できるようデリミタで囲んで表示する（ファイル名由来の偽 marker 混入防止。Step 4 と同一パターン）
     if [ -n "$dirty" ]; then
@@ -423,7 +423,7 @@ if [ "$cur_branch" = "{base_branch}" ]; then
   if [ "$_head_rc" -eq 0 ] && [ "$_base_rc" -eq 0 ] && [ -n "$_head_rev" ] && [ "$_head_rev" = "$_base_rev" ]; then
     echo "[CONTEXT] BASE_UPDATE=ok"
   else
-    _bu_dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || _bu_dirty=""
+    _bu_dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || _bu_dirty="?? (dirty-check failed — assume dirty for safety)"
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
     elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ]'; then

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -335,7 +335,7 @@ cleanup_wt=${detect#CLEANUP_WT=}; cleanup_wt=${cleanup_wt%%;*}
 flow_wt=${detect##*worktree=}
 case "$cleanup_wt" in
   in_worktree|in_worktree_unrecorded)
-    dirty=$(git status --porcelain 2>/dev/null)
+    dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null)
     echo "[CONTEXT] CLEANUP_WT=$cleanup_wt; worktree=$flow_wt; dirty=$([ -n "$dirty" ] && echo yes || echo no); main_root=$main_root"
     # dirty 一覧は marker と区別できるようデリミタで囲んで表示する（ファイル名由来の偽 marker 混入防止。Step 4 と同一パターン）
     if [ -n "$dirty" ]; then
@@ -423,7 +423,7 @@ if [ "$cur_branch" = "{base_branch}" ]; then
   if [ "$_head_rc" -eq 0 ] && [ "$_base_rc" -eq 0 ] && [ -n "$_head_rev" ] && [ "$_head_rev" = "$_base_rev" ]; then
     echo "[CONTEXT] BASE_UPDATE=ok"
   else
-    _bu_dirty=$(git status --porcelain 2>/dev/null) || _bu_dirty=""
+    _bu_dirty=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || _bu_dirty=""
     if [ -z "$_bu_dirty" ]; then
       echo "[CONTEXT] BASE_UPDATE=ff_failed_clean"
     elif printf '%s\n' "$_bu_dirty" | grep -q '^[^ ]'; then

--- a/plugins/rite/skills/issue-update/SKILL.md
+++ b/plugins/rite/skills/issue-update/SKILL.md
@@ -288,7 +288,7 @@ If this fails, fall back to the content retained from Phase 1. Retain this conte
 
 ```bash
 # 変更ファイル一覧を取得（ステージング済み + 未ステージング + 未追跡）
-changed_files=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh)
+changed_files=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh) || echo "WARNING: git-status-filtered.sh failed while collecting changed files; the 変更ファイル section may omit uncommitted changes" >&2
 # ベースブランチからの差分（コミット済みの変更も含む）
 diff_files=$(git diff --name-only origin/{base_branch}...HEAD 2>/dev/null || git diff --name-only HEAD)
 # 両方を結合して重複排除

--- a/plugins/rite/skills/issue-update/SKILL.md
+++ b/plugins/rite/skills/issue-update/SKILL.md
@@ -205,7 +205,7 @@ If the content contains `### 進捗サマリー`, treat it as v2; if it contains
 
 ```bash
 # ステージング状態を確認
-git status --porcelain
+bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh
 
 # 変更の統計を取得
 git diff --stat HEAD
@@ -288,7 +288,7 @@ If this fails, fall back to the content retained from Phase 1. Retain this conte
 
 ```bash
 # 変更ファイル一覧を取得（ステージング済み + 未ステージング + 未追跡）
-changed_files=$(git status --porcelain)
+changed_files=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh)
 # ベースブランチからの差分（コミット済みの変更も含む）
 diff_files=$(git diff --name-only origin/{base_branch}...HEAD 2>/dev/null || git diff --name-only HEAD)
 # 両方を結合して重複排除

--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -214,7 +214,7 @@ Terminate processing.
 ### 1.3 Verify Changes
 
 ```bash
-git status --porcelain
+bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh
 git diff --stat origin/{base_branch}...HEAD
 git log --oneline origin/{base_branch}...HEAD
 ```

--- a/plugins/rite/skills/recover/SKILL.md
+++ b/plugins/rite/skills/recover/SKILL.md
@@ -193,7 +193,7 @@ git_branch=$(git branch --show-current 2>/dev/null || echo "")
 base_branch="develop"
 git fetch origin "$base_branch" >/dev/null 2>&1 || true
 git_commit_count=$(git rev-list --count "origin/${base_branch}..HEAD" 2>/dev/null || echo "0")
-git_has_uncommitted=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || git_has_uncommitted="?? (dirty-check failed — assume uncommitted for safety)"; git_has_uncommitted="${git_has_uncommitted%%$'\n'*}"
+git_has_uncommitted=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh) || git_has_uncommitted="?? (dirty-check failed — assume uncommitted for safety)"; git_has_uncommitted="${git_has_uncommitted%%$'\n'*}"
 
 # コンフリクト / rebase 状態検出 (#1705): Phase 3.4.5 が phase 推定より優先させる signal。
 # worktree 運用でも正しい作業ツリーを判定するため .git/... を直書きせず git rev-parse --git-path で

--- a/plugins/rite/skills/recover/SKILL.md
+++ b/plugins/rite/skills/recover/SKILL.md
@@ -193,7 +193,7 @@ git_branch=$(git branch --show-current 2>/dev/null || echo "")
 base_branch="develop"
 git fetch origin "$base_branch" >/dev/null 2>&1 || true
 git_commit_count=$(git rev-list --count "origin/${base_branch}..HEAD" 2>/dev/null || echo "0")
-git_has_uncommitted=$(git status --porcelain 2>/dev/null | head -1)
+git_has_uncommitted=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | head -1)
 
 # コンフリクト / rebase 状態検出 (#1705): Phase 3.4.5 が phase 推定より優先させる signal。
 # worktree 運用でも正しい作業ツリーを判定するため .git/... を直書きせず git rev-parse --git-path で

--- a/plugins/rite/skills/recover/SKILL.md
+++ b/plugins/rite/skills/recover/SKILL.md
@@ -193,7 +193,7 @@ git_branch=$(git branch --show-current 2>/dev/null || echo "")
 base_branch="develop"
 git fetch origin "$base_branch" >/dev/null 2>&1 || true
 git_commit_count=$(git rev-list --count "origin/${base_branch}..HEAD" 2>/dev/null || echo "0")
-git_has_uncommitted=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | head -1)
+git_has_uncommitted=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null) || git_has_uncommitted="?? (dirty-check failed — assume uncommitted for safety)"; git_has_uncommitted="${git_has_uncommitted%%$'\n'*}"
 
 # コンフリクト / rebase 状態検出 (#1705): Phase 3.4.5 が phase 推定より優先させる signal。
 # worktree 運用でも正しい作業ツリーを判定するため .git/... を直書きせず git rev-parse --git-path で


### PR DESCRIPTION
## Summary

Bash tool sandbox が書き込みブロックのために配置する `/dev/null` character device マウントが `git status --porcelain` の untracked (`??`) エントリとして誤検出され、cleanup / recover / issue-update / pr-create の dirty チェックが実変更なしでも "dirty" と誤判定していた問題を修正する。

## Related Issue

Closes #1936

## Changes

- `plugins/rite/hooks/scripts/lib/git-status-filtered.sh`（新規）: `git status --porcelain -z` の出力から untracked (`??`) かつ character device（`test -c` 判定）のエントリのみを除外する共有フィルタ
- `plugins/rite/skills/cleanup/SKILL.md`: Step 4-W（worktree 退出時 dirty チェック）・Step 4（base 更新時 dirty チェック）を上記フィルタ経由に置換
- `plugins/rite/skills/recover/SKILL.md`: `git_has_uncommitted` 判定をフィルタ経由に置換
- `plugins/rite/skills/issue-update/SKILL.md`: 変更ファイル一覧生成の 2 箇所をフィルタ経由に置換
- `plugins/rite/skills/pr-create/SKILL.md`: 変更確認箇所をフィルタ経由に置換
- テスト新規追加: `git-status-filtered.test.sh`（フィルタ本体、14 assertions）、`sandbox-ghost-dirty-integration.test.sh`（cleanup Step 4-W / recover の該当行を SKILL.md から literal 抽出して pin）
- `base-update-classify.test.sh`: TC-9 追加（ゴーストマウントのみ + HEAD == origin → `BASE_UPDATE=ok`）。抽出 block に `{plugin_root}` プレースホルダが入ったため置換処理も追加

## 実装中の判断・計画逸脱

- Decision: character device は mknod ではなく `/dev/null` への symlink でテスト内で模擬した — mknod は root/CAP_MKNOD が必要で本環境・多くの CI で使えないため。`test -c` は symlink を辿るため実マウントと挙動が一致する
- Decision: issue-update/SKILL.md は Target Files の説明が指す「変更ファイル一覧生成」を Phase 2.1 の表示用呼び出しと Progress summary status detection 用の `changed_files=` 取得の両方と解釈し、両方を置換した — 同一ファイル内に filtered / unfiltered な呼び出しが混在するのを避けるため
- Decision: `base-update-classify.test.sh` は cleanup/SKILL.md の該当 bash block を literal 抽出して実行する既存の回帰テストのため、新たに導入した `{plugin_root}` プレースホルダの置換処理をテスト側にも追加した（既存の `{base_branch}` 置換と同じパターン）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
