### PR TITLE
refactor(wiki): wiki push を ingest フロー末尾に集約し sandbox バイパス反復を削減

### DIFF
--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -36,6 +36,15 @@
 # 5) ;; # no staged diff — caller decides policy (stdout is silent)
 # esac
 #
+# Batch/defer push (#1941): a caller processing several commits in a loop
+# (e.g. wiki-ingest, one commit per raw source) can defer the push to a
+# single call at the end of the loop instead of pushing after every commit:
+# WTGP_COMMIT_ONLY=1 worktree_commit_push "$worktree_path" "$wiki_branch" "$commit_msg" "$wiki_rel"
+# # rc 0/3/5 as above, minus 4 (no push attempted — stdout is "head=<sha>" only)
+# ...
+# worktree_push_branch "$worktree_path" "$wiki_branch" # once, after the loop
+# rc=$? # 0 pushed, 2 argument error, 4 push failed (commits stay local)
+#
 # Arguments:
 # WORKTREE path to the worktree (caller must have validated it)
 # BRANCH expected branch name for the push (caller-validated;
@@ -219,10 +228,10 @@ worktree_commit_push() {
  if [[ $_wtgp_errexit -eq 1 ]]; then set -e; else set +e; fi
  }
 
- local add_err="" diff_err="" commit_err="" push_err=""
+ local add_err="" diff_err="" commit_err=""
  # Internal cleanup trap (EXIT only — caller's signal traps are
  # re-applied below on any non-signal return path).
- trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"' EXIT INT TERM HUP
+ trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"' EXIT INT TERM HUP
 
  # mktemp failures are surfaced to stderr (not silently swallowed) so
  # operators can see when stderr capture is degraded to /dev/null.
@@ -238,10 +247,6 @@ worktree_commit_push() {
  echo "WARNING: mktemp for worktree_commit_push commit stderr capture failed — diagnostics will be lost" >&2
  commit_err=""
  fi
- if ! push_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-push-err-XXXXXX" 2>/dev/null); then
- echo "WARNING: mktemp for worktree_commit_push push stderr capture failed — diagnostics will be lost" >&2
- push_err=""
- fi
 
  # Step 1: stage paths. Quote the first pathspec in the error message
  # to mirror the pre-refactor wiki-worktree-commit.sh format, so log
@@ -251,7 +256,7 @@ worktree_commit_push() {
  echo "ERROR: git add '$_first_path' failed in worktree '$worktree'" >&2
  [ -n "$add_err" ] && [ -s "$add_err" ] && head -n 10 "$add_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " hint: index lock / path error / permission denied のいずれかを確認してください" >&2
- rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
  _wtgp_restore_caller_state
  return 3
  fi
@@ -270,7 +275,7 @@ worktree_commit_push() {
  # Silent on stdout: callers emit their own `reason=no-staged-diff`
  # status line (wiki-worktree-commit.sh / wiki-ingest-commit.sh
  # both do this). Returning 5 is the sole signal.
- rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
  _wtgp_restore_caller_state
  return 5
  ;;
@@ -278,7 +283,7 @@ worktree_commit_push() {
  *)
  echo "ERROR: git diff --cached failed in worktree '$worktree' (rc=$cached_rc)" >&2
  [ -n "$diff_err" ] && [ -s "$diff_err" ] && head -n 10 "$diff_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
- rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
  _wtgp_restore_caller_state
  return 3
  ;;
@@ -289,7 +294,7 @@ worktree_commit_push() {
  echo "ERROR: git commit failed in worktree '$worktree'" >&2
  [ -n "$commit_err" ] && [ -s "$commit_err" ] && head -n 10 "$commit_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
  echo " hint: pre-commit hook / gpg sign / author config / permission のいずれかを確認" >&2
- rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}"
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
  _wtgp_restore_caller_state
  return 3
  fi
@@ -297,12 +302,12 @@ worktree_commit_push() {
  # head_sha capture: post-commit rev-parse should normally succeed. If it
  # fails (corrupt worktree between commit and rev-parse, extremely rare),
  # surface a WARNING rather than silently embedding "unknown" in the
- # status line — otherwise the caller sees `head=unknown; push=ok` and
- # treats it as a successful commit.
+ # status line — otherwise the caller sees `head=unknown` and treats it
+ # as a successful commit.
  local head_sha head_err=""
  # Extend internal trap to cover head_err so SIGINT / SIGTERM / SIGHUP during
  # the post-commit rev-parse cannot leak the tempfile. Must be set BEFORE mktemp.
- trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}" "${head_err:-}"' EXIT INT TERM HUP
+ trap 'rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${head_err:-}"' EXIT INT TERM HUP
  head_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-head-err-XXXXXX" 2>/dev/null) || head_err=""
  if head_sha=$(git -C "$worktree" rev-parse HEAD 2>"${head_err:-/dev/null}"); then
  :
@@ -315,17 +320,161 @@ worktree_commit_push() {
  fi
  [ -n "$head_err" ] && rm -f "$head_err"
 
- # Step 4: push using the caller-supplied branch (no silent
- # `rev-parse --abbrev-ref HEAD` fallback to literal "HEAD"). On a
- # non-fast-forward rejection (a concurrent session advanced
- # origin/<branch>), fetch + rebase onto origin/<branch> and retry,
- # up to 3 push attempts (multi-session design §9). wiki commits are
- # append-mostly (new raw / new pages / log appends) so the rebase is
- # almost always conflict-free; a rebase conflict aborts and falls
- # through to the existing rc=4. Non-NFF failures (auth / network) do
- # NOT retry — they fail immediately, preserving the prior behavior.
- # The 0/3/4/5 exit-code contract is unchanged (return 4 on any push
- # failure; the caller owns the continue-vs-hard-fail policy).
+ # #1941 (wiki push batch/defer): a caller processing several commits in a
+ # loop (wiki-ingest per raw source) sets WTGP_COMMIT_ONLY=1 to stage+commit
+ # here WITHOUT pushing, then pushes once at the end of the loop via
+ # worktree_push_branch directly. A plain env var (not a new positional
+ # parameter) keeps the existing 3-fixed-args + variadic-paths call
+ # signature — and every existing caller (wiki-init / standalone
+ # wiki-lint) — untouched.
+ if [[ "${WTGP_COMMIT_ONLY:-0}" == "1" ]]; then
+ echo "head=${head_sha}"
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
+ _wtgp_restore_caller_state
+ return 0
+ fi
+
+ # Step 4: push using the caller-supplied branch. The NFF-retry push logic
+ # lives in worktree_push_branch (#1941) so a batch caller can invoke it
+ # standalone (push-only, after N commit-only commits) without duplicating
+ # the retry loop here — this call is that same function used inline for
+ # the traditional commit-then-push-immediately path.
+ local push_out push_rc
+ push_out=$(worktree_push_branch "$worktree" "$branch")
+ push_rc=$?
+ echo "$push_out"
+
+ rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}"
+ _wtgp_restore_caller_state
+
+ if [[ $push_rc -ne 0 ]]; then
+ return 4
+ fi
+ return 0
+}
+
+# -----------------------------------------------------------------------
+# worktree_push_branch: push WORKTREE's local BRANCH to origin, retrying
+# on non-fast-forward rejection (fetch + rebase) up to 3 attempts.
+#
+# Responsibility (#1941, wiki push batch/defer): hold the push-with-retry
+# logic extracted from worktree_commit_push's Step 4, so a caller that has
+# accumulated several WTGP_COMMIT_ONLY=1 commits (wiki-ingest processing
+# multiple raw sources) can push them all with a single call instead of
+# once per commit. worktree_commit_push calls this same function for its
+# own Step 4, so the retry behavior is identical on both paths.
+#
+# Usage:
+#   worktree_push_branch "$worktree" "$branch"
+#   rc=$?
+#   case "$rc" in
+#     0) ;; # pushed (or origin already up to date)
+#     2) ;; # argument error
+#     4) ;; # push failed after retry budget exhausted — commit(s) stay local
+#   esac
+#
+# Arguments:
+#   WORKTREE  path to the worktree (caller must have validated it)
+#   BRANCH    branch name to push (caller-validated; no silent
+#             rev-parse --abbrev-ref HEAD fallback — mirrors
+#             worktree_commit_push's detached-HEAD rationale)
+#
+# Self-gate: if BRANCH has no commits that the locally-known origin/BRANCH
+# lacks (`git rev-list origin/BRANCH..BRANCH --count`, no fetch — a pure
+# local ref comparison), no push is attempted at all (`push=no-op`). This
+# costs nothing extra on the commit-then-push-immediately path (a just-made
+# commit is always "ahead"), and lets a batch caller (#1941) invoke this
+# function unconditionally after a commit-only loop — without tracking its
+# own commit count, and without the network call this Issue is reducing
+# when there is genuinely nothing new to push (including a stale
+# already-committed-but-unpushed state left by a prior failed run: the
+# next call that reaches this function flushes it).
+#
+# Exit codes:
+#   0  push succeeded, or origin already up to date (push=no-op)
+#   2  argument error (missing worktree / branch)
+#   4  push failed after retry budget exhausted (error already on stderr)
+#
+# stdout: "head=<sha>; push=<ok|failed|no-op>"
+#
+# Contract: does not toggle caller's `set -e` / traps (same discipline as
+# worktree_commit_push — see that function's header for the full rationale).
+worktree_push_branch() {
+ local worktree="$1" branch="$2"
+
+ if [[ -z "$worktree" ]] || [[ -z "$branch" ]]; then
+ echo "ERROR: worktree_push_branch: WORKTREE / BRANCH required" >&2
+ return 2
+ fi
+
+ local _wpb_errexit=0
+ case $- in *e*) _wpb_errexit=1 ;; esac
+
+ local _wpb_outer_exit _wpb_outer_int _wpb_outer_term _wpb_outer_hup
+ _wpb_outer_exit=$(trap -p EXIT)
+ _wpb_outer_int=$(trap -p INT)
+ _wpb_outer_term=$(trap -p TERM)
+ _wpb_outer_hup=$(trap -p HUP)
+
+ _wpb_restore_caller_state() {
+ if [[ -n "$_wpb_outer_exit" ]]; then eval "$_wpb_outer_exit"; else trap - EXIT; fi
+ if [[ -n "$_wpb_outer_int" ]]; then eval "$_wpb_outer_int"; else trap - INT; fi
+ if [[ -n "$_wpb_outer_term" ]]; then eval "$_wpb_outer_term"; else trap - TERM; fi
+ if [[ -n "$_wpb_outer_hup" ]]; then eval "$_wpb_outer_hup"; else trap - HUP; fi
+ if [[ $_wpb_errexit -eq 1 ]]; then set -e; else set +e; fi
+ }
+
+ local push_err="" head_err=""
+ trap 'rm -f "${push_err:-}" "${head_err:-}"' EXIT INT TERM HUP
+
+ if ! push_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-push-err-XXXXXX" 2>/dev/null); then
+ echo "WARNING: mktemp for worktree_push_branch push stderr capture failed — diagnostics will be lost" >&2
+ push_err=""
+ fi
+ if ! head_err=$(mktemp "${TMPDIR:-/tmp}/rite-wtgit-head-err-XXXXXX" 2>/dev/null); then
+ echo "WARNING: mktemp for worktree_push_branch head stderr capture failed — diagnostics will be lost" >&2
+ head_err=""
+ fi
+
+ # head_sha here reports whatever is currently on BRANCH (the commit(s)
+ # about to be pushed) — not necessarily one just made in this call, since
+ # this function is also invoked standalone after a batch of prior
+ # WTGP_COMMIT_ONLY=1 commits.
+ local head_sha
+ if head_sha=$(git -C "$worktree" rev-parse HEAD 2>"${head_err:-/dev/null}"); then
+ :
+ else
+ local head_rc=$?
+ echo "WARNING: git -C '$worktree' rev-parse HEAD failed (rc=$head_rc)" >&2
+ [ -n "$head_err" ] && [ -s "$head_err" ] && head -n 5 "$head_err" | neutralize_ctrl --keep-newline | sed 's/^/ git: /' >&2
+ head_sha="unknown"
+ fi
+ [ -n "$head_err" ] && rm -f "$head_err"
+
+ # Self-gate (see function header): skip the push entirely when there is
+ # nothing local-only to send. Failure to compute ahead_count (rev-list
+ # error, unexpected output) falls through to attempting the push rather
+ # than silently skipping it.
+ local ahead_count
+ if ahead_count=$(git -C "$worktree" rev-list "origin/${branch}..${branch}" --count 2>/dev/null) \
+   && [[ "$ahead_count" =~ ^[0-9]+$ ]] && [ "$ahead_count" -eq 0 ]; then
+ echo "head=${head_sha}; push=no-op"
+ rm -f "${push_err:-}" "${head_err:-}"
+ _wpb_restore_caller_state
+ return 0
+ fi
+
+ # Push using the caller-supplied branch (no silent `rev-parse
+ # --abbrev-ref HEAD` fallback to literal "HEAD"). On a non-fast-forward
+ # rejection (a concurrent session advanced origin/<branch>), fetch +
+ # rebase onto origin/<branch> and retry, up to 3 push attempts
+ # (multi-session design §9). wiki commits are append-mostly (new raw /
+ # new pages / log appends) so the rebase is almost always conflict-free;
+ # a rebase conflict aborts and falls through to the existing rc=4.
+ # Non-NFF failures (auth / network) do NOT retry — they fail
+ # immediately (#1941 AC-3: a deferred push that fails is surfaced and
+ # left for manual/next-session recovery, not auto-retried within the
+ # same flow).
  local push_status="failed" _push_max=3 _push_i=0
  while [ "$_push_i" -lt "$_push_max" ]; do
  _push_i=$((_push_i + 1))
@@ -365,8 +514,8 @@ worktree_commit_push() {
 
  echo "head=${head_sha}; push=${push_status}"
 
- rm -f "${add_err:-}" "${diff_err:-}" "${commit_err:-}" "${push_err:-}" "${head_err:-}"
- _wtgp_restore_caller_state
+ rm -f "${push_err:-}" "${head_err:-}"
+ _wpb_restore_caller_state
 
  if [[ "$push_status" == "failed" ]]; then
  return 4

--- a/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
+++ b/plugins/rite/hooks/scripts/wiki-worktree-commit.sh
@@ -6,7 +6,12 @@
 # to origin. Used by skills/wiki-ingest/SKILL.md ステップ 5 after the LLM has
 # written raw-source `ingested: true` updates, new pages under
 # `.rite/wiki/pages/**`, index.md updates, and log.md appendices
-# directly into the worktree tree.
+# directly into the worktree tree. `--commit-only` / `--push-only` (#1941
+# wiki push batch/defer) split this into two calls so a caller looping over
+# several raw sources (wiki-ingest) or delegating to wiki-lint mid-flow can
+# commit each one locally and push ONCE at the end of the flow, instead of
+# once per commit — see skills/wiki-ingest/SKILL.md ステップ 5.1 / 8.6 and
+# skills/wiki-lint/SKILL.md ステップ 8.3.
 #
 # Design rationale: this script replaces the Block A/B
 # shell contract in ingest.md. Because the worktree lives at a stable
@@ -25,25 +30,41 @@
 #
 # Usage:
 # bash wiki-worktree-commit.sh [--message "<msg>"] [--dry-run]
+# bash wiki-worktree-commit.sh --commit-only [--message "<msg>"]
+# bash wiki-worktree-commit.sh --push-only
 #
 # Options:
 # --message MSG Commit message (default: "chore(wiki): ingest page integration")
 # --dry-run Report pending changes and target branch but perform no
-# git operations. Always exits 0.
+# git operations. Always exits 0. Not valid with --push-only
+# (push-only has no "pending changes" to report — it pushes
+# whatever is already committed).
+# --commit-only Stage + commit pending changes but do NOT push (#1941 wiki
+# push batch/defer). Intended for a caller processing several
+# raw sources in a loop: commit each one locally, then push
+# ONCE via --push-only after the loop. Mutually exclusive with
+# --push-only.
+# --push-only Push whatever is already committed on the worktree's branch;
+# does not stage or commit anything. Self-gates on "nothing to
+# push" (no-op, no network call) — safe to call unconditionally
+# at the end of a --commit-only loop. Mutually exclusive with
+# --commit-only and --dry-run.
 #
 # Output (stdout): one structured status line
 # [wiki-worktree-commit] committed=<N>; branch=<wiki>; head=<sha>[; push=<ok|failed>]
+# [wiki-worktree-commit] committed=1; branch=<wiki>; head=<sha>; push=deferred   (--commit-only)
+# [wiki-worktree-commit] branch=<wiki>; head=<sha>; push=<ok|failed|no-op>       (--push-only)
 # [wiki-worktree-commit] committed=0; branch=<wiki>; reason=<no-pending|no-staged-diff|concurrent-invocation>
 #
 # Exit codes:
-# 0 success (committed, or nothing pending)
+# 0 success (committed and/or pushed, or nothing pending/to push)
 # 1 environment / argument error (not a git repo, worktree missing, etc.)
 # 2 wiki feature disabled (skip)
 # 3 git operation failure (add / commit — push NOT included)
-# 4 push failed after successful local commit (caller MUST emit
-# wiki_ingest_push_failed sentinel; commit is preserved on the
-# local wiki branch and can be pushed manually with
-# `git -C .rite/wiki-worktree push origin wiki`)
+# 4 push failed (caller MUST emit wiki_ingest_push_failed sentinel;
+# commit is preserved on the local wiki branch and can be pushed
+# manually with `git -C .rite/wiki-worktree push origin wiki`).
+# Not reachable with --commit-only (no push is attempted).
 #
 # Notes:
 # - All git operations run with `git -C "$worktree_path"` to scope
@@ -63,11 +84,21 @@ export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -o BatchMode=yes}"
 # Option parsing
 # -----------------------------------------------------------------------
 DRY_RUN=false
+COMMIT_ONLY=false
+PUSH_ONLY=false
 COMMIT_MSG="chore(wiki): ingest page integration"
 while [[ $# -gt 0 ]]; do
  case "$1" in
  --dry-run)
  DRY_RUN=true
+ shift
+ ;;
+ --commit-only)
+ COMMIT_ONLY=true
+ shift
+ ;;
+ --push-only)
+ PUSH_ONLY=true
  shift
  ;;
  --message)
@@ -88,6 +119,15 @@ while [[ $# -gt 0 ]]; do
  ;;
  esac
 done
+
+if [[ "$COMMIT_ONLY" == "true" ]] && [[ "$PUSH_ONLY" == "true" ]]; then
+ echo "ERROR: --commit-only and --push-only are mutually exclusive" >&2
+ exit 1
+fi
+if [[ "$PUSH_ONLY" == "true" ]] && [[ "$DRY_RUN" == "true" ]]; then
+ echo "ERROR: --push-only and --dry-run are mutually exclusive (push-only has no pending changes to preview)" >&2
+ exit 1
+fi
 
 # Reject commit messages containing newlines or NUL to prevent smuggling
 # extra headers into `git commit -m`.
@@ -197,6 +237,27 @@ fi
 verify_worktree_branch "$worktree_path" "$wiki_branch" "wwc" "" || exit 1
 
 # -----------------------------------------------------------------------
+# --push-only: push whatever is already committed and return. No staging,
+# no commit, no "pending changes" detection — that concept does not apply
+# here (#1941 wiki push batch/defer).
+# -----------------------------------------------------------------------
+if [[ "$PUSH_ONLY" == "true" ]]; then
+ set +e
+ push_out=$(worktree_push_branch "$worktree_path" "$wiki_branch")
+ push_rc=$?
+ set -e
+ echo "[wiki-worktree-commit] branch=${wiki_branch}; ${push_out}"
+ case "$push_rc" in
+ 0) exit 0 ;;
+ 4) exit 4 ;;
+ *)
+ echo "ERROR: worktree_push_branch が予期しない exit code ($push_rc) を返しました" >&2
+ exit 1
+ ;;
+ esac
+fi
+
+# -----------------------------------------------------------------------
 # Detect pending changes within the worktree's .rite/wiki tree.
 # We intentionally scope to the wiki directory so unrelated worktree
 # state (e.g. a stray file left by a contributor) does not accidentally
@@ -290,20 +351,31 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 # -----------------------------------------------------------------------
-# Stage all changes under .rite/wiki, commit, and push via shared helper.
-# worktree_commit_push (lib/worktree-git.sh) handles the stderr capture +
-# head -n 10 extraction pattern for the caller. Exit codes: 3 = add/commit
-# failure, 4 = commit ok / push failed, 5 = no staged diff after add (no-op).
+# Stage all changes under .rite/wiki, commit, and (unless --commit-only)
+# push via shared helper. worktree_commit_push (lib/worktree-git.sh)
+# handles the stderr capture + head -n 10 extraction pattern for the
+# caller. Exit codes: 3 = add/commit failure, 4 = commit ok / push failed
+# (--commit-only never returns 4 — no push is attempted), 5 = no staged
+# diff after add (no-op).
 # -----------------------------------------------------------------------
 set +e
-wtcp_out=$(worktree_commit_push "$worktree_path" "$wiki_branch" "$COMMIT_MSG" "$wiki_rel")
+if [[ "$COMMIT_ONLY" == "true" ]]; then
+ wtcp_out=$(WTGP_COMMIT_ONLY=1 worktree_commit_push "$worktree_path" "$wiki_branch" "$COMMIT_MSG" "$wiki_rel")
+else
+ wtcp_out=$(worktree_commit_push "$worktree_path" "$wiki_branch" "$COMMIT_MSG" "$wiki_rel")
+fi
 wtcp_rc=$?
 set -e
 
 case "$wtcp_rc" in
  0)
- # "head=<sha>; push=ok"
+ if [[ "$COMMIT_ONLY" == "true" ]]; then
+ # wtcp_out = "head=<sha>" — push is deferred to a later --push-only call
+ echo "[wiki-worktree-commit] committed=1; branch=${wiki_branch}; ${wtcp_out}; push=deferred"
+ else
+ # wtcp_out = "head=<sha>; push=ok"
  echo "[wiki-worktree-commit] committed=1; branch=${wiki_branch}; ${wtcp_out}"
+ fi
  exit 0
  ;;
  4)

--- a/plugins/rite/hooks/tests/wiki-push-batch-defer-static-pin.test.sh
+++ b/plugins/rite/hooks/tests/wiki-push-batch-defer-static-pin.test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# wiki-push-batch-defer-static-pin.test.sh (#1941)
+#
+# Static-pin meta-test for the wiki push batch/defer contract: within one
+# /rite:wiki-ingest flow, `git push origin {wiki_branch}` must land at most
+# once (AC-1), regardless of how many raw sources are processed and whether
+# auto_lint runs. The guarantee is implemented as markdown orchestration
+# (wiki-ingest/SKILL.md ステップ 5.1 / 8.6, wiki-lint/SKILL.md ステップ 8.3)
+# calling `wiki-worktree-commit.sh --commit-only` / `--push-only`
+# (hooks/tests/wiki-worktree-commit.test.sh proves the script contract) —
+# nothing at the shell-script level would fail if a future edit quietly
+# reverted one of the three call sites back to the old commit+push-together
+# invocation. This test pins those three sites so such a regression fails
+# loudly instead of silently reintroducing per-page pushes.
+#
+# When this test fails:
+#   One of ingest.md ステップ 5.1 / 8.6 or lint.md ステップ 8.3 no longer
+#   matches the batch/defer contract. Re-read #1941's Before/After Contract
+#   and restore --commit-only (5.1, lint 8.3 --auto branch) / --push-only
+#   (8.6), or update this test if the contract has legitimately changed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+INGEST_MD="$PLUGIN_ROOT/skills/wiki-ingest/SKILL.md"
+LINT_MD="$PLUGIN_ROOT/skills/wiki-lint/SKILL.md"
+
+if [ ! -f "$INGEST_MD" ]; then
+  echo "ERROR: $INGEST_MD not found" >&2
+  exit 1
+fi
+if [ ! -f "$LINT_MD" ]; then
+  echo "ERROR: $LINT_MD not found" >&2
+  exit 1
+fi
+
+echo "=== wiki-push-batch-defer-static-pin.test.sh (#1941) ==="
+
+# --- ingest.md ステップ 5.1: per-raw-source commit is --commit-only (no push) ---
+assert_grep_in_section "ingest.md 5.1: wiki-worktree-commit.sh invoked with --commit-only" \
+  "$INGEST_MD" '^### 5\.1 separate_branch 戦略' '^### 5\.2' \
+  'wiki-worktree-commit\.sh" --commit-only'
+assert_not_grep "ingest.md 5.1 does not fall back to a bare (push-included) commit invocation" \
+  "$INGEST_MD" 'wiki-worktree-commit\.sh" --message "\$commit_msg"\)$'
+
+# --- ingest.md ステップ 8.6: the single aggregate push, always run (auto_lint-independent) ---
+assert_grep_in_section "ingest.md 8.6: wiki-worktree-commit.sh invoked with --push-only" \
+  "$INGEST_MD" '^### 8\.6 Wiki push の集約' '^## ステップ 9' \
+  'wiki-worktree-commit\.sh" --push-only'
+assert_grep "ingest.md auto_lint=false does NOT skip ステップ 8.6 (push must still run)" \
+  "$INGEST_MD" 'ステップ 8\.6.*スキップしない'
+
+# --- lint.md ステップ 8.3: --auto (from ingest) defers to --commit-only; standalone still pushes ---
+# (grep -E has no cross-line match, so the "auto_mode=true branch calls --commit-only" contract
+# is pinned as two independent assertions — the gate exists, and --commit-only exists in the
+# same section — rather than one pattern spanning both lines.)
+assert_grep_in_section "lint.md 8.3: auto_mode gate is present" \
+  "$LINT_MD" '^### 8\.3 書き込み手順' '^## ステップ 9' \
+  'if \[ "\$auto_mode" = "true" \]'
+assert_grep_in_section "lint.md 8.3: --commit-only call exists in the section" \
+  "$LINT_MD" '^### 8\.3 書き込み手順' '^## ステップ 9' \
+  'wiki-worktree-commit\.sh" --commit-only'
+assert_grep_in_section "lint.md 8.3: standalone (non-auto) branch still commits + pushes immediately" \
+  "$LINT_MD" '^### 8\.3 書き込み手順' '^## ステップ 9' \
+  'wiki-worktree-commit\.sh" --message "\$commit_msg"\)$'
+
+print_summary "wiki-push-batch-defer-static-pin.test.sh"

--- a/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
+++ b/plugins/rite/hooks/tests/wiki-worktree-commit.test.sh
@@ -79,11 +79,13 @@ setup_wiki_worktree() {
     || { echo "FAIL: setup_wiki_worktree failed (branch/bare/remote/push/worktree)" >&2; exit 1; }
 }
 
-# Drop an untracked page under the worktree's .rite/wiki tree.
+# Drop an untracked page under the worktree's .rite/wiki tree. NAME defaults
+# to test.md (existing single-page callers); pass a distinct NAME per call to
+# simulate multiple raw-source pages landing in one ingest run (#1941).
 add_pending() {
-  local repo="$1"
+  local repo="$1" name="${2:-test.md}"
   mkdir -p "$repo/.rite/wiki-worktree/.rite/wiki/pages"
-  printf '# test page\n' > "$repo/.rite/wiki-worktree/.rite/wiki/pages/test.md"
+  printf '# test page (%s)\n' "$name" > "$repo/.rite/wiki-worktree/.rite/wiki/pages/$name"
 }
 
 run_in() { local repo="$1"; shift; ( cd "$repo" && bash "$SCRIPT" "$@" ) 2>/dev/null; }
@@ -171,5 +173,104 @@ if git -C "$commit_repo" ls-tree -r --name-only wiki | grep -q '.rite/wiki/pages
 else
   fail "committed page not found on wiki branch"
 fi
+
+# --- --commit-only / --push-only: batch/defer push (#1941) -------------------
+# AC-1: a caller processing several raw sources commits each one locally
+# (--commit-only) and pushes ONCE (--push-only) instead of once per commit.
+
+# --commit-only lands the commit locally but does NOT push (origin/wiki stays put).
+commitonly_repo="$(new_repo true)"; SANDBOXES+=("$commitonly_repo")
+setup_wiki_worktree "$commitonly_repo"
+add_pending "$commitonly_repo" page1.md
+origin_before_co="$(git -C "$commitonly_repo" rev-parse origin/wiki)"
+co_out="$(run_in "$commitonly_repo" --commit-only)"
+if printf '%s' "$co_out" | grep -qE 'committed=1; branch=wiki;.*push=deferred'; then
+  pass "--commit-only reports committed=1 + push=deferred"
+else
+  fail "expected committed=1 + push=deferred; got: $co_out"
+fi
+origin_after_co="$(git -C "$commitonly_repo" rev-parse origin/wiki)"
+assert "--commit-only does not advance origin/wiki (push deferred, 0 pushes)" \
+  "$origin_before_co" "$origin_after_co"
+wiki_after_co="$(git -C "$commitonly_repo" rev-parse wiki)"
+assert "--commit-only advances the local wiki branch" \
+  "advanced" \
+  "$([ "$origin_before_co" != "$wiki_after_co" ] && echo advanced || echo unchanged)"
+
+# --push-only then pushes what --commit-only landed locally.
+po_out="$(run_in "$commitonly_repo" --push-only)"
+if printf '%s' "$po_out" | grep -qE 'branch=wiki;.*push=ok'; then
+  pass "--push-only reports push=ok"
+else
+  fail "expected push=ok; got: $po_out"
+fi
+origin_after_po="$(git -C "$commitonly_repo" rev-parse origin/wiki)"
+assert "--push-only advances origin/wiki to match local wiki HEAD" \
+  "$wiki_after_co" "$origin_after_po"
+
+# A second --push-only with nothing new to send self-gates to no-op (no network call).
+noop_out="$(run_in "$commitonly_repo" --push-only)"
+if printf '%s' "$noop_out" | grep -qE 'push=no-op'; then
+  pass "--push-only self-gates to push=no-op when nothing is ahead of origin"
+else
+  fail "expected push=no-op on a second --push-only call; got: $noop_out"
+fi
+
+# --- commit-only x N then push-only x 1 -> exactly one push lands all N commits ---
+# (#1941 AC-1 proxy: count actual `git push` invocations landing on the bare
+# origin via a post-receive hook, rather than inferring it from script output.)
+countpush_repo="$(new_repo true)"; SANDBOXES+=("$countpush_repo")
+setup_wiki_worktree "$countpush_repo"
+bare_dir="$(git -C "$countpush_repo" remote get-url origin)"
+push_count_file="$(mktemp)"; SANDBOXES+=("$push_count_file")
+cat > "$bare_dir/hooks/post-receive" <<HOOK
+#!/bin/sh
+echo push >> "$push_count_file"
+HOOK
+chmod +x "$bare_dir/hooks/post-receive"
+
+for i in 1 2 3; do
+  add_pending "$countpush_repo" "page-$i.md"
+  run_in "$countpush_repo" --commit-only --message "chore(wiki): page $i" >/dev/null
+done
+run_in "$countpush_repo" --push-only >/dev/null
+
+push_events="$(wc -l < "$push_count_file" | tr -d '[:space:]')"
+assert "3 commit-only commits + 1 push-only call -> exactly 1 push lands (#1941 AC-1)" \
+  "1" "$push_events"
+pages_on_wiki="$(git -C "$countpush_repo" ls-tree -r --name-only wiki | grep -c '\.rite/wiki/pages/page-' || true)"
+assert "all 3 commit-only commits are present on the wiki branch" "3" "$pages_on_wiki"
+assert "origin/wiki matches local wiki HEAD after the single push" \
+  "$(git -C "$countpush_repo" rev-parse wiki)" "$(git -C "$countpush_repo" rev-parse origin/wiki)"
+
+# --- --push-only failure (non-NFF): local commit survives, exit 4, no retry ---
+# (#1941 AC-2/AC-3: a failed deferred push does not lose the local commit and
+# is not auto-retried within the same call. The "no retry on non-NFF" internal
+# behavior itself is already pinned at the lib level by
+# worktree-git-nff-retry.test.sh TC-3; this test pins the wiki-worktree-commit.sh
+# integration contract: push=failed + local commit preserved.)
+pushfail_repo="$(new_repo true)"; SANDBOXES+=("$pushfail_repo")
+setup_wiki_worktree "$pushfail_repo"
+bogus_origin="$(mktemp -d)"; SANDBOXES+=("$bogus_origin")
+git -C "$pushfail_repo" remote set-url origin "$bogus_origin"
+add_pending "$pushfail_repo" pageX.md
+run_in "$pushfail_repo" --commit-only >/dev/null
+wiki_head_before_push="$(git -C "$pushfail_repo" rev-parse wiki)"
+pf_out="$(run_in "$pushfail_repo" --push-only)"; pf_rc=$?
+assert "--push-only against an unreachable origin exits 4" "4" "$pf_rc"
+if printf '%s' "$pf_out" | grep -qE 'push=failed'; then
+  pass "--push-only reports push=failed for a non-NFF failure"
+else
+  fail "expected push=failed; got: $pf_out"
+fi
+wiki_head_after_push="$(git -C "$pushfail_repo" rev-parse wiki)"
+assert "local wiki commit survives a failed deferred push" \
+  "$wiki_head_before_push" "$wiki_head_after_push"
+
+# --- --commit-only / --push-only mutual exclusivity + --dry-run guard --------
+assert "--commit-only and --push-only together exits 1" "1" \
+  "$(rc_in "$nopending_repo" --commit-only --push-only)"
+assert "--push-only with --dry-run exits 1" "1" \
+  "$(rc_in "$nopending_repo" --push-only --dry-run)"
 
 print_summary "wiki-worktree-commit.sh"

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -712,6 +712,8 @@ skill return 後、出力から以下のいずれかの sentinel を発火させ
 - 並行 ingest スキップ (ingest 出力に `WIKI_INGEST_SKIPPED reason=concurrent_ingest`): `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=concurrent_ingest`（別 live セッションが ingest 中。pending raw は wiki branch に残り次回 ingest が冪等回収する — multi-session §9）
 - 失敗: `[CONTEXT] WIKI_INGEST_FAILED=1; reason=ingest_error`
 
+> **#1941 wiki push batch/defer**: ingest.md はページ更新のたびに push していた旧挙動を、raw source ごとに commit のみ行い ingest フロー末尾（ステップ 8.6）で 1 回だけ push する方式に変更した（AC-1）。`push=failed` 部分文字列検出はそのまま機能する — 集約 push が失敗した場合も、その 1 回の push 結果として ingest の stdout に同じ文字列が現れるため、本ステップの検出ロジック自体の変更は不要（ローカル commit は保持され、次回 ingest のステップ 8.6 が自動で flush を試みる — AC-2 / SHOULD）。
+
 ingest の成否（skip 含む）に関わらずステップ 10 へ進む。
 
 ---

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -16,10 +16,10 @@ Wiki Ingest エンジン。`.rite/wiki/raw/` の Raw Source を読解し、`.rit
 2. Raw Source の候補列挙と `ingested: false` 判定
 3. 既存 Wiki インデックス (`index.md`) の読み込み
 4. LLM による読解と統合判定（新規 / 更新 / スキップ）
-5. ページの書き込み + commit/push（worktree ベース）
+5. ページの書き込み + commit（worktree ベース。push はステップ 8.6 で 1 回に集約）
 6. `index.md` の更新
 7. `log.md` への append-only 追記
-8. 自動 Lint (`/rite:wiki-lint --auto`)
+8. 自動 Lint (`/rite:wiki-lint --auto`) + push の集約（8.6）
 9. 完了レポート
 
 Raw Source の wiki branch 着地は `wiki-ingest-commit.sh` が `review` / `fix` / `issue-close` から直接呼ばれて完了している前提。本コマンドが扱うのは page 統合の LLM 責務のみ。
@@ -461,7 +461,7 @@ esac
 
 ### 5.1 separate_branch 戦略 (worktree ベース)
 
-ステップ 5.0 手順 1-7 を Write/Edit ツールで実施した後、以下の bash ブロックを実行して worktree 内の変更を commit + push する。commit 処理は `wiki-worktree-commit.sh` に委譲されており、LLM が bash 契約を書く必要はない:
+ステップ 5.0 手順 1-7 を Write/Edit ツールで実施した後、以下の bash ブロックを実行して worktree 内の変更を commit する。**push はここでは行わない**（#1941 wiki push batch/defer: 複数 raw source を処理するループの中で raw source ごとに push すると、SSH host alias 環境で毎回 sandbox バイパスが必要になり同一 push の短時間重複実行も起きていた。ステップ 8.6 で全 raw source 処理後にまとめて 1 回だけ push する）。commit 処理は `wiki-worktree-commit.sh --commit-only` に委譲されており、LLM が bash 契約を書く必要はない:
 
 ```bash
 # ステップ 5.2 と対称に set -euo pipefail を宣言する (strict mode)
@@ -495,7 +495,7 @@ if [ "$branch_strategy" = "separate_branch" ]; then
 
   # set -e 下で script の非 0 exit を許容して rc を capture する
   set +e
-  commit_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --message "$commit_msg")
+  commit_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --commit-only --message "$commit_msg")
   commit_rc=$?
   set -e
   echo "$commit_out"
@@ -508,12 +508,8 @@ if [ "$branch_strategy" = "separate_branch" ]; then
       echo "  対処: git -C \"$wiki_wt_abs\" status で worktree の状態を確認" >&2
       exit 1
       ;;
-    4)
-      echo "WARNING: commit は landed したが push に失敗しました (rc=4)" >&2
-      echo "  手動回復: git -C \"$wiki_wt_abs\" push origin $wiki_branch" >&2
-      # push 失敗は非 fatal — ユーザーが後で回復可能
-      ;;
     *)
+      # --commit-only は push を行わないため rc=4 (push 失敗) はここでは発生しない。
       echo "ERROR: wiki-worktree-commit.sh が予期しない exit code ($commit_rc) を返しました" >&2
       exit 1
       ;;
@@ -674,7 +670,7 @@ esac
 echo "auto_lint=$auto_lint"
 ```
 
-**`auto_lint=false` の場合**: ステップ 8.2-8.5 を skip しステップ 9 へ進む。Lint カウンタ 6 種はステップ 2.1 で 0 初期化済みのため placeholder 残留は発生しない。ステップ 9 完了レポートの「Wiki 品質警告」行は「スキップ (auto_lint disabled)」、「未登録 raw」行は `0` 件として表示する。
+**`auto_lint=false` の場合**: ステップ 8.2-8.5 を skip する。**ステップ 8.6 (push の集約) はスキップしない** — ステップ 5.1 で `--commit-only` 積んだ raw source の commit を push するのは auto_lint の有無に関わらず必須のため、ステップ 8.6 を実行してからステップ 9 へ進む。Lint カウンタ 6 種はステップ 2.1 で 0 初期化済みのため placeholder 残留は発生しない。ステップ 9 完了レポートの「Wiki 品質警告」行は「スキップ (auto_lint disabled)」、「未登録 raw」行は `0` 件として表示する。
 
 ### 8.2 Lint エンジンの呼び出し
 
@@ -797,6 +793,50 @@ n_warnings += n_contradictions + n_stale + n_orphans + n_missing_concept + n_bro
 
 **詳細な修正対応**: 検出結果の詳細確認は、Ingest 完了後に `/rite:wiki-lint`（`--auto` なし）で再実行して取得する。
 
+### 8.6 Wiki push の集約（#1941 wiki push batch/defer）
+
+**`auto_lint` の値に関わらず必ず実行する**（ステップ 8.1 参照）。ステップ 5.1 (separate_branch) は raw source ごとに `--commit-only` で commit のみを行い、push を意図的に遅延させてきた。ステップ 8.2 の自動 Lint (`--auto` モード) も同様に `--commit-only` で log.md 追記を積む（[skills/wiki-lint/SKILL.md](../wiki-lint/SKILL.md) ステップ 8.3 参照）。ここで、蓄積されたローカル commit（0 件のこともある）をまとめて 1 回だけ push する（AC-1: 1 回の ingest フローで `git push origin {wiki_branch}` は最大 1 回）。
+
+`same_branch` では worktree を使わず push もこのフローの管轄外（PR ブランチの通常 push に含まれる）のため本ステップは no-op:
+
+```bash
+branch_strategy="{branch_strategy}"
+if [ "$branch_strategy" = "separate_branch" ]; then
+  plugin_root="{plugin_root}"
+  wiki_wt_abs="{wiki_worktree_abs}"; wiki_wt_abs="${wiki_wt_abs:-.rite/wiki-worktree}"
+  wiki_branch="{wiki_branch}"
+
+  if [ ! -x "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" ]; then
+    echo "ERROR: wiki-worktree-commit.sh が見つからないか実行権限がありません: $plugin_root/hooks/scripts/wiki-worktree-commit.sh" >&2
+    exit 1
+  fi
+
+  # set -e 下で script の非 0 exit を許容して rc を capture する
+  set +e
+  push_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --push-only)
+  push_rc=$?
+  set -e
+  echo "$push_out"
+
+  case "$push_rc" in
+    0) echo "[CONTEXT] WIKI_INGEST_PUSH=ok" ;;
+    4)
+      echo "WARNING: 蓄積した wiki commit の push に失敗しました (rc=4)。commit は local wiki branch に landed 済みです（AC-2: 非ブロッキングで継続、次回セッションの push-only 呼び出しが自動で flush する）" >&2
+      echo "  手動回復: git -C \"$wiki_wt_abs\" push origin $wiki_branch" >&2
+      echo "[CONTEXT] WIKI_INGEST_PUSH=failed" >&2
+      ;;
+    *)
+      echo "ERROR: wiki-worktree-commit.sh --push-only が予期しない exit code ($push_rc) を返しました" >&2
+      exit 1
+      ;;
+  esac
+else
+  echo "[CONTEXT] WIKI_INGEST_PUSH=skipped; reason=same_branch"
+fi
+```
+
+`push_out` に含まれる `push=no-op` はそもそも push すべき commit が無かった（今回の全 raw source が skip 判定だった等）ことを示し、失敗ではない (`WIKI_INGEST_PUSH=ok` 扱いで問題ない)。`[CONTEXT] WIKI_INGEST_PUSH=` marker はステップ 9.0 完了レポートの push 状態表示、および `/rite:cleanup` ステップ 9 の push 失敗判定（stdout 中の `push=failed` 部分文字列を検出）に使う。
+
 ---
 
 ## ステップ 9: 完了レポート
@@ -819,6 +859,7 @@ Wiki Ingest が完了しました。
 - スキップした Raw Source: {n_skipped} 件
 - {wiki_warnings_line}
 - 未登録 raw（skip 済、warnings 不加算）: {n_unregistered_raw} 件
+- {wiki_push_line}
 
 新規/更新ページ:
 - {path1} ({action1})
@@ -839,6 +880,15 @@ Wiki Ingest が完了しました。
 「未登録 raw」行は `auto_lint=false` の場合も `0` 件として展開する (ステップ 2.1 で 0 初期化済みの値)。
 
 **等式**: `n_warnings = n_contradictions + n_stale + n_orphans + n_missing_concept + n_broken_refs + n_lint_anomaly`。step 2 成功時は `n_lint_anomaly=0` のため 5 カテゴリ合計が `n_warnings` と一致。step 1/3/4 anomaly 経路では 5 カテゴリは 0 fallback だが `n_lint_anomaly >= 1` のため `n_warnings >= 1` となる。
+
+`{wiki_push_line}` の展開ルール (ステップ 8.6 の `[CONTEXT] WIKI_INGEST_PUSH=` marker を上から評価し最初の一致を採用。#1941 AC-2: 未 push の wiki commit があれば回復コマンドを明示する):
+
+| `WIKI_INGEST_PUSH=` | 展開 |
+|---|---|
+| `ok` | `Wiki push: 完了`（`push=no-op` だった場合も含む — push すべき commit が無かっただけで失敗ではない） |
+| `failed` | `⚠️ Wiki push: commit は local wiki branch に landed しましたが origin への push に失敗しました。手動回復: git -C {wiki_worktree_abs} push origin {wiki_branch}` |
+| `skipped; reason=same_branch` | `Wiki push: 対象外 (same_branch 戦略。通常の PR push に含まれる)` |
+| marker なし（ステップ 8.6 未到達などの想定外経路） | `⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください` |
 
 ### 9.1 Return-to-Caller Signal
 
@@ -862,8 +912,8 @@ sentinel は grep 可能 (`grep -F '[ingest:returned-to-caller]'`) で rendered 
 | `wiki.enabled: false` | 早期 return（ステップ 1.1） |
 | Wiki 未初期化 / worktree セットアップ失敗 | `/rite:wiki-init` を案内、または `wiki-worktree-setup.sh` のエラー出力を確認して `git worktree prune` / `git fetch origin wiki:wiki` で復旧 (ステップ 1.3) |
 | 処理対象 0 件 | 静かに終了し情報メッセージのみ表示（ステップ 2.3） |
-| `wiki-worktree-commit.sh` exit 3 (git add/commit 失敗) | exit 1 で fail-fast。`git -C .rite/wiki-worktree status` で worktree の状態を確認 |
-| `wiki-worktree-commit.sh` exit 4 (push 失敗) | 非 fatal で継続。`git -C .rite/wiki-worktree push origin {wiki_branch}` で手動回復 |
+| `wiki-worktree-commit.sh --commit-only` exit 3 (git add/commit 失敗、ステップ 5.1) | exit 1 で fail-fast。`git -C .rite/wiki-worktree status` で worktree の状態を確認 |
+| `wiki-worktree-commit.sh --push-only` exit 4 (push 失敗、ステップ 8.6) | 非 fatal で継続。commit は local wiki branch に保持される。`git -C .rite/wiki-worktree push origin {wiki_branch}` で手動回復、または次回 ingest の ステップ 8.6 が自動で flush を試みる |
 | `wiki-worktree-commit.sh` 未知の exit code | exit 1 で fail-fast |
 | `branch_strategy` が未知の値 | ステップ 5.1 の if/elif/else 末尾 else 分岐で fail-fast (ステップ 5.2 の bash block は same_branch 単独分岐のため未知値はステップ 5.1 の else が catch する。`rite-config.yml` の `wiki.branch_strategy` を確認) |
 | LLM が経験則を抽出できない | 該当 Raw Source の raw frontmatter に `ingest_status: skipped` + `skip_reason` を追記（skip 状態の SoT）、`ingested: true` に変更、log.md に人間向け Skip bullet を追記、`n_skipped` を +1（ステップ 5 step 5 参照） |

--- a/plugins/rite/skills/wiki-lint/SKILL.md
+++ b/plugins/rite/skills/wiki-lint/SKILL.md
@@ -773,6 +773,24 @@ if [ -z "$plugin_root" ] || [ ! -d "$plugin_root/templates/wiki" ]; then
   exit 0
 fi
 
+# Claude placeholder {mode} 残留 fail-fast gate (同型 gate: ステップ 1.1 / 1.3)。#1941 wiki push
+# batch/defer: --auto (ingest から呼ばれた) なら push を ingest 側の集約 push (ingest.md ステップ 8.6)
+# に委ね、ここでは --commit-only で commit のみ行う。standalone 実行 (mode 空) は従来どおり commit + push
+# を即座に行う (standalone lint はそれ自身で完結した 1 フローのため、集約する相手が存在しない)。
+mode="{mode}"
+case "$mode" in
+  "{"*"}")
+    echo "ERROR: ステップ 8.3 の {mode} placeholder が literal substitute されていません (値: '$mode')" >&2
+    echo "  Claude は lint skill 呼び出し時の args 文字列 (--auto / 空) を literal で置換する必要があります" >&2
+    exit 1
+    ;;
+esac
+if printf '%s' "$mode" | grep -qE '(^|[[:space:]])--auto([[:space:]]|$)'; then
+  auto_mode=true
+else
+  auto_mode=false
+fi
+
 # {log_entry} placeholder 残留検知 fail-fast gate (同型 gate: ステップ 1.1 / 1.3 / 8.1 / 8.3 + helper 内 (4 / 5 / 6.0 / 6.2 / 7))
 log_entry="{log_entry}"
 case "$log_entry" in
@@ -794,7 +812,14 @@ case "$branch_strategy" in
     # set -euo pipefail 下で commit_out=$(bash ...) が rc != 0 のとき bash が即時 exit する罠を回避。
     # set +e で囲み rc capture を保証する。2>&1 は付けない (構造化 stdout / WARNING stderr の責務分離維持)。
     set +e
-    commit_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --message "$commit_msg")
+    if [ "$auto_mode" = "true" ]; then
+      # --auto: ingest から呼ばれている。push は ingest.md ステップ 8.6 の集約 push に委ね、
+      # ここでは commit のみ行う (#1941 AC-1)。
+      commit_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --commit-only --message "$commit_msg")
+    else
+      # standalone: この lint 実行自身が唯一のフローのため、従来どおり即座に commit + push する。
+      commit_out=$(bash "$plugin_root/hooks/scripts/wiki-worktree-commit.sh" --message "$commit_msg")
+    fi
     commit_rc=$?
     set -e
     echo "$commit_out"
@@ -803,7 +828,7 @@ case "$branch_strategy" in
       0) : ;;
       2) echo "[CONTEXT] WIKI_LINT_COMMIT=skipped; reason=wiki-disabled-or-no-pending" >&2 ;;
       3) echo "WARNING: wiki-worktree-commit.sh で git 操作失敗 (rc=3)。log.md 追記は非ブロッキングのため継続します" >&2 ;;
-      4) echo "WARNING: wiki-worktree-commit.sh で commit landed but push 失敗 (rc=4)。次回再 push が必要" >&2 ;;
+      4) echo "WARNING: wiki-worktree-commit.sh で commit landed but push 失敗 (rc=4)。次回再 push が必要 (standalone 実行時のみ到達 — --commit-only は push を行わない)" >&2 ;;
       *) echo "WARNING: wiki-worktree-commit.sh が予期しない rc=$commit_rc で失敗しました。log.md 追記は非ブロッキングのため継続します" >&2 ;;
     esac
     ;;

--- a/plugins/rite/skills/wiki-lint/SKILL.md
+++ b/plugins/rite/skills/wiki-lint/SKILL.md
@@ -1009,7 +1009,7 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 - **原則 exit 0**: 検出件数・事前チェック失敗・ブランチ読取失敗のいずれも非ブロッキング
 - **例外 (`exit 1` fail-fast)**:
   - `branch_strategy` 未知値 (ステップ 2.2 / 8.2 / 8.3 + helper 内 (4 / 5 / 6.0 / 6.2 / 7) で同型。設定ミスの silent 通過防止)
-  - `{mode}` placeholder 残留 (ステップ 1.1 / 1.3)
+  - `{mode}` placeholder 残留 (ステップ 1.1 / 1.3 / 8.3)
   - helper 委譲ステップ (4 / 5 / 6.0 / 6.2 / 7) の placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{stale_days}` / `{pages_list}` + 6.2 の partial pollution gate、LLM substitute 忘れによる silent 誤分類防止。各 helper 内で検知)
   - ステップ 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数検知 (silent `lint:clean` 誤 emit 防止)
   - ステップ 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種、literal 残留 commit landed 防止)
@@ -1025,7 +1025,7 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 | `wiki.enabled: false` | 早期 return (`--auto` モード時は ステップ 9.2 の 3 行出力後 exit 0、それ以外は警告のみ exit 0) | ステップ 1.1 |
 | GNU date 非互換環境 | 陳腐化検出 skip（exit 0 + WARNING + `stale_check_ok=skipped_no_gnu_date`） | ステップ 4 (helper 内) |
 | Wiki 未初期化 | `/rite:wiki-init` を案内 (`--auto` モード時は ステップ 9.2 の 3 行出力後 exit 0) | ステップ 1.3 |
-| `{mode}` placeholder 残留 (各 site で同型) | **exit 1 で fail-fast** | ステップ 1.1 / 1.3 |
+| `{mode}` placeholder 残留 (各 site で同型) | **exit 1 で fail-fast** | ステップ 1.1 / 1.3 / 8.3 |
 | helper 委譲ステップの placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{stale_days}` / `{pages_list}` + 6.2 の partial pollution) | **exit 1 で fail-fast** (silent 誤分類防止、各 helper 内で検知) | ステップ 4 / 5 / 6.0 / 6.2 / 7 |
 | ステップ 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数 | **exit 1 で fail-fast** (silent `lint:clean` 誤 emit 防止) | ステップ 8.1 |
 | ステップ 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種) | **exit 1 で fail-fast** (literal 残留 commit landed 防止) | ステップ 8.3 |


### PR DESCRIPTION
## Summary

wiki-ingest フローが raw source / lint 追記のたびに `git push origin wiki` を実行しており、SSH host alias 環境では push のたびに sandbox バイパスが必要だった（実測: 1 セッションで push 8 回、同一 push の 11 秒差重複実行あり）。commit は都度・push はフロー末尾に 1 回へ変更し、バイパス反復と重複 push を解消する。

## Related Issue

Closes #1941

## Changes

- `lib/worktree-git.sh`: push の retry loop を `worktree_push_branch()` として独立させ、`worktree_commit_push()` から呼び出す形に整理。`WTGP_COMMIT_ONLY=1` で commit のみ実行できるようにした。`worktree_push_branch()` は origin との rev-list 差分が無ければ push 自体を行わない（`push=no-op`）ため、次回セッションでの stale commit flush も兼ねる
- `wiki-worktree-commit.sh`: `--commit-only` / `--push-only` を追加。デフォルト（フラグ無し）の commit+push 一体動作は完全後方互換（`wiki-init` / standalone `/rite:wiki-lint` はそのまま利用）
- `wiki-ingest/SKILL.md`: ステップ 5.1（raw source ごとの commit）を `--commit-only` に変更し、新設のステップ 8.6 で全 raw source 処理後に `--push-only` を 1 回だけ実行。`auto_lint=false` でもステップ 8.6 は必ず実行する
- `wiki-lint/SKILL.md`: ステップ 8.3 を `auto_mode` でゲート。`--auto`（ingest から呼ばれた場合）は `--commit-only` で push を ingest 側に委ね、standalone 実行時は従来どおり即座に commit+push する
- `cleanup/SKILL.md`: push 失敗検出（stdout 中の `push=failed` 部分文字列 grep）が集約後の単一 push でも機能することを明記
- テスト: `wiki-worktree-commit.test.sh` に commit-only/push-only の往復テストを追加（AC-1: 3 commit-only + 1 push-only で実際の push 回数が 1 回であることを bare origin の `post-receive` hook でカウントして検証。AC-2: push 失敗時もローカル commit は保持。AC-3: 失敗後の自動再試行なし）。`wiki-push-batch-defer-static-pin.test.sh` を新設し、markdown オーケストレーション側の 3 サイト（ingest 5.1 = `--commit-only` / ingest 8.6 = `--push-only` / lint 8.3 = `auto_mode` ゲート）を static-pin して将来の silent regression を防止

## 実装中の判断・計画逸脱

- Decision: Target Files に無い `wiki-lint/SKILL.md` も変更対象に加えた — 理由: `auto_lint: true`（本リポジトリの既定）では ingest ステップ 8 の自動 Lint が `wiki-worktree-commit.sh` を独自に呼び出し log.md を commit+push しており、ここを変更しない限り 1 flow で push が 2 回（ingest 分 + lint 分）発生し AC-1「push は最大 1 回」を満たせないため。Target Files 一覧は当時未把握だったこの内部呼び出しにより不完全だった
- Decision: 既存の `worktree_commit_push()` の Step 1-3（add/diff/commit）はそのまま残し、Step 4（push）のみ `worktree_push_branch()` として抽出した — 理由: trap/errexit の save-restore 契約が複雑なため、動作実績のある commit 経路を変更せず、既存の `wiki-worktree-commit.test.sh` を無変更のまま通すことで後方互換を検証する方が安全と判断した

## Known Issues

- テスト全件実行（`run-tests.sh`）で `reviewer-hypothetical-nit-noted-ban.test.sh` の失敗 2 件を検出したが、`_reviewer-base.md` / `severity-levels.md` の database reviewer 参照漏れという本 Issue と無関係な既存 drift のため、別 Issue #1954 として切り出した（本 PR の変更ファイルには影響なし）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
