### PR TITLE
fix(hooks-tests): git-status-filtered.test.sh の merge に identity を付与

### DIFF
--- a/plugins/rite/hooks/tests/git-status-filtered.test.sh
+++ b/plugins/rite/hooks/tests/git-status-filtered.test.sh
@@ -101,7 +101,7 @@ base3u=$( cd "$sbx3u" && git branch --show-current )
   git checkout -q "$base3u"
   echo main > a
   git -c user.email=t@test.local -c user.name=test commit -q -am main
-  git merge conflict-side >/dev/null 2>&1
+  git -c user.email=t@test.local -c user.name=test merge conflict-side >/dev/null 2>&1
 ) >/dev/null 2>&1
 out=$(run_in "$sbx3u")
 case "$out" in


### PR DESCRIPTION
## Summary

`git-status-filtered.test.sh` T-03（unmerged UU pass-through）の `git merge` に identity を付与し、git identity 未設定環境（CI ubuntu ランナー等）でも決定的にパスするようにする。

## Related Issue

Closes #1961

## Changes

- `plugins/rite/hooks/tests/git-status-filtered.test.sh`: 104行目 `git merge conflict-side` に `-c user.email=t@test.local -c user.name=test` を付与（同ファイル内の `git commit` と同一の identity 慣習に統一）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (identity 未設定環境 / 通常環境の両方で PASS: 14 / FAIL: 0 を確認)
- [ ] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
