### PR TITLE
docs(git-worktree-patterns): lazy reap の corpse 例外と branch 回収の実挙動を反映

### DIFF
--- a/plugins/rite/references/git-worktree-patterns.md
+++ b/plugins/rite/references/git-worktree-patterns.md
@@ -453,9 +453,15 @@ Two helper-driven patterns bracket the session-worktree lifecycle:
   or nested under the candidate), so a long-lived session cannot delete its own active
   worktree mid-flight; then strict `^issue-[0-9]+$` name under
   `worktree_base`, claim not live (or absent + mtime > 24h), and a clean
-  `git status --porcelain` (a dirty worktree is never auto-reaped). Reap **never deletes
-  the branch** (push-pending / unpushed work is preserved; branch cleanup stays the
-  responsibility of the normal `cleanup` path).
+  `git status --porcelain` (a dirty worktree is never auto-reaped — the sole exception is
+  an admin-HEAD-missing, git-unrecognized **corpse** whose status is structurally
+  undeterminable: it bypasses the status gate and is reaped, working tree + admin dir,
+  behind the same claim + 24h age guards, Issue #1957). Once the worktree is gone, its
+  branch is recovered rather than left untouched: `git branch -d` (safe-delete) runs
+  first so an unmerged branch is preserved; if that's refused but the reap manifest
+  confirms the PR was merged, `git branch -D` force-deletes it; an unmerged,
+  manifest-unrecorded branch is kept with a WARNING (Issue #1670). A corpse's HEAD can't
+  be read, so branch recovery is structurally skipped for it.
 
 ### SSH host alias 経由の `git push`/`fetch` が sandbox のネットワーク許可リストでブロックされる
 


### PR DESCRIPTION
## 概要

PR #1959（Issue #1957）で実装された corpse 回収の挙動を `plugins/rite/references/git-worktree-patterns.md` の Lazy reap 段落に反映し、あわせて Issue #1670 の branch recovery 導入以降 stale だった「Reap never deletes the branch」の記述を実挙動に修正する。

## 関連 Issue

Closes #1960

## Changes

- `plugins/rite/references/git-worktree-patterns.md`: Lazy reap 段落（L449-458）に corpse 例外（status gate バイパス + claim/24h age guard は維持、Issue #1957）を追記し、「Reap never deletes the branch」を safe-delete → manifest 確認時のみ force-delete → 未マージ非記録は WARNING 付き保持（Issue #1670）という実挙動に置換

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
