### PR TITLE
fix(pr-review): drift-hash の worktree axis を sandbox ghost-mount 非依存にする

### DIFF
--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -27,7 +27,9 @@
 #   --original-branch <name>           Review 開始時の current branch 名 (required)
 #   --original-stash-count <N>         Review 開始時の `git stash list` 行数 (optional)
 #   --original-branch-list-hash <hash> Review 開始時の `git branch --list | sort | md5sum` (optional)
-#   --original-worktree-hash <hash>    Review 開始時の `git status --porcelain | md5sum` (optional、Issue #1860)
+#   --original-worktree-hash <hash>    Review 開始時の `lib/git-status-filtered.sh | md5sum` (optional、Issue #1860。
+#                                      #1944 で raw `git status --porcelain` から sandbox ghost-mount
+#                                      フィルタ経由に変更 — snapshot 側もこのコマンドで計算すること)
 #   --auto-recover                     drift 検出時に automatic recovery を行う (default: true)
 #
 # State vector axes (drift 検出の優先順): branch → stash → branch_list → worktree。
@@ -48,6 +50,8 @@
 #     {"drift": true, "type": "worktree", "detail": "...", "recovered": false}
 
 set -uo pipefail  # 意図的に -e なし: drift detection 自体を fail とせず、結果を JSON で返す
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ORIGINAL_BRANCH=""
 ORIGINAL_STASH_COUNT=""
@@ -136,8 +140,14 @@ fi
 # + index drift (modified / staged / untracked) that the branch / stash /
 # branch_list axes cannot see — e.g. a reviewer editing a source file in place via
 # Edit/Write and hand-restoring it, or leaving a `.bak` untracked. Advisory only.
+# Routed through git-status-filtered.sh (not raw `git status --porcelain`, Issue #1944):
+# the snapshot side (pr-review SKILL.md ステップ 4.0.A) and this verify side can run in
+# different sandbox contexts, and a bwrap sandbox overlays ghost-mount `??` entries
+# (#1936) that vary by context — comparing raw porcelain hashes false-positives on
+# those ghost entries alone. The filter drops them on both sides so the hash reflects
+# only real working-tree changes.
 if [ -n "$_hash_cmd" ]; then
-  current_worktree_hash=$(git status --porcelain 2>/dev/null | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
+  current_worktree_hash=$(bash "$SCRIPT_DIR/lib/git-status-filtered.sh" 2>/dev/null | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
 else
   current_worktree_hash=""
 fi

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -148,13 +148,18 @@ fi
 # only real working-tree changes.
 # Unlike raw `git status --porcelain`, the filter depends on `mktemp` (sandbox TMPDIR
 # restrictions can make this fail even though plain `git status` would succeed), so its
-# exit code is checked explicitly (pipefail propagates through the subshell command
-# substitution) instead of being silently treated as an empty-but-valid hash.
+# exit code is checked explicitly. The filter's own output is captured first (not piped
+# directly into the hash command) so the check does not depend on `pipefail` — this
+# mirrors the capture-first pattern used on the snapshot side (pr-review SKILL.md
+# ステップ 4.0.A), which cannot rely on pipefail because each Bash tool invocation starts
+# a fresh shell with pipefail off and no state carried over from prior blocks.
 if [ -n "$_hash_cmd" ]; then
-  current_worktree_hash=$(bash "$SCRIPT_DIR/lib/git-status-filtered.sh" | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
+  _wth_raw=$(bash "$SCRIPT_DIR/lib/git-status-filtered.sh")
   if [ $? -ne 0 ]; then
     echo "WARNING: git-status-filtered.sh failed — worktree drift axis skipped for this check" >&2
     current_worktree_hash=""
+  else
+    current_worktree_hash=$(printf '%s' "$_wth_raw" | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
   fi
 else
   current_worktree_hash=""

--- a/plugins/rite/hooks/scripts/post-review-state-verify.sh
+++ b/plugins/rite/hooks/scripts/post-review-state-verify.sh
@@ -146,8 +146,16 @@ fi
 # (#1936) that vary by context — comparing raw porcelain hashes false-positives on
 # those ghost entries alone. The filter drops them on both sides so the hash reflects
 # only real working-tree changes.
+# Unlike raw `git status --porcelain`, the filter depends on `mktemp` (sandbox TMPDIR
+# restrictions can make this fail even though plain `git status` would succeed), so its
+# exit code is checked explicitly (pipefail propagates through the subshell command
+# substitution) instead of being silently treated as an empty-but-valid hash.
 if [ -n "$_hash_cmd" ]; then
-  current_worktree_hash=$(bash "$SCRIPT_DIR/lib/git-status-filtered.sh" 2>/dev/null | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
+  current_worktree_hash=$(bash "$SCRIPT_DIR/lib/git-status-filtered.sh" | "$_hash_cmd" 2>/dev/null | awk '{print $1}')
+  if [ $? -ne 0 ]; then
+    echo "WARNING: git-status-filtered.sh failed — worktree drift axis skipped for this check" >&2
+    current_worktree_hash=""
+  fi
 else
   current_worktree_hash=""
 fi

--- a/plugins/rite/hooks/tests/post-review-state-verify.test.sh
+++ b/plugins/rite/hooks/tests/post-review-state-verify.test.sh
@@ -64,11 +64,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Snapshot helper: mirrors the exact command pr-review SKILL.md ステップ 4.0.A
-# uses for ORIG_WTH — capture-first (filter output captured before hashing, same
-# as production) so dirty-tree snapshots hash identically to the real 4.0.A /
-# verify-side computation (a direct pipe would keep the filter's trailing
-# newline that `$(...)` strips, diverging on non-empty output).
+# Snapshot helper: mirrors the happy-path hash computation pr-review SKILL.md
+# ステップ 4.0.A uses for ORIG_WTH — capture-first (filter output captured
+# before hashing, same as production) so dirty-tree snapshots hash identically
+# to the real 4.0.A / verify-side computation (a direct pipe would keep the
+# filter's trailing newline that `$(...)` strips, diverging on non-empty
+# output). Unlike 4.0.A / verify, this helper does not reproduce their
+# error-handling (stderr propagation, exit-code guard) — it only needs to
+# produce the same hash for the happy-path fixtures below.
 snapshot_hash() {
   local dir="$1"
   local raw
@@ -148,5 +151,22 @@ case "$(cat "$stderr4")" in
   *"git-status-filtered.sh failed"*) pass "T-03: filter failure surfaces a WARNING" ;;
   *) fail "T-03: filter failure surfaces a WARNING (stderr: $(cat "$stderr4"))" ;;
 esac
+
+# --- T-04: snapshot taken on an already-dirty tree, unchanged before verify,
+#     must NOT report drift ----------------------------------------------------
+# baseline/T-01/T-02/T-02b all snapshot a clean tree (empty filter output), so
+# they cannot distinguish the capture-first hash computation from a naive
+# direct-pipe one — both produce the same empty-input hash. This case snapshots
+# a tree that already has an uncommitted change, then verifies with no further
+# change, exercising the capture-first path on non-empty filter output (where
+# a direct pipe's retained trailing newline would diverge from `$(...)`'s
+# stripped one and falsely report drift).
+sbx5=$(make_sandbox) && cleanup_dirs+=("$sbx5") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch5=$(cd "$sbx5" && git branch --show-current)
+( cd "$sbx5" && echo already-dirty >> a ) >/dev/null 2>&1
+wth5=$(snapshot_hash "$sbx5")
+out5=$(cd "$sbx5" && bash "$VERIFY" --original-branch "$branch5" --original-worktree-hash "$wth5" --auto-recover true)
+drift5=$(printf '%s' "$out5" | jq -r '.drift' 2>/dev/null)
+assert "T-04: dirty-at-snapshot tree, unchanged at verify, reports drift=false" "false" "$drift5"
 
 print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/post-review-state-verify.test.sh
+++ b/plugins/rite/hooks/tests/post-review-state-verify.test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Tests for hooks/scripts/post-review-state-verify.sh worktree drift axis (#1944)
+#
+# post-review-state-verify.sh compares an ORIG_WTH snapshot (taken by
+# pr-review SKILL.md ステップ 4.0.A) against a current worktree hash computed
+# at verify time. Both sides now route through lib/git-status-filtered.sh
+# instead of raw `git status --porcelain` so that sandbox write-block ghost
+# mounts (#1936 — untracked character-device entries a bwrap sandbox overlays
+# over paths it blocks writes to) are stripped from the hash on both sides.
+# Without this, a ghost mount present at snapshot time but not at verify
+# time (or vice versa, e.g. a different sandbox context between the two
+# calls) changes the raw porcelain hash even though nothing in the tracked
+# working tree actually changed — a false-positive worktree drift warning.
+#
+# mknod requires root/CAP_MKNOD and is unavailable in this (and most CI)
+# environments, so tests simulate a ghost mount with a symlink to /dev/null
+# (`ln -s /dev/null <path>`) — same technique as git-status-filtered.test.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+
+VERIFY="$SCRIPT_DIR/../scripts/post-review-state-verify.sh"
+FILTER="$SCRIPT_DIR/../scripts/lib/git-status-filtered.sh"
+
+echo "=== post-review-state-verify.sh (worktree drift axis, ghost-mount consistency) ==="
+
+if [ ! -f "$VERIFY" ]; then
+  echo "ERROR: $VERIFY not found" >&2
+  exit 1
+fi
+
+cleanup_dirs=()
+cleanup() {
+  local d
+  for d in "${cleanup_dirs[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# Snapshot helper: mirrors the exact command pr-review SKILL.md ステップ 4.0.A
+# uses for ORIG_WTH — filtered porcelain output piped to md5sum.
+snapshot_hash() {
+  local dir="$1"
+  ( cd "$dir" && bash "$FILTER" 2>/dev/null | md5sum | awk '{print $1}' )
+}
+
+# --- Baseline: clean tree, no drift at all -----------------------------------
+sbx0=$(make_sandbox) && cleanup_dirs+=("$sbx0") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch0=$(cd "$sbx0" && git branch --show-current)
+wth0=$(snapshot_hash "$sbx0")
+out0=$(cd "$sbx0" && bash "$VERIFY" --original-branch "$branch0" --original-worktree-hash "$wth0" --auto-recover true)
+drift0=$(printf '%s' "$out0" | jq -r '.drift' 2>/dev/null)
+assert "baseline: clean tree reports drift=false" "false" "$drift0"
+
+# --- T-01 (AC-1): ghost-mount-only difference between snapshot and verify time
+#     must NOT be reported as drift -------------------------------------------
+sbx1=$(make_sandbox) && cleanup_dirs+=("$sbx1") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch1=$(cd "$sbx1" && git branch --show-current)
+wth1=$(snapshot_hash "$sbx1")
+# Simulate a ghost mount appearing between snapshot and verify (e.g. a
+# different sandbox context at verify time overlaying a write-block mount).
+( cd "$sbx1" && ln -s /dev/null ghost_devnull ) >/dev/null 2>&1
+out1=$(cd "$sbx1" && bash "$VERIFY" --original-branch "$branch1" --original-worktree-hash "$wth1" --auto-recover true)
+drift1=$(printf '%s' "$out1" | jq -r '.drift' 2>/dev/null)
+assert "T-01: ghost-mount-only diff reports drift=false" "false" "$drift1"
+
+# --- T-02 (AC-2): a real tracked-file edit between snapshot and verify time
+#     MUST still be reported as worktree drift --------------------------------
+sbx2=$(make_sandbox) && cleanup_dirs+=("$sbx2") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch2=$(cd "$sbx2" && git branch --show-current)
+wth2=$(snapshot_hash "$sbx2")
+( cd "$sbx2" && echo changed >> a ) >/dev/null 2>&1
+out2=$(cd "$sbx2" && bash "$VERIFY" --original-branch "$branch2" --original-worktree-hash "$wth2" --auto-recover true)
+drift2=$(printf '%s' "$out2" | jq -r '.drift' 2>/dev/null)
+type2=$(printf '%s' "$out2" | jq -r '.type' 2>/dev/null)
+recovered2=$(printf '%s' "$out2" | jq -r '.recovered' 2>/dev/null)
+assert "T-02: real tracked-file edit reports drift=true" "true" "$drift2"
+assert "T-02: drift type is worktree" "worktree" "$type2"
+assert "T-02: worktree drift is not auto-recovered" "false" "$recovered2"
+
+# --- T-02b: ghost mount + real edit together still detects the real drift ---
+sbx3=$(make_sandbox) && cleanup_dirs+=("$sbx3") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch3=$(cd "$sbx3" && git branch --show-current)
+wth3=$(snapshot_hash "$sbx3")
+( cd "$sbx3" && ln -s /dev/null ghost_devnull && echo changed >> a ) >/dev/null 2>&1
+out3=$(cd "$sbx3" && bash "$VERIFY" --original-branch "$branch3" --original-worktree-hash "$wth3" --auto-recover true)
+drift3=$(printf '%s' "$out3" | jq -r '.drift' 2>/dev/null)
+type3=$(printf '%s' "$out3" | jq -r '.type' 2>/dev/null)
+assert "T-02b: real edit alongside ghost mount still reports drift=true" "true" "$drift3"
+assert "T-02b: drift type is worktree" "worktree" "$type3"
+
+print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/post-review-state-verify.test.sh
+++ b/plugins/rite/hooks/tests/post-review-state-verify.test.sh
@@ -24,6 +24,7 @@ source "$SCRIPT_DIR/_test-helpers.sh"
 
 VERIFY="$SCRIPT_DIR/../scripts/post-review-state-verify.sh"
 FILTER="$SCRIPT_DIR/../scripts/lib/git-status-filtered.sh"
+PR_REVIEW_SKILL="$SCRIPT_DIR/../../skills/pr-review/SKILL.md"
 
 echo "=== post-review-state-verify.sh (worktree drift axis, ghost-mount consistency) ==="
 
@@ -31,6 +32,15 @@ if [ ! -f "$VERIFY" ]; then
   echo "ERROR: $VERIFY not found" >&2
   exit 1
 fi
+
+# --- Pin: snapshot side (pr-review SKILL.md ステップ 4.0.A) must route ORIG_WTH
+#     through git-status-filtered.sh -------------------------------------------
+# snapshot_hash() below reimplements the SKILL.md command rather than reading it,
+# so nothing else in this suite would catch a regression where the SKILL.md side
+# reverts to raw `git status --porcelain`. Pin the source text directly.
+assert_grep_in_section "SKILL.md 4.0.A: ORIG_WTH routed through git-status-filtered.sh" \
+  "$PR_REVIEW_SKILL" \
+  '^### 4\.0\.A ' '^### 4\.0\.W' 'ORIG_WTH=.*git-status-filtered'
 
 cleanup_dirs=()
 cleanup() {

--- a/plugins/rite/hooks/tests/post-review-state-verify.test.sh
+++ b/plugins/rite/hooks/tests/post-review-state-verify.test.sh
@@ -38,9 +38,13 @@ fi
 # snapshot_hash() below reimplements the SKILL.md command rather than reading it,
 # so nothing else in this suite would catch a regression where the SKILL.md side
 # reverts to raw `git status --porcelain`. Pin the source text directly.
+# The capture-first pattern (filter output captured into _wth_raw before hashing,
+# so the exit-code check does not depend on pipefail — each Bash tool invocation
+# starts a fresh shell with pipefail off) puts the git-status-filtered.sh call on
+# its own line rather than inline in the ORIG_WTH assignment.
 assert_grep_in_section "SKILL.md 4.0.A: ORIG_WTH routed through git-status-filtered.sh" \
   "$PR_REVIEW_SKILL" \
-  '^### 4\.0\.A ' '^### 4\.0\.W' 'ORIG_WTH=.*git-status-filtered'
+  '^### 4\.0\.A ' '^### 4\.0\.W' '_wth_raw=.*git-status-filtered'
 
 cleanup_dirs=()
 cleanup() {
@@ -102,5 +106,33 @@ drift3=$(printf '%s' "$out3" | jq -r '.drift' 2>/dev/null)
 type3=$(printf '%s' "$out3" | jq -r '.type' 2>/dev/null)
 assert "T-02b: real edit alongside ghost mount still reports drift=true" "true" "$drift3"
 assert "T-02b: drift type is worktree" "worktree" "$type3"
+
+# --- T-03: git-status-filtered.sh failure (e.g. mktemp failing under a
+#     write-restricted TMPDIR) must surface a WARNING and skip the worktree
+#     axis rather than silently treating an empty hash as a valid one -------
+# A copy of VERIFY is run from a scratch dir whose lib/git-status-filtered.sh
+# is a stub that always fails, so SCRIPT_DIR (derived from the copy's own
+# path) resolves to the failing stub regardless of cwd. This exercises the
+# capture-first exit-code check independent of pipefail state.
+fail_dir=$(mktemp -d) && cleanup_dirs+=("$fail_dir") || { echo "ERROR: mktemp -d failed, aborting" >&2; exit 1; }
+mkdir -p "$fail_dir/lib"
+cp "$VERIFY" "$fail_dir/post-review-state-verify.sh"
+cat > "$fail_dir/lib/git-status-filtered.sh" << 'STUB_EOF'
+#!/bin/bash
+echo "WARNING: git-status-filtered: mktemp failed" >&2
+exit 1
+STUB_EOF
+chmod +x "$fail_dir/lib/git-status-filtered.sh"
+
+sbx4=$(make_sandbox) && cleanup_dirs+=("$sbx4") || { echo "ERROR: make_sandbox failed, aborting" >&2; exit 1; }
+branch4=$(cd "$sbx4" && git branch --show-current)
+stderr4=$(mktemp) && cleanup_dirs+=("$stderr4")
+out4=$(cd "$sbx4" && bash "$fail_dir/post-review-state-verify.sh" --original-branch "$branch4" --original-worktree-hash "nonempty-snapshot-hash" --auto-recover true 2>"$stderr4")
+drift4=$(printf '%s' "$out4" | jq -r '.drift' 2>/dev/null)
+assert "T-03: filter failure does not report drift (axis skipped, not silently matched)" "false" "$drift4"
+case "$(cat "$stderr4")" in
+  *"git-status-filtered.sh failed"*) pass "T-03: filter failure surfaces a WARNING" ;;
+  *) fail "T-03: filter failure surfaces a WARNING (stderr: $(cat "$stderr4"))" ;;
+esac
 
 print_summary "$(basename "$0")"

--- a/plugins/rite/hooks/tests/post-review-state-verify.test.sh
+++ b/plugins/rite/hooks/tests/post-review-state-verify.test.sh
@@ -46,6 +46,15 @@ assert_grep_in_section "SKILL.md 4.0.A: ORIG_WTH routed through git-status-filte
   "$PR_REVIEW_SKILL" \
   '^### 4\.0\.A ' '^### 4\.0\.W' '_wth_raw=.*git-status-filtered'
 
+# --- Pin: snapshot side must also guard the filter's exit code -----------------
+# SKILL.md is markdown (not directly executable), so a partial revert that keeps
+# the `_wth_raw=...git-status-filtered.sh` routing line but drops the exit-code
+# check (`_wth_rc` + the "snapshot skipped" WARNING) would go undetected by the
+# routing pin alone. Pin the guard's presence too.
+assert_grep_in_section "SKILL.md 4.0.A: filter failure guard present (WARNING + skip on non-zero exit)" \
+  "$PR_REVIEW_SKILL" \
+  '^### 4\.0\.A ' '^### 4\.0\.W' '_wth_rc.*-ne 0'
+
 cleanup_dirs=()
 cleanup() {
   local d
@@ -56,10 +65,15 @@ cleanup() {
 trap cleanup EXIT
 
 # Snapshot helper: mirrors the exact command pr-review SKILL.md ステップ 4.0.A
-# uses for ORIG_WTH — filtered porcelain output piped to md5sum.
+# uses for ORIG_WTH — capture-first (filter output captured before hashing, same
+# as production) so dirty-tree snapshots hash identically to the real 4.0.A /
+# verify-side computation (a direct pipe would keep the filter's trailing
+# newline that `$(...)` strips, diverging on non-empty output).
 snapshot_hash() {
   local dir="$1"
-  ( cd "$dir" && bash "$FILTER" 2>/dev/null | md5sum | awk '{print $1}' )
+  local raw
+  raw=$(cd "$dir" && bash "$FILTER" 2>/dev/null)
+  printf '%s' "$raw" | md5sum | awk '{print $1}'
 }
 
 # --- Baseline: clean tree, no drift at all -----------------------------------

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1144,28 +1144,36 @@ Reviewer subagent が READ-ONLY 契約を破って parent session の working tr
 # 無くても hash 不一致 (false-positive drift) が起きる。フィルタを両側に適用することでその
 # ghost-mount 差分を打ち消し、実際の working-tree 変更のみが hash に反映されるようにする。
 # 生の `git status --porcelain` と異なりフィルタは `mktemp` に依存する (sandbox の TMPDIR 制限下では
-# plain `git status` は成功してもフィルタは失敗しうる) ため、exit code を明示チェックする
-# (pipefail はコマンド置換のサブシェルにも伝播するので `$?` で検出できる。post-review-state-verify.sh
-# 側の同型修正と対称)。
+# plain `git status` は成功してもフィルタは失敗しうる) ため、exit code を明示チェックする。
+# この bash block は Bash tool の 1 回の呼び出しとして新規シェルで実行され pipefail は既定 off
+# (呼び出し間でシェル状態は引き継がれない) なので、`filter | hash | awk` の `$?` は pipefail に
+# 依存させず、filter 自身の出力を先に非パイプで capture してから exit code を判定する
+# (capture-first)。post-review-state-verify.sh 側は単一スクリプト全体に `set -uo pipefail` が
+# かかるため pipefail 経由の `$?` チェックで足りるが、この SKILL.md block はそれとは独立した
+# 実行コンテキストのため同じ前提を流用できない。
 # rationale: references/design-rationale.md#state-snapshot-notes
 ORIG_BR=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$ORIG_BR" ]; then
  ORIG_BR="DETACHED:$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 fi
 ORIG_SC=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+_wth_raw=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh)
+_wth_rc=$?
 if command -v md5sum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | md5sum | awk '{print $1}')
- ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh | md5sum 2>/dev/null | awk '{print $1}')
- if [ $? -ne 0 ]; then
+ if [ "$_wth_rc" -ne 0 ]; then
    echo "WARNING: git-status-filtered.sh failed — worktree drift snapshot skipped" >&2
    ORIG_WTH=""
+ else
+   ORIG_WTH=$(printf '%s' "$_wth_raw" | md5sum | awk '{print $1}')
  fi
 elif command -v shasum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | shasum | awk '{print $1}')
- ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh | shasum 2>/dev/null | awk '{print $1}')
- if [ $? -ne 0 ]; then
+ if [ "$_wth_rc" -ne 0 ]; then
    echo "WARNING: git-status-filtered.sh failed — worktree drift snapshot skipped" >&2
    ORIG_WTH=""
+ else
+   ORIG_WTH=$(printf '%s' "$_wth_raw" | shasum | awk '{print $1}')
  fi
 else
  ORIG_BLH="" # hash 計算不可 — branch_list drift check は skip 扱い (verifier 側で空文字列を skip)

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1138,6 +1138,11 @@ Reviewer subagent が READ-ONLY 契約を破って parent session の working tr
 # detached HEAD は `DETACHED:<short-hash>` sentinel に置換 (verifier 側で branch drift check を skip)。
 # ORIG_WTH は working tree / index の drift (Edit/Write in-place mutation や state-changing git) を
 # 捕捉する 4 軸目 (Issue #1860)。branch/stash/branch_list では見えない porcelain 差分を検出する。
+# 生の `git status --porcelain` ではなく git-status-filtered.sh 経由で計算する (Issue #1944):
+# このスナップショットとステップ 5.0.A の verify は異なる sandbox 実行コンテキストで走りうるため、
+# bwrap sandbox が overlay する ghost-mount `??` エントリ (#1936) が両側で食い違い、実変更が
+# 無くても hash 不一致 (false-positive drift) が起きる。フィルタを両側に適用することでその
+# ghost-mount 差分を打ち消し、実際の working-tree 変更のみが hash に反映されるようにする。
 # rationale: references/design-rationale.md#state-snapshot-notes
 ORIG_BR=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$ORIG_BR" ]; then
@@ -1146,10 +1151,10 @@ fi
 ORIG_SC=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
 if command -v md5sum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | md5sum | awk '{print $1}')
- ORIG_WTH=$(git status --porcelain 2>/dev/null | md5sum | awk '{print $1}')
+ ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | md5sum | awk '{print $1}')
 elif command -v shasum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | shasum | awk '{print $1}')
- ORIG_WTH=$(git status --porcelain 2>/dev/null | shasum | awk '{print $1}')
+ ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | shasum | awk '{print $1}')
 else
  ORIG_BLH="" # hash 計算不可 — branch_list drift check は skip 扱い (verifier 側で空文字列を skip)
  ORIG_WTH="" # hash 計算不可 — worktree drift check は skip 扱い (verifier 側で空文字列を skip)

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1143,6 +1143,10 @@ Reviewer subagent が READ-ONLY 契約を破って parent session の working tr
 # bwrap sandbox が overlay する ghost-mount `??` エントリ (#1936) が両側で食い違い、実変更が
 # 無くても hash 不一致 (false-positive drift) が起きる。フィルタを両側に適用することでその
 # ghost-mount 差分を打ち消し、実際の working-tree 変更のみが hash に反映されるようにする。
+# 生の `git status --porcelain` と異なりフィルタは `mktemp` に依存する (sandbox の TMPDIR 制限下では
+# plain `git status` は成功してもフィルタは失敗しうる) ため、exit code を明示チェックする
+# (pipefail はコマンド置換のサブシェルにも伝播するので `$?` で検出できる。post-review-state-verify.sh
+# 側の同型修正と対称)。
 # rationale: references/design-rationale.md#state-snapshot-notes
 ORIG_BR=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$ORIG_BR" ]; then
@@ -1151,10 +1155,18 @@ fi
 ORIG_SC=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
 if command -v md5sum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | md5sum | awk '{print $1}')
- ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | md5sum | awk '{print $1}')
+ ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh | md5sum 2>/dev/null | awk '{print $1}')
+ if [ $? -ne 0 ]; then
+   echo "WARNING: git-status-filtered.sh failed — worktree drift snapshot skipped" >&2
+   ORIG_WTH=""
+ fi
 elif command -v shasum >/dev/null 2>&1; then
  ORIG_BLH=$(git branch --list 2>/dev/null | sort | shasum | awk '{print $1}')
- ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh 2>/dev/null | shasum | awk '{print $1}')
+ ORIG_WTH=$(bash {plugin_root}/hooks/scripts/lib/git-status-filtered.sh | shasum 2>/dev/null | awk '{print $1}')
+ if [ $? -ne 0 ]; then
+   echo "WARNING: git-status-filtered.sh failed — worktree drift snapshot skipped" >&2
+   ORIG_WTH=""
+ fi
 else
  ORIG_BLH="" # hash 計算不可 — branch_list drift check は skip 扱い (verifier 側で空文字列を skip)
  ORIG_WTH="" # hash 計算不可 — worktree drift check は skip 扱い (verifier 側で空文字列を skip)


### PR DESCRIPTION
## 概要

pr-review の drift 検出（worktree axis）が、snapshot（ステップ 4.0.A）と verify（post-review-state-verify.sh）で異なる sandbox 実行コンテキストを跨ぐと、bwrap sandbox が overlay する ghost-mount 由来の untracked エントリ（#1936）が片側にのみ現れ、実変更が無いのに `git status --porcelain` の hash が食い違って worktree drift が誤発火する問題を解消します。

## 関連 Issue

Closes #1944

## 変更内容

- `plugins/rite/hooks/scripts/post-review-state-verify.sh`: `current_worktree_hash` の算出を、生の `git status --porcelain` から既存の ghost-mount フィルタ `lib/git-status-filtered.sh`（#1936 で導入済み）経由に変更
- `plugins/rite/skills/pr-review/SKILL.md`: ステップ 4.0.A の `ORIG_WTH`（snapshot 側）算出も同様に `git-status-filtered.sh` 経由に変更（両側を同一フィルタで揃える）
- `plugins/rite/hooks/tests/post-review-state-verify.test.sh`（新規）: T-01（ghost-mount 相当の差分のみで drift 未検出）/ T-02（実変更で drift 検出）+ 補助ケースを追加

## 未完了の Issue チェック項目

以下は Issue 本文の Definition of Done のうち、本 PR のレビュー完了時点で自然にチェックが入る項目のため未完了のまま PR を作成しています:

- [ ] レビュー通過

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (`plugins/rite/hooks/tests/run-tests.sh` — 101/101 ファイル、全アサーション PASS）
- [x] Documentation updated (対象ファイル自体がドキュメント兼実装のため、変更箇所に説明コメントを追記済み。他ドキュメントへの影響調査済み・修正要箇所なし)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
