### PR TITLE
fix(worktree): corpse worktree の回収を reap manifest のパス記録で即時化

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -1077,7 +1077,22 @@ if [ -d "$session_wt_root" ]; then
     # stale-claim path too (AC-4: a fresh corpse is never reaped). The skip is
     # logged, not silent: a corpse's existence is itself an anomaly the user
     # should see before the guard expires.
-    if [ "$_corpse" -eq 1 ] && [ -z "$(find "$wt_path" -maxdepth 0 -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)" ]; then
+    #
+    # Manifest bypass (Issue #1945): a corpse cannot resolve its checked-out
+    # branch (git no longer recognizes the tree), so the branch-keyed bypass
+    # above (Issue #1966, free-claim arm) structurally never fires for it —
+    # every corpse would wait the full 24h even when cleanup.md already tried
+    # and failed to remove this exact path. cleanup.md Step 4-W records the
+    # worktree's own PATH (not branch) into the manifest at the moment
+    # `git worktree remove` fails or is skipped for a busy/sandbox-mask reason
+    # (only when {pr_merged}=true, mirroring the branch bypass's AC-4 gate), so
+    # a manifest hit here means "rite already confirmed this path needs reaping" —
+    # the same "reap me" intent the branch bypass encodes, keyed differently
+    # because a corpse has no resolvable branch.
+    if [ "$_corpse" -eq 1 ] && [ -f "$manifest_path" ] \
+       && grep -qxF "worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
+      echo "[pr-cycle-cleanup] manifest 記録済み (削除失敗確認済み) corpse session worktree のため age guard をバイパスします: $(printf '%s' "$wt_path" | neutralize_ctrl)" >&2
+    elif [ "$_corpse" -eq 1 ] && [ -z "$(find "$wt_path" -maxdepth 0 -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)" ]; then
       echo "WARNING: corpse session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' (admin HEAD 欠落・git 非認識) は age guard (24h) 未達のため回収を見送ります。" >&2
       continue
     fi
@@ -1120,6 +1135,34 @@ if [ -d "$session_wt_root" ]; then
       # (uses the pre-removal canonical path) so re-entry / harness cwd-restore is
       # not pointed at the just-removed dir. Non-blocking (AC-5).
       _rite_null_worktree_refs "$wt_path" "$_wt_canon"
+
+      # Manifest entry consumption (Issue #1945, symmetric with the branch
+      # consumption below — #1966): a lingering `worktree\t<path>` entry is not
+      # inert — the corpse age-guard bypass above is keyed on it, so a
+      # DIFFERENT worktree later created at this same path (e.g. the issue
+      # reopened) would inherit the bypass and skip the 24h protection it
+      # never earned. Step 4.5's own "already gone" check
+      # (`[ ! -e "$_m_val" ]`) does not catch this: once a NEW worktree exists
+      # at the reused path, the entry looks "present" again. Best-effort: each
+      # failure falls back to Step 4.5's indeterminate-status keep on the next
+      # run (never silently drops an entry a failed write left behind).
+      if [ -f "$manifest_path" ] && grep -qxF "worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
+        if _wt_mf_keep=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-wtmf-XXXXXX" 2>/dev/null); then
+          _wt_mf_rc=0
+          grep -vxF "worktree$(printf '\t')$wt_path" "$manifest_path" > "$_wt_mf_keep" 2>/dev/null || _wt_mf_rc=$?
+          if [ "$_wt_mf_rc" -ge 2 ]; then
+            echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（survivor 抽出）に失敗しました (rc=$_wt_mf_rc)（次 run の Step 4.5 による自己修復待ち）。" >&2
+          elif [ -s "$_wt_mf_keep" ]; then
+            cp "$_wt_mf_keep" "$manifest_path" 2>/dev/null \
+              || echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（書き戻し）に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+          elif ! rm -f "$manifest_path" 2>/dev/null; then
+            echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（manifest 削除）に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+          fi
+          rm -f "$_wt_mf_keep" 2>/dev/null || true
+        else
+          echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費用 mktemp に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+        fi
+      fi
 
       # Branch recovery (#1670): the worktree is gone, so its branch is no longer
       # checked out and can be deleted. SAFE-delete first — `git branch -d` refuses

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -1116,9 +1116,10 @@ if [ -d "$session_wt_root" ]; then
     # header comment "session worktrees go through Step 5's gated reap, never
     # here"). Recording a session worktree path under `worktree` would let
     # Step 4.5 reap it — possibly a live, claimed worktree — before this Step 5
-    # gate ever runs. `session_worktree` is a distinct type Step 4.5's case
-    # statement does not recognize (falls through to its `*)` preserve-verbatim
-    # arm), so only this gated Step 5 bypass ever consumes it.
+    # gate ever runs. `session_worktree` is a distinct type handled by Step
+    # 4.5's own dedicated case arm (below), which never reaps — it only drops
+    # a stale entry once the path is already gone and otherwise preserves it
+    # verbatim — so only this gated Step 5 bypass ever actually reaps it.
     if [ "$_corpse" -eq 1 ] && [ -f "$manifest_path" ] \
        && grep -qxF "session_worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
       echo "[pr-cycle-cleanup] manifest 記録済み (削除失敗確認済み) corpse session worktree のため age guard をバイパスします: $(printf '%s' "$wt_path" | neutralize_ctrl)" >&2

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -164,10 +164,12 @@ revert_find_out=""
 manifest_keep=""
 # Step 5 branch recovery の manifest エントリ即時消費用 (Issue #1966)
 session_branch_mf_keep=""
+# Step 5 corpse reap の session_worktree manifest エントリ即時消費用 (Issue #1945)
+_wt_mf_keep=""
 _rite_pr_cycle_cleanup() {
   rm -f "${wt_list_err:-}" "${prune_err:-}" "${ref_err:-}" "${workdir_find_err:-}" "${mutation_find_err:-}" \
         "${revert_find_err:-}" "${workdir_find_out:-}" "${mutation_find_out:-}" "${revert_find_out:-}" \
-        "${manifest_keep:-}" "${session_branch_mf_keep:-}"
+        "${manifest_keep:-}" "${session_branch_mf_keep:-}" "${_wt_mf_keep:-}"
 }
 trap 'rc=$?; _rite_pr_cycle_cleanup; exit $rc' EXIT
 trap '_rite_pr_cycle_cleanup; exit 130' INT
@@ -466,8 +468,10 @@ fi
 # intent, so there is no in-flight ambiguity to protect against (unlike the
 # path-name sweeps of Steps 3/4). Worktree entries still honor AC-6 — a dirty
 # worktree is skipped (and kept in the manifest for a later retry) so uncommitted
-# work is never destroyed. The manifest is contract-bound to EPHEMERAL tmp
-# artifacts; session worktrees go through Step 5's gated reap, never here.
+# work is never destroyed. The `worktree` type is contract-bound to EPHEMERAL
+# tmp artifacts; session worktrees go through Step 5's gated reap, never here
+# (Issue #1945: they use the distinct `session_worktree` type below, which
+# this step never reaps — only drops once the path is already gone).
 #
 # Manifest rewrite: lines we reap (or find already-gone) are dropped; skipped
 # (dirty) and failed entries are preserved so the next run retries them.
@@ -578,6 +582,22 @@ if [ -f "$manifest_path" ]; then
             errors=$((errors + 1))
             printf '%s\n' "$_m_line" >> "$manifest_keep"
           fi
+          ;;
+        session_worktree)
+          # Issue #1945: session worktree paths (`.rite/worktrees/issue-N`) are
+          # NEVER reaped here — that is Step 5's job, behind its claim /
+          # self-exclusion / live-cwd gates (the "worktree" type case above is
+          # ungated and reserved for ephemeral tmp artifacts only; mixing
+          # session worktrees into it would let this step destroy a live,
+          # claimed worktree). The only action this step takes is dropping a
+          # stale reference once the path is already gone (harmless — no gate
+          # needed to delete a pointer to nothing), mirroring the "already
+          # gone" self-heal the `worktree` case has. A still-existing path is
+          # preserved verbatim so Step 5 sees it on this same run.
+          if [ ! -e "$_m_val" ]; then
+            continue
+          fi
+          printf '%s\n' "$_m_line" >> "$manifest_keep"
           ;;
         *)
           # Unknown type — preserve verbatim (forward-compat / conservative).
@@ -1089,8 +1109,18 @@ if [ -d "$session_wt_root" ]; then
     # a manifest hit here means "rite already confirmed this path needs reaping" —
     # the same "reap me" intent the branch bypass encodes, keyed differently
     # because a corpse has no resolvable branch.
+    #
+    # `session_worktree` type (NOT `worktree`): the `worktree` manifest type is
+    # reserved for EPHEMERAL tmp artifacts consumed by Step 4.5's ungated reap
+    # (dirty-check only — no claim/self-exclusion/live-cwd gates, see Step 4.5's
+    # header comment "session worktrees go through Step 5's gated reap, never
+    # here"). Recording a session worktree path under `worktree` would let
+    # Step 4.5 reap it — possibly a live, claimed worktree — before this Step 5
+    # gate ever runs. `session_worktree` is a distinct type Step 4.5's case
+    # statement does not recognize (falls through to its `*)` preserve-verbatim
+    # arm), so only this gated Step 5 bypass ever consumes it.
     if [ "$_corpse" -eq 1 ] && [ -f "$manifest_path" ] \
-       && grep -qxF "worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
+       && grep -qxF "session_worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
       echo "[pr-cycle-cleanup] manifest 記録済み (削除失敗確認済み) corpse session worktree のため age guard をバイパスします: $(printf '%s' "$wt_path" | neutralize_ctrl)" >&2
     elif [ "$_corpse" -eq 1 ] && [ -z "$(find "$wt_path" -maxdepth 0 -mmin +"$WORKDIR_REAP_AGE_MINUTES" 2>/dev/null)" ]; then
       echo "WARNING: corpse session worktree '$(printf '%s' "$wt_path" | neutralize_ctrl)' (admin HEAD 欠落・git 非認識) は age guard (24h) 未達のため回収を見送ります。" >&2
@@ -1137,30 +1167,32 @@ if [ -d "$session_wt_root" ]; then
       _rite_null_worktree_refs "$wt_path" "$_wt_canon"
 
       # Manifest entry consumption (Issue #1945, symmetric with the branch
-      # consumption below — #1966): a lingering `worktree\t<path>` entry is not
-      # inert — the corpse age-guard bypass above is keyed on it, so a
-      # DIFFERENT worktree later created at this same path (e.g. the issue
-      # reopened) would inherit the bypass and skip the 24h protection it
-      # never earned. Step 4.5's own "already gone" check
-      # (`[ ! -e "$_m_val" ]`) does not catch this: once a NEW worktree exists
-      # at the reused path, the entry looks "present" again. Best-effort: each
-      # failure falls back to Step 4.5's indeterminate-status keep on the next
-      # run (never silently drops an entry a failed write left behind).
-      if [ -f "$manifest_path" ] && grep -qxF "worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
+      # consumption below — #1966): a lingering `session_worktree\t<path>`
+      # entry is not inert — the corpse age-guard bypass above is keyed on it,
+      # so a DIFFERENT worktree later created at this same path (e.g. the
+      # issue reopened) would inherit the bypass and skip the 24h protection
+      # it never earned. Best-effort: on failure, the entry survives Step 4.5's
+      # own "already gone" check for this type (added alongside this Step 5
+      # consumer above) on the *next* run only if this exact path is gone by
+      # then — while the worktree still exists here, retrying the consumption
+      # is this step's own responsibility (never silently drops an entry a
+      # failed write left behind).
+      if [ -f "$manifest_path" ] && grep -qxF "session_worktree$(printf '\t')$wt_path" "$manifest_path" 2>/dev/null; then
         if _wt_mf_keep=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-wtmf-XXXXXX" 2>/dev/null); then
           _wt_mf_rc=0
-          grep -vxF "worktree$(printf '\t')$wt_path" "$manifest_path" > "$_wt_mf_keep" 2>/dev/null || _wt_mf_rc=$?
+          grep -vxF "session_worktree$(printf '\t')$wt_path" "$manifest_path" > "$_wt_mf_keep" 2>/dev/null || _wt_mf_rc=$?
           if [ "$_wt_mf_rc" -ge 2 ]; then
-            echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（survivor 抽出）に失敗しました (rc=$_wt_mf_rc)（次 run の Step 4.5 による自己修復待ち）。" >&2
+            echo "WARNING: manifest エントリ 'session_worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（survivor 抽出）に失敗しました (rc=$_wt_mf_rc)（reap 済みでパス自体は既に存在しないため、次回セッション開始時に Step 4.5 の「既に消滅」チェックで自動的に破棄されます — 手動確認: $manifest_path）。" >&2
           elif [ -s "$_wt_mf_keep" ]; then
             cp "$_wt_mf_keep" "$manifest_path" 2>/dev/null \
-              || echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（書き戻し）に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+              || echo "WARNING: manifest エントリ 'session_worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（書き戻し）に失敗しました（reap 済みでパス自体は既に存在しないため、次回セッション開始時に Step 4.5 の「既に消滅」チェックで自動的に破棄されます — 手動確認: $manifest_path）。" >&2
           elif ! rm -f "$manifest_path" 2>/dev/null; then
-            echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（manifest 削除）に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+            echo "WARNING: manifest エントリ 'session_worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費（manifest 削除）に失敗しました（reap 済みでパス自体は既に存在しないため、次回セッション開始時に Step 4.5 の「既に消滅」チェックで自動的に破棄されます — 手動確認: $manifest_path）。" >&2
           fi
           rm -f "$_wt_mf_keep" 2>/dev/null || true
+          _wt_mf_keep=""
         else
-          echo "WARNING: manifest エントリ 'worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費用 mktemp に失敗しました（次 run の Step 4.5 による自己修復待ち）。" >&2
+          echo "WARNING: manifest エントリ 'session_worktree $(printf '%s' "$wt_path" | neutralize_ctrl)' の即時消費用 mktemp に失敗しました（reap 済みでパス自体は既に存在しないため、次回セッション開始時に Step 4.5 の「既に消滅」チェックで自動的に破棄されます — 手動確認: $manifest_path）。" >&2
         fi
       fi
 

--- a/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
+++ b/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
@@ -16,10 +16,12 @@
 #       type=session_worktree). `worktree` is reserved for EPHEMERAL tmp
 #       artifacts consumed by pr-cycle-cleanup.sh Step 4.5's ungated reap
 #       (dirty-check only — no claim/self-exclusion/live-cwd gates).
-#       `session_worktree` is for `.rite/worktrees/issue-N` paths, consumed
-#       ONLY by Step 5's gated corpse-age-guard bypass (Issue #1945); Step 4.5
-#       does not recognize this type and preserves it verbatim, per the
-#       existing "session worktrees go through Step 5's gated reap, never
+#       `session_worktree` is for `.rite/worktrees/issue-N` paths, actually
+#       reaped ONLY by Step 5's gated corpse-age-guard bypass (Issue #1945).
+#       Step 4.5 has a dedicated case arm for this type too, but that arm
+#       never reaps — it only drops a stale entry once the path is already
+#       gone (self-heal) and otherwise preserves it verbatim for Step 5, per
+#       the existing "session worktrees go through Step 5's gated reap, never
 #       here" contract.
 #
 # Data contract (`<shared-root>/.rite/tmp-artifacts.tsv`, TAB-separated):

--- a/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
+++ b/plugins/rite/hooks/scripts/rite-tmp-artifact.sh
@@ -10,9 +10,17 @@
 # explicitly recorded, so an unrelated user branch/worktree is never touched.
 #
 # Subcommand:
-#   record --type <branch|worktree> --id <value>
+#   record --type <branch|worktree|session_worktree> --id <value>
 #       Append one entry to the manifest. `value` is a local branch name
-#       (type=branch) or an absolute worktree path (type=worktree).
+#       (type=branch) or an absolute worktree path (type=worktree /
+#       type=session_worktree). `worktree` is reserved for EPHEMERAL tmp
+#       artifacts consumed by pr-cycle-cleanup.sh Step 4.5's ungated reap
+#       (dirty-check only — no claim/self-exclusion/live-cwd gates).
+#       `session_worktree` is for `.rite/worktrees/issue-N` paths, consumed
+#       ONLY by Step 5's gated corpse-age-guard bypass (Issue #1945); Step 4.5
+#       does not recognize this type and preserves it verbatim, per the
+#       existing "session worktrees go through Step 5's gated reap, never
+#       here" contract.
 #
 # Data contract (`<shared-root>/.rite/tmp-artifacts.tsv`, TAB-separated):
 #   <type>\t<value>
@@ -35,7 +43,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANIFEST_REL=".rite/tmp-artifacts.tsv"
 
 usage() {
-  echo "Usage: rite-tmp-artifact.sh record --type <branch|worktree> --id <value>" >&2
+  echo "Usage: rite-tmp-artifact.sh record --type <branch|worktree|session_worktree> --id <value>" >&2
 }
 
 cmd="${1:-}"
@@ -57,8 +65,8 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$art_type" in
-  branch|worktree) : ;;
-  *) echo "ERROR: --type must be 'branch' or 'worktree' (got '${art_type}')" >&2; exit 1 ;;
+  branch|worktree|session_worktree) : ;;
+  *) echo "ERROR: --type must be 'branch', 'worktree', or 'session_worktree' (got '${art_type}')" >&2; exit 1 ;;
 esac
 if [ -z "$art_id" ]; then
   echo "ERROR: --id is required and must be non-empty" >&2
@@ -96,12 +104,12 @@ case "$art_type" in
         echo "ERROR: branch --id may contain only [A-Za-z0-9._/-]" >&2; exit 1 ;;
     esac
     ;;
-  worktree)
+  worktree|session_worktree)
     # Worktree paths recorded by rite are always absolute (git worktree list /
     # mktemp -d -t emit absolute paths); a relative path here is a producer bug.
     case "$art_id" in
       /*) : ;;
-      *) echo "ERROR: worktree --id must be an absolute path" >&2; exit 1 ;;
+      *) echo "ERROR: $art_type --id must be an absolute path" >&2; exit 1 ;;
     esac
     ;;
 esac

--- a/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
@@ -23,18 +23,29 @@ echo "=== ステップ 4-W: session_worktree manifest 記録が {pr_merged}=true
 # バイパス（dirty チェック無し）に晒される事故を防ぐ唯一の防波堤。ガード行と record 呼び出しの
 # 両方を、それぞれの分岐（sandbox マスク検知 / busy 削除失敗）の狭いセクション内で固定する — 汎用の
 # "pr_merged という語がどこかにある" だけの assert では、ガードが record 呼び出しから外れて
-# 常時記録に regression しても検知できない (Issue #1945 fix.md cycle 2 test reviewer 指摘)。
+# 常時記録に regression しても検知できない。
+## start パターンは `echo "[CONTEXT] ...` 形式の bash コード行にのみ一致させる（`[CONTEXT]` 接頭辞
+## を含めない生の marker 名だけだと、ステップ 12 の説明文（同じ marker 名をバッククォート引用する
+## prose 行）にも一致し、awk flip-flop レンジが最初の end 一致後にそこで再起動して EOF まで伸びる
+## — section scoping が実質無効化され、コード側 guard が regression しても prose 側の記述が
+## 生き残る限り silent pass しうる。`echo "[CONTEXT] ` 接頭辞は bash コード行にしか出現しないため、
+## この曖昧さを構造的に排除する。
+## start/end は assert_grep_in_section 内部で `awk -v` に渡り、awk の -v 引数は C 風エスケープを
+## 1段階解釈してから正規表現エンジンに渡す（`\[` は「不要なエスケープ」として警告付きで `[` に
+## 潰される）。ERE として `\[`/`\]`（リテラル bracket）を正規表現エンジンまで届けるには、-v 側の
+## 解釈で 1 段階消費される分を見越して `\\[`/`\\]`（バックスラッシュ2つ）を渡す必要がある
+## （1つだけだと `[CONTEXT]` が bracket 式として解釈され match しなくなる／過剰マッチの温床にもなる）。
 assert_grep_in_section "4-W sandbox-mask branch: session_worktree record call present" \
-  "$CLEANUP" 'WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
+  "$CLEANUP" 'echo "\\[CONTEXT\\] WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
   'record --type session_worktree'
 assert_grep_in_section "4-W sandbox-mask branch: record is inside the {pr_merged}=true guard" \
-  "$CLEANUP" 'WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
+  "$CLEANUP" 'echo "\\[CONTEXT\\] WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
   '\{pr_merged\}" = "true"'
 assert_grep_in_section "4-W busy-failed branch: session_worktree record call present" \
-  "$CLEANUP" 'WORKTREE_REMOVE_FAILED=1' '\[ -n "\$_wt_rm_err" \] && rm -f' \
+  "$CLEANUP" 'echo "\\[CONTEXT\\] WORKTREE_REMOVE_FAILED=1' '\\[ -n "\\$_wt_rm_err" \\] && rm -f' \
   'record --type session_worktree'
 assert_grep_in_section "4-W busy-failed branch: record is inside the {pr_merged}=true guard" \
-  "$CLEANUP" 'WORKTREE_REMOVE_FAILED=1' '\[ -n "\$_wt_rm_err" \] && rm -f' \
+  "$CLEANUP" 'echo "\\[CONTEXT\\] WORKTREE_REMOVE_FAILED=1' '\\[ -n "\\$_wt_rm_err" \\] && rm -f' \
   '\{pr_merged\}" = "true"'
 
 echo "=== ステップ 5: squash-merge 確認済みブランチの強制削除 + 遅延ブランチの manifest 記録 ==="

--- a/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-message-contract.test.sh
@@ -18,6 +18,25 @@ echo "=== ステップ 4-W: self-exclusion 付き live-cwd guard の配線 ==="
 assert_grep "4-W uses worktree-foreign-cwd.sh (not the bare live-cwd probe)" "$CLEANUP" "worktree-foreign-cwd\.sh"
 assert_grep "4-W passes --self-root \$PPID (excludes the cleanup session's harness)" "$CLEANUP" 'worktree-foreign-cwd\.sh.*--self-root'
 
+echo "=== ステップ 4-W: session_worktree manifest 記録が {pr_merged}=true ガード配下にあること (Issue #1945 AC-4) ==="
+# 未マージ PR の強制 cleanup で corpse worktree のパスが記録され、Step 5 の corpse age-guard
+# バイパス（dirty チェック無し）に晒される事故を防ぐ唯一の防波堤。ガード行と record 呼び出しの
+# 両方を、それぞれの分岐（sandbox マスク検知 / busy 削除失敗）の狭いセクション内で固定する — 汎用の
+# "pr_merged という語がどこかにある" だけの assert では、ガードが record 呼び出しから外れて
+# 常時記録に regression しても検知できない (Issue #1945 fix.md cycle 2 test reviewer 指摘)。
+assert_grep_in_section "4-W sandbox-mask branch: session_worktree record call present" \
+  "$CLEANUP" 'WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
+  'record --type session_worktree'
+assert_grep_in_section "4-W sandbox-mask branch: record is inside the {pr_merged}=true guard" \
+  "$CLEANUP" 'WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1' '^     else$' \
+  '\{pr_merged\}" = "true"'
+assert_grep_in_section "4-W busy-failed branch: session_worktree record call present" \
+  "$CLEANUP" 'WORKTREE_REMOVE_FAILED=1' '\[ -n "\$_wt_rm_err" \] && rm -f' \
+  'record --type session_worktree'
+assert_grep_in_section "4-W busy-failed branch: record is inside the {pr_merged}=true guard" \
+  "$CLEANUP" 'WORKTREE_REMOVE_FAILED=1' '\[ -n "\$_wt_rm_err" \] && rm -f' \
+  '\{pr_merged\}" = "true"'
+
 echo "=== ステップ 5: squash-merge 確認済みブランチの強制削除 + 遅延ブランチの manifest 記録 ==="
 assert_grep "Step 5 reads the {pr_merged} signal" "$CLEANUP" "pr_merged"
 assert_grep "Step 5 emits via=squash-merged on confirmed-merged force delete" "$CLEANUP" "via=squash-merged"

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -638,17 +638,18 @@ case "$out" in *"session_worktrees=0"*) pass "C-04 status reports session_worktr
 # tree), so the #1966 branch-keyed bypass above structurally never matches
 # one — every corpse would wait the full 24h even when cleanup.md Step 4-W
 # already recorded the failed removal. cleanup.md now records the worktree's
-# own PATH into the manifest when removal fails/is skipped for a
-# busy/sandbox-mask reason (only when the PR was merged — AC-4 parity with
-# the branch bypass). Step 5's corpse age guard checks for that PATH entry
-# before falling back to the 24h wait.
+# own PATH into the manifest (under the distinct `session_worktree` type —
+# NOT the ephemeral-artifact `worktree` type Step 4.5 reaps ungated) when
+# removal fails/is skipped for a busy/sandbox-mask reason (only when the PR
+# was merged — AC-4 parity with the branch bypass). Step 5's corpse age
+# guard checks for that PATH entry before falling back to the 24h wait.
 # ===========================================================================
 
 echo "=== C-05 (#1945): fresh corpse + manifest-recorded PATH → reaped (age-guard bypass, no branch needed) ==="
 R=$(make_repo 140); cleanup_dirs+=("$R")
 RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
 rm -f "$R/.rite/state/issue-claims/issue-140.json"   # cleanup releases the claim unconditionally
-printf 'worktree\t%s\n' "$R/.rite/worktrees/issue-140" > "$R/.rite/tmp-artifacts.tsv"
+printf 'session_worktree\t%s\n' "$R/.rite/worktrees/issue-140" > "$R/.rite/tmp-artifacts.tsv"
 make_corpse "$R" 140
 out=$(run_pcc "$R")
 assert "C-05 fresh manifest-recorded corpse reaped (working tree)" "0" "$( [ -d "$R/.rite/worktrees/issue-140" ] && echo 1 || echo 0 )"
@@ -661,18 +662,68 @@ echo "=== C-05b (#1945 control): fresh corpse + manifest records a DIFFERENT pat
 R=$(make_repo 141); cleanup_dirs+=("$R")
 RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
 rm -f "$R/.rite/state/issue-claims/issue-141.json"
-# A real, existing-but-not-a-git-worktree directory: Step 4.5's dirty check on
-# it is indeterminate (not a worktree) so it KEEPS the entry (survives to
-# reach Step 5's exact-match grep) — a non-vacuous mismatch, mirroring D-03's
-# approach for the branch bypass.
+# A real, existing-but-not-a-git-worktree directory: Step 4.5's new
+# session_worktree case only checks path existence (no dirty check, no reap —
+# it defers entirely to Step 5), so an existing decoy path KEEPS the entry
+# (survives to reach Step 5's exact-match grep) — a non-vacuous mismatch,
+# mirroring D-03's approach for the branch bypass.
 mkdir -p "$R/.rite/worktrees/issue-141-decoy"
-printf 'worktree\t%s\n' "$R/.rite/worktrees/issue-141-decoy" > "$R/.rite/tmp-artifacts.tsv"
+printf 'session_worktree\t%s\n' "$R/.rite/worktrees/issue-141-decoy" > "$R/.rite/tmp-artifacts.tsv"
 make_corpse "$R" 141
 out=$(run_pcc "$R")
 assert "C-05b mismatched-entry fresh corpse survives (age guard)" "1" "$( [ -d "$R/.rite/worktrees/issue-141" ] && echo 1 || echo 0 )"
 assert_grep "C-05b age-guard skip WARNING on stderr (not silent)" "$R/pcc.err" "age guard \(24h\) 未達のため回収を見送ります"
-assert "C-05b mismatch entry survived Step 4.5 (non-vacuous: bypass grep saw it)" "1" "$( grep -qxF "worktree$(printf '\t')$R/.rite/worktrees/issue-141-decoy" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
+assert "C-05b mismatch entry survived Step 4.5 (non-vacuous: bypass grep saw it)" "1" "$( grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-141-decoy" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=0"*) pass "C-05b status reports session_worktrees=0" ;; *) fail "C-05b status: $out" ;; esac
+
+echo "=== C-05c (#1945, error-handling review finding): manifest-recorded LIVE session worktree is NOT reaped by Step 4.5's ungated pass ==="
+R=$(make_repo 142); cleanup_dirs+=("$R")
+# The exact scenario the error-handling reviewer reproduced: a clean, healthy
+# (non-corpse) session worktree whose path is manifest-recorded (as would
+# happen from a sandbox-mask-skip deferred removal) but SID_A (the claim
+# holder) stays live. If session_worktree entries were reaped by Step 4.5's
+# ungated worktree-type pass (dirty-check only, no claim/self-exclusion/
+# live-cwd gates), this live worktree would be destroyed silently. It must
+# survive entirely (Step 4.5 defers, Step 5's own claim-liveness Gate 2 also
+# protects it).
+printf 'session_worktree\t%s\n' "$R/.rite/worktrees/issue-142" > "$R/.rite/tmp-artifacts.tsv"
+out=$(run_pcc "$R")
+assert "C-05c live session worktree survives Step 4.5's ungated pass" "1" "$( [ -d "$R/.rite/worktrees/issue-142" ] && echo 1 || echo 0 )"
+assert "C-05c claim file survives (worktree never reached Step 5 reap either)" "1" "$( [ -f "$R/.rite/state/issue-claims/issue-142.json" ] && echo 1 || echo 0 )"
+assert "C-05c manifest entry survives (Step 4.5 preserved it verbatim, path still exists)" "1" "$( grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-142" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=0"*) pass "C-05c status reports session_worktrees=0 (nothing reaped)" ;; *) fail "C-05c status: $out" ;; esac
+
+echo "=== C-05d (#1945): manifest-recorded session_worktree entry for an ALREADY-GONE path is dropped by Step 4.5 (self-heal) ==="
+R=$(make_repo 143); cleanup_dirs+=("$R")
+# The worktree was already reaped by a prior run (or never existed at this
+# path); the manifest entry is a stale leftover. Step 4.5's session_worktree
+# case must drop it (the "already gone" self-heal), same as the worktree/
+# branch cases already do for their own types.
+printf 'session_worktree\t%s\n' "$R/.rite/worktrees/issue-999-gone" > "$R/.rite/tmp-artifacts.tsv"
+run_pcc "$R" >/dev/null
+assert "C-05d stale already-gone entry is dropped" "0" "$( [ -f "$R/.rite/tmp-artifacts.tsv" ] && grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-999-gone" "$R/.rite/tmp-artifacts.tsv" && echo 1 || echo 0 )"
+
+echo "=== C-06 (#1945, mirrors D-04): multi-entry session_worktree manifest → only the reaped entry is consumed ==="
+R=$(make_repo 150); cleanup_dirs+=("$R")
+# Two recorded session_worktree entries: issue-150 (reap target — fresh
+# corpse, claim-free) and a co-pending decoy path that must survive the
+# consumption write-back untouched. This exercises the survivor-preserving
+# `cp` branch (multi-entry manifest) that C-05's single-entry `rm -f` branch
+# cannot reach — the exact coverage gap the test reviewer identified via
+# mutation testing (a survivor-drop bug in the cp branch went undetected by
+# the full suite without this test).
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+rm -f "$R/.rite/state/issue-claims/issue-150.json"
+mkdir -p "$R/.rite/worktrees/issue-150-copending-decoy"
+printf 'session_worktree\t%s\nsession_worktree\t%s\n' \
+  "$R/.rite/worktrees/issue-150" "$R/.rite/worktrees/issue-150-copending-decoy" > "$R/.rite/tmp-artifacts.tsv"
+make_corpse "$R" 150
+out=$(run_pcc "$R")
+assert "C-06 target corpse reaped (bypass)" "0" "$( [ -d "$R/.rite/worktrees/issue-150" ] && echo 1 || echo 0 )"
+assert "C-06 target manifest entry consumed" "0" "$( grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-150" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
+assert "C-06 co-pending entry preserved (cp survivors branch, not silently dropped)" "1" "$( grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-150-copending-decoy" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
+assert "C-06 co-pending decoy directory untouched" "1" "$( [ -d "$R/.rite/worktrees/issue-150-copending-decoy" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "C-06 status reports session_worktrees=1" ;; *) fail "C-06 status: $out" ;; esac
 
 print_summary "$(basename "$0")" \
   "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); Issue #1957 corpse reap: admin-HEAD-missing AND git-unrecognized trees bypass Gate 3 and reap (rm -rf tree + admin dir) behind claim + 24h age guards — HEAD-present rc≠0 trees stay on the conservative skip; Issue #1670 branch recovery: after reap, SAFE-delete the branch (merged → recovered) and FORCE-delete only manifest-recorded (merge-confirmed) branches, preserving unmerged work; Issue #1966 free-arm manifest bypass: a claim-free worktree whose checked-out branch is manifest-recorded (merge-confirmed) bypasses the 24h age guard (harness mtime churn would otherwise leak it forever) and its manifest entry is consumed immediately after any successful branch recovery (-d and -D alike, best-effort with WARNING on failure); Issue #1945 corpse-path manifest bypass: a corpse cannot resolve its branch (git doesn't recognize the tree) so the #1966 branch bypass never fires for one — cleanup.md Step 4-W now records the worktree's own PATH (not branch) into the manifest when removal fails/is skipped for busy/sandbox-mask reasons (merge-confirmed only), and the corpse age guard checks that PATH before falling back to the 24h wait, consuming the entry on successful reap (surgical: a mismatched path entry does not bypass); wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -676,13 +676,12 @@ assert_grep "C-05b age-guard skip WARNING on stderr (not silent)" "$R/pcc.err" "
 assert "C-05b mismatch entry survived Step 4.5 (non-vacuous: bypass grep saw it)" "1" "$( grep -qxF "session_worktree$(printf '\t')$R/.rite/worktrees/issue-141-decoy" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
 case "$out" in *"session_worktrees=0"*) pass "C-05b status reports session_worktrees=0" ;; *) fail "C-05b status: $out" ;; esac
 
-echo "=== C-05c (#1945, error-handling review finding): manifest-recorded LIVE session worktree is NOT reaped by Step 4.5's ungated pass ==="
+echo "=== C-05c (#1945): manifest-recorded LIVE session worktree is NOT reaped by Step 4.5's ungated pass ==="
 R=$(make_repo 142); cleanup_dirs+=("$R")
-# The exact scenario the error-handling reviewer reproduced: a clean, healthy
-# (non-corpse) session worktree whose path is manifest-recorded (as would
-# happen from a sandbox-mask-skip deferred removal) but SID_A (the claim
-# holder) stays live. If session_worktree entries were reaped by Step 4.5's
-# ungated worktree-type pass (dirty-check only, no claim/self-exclusion/
+# A clean, healthy (non-corpse) session worktree whose path is manifest-recorded
+# (as would happen from a sandbox-mask-skip deferred removal) but SID_A (the
+# claim holder) stays live. If session_worktree entries were reaped by Step
+# 4.5's ungated worktree-type pass (dirty-check only, no claim/self-exclusion/
 # live-cwd gates), this live worktree would be destroyed silently. It must
 # survive entirely (Step 4.5 defers, Step 5's own claim-liveness Gate 2 also
 # protects it).
@@ -709,9 +708,8 @@ R=$(make_repo 150); cleanup_dirs+=("$R")
 # corpse, claim-free) and a co-pending decoy path that must survive the
 # consumption write-back untouched. This exercises the survivor-preserving
 # `cp` branch (multi-entry manifest) that C-05's single-entry `rm -f` branch
-# cannot reach — the exact coverage gap the test reviewer identified via
-# mutation testing (a survivor-drop bug in the cp branch went undetected by
-# the full suite without this test).
+# cannot reach — without this test, a survivor-drop bug in the cp branch
+# would go undetected by the full suite.
 RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
 rm -f "$R/.rite/state/issue-claims/issue-150.json"
 mkdir -p "$R/.rite/worktrees/issue-150-copending-decoy"

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -632,5 +632,47 @@ assert_grep "C-04 Gate 3 conservative-skip WARNING (not the corpse path)" "$R/pc
 assert_not_grep "C-04 no corpse WARNING emitted" "$R/pcc.err" "corpse session worktree"
 case "$out" in *"session_worktrees=0"*) pass "C-04 status reports session_worktrees=0" ;; *) fail "C-04 status: $out" ;; esac
 
+# ===========================================================================
+# Issue #1945 — corpse age-guard manifest bypass, keyed on PATH not branch. A
+# corpse cannot resolve its checked-out branch (git no longer recognizes the
+# tree), so the #1966 branch-keyed bypass above structurally never matches
+# one — every corpse would wait the full 24h even when cleanup.md Step 4-W
+# already recorded the failed removal. cleanup.md now records the worktree's
+# own PATH into the manifest when removal fails/is skipped for a
+# busy/sandbox-mask reason (only when the PR was merged — AC-4 parity with
+# the branch bypass). Step 5's corpse age guard checks for that PATH entry
+# before falling back to the 24h wait.
+# ===========================================================================
+
+echo "=== C-05 (#1945): fresh corpse + manifest-recorded PATH → reaped (age-guard bypass, no branch needed) ==="
+R=$(make_repo 140); cleanup_dirs+=("$R")
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+rm -f "$R/.rite/state/issue-claims/issue-140.json"   # cleanup releases the claim unconditionally
+printf 'worktree\t%s\n' "$R/.rite/worktrees/issue-140" > "$R/.rite/tmp-artifacts.tsv"
+make_corpse "$R" 140
+out=$(run_pcc "$R")
+assert "C-05 fresh manifest-recorded corpse reaped (working tree)" "0" "$( [ -d "$R/.rite/worktrees/issue-140" ] && echo 1 || echo 0 )"
+assert "C-05 fresh manifest-recorded corpse reaped (admin dir)" "0" "$( [ -d "$R/.git/worktrees/issue-140" ] && echo 1 || echo 0 )"
+assert_grep "C-05 bypass is LOGGED (not silent)" "$R/pcc.err" "manifest 記録済み \(削除失敗確認済み\) corpse session worktree のため age guard をバイパスします"
+assert "C-05 manifest entry consumed (file removed)" "0" "$( [ -f "$R/.rite/tmp-artifacts.tsv" ] && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=1"*) pass "C-05 status reports session_worktrees=1" ;; *) fail "C-05 status: $out" ;; esac
+
+echo "=== C-05b (#1945 control): fresh corpse + manifest records a DIFFERENT path → survives (surgical, age guard intact) ==="
+R=$(make_repo 141); cleanup_dirs+=("$R")
+RITE_STATE_ROOT="$R" bash "$FS" deactivate --session "$SID_A" --next done >/dev/null 2>&1
+rm -f "$R/.rite/state/issue-claims/issue-141.json"
+# A real, existing-but-not-a-git-worktree directory: Step 4.5's dirty check on
+# it is indeterminate (not a worktree) so it KEEPS the entry (survives to
+# reach Step 5's exact-match grep) — a non-vacuous mismatch, mirroring D-03's
+# approach for the branch bypass.
+mkdir -p "$R/.rite/worktrees/issue-141-decoy"
+printf 'worktree\t%s\n' "$R/.rite/worktrees/issue-141-decoy" > "$R/.rite/tmp-artifacts.tsv"
+make_corpse "$R" 141
+out=$(run_pcc "$R")
+assert "C-05b mismatched-entry fresh corpse survives (age guard)" "1" "$( [ -d "$R/.rite/worktrees/issue-141" ] && echo 1 || echo 0 )"
+assert_grep "C-05b age-guard skip WARNING on stderr (not silent)" "$R/pcc.err" "age guard \(24h\) 未達のため回収を見送ります"
+assert "C-05b mismatch entry survived Step 4.5 (non-vacuous: bypass grep saw it)" "1" "$( grep -qxF "worktree$(printf '\t')$R/.rite/worktrees/issue-141-decoy" "$R/.rite/tmp-artifacts.tsv" 2>/dev/null && echo 1 || echo 0 )"
+case "$out" in *"session_worktrees=0"*) pass "C-05b status reports session_worktrees=0" ;; *) fail "C-05b status: $out" ;; esac
+
 print_summary "$(basename "$0")" \
-  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); Issue #1957 corpse reap: admin-HEAD-missing AND git-unrecognized trees bypass Gate 3 and reap (rm -rf tree + admin dir) behind claim + 24h age guards — HEAD-present rc≠0 trees stay on the conservative skip; Issue #1670 branch recovery: after reap, SAFE-delete the branch (merged → recovered) and FORCE-delete only manifest-recorded (merge-confirmed) branches, preserving unmerged work; Issue #1966 free-arm manifest bypass: a claim-free worktree whose checked-out branch is manifest-recorded (merge-confirmed) bypasses the 24h age guard (harness mtime churn would otherwise leak it forever) and its manifest entry is consumed immediately after any successful branch recovery (-d and -D alike, best-effort with WARNING on failure); wiki-worktree excluded; session-start best-effort wiring."
+  "Drift hint: pr-cycle-cleanup.sh Step 5 §8 — Gate 0 self-exclusion (cwd/RITE_WORKTREE == self → never reap) + worktree liveness guard (Issue #1524: a session's active flow-state worktree ref → never reap; reap → null owner ref / Issue #1552: claim-join — issue's claim holder still active=true, even with a stale 2h heartbeat → never reap) + OS-level live-cwd guard (Issue #1544: any live process standing in the tree → never reap, via worktree-live-cwd.sh) + 3 gates (strict ^issue-[0-9]+$ / claim not-live / clean); Issue #1957 corpse reap: admin-HEAD-missing AND git-unrecognized trees bypass Gate 3 and reap (rm -rf tree + admin dir) behind claim + 24h age guards — HEAD-present rc≠0 trees stay on the conservative skip; Issue #1670 branch recovery: after reap, SAFE-delete the branch (merged → recovered) and FORCE-delete only manifest-recorded (merge-confirmed) branches, preserving unmerged work; Issue #1966 free-arm manifest bypass: a claim-free worktree whose checked-out branch is manifest-recorded (merge-confirmed) bypasses the 24h age guard (harness mtime churn would otherwise leak it forever) and its manifest entry is consumed immediately after any successful branch recovery (-d and -D alike, best-effort with WARNING on failure); Issue #1945 corpse-path manifest bypass: a corpse cannot resolve its branch (git doesn't recognize the tree) so the #1966 branch bypass never fires for one — cleanup.md Step 4-W now records the worktree's own PATH (not branch) into the manifest when removal fails/is skipped for busy/sandbox-mask reasons (merge-confirmed only), and the corpse age guard checks that PATH before falling back to the 24h wait, consuming the entry on successful reap (surgical: a mismatched path entry does not bypass); wiki-worktree excluded; session-start best-effort wiring."

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -753,6 +753,11 @@ fi
 #   T-27 → Issue T-06 / AC-6: manifest worktree pointing at a non-git path is
 #          skipped WITHOUT aborting the run (regression for the set -e rc-capture fix)
 #   T-28 → Issue T-04 / AC-4: stale manifest entry (branch already gone) is dropped
+#   T-29 → Issue #1945: rite-tmp-artifact.sh `session_worktree` type round-trip
+#          (helper writes the manifest line for an absolute path, rejects a
+#          relative one) — the reap-side behavior for this type is covered by
+#          pr-cycle-cleanup-session-reap.test.sh's C-05/C-05b/C-05c/C-05d/C-06;
+#          this test covers the producer (recorder) side only.
 # (Steps 1-4 non-blocking failure paths are covered by T-10..T-16; T-26 adds the
 #  same contract for the new Step 4.5 manifest reap. Issue T-06 session-worktree
 #  protection by the gated Step 5 reap lives in pr-cycle-cleanup-session-reap.test.sh.)
@@ -970,6 +975,24 @@ if [ "$t28_rc" = "0" ] \
   pass "T-28: stale エントリは status≠failed + manifest=0 + 空 manifest 削除で drop"
 else
   fail "T-28: rc=$t28_rc, manifest_gone=$t28_manifest_gone. Output: $t28_output"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# T-29: rite-tmp-artifact.sh `session_worktree` type round-trip (Issue #1945, producer side)
+echo "T-29: rite-tmp-artifact.sh session_worktree type の記録・バリデーション (Issue #1945)"
+TEST_REPO=$(make_temp_repo)
+t29_abs_id="$TEST_REPO/.rite/worktrees/issue-t29"
+(
+  cd "$TEST_REPO"
+  bash "$ARTIFACT_HELPER" record --type session_worktree --id "$t29_abs_id" >/dev/null 2>&1
+)
+t29_recorded=$(grep -qxF "session_worktree$(printf '\t')$t29_abs_id" "$TEST_REPO/.rite/tmp-artifacts.tsv" 2>/dev/null && echo yes || echo no)
+t29_rel_rc=0
+( cd "$TEST_REPO" && bash "$ARTIFACT_HELPER" record --type session_worktree --id "relative/path" >/dev/null 2>&1 ) || t29_rel_rc=$?
+if [ "$t29_recorded" = "yes" ] && [ "$t29_rel_rc" -ne 0 ]; then
+  pass "T-29: session_worktree type は絶対パスで manifest に記録され、相対パスは拒否される (rc=$t29_rel_rc)"
+else
+  fail "T-29: recorded=$t29_recorded, rel_rc=$t29_rel_rc"
 fi
 cleanup_temp_repo "$TEST_REPO"
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -378,12 +378,19 @@ esac
        echo "[CONTEXT] WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1; path={flow_wt}" >&2
        # Issue #1945: このマスク検知は次に control が渡る側（admin dir 半壊 = corpse）の
        # 直接の前兆であり、corpse は checkout 中 branch を git で解決できないため
-       # ステップ 5 のブランチ名 manifest bypass（#1966）が構造的に効かない。パス自体を
+       # pr-cycle-cleanup.sh Step 5 のブランチ名 manifest bypass（#1966）が構造的に効かない。パス自体を
        # 事前に記録しておけば、pr-cycle-cleanup.sh の corpse age guard がこの記録を見て
        # 24h 待ちをバイパスできる（{pr_merged}=true のときのみ — AC-4: 未マージ PR の
        # 強制 cleanup では記録しない）。record 自体は non-blocking 契約（rite-tmp-artifact.sh）。
+       # `--type session_worktree`（`worktree` ではない）: `worktree` type は Step 4.5 の
+       # ungated reap（dirty チェックのみ、claim/self-exclusion/live-cwd ガード無し）が
+       # 消費する EPHEMERAL tmp artifact 専用の契約を持つ。session worktree のパスをそこに
+       # 混ぜると、Step 4.5 が Step 5 の保護ゲートを経ずに生存中の worktree を reap しうる
+       # （"session worktrees go through Step 5's gated reap, never here" 契約違反）。
+       # `session_worktree` type は Step 4.5 の case 文が未知 type として素通しするため、
+       # Step 5 の gated bypass（下記）のみがこの記録を消費する。
        if [ "{pr_merged}" = "true" ]; then
-         bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type worktree --id "{flow_wt}" 2>/dev/null || true
+         bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type session_worktree --id "{flow_wt}" 2>/dev/null || true
        fi
      else
        # git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定し、busy 検出の
@@ -403,10 +410,11 @@ esac
          # 部分破壊し corpse 化した場合、上記マスク検知分岐と同じ理由でブランチ名
          # bypass（#1966）が効かなくなる。パスを reap manifest に記録し、
          # pr-cycle-cleanup.sh の corpse age guard バイパスに委ねる
-         # （{pr_merged}=true のときのみ — AC-4）。非 corpse のまま残った場合は
-         # Step 4.5 の manifest worktree reap（age guard 無し・dirty チェックあり）が拾う。
+         # （{pr_merged}=true のときのみ — AC-4）。`--type session_worktree` を使う理由は
+         # 上記マスク検知分岐のコメントを参照（Step 4.5 の ungated ephemeral-worktree reap
+         # と混ぜず、Step 5 の gated bypass のみに消費させるため）。
          if [ "{pr_merged}" = "true" ]; then
-           bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type worktree --id "{flow_wt}" 2>/dev/null || true
+           bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type session_worktree --id "{flow_wt}" 2>/dev/null || true
          fi
        fi
        [ -n "$_wt_rm_err" ] && rm -f "$_wt_rm_err"
@@ -414,7 +422,7 @@ esac
      fi
      ```
      > 通常の `in_worktree` 経路ではステップ 2 の `ExitWorktree(keep)` で自セッションの harness cwd が main に退避済みのため、worktree には自他いずれの cwd も無く `worktree-foreign-cwd.sh` は rc=1（削除）を返す。`ExitWorktree(keep)` が no-op だった経路（`in_worktree_unrecorded` 等）でも、残る live cwd は自セッションのハーネス（`$PPID` subtree）だけなので self-exclusion により rc=1（削除）となり、自己ブロッキングしない。rc=0（遅延）になるのは別セッションのハーネスが実際にこの worktree 内に cwd を持つ場合のみ。`/proc` の無い環境では rc=2 となり従来どおり削除を実行する（後方互換）。
-  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — Issue #1957。remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（Issue #1923 AC-5）。`WORKTREE_REMOVE_FAILED` / `WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` は `{pr_merged}=true` のときのみ reap manifest（`.rite/tmp-artifacts.tsv`）へパスを記録する（Issue #1945）。corpse 化（admin dir 半壊で git がツリーを認識できなくなる状態）した場合、checkout 中 branch が解決不能でブランチ名 bypass（#1966）が構造的に効かないため、パス自体の記録で `pr-cycle-cleanup.sh` の corpse age guard（24h 待ち）をバイパスさせ、mount 解放後の次回セッションで即座に回収できるようにする。
+  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — Issue #1957。remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（Issue #1923 AC-5）。`WORKTREE_REMOVE_FAILED` / `WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` は `{pr_merged}=true` のときのみ reap manifest（`.rite/tmp-artifacts.tsv`）へ `session_worktree` type でパスを記録する（Issue #1945。`worktree` type ではない — Step 4.5 の ephemeral tmp artifact 専用 ungated reap と混ぜないため）。corpse 化（admin dir 半壊で git がツリーを認識できなくなる状態）した場合、checkout 中 branch が解決不能でブランチ名 bypass（#1966）が構造的に効かないため、パス自体の記録で `pr-cycle-cleanup.sh` Step 5 の corpse age guard（24h 待ち）をバイパスさせ、mount 解放後の次回セッションで即座に回収できるようにする。
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の self-exclusion 付き live-cwd guard が特に重要（live-cwd guard による遅延は別セッション在席時。これに加え sandbox マスク検知時（#1957）も削除を試行せず遅延する）。
 - `CLEANUP_WT=none`（multi_session 無効、または worktree 関連なし = 物理 cwd も当該 Issue の worktree でない）: 4-W 全体を no-op でスキップ。**注**: flow-state 未記録でも物理 cwd が当該 Issue の worktree なら `in_worktree_unrecorded` に分類されここには落ちない（#1622）。
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -376,6 +376,15 @@ esac
      elif [ -n "$_wt_admin" ] && [ -c "$_wt_admin/config.worktree" ]; then
        echo "WARNING: sandbox が作業ツリーの管理ディレクトリ（$_wt_admin/config.worktree）にマスクマウントを張っているため、削除を見送りました。この状態で git worktree remove を実行すると管理ディレクトリが半壊するため、削除自体を試行しません。次回のセッション開始時（sandbox 外）に作業ツリーとローカルブランチが自動で回収されます。実行エージェントはこの場で sandbox を無効化して remove を再試行しないこと。" >&2
        echo "[CONTEXT] WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK=1; path={flow_wt}" >&2
+       # Issue #1945: このマスク検知は次に control が渡る側（admin dir 半壊 = corpse）の
+       # 直接の前兆であり、corpse は checkout 中 branch を git で解決できないため
+       # ステップ 5 のブランチ名 manifest bypass（#1966）が構造的に効かない。パス自体を
+       # 事前に記録しておけば、pr-cycle-cleanup.sh の corpse age guard がこの記録を見て
+       # 24h 待ちをバイパスできる（{pr_merged}=true のときのみ — AC-4: 未マージ PR の
+       # 強制 cleanup では記録しない）。record 自体は non-blocking 契約（rite-tmp-artifact.sh）。
+       if [ "{pr_merged}" = "true" ]; then
+         bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type worktree --id "{flow_wt}" 2>/dev/null || true
+       fi
      else
        # git 診断メッセージは locale 翻訳で揺れるため LC_ALL=C で固定し、busy 検出の
        # substring マッチを安定させる（repo 既存の LC_ALL=C 規約と統一）。stderr を
@@ -390,13 +399,22 @@ esac
          if [ -n "$_wt_rm_err" ] && grep -qi "busy" "$_wt_rm_err" 2>/dev/null; then
            echo "WARNING: worktree 削除が「Device or resource busy」で失敗しました。Claude Code の sandbox が worktree の .git/worktrees/*/config.worktree・commondir に read-only bind mount を張っている環境では、sandbox 内からの git worktree remove（--force 含む）は構造的に失敗します。この失敗は意図的に non-blocking として遅延 reap（pr-cycle-cleanup.sh）へ委譲するため、実行エージェントはこの場で sandbox を無効化して同コマンドを再試行しないこと。復旧: ユーザーが sandbox 外のシェルで次を実行してください: git worktree remove --force '{flow_wt}' && git worktree prune" >&2
          fi
+         # Issue #1945: remove --force 自体がこの busy 失敗の過程で admin dir を
+         # 部分破壊し corpse 化した場合、上記マスク検知分岐と同じ理由でブランチ名
+         # bypass（#1966）が効かなくなる。パスを reap manifest に記録し、
+         # pr-cycle-cleanup.sh の corpse age guard バイパスに委ねる
+         # （{pr_merged}=true のときのみ — AC-4）。非 corpse のまま残った場合は
+         # Step 4.5 の manifest worktree reap（age guard 無し・dirty チェックあり）が拾う。
+         if [ "{pr_merged}" = "true" ]; then
+           bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type worktree --id "{flow_wt}" 2>/dev/null || true
+         fi
        fi
        [ -n "$_wt_rm_err" ] && rm -f "$_wt_rm_err"
        git worktree prune 2>/dev/null || true
      fi
      ```
      > 通常の `in_worktree` 経路ではステップ 2 の `ExitWorktree(keep)` で自セッションの harness cwd が main に退避済みのため、worktree には自他いずれの cwd も無く `worktree-foreign-cwd.sh` は rc=1（削除）を返す。`ExitWorktree(keep)` が no-op だった経路（`in_worktree_unrecorded` 等）でも、残る live cwd は自セッションのハーネス（`$PPID` subtree）だけなので self-exclusion により rc=1（削除）となり、自己ブロッキングしない。rc=0（遅延）になるのは別セッションのハーネスが実際にこの worktree 内に cwd を持つ場合のみ。`/proc` の無い環境では rc=2 となり従来どおり削除を実行する（後方互換）。
-  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — Issue #1957。remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（Issue #1923 AC-5）。
+  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — Issue #1957。remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（Issue #1923 AC-5）。`WORKTREE_REMOVE_FAILED` / `WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` は `{pr_merged}=true` のときのみ reap manifest（`.rite/tmp-artifacts.tsv`）へパスを記録する（Issue #1945）。corpse 化（admin dir 半壊で git がツリーを認識できなくなる状態）した場合、checkout 中 branch が解決不能でブランチ名 bypass（#1966）が構造的に効かないため、パス自体の記録で `pr-cycle-cleanup.sh` の corpse age guard（24h 待ち）をバイパスさせ、mount 解放後の次回セッションで即座に回収できるようにする。
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の self-exclusion 付き live-cwd guard が特に重要（live-cwd guard による遅延は別セッション在席時。これに加え sandbox マスク検知時（#1957）も削除を試行せず遅延する）。
 - `CLEANUP_WT=none`（multi_session 無効、または worktree 関連なし = 物理 cwd も当該 Issue の worktree でない）: 4-W 全体を no-op でスキップ。**注**: flow-state 未記録でも物理 cwd が当該 Issue の worktree なら `in_worktree_unrecorded` に分類されここには落ちない（#1622）。
 

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -74,7 +74,7 @@ gh pr list -R {owner_repo} --head {branch_name} --state all --json number,title,
 
 PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャンセル」を確認。未マージ PR: 「キャンセル (推奨) / 強制クリーンアップ」を確認。
 
-`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。これによりステップ 5 のすべての分岐で `{pr_merged}` が必ず literal substitute 可能になる（未定義値参照を防ぐ）。ステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
+`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。これによりステップ 4-W / ステップ 5 のすべての分岐で `{pr_merged}` が必ず literal substitute 可能になる（未定義値参照を防ぐ）。ステップ 4-W の worktree パス manifest 記録（Issue #1945）、およびステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
 
 ### 1.4 リポジトリ情報取得
 
@@ -387,8 +387,10 @@ esac
        # 消費する EPHEMERAL tmp artifact 専用の契約を持つ。session worktree のパスをそこに
        # 混ぜると、Step 4.5 が Step 5 の保護ゲートを経ずに生存中の worktree を reap しうる
        # （"session worktrees go through Step 5's gated reap, never here" 契約違反）。
-       # `session_worktree` type は Step 4.5 の case 文が未知 type として素通しするため、
-       # Step 5 の gated bypass（下記）のみがこの記録を消費する。
+       # `session_worktree` type は Step 4.5 の専用 case arm が扱うが、この arm は reap を
+       # 一切行わず、パスが既に消滅している場合のみ stale 参照を drop（self-heal）し、
+       # 存在する場合は verbatim 保持して Step 5 に委ねる。実 reap の消費は
+       # Step 5 の gated bypass（下記）のみが行う。
        if [ "{pr_merged}" = "true" ]; then
          bash {plugin_root}/hooks/scripts/rite-tmp-artifact.sh record --type session_worktree --id "{flow_wt}" 2>/dev/null || true
        fi


### PR DESCRIPTION
## Summary

sandbox 環境で `git worktree remove` が busy 失敗・スキップされた際、worktree の削除パスを reap manifest（`.rite/tmp-artifacts.tsv`）へ記録するようにした。corpse 化した worktree（admin dir 半壊で git がツリーを認識できない状態）は checkout 中の branch を解決できず、既存のブランチ名ベースの manifest bypass（#1966）が構造的に効かないため、24h の age guard を待たずに次回セッションで即座に回収できるようにする。

## Related Issue

Closes #1945

## Changes

- `plugins/rite/skills/cleanup/SKILL.md`: Step 4-W の busy 失敗 / sandbox マスク skip 時、`{pr_merged}=true` のときのみ worktree パスを reap manifest へ記録
- `plugins/rite/hooks/scripts/pr-cycle-cleanup.sh`: corpse age guard にパスベースの manifest bypass を追加。reap 成功後は manifest エントリを消費し、同じパスに新しい worktree が作られた際に古い bypass 意図を誤継承しないようにする
- `plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh`: C-05（bypass 適用）/ C-05b（パス不一致時は従来どおり 24h ガードが機能する control）を追加

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [ ] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
