### PR TITLE
docs(readme): README の仕様詳細を docs 正本へ委譲し案内板に戻す

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,7 +19,7 @@ https://github.com/user-attachments/assets/900476d1-fbf0-4f8c-a3ef-3f286638568a
 
 ## 概要
 
-**Claude Code Rite Workflow** は、Issue ドリブン開発の完全なワークフローを提供する Claude Code プラグインです。言語やフレームワークを問わず、あらゆるソフトウェア開発プロジェクトで動作します。
+**Claude Code Rite Workflow** は、Issue ドリブン開発のワークフローを提供する Claude Code プラグインです。言語やフレームワークを問わず、あらゆるソフトウェア開発プロジェクトで動作します。
 
 ### 特徴
 
@@ -27,14 +27,14 @@ https://github.com/user-attachments/assets/900476d1-fbf0-4f8c-a3ef-3f286638568a
 - **自動化 (Automated)**: 自動検出・自動設定
 - **カスタマイズ可能 (Customizable)**: YAML による柔軟な設定
 - **統合 (Integrated)**: GitHub Projects 連携
-- **スマートレビュー (Smart Reviews)**: ドキュメント中心の PR 向け **Doc-Heavy PR Mode** を備えた動的マルチレビュアーコードレビュー。PR が doc-heavy と判定されると、tech-writer レビュアーが Grep/Read/Glob を使って 5 つのドキュメント–実装整合カテゴリ（Implementation Coverage / Enumeration Completeness / UX Flow Accuracy / Order-Emphasis Consistency / Screenshot Presence）を検証します。完全な検証プロトコルは [`plugins/rite/skills/pr-review/references/internal-consistency.md`](plugins/rite/skills/pr-review/references/internal-consistency.md) を参照
+- **スマートレビュー (Smart Reviews)**: ドキュメント中心の PR に対しドキュメント–実装整合を検証する Doc-Heavy PR Mode を備えた動的マルチレビュアーコードレビュー。検証プロトコルは [`plugins/rite/skills/pr-review/references/internal-consistency.md`](plugins/rite/skills/pr-review/references/internal-consistency.md) を参照
 - **外部レビュー連携 (External Review Integration)**: `/rite:fix` は PR URL またはコメント URL を引数に取れるため、外部レビューツールの出力をそのまま fix ループに流し込めます
 - **イテレーション追跡 (Iteration Tracking)**: 任意の GitHub Projects Iteration フィールド連携（`/rite:open` 時に自動割当、`/rite:issue-list` の `--sprint` / `--backlog` フィルタ）
 - **ローカル作業メモリ (Local Work Memory)**: lock / 再開サポート付きの compact 耐性のある作業状態管理
 - **Implementation Contract**: 仕様を明確にする構造化 Issue テンプレート形式
-- **仮定の表面化 (Assumption Surfacing)**: Implementation Contract を生成する前に、`/rite:issue-create` はモデルが暗黙に補った仮定を表面化し、3 つのカテゴリで処理します — 導出可能（リポジトリ/Wiki から自己解決）、ユーザー固有の判断（推奨選択肢付きの質問を最大 3 件で確認）、保留可能（Issue 本文に Assumptions / Open Questions として記録）。**設計原則**: 質問はユーザーの頭の中にしか存在しない情報に限定し、リポジトリや Wiki から導出可能なものはモデルが解決します。これにより、暗黙の推測が下流パイプライン全体を駆動する contract に黙って固定化されるのを防ぎます
-- **Experience Wiki**: LLM 駆動のプロジェクト知識ベース。[OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog) 準拠のバンドル（`type`/`okf_version` frontmatter、OKF index/log）として保存されます。レビュー/修正の結果をトピック別ページへ自動取り込み（ingest）し、各 Issue の冒頭で関連する経験則を注入します（opt-out 可）。準拠バンドルは上流 OKF の静的ビジュアライザで概念グラフとして閲覧できます（同梱はしていません。`plugins/rite/references/wiki-patterns.md` を参照）
-- **sandbox 対応 (Sandbox-aware)**: `/rite:setup` が sandbox 環境特有の 2 つの制約を、失敗が発生する前に事前検出・案内します — `EnterWorktree` 後にセッション worktree の state 書込が main checkout で拒否される制約と、SSH host alias remote 経由の `git push`/`fetch` がブロックされる制約です。対応する回避策も事前に提示されます
+- **仮定の表面化 (Assumption Surfacing)**: `/rite:issue-create` はモデルが暗黙に補った仮定を Implementation Contract に固定される前に表面化して解決し、リポジトリや Wiki から導出できない事項だけをユーザーに質問します。詳細なプロトコルは [docs/SPEC.md](docs/SPEC.md)（Phase 1.5）を参照
+- **Experience Wiki**: レビュー/修正の結果を自動取り込みし、各 Issue の冒頭で関連する経験則を注入する LLM 駆動のプロジェクト知識ベース（opt-out 可）。[OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog) 準拠バンドルとして保存されます。詳細は [`plugins/rite/references/wiki-patterns.md`](plugins/rite/references/wiki-patterns.md) を参照
+- **sandbox 対応 (Sandbox-aware)**: `/rite:setup` が既知の sandbox 環境制約を失敗が発生する前に事前検出し、対応する回避策を提示します
 
 ## インストール
 
@@ -71,7 +71,7 @@ Rite Workflow は 2 ステップでインストールします。まずマーケ
 | リモート `wiki` ブランチ | GitHub リモート（Wiki 自動初期化で作成） | なし | `git push origin --delete <ブランチ名>`（`<ブランチ名>` は `rite-config.yml` の `wiki.branch_name`、デフォルトは `wiki`） |
 | ローカル生成物（gitignore 済み） | `.rite-work-memory/`, `.rite-flow-state*`, `.rite-compact-state*`, `.rite-flow-debug.log`, `.rite-session-id` 等 | なし（未 commit） | `rm -rf .rite-work-memory .rite-flow-state* .rite-compact-state* .rite-flow-debug.log .rite-session-id .rite-guidance-shown .rite-plugin-root .rite-initialized-version .rite-settings-hooks-cleaned` |
 | `.rite/` 配下の内部ディレクトリ（gitignore 済み、live な git worktree を含む場合あり） | `.rite/wiki-worktree/`（Wiki `separate_branch` 戦略）、`.rite/worktrees/issue-*`（`multi_session` 有効時のセッション worktree） | 生の `rm -rf` で削除すると git worktree メタデータが孤立し未コミット差分を失う可能性があり、害あり | まず `git worktree list` で確認し、該当パスが登録されていれば `git worktree remove <path>`（未コミット差分がないか確認の上）→ `git worktree prune` を実行してから、残りの `.rite/` を `rm -rf .rite` で削除する |
-| レガシー hook 登録 | `.claude/settings.local.json`（`hooks.json` によるネイティブ管理以前のインストールのみ） | なし（ただしプラグイン削除後にエラーになる場合あり） | command パスに `rite/` と `hooks/` を path segment として含む hook エントリを削除（間にプラグインバージョンセグメントが入る場合あり。例: `.../rite/hooks/foo.sh` や `.../rite/0.7.0/hooks/foo.sh` は該当、`favorite/hooks/foo.sh` は非該当） |
+| レガシー hook 登録 | `.claude/settings.local.json`（`hooks.json` によるネイティブ管理以前のインストールのみ） | なし（ただしプラグイン削除後にエラーになる場合あり） | command パスが rite プラグインの `hooks/` ディレクトリを指す hook エントリを削除 |
 
 いずれも再インストールを妨げたり他のツールに影響したりしないため、都合の良いタイミングで削除してください。
 
@@ -115,7 +115,7 @@ Rite Workflow は 2 ステップでインストールします。まずマーケ
 | `/rite:wiki-init` | Experience Wiki のブランチとディレクトリ構成を初期化 |
 | `/rite:wiki-query` | キーワードに一致する経験則を Wiki ページから検索 |
 | `/rite:wiki-ingest` | Raw Source（レビュー・修正・Issue）を Wiki ページへ取り込み |
-| `/rite:wiki-lint` | 矛盾・陳腐化・孤児・欠落概念（`missing_concept`）・未登録 raw（`unregistered_raw`、informational — `n_warnings` には加算しない）・壊れた相互参照を Wiki ページについて lint |
+| `/rite:wiki-lint` | 矛盾・陳腐化・孤児・壊れた相互参照を Wiki ページについて lint |
 | `/rite:recover` | 中断した作業を再開 |
 | `/rite:skill-suggest` | コンテキストを分析し適用可能なスキルを提案 |
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -115,7 +115,7 @@ Rite Workflow は 2 ステップでインストールします。まずマーケ
 | `/rite:wiki-init` | Experience Wiki のブランチとディレクトリ構成を初期化 |
 | `/rite:wiki-query` | キーワードに一致する経験則を Wiki ページから検索 |
 | `/rite:wiki-ingest` | Raw Source（レビュー・修正・Issue）を Wiki ページへ取り込み |
-| `/rite:wiki-lint` | 矛盾・陳腐化・孤児・壊れた相互参照を Wiki ページについて lint |
+| `/rite:wiki-lint` | 矛盾・陳腐化・孤児・欠落概念・壊れた相互参照を Wiki ページについて lint |
 | `/rite:recover` | 中断した作業を再開 |
 | `/rite:skill-suggest` | コンテキストを分析し適用可能なスキルを提案 |
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This will:
 | `/rite:wiki-init` | Initialize Experience Wiki branch and directory layout |
 | `/rite:wiki-query` | Query Wiki pages for heuristics matching keywords |
 | `/rite:wiki-ingest` | Ingest raw sources (reviews, fixes, Issues) into Wiki pages |
-| `/rite:wiki-lint` | Lint Wiki pages for contradictions, staleness, orphans, and broken cross-refs |
+| `/rite:wiki-lint` | Lint Wiki pages for contradictions, staleness, orphans, missing concepts, and broken cross-refs |
 | `/rite:recover` | Resume interrupted work |
 | `/rite:skill-suggest` | Analyze context and suggest applicable skills |
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The name comes from the English word **rite**, meaning "ritual" or "ceremony." I
 
 ## Overview
 
-**Claude Code Rite Workflow** is a Claude Code plugin that provides a complete Issue-driven development workflow. It works with any software development project regardless of language or framework.
+**Claude Code Rite Workflow** is a Claude Code plugin that provides an Issue-driven development workflow. It works with any software development project regardless of language or framework.
 
 ### Features
 
@@ -27,14 +27,14 @@ The name comes from the English word **rite**, meaning "ritual" or "ceremony." I
 - **Automated**: Auto-detection and auto-configuration
 - **Customizable**: Flexible configuration via YAML
 - **Integrated**: GitHub Projects
-- **Smart Reviews**: Dynamic multi-reviewer code review with **Doc-Heavy PR Mode** for documentation-centric PRs. When a PR is detected as doc-heavy, the tech-writer reviewer verifies five doc-implementation consistency categories (Implementation Coverage / Enumeration Completeness / UX Flow Accuracy / Order-Emphasis Consistency / Screenshot Presence) using Grep/Read/Glob. See [`plugins/rite/skills/pr-review/references/internal-consistency.md`](plugins/rite/skills/pr-review/references/internal-consistency.md) for the full verification protocol
+- **Smart Reviews**: Dynamic multi-reviewer code review with a Doc-Heavy PR Mode that verifies doc-implementation consistency on documentation-centric PRs. See [`plugins/rite/skills/pr-review/references/internal-consistency.md`](plugins/rite/skills/pr-review/references/internal-consistency.md) for the verification protocol
 - **External Review Integration**: `/rite:fix` accepts PR URL or comment URL arguments, so output from external review tools can feed directly into the fix loop
 - **Iteration Tracking**: Optional GitHub Projects Iteration field integration (auto-assign on `/rite:open`, `--sprint` / `--backlog` filters in `/rite:issue-list`)
 - **Local Work Memory**: Compact-resilient work state management with lock/resuming support
 - **Implementation Contract**: Structured Issue template format for clear specifications
-- **Assumption Surfacing**: Before generating the Implementation Contract, `/rite:issue-create` surfaces the assumptions the model implicitly filled in and processes them in three categories — derivable (self-resolved from the repository/Wiki), user-specific decisions (confirmed with up to three recommended-option questions), and deferrable (documented as Assumptions / Open Questions in the Issue body). **Design principle**: questions are limited to information that exists only in the user's head; anything derivable from the repository or Wiki is resolved by the model. This keeps implicit guesses from being silently locked into the contract that drives the whole downstream pipeline
-- **Experience Wiki**: LLM-driven project knowledge base, stored as an [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog)-conformant bundle (`type`/`okf_version` frontmatter, OKF index/log). Auto-ingests review/fix outcomes into topical pages and injects relevant heuristics at the start of each Issue (opt-out). The conformant bundle can be browsed as a concept graph with the upstream OKF static visualizer (not vendored; see `plugins/rite/references/wiki-patterns.md`)
-- **Sandbox-aware**: `/rite:setup` proactively detects and warns about two sandbox environment constraints before they cause a failure — a session worktree's state writes into the main checkout being rejected after `EnterWorktree`, and `git push`/`fetch` being blocked over an SSH host alias remote — with the supported workaround surfaced up front
+- **Assumption Surfacing**: `/rite:issue-create` surfaces the assumptions the model implicitly filled in and resolves them before they are locked into the Implementation Contract, asking the user only what cannot be derived from the repository or Wiki. See [docs/SPEC.md](docs/SPEC.md) (Phase 1.5) for the full protocol
+- **Experience Wiki**: LLM-driven project knowledge base that auto-ingests review/fix outcomes and injects relevant heuristics at the start of each Issue (opt-out). Stored as an [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog)-conformant bundle; see [`plugins/rite/references/wiki-patterns.md`](plugins/rite/references/wiki-patterns.md) for details
+- **Sandbox-aware**: `/rite:setup` proactively detects known sandbox environment constraints and surfaces the supported workarounds before they cause a failure
 
 ## Installation
 
@@ -71,7 +71,7 @@ This removes the plugin code but leaves behind the artifacts it created in your 
 | Remote `wiki` branch | GitHub remote (created by Wiki auto-init) | No | `git push origin --delete <branch>`, where `<branch>` is `wiki.branch_name` in `rite-config.yml` (default `wiki`) |
 | Local generated files (gitignored) | `.rite-work-memory/`, `.rite-flow-state*`, `.rite-compact-state*`, `.rite-flow-debug.log`, `.rite-session-id`, etc. | No (untracked) | `rm -rf .rite-work-memory .rite-flow-state* .rite-compact-state* .rite-flow-debug.log .rite-session-id .rite-guidance-shown .rite-plugin-root .rite-initialized-version .rite-settings-hooks-cleaned` |
 | `.rite/` internal directories (gitignored, may hold live git worktrees) | `.rite/wiki-worktree/` (Wiki `separate_branch` strategy), `.rite/worktrees/issue-*` (per-session worktrees when `multi_session` is enabled) | Yes if removed with a plain `rm -rf` — this can orphan git worktree metadata and destroy uncommitted work | Check `git worktree list` first; if either path is registered, run `git worktree remove <path>` (confirming no uncommitted changes) then `git worktree prune`. Only after that, remove the rest of `.rite/` with `rm -rf .rite` |
-| Legacy hook registration | `.claude/settings.local.json` (only from installs predating native `hooks.json` management) | No, but may error if the plugin is gone | Remove any hook entries whose command path contains `rite/` and `hooks/` as path segments — a plugin version segment may appear in between (e.g. `.../rite/hooks/foo.sh` or `.../rite/0.7.0/hooks/foo.sh` — not `favorite/hooks/foo.sh`) |
+| Legacy hook registration | `.claude/settings.local.json` (only from installs predating native `hooks.json` management) | No, but may error if the plugin is gone | Remove hook entries whose command path points into the rite plugin's `hooks/` directory |
 
 None of these block reinstallation or affect other tooling — clean them up at your convenience.
 
@@ -115,7 +115,7 @@ This will:
 | `/rite:wiki-init` | Initialize Experience Wiki branch and directory layout |
 | `/rite:wiki-query` | Query Wiki pages for heuristics matching keywords |
 | `/rite:wiki-ingest` | Ingest raw sources (reviews, fixes, Issues) into Wiki pages |
-| `/rite:wiki-lint` | Lint Wiki pages for contradictions, staleness, orphans, missing concepts (`missing_concept`), unregistered raw sources (`unregistered_raw`, informational — not added to `n_warnings`), and broken cross-refs |
+| `/rite:wiki-lint` | Lint Wiki pages for contradictions, staleness, orphans, and broken cross-refs |
 | `/rite:recover` | Resume interrupted work |
 | `/rite:skill-suggest` | Analyze context and suggest applicable skills |
 


### PR DESCRIPTION
## 概要

tech-review 監査(2026-07-23)で検出された README の仕様詳細堆積(high 3 件・medium 3 件・low 2 件)を解消し、README を「案内板」(要約 1〜2 行 + docs 正本へのリンク)に戻します。削除した詳細はすべて docs 側の正本(docs/SPEC.md・docs/CONFIGURATION.md・internal-consistency.md)で読めることを確認済みです。

Open Question だった Uninstallation 表「Legacy hook registration」セルは、docs へ退避せず表内 1 行圧縮(要点のみ)としました。

## 関連 Issue

Closes #1979

## 変更内容

- `README.md` / `README.ja.md`(両ファイル同期適用):
  - Features 4 bullet 圧縮: Assumption Surfacing(SPEC Phase 1.5 リンクへ委譲)/ Smart Reviews(5 検証カテゴリ列挙を internal-consistency.md へ委譲)/ Experience Wiki / Sandbox-aware
  - Commands 表 `/rite:wiki-lint` 行から内部カウンタ名(`n_warnings` 等)と加算挙動を削除し他コマンド行と同粒度に統一
  - Uninstallation 表「Legacy hook registration」セルを要点のみ 1 行に圧縮
  - Overview の万能語(EN "complete" / JA「完全な」)を削除
  - inline bold(`Doc-Heavy PR Mode` / `Design principle`・`設計原則`)の二重強調を解除

## 検証結果

- AC-1: 圧縮対象の全 bullet が要約 1〜2 行 + リンクに収まることを確認
- AC-2: `grep -E "n_warnings|missing_concept|unregistered_raw"` が README 両ファイルで 0 件
- AC-3: 削除した詳細の正本存在を grep で確認(SPEC.md Phase 1.5 / L78 / L1644、CONFIGURATION.md L683、internal-consistency.md)
- AC-4: 英日の見出し数 17/17・表行数 40/40・Features bullet 数 12/12 が一致

## 未完了の Issue チェック項目

以下は Issue の Definition of Done 欄で、Issue クローズ時の最終確認として検証されます(実装チェックリスト Step 1-8 は全完了):

- [ ] All MUST requirements implemented
- [ ] All Acceptance Criteria (AC-xx) verified
- [ ] All test cases (T-xx) passing
- [ ] No regression in existing functionality
- [ ] Target files modified, non-target files untouched
- [ ] Code follows project conventions

## チェックリスト

- [x] 変更は Issue のスコープ内(README 両ファイルのみ、非対象ファイル無変更)
- [x] コミットは Conventional Commits 形式
- [x] 英日同期(見出し構成・表行数・リンク先一致)
- [ ] レビュー完了

🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
