### PR TITLE
docs(intro-video): 紹介動画のバージョン表記をv0.9.1へ更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 
 Issue から PR まで、開発を“儀式”に変える — 約125秒で分かる紹介動画（日本語字幕）。
 
-https://github.com/user-attachments/assets/900476d1-fbf0-4f8c-a3ef-3f286638568a
+https://github.com/user-attachments/assets/82ba8e65-0c07-4346-9964-5a482a1f4df5
 
 ## なぜ "Rite" なのか
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 From Issue to PR — see Rite Workflow turn development into a *rite*. A ~125-second intro (English).
 
-https://github.com/user-attachments/assets/abc7455a-ed0a-40c9-964e-cee8c4262f35
+https://github.com/user-attachments/assets/b1f50f60-6c7c-4d86-9ceb-9071ae4b1c9f
 
 ## Why "Rite"?
 

--- a/media/intro-video-en/compositions/scene-1.html
+++ b/media/intro-video-en/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">From Issue to PR — turn development into a rite</div>
         <div class="sub">A Claude Code plugin</div>
-        <div class="badge">v0.8.0 · MIT</div>
+        <div class="badge">v0.9.1 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video-en/compositions/scene-7.html
+++ b/media/intro-video-en/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.8.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.9.1 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>

--- a/media/intro-video/compositions/scene-1.html
+++ b/media/intro-video/compositions/scene-1.html
@@ -9,7 +9,7 @@
         </div>
         <div class="tagline">Issue から PR まで、開発を“儀式”に変える</div>
         <div class="sub">Claude Code プラグイン</div>
-        <div class="badge">v0.8.0 · MIT</div>
+        <div class="badge">v0.9.1 · MIT</div>
       </div>
     </div>
 

--- a/media/intro-video/compositions/scene-7.html
+++ b/media/intro-video/compositions/scene-7.html
@@ -23,7 +23,7 @@
 
         <div class="outro">
           <div class="wordmark"><span class="scroll">📜</span> <span class="rite">Rite</span> Workflow</div>
-          <div class="meta">v0.8.0 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
+          <div class="meta">v0.9.1 · MIT · github.com/asakaguchi/cc-rite-workflow</div>
           <div class="made">Made with 📜 rite</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

v0.9.1 リリースに合わせ、README の Demo 節が参照する紹介動画（日英）のバッジ・エンディングメタのバージョン表記を `v0.8.0` → `v0.9.1` に更新した。シーン構成・尺（約125秒）は変更せず、#1814 で確立した軽量更新パターンを踏襲している。BGM合成済みの最終動画をアップロードし、READMEの動画URLも新しいものに差し替え済み。

## Related Issue

Closes #1985

## Changes

- `media/intro-video/compositions/scene-1.html`: バッジ `v0.8.0 · MIT` → `v0.9.1 · MIT`
- `media/intro-video/compositions/scene-7.html`: メタ `v0.8.0 · MIT · github.com/...` → `v0.9.1 · MIT · github.com/...`
- `media/intro-video-en/compositions/scene-1.html`: 同上
- `media/intro-video-en/compositions/scene-7.html`: 同上
- `README.md` / `README.ja.md`: Demo節の動画URLを新しいuser-attachments URL（BGM合成済み最終版）へ差し替え

検証内容:
- 日英両プロジェクトで `npm run check`（lint/validate/inspect）がエラー0で通過（AC-1）
- BGM合成済みの最終MP4は日英とも10MB制限内（AC-2）
- scene-1/scene-7のフレーム抽出で `v0.9.1` 表記を確認（AC-3）
- README.md / README.ja.md が新しいuser-attachments URLを指し、尺表記は変更していないことを確認（AC-4）
- `.mp4` / `.mp3` はコミットに含まれない（AC-5、`.gitignore` 除外済み）
- JA版のレンダリング出力で日本語テキストがNoto Sans CJK JPで正しく描画され、中国語グリフへのフォールバックがないことを確認（AC-6）

## Implementation Notes

- Decision: 新規シーン追加（Sandbox-aware setup 等 v0.9 系新機能）は見送り、バージョン表記のみの最小更新とした — シーン追加は尺増加により10MB制約への抵触リスクを高めるため（Issue #1985 Decision Log）
- Decision: BGM合成用Pixabayトラックの自動ダウンロードはCloudflareのbot対策により自動化環境から取得不能と判明したが、mp3本体は`media/intro-video*/`配下（gitignore対象・ローカル保存）に既に存在していたためそれを使用した
- Decision: HyperFramesの`npm run render`はBGMを自動合成しない（`index.html`への`<audio>`タグ追加は本Issueの変更禁止対象）ため、動画のみ`--video-bitrate 480k`で軽量レンダリングした後、ffmpegでBGM（約90秒）を動画尺（125秒）にループ+2秒フェードアウトで合成する2段階方式を採用した

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — `npm run check` エラー0（日英両方）
- [x] Documentation updated (if applicable) — README.md / README.ja.md の動画URLを差し替え済み

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
