### PR TITLE
docs: インストール手順に /reload-plugins ステップを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ https://github.com/user-attachments/assets/82ba8e65-0c07-4346-9964-5a482a1f4df5
 
 ## インストール
 
-Rite Workflow は 2 ステップでインストールします。まずマーケットプレイスを登録し、次にそこからプラグインをインストールします。
+Rite Workflow は 3 ステップでインストールします。マーケットプレイスを登録し、プラグインをインストールし、最後にプラグインを再読み込みして新しいコマンドを有効化します。
 
 **ステップ 1**: マーケットプレイスを追加
 
@@ -51,6 +51,14 @@ Rite Workflow は 2 ステップでインストールします。まずマーケ
 ```bash
 /plugin install rite@rite-marketplace
 ```
+
+**ステップ 3**: プラグインを再読み込み
+
+```bash
+/reload-plugins
+```
+
+`/reload-plugins` の実行後も `/rite:` コマンドが認識されない場合は、Claude Code を再起動してください。
 
 **インストール確認**: `/rite:setup` を実行してプラグインが動作することを確認します。
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The name comes from the English word **rite**, meaning "ritual" or "ceremony." I
 
 ## Installation
 
-Rite Workflow uses a two-step installation: first register the marketplace, then install the plugin from it.
+Rite Workflow uses a three-step installation: register the marketplace, install the plugin, then reload plugins to activate the new commands.
 
 **Step 1**: Add the marketplace
 
@@ -51,6 +51,14 @@ Rite Workflow uses a two-step installation: first register the marketplace, then
 ```bash
 /plugin install rite@rite-marketplace
 ```
+
+**Step 3**: Reload plugins
+
+```bash
+/reload-plugins
+```
+
+If `/rite:` commands are still not recognized after this, restart Claude Code.
 
 **Verify installation**: Run `/rite:setup` to confirm the plugin is working.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1919,6 +1919,9 @@ Distributed via Claude Code plugin system:
 
 # Install the plugin
 /plugin install rite@rite-marketplace
+
+# Reload plugins to activate the new commands
+/reload-plugins
 ```
 
 ---


### PR DESCRIPTION
## 概要

README.md / README.ja.md / docs/SPEC.md のインストール手順に `/reload-plugins` の実行ステップを追加し、`/plugin install` 直後にセッション内でコマンドを反映させないまま `/rite:setup` へ進んでしまい `/rite:*` コマンドが認識されなくなる問題を防ぐ。

## Related Issue

Closes #1991

## Changes

- README.md: Installation セクションに Step 3（`/reload-plugins`）を追加し、導入文を three-step installation に更新
- README.ja.md: インストールセクションにステップ 3（`/reload-plugins`）を追加し、導入文を 3 ステップに更新（英語版と同期）
- docs/SPEC.md: Distribution セクションの bash snippet に `/reload-plugins` 行を追加

いずれのステップにも「実行後も `/rite:` コマンドが認識されない場合は Claude Code を再起動する」旨のフォールバック文言を明記した。

## Checklist

- [x] Code follows project conventions
- [ ] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
