### PR TITLE
chore(ci): shellcheck を error severity で blocking 化し既存 error 5 件を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   shellcheck:
-    name: shellcheck (informational)
+    name: shellcheck
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -132,22 +132,25 @@ jobs:
           fetch-depth: 1
 
       # shellcheck is pre-installed on GitHub ubuntu runners. It runs over EVERY
-      # *.sh under plugins/rite (Issue #2002 AC-3) but is NON-BLOCKING during the
-      # staged rollout (D-04): the existing tree has a known backlog (baseline at
-      # introduction: error=5, warning=104, info=722, style=734) living in files
-      # this Issue must not modify. The counts are reported to the job summary so
-      # regressions are visible; making it blocking + clearing the backlog is a
-      # follow-up. This step always exits 0.
-      - name: shellcheck plugins/rite/**/*.sh (informational, non-blocking)
+      # *.sh under plugins/rite (Issue #2002 AC-3). error-severity findings are a
+      # BLOCKING gate (Issue #2006): the backlog that kept this informational at
+      # introduction (baseline error=5) is cleared, so a newly introduced
+      # error-level finding fails the job. warning/info/style stay informational
+      # and are reported to the job summary for the staged reduction tracked
+      # separately (Issue #2006 step 3).
+      #
+      # Note: a failing job only *blocks a merge* once this check is added to the
+      # branch's required status checks — a repo-admin setting outside this file.
+      - name: shellcheck plugins/rite/**/*.sh (error = blocking gate)
         run: |
           set -u
           shellcheck --version
           mapfile -t files < <(find plugins/rite -name '*.sh' -type f | sort)
           echo "shellcheck targets: ${#files[@]} files"
-          # One scan at the lowest threshold captures every finding; count by level.
+          # One scan at the lowest threshold captures every finding for the report.
           report=$(shellcheck --severity=style --format=json "${files[@]}" 2>/dev/null || true)
           {
-            echo "## shellcheck report — plugins/rite/**/*.sh (informational)"
+            echo "## shellcheck report — plugins/rite/**/*.sh"
             echo ""
             echo "Target files: ${#files[@]}"
             echo ""
@@ -158,7 +161,7 @@ jobs:
               echo "| $lvl | $n |"
             done
             echo ""
-            echo "> Non-blocking during staged rollout (Issue #2002, D-04). Blocking-ization + backlog cleanup tracked as a follow-up."
+            echo "> error is a blocking gate (Issue #2006). warning/info/style stay informational; staged reduction tracked separately."
             echo ""
             echo "<details><summary>error-level findings</summary>"
             echo ""
@@ -167,6 +170,14 @@ jobs:
             echo '```'
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
-          err_count=$(printf '%s' "$report" | jq '[.[] | select(.level == "error")] | length' 2>/dev/null || echo '?')
-          echo "error-level findings: $err_count (informational — not failing the job)"
-          exit 0
+          # Blocking gate: re-scan at severity=error and let shellcheck's own exit
+          # code decide (non-zero iff findings at/above the threshold). Using the
+          # exit code rather than a jq-parsed count means a shellcheck invocation
+          # failure fails the job loudly instead of passing silently on an empty
+          # report.
+          if shellcheck --severity=error "${files[@]}"; then
+            echo "✅ shellcheck: no error-severity findings (blocking gate passed)"
+          else
+            echo "::error::shellcheck found error-severity findings — blocking gate failed"
+            exit 1
+          fi

--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -45,7 +45,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/state-path-resolve.sh"
 # shellcheck source=control-char-neutralize.sh
 source "$SCRIPT_DIR/control-char-neutralize.sh"
-# shellcheck source=session-ownership.sh  (parse_iso8601_to_epoch + 2h threshold)
+# session-ownership.sh: parse_iso8601_to_epoch + 2h threshold
+# shellcheck source=session-ownership.sh
 source "$SCRIPT_DIR/session-ownership.sh"
 
 export GIT_TERMINAL_PROMPT=0

--- a/plugins/rite/hooks/scripts/lib/git-remote.sh
+++ b/plugins/rite/hooks/scripts/lib/git-remote.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # rite workflow - Git remote owner/repo resolution
 #
 # Responsibility: resolve "owner" and "repo" from the `origin` remote URL

--- a/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
+++ b/plugins/rite/hooks/scripts/lib/git-status-filtered.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # rite workflow - git status filtered for sandbox write-block ghost mounts
 #
 # Responsibility: wrap `git status --porcelain -z` and drop untracked (`??`)

--- a/plugins/rite/hooks/scripts/lib/wiki-config.sh
+++ b/plugins/rite/hooks/scripts/lib/wiki-config.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # rite workflow - Wiki config parsing / branch name validation helpers
 #
 # Responsibility: provide the canonical implementations of

--- a/plugins/rite/hooks/scripts/lib/worktree-git.sh
+++ b/plugins/rite/hooks/scripts/lib/worktree-git.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # rite workflow - Worktree git helpers (commit/push + session-worktree ensure)
 #
 # Responsibility 1 (source-only): provide the canonical


### PR DESCRIPTION
## 概要

#2002 で導入した matrix CI の shellcheck ジョブは、既存 backlog（error 5 件）のため **informational（非ブロッキング）** で開始していた。本 PR でその backlog を解消し、shellcheck を **error severity の blocking gate** に昇格する。

## 関連 Issue

Closes #2006

## 変更内容

### error 5 件の解消

| ファイル | 指摘 | 対応 |
|---|---|---|
| `hooks/scripts/lib/worktree-git.sh` | SC2148 | 先頭に `# shellcheck shell=bash` を追加 |
| `hooks/scripts/lib/wiki-config.sh` | SC2148 | 同上 |
| `hooks/scripts/lib/git-status-filtered.sh` | SC2148 | 同上 |
| `hooks/scripts/lib/git-remote.sh` | SC2148 | 同上 |
| `hooks/issue-claim.sh:48` | SC1125 | `# shellcheck source=` directive 末尾の散文を別行コメントへ分離 |

### `ci.yml` の blocking 化

- ジョブ名を `shellcheck (informational)` → `shellcheck` に変更。
- `shellcheck --severity=error` の **終了コード**を gate に採用（`jq` によるパース数ではなく shellcheck 自身の exit code）。これにより shellcheck の実行失敗も fail-loud になり、空レポートで silent pass しない。
- warning/info/style は従来どおり informational として job summary に集約（段階削減は Issue の step 3 として別途）。

## 検証

ローカル shellcheck **0.10.0**（Issue baseline と同一）で実測:

| | clean develop | 本 PR |
|---|---|---|
| error | 5 | **0** |
| warning | 99 | 99 |
| info | 618 | 618 |
| style | 12 | 12 |

- error は **5 → 0**。warning/info/style は**完全に不変**（本変更は error のみに作用し、回帰・過剰抑制なし）。
- gate の負テスト: 意図的に SC2148 を持つファイルに対し `shellcheck --severity=error` が **exit 1** で fail することを確認（AC2）。
- YAML 妥当性（`yq` パース）と埋め込み bash の構文（`bash -n`）＋実行シミュレーションを確認。

## 補足（レビュー観点）

- **`shell=bash`（`sh` ではない）**: rite は bash 4+ を要件とするため。
- **shebang ではなく directive を採用**: Issue の明示指示に従った。ただし `git-remote.sh` 等は実際には `bash git-remote.sh resolve-owner-repo` として**実行**されており、Issue の「source 専用 lib」という表現は不正確。directive は source/実行いずれでも SC2148 を解消するため対応そのものは有効。
- **"blocking" の到達範囲**: ジョブが fail しても、それが **merge をブロック**するのは branch protection の required status check に追加された後（リポジトリ管理者の設定、本 PR 外）。本 PR はジョブレベルの blocking 化まで。ジョブ名を `shellcheck (informational)` → `shellcheck` に変更したため、required check 登録時はこの新名で行う。
- **既存 finding（本 PR 由来ではない）**: `wiki-config.sh:35` に comment-journal warning が 1 件あるが、これは clean develop の line 34 に既存のもので、先頭への 1 行追加で行番号が +1 ずれただけ。非ブロッキング warning かつ Issue #2006 のスコープ外のため本 PR では未修正。
- **既存ワークフローとの整合（AC3）**: `test-hooks.yml` / `sentinel-contract-check.yml` はいずれも shellcheck を実行せず、重複なし。3 ワークフローは同一規約（`permissions: contents: read` / SHA-pin checkout v4.2.2 / concurrency cancel）に準拠。

- **受容リスク（レビュー指摘、pin しない判断）**: shellcheck を runner プリインストール版（バージョン非固定）のまま blocking 化した。runner イメージの shellcheck 昇格で未変更コードが CI ブロックされる可能性がある（Likelihood: Hypothetical）。Issue #2006 のスコープ外かつ既存の informational ジョブも同版に依存していたため、本 PR では version 固定せず受容する。将来必要なら別途 pin を検討。

## Checklist

- [x] error severity の shellcheck 指摘が 0 件（実測確認）
- [x] `ci.yml` の shellcheck ジョブが error 検出時に fail（負テスト確認）
- [x] 既存 test-hooks.yml / sentinel-contract-check.yml との整合を確認
- [x] Code follows project conventions

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
