### PR TITLE
fix(hooks): pre-tool-edit-guard の AC-2 symlink 解決を realpath 非依存にする

### DIFF
--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -193,8 +193,8 @@ esac
 #   is defense-in-depth — it does not rely on that (undocumented) harness behavior.
 _hop=0
 while [ -L "$ABS_PATH" ] && [ "$_hop" -lt 40 ]; do
-  # Bare `readlink` (never `readlink -f`): the one-level form is POSIX and behaves the same on
-  # BSD, whereas `-f` is a GNU extension historically absent from macOS.
+  # `readlink -n` (never `readlink -f`): the one-level form exists on both GNU and BSD, whereas
+  # `-f` is a GNU extension historically absent from macOS.
   #
   # BYTE-EXACT capture is a hard requirement here, not a style choice. A plain `$(readlink …)`
   # strips EVERY trailing newline, so a link target that legitimately ends in LF comes back
@@ -202,11 +202,16 @@ while [ -L "$ABS_PATH" ] && [ "$_hop" -lt 40 ]; do
   # when the write lands. `ln -s $'y\n' <iso>/evil` with `<iso>/y<LF> -> <main>/.git/hooks/…`
   # scoped to `<iso>/y` (inside the isolation worktree → allowed) while the write itself
   # followed the real link into the parent .git. The `&& printf 'X'` sentinel makes the capture
-  # end in a non-newline byte so nothing is stripped; `%X` drops the sentinel and `%$'\n'`
-  # drops exactly the one newline readlink itself appends.
-  _lt=$(readlink "$ABS_PATH" 2>/dev/null && printf 'X') || _lt=""
+  # end in a non-newline byte so nothing is stripped, and `%X` drops the sentinel.
+  #
+  # `-n` is what makes that byte-exact on BOTH platforms. Without it the capture ends in an
+  # ambiguous newline — GNU readlink appends one, macOS readlink does not — and "strip exactly
+  # one trailing LF" therefore either restores the target (GNU) or eats a genuine trailing LF
+  # (macOS), where the deref then lands on a nonexistent path and falls back to allow. That
+  # divergence is the same shape as the realpath one this Issue exists to remove, so suppress
+  # the delimiter at the source rather than compensate for it afterwards.
+  _lt=$(readlink -n "$ABS_PATH" 2>/dev/null && printf 'X') || _lt=""
   _lt=${_lt%X}
-  _lt=${_lt%$'\n'}
   [ -n "$_lt" ] || break
   case "$_lt" in
     /*) ;;

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -220,6 +220,19 @@ while [ -L "$ABS_PATH" ] && [ "$_hop" -lt 40 ]; do
   ABS_PATH="$_lt"
   _hop=$((_hop + 1))
 done
+# Both give-up arms above (readlink failed → break; hop cap reached → loop exit) leave
+# ABS_PATH a link, so a link that stays inside the isolation worktree is allowed with AC-2
+# effectively off. That fail-open direction is correct here — scope is not yet confirmed, and
+# a legitimate isolation-internal symlink must not be false-denied — but the operator would
+# otherwise have no way to tell "allowed because it was safe" from "allowed because the deref
+# gave up". Record the give-up under RITE_DEBUG, same channel as the subagent-detection
+# fallback above. Not a fallback of its own: the decision is unchanged either way.
+if [ -n "${RITE_DEBUG:-}" ] && [ -L "$ABS_PATH" ]; then
+  printf '[%s] pre-tool-edit-guard: AC-2 deref gave up after %s hop(s), target still a symlink: %s\n' \
+    "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$_hop" \
+    "$(printf '%s' "${ABS_PATH:0:120}" | neutralize_ctrl --c0-only)" \
+    >> "${STATE_ROOT:-/tmp}/.rite-flow-debug.log" 2>/dev/null || true
+fi
 
 # --- Resolve the git worktree that OWNS the target ---
 # The isolation allowance is defined by "the target lives inside a sanctioned reviewer isolation

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -275,7 +275,11 @@ fi
 trap '_rite_teg_fail_closed' ERR
 
 # Log block event (stderr, for effect measurement) — mirror bash-guard's format.
-PATH_SUMMARY="${ABS_PATH:0:120}"
+# The deref loop above made a raw LF reachable in ABS_PATH for the first time (a link target
+# may legitimately end in one, and the capture now preserves it), so a path carrying one would
+# split this single-line record in two and let a forged `edit-guard: BLOCKED …` line be
+# injected. Neutralize control characters the same way the RITE_DEBUG snippet above does.
+PATH_SUMMARY=$(printf '%s' "${ABS_PATH:0:120}" | neutralize_ctrl --c0-only)
 PATH_SUMMARY="${PATH_SUMMARY//\"/\\\"}"
 echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED kind=$_deny_kind tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2
 

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -156,26 +156,54 @@ case "$FILE_PATH" in
   *)  ABS_PATH="${CWD%/}/$FILE_PATH" ;;
 esac
 
-# --- Physically resolve a FINAL-element symlink before isolation scoping (Issue #1864 AC-2) ---
+# --- Dereference a FINAL-element symlink before isolation scoping (Issue #1864 AC-2) ---
 # The _tdir walk below resolves INTERMEDIATE dirs physically (via `[ -d ]` / `git -C`), but the
 # target's own final element is never dereferenced. A reviewer could drop a symlink inside its
 # sanctioned isolation worktree pointing at the parent repo's .git —
 # `ln -s <main>/.git/hooks/pre-commit <iso>/evil` (ln is a Bash-tool op, out of THIS hook's Edit
 # path) — then `Write file_path=<iso>/evil`: _tdir resolves to the isolation root → allowed, and
-# the write follows the link into the parent .git. Resolve the final symlink PHYSICALLY here so
-# such a target lands on the real parent .git (→ git-dir deny below) instead. `realpath` follows
-# every link and resolves `..` against the REAL directory tree, so it cannot be forged the way a
-# lexical `..` collapse could (the property the block below relies on). A legitimate symlink that
-# stays inside the isolation worktree still resolves to a path inside it → still allowed (no
-# regression). realpath failure (e.g. the link's target parent dir is missing) leaves ABS_PATH
-# unchanged and falls through to the _tdir walk — no worse than before this fix.
+# the write follows the link into the parent .git. Retarget ABS_PATH at the link's destination
+# here so such a write lands on the real parent .git (→ git-dir deny below) instead.
+#
+# The retarget is LEXICAL on purpose (`readlink` + absolutize a relative target against the
+# link's own directory); it deliberately does NOT canonicalize `..` or intermediate symlinks.
+# That is safe because the _tdir walk immediately below does the physical resolution: `[ -d ]`
+# and `git -C` both chdir, so a target carrying `..` or a directory symlink lands on the REAL
+# tree that owns it — the same property that closes the `..` re-entry forgery for non-symlink
+# targets. So a forged `..` cannot escape here either, and nothing downstream of the walk needs
+# a canonical ABS_PATH (it is only echoed into the deny reason; the decision is made on
+# TARGET_ROOT, which `git -C` produces already-resolved).
+#
+# Why not `realpath` (Issue #2014): it is the one step that would need the target to EXIST.
+# GNU realpath tolerates a dangling final component, BSD/macOS realpath errors on it, so the
+# old `realpath "$ABS_PATH"` returned empty for exactly the attack shape above (the target
+# `.git/hooks/pre-commit` normally does not exist) and this whole block silently no-op'd on
+# macOS. Resolving only the target's PARENT would still no-op when that parent is itself
+# not-yet-created (`<iso>/evil → <main>/src/newdir/newfile.py`), which is precisely the
+# parent-tree case the walk already handles. Handing the raw target to the walk needs no
+# existence check at all and behaves identically on GNU and BSD — there is no platform branch
+# left to diverge.
+#
+# The loop follows a MULTI-HOP chain (`evil → hop → <main>/.git/...`); stopping after one hop
+# would let a two-link chain land _tdir back on the isolation root. Capped at 40 hops (Linux's
+# own ELOOP limit) so a symlink cycle terminates; a cycle then falls through to the walk with
+# ABS_PATH still a link inside the isolation worktree → allowed, exactly as before this fix.
 #   Note (Issue #1864 AC-3): Claude Code's own Edit/Write tools REFUSE to write through a
 #   final-element symlink ("Refusing to write through symlink …"), verified empirically, so this
 #   is defense-in-depth — it does not rely on that (undocumented) harness behavior.
-if [ -L "$ABS_PATH" ]; then
-  _resolved=$(realpath "$ABS_PATH" 2>/dev/null) || _resolved=""
-  [ -n "$_resolved" ] && ABS_PATH="$_resolved"
-fi
+_hop=0
+while [ -L "$ABS_PATH" ] && [ "$_hop" -lt 40 ]; do
+  # Bare `readlink` (never `readlink -f`): the one-level form is POSIX and behaves the same on
+  # BSD, whereas `-f` is a GNU extension historically absent from macOS.
+  _lt=$(readlink "$ABS_PATH" 2>/dev/null) || _lt=""
+  [ -n "$_lt" ] || break
+  case "$_lt" in
+    /*) ;;
+    *)  _lt="$(dirname "$ABS_PATH")/$_lt" ;;
+  esac
+  ABS_PATH="$_lt"
+  _hop=$((_hop + 1))
+done
 
 # --- Resolve the git worktree that OWNS the target ---
 # The isolation allowance is defined by "the target lives inside a sanctioned reviewer isolation

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -275,10 +275,14 @@ fi
 trap '_rite_teg_fail_closed' ERR
 
 # Log block event (stderr, for effect measurement) — mirror bash-guard's format.
-# The deref loop above made a raw LF reachable in ABS_PATH for the first time (a link target
-# may legitimately end in one, and the capture now preserves it), so a path carrying one would
-# split this single-line record in two and let a forged `edit-guard: BLOCKED …` line be
-# injected. Neutralize control characters the same way the RITE_DEBUG snippet above does.
+# ABS_PATH can carry a raw LF regardless of how the final element is resolved, so neutralize
+# independently of the resolution strategy: the pre-#2014 `realpath` capture already preserved
+# a MID-string LF (command substitution strips only TRAILING newlines — verified: on
+# origin/develop this stderr record splits in two), and the deref loop additionally admits link
+# targets that legitimately END in one. A raw LF here would split this single-line record and
+# let a forged `edit-guard: BLOCKED …` line be injected, so the neutralization closes a
+# pre-existing forgery vector rather than one this fix opened — do not drop it if the deref
+# loop is ever reworked. Same helper the RITE_DEBUG snippet above uses.
 PATH_SUMMARY=$(printf '%s' "${ABS_PATH:0:120}" | neutralize_ctrl --c0-only)
 PATH_SUMMARY="${PATH_SUMMARY//\"/\\\"}"
 echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] edit-guard: BLOCKED kind=$_deny_kind tool=$TOOL_NAME path=\"$PATH_SUMMARY\"" >&2

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -195,11 +195,27 @@ _hop=0
 while [ -L "$ABS_PATH" ] && [ "$_hop" -lt 40 ]; do
   # Bare `readlink` (never `readlink -f`): the one-level form is POSIX and behaves the same on
   # BSD, whereas `-f` is a GNU extension historically absent from macOS.
-  _lt=$(readlink "$ABS_PATH" 2>/dev/null) || _lt=""
+  #
+  # BYTE-EXACT capture is a hard requirement here, not a style choice. A plain `$(readlink …)`
+  # strips EVERY trailing newline, so a link target that legitimately ends in LF comes back
+  # truncated — and the hook would then scope a DIFFERENT path than the one the kernel follows
+  # when the write lands. `ln -s $'y\n' <iso>/evil` with `<iso>/y<LF> -> <main>/.git/hooks/…`
+  # scoped to `<iso>/y` (inside the isolation worktree → allowed) while the write itself
+  # followed the real link into the parent .git. The `&& printf 'X'` sentinel makes the capture
+  # end in a non-newline byte so nothing is stripped; `%X` drops the sentinel and `%$'\n'`
+  # drops exactly the one newline readlink itself appends.
+  _lt=$(readlink "$ABS_PATH" 2>/dev/null && printf 'X') || _lt=""
+  _lt=${_lt%X}
+  _lt=${_lt%$'\n'}
   [ -n "$_lt" ] || break
   case "$_lt" in
     /*) ;;
-    *)  _lt="$(dirname "$ABS_PATH")/$_lt" ;;
+    # `${ABS_PATH%/*}` rather than `$(dirname …)` for the same byte-exactness reason: the
+    # command substitution would strip a trailing LF from a directory name that ends in one.
+    # ABS_PATH is always absolute here (set from `/*` or `${CWD%/}/…` above), so it always
+    # contains a slash; at the root the expansion yields "" and the result is "/target",
+    # which is what dirname would have meant.
+    *)  _lt="${ABS_PATH%/*}/$_lt" ;;
   esac
   ABS_PATH="$_lt"
   _hop=$((_hop + 1))

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -171,8 +171,8 @@ esac
 # and `git -C` both chdir, so a target carrying `..` or a directory symlink lands on the REAL
 # tree that owns it — the same property that closes the `..` re-entry forgery for non-symlink
 # targets. So a forged `..` cannot escape here either, and nothing downstream of the walk needs
-# a canonical ABS_PATH (it is only echoed into the deny reason; the decision is made on
-# TARGET_ROOT, which `git -C` produces already-resolved).
+# a canonical ABS_PATH — it is only reported (the deny reason and the BLOCKED stderr log); the
+# decision is made on TARGET_ROOT, which `git -C` produces already-resolved.
 #
 # Why not `realpath` (Issue #2014): it is the one step that would need the target to EXIST.
 # GNU realpath tolerates a dangling final component, BSD/macOS realpath errors on it, so the

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -118,7 +118,7 @@ pass() {
 # Skips are counted, not just printed. A platform-gated suite that prints
 # "PASS: 8, FAIL: 0" tells the reader nothing about what never ran; on the macOS
 # leg roughly 30 assertions are gated away, several of them guarding known
-# production bugs (#2010 / #2011 / #2014). Counting keeps "green" honest and
+# production bugs (#2010 / #2011). Counting keeps "green" honest and
 # makes a growing skip set visible.
 #
 # The unit is one skip CALL, not one assertion — a single call can gate a whole

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -387,6 +387,10 @@ ln -s "$TEST_REPO/src/newdir/newfile.py" "$ISO_MUT_DIR/evil-missing-parent"
 out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-missing-parent" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
 assert_deny "symlink to a not-yet-created parent-tree path resolved & blocked" "$out"
 rm -f "$ISO_MUT_DIR/evil-missing-parent"
+# Roll the fixture back so no later TC silently depends on $TEST_REPO/src existing (several
+# earlier TCs exercise the walk-up branch precisely because it does NOT). Best-effort: the
+# directory is inside $TEST_REPO, which cleanup() removes wholesale either way.
+rmdir "$TEST_REPO/src" 2>/dev/null || true
 echo ""
 
 # Every TC above uses an ABSOLUTE link target, so none of them execute the relative-target
@@ -487,6 +491,10 @@ assert_deny "LF-terminated directory component preserved & blocked" "$out"
 # stays one line even with the neutralization removed — the pin would silently stop testing
 # anything. Floor it the same two-tier way the rest of this file does: hard-fail on the
 # blocking gate, skip elsewhere so a long-$TMPDIR workstation is not spuriously red.
+#
+# `[^"]*` relies on this fixture's path containing no `"` — the hook escapes an embedded quote
+# to `\"` (pre-tool-edit-guard.sh), which would stop the class short of the closing quote and
+# fail even with the defense intact. Keep quotes out of the names used here.
 _lf_off=$(( ${#ISO_MUT_DIR} + ${#lf_dir} ))   # byte offset of the LF within "<iso>/lf-dir<LF>"
 if [ "$_lf_off" -ge 120 ]; then
   if [ -d /proc ]; then

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -36,12 +36,13 @@ ISO_REV_DIR=$(mktemp -u -t rite-revert-test-XXXXXX)
 ( cd "$TEST_REPO" && git worktree add --detach -q "$ISO_REV_DIR" HEAD )
 OUTSIDE_DIR=$(mktemp -d)   # a plain, non-repo scratch dir
 shimdir=""                 # set by TC-FAILCLOSED; cleaned here so an interrupt leaves no residue
+rp_shimdir=""              # set by TC-SYMLINK-BSD-REALPATH; tracked separately for the same reason
 
 cleanup() {
   rm -f "$STDERR_FILE"
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_MUT_DIR" 2>/dev/null ) || true
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_REV_DIR" 2>/dev/null ) || true
-  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR" ${shimdir:+"$shimdir"}
+  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR" ${shimdir:+"$shimdir"} ${rp_shimdir:+"$rp_shimdir"}
 }
 trap cleanup EXIT
 
@@ -50,6 +51,9 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 REAL_JQ=$(command -v jq)   # absolute path, captured before any PATH-shim test shadows `jq`
+# Same reason for realpath: TC-SYMLINK-BSD-REALPATH shims it, and the shim itself
+# execs the real binary. Empty when realpath is absent — that TC then skips.
+REAL_REALPATH=$(command -v realpath 2>/dev/null) || REAL_REALPATH=""
 
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
@@ -285,49 +289,18 @@ echo ""
 # --------------------------------------------------------------------------
 # Final-element symlink resolution (Issue #1864 AC-2): a symlink dropped INSIDE a
 # sanctioned isolation worktree that points at the parent repo's .git / working tree
-# is physically resolved (realpath) BEFORE the isolation decision, so it can no longer
-# dodge the guard by landing _tdir on the isolation root. AC-3 note: Claude Code's own
-# Edit/Write tools already refuse symlink writes, so this is defense-in-depth.
+# is dereferenced BEFORE the isolation decision, so it can no longer dodge the guard
+# by landing _tdir on the isolation root. AC-3 note: Claude Code's own Edit/Write
+# tools already refuse symlink writes, so this is defense-in-depth.
 # --------------------------------------------------------------------------
-# The AC-2 resolution relies on `realpath` resolving a symlink whose target does
-# not yet exist (the symlink targets below are never created). GNU realpath does;
-# BSD/macOS realpath errors, so the final-element resolution no-ops there — the
-# hook comment above already notes this fallthrough is "no worse than before".
-# Probe the exact behavior and skip these two TCs where realpath can't resolve a
-# dangling symlink (Issue #2008).
-#
-# This is a production gap on macOS, not a test-only quirk, and it is tracked in
-# Issue #2014 — the fix resolves the link target's parent instead of the final
-# element, which works on BSD too. Do NOT describe AC-3 (Claude Code's Edit/Write
-# refusing symlink writes) as the backstop here: pre-tool-edit-guard.sh states
-# that the guard "does not rely on that (undocumented) harness behavior", so
-# leaning on it as the macOS safety net contradicts the hook's own design.
-#
-# Do not name pre-tool-bash-guard.sh's `_gd_fileverb` as the backstop either.
-# That gate is on the Bash tool and never sees the Edit/Write path, and its own
-# header declares the verb list a deliberately non-exhaustive COMMON-SET rather
-# than full closure — a reviewer that creates the symlink by any means outside
-# that list still reaches the parent `.git` on BSD. While #2014 is open, the only
-# layers left on macOS are the reviewer prompt contract (Layer 1) and AC-3.
-# Do not narrow the residual exposure to "a new file in the parent working tree".
-_sym_probe=$(mktemp -d); ln -s "$_sym_probe/no-such-target" "$_sym_probe/lnk"
-if realpath "$_sym_probe/lnk" >/dev/null 2>&1; then RESOLVES_DANGLING_SYMLINK=1; else RESOLVES_DANGLING_SYMLINK=0; fi
-rm -rf "$_sym_probe"
-
-# The probe is a capability check, not a platform check, so a Linux host with
-# realpath missing or shadowed on PATH would silently skip the only coverage of
-# AC-2 — a security control — and still report green. Linux is the blocking gate,
-# so require the probe to succeed there.
-#
-# `[ -d /proc ]` rather than `uname -s`: the threat this floor guards against is a
-# tampered PATH, and `uname` is looked up on the same PATH as the shadowed
-# `realpath`. A filesystem fact cannot be shadowed, and it matches the platform
-# predicate the other gates in this suite already use.
-if [ -d /proc ] && [ "$RESOLVES_DANGLING_SYMLINK" != 1 ]; then
-  fail "TC-SYMLINK probe: realpath cannot resolve a dangling symlink on Linux (missing or shadowed on PATH?) — the AC-2 symlink TCs must never be skipped on the blocking gate"
-fi
-
-if [ "$RESOLVES_DANGLING_SYMLINK" = 1 ]; then
+# These TCs used to be skipped wherever `realpath` could not resolve a dangling
+# symlink, because the hook resolved the final element with `realpath` and that
+# no-op'd on BSD/macOS — a production gap, not a test quirk (Issue #2008 → #2014).
+# The hook now retargets ABS_PATH via bare `readlink` and lets the _tdir walk do the
+# physical resolution, which needs no existence check and has no platform branch, so
+# the skip is gone and these run everywhere. TC-SYMLINK-BSD-REALPATH below pins that
+# platform-independence down by proving the chain still denies when `realpath` is
+# shimmed to BSD semantics.
 echo "TC-SYMLINK-gitdir: isolation symlink → parent .git → deny (git-dir)"
 ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/evil-into-gitdir"
 out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-into-gitdir" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
@@ -341,8 +314,81 @@ out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-into-tree" "$ISO_MUT_DIR" "$SUBA
 assert_deny "isolation symlink into parent working tree resolved & blocked" "$out"
 rm -f "$ISO_MUT_DIR/evil-into-tree"
 echo ""
+
+# A two-link chain: resolving only ONE hop would leave ABS_PATH at `$ISO_MUT_DIR/hop`,
+# landing _tdir back on the isolation root → allow. Pins the loop against a future
+# "just dereference once" simplification (Issue #2014).
+echo "TC-SYMLINK-chain: isolation symlink → symlink → parent .git → deny (git-dir)"
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/hop"
+ln -s "$ISO_MUT_DIR/hop" "$ISO_MUT_DIR/evil-chain"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-chain" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "multi-hop symlink chain into parent .git resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-chain" "$ISO_MUT_DIR/hop"
+echo ""
+
+# The target's PARENT does not exist either, so any fix that canonicalizes the link
+# target's parent dir (the shape first proposed in Issue #2014) still no-ops here and
+# falls through to allow. Handing the raw target to the _tdir walk denies, because the
+# walk climbs to the nearest EXISTING ancestor ($TEST_REPO/src) before asking git.
+echo "TC-SYMLINK-missing-parent: isolation symlink → not-yet-created dir in parent tree → deny (parent-tree)"
+mkdir -p "$TEST_REPO/src"
+ln -s "$TEST_REPO/src/newdir/newfile.py" "$ISO_MUT_DIR/evil-missing-parent"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-missing-parent" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "symlink to a not-yet-created parent-tree path resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-missing-parent"
+echo ""
+
+# --------------------------------------------------------------------------
+# BSD/macOS realpath parity (Issue #2014). The gitdir TC above passes on Linux even
+# with a realpath-based resolution, so it alone cannot catch a regression back to one
+# that needs `realpath` to tolerate a dangling final component. Shim `realpath` to BSD
+# semantics — every component INCLUDING the last must exist — and re-run the two attack
+# shapes. `[ -e ]` follows symlinks, so a dangling link fails the shim exactly as BSD
+# realpath does, while an existing dir passes straight through to the real binary (which
+# keeps hook-preamble.sh's own realpath call working).
+# --------------------------------------------------------------------------
+if [ -n "$REAL_REALPATH" ]; then
+  echo "TC-SYMLINK-BSD-REALPATH: AC-2 resolution does not depend on GNU realpath"
+  rp_shimdir=$(mktemp -d)
+  cat > "$rp_shimdir/realpath" <<SHIM
+#!/bin/bash
+for a in "\$@"; do
+  case "\$a" in -*) continue ;; esac
+  [ -e "\$a" ] || exit 1
+done
+exec "$REAL_REALPATH" "\$@"
+SHIM
+  chmod +x "$rp_shimdir/realpath"
+
+  # Floor: a shim that never gets picked up would turn this whole TC into a false green.
+  ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/shim-probe"
+  if PATH="$rp_shimdir:$PATH" realpath "$ISO_MUT_DIR/shim-probe" >/dev/null 2>&1; then
+    fail "TC-SYMLINK-BSD-REALPATH: the BSD realpath shim did not take effect (still resolving a dangling symlink) — the GNU-independence assertions below would be vacuous"
+  else
+    pass "BSD realpath shim is in effect (dangling symlink errors, as on macOS)"
+  fi
+  rm -f "$ISO_MUT_DIR/shim-probe"
+
+  ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/bsd-into-gitdir"
+  out=$(PATH="$rp_shimdir:$PATH" jq -n --arg p "$ISO_MUT_DIR/bsd-into-gitdir" --arg cwd "$ISO_MUT_DIR" \
+    --arg tp "$SUBAGENT_TRANSCRIPT" \
+    '{tool_name: "Write", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+    | PATH="$rp_shimdir:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || true
+  assert_deny_gitdir "isolation symlink into parent .git blocked under BSD realpath" "$out"
+  rm -f "$ISO_MUT_DIR/bsd-into-gitdir"
+
+  ln -s "$TEST_REPO/tracked.py" "$ISO_MUT_DIR/bsd-into-tree"
+  out=$(PATH="$rp_shimdir:$PATH" jq -n --arg p "$ISO_MUT_DIR/bsd-into-tree" --arg cwd "$ISO_MUT_DIR" \
+    --arg tp "$SUBAGENT_TRANSCRIPT" \
+    '{tool_name: "Write", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+    | PATH="$rp_shimdir:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || true
+  assert_deny "isolation symlink into parent working tree blocked under BSD realpath" "$out"
+  rm -f "$ISO_MUT_DIR/bsd-into-tree"
+
+  rm -rf "$rp_shimdir"; rp_shimdir=""
+  echo ""
 else
-  skip "TC-SYMLINK-gitdir/tree skipped (realpath can't resolve a dangling symlink here; AC-2 final-element resolution no-ops on BSD/macOS — production gap tracked in Issue #2014, skip introduced by Issue #2008)"
+  skip "TC-SYMLINK-BSD-REALPATH skipped (no realpath on PATH, so BSD semantics cannot be shimmed; the TCs above already cover the resolution itself)"
 fi
 
 echo "TC-SYMLINK-local: isolation-internal symlink → allow (no regression)"

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -37,12 +37,13 @@ ISO_REV_DIR=$(mktemp -u -t rite-revert-test-XXXXXX)
 OUTSIDE_DIR=$(mktemp -d)   # a plain, non-repo scratch dir
 shimdir=""                 # set by TC-FAILCLOSED; cleaned here so an interrupt leaves no residue
 rp_shimdir=""              # set by TC-SYMLINK-BSD-REALPATH; tracked separately for the same reason
+rl_shimdir=""              # set by TC-SYMLINK-lf-target-bsd; tracked separately for the same reason
 
 cleanup() {
   rm -f "$STDERR_FILE"
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_MUT_DIR" 2>/dev/null ) || true
   ( cd "$TEST_REPO" 2>/dev/null && git worktree remove --force "$ISO_REV_DIR" 2>/dev/null ) || true
-  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR" ${shimdir:+"$shimdir"} ${rp_shimdir:+"$rp_shimdir"}
+  rm -rf "$TEST_REPO" "$ISO_MUT_DIR" "$ISO_REV_DIR" "$OUTSIDE_DIR" ${shimdir:+"$shimdir"} ${rp_shimdir:+"$rp_shimdir"} ${rl_shimdir:+"$rl_shimdir"}
 }
 trap cleanup EXIT
 
@@ -54,6 +55,9 @@ REAL_JQ=$(command -v jq)   # absolute path, captured before any PATH-shim test s
 # Same reason for realpath: TC-SYMLINK-BSD-REALPATH shims it, and the shim itself
 # execs the real binary. Empty when realpath is absent — that TC then skips.
 REAL_REALPATH=$(command -v realpath 2>/dev/null) || REAL_REALPATH=""
+# Same for readlink: TC-SYMLINK-lf-target-bsd shims it to the macOS-observed
+# no-delimiter behaviour. Empty when readlink is absent — that TC then skips.
+REAL_READLINK=$(command -v readlink 2>/dev/null) || REAL_READLINK=""
 
 # _timeout <seconds> <command...> — portable timeout(1) for this test (Issue #2008).
 #
@@ -466,6 +470,52 @@ ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/$lf_name"
 ln -s "$lf_name" "$ISO_MUT_DIR/evil-lf"
 out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-lf" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
 assert_deny_gitdir "LF-terminated link target resolved & blocked" "$out"
+
+# The assertion above passes on GNU even when the capture is NOT byte-exact, because GNU
+# readlink appends a newline that a "strip one trailing LF" step happens to undo. macOS
+# readlink appends nothing, so the same step eats a GENUINE trailing LF and the deref lands on
+# a nonexistent path → allow. That divergence reached CI as a macOS-only failure of this very
+# TC while Linux stayed green, i.e. exactly the platform-gap shape #2014 exists to close.
+# Shim readlink to the macOS-observed behaviour (no trailing delimiter) so the blocking gate
+# sees it too. perl reads the link raw and prints it without a delimiter; `$(…)` cannot be used
+# inside the shim because it would strip the very byte under test.
+if [ -n "$REAL_READLINK" ] && command -v perl >/dev/null 2>&1; then
+  echo "TC-SYMLINK-lf-target-bsd: LF-terminated target under a no-delimiter readlink → deny (git-dir)"
+  rl_shimdir=$(mktemp -d)
+  cat > "$rl_shimdir/readlink" <<'SHIM'
+#!/bin/bash
+_t=""
+for a in "$@"; do case "$a" in -*) continue ;; *) _t=$a ;; esac; done
+exec perl -e 'my $l = readlink($ARGV[0]); exit 1 unless defined $l; print $l;' "$_t"
+SHIM
+  chmod +x "$rl_shimdir/readlink"
+
+  # Floor: a shim that never gets picked up would make the assertion below a duplicate of the
+  # GNU one above rather than a BSD-parity check. Probe with a target that does NOT end in LF
+  # and capture through a sentinel, so the comparison sees the delimiter byte itself rather
+  # than losing it to `$( )` — the exact trap this whole TC exists to pin.
+  ln -s "rl-probe-target" "$ISO_MUT_DIR/rl-probe"
+  _rl_probe=$(PATH="$rl_shimdir:$PATH" readlink "$ISO_MUT_DIR/rl-probe"; printf 'X')
+  if [ "${_rl_probe%X}" = "rl-probe-target" ]; then
+    pass "no-delimiter readlink shim is in effect (emits no trailing newline)"
+  else
+    fail "TC-SYMLINK-lf-target-bsd: the no-delimiter readlink shim did not take effect — the BSD-parity assertion below would be vacuous"
+  fi
+  rm -f "$ISO_MUT_DIR/rl-probe"
+
+  out=$(PATH="$rl_shimdir:$PATH" jq -n --arg p "$ISO_MUT_DIR/evil-lf" --arg cwd "$ISO_MUT_DIR" \
+    --arg tp "$SUBAGENT_TRANSCRIPT" \
+    '{tool_name: "Write", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+    | PATH="$rl_shimdir:$PATH" bash "$HOOK" 2>"$STDERR_FILE") || true
+  assert_deny_gitdir "LF-terminated target blocked under a no-delimiter readlink" "$out"
+
+  rm -rf "$rl_shimdir"; rl_shimdir=""
+elif [ -d /proc ]; then
+  fail "TC-SYMLINK-lf-target-bsd floor: readlink or perl unavailable on Linux — the BSD readlink-parity pin must never be skipped on the blocking gate"
+else
+  skip "TC-SYMLINK-lf-target-bsd skipped (readlink or perl unavailable, so the no-delimiter behaviour cannot be shimmed)"
+fi
+
 rm -f "$ISO_MUT_DIR/evil-lf" "$ISO_MUT_DIR/$lf_name"
 echo ""
 

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -338,6 +338,74 @@ assert_deny "symlink to a not-yet-created parent-tree path resolved & blocked" "
 rm -f "$ISO_MUT_DIR/evil-missing-parent"
 echo ""
 
+# Every TC above uses an ABSOLUTE link target, so none of them execute the relative-target
+# branch (`*) _lt="${ABS_PATH%/*}/$_lt"`). That branch is load-bearing — stubbing it out to
+# `: ;` leaves the whole suite green while a relative `../<repo>/.git/hooks/pre-commit` link
+# walks straight into the parent .git. Assert the deny KIND, not just "deny": with the branch
+# stubbed and the hook's cwd inside some other repo the target still denies as parent-tree,
+# so only the git-dir kind distinguishes a working branch from a stubbed one.
+echo "TC-SYMLINK-relative: isolation symlink with a RELATIVE target → parent .git → deny (git-dir)"
+ln -s "../$(basename "$TEST_REPO")/.git/hooks/pre-commit" "$ISO_MUT_DIR/evil-rel"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-rel" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "relative symlink target into parent .git resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-rel"
+
+# Pair the deny case with an allow case, or "make the relative branch always deny" would pass.
+: > "$ISO_MUT_DIR/rel-target.txt"
+ln -s "rel-target.txt" "$ISO_MUT_DIR/rel-local"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/rel-local" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") && rc=0 || rc=$?
+assert_allow "isolation-internal relative symlink still allowed" "$out" "$rc"
+rm -f "$ISO_MUT_DIR/rel-local" "$ISO_MUT_DIR/rel-target.txt"
+echo ""
+
+# The hop cap is what makes a symlink CYCLE terminate. Without it this PreToolUse hook spins
+# until the harness 10s timeout on every Edit/Write — invisible to CI, fatal in production.
+# Asserting "allow" alone would be vacuous (deleting the whole deref block also allows), so
+# assert TERMINATION: run under `timeout` and treat rc=124 as the failure.
+echo "TC-SYMLINK-cycle: symlink cycle → terminates via hop cap (no hang) → allow"
+ln -s "$ISO_MUT_DIR/cyc2" "$ISO_MUT_DIR/cyc1"
+ln -s "$ISO_MUT_DIR/cyc1" "$ISO_MUT_DIR/cyc2"
+rc=0
+out=$(jq -n --arg p "$ISO_MUT_DIR/cyc1" --arg cwd "$ISO_MUT_DIR" --arg tp "$SUBAGENT_TRANSCRIPT" \
+  '{tool_name: "Write", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
+  | timeout 10 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+if [ "$rc" = "124" ]; then
+  fail "symlink cycle did not terminate within 10s (hop cap missing?)"
+else
+  assert_allow "symlink cycle terminates and falls through to allow" "$out" "$rc"
+fi
+rm -f "$ISO_MUT_DIR/cyc1" "$ISO_MUT_DIR/cyc2"
+echo ""
+
+# A link target that ends in LF is where a command-substitution capture silently truncates:
+# `$(readlink …)` strips every trailing newline, so the hook would scope `<iso>/lf-mid`
+# (inside the isolation worktree → allow) while the kernel follows `<iso>/lf-mid<LF>` into the
+# parent tree. Both shapes below deny only when the capture is byte-exact.
+echo "TC-SYMLINK-lf-target: link target ending in LF → parent .git → deny (git-dir)"
+lf_name=$'lf-mid\n'
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/$lf_name"
+ln -s "$lf_name" "$ISO_MUT_DIR/evil-lf"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-lf" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "LF-terminated link target resolved & blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-lf" "$ISO_MUT_DIR/$lf_name"
+echo ""
+
+# Same truncation, but via the DIRECTORY component: `$(dirname …)` on `<iso>/lf-dir<LF>/rel`
+# returns `<iso>/lf-dir` once the trailing LF is stripped. Only a parameter-expansion split
+# keeps the byte. Uses a relative target so the dirname branch is the one under test.
+echo "TC-SYMLINK-lf-dirname: link inside an LF-terminated directory → parent tree → deny (parent-tree)"
+lf_dir=$'lf-dir\n'
+mkdir -p "$ISO_MUT_DIR/$lf_dir"
+ln -s "../../$(basename "$TEST_REPO")/tracked.py" "$ISO_MUT_DIR/$lf_dir/rel"
+ln -s "$ISO_MUT_DIR/$lf_dir/rel" "$ISO_MUT_DIR/evil-lf-dir"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-lf-dir" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "LF-terminated directory component preserved & blocked" "$out"
+# Remove the exact entries rather than `rm -rf` the directory: an empty $ISO_MUT_DIR would
+# make a recursive delete target the filesystem root (SC2115).
+rm -f "$ISO_MUT_DIR/evil-lf-dir" "$ISO_MUT_DIR/$lf_dir/rel"
+rmdir "$ISO_MUT_DIR/$lf_dir"
+echo ""
+
 # --------------------------------------------------------------------------
 # BSD/macOS realpath parity (Issue #2014). The gitdir TC above passes on Linux even
 # with a realpath-based resolution, so it alone cannot catch a regression back to one
@@ -347,6 +415,16 @@ echo ""
 # realpath does, while an existing dir passes straight through to the real binary (which
 # keeps hook-preamble.sh's own realpath call working).
 # --------------------------------------------------------------------------
+# Linux is the blocking gate, so a security TC must never skip there. The old
+# RESOLVES_DANGLING_SYMLINK floor guarded the AC-2 TCs; those now run unconditionally, but this
+# gate introduces a NEW skip path (`realpath` missing or shadowed on PATH) that would silently
+# drop the only regression pin against going back to a realpath-dependent resolution. Same
+# floor shape as wiki-lint-broken-refs.test.sh — `[ -d /proc ]` rather than `uname -s` because
+# the threat is a tampered PATH and `uname` is looked up on that same PATH.
+if [ -d /proc ] && [ -z "$REAL_REALPATH" ]; then
+  fail "TC-SYMLINK-BSD-REALPATH floor: realpath unavailable on Linux (missing or shadowed on PATH?) — the BSD-parity regression pin must never be skipped on the blocking gate"
+fi
+
 if [ -n "$REAL_REALPATH" ]; then
   echo "TC-SYMLINK-BSD-REALPATH: AC-2 resolution does not depend on GNU realpath"
   rp_shimdir=$(mktemp -d)
@@ -361,7 +439,10 @@ SHIM
   chmod +x "$rp_shimdir/realpath"
 
   # Floor: a shim that never gets picked up would turn this whole TC into a false green.
-  ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/shim-probe"
+  # The probe target must be a name `git init` can never materialise — pointing it at
+  # .git/hooks/pre-commit would spuriously fail this floor on a host whose
+  # init.templateDir ships a real pre-commit hook (husky-style templates do).
+  ln -s "$TEST_REPO/.git/hooks/rite-2014-no-such-hook" "$ISO_MUT_DIR/shim-probe"
   if PATH="$rp_shimdir:$PATH" realpath "$ISO_MUT_DIR/shim-probe" >/dev/null 2>&1; then
     fail "TC-SYMLINK-BSD-REALPATH: the BSD realpath shim did not take effect (still resolving a dangling symlink) — the GNU-independence assertions below would be vacuous"
   else

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -57,10 +57,11 @@ REAL_REALPATH=$(command -v realpath 2>/dev/null) || REAL_REALPATH=""
 
 # _timeout <seconds> <command...> — portable timeout(1) for this test (Issue #2008).
 #
-# Byte-identical copy of the reference definition in _test-helpers.sh, which this file
-# deliberately does not source (see the note above). timeout-shim.test.sh TC-7 compares
-# every discovered copy against that reference and TC-8 requires the fail-closed guard
-# below, so edit the reference first and re-copy — do not hand-tune this block.
+# Byte-identical copy of the reference definition in _test-helpers.sh. This file does not
+# source _test-helpers.sh (it defines its own pass/fail/skip counters below), so the shim is
+# inlined here. timeout-shim.test.sh TC-7 compares every discovered copy against that
+# reference and TC-8 requires the fail-closed guard below, so edit the reference first and
+# re-copy — do not hand-tune this block.
 _timeout() {
   local _d="$1"; shift
   if command -v timeout >/dev/null 2>&1; then
@@ -392,11 +393,17 @@ echo ""
 # branch (`*) _lt="${ABS_PATH%/*}/$_lt"`). That branch is load-bearing — stubbing it out to
 # `: ;` leaves the whole suite green while a relative `../<repo>/.git/hooks/pre-commit` link
 # walks straight into the parent .git. Assert the deny KIND, not just "deny": with the branch
-# stubbed and the hook's cwd inside some other repo the target still denies as parent-tree,
-# so only the git-dir kind distinguishes a working branch from a stubbed one.
+# stubbed the target can still deny as parent-tree, so only the git-dir kind tells a working
+# branch from a stubbed one.
+#
+# Run the hook from `/` rather than inheriting the caller's cwd. With the branch stubbed,
+# ABS_PATH stays the RELATIVE `../<repo>/.git/hooks/pre-commit`, which the _tdir walk resolves
+# against the hook process's own cwd — so a caller sitting one level under $TMPDIR (exactly
+# where agents/_reviewer-base.md tells reviewers to run their mutation experiments) makes the
+# stubbed branch resolve correctly by accident and the TC pass. `/` has no such sibling.
 echo "TC-SYMLINK-relative: isolation symlink with a RELATIVE target → parent .git → deny (git-dir)"
 ln -s "../$(basename "$TEST_REPO")/.git/hooks/pre-commit" "$ISO_MUT_DIR/evil-rel"
-out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-rel" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+out=$(cd / && run_edit_guard "Write" "$ISO_MUT_DIR/evil-rel" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
 assert_deny_gitdir "relative symlink target into parent .git resolved & blocked" "$out"
 rm -f "$ISO_MUT_DIR/evil-rel"
 
@@ -471,13 +478,26 @@ assert_deny "LF-terminated directory component preserved & blocked" "$out"
 # The resolved ABS_PATH here carries a raw LF, which is exactly what would split the
 # single-line `edit-guard: BLOCKED … path="…"` audit record in two and let a reviewer forge a
 # second record. `grep -c 'edit-guard: BLOCKED'` cannot see that — the split happens INSIDE
-# path="…", so the count stays 1 either way. Requiring the closing quote to land on the same
-# line is what distinguishes a neutralized record from a split one, and it stays robust when
-# hook-preamble or other callers add unrelated stderr lines.
-if grep -q 'edit-guard: BLOCKED .*path="[^"]*"$' "$STDERR_FILE"; then
-  pass "BLOCKED audit record stays one physical line under an LF-bearing path"
+# path="…", so the count stays 1 either way. Requiring the closing quote AND the neutralized
+# `lf-dir?` on the same line distinguishes a neutralized record from a split one, and it stays
+# robust when hook-preamble or other callers add unrelated stderr lines.
+#
+# The hook only reports ${ABS_PATH:0:120}, so this pin can only observe a split while the LF
+# lands inside that window. Under a long $TMPDIR the truncation drops the LF and the record
+# stays one line even with the neutralization removed — the pin would silently stop testing
+# anything. Floor it the same two-tier way the rest of this file does: hard-fail on the
+# blocking gate, skip elsewhere so a long-$TMPDIR workstation is not spuriously red.
+_lf_off=$(( ${#ISO_MUT_DIR} + ${#lf_dir} ))   # byte offset of the LF within "<iso>/lf-dir<LF>"
+if [ "$_lf_off" -ge 120 ]; then
+  if [ -d /proc ]; then
+    fail "TC-SYMLINK-lf-dirname floor: the LF sits at byte $_lf_off, outside the hook's 120-byte path summary window (\$TMPDIR too long) — the log-injection pin below would be vacuous"
+  else
+    skip "TC-SYMLINK-lf-dirname log-injection pin (LF at byte $_lf_off is outside the hook's 120-byte window; \$TMPDIR is ${#TMPDIR} chars)"
+  fi
+elif grep -q 'edit-guard: BLOCKED .*path="[^"]*lf-dir?[^"]*"$' "$STDERR_FILE"; then
+  pass "BLOCKED audit record stays one physical line with the LF neutralized"
 else
-  fail "BLOCKED audit record was split by a raw LF (log-injection defense missing): $(cat -A "$STDERR_FILE" | head -3)"
+  fail "BLOCKED audit record was split by a raw LF (log-injection defense missing): $(cat -e "$STDERR_FILE" | head -3)"
 fi
 # Remove the exact entries rather than `rm -rf` the directory: an empty $ISO_MUT_DIR would
 # make a recursive delete target the filesystem root (SC2115). `|| fail` rather than a bare

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -55,6 +55,56 @@ REAL_JQ=$(command -v jq)   # absolute path, captured before any PATH-shim test s
 # execs the real binary. Empty when realpath is absent — that TC then skips.
 REAL_REALPATH=$(command -v realpath 2>/dev/null) || REAL_REALPATH=""
 
+# _timeout <seconds> <command...> — portable timeout(1) for this test (Issue #2008).
+#
+# Byte-identical copy of the reference definition in _test-helpers.sh, which this file
+# deliberately does not source (see the note above). timeout-shim.test.sh TC-7 compares
+# every discovered copy against that reference and TC-8 requires the fail-closed guard
+# below, so edit the reference first and re-copy — do not hand-tune this block.
+_timeout() {
+  local _d="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_d" "$@"
+  else
+    perl -e '
+      my $d = shift;
+      # alarm truncates to an integer, so a fractional deadline silently becomes
+      # alarm 0 — no timeout at all, and waitpid blocks until the CI job limit.
+      # Reject rather than degrade, and exit 125 rather than die: die exits 255,
+      # which every caller reads as "not 124, so no hang" — the same silent pass
+      # the rejection exists to prevent. GNU timeout accepts fractions, so this
+      # shim only claims the contract for integer seconds.
+      if ($d !~ /^[0-9]+$/) {
+        print STDERR "_timeout: fractional seconds are not supported by the perl fallback: $d\n";
+        exit 125;
+      }
+      my $pid = fork;
+      exit 127 unless defined $pid;
+      # setpgrp puts the child in its own process group so the alarm handler can
+      # signal the whole tree with a negative pid. GNU timeout does the same; without
+      # it the deadline only reaches the direct child, and a grandchild holding the
+      # captured stdout keeps the caller blocked long past the timeout (measured 30s
+      # against a 1s deadline). The runners capture output with $( ), so that stall
+      # would consume the CI job limit instead of failing at 124.
+      if ($pid == 0) { setpgrp(0, 0); exec { $ARGV[0] } @ARGV; exit 127; }
+      $SIG{ALRM} = sub { kill "TERM", -$pid; waitpid($pid, 0); exit 124; };
+      alarm $d; waitpid $pid, 0;
+      my $st = $?; exit($st & 127 ? 128 + ($st & 127) : $st >> 8);
+    ' "$_d" "$@"
+  fi
+}
+
+# Fail closed when no backend exists. Every `_timeout` caller reads a non-124 rc
+# as "no hang", so a missing backend would silently turn each hang assertion into
+# a pass. Abort at source time rather than degrade.
+if ! command -v timeout >/dev/null 2>&1 && ! command -v perl >/dev/null 2>&1; then
+  echo "ERROR: neither timeout(1) nor perl(1) is available — _timeout cannot detect" >&2
+  echo "  hangs, and every hang assertion in this suite would silently pass." >&2
+  echo "  Install GNU coreutils (timeout) or perl before running the test suite." >&2
+  exit 1
+fi
+
+
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
 # Skips are counted so a platform-gated green states how many assertions never ran
@@ -361,20 +411,38 @@ echo ""
 # The hop cap is what makes a symlink CYCLE terminate. Without it this PreToolUse hook spins
 # until the harness 10s timeout on every Edit/Write — invisible to CI, fatal in production.
 # Asserting "allow" alone would be vacuous (deleting the whole deref block also allows), so
-# assert TERMINATION: run under `timeout` and treat rc=124 as the failure.
+# assert TERMINATION: run under the portable `_timeout` shim and treat rc=124 as the failure.
+# Bare `timeout(1)` must not be used — it is absent on macOS (the CI leg deliberately omits
+# coreutils), where the call would exit 127 and this pin would silently stop testing anything.
 echo "TC-SYMLINK-cycle: symlink cycle → terminates via hop cap (no hang) → allow"
 ln -s "$ISO_MUT_DIR/cyc2" "$ISO_MUT_DIR/cyc1"
 ln -s "$ISO_MUT_DIR/cyc1" "$ISO_MUT_DIR/cyc2"
 rc=0
 out=$(jq -n --arg p "$ISO_MUT_DIR/cyc1" --arg cwd "$ISO_MUT_DIR" --arg tp "$SUBAGENT_TRANSCRIPT" \
   '{tool_name: "Write", tool_input: {file_path: $p}, cwd: $cwd, transcript_path: $tp}' \
-  | timeout 10 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  | _timeout 10 bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
 if [ "$rc" = "124" ]; then
   fail "symlink cycle did not terminate within 10s (hop cap missing?)"
 else
   assert_allow "symlink cycle terminates and falls through to allow" "$out" "$rc"
 fi
 rm -f "$ISO_MUT_DIR/cyc1" "$ISO_MUT_DIR/cyc2"
+echo ""
+
+# TC-SYMLINK-cycle above pins that a cap EXISTS; it does not pin its VALUE. Lowering the cap
+# to anything >= 2 leaves the whole suite green, yet a cap below the kernel's own limit
+# reopens the multi-hop bypass: for chain lengths between cap+1 and the kernel limit the hook
+# gives up (leaving ABS_PATH a link inside the isolation worktree → allow) while the kernel
+# happily follows the rest of the chain into the parent .git. Pin the LOWER bound only — a
+# larger cap is equally safe, so asserting the upper side would over-pin the implementation.
+echo "TC-SYMLINK-hop-cap-value: a chain exactly at the cap still resolves → deny (git-dir)"
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/hopchain-0"
+for _i in $(seq 1 39); do
+  ln -s "$ISO_MUT_DIR/hopchain-$((_i - 1))" "$ISO_MUT_DIR/hopchain-$_i"
+done
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/hopchain-39" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny_gitdir "40-hop chain into parent .git resolved & blocked (cap must be >= 40)" "$out"
+for _i in $(seq 0 39); do rm -f "$ISO_MUT_DIR/hopchain-$_i"; done
 echo ""
 
 # A link target that ends in LF is where a command-substitution capture silently truncates:

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -468,10 +468,23 @@ ln -s "../../$(basename "$TEST_REPO")/tracked.py" "$ISO_MUT_DIR/$lf_dir/rel"
 ln -s "$ISO_MUT_DIR/$lf_dir/rel" "$ISO_MUT_DIR/evil-lf-dir"
 out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-lf-dir" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
 assert_deny "LF-terminated directory component preserved & blocked" "$out"
+# The resolved ABS_PATH here carries a raw LF, which is exactly what would split the
+# single-line `edit-guard: BLOCKED … path="…"` audit record in two and let a reviewer forge a
+# second record. `grep -c 'edit-guard: BLOCKED'` cannot see that — the split happens INSIDE
+# path="…", so the count stays 1 either way. Requiring the closing quote to land on the same
+# line is what distinguishes a neutralized record from a split one, and it stays robust when
+# hook-preamble or other callers add unrelated stderr lines.
+if grep -q 'edit-guard: BLOCKED .*path="[^"]*"$' "$STDERR_FILE"; then
+  pass "BLOCKED audit record stays one physical line under an LF-bearing path"
+else
+  fail "BLOCKED audit record was split by a raw LF (log-injection defense missing): $(cat -A "$STDERR_FILE" | head -3)"
+fi
 # Remove the exact entries rather than `rm -rf` the directory: an empty $ISO_MUT_DIR would
-# make a recursive delete target the filesystem root (SC2115).
+# make a recursive delete target the filesystem root (SC2115). `|| fail` rather than a bare
+# rmdir: under `set -e` a leftover entry would abort the suite before the `=== Results ===`
+# summary, hiding how many assertions ran (the honesty the SKIP counter exists to protect).
 rm -f "$ISO_MUT_DIR/evil-lf-dir" "$ISO_MUT_DIR/$lf_dir/rel"
-rmdir "$ISO_MUT_DIR/$lf_dir"
+rmdir "$ISO_MUT_DIR/$lf_dir" || fail "TC-SYMLINK-lf-dirname cleanup: $ISO_MUT_DIR/\$lf_dir not empty"
 echo ""
 
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/timeout-shim.test.sh
+++ b/plugins/rite/hooks/tests/timeout-shim.test.sh
@@ -239,9 +239,11 @@ mapfile -t TIMEOUT_COPIES < <(grep -rlE '^[[:space:]]*(function[[:space:]]+)?_ti
 REFERENCE_COPY="$PLUGIN_ROOT/hooks/tests/_test-helpers.sh"
 # Floor check: discovery returning too few files is itself a failure mode (a moved
 # directory, a reformatted definition line), and would otherwise make TC-7/TC-8
-# vacuously green over an empty or truncated set.
-if [ "${#TIMEOUT_COPIES[@]}" -lt 6 ]; then
-  fail "TC-7 discovery found only ${#TIMEOUT_COPIES[@]} _timeout definition(s) (expected >= 6) — either the grep pattern or the layout changed, or copies were deliberately consolidated, in which case lower this floor and TC-8's: ${TIMEOUT_COPIES[*]-<none>}"
+# vacuously green over an empty or truncated set. The floor only does that job while it
+# equals the real copy count — leaving it below the count buys slack that hides exactly the
+# reformatted-definition case, so a PR that ADDS a copy must raise it in the same change.
+if [ "${#TIMEOUT_COPIES[@]}" -lt 7 ]; then
+  fail "TC-7 discovery found only ${#TIMEOUT_COPIES[@]} _timeout definition(s) (expected >= 7) — either the grep pattern or the layout changed, or copies were deliberately consolidated, in which case lower this floor and TC-8's; conversely, raise both when you add a copy: ${TIMEOUT_COPIES[*]-<none>}"
 elif ! printf '%s\n' "${TIMEOUT_COPIES[@]}" | grep -qxF "$REFERENCE_COPY"; then
   fail "TC-7 discovery did not include the reference copy $REFERENCE_COPY"
 else
@@ -273,7 +275,7 @@ fi
 echo "=== TC-8: every _timeout definition carries the fail-closed guard ==="
 # Without the guard a host lacking both backends falls through to rc 127, which
 # every caller reads as "no hang" — the exact silent pass the shim exists to stop.
-if [ "${#TIMEOUT_COPIES[@]}" -lt 6 ]; then
+if [ "${#TIMEOUT_COPIES[@]}" -lt 7 ]; then
   fail "TC-8 skipped because discovery failed (see TC-7)"
 else
   missing_guard=()


### PR DESCRIPTION
## 概要

`pre-tool-edit-guard.sh` の最終要素 symlink 解決（AC-2）が `realpath` に依存していたため、dangling な最終要素をエラーにする BSD/macOS の `realpath` では常に空文字が返り、ブロック全体が no-op になっていた。攻撃形の target（`.git/hooks/pre-commit` 等）は通常まだ存在しないので、macOS では実質的に無効化されていた。

解決を `realpath` 非依存にして塞ぐ。`readlink`（フラグなし、POSIX/BSD 共通）でリンク先を辿って `ABS_PATH` を差し替え、物理解決は直後の**既存の `_tdir` walk** に委ねる。`[ -d ]` と `git -C` はどちらも chdir するため `..` とディレクトリ symlink を実ツリー上で解決する — 非 symlink target に対する `..` 再侵入フォージェリを塞いでいるのと同じ性質で、target の存在確認が一切不要になり、GNU/BSD で分岐が生じない。

## 関連 Issue

Closes #2014

## 変更内容

- `plugins/rite/hooks/pre-tool-edit-guard.sh` — 変更
- `plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh` — 変更
- `plugins/rite/hooks/tests/_test-helpers.sh` — 変更

### 副次的に塞いだ Linux 側のギャップ 2 件

Issue が想定していたのは macOS ギャップのみだったが、実測で以下 2 件が GNU realpath 下でも穴になっていることを確認した。

1. **target の親ディレクトリも未作成のケース**（`<iso>/evil → <main>/src/newdir/newfile.py`）: GNU `realpath` は最終要素の欠落しか許容しないため解決に失敗し、`ABS_PATH` が symlink のまま `_tdir` が isolation root に着地して **allow** になっていた。`_tdir` walk は最寄りの実在祖先まで遡るので、raw target を渡すだけで `parent-tree` deny になる。変更前 hook + GNU realpath で allow、変更後 deny を実測
2. **多段チェーン**（`evil → hop → <main>/.git/...`）: 現行は GNU realpath がチェーン全体を辿るため deny だったが、Issue 本文が提案していた「link target の親を解決する」1 ホップ形に置き換えると allow に退行する。ホップ上限 40（Linux の ELOOP 上限）付きのループで追跡し、退行を防ぐ

## 実装中の判断・計画逸脱

- 判断: Issue 本文の提案コードをそのまま採用しなかった — 内側 `realpath` の失敗時に `/pre-commit` という偽の絶対パスを生成して fail-open する欠陥、1 ホップのみで多段チェーンが退行する欠陥、target の親も未作成なら解決できない欠陥の 3 点があるため
- 判断: `realpath` による正規化自体を捨てて `_tdir` walk に委ねた — 判定に使うのは `git -C` が返す `TARGET_ROOT`（既に解決済み）で、`ABS_PATH` は deny 理由文への埋め込みにしか使われないため、正規形である必要がない。プラットフォーム分岐が消え「テストされない BSD 専用フォールバック」が構造的に生まれない
- 逸脱: Issue の受入基準は 3 項目だが、上記「副次的に塞いだギャップ」2 件の回帰テストを追加した

## テスト

- `TC-SYMLINK-gitdir` / `TC-SYMLINK-tree` の realpath capability probe・Linux floor・skip ガードを削除して無条件実行化（受入基準 2）
- `TC-SYMLINK-BSD-REALPATH` を追加。`realpath` を BSD セマンティクス（最終要素を含め全要素が実在必須）に shim して deny を検証する。GNU realpath 下では旧実装でも gitdir TC が通ってしまい退行を検出できないため、この shim がないと「realpath 依存に戻す」変更が素通りする。shim が効いていない場合に `fail` する floor 付き（効かない shim は false green になるため）
- `TC-SYMLINK-chain`（多段チェーン）/ `TC-SYMLINK-missing-parent`（target の親が未作成）を追加
- 検証: 変更前 hook + BSD shim で **allow** → 変更後 **deny** を実測。同じく missing-parent は変更前 hook + GNU realpath で **allow** → 変更後 **deny**
- `pre-tool-edit-guard.test.sh` 36 件すべて pass、skip 0 件
- hook テストスイート全体 104/104 green
- `shellcheck --severity=error` クリーン（style 重大度も新規指摘なし）

## Checklist

- [x] 受入基準 1: BSD/macOS realpath 環境でも AC-2 の最終要素解決が機能する
- [x] 受入基準 2: `TC-SYMLINK-gitdir` / `TC-SYMLINK-tree` の skip ガードを解除
- [x] 受入基準 3: AC-3 に関するコメントと skip 文言が「undocumented harness 挙動に依拠しない」方針と整合する
- [x] テスト追加
- [x] `_test-helpers.sh` の macOS skip 注釈から本 Issue の言及を除去

## 補足

Issue 本文が言及する `pre-tool-bash-guard.sh` の `_gd_fileverb` / block (H) の穴（Bash ツールから `python3 -c "open(...).write(...)"` で `.git/hooks/*` に到達できる件）は本 PR のスコープ外。当該ブロックのヘッダが自ら out-of-scope と明記している既知・意図的な設計上の穴であり、本 Issue の受入基準にも含まれない。

## Known Issues

- lint 未実行（`commands.lint` が本リポジトリでは恒久的に未設定）。代わりにプラグイン固有チェック 16 件を実行し、変更ファイル起因の指摘は 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
