### PR TITLE
test(hooks): TC-124 (d) に positive control を付け vacuous pass を排除する

### DIFF
--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1200,32 +1200,45 @@ jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \
   '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/mainin.json"
 # Positive control for the negative assertion that follows. The hook prints NOTHING
 # when it permits a command — a deny JSON is the only thing it ever emits, which is
-# why assert_subagent_allow spells allow as "rc 0 AND empty stdout" — so `decision`
-# is legitimately empty in the passing case and cannot double as the liveness signal.
-# Prove the fixture reaches the length guard instead: the same input with only
+# why assert_subagent_allow spells allow as "rc 0 AND empty stdout" — so an empty
+# stdout is exactly what the passing case looks like and cannot double as the liveness
+# signal. Prove the fixture reaches the length guard instead: the same input with only
 # transcript_path flipped to the reviewer transcript must be denied. Without that
 # proof, a malformed input JSON or a hook that never ran reads as "correctly permitted".
+#
+# Both assertions match the raw stdout instead of piping it through jq. Under
+# `set -euo pipefail` a non-JSON stdout makes the extraction assignment abort the whole
+# file before any assertion runs, which loses the diagnosis entirely — the very failure
+# mode this control exists to surface. The deny envelope carries `"deny"` exactly once
+# and never inside the reason text, so the substring test is as strict as the parse was,
+# and it keeps `rc` free to distinguish a crash from a deny that exits non-zero.
 jq --arg tp "$SUBAGENT_TRANSCRIPT" '.transcript_path = $tp' "$tc124_dir/mainin.json" > "$tc124_dir/mainctl.json"
 rc=0
 output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainctl.json" 2>"$STDERR_FILE") || rc=$?
-decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
-if [ "$decision" = "deny" ]; then
-  pass "TC-124 (d) control: the fixture drives the length guard (same input, reviewer transcript → deny)"
-else
-  fail "TC-124 (d) control: expected deny with the reviewer transcript, got decision='$decision' rc=$rc — the fixture is broken and the MUST NOT assertion below would be vacuous"
-fi
+case "$output" in
+  *'"deny"'*)
+    pass "TC-124 (d) control: the fixture drives the length guard (same input, reviewer transcript → deny)"
+    ;;
+  *)
+    fail "TC-124 (d) control: expected deny with the reviewer transcript, got rc=$rc output='$output' — the fixture or the guard regressed, so the MUST NOT assertion below would be vacuous: $(cat -v "$STDERR_FILE")"
+    ;;
+esac
 rc=0
 output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainin.json" 2>"$STDERR_FILE") || rc=$?
-decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
-# Assert the permit contract positively (rc 0 + no output) rather than `!= "deny"`:
-# a crash, a timeout, or any output shape the hook was never meant to produce all
-# leave `decision` empty, and the negation alone accepted every one of them.
-if [ "$rc" != "0" ]; then
-  fail "TC-124 oversized main-session command: hook exited rc=$rc instead of permitting (a crash or timeout empties decision too)"
-elif [ "$decision" = "deny" ]; then
-  fail "TC-124 oversized main-session command was wrongly denied (MUST NOT violation)"
-elif [ -n "$output" ]; then
-  fail "TC-124 oversized main-session command: expected no output (permit), got: $output"
+# Assert the permit contract positively (no output, then rc 0). The old `!= "deny"` form
+# accepted a crash, a timeout, and every output shape the hook was never meant to produce,
+# because all of them left the extracted decision empty.
+if [ -n "$output" ]; then
+  case "$output" in
+    *'"deny"'*)
+      fail "TC-124 oversized main-session command was wrongly denied (MUST NOT violation): $output"
+      ;;
+    *)
+      fail "TC-124 oversized main-session command: expected no output (permit), got: $output"
+      ;;
+  esac
+elif [ "$rc" != "0" ]; then
+  fail "TC-124 oversized main-session command: hook exited rc=$rc with no output instead of permitting: $(cat -v "$STDERR_FILE")"
 else
   pass "TC-124 oversized MAIN-session command is not denied by the reviewer-only length guard"
 fi

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1216,8 +1216,9 @@ jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \
 # `set -euo pipefail` a non-JSON stdout makes the extraction assignment abort before any
 # assertion in this block runs, which loses the diagnosis entirely — the very failure
 # mode this control exists to surface. The deny envelope carries `"deny"` exactly once
-# and never inside the reason text, so the substring test is as strict as the parse was,
-# and it keeps `rc` free to distinguish a crash from a deny that exits non-zero. The
+# and never inside the reason text, so the substring test is as strict as a
+# `permissionDecision` parse would be, and it keeps `rc` free to distinguish a crash
+# from a deny that exits non-zero. The
 # fixture jq below can still abort the same way, but it builds our own input rather than
 # reading the hook's output, and run-tests.sh reports that abort as a file-level failure.
 jq --arg tp "$SUBAGENT_TRANSCRIPT" '.transcript_path = $tp' "$tc124_dir/mainin.json" > "$tc124_dir/mainctl.json"
@@ -1233,9 +1234,9 @@ case "$output" in
 esac
 rc=0
 output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainin.json" 2>"$STDERR_FILE") || rc=$?
-# Assert the permit contract positively (no output, then rc 0). The old `!= "deny"` form
-# accepted a crash, a timeout, and every output shape the hook was never meant to produce,
-# because all of them left the extracted decision empty.
+# Assert the permit contract positively (no output, then rc 0). A bare `!= "deny"` test
+# cannot express this contract: a crash, a timeout, and every output shape the hook never
+# emits all leave the extracted decision empty, so they would all pass.
 if [ -n "$output" ]; then
   case "$output" in
     *'"deny"'*)

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1204,14 +1204,22 @@ jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \
 # stdout is exactly what the passing case looks like and cannot double as the liveness
 # signal. Prove the fixture reaches the length guard instead: the same input with only
 # transcript_path flipped to the reviewer transcript must be denied. Without that
-# proof, a malformed input JSON or a hook that never ran reads as "correctly permitted".
+# proof, a padding shortfall that drops ro.txt back under the byte ceiling, a corrupted
+# tool_name, or a hook that allows everything early all read as "correctly permitted".
+#
+# Deriving the control from mainin.json is load-bearing, not a duplicate of (b): (b)
+# builds roin.json independently, so a break in the jq that assembles mainin.json leaves
+# (b) green while the assertion below goes vacuous. Only a control fed by the very file
+# that assertion reads can catch it.
 #
 # Both assertions match the raw stdout instead of piping it through jq. Under
-# `set -euo pipefail` a non-JSON stdout makes the extraction assignment abort the whole
-# file before any assertion runs, which loses the diagnosis entirely — the very failure
+# `set -euo pipefail` a non-JSON stdout makes the extraction assignment abort before any
+# assertion in this block runs, which loses the diagnosis entirely — the very failure
 # mode this control exists to surface. The deny envelope carries `"deny"` exactly once
 # and never inside the reason text, so the substring test is as strict as the parse was,
-# and it keeps `rc` free to distinguish a crash from a deny that exits non-zero.
+# and it keeps `rc` free to distinguish a crash from a deny that exits non-zero. The
+# fixture jq below can still abort the same way, but it builds our own input rather than
+# reading the hook's output, and run-tests.sh reports that abort as a file-level failure.
 jq --arg tp "$SUBAGENT_TRANSCRIPT" '.transcript_path = $tp' "$tc124_dir/mainin.json" > "$tc124_dir/mainctl.json"
 rc=0
 output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainctl.json" 2>"$STDERR_FILE") || rc=$?

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1198,13 +1198,36 @@ fi
 # (d) oversized (~80KB) MAIN-session command → must NOT be denied (MUST NOT — reviewer-only guard)
 jq -n --rawfile cmd "$tc124_dir/ro.txt" --arg tp "$MAIN_TRANSCRIPT" \
   '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: "/tmp", transcript_path: $tp}' > "$tc124_dir/mainin.json"
+# Positive control for the negative assertion that follows. The hook prints NOTHING
+# when it permits a command — a deny JSON is the only thing it ever emits, which is
+# why assert_subagent_allow spells allow as "rc 0 AND empty stdout" — so `decision`
+# is legitimately empty in the passing case and cannot double as the liveness signal.
+# Prove the fixture reaches the length guard instead: the same input with only
+# transcript_path flipped to the reviewer transcript must be denied. Without that
+# proof, a malformed input JSON or a hook that never ran reads as "correctly permitted".
+jq --arg tp "$SUBAGENT_TRANSCRIPT" '.transcript_path = $tp' "$tc124_dir/mainin.json" > "$tc124_dir/mainctl.json"
+rc=0
+output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainctl.json" 2>"$STDERR_FILE") || rc=$?
+decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-124 (d) control: the fixture drives the length guard (same input, reviewer transcript → deny)"
+else
+  fail "TC-124 (d) control: expected deny with the reviewer transcript, got decision='$decision' rc=$rc — the fixture is broken and the MUST NOT assertion below would be vacuous"
+fi
 rc=0
 output=$(_timeout 15 bash "$HOOK" < "$tc124_dir/mainin.json" 2>"$STDERR_FILE") || rc=$?
 decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
-if [ "$decision" != "deny" ]; then
-  pass "TC-124 oversized MAIN-session command is not denied by the reviewer-only length guard"
-else
+# Assert the permit contract positively (rc 0 + no output) rather than `!= "deny"`:
+# a crash, a timeout, or any output shape the hook was never meant to produce all
+# leave `decision` empty, and the negation alone accepted every one of them.
+if [ "$rc" != "0" ]; then
+  fail "TC-124 oversized main-session command: hook exited rc=$rc instead of permitting (a crash or timeout empties decision too)"
+elif [ "$decision" = "deny" ]; then
   fail "TC-124 oversized main-session command was wrongly denied (MUST NOT violation)"
+elif [ -n "$output" ]; then
+  fail "TC-124 oversized main-session command: expected no output (permit), got: $output"
+else
+  pass "TC-124 oversized MAIN-session command is not denied by the reviewer-only length guard"
 fi
 rm -rf "$tc124_dir"
 echo ""


### PR DESCRIPTION
## 概要

`pre-tool-bash-guard.test.sh` TC-124 (d) の否定アサーション `[ "$decision" != "deny" ]` は、`// empty` 経由で `decision` が空になる経路すべてを PASS にしていた。hook のクラッシュ・不正 JSON・想定外の出力形式が「main セッションを誤 deny しない」という MUST NOT 契約の充足と区別できず、テストの緑が契約の検証を意味していなかった。CONTRIBUTING.md 規則 8（すべての否定アサーションに positive control を付ける）が想定するパターンそのもの。

positive control を前置し、(d) 本体の判定を肯定形に置き換えた。

## 関連 Issue

Closes #2015

## Changes

- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`: TC-124 (d) に positive control を追加し、判定を `rc=0` かつ空出力の肯定形へ置換（+26/-3）

### Issue 記載の修正案 (a)/(b) を採用しなかった理由

Issue は「`[ -n "$decision" ]` を要求する」(a) と「小さなコマンドで `decision` が非空で返ることを先に assert する」(b) を提示していたが、いずれも hook の実挙動と両立しない。

`pre-tool-bash-guard.sh` はヘッダで契約をこう宣言している。

> Exit behavior: exit 0 — allow (no output); stdout JSON with permissionDecision: "deny" — block.

permit 時は**何も出力しない**（同ファイルの `assert_subagent_allow` が allow を `[ "$rc" = "0" ] && [ -z "$output" ]` と定義しているのが正典）。実測でも main transcript + oversized command、および main transcript + 小さな `git status` の双方が `rc=0` かつ stdout 0 バイトを返した。したがって正常系の `decision` は常に空であり、非空を要求すると受入基準 2（正常系は従来どおり PASS）に反する。`decision` の非空は liveness signal に使えない。

### 採用した形

**positive control**: (d) と同一の入力の `transcript_path` だけを reviewer 側へ差し替え、length guard が deny を返すことを先に assert する。これにより fixture（コマンドファイル・入力 JSON の組み立て・hook 呼び出し）が guard に到達していることを証明する。(b) ケースの `roin.json` とは別ファイルなので、`mainin.json` 自体の健全性は既存ケースでは代替できない。

**本体**: permit 契約を肯定形で assert し、`rc` 非 0（クラッシュ・timeout）/ `deny`（MUST NOT 違反）/ 非空出力（想定外形式）をそれぞれ別の診断メッセージで FAIL させる。

## 検証

同一 fixture・同一入力に対し、hook をスタブへ差し替えて旧判定と新判定を対比した（hook 本体・テストファイルは変更していない）。

| hook の挙動 | 旧判定 | 新判定 |
|---|---|---|
| 本物（正常系） | PASS | control=PASS body=PASS |
| 空出力 rc0 | PASS | **control=FAIL** |
| `not json` | PASS | **control=FAIL body=FAIL** |
| `{"unrelated":1}` | PASS | **control=FAIL body=FAIL** |
| クラッシュ rc1 空出力 | PASS | **control=FAIL body=FAIL** |
| 常に deny（MUST NOT 違反） | FAIL | control=PASS **body=FAIL** |

Issue が報告した vacuous pass 3 パターンはすべて FAIL に落ちる。`rc=0` の空出力は hook の正しい permit 出力と同一形なので、fixture 破損由来かどうかは control が切り分ける。既存の MUST NOT 違反検出力も保持している。

スイート実行: `bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` → **217 passed, 0 failed**。

`shellcheck` はローカル未インストールのため CI の blocking gate に委ねる。

## 実装中に発見した別問題

CONTRIBUTING.md の Hook Conventions が guard hook の exit code を「`0` means allow, non-zero means block」と説明しているが、上記のとおり deny の主経路は `rc=0` + deny JSON で、記述が実装と食い違う。本 PR のスコープ（テストの検証力）外のため #2019 として切り出した。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (217 passed, 0 failed)
- [ ] Documentation updated (該当なし — TC-124 に言及するドキュメントは存在せず、変更はテストファイルのみ)

---
🤖 Generated with [rite workflow](https://github.com/asakaguchi/cc-rite-workflow)
