### PR TITLE
feat(fix): 修正方針ゲートに Simplification-First 原則を追加する

### DIFF
--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -1843,6 +1843,22 @@ rm -f "${TMPDIR:-/tmp}/rite-fix-target-body-{pr_number}-{target_comment_id}.txt"
 
 これらに該当しない修正を採用する場合、Wiki (`/rite:wiki-query`) で project-specific な許容パターンを事前確認すること。本原則は fix.md の手順として常時適用される（config での opt-out は不可）。
 
+### Simplification-First Response Principle（追加より削除を先に検討）
+
+指摘に対する修正方針を決定する前に、以下のチェックリストを必ず通過させること（Fail-Fast Response Principle と同様、config での opt-out は不可）:
+
+- [ ] 機構の**追加**（新しい分岐・ガード・規約・注記・例外条項）ではなく、既存機構の**削除・単純化**（分岐の統合、規則の一般化、複製の一本化）で指摘を解消できないか検討したか
+- [ ] 追加しようとしている分岐 / ガード / 規約は、指摘された 1 ケース専用になっていないか（1 ケース対応の追加は、次 cycle でその追加自体が新たなレビュー対象面となり指摘を再生産する）
+- [ ] 修正 diff は指摘の解消に必要な最小か。指摘されていない「ついで」の防御・柔軟性・将来対応を含んでいないか
+
+本原則の対象は**機構の追加**（分岐・ガード・規約・注記・例外条項）である。テストケースの追加や既存複製の同期更新は対象外（それらは通常それ自体が正しい修正であり、削除で代替しない）。
+
+**Escalation trigger（パッチの重ね掛け停止）**: 対応中の finding が**同一 PR の前 cycle の fix が導入・変更した箇所**への指摘である場合（description が「cycle N で導入した」「前 cycle で追加した」等で当該 fix を名指しする場合を含む）、同じ機構への追加パッチを既定選択にしないこと。まず「当該機構ごと削除・単純化して指摘群を根から消せないか」を検討し、修正案の提示（ステップ 2.3）の前にその判断を chat へ 1 行明示する（例: `simplification-first: 分岐機構を削除し行全体再生成へ単純化` / `simplification-first: 追加パッチを選択 — 理由: {reason}`）。
+
+**追加で修正する場合**、commit message に「なぜ削除・単純化ではなく追加を選んだか」を明示すること（Fail-Fast の fallback 明示義務と同型）。
+
+rationale: references/design-rationale.md#simplification-first-rationale
+
 ### 2.1 Confirm Fix Approach
 
 **Entry routing — scope=nit-noted skip**:

--- a/plugins/rite/skills/fix/references/design-rationale.md
+++ b/plugins/rite/skills/fix/references/design-rationale.md
@@ -116,6 +116,14 @@ caller の `exit 1` 直前に emit が必要になる。
 - **`wc -l` の stderr を独立退避する理由**: `2>/dev/null` だと read permission 拒否 / inode 破損 / ファイル内容破壊などの IO エラーで silent に空文字列 → count=0 に落ちて、policy override の監査トレースが完成報告から silent drop する。
 - **exit 時に confidence_override / pr-comment tempfile を明示的に rm する理由 (defense-in-depth)**: ステップ 1.2 進入時の無条件 truncate (`: >`) に削除を委ねると、何らかの経路で truncate 呼び出しが skip された場合に前セッションの stale データが混入する silent regression が起きる。ステップ 5.1 (E2E) / ステップ 5.2 (Standalone) の終了経路で specific path による明示 rm を行い、次回実行時の混入を決定論的に防ぐ。
 
+## simplification-first-rationale
+
+ステップ 2 冒頭に本原則を置く理由: 多サイクル PR の実測分析（2026-07、PR #2052 / #2066 / #2070 の永続レビュー結果 JSON 9 cycle 分）で、cycle 2 以降の blocking 指摘の約 8 割が「前 cycle の fix が導入した機構への指摘」だった。指摘への修正が規約・分岐・ガードの**追加**で行われると、次 cycle がその追加物を同じ厳密さでレビューして新たな構造欠陥を検出し、ループが収束しない。実例: PR #2052 は +64/-16 の docs 変更に fix 6 cycle・実時間 10 時間超を要し、序盤 cycle が積み上げた分岐機構を「削除して行全体再生成へ単純化する」fix が入った時点で初めて収束へ向かった。
+
+新しいモデル世代（Opus 4.5 以降）には頼まれていない抽象・柔軟性を足す overengineering 傾向が公式に文書化されており（[Claude prompting best practices §Overeagerness](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-4-best-practices)）、追加型 fix はこの傾向と毎 cycle の全力 re-review の相互作用で発散する。
+
+Escalation trigger が「前 cycle fix への指摘」を名指しする理由: 同分析で cycle 3 以降の指摘はほぼ全てこの型であり、パッチ重ね掛けスパイラルの最も確度の高い観測シグナルであるため。Root Cause Gate（ステップ 3.2.1）とは直交する — あちらは commit body に根本原因の**記名**を求め、本原則は修正の**形**（追加 vs 削除・単純化）を問う。
+
 ## impact-scan-rationale
 
 ステップ 2.2.A Pre-Fix Impact Scan が必須である理由: 「指摘箇所だけ直す」では既存 caller / test / 他 file の同名


### PR DESCRIPTION
## 概要

review⇄fix ループが新モデル世代（Opus 4.8 / Opus 5 / Sonnet 5）で極端に収束しにくくなった問題への対策第 1 弾。`/rite:fix` の修正方針決定に **Simplification-First Response Principle（追加より削除・単純化を先に検討）** を事前ゲートとして追加する。

## 背景（実測）

直近の多サイクル PR 3 件（#2052 / #2066 / #2070、`.rite/review-results/` の永続レビュー結果 JSON 9 cycle 分）の集計:

- cycle 2 以降の blocking 指摘 32 件のうち **約 8 割が「前 cycle の fix が導入した機構（分岐・ガード・規約・注記）への指摘」**。初回レビューの見逃しは約 19%、bikeshedding は 3%
- 非収束の主因は指摘の質ではなく、**fix が機構の追加で行われることで次 cycle のレビュー対象面が増え続ける**こと
- 実例: PR #2052 は +64/-16 の docs 変更に fix 6 cycle・実時間 10 時間超を要し、序盤 cycle が積み上げた分岐機構を「削除し行全体再生成へ単純化する」fix が入った時点で初めて収束へ向かった

新モデル世代（Opus 4.5 以降）の overengineering 傾向は公式に文書化されており（[Claude prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-4-best-practices) §Overeagerness）、追加型 fix と毎 cycle の全力 re-review の相互作用で発散する。

## 変更内容

- `plugins/rite/skills/fix/SKILL.md`（+16 行）: Fail-Fast Response Principle 直後に同型の事前ゲートを追加
  - 修正方針決定前のチェックリスト: 削除・単純化の優先検討 / 指摘 1 ケース専用の追加の抑止 / 最小 diff
  - **Escalation trigger（パッチの重ね掛け停止）**: 前 cycle fix への指摘では追加パッチを既定選択にせず、機構ごとの削除・単純化を先に検討。判断を `simplification-first:` 行で chat に明示
  - 追加を選ぶ場合は commit message に理由を明示（Fail-Fast の fallback 明示義務と同型）
  - テストケース追加・既存複製の同期更新は対象外と明記（字義的な誤適用の防止）
- `plugins/rite/skills/fix/references/design-rationale.md`（+8 行）: 設計理由を `#simplification-first-rationale` へ退避（行数原則に従い本体は 1 行ポインタ）

## 検証

- `Fail-Fast Response Principle` を列挙する他ファイルなし（複製同期義務は発生しない）
- fix/SKILL.md は 3,802 行（実行手順書スキルの上限 4,000 行以内）
- bash ブロック追加なし（bash-heaviness / dollar-zero チェック対象外）
- Root Cause Gate（ステップ 3.2.1）とは直交: あちらは commit body への根本原因の記名、本原則は修正の形（追加 vs 削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
