### PR TITLE
fix(hooks): mktemp テンプレートの X を末尾へ移し BSD/macOS で tempfile 名の一意性を回復する

### DIFF
--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -153,7 +153,8 @@ trap '_rite_review_p61b_cleanup; exit 129' HUP
 # ため、`-XXXXXX.md` のように suffix が続く形では X が展開されず literal 名がそのまま使われる。
 # その場合 O_CREAT|O_EXCL は初回だけ成功し、同名ファイルが 1 つでも残っていると以降の全実行が
 # EEXIST で失敗する (上記の trap は SIGKILL では動かないため、残留は起こりうる)。
-# 拡張子は不要 — 本 tempfile は awk の出力先と `gh pr comment --body-file` の引数としてのみ使う。
+# 拡張子は不要 — 本 tempfile は awk の入出力先 (置換の出力先と 2 つの post-condition の入力) と
+# `gh pr comment --body-file` の引数として使うだけで、いずれも拡張子を見ない。
 tmpfile_patched=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-comment-patched-XXXXXX") || {
   echo "ERROR: timestamp 置換用 tmpfile 作成失敗" >&2
   echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=tmpfile_write_failure" >&2

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -152,7 +152,7 @@ trap '_rite_review_p61b_cleanup; exit 129' HUP
 # テンプレートの `X` は**末尾**に置く。BSD/macOS の mktemp(1) は "trailing Xs" しか置換しない
 # ため、`-XXXXXX.md` のように suffix が続く形では X が展開されず literal 名がそのまま使われる。
 # その場合 O_CREAT|O_EXCL は初回だけ成功し、同名ファイルが 1 つでも残っていると以降の全実行が
-# EEXIST で失敗する (下記 trap は SIGKILL では動かないため、残留は起こりうる)。
+# EEXIST で失敗する (上記の trap は SIGKILL では動かないため、残留は起こりうる)。
 # 拡張子は不要 — 本 tempfile は awk の出力先と `gh pr comment --body-file` の引数としてのみ使う。
 tmpfile_patched=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-comment-patched-XXXXXX") || {
   echo "ERROR: timestamp 置換用 tmpfile 作成失敗" >&2

--- a/plugins/rite/hooks/review-comment-post.sh
+++ b/plugins/rite/hooks/review-comment-post.sh
@@ -149,7 +149,12 @@ trap '_rite_review_p61b_cleanup; exit 130' INT
 trap '_rite_review_p61b_cleanup; exit 143' TERM
 trap '_rite_review_p61b_cleanup; exit 129' HUP
 
-tmpfile_patched=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-comment-patched-XXXXXX.md") || {
+# テンプレートの `X` は**末尾**に置く。BSD/macOS の mktemp(1) は "trailing Xs" しか置換しない
+# ため、`-XXXXXX.md` のように suffix が続く形では X が展開されず literal 名がそのまま使われる。
+# その場合 O_CREAT|O_EXCL は初回だけ成功し、同名ファイルが 1 つでも残っていると以降の全実行が
+# EEXIST で失敗する (下記 trap は SIGKILL では動かないため、残留は起こりうる)。
+# 拡張子は不要 — 本 tempfile は awk の出力先と `gh pr comment --body-file` の引数としてのみ使う。
+tmpfile_patched=$(mktemp "${TMPDIR:-/tmp}/rite-review-p61b-comment-patched-XXXXXX") || {
   echo "ERROR: timestamp 置換用 tmpfile 作成失敗" >&2
   echo "[CONTEXT] REVIEW_OUTPUT_FAILED=1; reason=tmpfile_write_failure" >&2
   exit 1

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -433,6 +433,17 @@ echo "=== TC-8b-i: every mktemp template in plugins/rite shell scripts ends in t
 # literal — an interval here would silently stop matching on the very platform this guard
 # protects (no other scan in this suite relies on one). And the Xs are concatenated from a
 # -v variable at run time because spelling them out would make this line match its own scan.
+#
+# Scope limits, stated honestly:
+#   - bash fenced in SKILL.md / references is NOT scanned, same as TC-8b-h. One such site is
+#     live today: skills/fix/SKILL.md builds a `-XXXXXX.md` reply tempfile inside a bash fence
+#     that /rite:fix executes per nit-noted finding. Widening this scan to `.md` would turn the
+#     suite red until that site is fixed, so the two belong in one follow-up change rather than
+#     here. Until then, a green TC-8b-i means "no suffixed template in *.sh", not "the class is
+#     extinct".
+#   - The detector only sees `mktemp` and its template on the SAME line. A template assembled
+#     into a variable first (`tpl="foo-XXXXXX.md"; mktemp "$tpl"`) or split across a line
+#     continuation slips through. No such call exists in the repo today.
 _tc8bi_detect() {
   LC_ALL=C awk -v x=X '!/^[[:space:]]*#/ && /mktemp/ && $0 ~ (x x x "[^X[:space:]\"'"'"'`)]") { print FILENAME ":" NR ": " $0 }' "$1"
 }
@@ -466,7 +477,7 @@ done < <(find "$PLUGIN_ROOT" -name '*.sh' -type f | sort)
 if [ "$_tc8bi_scanned" -eq 0 ]; then
   fail "TC-8b-i: found no *.sh under $PLUGIN_ROOT — the scan matched nothing to check (layout changed?)"
 elif [ "$suffixed_total" = "0" ]; then
-  pass "TC-8b-i: every mktemp template ends in trailing Xs ($_tc8bi_scanned files scanned)"
+  pass "TC-8b-i: every mktemp template in *.sh ends in trailing Xs ($_tc8bi_scanned files scanned; markdown fences not covered)"
 else
   fail "TC-8b-i: $suffixed_total mktemp template(s) put characters after the Xs — BSD mktemp leaves those templates unsubstituted, so the name is not unique:$suffixed_report"
 fi

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -377,7 +377,10 @@ _tc8bh_detect() {
 # detector or an empty file list would report success. Prove the detector fires on a known
 # violation through the SAME function the scan uses, otherwise a rotted pattern would sail through
 # its own control.
-_tc8bh_probe=$(mktemp "${TMPDIR:-/tmp}/rite-tc8bh-probe-XXXXXX.sh")
+# No extension on the template: BSD mktemp(1) substitutes only trailing Xs, so a `-XXXXXX.sh`
+# template would hand back that literal name and collide on a leftover file. The detector below
+# reads the probe as a plain path, so the suffix bought nothing anyway.
+_tc8bh_probe=$(mktemp "${TMPDIR:-/tmp}/rite-tc8bh-probe-XXXXXX")
 printf 'sv=2\necho "v$sv\xe2\x86\x92v3"\n' > "$_tc8bh_probe"
 if [ "$(_tc8bh_detect "$_tc8bh_probe" | wc -l | tr -d '[:space:]')" = "1" ]; then
   pass "TC-8b-h control: the detector reports a known unbraced-\$var violation"
@@ -409,6 +412,66 @@ else
 fi
 unset -f _tc8bh_detect
 unset unbraced_report unbraced_total _sh _hits _found _tc8bh_probe _tc8bh_scanned
+
+echo ""
+echo "=== TC-8b-i: every mktemp template in plugins/rite shell scripts ends in trailing Xs ==="
+#
+# BSD/macOS mktemp(1) substitutes only *trailing* Xs, so a template that carries a suffix
+# (`-XXXXXX.md`) is taken literally: the name never varies, and once one such file survives
+# a SIGKILL the next O_CREAT|O_EXCL fails with EEXIST for every later run on that machine.
+# GNU coreutils substitutes suffixed templates anyway, so the Linux leg cannot observe the
+# regression at runtime — the guard has to be static to protect the macOS leg.
+#
+# The detector pairs `mktemp` with "Xs followed by something that is not a template
+# terminator". Quote / whitespace / backtick / closing-paren after the Xs are the legitimate
+# endings; anything else (`.md`, `.sh`, `.json`) is a suffix. Comment lines are skipped
+# because prose about tempfile names ("...orphan ${TMPDIR:-/tmp}/rite-wiki-stage-XXXXXX.")
+# ends in a full stop and would otherwise read as a violation.
+#
+# Two constraints shape how the pattern is written. It matches three consecutive Xs rather
+# than an `X{3,}` interval because macOS ships BWK awk, whose older builds read `{` as a
+# literal — an interval here would silently stop matching on the very platform this guard
+# protects (no other scan in this suite relies on one). And the Xs are concatenated from a
+# -v variable at run time because spelling them out would make this line match its own scan.
+_tc8bi_detect() {
+  LC_ALL=C awk -v x=X '!/^[[:space:]]*#/ && /mktemp/ && $0 ~ (x x x "[^X[:space:]\"'"'"'`)]") { print FILENAME ":" NR ": " $0 }' "$1"
+}
+
+# Positive control, for the same reason TC-8b-h carries one: a negative assertion reports
+# success when the detector itself is broken. The probe body spells its Xs as octal escapes
+# so the line writing it does not match the very scan it feeds.
+_tc8bi_probe=$(mktemp "${TMPDIR:-/tmp}/rite-tc8bi-probe-XXXXXX")
+printf 'p=$(mktemp "probe-\130\130\130\130\130\130.md")\n' > "$_tc8bi_probe"
+if [ "$(_tc8bi_detect "$_tc8bi_probe" | wc -l | tr -d '[:space:]')" = "1" ]; then
+  pass "TC-8b-i control: the detector reports a known suffixed-template violation"
+else
+  fail "TC-8b-i control: the detector did NOT report a known violation — the scan below is vacuous"
+fi
+rm -f "$_tc8bi_probe"
+
+suffixed_report=""
+suffixed_total=0
+_tc8bi_scanned=0
+while IFS= read -r _sh; do
+  _tc8bi_scanned=$((_tc8bi_scanned + 1))
+  _found=$(_tc8bi_detect "$_sh")
+  if [ -n "$_found" ]; then
+    _hits=$(printf '%s\n' "$_found" | wc -l | tr -d '[:space:]')
+    suffixed_total=$((suffixed_total + _hits))
+    suffixed_report="$suffixed_report
+$_found"
+  fi
+done < <(find "$PLUGIN_ROOT" -name '*.sh' -type f | sort)
+# A discovery that returns nothing is a broken scan, not a clean one.
+if [ "$_tc8bi_scanned" -eq 0 ]; then
+  fail "TC-8b-i: found no *.sh under $PLUGIN_ROOT — the scan matched nothing to check (layout changed?)"
+elif [ "$suffixed_total" = "0" ]; then
+  pass "TC-8b-i: every mktemp template ends in trailing Xs ($_tc8bi_scanned files scanned)"
+else
+  fail "TC-8b-i: $suffixed_total mktemp template(s) put characters after the Xs — BSD mktemp leaves those templates unsubstituted, so the name is not unique:$suffixed_report"
+fi
+unset -f _tc8bi_detect
+unset suffixed_report suffixed_total _sh _hits _found _tc8bi_probe _tc8bi_scanned
 
 # --- TC-9: phase enum validation warns but accepts unknown phase ---
 echo ""

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -441,9 +441,12 @@ echo "=== TC-8b-i: every mktemp template in plugins/rite shell scripts ends in t
 #     suite red until that site is fixed, so the two belong in one follow-up change rather than
 #     here. Until then, a green TC-8b-i means "no suffixed template in *.sh", not "the class is
 #     extinct".
-#   - The detector only sees `mktemp` and its template on the SAME line. A template assembled
-#     into a variable first (`tpl="foo-XXXXXX.md"; mktemp "$tpl"`) or split across a line
-#     continuation slips through. No such call exists in the repo today.
+#   - The detector only sees `mktemp` and its template on the SAME line. A template built on one
+#     line and passed on the next (`tpl=...` then `mktemp "$tpl"`), or split across a line
+#     continuation, slips through. Writing both on one line does NOT slip through — the template
+#     is still on the `mktemp` line, so the scan catches it. No such call exists in the repo today.
+#   - Only leading-`#` comment LINES are exempt, same as TC-8b-h. A trailing comment that quotes a
+#     suffixed template is still reported.
 _tc8bi_detect() {
   LC_ALL=C awk -v x=X '!/^[[:space:]]*#/ && /mktemp/ && $0 ~ (x x x "[^X[:space:]\"'"'"'`)]") { print FILENAME ":" NR ": " $0 }' "$1"
 }


### PR DESCRIPTION
## 概要

BSD/macOS の `mktemp(1)` は trailing Xs しか置換しないため、suffix が続くテンプレート（`-XXXXXX.md` / `-XXXXXX.sh`）では X が展開されず literal 名がそのまま使われる。`O_CREAT|O_EXCL` は初回だけ成功し、SIGKILL や並行実行で同名ファイルが 1 つでも残ると以降が EEXIST で失敗し続ける。`review-result-save.sh` の同型 2 箇所を直した際の全域スキャンで検出した残り 2 箇所を解消し、再混入を静的チェックで塞ぐ。

## 関連 Issue

Closes #2079

## 変更内容

- `plugins/rite/hooks/review-comment-post.sh` — 変更: mktemp テンプレートから `.md` suffix を除去。この tempfile は awk の出力先と `gh pr comment --body-file` の引数としてのみ使われ、拡張子に依存する読み手は存在しない（呼び出し箇所を実測確認）
- `plugins/rite/hooks/tests/flow-state.test.sh` — 変更: probe テンプレートから `.sh` suffix を除去。あわせて再混入防止の TC-8b-i を追加（`plugins/rite` 配下の全 `*.sh` を find で走査し、非コメント行の mktemp テンプレートが trailing X で終わることを pin。TC-8b-h と同型の positive control probe + 空スキャン検出つき）

## 実装中の判断・計画逸脱

- 判断: 静的チェックは既存 scanner の `tmp-hardcode-check.sh` ではなく `flow-state.test.sh` の TC に置いた — 前者は `*/tests/*` を除外するため、本 Issue の対象である `flow-state.test.sh` 自身を構造的に守れない。Issue 4.4 の「既存 scanner 形式に揃える」SHOULD より実効カバレッジを優先した
- 判断: Issue の T-02（同名 tempfile を先置きしての実挙動テスト）は静的 pin に統合した — GNU coreutils は suffix 付きテンプレートでも X を置換するため、Linux leg では修正前でもテストが通ってしまい退行検知にならない
- 逸脱: 検出器の正規表現を当初案の `X{3,}` interval から X の 3 連結へ変更した — macOS が同梱する BWK awk の旧ビルドは `{` をリテラルとして読むため、interval を使うとこの guard が守るべき当のプラットフォームで無言のまま機能しなくなる。既存の TC-8b-h も interval を使っていない

## 検証

| 検証 | 結果 |
|------|------|
| `flow-state.test.sh` | 166 PASS / 0 FAIL（TC-8b-i: positive control 1 件検出 + 212 ファイル走査で違反 0） |
| `hooks/tests/run-tests.sh`（CI と同一） | 111/111 passed, 0 failed |
| `scripts/tests/run-all.sh`（CI と同一） | 142 passed, 0 failed |
| 検出器の等価性 | 修正前ファイル（`origin/develop` 版）に対し新パターンが違反を正しく検出することを実測 |

## 未完了の Issue チェック項目

以下のチェック項目が Issue 本文で未完了です:

- [ ] All Acceptance Criteria (AC-xx) verified

AC-1 / AC-2 / AC-3 はローカル検証済み。AC-4（`tests (macos-latest)` と `tests (ubuntu-latest)` が両方 green）は本 PR の CI 実行でのみ確認できるため未チェックのまま残しています。

## チェックリスト

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [ ] Documentation updated (if applicable) — ユーザー可視の識別子変更がないためドキュメント更新なし（影響調査は実施済み、該当 0 件）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
