### PR TITLE
docs(templates): Issue テンプレート Section 9 に Decision Log の受け入れ基準を明文化する

### DIFF
--- a/plugins/rite/templates/issue/template-structure.md
+++ b/plugins/rite/templates/issue/template-structure.md
@@ -291,16 +291,16 @@ Select ONE matching the Issue type. The type confirmed in `create.md` ステッ�
 ```markdown
 ## 9. Decision Log
 
-<!-- Record decisions only. A decision not to act (out of scope, deferred, rejected) belongs here; the undone work itself does not -->
-<!-- NOT here — each has its own medium: an open work item (work memory's plan-deviation log), a planned test (a T-xx row in Section 6), a fix rationale (the commit body) -->
+<!-- Record decisions only. A decision not to act (out of scope, deferred, rejected) belongs here, and so does the work item it declines; work you have taken on and not yet finished does not -->
+<!-- NOT here — each has its own medium: an open work item you have taken on (work memory's plan-deviation log), a planned test (a T-xx row in Section 6), a fix rationale, a review response included (the commit body) -->
 - YYYY-MM-DD D-01: {decision} / Reason: {reason} / Impact: {AC_or_Test_ID}
 ```
 
 **Rules**:
-- Record only decisions the code and tests cannot state: a scope boundary, a rejected alternative, a compatibility decision Section 3.3 does not already carry, a knowingly accepted exception
-- A decision *not* to act — "out of scope for this PR", "deferred", "rejected" — is itself a scope boundary and belongs here. The undone work does not
-- Do not record the work itself, or its count grows with the number of review cycles until the real decisions are buried. Each kind has its own medium, so route rather than drop:
-  - an open work item → the work memory's plan-deviation log (deviation type `追加`)
+- Record only decisions the code and tests cannot state: a scope boundary, a rejected alternative, a compatibility decision Section 3.3 (Refactor Issues) does not already carry, a knowingly accepted exception
+- A decision *not* to act — "out of scope for this PR", "deferred", "rejected" — is itself a scope boundary and belongs here, and so does the work item it declines. What does not belong is work you have taken on and not yet finished
+- Do not record that work here, or its count grows with the number of review cycles until the real decisions are buried. Each kind has its own medium, so route rather than drop:
+  - an open work item you have taken on → the work memory's plan-deviation log (deviation type `追加`)
   - a planned test → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface)
   - a fix rationale, a review response included → the commit body (`skills/fix/SKILL.md` ステップ 3.2 requires the chosen 対応方針 there, ステップ 3.2.1 the root cause)
 - This extends `knowledge_routing` (`skills/rite-workflow/references/coding-principles.md`) from code artifacts to this Issue section: each kind of knowledge is recorded once, in the medium where it survives

--- a/plugins/rite/templates/issue/template-structure.md
+++ b/plugins/rite/templates/issue/template-structure.md
@@ -291,15 +291,19 @@ Select ONE matching the Issue type. The type confirmed in `create.md` ステッ�
 ```markdown
 ## 9. Decision Log
 
-<!-- Record only choices the code and tests cannot state: scope boundary, rejected alternative, compatibility policy, knowingly accepted exception -->
-<!-- NOT here — each of these has its own medium: work item (work memory's plan-deviation log), planned test (a T-xx row in Section 6), fix rationale (the commit body) -->
+<!-- Record decisions only. A decision not to act (out of scope, deferred, rejected) belongs here; the undone work itself does not -->
+<!-- NOT here — each has its own medium: an open work item (work memory's plan-deviation log), a planned test (a T-xx row in Section 6), a fix rationale (the commit body) -->
 - YYYY-MM-DD D-01: {decision} / Reason: {reason} / Impact: {AC_or_Test_ID}
 ```
 
 **Rules**:
-- Record only what the code and tests cannot state: scope boundaries, rejected alternatives, compatibility policy, knowingly accepted exceptions
-- Do NOT record work items, planned tests, or fix rationale here — they are not decisions, and their count grows with the number of review cycles until the real decisions are buried. Each has its own medium, so route rather than drop: a work item found during implementation → the work memory's plan-deviation log (deviation type `追加`); a test need → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface); the reason behind a fix, a review response included → the commit body (`skills/fix/SKILL.md` ステップ 3.2.1 Root Cause Gate already requires it there)
-- This applies `knowledge_routing` (`skills/rite-workflow/references/coding-principles.md`) to this section: each kind of knowledge is recorded once, in the medium where it survives
+- Record only decisions the code and tests cannot state: a scope boundary, a rejected alternative, a compatibility decision Section 3.3 does not already carry, a knowingly accepted exception
+- A decision *not* to act — "out of scope for this PR", "deferred", "rejected" — is itself a scope boundary and belongs here. The undone work does not
+- Do not record the work itself, or its count grows with the number of review cycles until the real decisions are buried. Each kind has its own medium, so route rather than drop:
+  - an open work item → the work memory's plan-deviation log (deviation type `追加`)
+  - a planned test → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface)
+  - a fix rationale, a review response included → the commit body (`skills/fix/SKILL.md` ステップ 3.2 requires the chosen 対応方針 there, ステップ 3.2.1 the root cause)
+- This extends `knowledge_routing` (`skills/rite-workflow/references/coding-principles.md`) from code artifacts to this Issue section: each kind of knowledge is recorded once, in the medium where it survives
 
 ---
 

--- a/plugins/rite/templates/issue/template-structure.md
+++ b/plugins/rite/templates/issue/template-structure.md
@@ -292,14 +292,13 @@ Select ONE matching the Issue type. The type confirmed in `create.md` ステッ�
 ## 9. Decision Log
 
 <!-- Record only choices the code and tests cannot state: scope boundary, rejected alternative, compatibility policy, knowingly accepted exception -->
-<!-- NOT here: work items, planned tests (append a T-xx row to Section 6 instead), fix rationale (commit body instead) -->
+<!-- NOT here — each of these has its own medium: work item (work memory's plan-deviation log), planned test (a T-xx row in Section 6), fix rationale (the commit body) -->
 - YYYY-MM-DD D-01: {decision} / Reason: {reason} / Impact: {AC_or_Test_ID}
 ```
 
 **Rules**:
 - Record only what the code and tests cannot state: scope boundaries, rejected alternatives, compatibility policy, knowingly accepted exceptions
-- Do NOT record work items, planned tests, or review-response notes — they are not decisions, and their count grows with the number of review cycles until the real decisions are buried
-- Route them instead of dropping them: a test need found during implementation → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface); the reason behind a fix → the commit body (`skills/fix/SKILL.md` ステップ 3.2.1 Root Cause Gate already requires it there)
+- Do NOT record work items, planned tests, or fix rationale here — they are not decisions, and their count grows with the number of review cycles until the real decisions are buried. Each has its own medium, so route rather than drop: a work item found during implementation → the work memory's plan-deviation log (deviation type `追加`); a test need → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface); the reason behind a fix, a review response included → the commit body (`skills/fix/SKILL.md` ステップ 3.2.1 Root Cause Gate already requires it there)
 - This applies `knowledge_routing` (`skills/rite-workflow/references/coding-principles.md`) to this section: each kind of knowledge is recorded once, in the medium where it survives
 
 ---

--- a/plugins/rite/templates/issue/template-structure.md
+++ b/plugins/rite/templates/issue/template-structure.md
@@ -291,9 +291,16 @@ Select ONE matching the Issue type. The type confirmed in `create.md` ステッ�
 ```markdown
 ## 9. Decision Log
 
-<!-- Record decisions made during implementation that affect the spec -->
+<!-- Record only choices the code and tests cannot state: scope boundary, rejected alternative, compatibility policy, knowingly accepted exception -->
+<!-- NOT here: work items, planned tests (append a T-xx row to Section 6 instead), fix rationale (commit body instead) -->
 - YYYY-MM-DD D-01: {decision} / Reason: {reason} / Impact: {AC_or_Test_ID}
 ```
+
+**Rules**:
+- Record only what the code and tests cannot state: scope boundaries, rejected alternatives, compatibility policy, knowingly accepted exceptions
+- Do NOT record work items, planned tests, or review-response notes — they are not decisions, and their count grows with the number of review cycles until the real decisions are buried
+- Route them instead of dropping them: a test need found during implementation → a new `T-xx` row in Section 6 (its Canon TDD test list is appended to as behaviors surface); the reason behind a fix → the commit body (`skills/fix/SKILL.md` ステップ 3.2.1 Root Cause Gate already requires it there)
+- This applies `knowledge_routing` (`skills/rite-workflow/references/coding-principles.md`) to this section: each kind of knowledge is recorded once, in the medium where it survives
 
 ---
 


### PR DESCRIPTION
## 概要

Issue テンプレートの Section 9 Decision Log に「何を載せ、何を載せないか」の受け入れ基準を明文化し、設計判断ではない作業ジャーナルの流入を生成則の側で止める。

Decision Log は従来「実装中の判断を記録する」としか規定していなかったため、記録を義務付ける複数レイヤー（仮定表明・計画逸脱ログ・Root Cause Gate）に忠実なモデルが、作業項目やテスト追加予定・レビュー対応の記録まで Section 9 へ流し込んでいた。実測では Issue #2069 の Decision Log が 28 件に肥大し、うち約 21 件は 14 レビューサイクル中に追加された作業ジャーナルで、本物の設計判断 7 件がその中に埋もれていた。

新しいゲートや lint は追加せず、`knowledge_routing` 原則（各知識はその耐久メディアへ 1 回だけ記録する）の適用先を Section 9 に 1 箇所書き足すだけで塞ぐ。

## Related Issue

Closes #2083

## Changes

- `plugins/rite/templates/issue/template-structure.md` — Section 9 Decision Log を更新（+8/-1 行）
  - テンプレート内 HTML コメントを受け入れ基準の要約 2 行に差し替え
  - コードブロック直後に `**Rules**:` を追加し、載せるもの（スコープ境界・不採用案・互換方針・例外の許容）／載せないもの（作業項目・テスト追加予定・レビュー対応記録）と、載せないものの行き先（Section 6 の T-xx 行 / commit body）を明記

HTML コメント側にも基準を入れているのは、fix ループが Section 9 へ追記する時点で読むのは**生成済み Issue body** であり、本テンプレートファイルではないため。テンプレート側の `**Rules**:` だけでは追記時点に届かない。

エントリ形式（`YYYY-MM-DD D-NN: {decision} / Reason: ... / Impact: ...`）・見出し・`default.md` の Complexity Gate 配分はいずれも変更していない（AC-2）。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable) — 本リポジトリは `commands.test` 未設定。プラグイン固有チェック 17 件を実行し、変更ファイル起因の finding 0 件を確認
- [x] Documentation updated (if applicable) — 本 PR 自体がドキュメント変更。Section 9 に言及する既存箇所（`pr-review` 7.4.3 のスコープ外指摘記録・`pr-create` の PR body 要約・`default.md` の Section Details）を確認し、新基準と矛盾しないことを検証済み

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
