### PR TITLE
fix(tests): TC-036a の floor 条件を Linux 判定から blocking gate 判定へ是正する

### DIFF
--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -732,7 +732,8 @@ trap '_rite_issue518_cleanup; cleanup' EXIT
 # NOTE: content-file の /tmp/rite-* literal は被テスト hook の path-containment allowlist
 # ($PWD/* | /tmp/rite-* | /private/tmp/rite-*) に一致させる load-bearing fixture であり、
 # ${TMPDIR:-/tmp} 化してはならない (TMPDIR≠/tmp の環境で hook が正しく拒否し偽 FAIL する)。
-# /tmp 直下が書込不可な sandbox 環境では本 TC は検証不能のため明示 skip する。
+# /tmp 直下が書込不可な環境では本 TC は検証不能。CI (blocking gate) では floor として
+# fail し、それ以外の環境では明示 skip する。
 echo "TC-036a: Content-file in /tmp/rite-* prefix → exit 0 (regression)"
 if _probe36a=$(mktemp /tmp/rite-probe-XXXXXX 2>/dev/null); then
   rm -f "$_probe36a"
@@ -758,15 +759,21 @@ EOF
   else
     fail "Expected rc=0 for /tmp/rite-* prefix, got rc=$rc, stderr=$(cat "$dir36a/err.log")"
   fi
-elif [ -d /proc ]; then
-  # Floor: writability of /tmp is a capability probe, not a platform fact. On the
-  # blocking gate a non-writable /tmp means the environment was constrained, not
-  # that the platform cannot do this — skipping there would drop the only coverage
-  # of the hook's /tmp/rite-* allowlist arm while the run stays green.
-  # `[ -d /proc ]` rather than `uname -s`, which resolves through the same PATH.
-  fail "TC-036a floor: /tmp is not writable on Linux (constrained sandbox?) — the /tmp/rite-* prefix acceptance must never be skipped on the blocking gate"
+elif [ -n "${CI:-}" ] && [ -d /proc ]; then
+  # Floor: writability of /tmp is a capability probe, not a platform fact, so the
+  # gate has to name the environment where that capability is actually guaranteed
+  # — the Linux CI leg, which ci.yml designates the blocking gate (macOS runs
+  # informational). "Any Linux" is too wide a stand-in: a developer machine whose
+  # sandbox mounts /tmp read-only is Linux too, and a permanent red there is noise
+  # that masks real regressions rather than signal. On the blocking gate a
+  # non-writable /tmp does mean the environment was constrained, not that the
+  # platform cannot do this — skipping there would drop the only coverage of the
+  # hook's /tmp/rite-* allowlist arm while the run stays green. `$CI` is what
+  # GitHub Actions sets; `[ -d /proc ]` rather than `uname -s`, which resolves
+  # through the same PATH.
+  fail "TC-036a floor: /tmp is not writable on the Linux blocking gate (CI) — the /tmp/rite-* prefix acceptance must never be skipped there"
 else
-  skip "TC-036a — /tmp 直下が書込不可 (sandbox 環境) のため /tmp/rite-* prefix 受容を検証できません"
+  skip "TC-036a — /tmp 直下が書込不可 (sandbox 環境等) のため /tmp/rite-* prefix 受容を検証できません (CI では floor として fail する)"
 fi
 echo ""
 


### PR DESCRIPTION
## 概要

`wiki-ingest-trigger.test.sh` の TC-036a が、sandbox 有効な開発機で常に失敗していた問題を解消する。floor（skip を禁じて fail させるガード）の発火条件が「Linux か」になっていたため、`/tmp` を読み込み専用でマウントする sandbox 下の Linux 開発機も blocking gate 扱いされていた。

根本原因は判定の代理指標のズレにある。コメント自身が `writability of /tmp is a capability probe, not a platform fact` と述べているにもかかわらず、判定はプラットフォーム事実の代理（`[ -d /proc ]`）だった。この capability が実際に保証されるのは ci.yml が blocking gate と定める Linux CI leg であって「Linux 一般」ではない。

## 関連 Issue

Closes #2064

## 変更内容

- `plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh` — TC-036a の floor 条件を `[ -d /proc ]` から `[ -n "${CI:-}" ] && [ -d /proc ]` へ是正。あわせて floor / skip メッセージと rationale コメントを実態（blocking gate = Linux CI leg）に合わせて更新

契約は空洞化させていない。CI 環境（GitHub Actions が `CI=true` を設定）で `/tmp` が書けない場合は従来どおり fail するため、`/tmp/rite-*` allowlist arm のカバレッジ落ちを緑のまま見逃す経路は生じない。ローカルの skip も `run-tests.sh` が gated group として集計・表示するため silent にはならない。

`${TMPDIR:-/tmp}` へ寄せる案は採らなかった。既存コメントが示すとおり `/tmp/rite-*` リテラルは被テスト hook の path-containment allowlist に一致させる load-bearing fixture であり、TMPDIR 化すると TC-036c（`$TMPDIR/rite-*` arm）と重複して `/tmp/rite-*` arm のカバレッジ自体が消える。

## 検証

| 環境 | 結果 |
|------|------|
| ローカル（sandbox・`CI` 未設定） | `wiki-ingest-trigger.test.sh`: 58 passed, 0 failed, 1 skipped |
| `CI=true` 擬似実行 | TC-036a floor が fail（契約が生きていることを確認） |
| スイート全体（ローカル） | `run-tests.sh`: 111/111 passed, 0 failed, 1 gated group skipped |

変更前のスイート全体は 110/111（TC-036a のみ恒常的に赤）だった。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable) — test-only change のためドキュメント影響なし

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
