### PR TITLE
fix(wiki-query): 診断文言の em-dash を ASCII 化し macOS CI の不正 UTF-8 破壊を止める

### DIFF
--- a/plugins/rite/hooks/wiki-query-inject.sh
+++ b/plugins/rite/hooks/wiki-query-inject.sh
@@ -582,7 +582,7 @@ while IFS=$'\x1f' read -r title path description; do
     # `path` comes from index.md too, so it goes through the same neutralizer as
     # the drop samples above (this site became reachable for 360 candidates once
     # table rows started producing candidates).
-    printf 'WARNING: cannot read frontmatter of %s — skipping candidate (index.md may be stale)\n' "$path" \
+    printf 'WARNING: cannot read frontmatter of %s - skipping candidate (index.md may be stale)\n' "$path" \
       | neutralize_ctrl --keep-newline >&2
     continue
   fi


### PR DESCRIPTION
## 概要

develop の `tests (macos-latest)` を赤にしている 1 文字バグの hotfix。`wiki-query-inject.sh` の frontmatter 読取失敗 WARNING に含まれる em-dash（U+2014）を ASCII ハイフンへ変更する。

## 根本原因（実測済み）

1. WARNING 文言の em-dash（UTF-8: `e2 80 94`）が `neutralize_ctrl --keep-newline` を通ると、C1 範囲（0x80-0x9f）のバイト単位置換で**継続バイト 2 つだけが `?` に潰され、`e2 3f 3f` という不正 UTF-8 列**が stderr に出る（od で実測）
2. GNU ツールチェーン（ubuntu）はバイト単位処理のため `wiki-query-inject.test.sh` TC-3 の grep が通るが、**macOS の BSD ツールは UTF-8 ロケールで不正バイト列に `sed: RE error: illegal byte sequence` / マッチ不能**を起こし TC-3 が fail
3. この経路は PR #2097（テーブル対応）で候補処理が実運用到達可能になったことで露出した。落とし主は #2099 ではなく #2097 世代のテスト × 既存 helper の組合せ

## 修正

neutralize を通る**固定文言**からマルチバイトを除く最小修正（1 文字）。`--c0-only` への切替は 0x0a（改行）も潰して行構造を壊すため採らない。

## 検証

- `wiki-query-inject.test.sh` **17/17 green**（ローカル、修正前は TC-3 相当が CI で fail）
- 置換後の WARNING 出力が全 ASCII であることを od で実測（`e2` バイト残骸なし)

## 残課題（本 PR ではやらない）

「マルチバイトを含む文字列 × `neutralize_ctrl` default/--keep-newline = 不正 UTF-8 生成」の構造は残る（docstring 自認済みの設計）。path 等の動的値に非 ASCII が入ると同型が再発しうるため、必要になったら「C0+DEL のみ潰し改行を保持する」モードの追加を別 Issue で検討（no_speculative_structure に従い実需発生まで保留）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
