### PR TITLE
docs(spec): Plugin Structure 節の reference 列挙の記載漏れ 2 件を補う

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -158,7 +158,7 @@ rite-workflow/
 │ ├── batch-run/ # /rite:batch-run (複数 Issue 順次 open→iterate; --merge で ready→merge→cleanup まで)
 │ ├── pr-create/ # /rite:pr-create (draft PR 作成) — sub-skill
 │ # --- Issue 管理 ---
-│ ├── issue-create/ # /rite:issue-create (+ references/: complexity-gate / contract-section-mapping / slug-generation / body-fact-check)
+│ ├── issue-create/ # /rite:issue-create (+ references/: complexity-gate / contract-section-mapping / slug-generation / body-fact-check / unknowns-boundary-rationale)
 │ ├── issue-list/ # /rite:issue-list
 │ ├── issue-update/ # /rite:issue-update
 │ ├── issue-close/ # /rite:issue-close
@@ -168,7 +168,7 @@ rite-workflow/
 │ ├── wiki-init/ # /rite:wiki-init
 │ ├── wiki-query/ # /rite:wiki-query
 │ ├── wiki-ingest/ # /rite:wiki-ingest (+ references/wiki-troubleshooting.md)
-│ ├── wiki-lint/ # /rite:wiki-lint (+ references/: broken-ref-resolution / bash-cross-boundary-state-transfer)
+│ ├── wiki-lint/ # /rite:wiki-lint (+ references/: broken-ref-resolution / bash-cross-boundary-state-transfer / descriptive-refs-rationale)
 │ # --- meta / top-level ---
 │ ├── setup/ # /rite:setup (+ --upgrade)
 │ ├── getting-started/ # /rite:getting-started


### PR DESCRIPTION
## 概要

CLAUDE.md は「ディレクトリ・ファイルの完全な一覧は `docs/SPEC.md` の Plugin Structure 節を参照」と宣言しているが、列挙形式（`references/: a / b / c`）を使う **2 行の双方**に記載漏れがあった。SPEC.md を信頼して構造を把握しようとした読者が現用 reference を見落とす。

## 関連 Issue

Closes #2055

## 変更内容

| 行 | スキル | 追加した reference | 検出経緯 |
|---|---|---|---|
| `docs/SPEC.md:161` | `issue-create` | `unknowns-boundary-rationale` | Issue の主対象 |
| `docs/SPEC.md:171` | `wiki-lint` | `descriptive-refs-rationale` | **本 PR の横断確認で発見** |

いずれも `SKILL.md` から参照されている現用 reference（`issue-create` はステップ 1.3.1 / 4.0、`wiki-lint` はステップ 7.5）で、意図的な除外ではなく追記漏れ。

## 横断確認の結果

Issue が求めた「他スキルの reference 列挙にも同種の漏れがないか横断確認する」を実施した。

- **列挙形式（`references/: a / b / c`）を使う行は SPEC.md 内にこの 2 行のみ**。双方に漏れがあり、本 PR で補正済み。修正後は両スキルとも実在ファイル集合と列挙が完全一致（漏れ・余分ともゼロ）
- **単一ファイル形式（`+ references/xxx.md`）の 4 行**（`cleanup` / `unknowns` / `lint` / `wiki-ingest`）はすべて実在ファイルを指しており漏れなし
- **列挙を持たないスキル**（`pr-review` / `fix` / `rite-workflow` / `reviewers`）は `+ references/` とだけ書く意図的な形式で、記載漏れではない

## 検証

- 修正後、`issue-create` / `wiki-lint` の実在ファイル集合と SPEC.md の列挙が完全一致（`comm` で漏れ・余分ともゼロを確認）
- `orphan-reference-check` で両 reference とも参照ありを確認
- `bang-backtick-check` PASS
- `bash plugins/rite/hooks/tests/run-tests.sh` — 112/112 passed
- `bash plugins/rite/scripts/tests/run-all.sh` — 142/142 passed

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
