### PR TITLE
refactor(wiki-ingest): ステップ 6 の index 操作をテスト付き helper へ降ろす

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -206,6 +206,7 @@ rite-workflow/
 │ │ ├── wiki-lint-source-refs.sh # skills/wiki-lint/SKILL.md 6.2 委譲
 │ │ ├── wiki-lint-stale.sh / wiki-lint-orphans.sh / wiki-lint-broken-refs.sh # skills/wiki-lint/SKILL.md 4/5/7 委譲
 │ │ ├── wiki-lint-descriptive-refs.sh # skills/wiki-lint/SKILL.md 7.5 委譲
+│ │ ├── wiki-index-update.sh # skills/wiki-ingest/SKILL.md ステップ 6 委譲 (index.md 登録行 + 統計同期)
 │ │ ├── wiki-growth-check.sh # lint layer-3
 │ │ ├── wiki-ingest-lock.sh # /rite:wiki-ingest のセッション間直列化ロック
 │ │ ├── backlink-format-check.sh / bang-backtick-check.sh
@@ -1323,6 +1324,7 @@ Non-hook helper scripts invoked either directly from orchestrator skills or by o
 | `wiki-lint-orphans.sh` | `/rite:wiki-lint` ステップ 5 — index.md 登録ページと pages_list の集合差分を marker block + `orphan_check_ok` enum で構築 (index.md 読出内包) | — |
 | `wiki-lint-broken-refs.sh` | `/rite:wiki-lint` ステップ 7 — Markdown link の page-dir 起点 `realpath -m -s` 解決で壊れた相互参照集合を構築 (awk indent 不問 fence tracking) | — |
 | `wiki-lint-descriptive-refs.sh` | `/rite:wiki-lint` ステップ 7.5 — ページ本文と `index.md` のエントリサマリーに残った説明的 Issue/PR 番号参照 (裸の `PR #N` / `Issue #N` を含む) を検出し marker block + `WIKI_DESCRIPTIVE_REFS` 合計 + `descriptive_refs_read_ok` enum で構築。`index.md` は helper が自力で読み出す (stdin 不要、エントリごとのサマリーのみ — テーブル / OKF 箇条書きを行単位で判別)。frontmatter の `sources:` ブロック / `## ソース` 節 / コードフェンス / コードスパン / TODO・FIXME を除外し、`index.md` に限り行頭 `<!--` の HTML コメントブロックも落とす（箇条書きテンプレートが配布されていた期間に初期化された bundle の index.md 前文に残る記法例、および手書き index のコメントを実エントリと数えないため）。サマリーを抽出できなかった行数（列位置不明 / 列数不一致）は `descriptive_refs_skipped_rows` で surface し、**`index.md` の HTML コメントブロック / コードフェンス**が未閉鎖のまま EOF に達した場合は検出失敗として `descriptive_refs_read_errors` に載せる（frontmatter の `sources:` ブロックと `## ソース` 節、およびページ本文側は検査対象外）。`log.md` / `raw/**` / `SCHEMA.md` は意図的に走査しない (informational 指標、`n_warnings` 不加算) | — |
+| `wiki-index-update.sh` | `/rite:wiki-ingest` ステップ 6 — index.md `## ページ一覧` テーブルの登録行 追加/更新・重複行回収・`## 統計` 3 行同期の決定論的実装 (旧散文手順の 1:1 移植)。同定述語・エスケープ規約・中止条項は helper docstring が SoT。`row_action` / `dedup_removed` / `stats_sync` marker + atomic 書込 (tmp→mv 1 回)、fail-loud (exit 1/2) | — |
 | `bang-backtick-edit-hook.sh` | `bang-backtick-check.sh` の PostToolUse(Edit\|Write\|MultiEdit) wrapper — `hooks.json` 登録済 (`tool_input.file_path` でスコープを絞る) | — |
 | `bash-heaviness-check.sh` | `skills/**/*.md` 内の heavy operational bash block を non-blocking warning で検出 | — |
 | `hardcoded-line-number-check.sh` | procedural markdown (`skills/**/*.md`) 内のハードコード行番号参照を検出 | — |

--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -33,6 +33,7 @@
 #   head -3 "$file" | neutralize_ctrl --keep-newline        # \n は保持 (行構造を保つ snippet 用)
 #   printf '%s' "$value" | neutralize_ctrl --c0-only        # C0+DEL のみ (UTF-8 本文を保持する JSON 用)
 #   contains_ctrl "$value" && reject                        # 検出 (reject) 用 — 範囲は default と同一
+#   contains_ctrl "$value" --c0-only && reject              # 検出 (reject) 用 — 範囲は --c0-only と同一
 #
 # Contract:
 #   - stdin → stdout byte filter; LC_ALL=C tr なので NUL を含む任意バイト列を扱える
@@ -66,26 +67,32 @@ neutralize_ctrl() {
 # validation. Sharing the byte-range definition here keeps detection and
 # replacement symmetric.
 #
-# Usage: contains_ctrl "$value"   # rc 0 = C0/DEL/C1 byte present, rc 1 = clean
+# Usage: contains_ctrl "$value"              # rc 0 = C0/DEL/C1 byte present, rc 1 = clean
+#        contains_ctrl "$value" --c0-only    # rc 0 = C0/DEL byte present (0x80 以上は素通し)
 #
 # Contract:
 #   - argument-based, not a stdin filter: every call site tests a bash
 #     variable, and bash variables cannot carry NUL — so 0x00 is structurally
 #     unreachable here (the stdin-filter neutralize_ctrl still covers it)
-#   - byte-wise under LC_ALL=C: UTF-8 continuation bytes overlapping 0x80-0x9f
-#     (e.g. most Japanese characters) are detected as control bytes — accepted
-#     設計判断: all call sites are ASCII-identifier / ASCII-title
-#     fields. 日本語 TITLE が必要になったら UTF-8 セーフモードを別途追加する
-#   - implementation reuses the exact neutralize_ctrl default tr range and
-#     compares byte counts before/after deletion. grep は使わない — grep 実装に
-#     よっては (例: ugrep) LC_ALL=C でも raw 8-bit バイトを UTF-8 として扱い
-#     リテラル 0x9b にすらマッチしないため、検出が環境依存で silent に壊れる
+#   - byte-wise under LC_ALL=C: in the default range, UTF-8 continuation bytes
+#     overlapping 0x80-0x9f (e.g. most Japanese characters) are detected as
+#     control bytes — accepted 設計判断 for the ASCII-identifier / ASCII-title
+#     call sites. **UTF-8 本文 (日本語 TITLE 等) を検査する call site は
+#     `--c0-only` を使う**: 範囲は neutralize_ctrl --c0-only と同一 (C0 + DEL)
+#     で、行構造を壊す制御バイトだけを拒否しつつ多バイト文字を通す。raw 8-bit
+#     単独の C1 が素通しになる点は neutralize_ctrl --c0-only と同じ非対称
+#   - implementation reuses the exact neutralize_ctrl tr range of the selected
+#     mode and compares byte counts before/after deletion. grep は使わない —
+#     grep 実装によっては (例: ugrep) LC_ALL=C でも raw 8-bit バイトを UTF-8
+#     として扱いリテラル 0x9b にすらマッチしないため、検出が環境依存で silent
+#     に壊れる
 #   - fail-closed: pipeline failure / non-numeric wc output counts as
 #     "detected" so the reject path cannot silently degrade into pass-through
 contains_ctrl() {
-  local _in_bytes _stripped_bytes
+  local _in_bytes _stripped_bytes _range='\000-\037\177\200-\237'
+  [ "${2:-}" = "--c0-only" ] && _range='\000-\037\177'
   _in_bytes=$(printf '%s' "$1" | LC_ALL=C wc -c) || _in_bytes=""
-  _stripped_bytes=$(printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\177\200-\237' | LC_ALL=C wc -c) || _stripped_bytes=""
+  _stripped_bytes=$(printf '%s' "$1" | LC_ALL=C tr -d "$_range" | LC_ALL=C wc -c) || _stripped_bytes=""
   # BSD wc は数値を空白パディングするため除去してから数値検証する
   _in_bytes=${_in_bytes//[[:space:]]/}
   _stripped_bytes=${_stripped_bytes//[[:space:]]/}

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -378,6 +378,21 @@ LC_ALL=C awk '
     sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s)
     return s
   }
+  # C0 + DEL を `?` へ潰す診断用サニタイズ。破損 index の行内容をそのまま stderr へ
+  # 出すと生の制御バイト (ESC / CSI) が端末・transcript へ素通しする — SKILL.md
+  # ステップ 6 の exit 1 行は「ERROR をそのまま表示」を指示するため、corrupt-input
+  # 診断こそ中和対象。範囲は contains_ctrl --c0-only (control-char-neutralize.sh) と
+  # 同一で、awk から shell helper を呼べないための範囲ミラー。C1 まで潰す default
+  # 範囲を使わないのは、行内の日本語サマリーが `?` 列に潰れて診断価値を失うため。
+  function sanitize_diag(s,   out, i, c) {
+    out = ""
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (c < " " || c == "\177") out = out "?"
+      else                        out = out c
+    }
+    return out
+  }
   function is_heading(s)   { return s ~ /^##[^#]/ || s ~ /^##$/ }
   function is_list_head(s) { return s ~ /^##[ \t]*ページ一覧[ \t]*$/ }
   function is_stats_head(s){ return s ~ /^##[ \t]*統計[ \t]*$/ }
@@ -413,7 +428,7 @@ LC_ALL=C awk '
     # summary that later overwrites the accumulated value — the exact loss the
     # header spec forbids. Fail loud instead (rides the row-rewrite-failed path).
     if (trim(parts[1]) != "" || trim(parts[n]) != "") {
-      printf "ERROR: wiki-index-update: malformed registration row (content outside the cell delimiters — likely a missing row-end delimiter): %s\n", s > "/dev/stderr"
+      printf "ERROR: wiki-index-update: malformed registration row (content outside the cell delimiters — likely a missing row-end delimiter): %s\n", sanitize_diag(s) > "/dev/stderr"
       exit 1
     }
     # After dropping the two boundary fragments a well-formed row keeps at
@@ -424,7 +439,7 @@ LC_ALL=C awk '
     # (An empty summary CELL in a full 5-column row keeps n - 2 == 4 and
     # legitimately returns "".)
     if (n - 2 < 4) {
-      printf "ERROR: wiki-index-update: malformed registration row (fewer cells than the 5-column layout — cannot locate the summary cell): %s\n", s > "/dev/stderr"
+      printf "ERROR: wiki-index-update: malformed registration row (fewer cells than the 5-column layout — cannot locate the summary cell): %s\n", sanitize_diag(s) > "/dev/stderr"
       exit 1
     }
     mid = ""
@@ -543,13 +558,12 @@ LC_ALL=C awk '
       new_row = build_row(esc_frontmatter(DESCRIPTION))
       for (i = N; i > last_pipe; i--) lines[i + 1] = lines[i]
       lines[last_pipe + 1] = new_row
-      N++; if (E > last_pipe) E++
+      N++; E++                                           # last_pipe は必ず節内 (H < last_pipe < E)
       row_action = "added"
     }
 
     # ── procedure 3a: reclaim duplicate rows (all pages, keep first) ──
     dedup_removed = 0
-    delete seen
     n2 = 0
     for (i = 1; i <= N; i++) {
       if (i > H && i < E) {

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -50,6 +50,17 @@
 #       exempt — GFM treats a raw `|` inside a code span as a cell delimiter.
 #       Rewording the value to avoid `|` is prohibited (the title contract
 #       requires literal identity with frontmatter `title`).
+#   (a') the title ADDITIONALLY neutralizes `]` to the HTML entity `&#93;`.
+#       The title is emitted inside the link text of the page column — the same
+#       region the identification predicate scans — so a raw `]` lets a title
+#       containing `](pages/{d}/{s}.md)` forge the FIRST-link key and hijack
+#       another page's registration row with rc=0 and success markers.
+#       Backslash-escaping (`\]`) does not help: the predicate regex matches
+#       `](pages/` regardless of a preceding backslash. `&#93;` renders as `]`
+#       in GFM, so the literal-title contract holds in the rendered view.
+#       Title only: the summary column sits AFTER the genuine page link, so a
+#       `]` there can never become the FIRST link, and neutralizing preserved
+#       summaries would corrupt accumulated values.
 #   (b) summary values preserved from an existing row: already-escaped text —
 #       do NOT re-escape (re-escaping `\|` would grow one `\` per update cycle,
 #       unrecoverably). Only a raw `|` whose preceding character is not `\` is
@@ -113,7 +124,13 @@
 #   signal).
 #
 # Procedure 3b (`## 統計` 3-line sync):
-#   Only when the `## 統計` section exists (never create it). total = count of
+#   Only when EXACTLY ONE `## 統計` section exists (never create it). A
+#   duplicated stats heading (2+) is ambiguous the same way a duplicated
+#   `## ページ一覧` heading is, but exiting 1 would also wedge row operations
+#   (including the only duplicate-repair path, 3a) on a stats-side ambiguity —
+#   so the sync is skipped whole with a WARNING and the marker reports
+#   skipped_unreadable (no first-match sync; every stats section keeps its
+#   previous values). total = count of
 #   `*.md` files under --pages-root (non-page files like .gitkeep excluded by
 #   the `*.md` filter); breakdown = per-domain `*.md` counts; 最終更新 = this
 #   invocation's --updated. When the pages listing fails or is empty, emit a
@@ -328,6 +345,22 @@ LC_ALL=C awk '
     }
     return out
   }
+  # escape rule a-prime: title = rule (a) plus `]` -> `&#93;`. The title lands
+  # in the link text of the page column, which is the identification predicate
+  # scan target: a raw `]` lets a title containing `](pages/{d}/{s}.md)` forge
+  # the FIRST-link key (backslash-escaping would not help — the predicate
+  # matches `](pages/` regardless of a preceding `\`). See docstring rule (a-prime).
+  function esc_title(s,   out, i, c) {
+    out = ""
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (c == "\\")      out = out "\\\\"
+      else if (c == "|")  out = out "\\|"
+      else if (c == "]")  out = out "&#93;"
+      else                out = out c
+    }
+    return out
+  }
   # escape rule (b): preserved summary — only a raw `|` not preceded by `\`
   function esc_preserved(s,   out, i, c, prev) {
     out = ""; prev = ""
@@ -364,7 +397,7 @@ LC_ALL=C awk '
     return parts[2] "/" parts[nparts]
   }
   function build_row(summary) {
-    return "| [" esc_frontmatter(TITLE) "](pages/" DOMAIN "/" SLUG ".md) | " DOMAIN " | " summary " | " UPDATED " | " CONFIDENCE " |"
+    return "| [" esc_title(TITLE) "](pages/" DOMAIN "/" SLUG ".md) | " DOMAIN " | " summary " | " UPDATED " | " CONFIDENCE " |"
   }
   # summary of an existing row by positional extraction (see header spec)
   function extract_summary(s,   rest, n, parts, m, mid, i) {
@@ -549,7 +582,16 @@ fi
 
 # ── Procedure 3b: `## 統計` 3-line sync (on the buffered content) ───────────
 stats_sync="skipped_no_section"
-if LC_ALL=C grep -q '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows"; then
+stats_head_count=$(LC_ALL=C grep -c '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows")
+if [ "$stats_head_count" -gt 1 ]; then
+  # Duplicated stats headings: the sync target is ambiguous. The row-side
+  # duplicate heading exits 1 (nothing can proceed safely there), but wedging
+  # row operations — including the only duplicate-repair path, 3a — on a
+  # stats-side ambiguity would be excessive, so skip the sync whole instead
+  # (no first-match sync; docstring Procedure 3b).
+  echo "WARNING: wiki-index-update: index.md has $stats_head_count '## 統計' headings — ambiguous sync target, skipping stats sync (all stats sections keep their previous values; fix the index structure)" >&2
+  stats_sync="skipped_unreadable"
+elif [ "$stats_head_count" -eq 1 ]; then
   pages_list=""
   if [ -z "$pages_root" ]; then
     echo "WARNING: wiki-index-update: index.md has a '## 統計' section but --pages-root was not given。誤った値で正しい統計を上書きしないため、本サイクルの統計同期をスキップします" >&2

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -99,6 +99,11 @@
 #   assumptions do not hold, and extracting from such a row would return an
 #   empty summary — violating the never-overwrite rule above. That is an
 #   unexpected-structure error: ERROR to stderr + exit 1, index.md unmodified.
+#   The same loud exit covers rows with FEWER CELLS than the 5-column layout
+#   (after dropping the boundary fragments, fewer than domain + summary +
+#   updated + confidence remain): which cell is missing cannot be determined,
+#   so no summary can be preserved. An empty summary CELL in a full 5-column
+#   row is legitimate and extracts as "" without error.
 #
 # Procedure 3a (duplicate-row reclamation, runs every invocation):
 #   For any page whose predicate matches 2+ rows, delete the later rows. Not
@@ -116,8 +121,11 @@
 #   than overwriting correct stats with an undercount). Line shapes follow the
 #   existing lines (`- 総ページ数: {n}` / `- ドメイン別: patterns={n},
 #   heuristics={n}, anti-patterns={n}` / `- 最終更新: {updated}`); a missing
-#   line is warned about and skipped, never invented. A total that differs from
-#   the table's row count triggers nothing here — duplicates were reclaimed by
+#   line is warned about and skipped, never invented. When NONE of the 3 lines
+#   could be rewritten, the marker reports skipped_unreadable, not synced — the
+#   section kept its previous values, which is exactly what skipped_unreadable
+#   means on the listing-failure path too. A total that differs from the
+#   table's row count triggers nothing here — duplicates were reclaimed by
 #   3a and unregistered pages are wiki-lint's job.
 #
 # ── Interface ────────────────────────────────────────────────────────────────
@@ -134,7 +142,7 @@
 #   --confidence VALUE  high|medium|low (required)
 #   --pages-root DIR    pages/ directory for procedure 3b counting (optional;
 #                       when omitted and `## 統計` exists, 3b is skipped with a
-#                       WARNING)
+#                       WARNING and the marker reports skipped_unreadable)
 #
 # stdout contract (the LLM transcribes these markers; no other write channel):
 #   row_action={added|updated|aborted_duplicate}
@@ -145,8 +153,9 @@
 # Exit codes:
 #   0  normal (aborted_duplicate included — 3a ran as the repair path)
 #   1  fail-loud (index.md missing/unreadable, duplicated `## ページ一覧`
-#      heading, write failure — nothing is partially applied: the file is
-#      rewritten once via tmp + mv only on full success)
+#      heading, malformed registration row on the summary-preserve path,
+#      write failure — nothing is partially applied: the file is rewritten
+#      once via tmp + mv only on full success)
 #   2  invocation error (missing/invalid arguments)
 #
 # NOTE on shell flags: sibling helpers と同じく per-command rc 管理のため
@@ -279,9 +288,25 @@ if [ "$heading_count" -gt 1 ]; then
 fi
 
 tmp_dir=$(dirname "$index_path")
+# canonical 4-line trap (references/bash-trap-patterns.md): declare-before-
+# mktemp + explicit signal exit codes. A lone EXIT trap armed after mktemp
+# lets an INT land as exit 0 with no markers written — the SKILL.md marker
+# table reads exit 0 as success, turning an interrupt into a silent no-op.
+tmp_rows=""
+result_file=""
+tmp_stats=""
+_rite_wiki_index_update_cleanup() {
+  [ -n "${tmp_rows:-}" ] && rm -f "$tmp_rows"
+  [ -n "${result_file:-}" ] && rm -f "$result_file"
+  [ -n "${tmp_stats:-}" ] && rm -f "$tmp_stats"
+  return 0
+}
+trap 'rc=$?; _rite_wiki_index_update_cleanup; exit $rc' EXIT
+trap '_rite_wiki_index_update_cleanup; exit 130' INT
+trap '_rite_wiki_index_update_cleanup; exit 143' TERM
+trap '_rite_wiki_index_update_cleanup; exit 129' HUP
 tmp_rows=$(mktemp "$tmp_dir/.wiki-index-update.rows.XXXXXX") || { echo "ERROR: wiki-index-update: mktemp failed in $tmp_dir" >&2; exit 1; }
-result_file=$(mktemp) || { rm -f "$tmp_rows"; echo "ERROR: wiki-index-update: mktemp failed" >&2; exit 1; }
-trap 'rm -f "$tmp_rows" "$result_file"' EXIT
+result_file=$(mktemp) || { echo "ERROR: wiki-index-update: mktemp failed" >&2; exit 1; }
 
 # ── Procedures 0 / 1 / 2 / 3a (single awk pass, buffered) ───────────────────
 # Values are passed via ENVIRON (awk -v applies C-escape processing and would
@@ -356,8 +381,17 @@ LC_ALL=C awk '
       printf "ERROR: wiki-index-update: malformed registration row (content outside the cell delimiters — likely a missing row-end delimiter): %s\n", s > "/dev/stderr"
       exit 1
     }
-    m = n - 2                                           # drop first and last fragment
-    if (m < 3) return ""                                # no summary cell survives
+    # After dropping the two boundary fragments a well-formed row keeps at
+    # least 4: domain, summary (possibly empty, possibly split by raw pipes),
+    # updated, confidence. Fewer means a cell is missing and the positional
+    # walk cannot tell WHICH one — extracting would return an empty summary
+    # with the same silent loss as above, so it takes the same loud exit.
+    # (An empty summary CELL in a full 5-column row keeps n - 2 == 4 and
+    # legitimately returns "".)
+    if (n - 2 < 4) {
+      printf "ERROR: wiki-index-update: malformed registration row (fewer cells than the 5-column layout — cannot locate the summary cell): %s\n", s > "/dev/stderr"
+      exit 1
+    }
     mid = ""
     for (i = 3; i <= n - 3; i++) mid = mid (mid == "" ? "" : "|") parts[i]
     return trim(mid)
@@ -543,7 +577,6 @@ if LC_ALL=C grep -q '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows"; then
     breakdown_heuristics="${2#heuristics=}"
     breakdown_anti="${3#anti-patterns=}"
     tmp_stats=$(mktemp "$tmp_dir/.wiki-index-update.stats.XXXXXX") || { echo "ERROR: wiki-index-update: mktemp failed in $tmp_dir" >&2; exit 1; }
-    trap 'rm -f "$tmp_rows" "$result_file" "$tmp_stats"' EXIT
     WIU_TOTAL="$total" WIU_P="$breakdown_patterns" WIU_H="$breakdown_heuristics" \
     WIU_A="$breakdown_anti" WIU_UPDATED="$updated" WIU_RESULT_FILE="$result_file" \
     LC_ALL=C awk '

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -427,7 +427,7 @@ LC_ALL=C awk '
 
     # ── procedures 1 / 2 (abort clause applies here only) ──
     if (match_count >= 2) {
-      printf "WARNING: wiki-index-update: %d rows register slug \x27%s\x27 — aborting this page\x27s add/update (no first-match fallback); procedure 3a reclaims the later rows\n", match_count, SLUG > "/dev/stderr"
+      printf "WARNING: wiki-index-update: %d rows register page \x27%s/%s\x27 — aborting this page\x27s add/update (no first-match fallback); procedure 3a reclaims the later rows\n", match_count, DOMAIN, SLUG > "/dev/stderr"
       row_action = "aborted_duplicate"
     } else if (match_count == 1) {
       i = match_idx[1]

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -94,6 +94,11 @@
 #   end is deterministic even when a raw `|` remains in the summary, because
 #   updated (ISO 8601) and confidence (enum) cannot contain `|`. This also
 #   heals rows previously misaligned by a raw `|` back to a proper 5 columns.
+#   The two dropped fragments are VERIFIED blank before dropping: a non-blank
+#   fragment (e.g. a row missing its row-end delimiter) means the positional
+#   assumptions do not hold, and extracting from such a row would return an
+#   empty summary — violating the never-overwrite rule above. That is an
+#   unexpected-structure error: ERROR to stderr + exit 1, index.md unmodified.
 #
 # Procedure 3a (duplicate-row reclamation, runs every invocation):
 #   For any page whose predicate matches 2+ rows, delete the later rows. Not
@@ -213,17 +218,21 @@ done
 # Placeholder residue gate: the caller (wiki-ingest SKILL.md ステップ 6) literal-
 # substitutes {title}/{description}/{updated}; an unsubstituted brace token would
 # be written into the registration row and the 統計 最終更新 line, overwriting
-# the accumulated summary the docstring declares unrecoverable. The other flags
-# need no gate — domain/confidence enum and slug charset validation below
-# already reject residue with exit 2 (same canonical gate as SKILL.md 5.0.c).
+# the accumulated summary the docstring declares unrecoverable. The match is
+# exact — the caller passes these literals verbatim when substitution is missed,
+# and title/description are free text where a shape heuristic (leading/trailing
+# brace) would reject legitimate values. Shape-based residue gates in sibling
+# helpers guard closed value domains (enums, branch names), not free text. The
+# other flags need no gate — domain/confidence enum and slug charset validation
+# below already reject residue with exit 2.
 case "$title" in
-  "{"*"}") echo "ERROR: wiki-index-update: --title looks like an unsubstituted placeholder: '$title'" >&2; exit 2 ;;
+  "{title}") echo "ERROR: wiki-index-update: --title looks like an unsubstituted placeholder: '$title'" >&2; exit 2 ;;
 esac
 case "$description" in
-  "{"*"}") echo "ERROR: wiki-index-update: --description looks like an unsubstituted placeholder: '$description'" >&2; exit 2 ;;
+  "{description}") echo "ERROR: wiki-index-update: --description looks like an unsubstituted placeholder: '$description'" >&2; exit 2 ;;
 esac
 case "$updated" in
-  "{"*"}") echo "ERROR: wiki-index-update: --updated looks like an unsubstituted placeholder: '$updated'" >&2; exit 2 ;;
+  "{updated}") echo "ERROR: wiki-index-update: --updated looks like an unsubstituted placeholder: '$updated'" >&2; exit 2 ;;
 esac
 [ -n "$slug" ] || { echo "ERROR: wiki-index-update: --slug is required" >&2; exit 2; }
 [ -n "$updated" ] || { echo "ERROR: wiki-index-update: --updated is required" >&2; exit 2; }
@@ -337,6 +346,16 @@ LC_ALL=C awk '
     first_link_key(s)                                   # sets _link_end
     rest = substr(s, _link_end)
     n = split(rest, parts, "|")
+    # The positional walk silently discards the fragment before the first
+    # delimiter and the one after the last. Both must be blank in a well-formed
+    # row; non-blank means the row structure the extraction assumes is absent
+    # (e.g. a missing row-end delimiter), and continuing would return an empty
+    # summary that later overwrites the accumulated value — the exact loss the
+    # header spec forbids. Fail loud instead (rides the row-rewrite-failed path).
+    if (trim(parts[1]) != "" || trim(parts[n]) != "") {
+      printf "ERROR: wiki-index-update: malformed registration row (content outside the cell delimiters — likely a missing row-end delimiter): %s\n", s > "/dev/stderr"
+      exit 1
+    }
     m = n - 2                                           # drop first and last fragment
     if (m < 3) return ""                                # no summary cell survives
     mid = ""
@@ -545,6 +564,7 @@ if LC_ALL=C grep -q '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows"; then
         }
         for (i = 1; i <= N; i++) print lines[i]
         printf "stats_missing=%s%s%s\n", (f_total ? "" : " 総ページ数"), (f_breakdown ? "" : " ドメイン別"), (f_updated ? "" : " 最終更新") > RESULT
+        printf "stats_synced_lines=%d\n", f_total + f_breakdown + f_updated > RESULT
       }
     ' "$tmp_rows" > "$tmp_stats"
     awk_rc=$?
@@ -558,7 +578,16 @@ if LC_ALL=C grep -q '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows"; then
       stats_missing_trimmed=$(printf '%s' "$stats_missing" | sed 's/^ *//')
       [ -n "$stats_missing_trimmed" ] && echo "WARNING: wiki-index-update: '## 統計' 節に既存行が見つからない統計行があります (${stats_missing_trimmed})。行を新設せずスキップします" >&2
     fi
-    stats_sync="synced"
+    # The marker is the caller's only machine-readable channel: when none of
+    # the 3 stats lines could be rewritten, "synced" would contradict the
+    # WARNING above. Zero rewritten lines means the section kept its previous
+    # values — the same meaning skipped_unreadable already carries.
+    stats_synced_lines=$(sed -n 's/^stats_synced_lines=//p' "$result_file" | tail -1)
+    if [ "$stats_synced_lines" = "0" ]; then
+      stats_sync="skipped_unreadable"
+    else
+      stats_sync="synced"
+    fi
   fi
 fi
 

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -210,6 +210,21 @@ done
 # ── Invocation validation (exit 2) ──────────────────────────────────────────
 [ -n "$index_path" ] || { echo "ERROR: wiki-index-update: --index is required" >&2; exit 2; }
 [ -n "$title" ] || { echo "ERROR: wiki-index-update: --title is required (must equal page frontmatter title)" >&2; exit 2; }
+# Placeholder residue gate: the caller (wiki-ingest SKILL.md ステップ 6) literal-
+# substitutes {title}/{description}/{updated}; an unsubstituted brace token would
+# be written into the registration row and the 統計 最終更新 line, overwriting
+# the accumulated summary the docstring declares unrecoverable. The other flags
+# need no gate — domain/confidence enum and slug charset validation below
+# already reject residue with exit 2 (same canonical gate as SKILL.md 5.0.c).
+case "$title" in
+  "{"*"}") echo "ERROR: wiki-index-update: --title looks like an unsubstituted placeholder: '$title'" >&2; exit 2 ;;
+esac
+case "$description" in
+  "{"*"}") echo "ERROR: wiki-index-update: --description looks like an unsubstituted placeholder: '$description'" >&2; exit 2 ;;
+esac
+case "$updated" in
+  "{"*"}") echo "ERROR: wiki-index-update: --updated looks like an unsubstituted placeholder: '$updated'" >&2; exit 2 ;;
+esac
 [ -n "$slug" ] || { echo "ERROR: wiki-index-update: --slug is required" >&2; exit 2; }
 [ -n "$updated" ] || { echo "ERROR: wiki-index-update: --updated is required" >&2; exit 2; }
 case "$domain" in

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -20,8 +20,11 @@
 # Registration-row identification predicate (procedures 1 / 2 / 3 shared):
 #   Within the range from the `## ページ一覧` heading to the next `##` heading,
 #   a row is any line starting with `|` (header row and separator row excluded).
-#   The row "registers" the page whose slug appears in the FIRST occurrence of
-#   `](pages/{domain}/{slug}.md)` in that line. The page column is defined as
+#   The row "registers" the page identified by the `{domain}/{slug}` pair of
+#   the FIRST occurrence of `](pages/{domain}/{slug}.md)` in that line — page
+#   identity is the page path, so two pages sharing a slug across domains are
+#   distinct pages (a slug-only key would delete one of them as a "duplicate"
+#   in procedure 3a). The page column is defined as
 #   "from the leading `|` to the closing paren of that first link" — NOT "the
 #   first `|`-split cell" — because a title containing an unescaped raw `|`
 #   pushes the link into later cells and cell-splitting would fail to identify
@@ -184,16 +187,21 @@ reclamation, stats sync) deterministically. See the header comment for the spec.
 EOF
 }
 
+# `shift; shift` (not `shift 2`): a valueless flag at the end of argv leaves
+# $#=1, where `shift 2` returns rc=1 WITHOUT consuming — with no `set -e` the
+# while loop then spins forever. Two single shifts always consume (the second
+# is a no-op at $#=0), so the empty value falls through to the required-value
+# guards below and exits 2 as documented (suite: tests/shift2-loop-hardening.test.sh).
 while [ $# -gt 0 ]; do
   case "$1" in
-    --index)       index_path="${2-}"; shift 2 ;;
-    --title)       title="${2-}"; shift 2 ;;
-    --domain)      domain="${2-}"; shift 2 ;;
-    --slug)        slug="${2-}"; shift 2 ;;
-    --description) description="${2-}"; shift 2 ;;
-    --updated)     updated="${2-}"; shift 2 ;;
-    --confidence)  confidence="${2-}"; shift 2 ;;
-    --pages-root)  pages_root="${2-}"; shift 2 ;;
+    --index)       index_path="${2-}"; shift; shift ;;
+    --title)       title="${2-}"; shift; shift ;;
+    --domain)      domain="${2-}"; shift; shift ;;
+    --slug)        slug="${2-}"; shift; shift ;;
+    --description) description="${2-}"; shift; shift ;;
+    --updated)     updated="${2-}"; shift; shift ;;
+    --confidence)  confidence="${2-}"; shift; shift ;;
+    --pages-root)  pages_root="${2-}"; shift; shift ;;
     -h|--help)     usage; exit 0 ;;
     *) echo "ERROR: wiki-index-update: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -292,22 +300,26 @@ LC_ALL=C awk '
   function is_pipe_row(s)  { return s ~ /^\|/ }
   function is_header_row(s){ return s ~ /^\|[ \t]*ページ[ \t]*\|/ }
   function is_sep_row(s)   { return s ~ /^\|[ \t:|-]+$/ }
-  # slug of the FIRST `](pages/{domain}/{slug}.md)` link; "" when none.
+  # page key (`{domain}/{slug}`) of the FIRST `](pages/{domain}/{slug}.md)`
+  # link; "" when none. Page identity is the path (pages/{domain}/{slug}.md),
+  # so the key includes the domain — a slug-only key would misidentify two
+  # pages sharing a slug across domains and silently delete one as a
+  # "duplicate" in procedure 3a.
   # Also records the byte offset just past the closing paren in _link_end.
-  function first_link_slug(s,   m, path, nparts, parts) {
+  function first_link_key(s,   path, nparts, parts) {
     if (match(s, /\]\(pages\/[^\/)]+\/[^\/)]+\.md\)/) == 0) { _link_end = 0; return "" }
     _link_end = RSTART + RLENGTH
     path = substr(s, RSTART + 2, RLENGTH - 3)          # pages/{domain}/{slug}.md
     nparts = split(path, parts, "/")
     sub(/\.md$/, "", parts[nparts])
-    return parts[nparts]
+    return parts[2] "/" parts[nparts]
   }
   function build_row(summary) {
     return "| [" esc_frontmatter(TITLE) "](pages/" DOMAIN "/" SLUG ".md) | " DOMAIN " | " summary " | " UPDATED " | " CONFIDENCE " |"
   }
   # summary of an existing row by positional extraction (see header spec)
   function extract_summary(s,   rest, n, parts, m, mid, i) {
-    first_link_slug(s)                                  # sets _link_end
+    first_link_key(s)                                   # sets _link_end
     rest = substr(s, _link_end)
     n = split(rest, parts, "|")
     m = n - 2                                           # drop first and last fragment
@@ -408,8 +420,8 @@ LC_ALL=C awk '
       if (!is_pipe_row(s)) continue
       last_pipe = i
       if (is_header_row(s) || is_sep_row(s)) continue
-      rs = first_link_slug(s)
-      if (rs != "" && rs == SLUG) { match_count++; match_idx[match_count] = i }
+      rs = first_link_key(s)
+      if (rs != "" && rs == DOMAIN "/" SLUG) { match_count++; match_idx[match_count] = i }
     }
     if (last_pipe == 0) last_pipe = H + 1                # fresh section: after separator
 
@@ -439,7 +451,7 @@ LC_ALL=C awk '
       if (i > H && i < E) {
         s = lines[i]
         if (is_pipe_row(s) && !is_header_row(s) && !is_sep_row(s)) {
-          rs = first_link_slug(s)
+          rs = first_link_key(s)
           if (rs != "") {
             if (rs in seen) { dedup_removed++; continue }
             seen[rs] = 1

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# wiki-index-update.sh
+#
+# Deterministic implementation of wiki/ingest.md ステップ 6 (index.md の更新).
+# Updates the 5-column GFM table (ページ / ドメイン / サマリー / 更新日 / 確信度)
+# in the `## ページ一覧` section of index.md, then reclaims duplicate rows and
+# syncs the `## 統計` section. The LLM only substitutes page metadata into the
+# invocation and reads the result markers — all line manipulation happens here.
+#
+# Why a helper:
+#   The prose procedure (identification predicate, escaping, positional summary
+#   extraction, stats sync) is a deterministic algorithm. Keeping it as prose in
+#   SKILL.md made review⇄fix loops re-litigate the wording (the prose-only fix
+#   of this step diverged over multiple runs) while code+test anchored changes
+#   converged. Moving the algorithm here gives the loop a code anchor and
+#   removes LLM Edit application variance.
+#
+# ── Spec (moved 1:1 from wiki-ingest SKILL.md ステップ 6) ────────────────────
+#
+# Registration-row identification predicate (procedures 1 / 2 / 3 shared):
+#   Within the range from the `## ページ一覧` heading to the next `##` heading,
+#   a row is any line starting with `|` (header row and separator row excluded).
+#   The row "registers" the page whose slug appears in the FIRST occurrence of
+#   `](pages/{domain}/{slug}.md)` in that line. The page column is defined as
+#   "from the leading `|` to the closing paren of that first link" — NOT "the
+#   first `|`-split cell" — because a title containing an unescaped raw `|`
+#   pushes the link into later cells and cell-splitting would fail to identify
+#   the existing row (procedure 1 would then add a duplicate the same predicate
+#   in procedure 3 could not reclaim). Looking only at the FIRST link makes
+#   cross-reference links in the summary column automatically non-identifying.
+#   The predicate is positional, NOT "lines GFM renders as table rows": a blank
+#   line inside the section makes GFM render only the leading block as a table,
+#   so a rendering-based predicate would miss real registration rows.
+#
+# Abort clause (procedures 1 / 2 ONLY):
+#   If identification finds 2+ rows for the target page, emit WARNING and abort
+#   this page's add/update (no "take the first match" fallback — that would
+#   silently rewrite the wrong row). Procedure 3a is explicitly NOT subject to
+#   this clause: it takes the 2+ row state as input and deletes the later rows.
+#   Applying the abort clause to 3a as well would permanently wedge the index
+#   (1/2 abort forever, and the only repair path is closed too).
+#
+# Cell-delimiter escaping (applied on both the add and update paths):
+#   (a) frontmatter-derived raw values (--title / --description): escape `\` to
+#       `\\` first, then `|` to `\|` (so a value containing a literal `\|` is
+#       not misread by GFM consuming the backslash). Inline code spans are NOT
+#       exempt — GFM treats a raw `|` inside a code span as a cell delimiter.
+#       Rewording the value to avoid `|` is prohibited (the title contract
+#       requires literal identity with frontmatter `title`).
+#   (b) summary values preserved from an existing row: already-escaped text —
+#       do NOT re-escape (re-escaping `\|` would grow one `\` per update cycle,
+#       unrecoverably). Only a raw `|` whose preceding character is not `\` is
+#       escaped.
+#   Escaping applies to the index registration row only; page frontmatter is
+#   never modified. {path}/{domain}/{updated}/{confidence} are slug / enum /
+#   ISO 8601 values that cannot contain `|` (validated below, fail-loud).
+#
+# Procedure 0 (unconditional, every invocation):
+#   If the `## ページ一覧` section is missing, create the heading + the 2 table
+#   header lines. Insertion position: after existing body / HTML comments —
+#   directly before `## 統計` if that section exists, else at EOF. If the
+#   section exists but the header/separator rows are missing, insert them right
+#   after the heading (before existing registration rows). Blank lines between
+#   `|`-starting lines inside the section are removed (a blank line splits the
+#   GFM table block and the rows after it stop rendering as a table).
+#
+# Procedure 1 (add):
+#   If a row already matches the predicate, route to procedure 2 instead (no
+#   double registration). Old-format bullet lines OUTSIDE the table never count
+#   as registration (a page that only has a bullet line is added as new; the
+#   old bullet is left untouched — GFM keeps them as a separate block).
+#   Otherwise append to the end of the table:
+#     | [{title}]({path}) | {domain} | {description} | {updated} | {confidence} |
+#   {path} keeps the `pages/{domain}/{slug}.md` shape (wiki-lint-orphans.sh
+#   greps `](pages/...)` for survival). {updated}/{confidence} carry no YAML
+#   quotes.
+#
+# Procedure 2 (update):
+#   Regenerate the identified row whole in the procedure-1 format (never edit a
+#   single cell by counting columns). Summary column resolution order:
+#     (1) --description non-empty -> that value (escape rule (a));
+#     (2) empty -> PRESERVE the existing row's summary (rule (b) escaping only).
+#   Never overwrite an accumulated summary with an empty string — description
+#   is optional in the page schema and summary regeneration only happens at
+#   page creation, so the accumulated value is unrecoverable.
+#   Positional extraction of the existing summary: take everything after the
+#   page column, split by `|`; the first and last fragments stem from the
+#   leading/trailing delimiters and are always blank — drop them. Of the rest,
+#   the head is the domain cell, the LAST TWO are updated/confidence, and
+#   everything in between re-joined with `|` is the summary. Counting from the
+#   end is deterministic even when a raw `|` remains in the summary, because
+#   updated (ISO 8601) and confidence (enum) cannot contain `|`. This also
+#   heals rows previously misaligned by a raw `|` back to a proper 5 columns.
+#
+# Procedure 3a (duplicate-row reclamation, runs every invocation):
+#   For any page whose predicate matches 2+ rows, delete the later rows. Not
+#   gated on the stats section or stats sync success. Unregistered pages and
+#   old-format bullet-only pages are left to wiki-lint (speculatively adding or
+#   deleting pages not read this cycle would destroy the orphan-detection
+#   signal).
+#
+# Procedure 3b (`## 統計` 3-line sync):
+#   Only when the `## 統計` section exists (never create it). total = count of
+#   `*.md` files under --pages-root (non-page files like .gitkeep excluded by
+#   the `*.md` filter); breakdown = per-domain `*.md` counts; 最終更新 = this
+#   invocation's --updated. When the pages listing fails or is empty, emit a
+#   WARNING and skip the sync (keeping the previous cycle's values is safer
+#   than overwriting correct stats with an undercount). Line shapes follow the
+#   existing lines (`- 総ページ数: {n}` / `- ドメイン別: patterns={n},
+#   heuristics={n}, anti-patterns={n}` / `- 最終更新: {updated}`); a missing
+#   line is warned about and skipped, never invented. A total that differs from
+#   the table's row count triggers nothing here — duplicates were reclaimed by
+#   3a and unregistered pages are wiki-lint's job.
+#
+# ── Interface ────────────────────────────────────────────────────────────────
+#
+# Inputs:
+#   --index PATH        index.md path, resolved by the caller per branch
+#                       strategy (required; must exist and be readable)
+#   --title VALUE       page frontmatter `title` raw value (required)
+#   --domain VALUE      patterns|heuristics|anti-patterns (required)
+#   --slug VALUE        page slug, [A-Za-z0-9._-]+ (required)
+#   --description VALUE summary raw value; empty/omitted = preserve existing
+#                       summary on the update path (optional)
+#   --updated VALUE     ISO 8601 timestamp, no `|` (required)
+#   --confidence VALUE  high|medium|low (required)
+#   --pages-root DIR    pages/ directory for procedure 3b counting (optional;
+#                       when omitted and `## 統計` exists, 3b is skipped with a
+#                       WARNING)
+#
+# stdout contract (the LLM transcribes these markers; no other write channel):
+#   row_action={added|updated|aborted_duplicate}
+#   dedup_removed={n}
+#   stats_sync={synced|skipped_no_section|skipped_unreadable}
+#   [CONTEXT] WIKI_INDEX_UPDATE=row_action={...}; dedup_removed={n}; stats_sync={...}
+#
+# Exit codes:
+#   0  normal (aborted_duplicate included — 3a ran as the repair path)
+#   1  fail-loud (index.md missing/unreadable, duplicated `## ページ一覧`
+#      heading, write failure — nothing is partially applied: the file is
+#      rewritten once via tmp + mv only on full success)
+#   2  invocation error (missing/invalid arguments)
+#
+# NOTE on shell flags: sibling helpers と同じく per-command rc 管理のため
+# `set -e` は意図的に設定しない。
+
+# shellcheck source=../control-char-neutralize.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
+
+# C0+DEL detection that lets UTF-8 multibyte content pass. The shared
+# contains_ctrl() also rejects C1 bytes (0x80-0x9f) byte-wise, which
+# false-positives on UTF-8 continuation bytes — its in-repo callers pass
+# ASCII-fixed values, but title/description here are Japanese frontmatter
+# text. A raw C1 byte is invalid UTF-8 to begin with; the row-integrity
+# concern is C0 (newline breaks the single-row model) + DEL.
+_has_c0_del() {
+  local _in_bytes _stripped_bytes
+  _in_bytes=$(printf '%s' "$1" | LC_ALL=C wc -c) || return 0
+  _stripped_bytes=$(printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\177' | LC_ALL=C wc -c) || return 0
+  _in_bytes=${_in_bytes//[[:space:]]/}
+  _stripped_bytes=${_stripped_bytes//[[:space:]]/}
+  case "${_in_bytes}:${_stripped_bytes}" in
+    *[!0-9:]*|:*|*:) return 0 ;;
+  esac
+  [ "$_in_bytes" -ne "$_stripped_bytes" ]
+}
+
+index_path=""
+title=""
+domain=""
+slug=""
+description=""
+updated=""
+confidence=""
+pages_root=""
+
+usage() {
+  cat <<'EOF'
+Usage: wiki-index-update.sh --index PATH --title VALUE --domain DOMAIN --slug SLUG \
+         [--description VALUE] --updated TS --confidence LEVEL [--pages-root DIR]
+
+Applies wiki-ingest ステップ 6 (index.md registration-row add/update, duplicate
+reclamation, stats sync) deterministically. See the header comment for the spec.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --index)       index_path="${2-}"; shift 2 ;;
+    --title)       title="${2-}"; shift 2 ;;
+    --domain)      domain="${2-}"; shift 2 ;;
+    --slug)        slug="${2-}"; shift 2 ;;
+    --description) description="${2-}"; shift 2 ;;
+    --updated)     updated="${2-}"; shift 2 ;;
+    --confidence)  confidence="${2-}"; shift 2 ;;
+    --pages-root)  pages_root="${2-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "ERROR: wiki-index-update: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ── Invocation validation (exit 2) ──────────────────────────────────────────
+[ -n "$index_path" ] || { echo "ERROR: wiki-index-update: --index is required" >&2; exit 2; }
+[ -n "$title" ] || { echo "ERROR: wiki-index-update: --title is required (must equal page frontmatter title)" >&2; exit 2; }
+[ -n "$slug" ] || { echo "ERROR: wiki-index-update: --slug is required" >&2; exit 2; }
+[ -n "$updated" ] || { echo "ERROR: wiki-index-update: --updated is required" >&2; exit 2; }
+case "$domain" in
+  patterns|heuristics|anti-patterns) ;;
+  *) echo "ERROR: wiki-index-update: --domain must be patterns|heuristics|anti-patterns (got: '$(printf '%s' "$domain" | neutralize_ctrl)')" >&2; exit 2 ;;
+esac
+case "$confidence" in
+  high|medium|low) ;;
+  *) echo "ERROR: wiki-index-update: --confidence must be high|medium|low (got: '$(printf '%s' "$confidence" | neutralize_ctrl)')" >&2; exit 2 ;;
+esac
+case "$slug" in
+  *[!A-Za-z0-9._-]*) echo "ERROR: wiki-index-update: --slug must match [A-Za-z0-9._-]+ (got: '$(printf '%s' "$slug" | neutralize_ctrl)')" >&2; exit 2 ;;
+esac
+# updated feeds both the row and the stats line; a `|` (or any control char)
+# would break the no-escape assumption for that column — reject, never escape.
+case "$updated" in
+  *'|'*) echo "ERROR: wiki-index-update: --updated must not contain '|' (got: '$(printf '%s' "$updated" | neutralize_ctrl)')" >&2; exit 2 ;;
+esac
+if _has_c0_del "$updated"; then
+  echo "ERROR: wiki-index-update: --updated contains control characters" >&2; exit 2
+fi
+# title/description become single-row cell content: a newline (or any control
+# char) cannot be represented in one table row — reject rather than mangle.
+if _has_c0_del "$title"; then
+  echo "ERROR: wiki-index-update: --title contains control characters (multi-line titles cannot form a table row)" >&2; exit 2
+fi
+if _has_c0_del "$description"; then
+  echo "ERROR: wiki-index-update: --description contains control characters (multi-line summaries cannot form a table row)" >&2; exit 2
+fi
+
+# ── Fail-loud preconditions (exit 1) ────────────────────────────────────────
+if [ ! -f "$index_path" ]; then
+  echo "ERROR: wiki-index-update: index.md not found: $index_path" >&2; exit 1
+fi
+if [ ! -r "$index_path" ]; then
+  echo "ERROR: wiki-index-update: index.md not readable: $index_path" >&2; exit 1
+fi
+
+heading_count=$(LC_ALL=C grep -c '^##[[:blank:]]*ページ一覧[[:blank:]]*$' "$index_path")
+if [ "$heading_count" -gt 1 ]; then
+  echo "ERROR: wiki-index-update: index.md has $heading_count '## ページ一覧' headings — ambiguous target, refusing to guess (fix the index structure first)" >&2
+  exit 1
+fi
+
+tmp_dir=$(dirname "$index_path")
+tmp_rows=$(mktemp "$tmp_dir/.wiki-index-update.rows.XXXXXX") || { echo "ERROR: wiki-index-update: mktemp failed in $tmp_dir" >&2; exit 1; }
+result_file=$(mktemp) || { rm -f "$tmp_rows"; echo "ERROR: wiki-index-update: mktemp failed" >&2; exit 1; }
+trap 'rm -f "$tmp_rows" "$result_file"' EXIT
+
+# ── Procedures 0 / 1 / 2 / 3a (single awk pass, buffered) ───────────────────
+# Values are passed via ENVIRON (awk -v applies C-escape processing and would
+# corrupt a literal backslash in the title). LC_ALL=C keeps substr/length
+# byte-based; the per-byte scan only compares ASCII `\` and `|`, so UTF-8
+# multibyte content passes through unchanged.
+WIU_TITLE="$title" WIU_DOMAIN="$domain" WIU_SLUG="$slug" \
+WIU_DESCRIPTION="$description" WIU_UPDATED="$updated" WIU_CONFIDENCE="$confidence" \
+WIU_RESULT_FILE="$result_file" \
+LC_ALL=C awk '
+  # escape rule (a): frontmatter-derived raw value
+  function esc_frontmatter(s,   out, i, c) {
+    out = ""
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (c == "\\")     out = out "\\\\"
+      else if (c == "|") out = out "\\|"
+      else               out = out c
+    }
+    return out
+  }
+  # escape rule (b): preserved summary — only a raw `|` not preceded by `\`
+  function esc_preserved(s,   out, i, c, prev) {
+    out = ""; prev = ""
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (c == "|" && prev != "\\") out = out "\\|"
+      else                          out = out c
+      prev = c
+    }
+    return out
+  }
+  function trim(s) {
+    sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s)
+    return s
+  }
+  function is_heading(s)   { return s ~ /^##[^#]/ || s ~ /^##$/ }
+  function is_list_head(s) { return s ~ /^##[ \t]*ページ一覧[ \t]*$/ }
+  function is_stats_head(s){ return s ~ /^##[ \t]*統計[ \t]*$/ }
+  function is_pipe_row(s)  { return s ~ /^\|/ }
+  function is_header_row(s){ return s ~ /^\|[ \t]*ページ[ \t]*\|/ }
+  function is_sep_row(s)   { return s ~ /^\|[ \t:|-]+$/ }
+  # slug of the FIRST `](pages/{domain}/{slug}.md)` link; "" when none.
+  # Also records the byte offset just past the closing paren in _link_end.
+  function first_link_slug(s,   m, path, nparts, parts) {
+    if (match(s, /\]\(pages\/[^\/)]+\/[^\/)]+\.md\)/) == 0) { _link_end = 0; return "" }
+    _link_end = RSTART + RLENGTH
+    path = substr(s, RSTART + 2, RLENGTH - 3)          # pages/{domain}/{slug}.md
+    nparts = split(path, parts, "/")
+    sub(/\.md$/, "", parts[nparts])
+    return parts[nparts]
+  }
+  function build_row(summary) {
+    return "| [" esc_frontmatter(TITLE) "](pages/" DOMAIN "/" SLUG ".md) | " DOMAIN " | " summary " | " UPDATED " | " CONFIDENCE " |"
+  }
+  # summary of an existing row by positional extraction (see header spec)
+  function extract_summary(s,   rest, n, parts, m, mid, i) {
+    first_link_slug(s)                                  # sets _link_end
+    rest = substr(s, _link_end)
+    n = split(rest, parts, "|")
+    m = n - 2                                           # drop first and last fragment
+    if (m < 3) return ""                                # no summary cell survives
+    mid = ""
+    for (i = 3; i <= n - 3; i++) mid = mid (mid == "" ? "" : "|") parts[i]
+    return trim(mid)
+  }
+
+  { lines[++N] = $0 }
+
+  END {
+    TITLE = ENVIRON["WIU_TITLE"];       DOMAIN = ENVIRON["WIU_DOMAIN"]
+    SLUG = ENVIRON["WIU_SLUG"];         DESCRIPTION = ENVIRON["WIU_DESCRIPTION"]
+    UPDATED = ENVIRON["WIU_UPDATED"];   CONFIDENCE = ENVIRON["WIU_CONFIDENCE"]
+    RESULT = ENVIRON["WIU_RESULT_FILE"]
+    HEADER = "| ページ | ドメイン | サマリー | 更新日 | 確信度 |"
+    SEP    = "|--------|---------|---------|--------|--------|"
+
+    # ── locate the section ──
+    H = 0
+    for (i = 1; i <= N; i++) if (is_list_head(lines[i])) { H = i; break }
+
+    # ── procedure 0: create the section when missing ──
+    if (H == 0) {
+      S = 0
+      for (i = 1; i <= N; i++) if (is_stats_head(lines[i])) { S = i; break }
+      P = (S > 0) ? S : N + 1                           # insert before ## 統計, else EOF
+      for (i = N; i >= P; i--) lines[i + 4] = lines[i]
+      lines[P] = "## ページ一覧"; lines[P + 1] = ""      # blank line matches index-template.md
+      lines[P + 2] = HEADER; lines[P + 3] = SEP
+      N += 4; H = P
+      # keep a blank line between the new section and its neighbours
+      if (H > 1 && lines[H - 1] != "") {
+        for (i = N; i >= H; i--) lines[i + 1] = lines[i]
+        lines[H] = ""; N++; H++
+      }
+      if (H + 4 <= N && lines[H + 4] != "") {
+        for (i = N; i >= H + 4; i--) lines[i + 1] = lines[i]
+        lines[H + 4] = ""; N++
+      }
+    }
+
+    # section end = next `##` heading after H
+    E = N + 1
+    for (i = H + 1; i <= N; i++) if (is_heading(lines[i])) { E = i; break }
+
+    # ── procedure 0: restore missing header/separator rows ──
+    has_header = 0; has_sep = 0
+    for (i = H + 1; i < E; i++) {
+      if (is_header_row(lines[i])) has_header = 1
+      else if (is_sep_row(lines[i])) has_sep = 1
+    }
+    ins = 0
+    if (!has_header && !has_sep)      { add1 = HEADER; add2 = SEP; ins = 2 }
+    else if (!has_header)             { add1 = HEADER; ins = 1 }
+    else if (!has_sep)                { add1 = SEP; ins = 1 }
+    if (ins > 0) {
+      # insert right after the heading (before existing registration rows);
+      # when a header exists and only the separator is missing, insert after it
+      P = H + 1
+      if (has_header && !has_sep) {
+        for (i = H + 1; i < E; i++) if (is_header_row(lines[i])) { P = i + 1; break }
+      }
+      for (i = N; i >= P; i--) lines[i + ins] = lines[i]
+      lines[P] = add1
+      if (ins == 2) lines[P + 1] = add2
+      N += ins; E += ins
+    }
+
+    # ── procedure 0: drop blank lines between `|` rows inside the section ──
+    out_n = 0
+    for (i = 1; i <= N; i++) {
+      if (i > H && i < E && lines[i] ~ /^[ \t]*$/) {
+        prev_pipe = 0; next_pipe = 0
+        for (j = i - 1; j > H; j--) if (lines[j] !~ /^[ \t]*$/) { prev_pipe = is_pipe_row(lines[j]); break }
+        for (j = i + 1; j < E; j++) if (lines[j] !~ /^[ \t]*$/) { next_pipe = is_pipe_row(lines[j]); break }
+        if (prev_pipe && next_pipe) { drop[i] = 1; continue }
+      }
+      keep[++out_n] = i
+    }
+    n2 = 0
+    delete map
+    for (k = 1; k <= out_n; k++) {
+      i = keep[k]
+      n2++; buf[n2] = lines[i]
+      if (i == H) H2 = n2
+      if (i == E) E2 = n2
+    }
+    if (E > N) E2 = n2 + 1
+    N = n2; H = H2; E = E2
+    for (i = 1; i <= N; i++) lines[i] = buf[i]
+
+    # ── identification over the section rows ──
+    match_count = 0; last_pipe = 0
+    for (i = H + 1; i < E; i++) {
+      s = lines[i]
+      if (!is_pipe_row(s)) continue
+      last_pipe = i
+      if (is_header_row(s) || is_sep_row(s)) continue
+      rs = first_link_slug(s)
+      if (rs != "" && rs == SLUG) { match_count++; match_idx[match_count] = i }
+    }
+    if (last_pipe == 0) last_pipe = H + 1                # fresh section: after separator
+
+    # ── procedures 1 / 2 (abort clause applies here only) ──
+    if (match_count >= 2) {
+      printf "WARNING: wiki-index-update: %d rows register slug \x27%s\x27 — aborting this page\x27s add/update (no first-match fallback); procedure 3a reclaims the later rows\n", match_count, SLUG > "/dev/stderr"
+      row_action = "aborted_duplicate"
+    } else if (match_count == 1) {
+      i = match_idx[1]
+      if (DESCRIPTION != "") summary = esc_frontmatter(DESCRIPTION)
+      else                   summary = esc_preserved(extract_summary(lines[i]))
+      lines[i] = build_row(summary)
+      row_action = "updated"
+    } else {
+      new_row = build_row(esc_frontmatter(DESCRIPTION))
+      for (i = N; i > last_pipe; i--) lines[i + 1] = lines[i]
+      lines[last_pipe + 1] = new_row
+      N++; if (E > last_pipe) E++
+      row_action = "added"
+    }
+
+    # ── procedure 3a: reclaim duplicate rows (all pages, keep first) ──
+    dedup_removed = 0
+    delete seen
+    n2 = 0
+    for (i = 1; i <= N; i++) {
+      if (i > H && i < E) {
+        s = lines[i]
+        if (is_pipe_row(s) && !is_header_row(s) && !is_sep_row(s)) {
+          rs = first_link_slug(s)
+          if (rs != "") {
+            if (rs in seen) { dedup_removed++; continue }
+            seen[rs] = 1
+          }
+        }
+      }
+      buf2[++n2] = lines[i]
+    }
+
+    for (i = 1; i <= n2; i++) print buf2[i]
+    printf "row_action=%s\n", row_action > RESULT
+    printf "dedup_removed=%d\n", dedup_removed > RESULT
+  }
+' "$index_path" > "$tmp_rows"
+awk_rc=$?
+if [ "$awk_rc" -ne 0 ] || [ ! -s "$tmp_rows" ]; then
+  echo "ERROR: wiki-index-update: row rewrite failed (awk rc=$awk_rc) — index.md left unmodified" >&2
+  exit 1
+fi
+
+row_action=$(sed -n 's/^row_action=//p' "$result_file")
+dedup_removed=$(sed -n 's/^dedup_removed=//p' "$result_file")
+if [ -z "$row_action" ] || [ -z "$dedup_removed" ]; then
+  echo "ERROR: wiki-index-update: row rewrite produced no result markers — index.md left unmodified" >&2
+  exit 1
+fi
+
+# ── Procedure 3b: `## 統計` 3-line sync (on the buffered content) ───────────
+stats_sync="skipped_no_section"
+if LC_ALL=C grep -q '^##[[:blank:]]*統計[[:blank:]]*$' "$tmp_rows"; then
+  pages_list=""
+  if [ -z "$pages_root" ]; then
+    echo "WARNING: wiki-index-update: index.md has a '## 統計' section but --pages-root was not given。誤った値で正しい統計を上書きしないため、本サイクルの統計同期をスキップします" >&2
+    stats_sync="skipped_unreadable"
+  # find の stderr は捨てない (読めないディレクトリがあれば errno がそのまま画面に残る)。
+  # find は 1 つでも読めない経路があると非ゼロ終了するため、rc 検査が部分失敗も拾う。
+  elif ! pages_list=$(find "$pages_root" -type f -name '*.md') || [ -z "$pages_list" ]; then
+    echo "WARNING: wiki-index-update: pages 一覧を取得できないか 0 件です (root=$pages_root)。誤った値で正しい統計を上書きしないため、本サイクルの統計同期をスキップします" >&2
+    stats_sync="skipped_unreadable"
+  else
+    total=$(printf '%s\n' "$pages_list" | wc -l | tr -d ' ')
+    # 内訳は $pages_root を前方一致の anchor にする — 素の "/${d}/" は基点より上の
+    # ディレクトリ名にも一致し、内訳だけが膨張して総数と別の述語になる。case の
+    # literal 前方一致なら正規表現メタ文字を含むチェックアウトパスでも誤らない。
+    counts=""
+    for d in patterns heuristics anti-patterns; do
+      n=0
+      while IFS= read -r p; do
+        case "$p" in "${pages_root}/${d}/"*) n=$((n + 1)) ;; esac
+      done <<< "$pages_list"
+      counts="$counts${counts:+ }$d=$n"
+    done
+    set -- $counts
+    breakdown_patterns="${1#patterns=}"
+    breakdown_heuristics="${2#heuristics=}"
+    breakdown_anti="${3#anti-patterns=}"
+    tmp_stats=$(mktemp "$tmp_dir/.wiki-index-update.stats.XXXXXX") || { echo "ERROR: wiki-index-update: mktemp failed in $tmp_dir" >&2; exit 1; }
+    trap 'rm -f "$tmp_rows" "$result_file" "$tmp_stats"' EXIT
+    WIU_TOTAL="$total" WIU_P="$breakdown_patterns" WIU_H="$breakdown_heuristics" \
+    WIU_A="$breakdown_anti" WIU_UPDATED="$updated" WIU_RESULT_FILE="$result_file" \
+    LC_ALL=C awk '
+      { lines[++N] = $0 }
+      END {
+        TOTAL = ENVIRON["WIU_TOTAL"]; PN = ENVIRON["WIU_P"]; HN = ENVIRON["WIU_H"]
+        AN = ENVIRON["WIU_A"]; UPDATED = ENVIRON["WIU_UPDATED"]
+        RESULT = ENVIRON["WIU_RESULT_FILE"]
+        S = 0
+        for (i = 1; i <= N; i++) if (lines[i] ~ /^##[ \t]*統計[ \t]*$/) { S = i; break }
+        E = N + 1
+        for (i = S + 1; i <= N; i++) if (lines[i] ~ /^##[^#]/ || lines[i] ~ /^##$/) { E = i; break }
+        f_total = 0; f_breakdown = 0; f_updated = 0
+        for (i = S + 1; i < E; i++) {
+          if (lines[i] ~ /^-[ \t]*総ページ数:/)   { lines[i] = "- 総ページ数: " TOTAL; f_total = 1 }
+          else if (lines[i] ~ /^-[ \t]*ドメイン別:/) { lines[i] = "- ドメイン別: patterns=" PN ", heuristics=" HN ", anti-patterns=" AN; f_breakdown = 1 }
+          else if (lines[i] ~ /^-[ \t]*最終更新:/)  { lines[i] = "- 最終更新: " UPDATED; f_updated = 1 }
+        }
+        for (i = 1; i <= N; i++) print lines[i]
+        printf "stats_missing=%s%s%s\n", (f_total ? "" : " 総ページ数"), (f_breakdown ? "" : " ドメイン別"), (f_updated ? "" : " 最終更新") > RESULT
+      }
+    ' "$tmp_rows" > "$tmp_stats"
+    awk_rc=$?
+    if [ "$awk_rc" -ne 0 ] || [ ! -s "$tmp_stats" ]; then
+      echo "ERROR: wiki-index-update: stats sync rewrite failed (awk rc=$awk_rc) — index.md left unmodified" >&2
+      exit 1
+    fi
+    mv "$tmp_stats" "$tmp_rows" || { echo "ERROR: wiki-index-update: stats buffer swap failed — index.md left unmodified" >&2; exit 1; }
+    stats_missing=$(sed -n 's/^stats_missing=//p' "$result_file" | tail -1)
+    if [ -n "$stats_missing" ] && [ "$stats_missing" != "" ]; then
+      stats_missing_trimmed=$(printf '%s' "$stats_missing" | sed 's/^ *//')
+      [ -n "$stats_missing_trimmed" ] && echo "WARNING: wiki-index-update: '## 統計' 節に既存行が見つからない統計行があります (${stats_missing_trimmed})。行を新設せずスキップします" >&2
+    fi
+    stats_sync="synced"
+  fi
+fi
+
+# ── Single atomic apply ─────────────────────────────────────────────────────
+if ! mv "$tmp_rows" "$index_path"; then
+  echo "ERROR: wiki-index-update: failed to write $index_path — original left unmodified" >&2
+  exit 1
+fi
+
+echo "row_action=$row_action"
+echo "dedup_removed=$dedup_removed"
+echo "stats_sync=$stats_sync"
+echo "[CONTEXT] WIKI_INDEX_UPDATE=row_action=$row_action; dedup_removed=$dedup_removed; stats_sync=$stats_sync"
+exit 0

--- a/plugins/rite/hooks/scripts/wiki-index-update.sh
+++ b/plugins/rite/hooks/scripts/wiki-index-update.sh
@@ -50,14 +50,20 @@
 #       exempt — GFM treats a raw `|` inside a code span as a cell delimiter.
 #       Rewording the value to avoid `|` is prohibited (the title contract
 #       requires literal identity with frontmatter `title`).
-#   (a') the title ADDITIONALLY neutralizes `]` to the HTML entity `&#93;`.
-#       The title is emitted inside the link text of the page column — the same
-#       region the identification predicate scans — so a raw `]` lets a title
-#       containing `](pages/{d}/{s}.md)` forge the FIRST-link key and hijack
-#       another page's registration row with rc=0 and success markers.
-#       Backslash-escaping (`\]`) does not help: the predicate regex matches
-#       `](pages/` regardless of a preceding backslash. `&#93;` renders as `]`
-#       in GFM, so the literal-title contract holds in the rendered view.
+#   (a-prime) the title ADDITIONALLY neutralizes `]` to the HTML entity `&#93;`
+#       — but ONLY when the next character is `(`. The title is emitted inside
+#       the link text of the page column (the region the identification
+#       predicate scans), so a title containing `](pages/{d}/{s}.md)` would
+#       forge the FIRST-link key and hijack another page's registration row
+#       with rc=0 and success markers. Backslash-escaping (`\]`) does not help:
+#       the predicate regex matches `](pages/` regardless of a preceding
+#       backslash. Forgery needs the literal `](` sequence, so narrowing to
+#       `](` keeps titles like `[CONTEXT]` / `.errors[]` / `` `[[:cntrl:]]` ``
+#       byte-identical — neutralizing every `]` unbalances the link text's
+#       brackets (GFM then starts the link at an inner `[` and drops the title
+#       prefix out of the link) and inside a code span `&#93;` is not decoded
+#       at all, so it would render literally. `&#93;` renders as `]` outside
+#       code spans, so the literal-title contract holds in the rendered view.
 #       Title only: the summary column sits AFTER the genuine page link, so a
 #       `]` there can never become the FIRST link, and neutralizing preserved
 #       summaries would corrupt accumulated values.
@@ -182,21 +188,14 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../control-char-neutralize.sh"
 
 # C0+DEL detection that lets UTF-8 multibyte content pass. The shared
-# contains_ctrl() also rejects C1 bytes (0x80-0x9f) byte-wise, which
-# false-positives on UTF-8 continuation bytes — its in-repo callers pass
-# ASCII-fixed values, but title/description here are Japanese frontmatter
-# text. A raw C1 byte is invalid UTF-8 to begin with; the row-integrity
-# concern is C0 (newline breaks the single-row model) + DEL.
+# contains_ctrl() default range also rejects C1 bytes (0x80-0x9f) byte-wise,
+# which false-positives on UTF-8 continuation bytes — its other in-repo callers
+# pass ASCII-fixed values, but title/description here are Japanese frontmatter
+# text. A raw C1 byte is invalid UTF-8 to begin with; the row-integrity concern
+# is C0 (newline breaks the single-row model) + DEL, which is exactly the
+# shared `--c0-only` range (byte range stays defined in one place).
 _has_c0_del() {
-  local _in_bytes _stripped_bytes
-  _in_bytes=$(printf '%s' "$1" | LC_ALL=C wc -c) || return 0
-  _stripped_bytes=$(printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\177' | LC_ALL=C wc -c) || return 0
-  _in_bytes=${_in_bytes//[[:space:]]/}
-  _stripped_bytes=${_stripped_bytes//[[:space:]]/}
-  case "${_in_bytes}:${_stripped_bytes}" in
-    *[!0-9:]*|:*|*:) return 0 ;;
-  esac
-  [ "$_in_bytes" -ne "$_stripped_bytes" ]
+  contains_ctrl "$1" --c0-only
 }
 
 index_path=""
@@ -345,18 +344,21 @@ LC_ALL=C awk '
     }
     return out
   }
-  # escape rule a-prime: title = rule (a) plus `]` -> `&#93;`. The title lands
-  # in the link text of the page column, which is the identification predicate
-  # scan target: a raw `]` lets a title containing `](pages/{d}/{s}.md)` forge
-  # the FIRST-link key (backslash-escaping would not help — the predicate
-  # matches `](pages/` regardless of a preceding `\`). See docstring rule (a-prime).
+  # escape rule a-prime: title = rule (a) plus `]` -> `&#93;` ONLY when the next
+  # character is `(`. The title lands in the link text of the page column, which
+  # is the identification predicate scan target: `](pages/{d}/{s}.md)` in a title
+  # would forge the FIRST-link key (backslash-escaping would not help — the
+  # predicate matches `](pages/` regardless of a preceding `\`). Forgery needs
+  # the literal `](`, so a bare `]` is left alone: neutralizing it would unbalance
+  # the link text (`[CONTEXT]`, `.errors[]`) and render literally inside a code
+  # span. See docstring rule (a-prime).
   function esc_title(s,   out, i, c) {
     out = ""
     for (i = 1; i <= length(s); i++) {
       c = substr(s, i, 1)
       if (c == "\\")      out = out "\\\\"
       else if (c == "|")  out = out "\\|"
-      else if (c == "]")  out = out "&#93;"
+      else if (c == "]" && substr(s, i + 1, 1) == "(") out = out "&#93;"
       else                out = out c
     }
     return out
@@ -498,12 +500,11 @@ LC_ALL=C awk '
         prev_pipe = 0; next_pipe = 0
         for (j = i - 1; j > H; j--) if (lines[j] !~ /^[ \t]*$/) { prev_pipe = is_pipe_row(lines[j]); break }
         for (j = i + 1; j < E; j++) if (lines[j] !~ /^[ \t]*$/) { next_pipe = is_pipe_row(lines[j]); break }
-        if (prev_pipe && next_pipe) { drop[i] = 1; continue }
+        if (prev_pipe && next_pipe) continue
       }
       keep[++out_n] = i
     }
     n2 = 0
-    delete map
     for (k = 1; k <= out_n; k++) {
       i = keep[k]
       n2++; buf[n2] = lines[i]
@@ -524,7 +525,9 @@ LC_ALL=C awk '
       rs = first_link_key(s)
       if (rs != "" && rs == DOMAIN "/" SLUG) { match_count++; match_idx[match_count] = i }
     }
-    if (last_pipe == 0) last_pipe = H + 1                # fresh section: after separator
+    # procedure 0 guarantees header + separator rows inside the section on every
+    # path, and the blank-line pass never drops `|` rows, so last_pipe is always
+    # set by the loop above (no fallback needed).
 
     # ── procedures 1 / 2 (abort clause applies here only) ──
     if (match_count >= 2) {
@@ -649,10 +652,8 @@ elif [ "$stats_head_count" -eq 1 ]; then
     fi
     mv "$tmp_stats" "$tmp_rows" || { echo "ERROR: wiki-index-update: stats buffer swap failed — index.md left unmodified" >&2; exit 1; }
     stats_missing=$(sed -n 's/^stats_missing=//p' "$result_file" | tail -1)
-    if [ -n "$stats_missing" ] && [ "$stats_missing" != "" ]; then
-      stats_missing_trimmed=$(printf '%s' "$stats_missing" | sed 's/^ *//')
-      [ -n "$stats_missing_trimmed" ] && echo "WARNING: wiki-index-update: '## 統計' 節に既存行が見つからない統計行があります (${stats_missing_trimmed})。行を新設せずスキップします" >&2
-    fi
+    stats_missing_trimmed=$(printf '%s' "$stats_missing" | sed 's/^ *//')
+    [ -n "$stats_missing_trimmed" ] && echo "WARNING: wiki-index-update: '## 統計' 節に既存行が見つからない統計行があります (${stats_missing_trimmed})。行を新設せずスキップします" >&2
     # The marker is the caller's only machine-readable channel: when none of
     # the 3 stats lines could be rewritten, "synced" would contradict the
     # WARNING above. Zero rewritten lines means the section kept its previous

--- a/plugins/rite/hooks/tests/control-char-neutralize.test.sh
+++ b/plugins/rite/hooks/tests/control-char-neutralize.test.sh
@@ -32,6 +32,9 @@
 #   TC-18: contains_ctrl: UTF-8 U+009B (0xc2 0x9b) を 2 バイト目で検出
 #   TC-19: contains_ctrl: empty string は clean / UTF-8 マルチバイト (日本語) は検出
 #          (byte-wise 設計判断 pin — 継続バイト 0x80-0x9f 重複は accepted trade-off)
+#   TC-20: contains_ctrl --c0-only: C0+DEL のみ検出・C1/日本語は clean
+#          (neutralize_ctrl --c0-only と同一範囲を共有する検出側モード。UTF-8 本文を
+#           検査する call site 用。未知の第 2 引数は default 範囲へ倒す fail-closed も pin)
 #
 # Usage: bash plugins/rite/hooks/tests/control-char-neutralize.test.sh
 set -euo pipefail
@@ -156,6 +159,24 @@ assert "TC-19: empty string clean" "clean" "$(ctrl_verdict '')"
 # UTF-8 継続バイト (0x80-0x9f 重複) の検出は accepted trade-off (設計判断)。
 # この assert が fail し始めたら byte-wise 契約自体が変わったことを意味する。
 assert "TC-19: multibyte (Japanese) detected via continuation bytes" "detected" "$(ctrl_verdict 'あ')"
+
+echo ""
+echo "=== TC-20: contains_ctrl --c0-only — 範囲は neutralize_ctrl --c0-only と同一 ==="
+# UTF-8 本文 (日本語 title 等) を検査する call site 用モード。default 範囲との差分は
+# C1 (0x80-0x9f) の扱いのみで、そこが継続バイトを巻き込む false positive の発生源。
+# neutralize_ctrl --c0-only (TC-10〜13) と同じ範囲を共有していることを両側で pin する。
+ctrl_verdict_c0() { if contains_ctrl "$1" --c0-only; then echo detected; else echo clean; fi; }
+assert "TC-20: C0 (SOH) detected in --c0-only" "detected" "$(ctrl_verdict_c0 $'a\x01b')"
+assert "TC-20: TAB detected in --c0-only" "detected" "$(ctrl_verdict_c0 $'a\tb')"
+assert "TC-20: newline detected in --c0-only" "detected" "$(ctrl_verdict_c0 $'a\nb')"
+assert "TC-20: DEL detected in --c0-only" "detected" "$(ctrl_verdict_c0 $'a\x7fb')"
+# 本モードの存在意義: default が detected を返す日本語が clean になる (TC-19 と対の差分 pin)
+assert "TC-20: multibyte (Japanese) clean in --c0-only" "clean" "$(ctrl_verdict_c0 'あ')"
+assert "TC-20: C1 (0x9b CSI) clean in --c0-only" "clean" "$(ctrl_verdict_c0 $'a\x9bb')"
+assert "TC-20: printable ASCII clean in --c0-only" "clean" "$(ctrl_verdict_c0 'a-b_c.d')"
+assert "TC-20: empty string clean in --c0-only" "clean" "$(ctrl_verdict_c0 '')"
+# 未知の第 2 引数は default 範囲へ倒す (typo を silent に緩い判定へ落とさない fail-closed 側)
+assert "TC-20: unknown 2nd arg falls back to default range" "detected" "$(ctrl_verdict_c0_typo() { if contains_ctrl "$1" --c0only; then echo detected; else echo clean; fi; }; ctrl_verdict_c0_typo 'あ')"
 
 if ! print_summary "$(basename "$0")" "control-char-neutralize.sh — C0+DEL+C1 byte-wise neutralization + detection shared helper"; then
   exit 1

--- a/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
+++ b/plugins/rite/hooks/tests/shift2-loop-hardening.test.sh
@@ -20,7 +20,8 @@
 #   TC-5 decompose-issues.sh         (scripts/,       1 箇所) — 値なしフラグ末尾 → no-hang + exit 2
 #   TC-6 review-skip-notification.sh (hooks/,         4 箇所) — 値なしフラグ末尾 → no-hang (新規 helper、当初から shift; shift 採用)
 #   TC-6b review-nonblocking-record.sh (hooks/,        5 箇所) — 値なしフラグ末尾 → no-hang + exit 1
-#   TC-7 anti-pattern guard — 7 スクリプトに実 `shift 2` 文が残存しないこと (comment 参照は許容)
+#   TC-6c wiki-index-update.sh         (hooks/scripts/, 8 箇所) — 値なしフラグ末尾 → no-hang + exit 2
+#   TC-7 anti-pattern guard — 8 スクリプトに実 `shift 2` 文が残存しないこと (comment 参照は許容)
 #
 # 各 TC は `timeout 5` で hang (exit 124) を検出する。値なしフラグはいずれも required value を
 # 空にし、ループ完了後のローカル guard で exit する経路 (network/git に触れない) を選択している。
@@ -61,6 +62,7 @@ run_no_hang "TC-4 review-source-resolve"    "scripts/review-source-resolve.sh"  
 run_no_hang "TC-5 decompose-issues"         "scripts/decompose-issues.sh"              "--spec"            "2"
 run_no_hang "TC-6 review-skip-notification" "hooks/review-skip-notification.sh"         "--pr"              ""
 run_no_hang "TC-6b review-nonblocking-record" "hooks/review-nonblocking-record.sh"       "--pr"              "1"
+run_no_hang "TC-6c wiki-index-update"         "hooks/scripts/wiki-index-update.sh"       "--title"           "2"
 
 # === TC-7: anti-pattern guard — 実 `shift 2` 文が再混入していないこと ===
 # comment 内の `shift 2` 参照 (backtick 囲み) は許容し、実際の statement だけを検出する。
@@ -72,6 +74,7 @@ for script in \
   "hooks/review-result-save.sh" \
   "hooks/review-skip-notification.sh" \
   "hooks/review-nonblocking-record.sh" \
+  "hooks/scripts/wiki-index-update.sh" \
   "scripts/review-source-resolve.sh" \
   "scripts/decompose-issues.sh"; do
   path="$PLUGIN_ROOT/$script"

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -25,6 +25,10 @@
 #   TC-13 (T-04) index.md 不在 → exit 1 (fail-loud)
 #   TC-14 (T-04) `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
 #   TC-15b (T-04) UTF-8 日本語 title/description の制御文字誤検出なし (rc=0、C1 除外の意図を pin)
+#   TC-15c (T-04) brace 含み正当 title は residue gate に棄却されない (exact 突合の意図を pin)
+#   TC-16g (T-04) 統計 3 行が全欠落 → stats_sync=skipped_unreadable (0 行同期を synced にしない)
+#   TC-22 (T-04) 行末区切り欠落の登録行から summary 保持抽出 → exit 1 + 無変更
+#         (positional 抽出の前提崩れを silent 空文字化させない)
 #   TC-12b (T-03) 統計節も不在なら EOF に節新設 (golden)
 #   TC-16b (T-04) pages 一覧 0 件 (*.md ゼロ、find rc=0) → skip + 統計保持
 #   TC-16c (T-04) --pages-root 省略 (統計節あり) → skipped_unreadable + 統計保持
@@ -589,6 +593,23 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
+# TC-15c (T-04): brace 含み正当 title は residue gate に棄却されない
+# gate は literal `{title}`/`{description}`/`{updated}` の exact 突合のみ
+# (形状ヒューリスティックだと free text の正当値を棄却し当該ページが孤児化する)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc15c)
+run_helper --index "$dir/index.md" --title '{CONTEXT} マーカーの設計 {emit}' --domain patterns \
+  --slug foo --description '{description 風だが正当} な値' \
+  --updated "2026-08-05T09:40:00+09:00" --confidence high --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF '| [{CONTEXT} マーカーの設計 {emit}](pages/patterns/foo.md) | patterns | {description 風だが正当} な値 | 2026-08-05T09:40:00+09:00 | high |' "$dir/index.md"; then
+  pass "TC-15c brace 含み正当 title/description が residue gate に棄却されない (rc=0)"
+else
+  fail "TC-15c (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
 # TC-16 (T-04): pages ディレクトリ不在 (find 非ゼロ終了) → stats skip + 既存統計値保持
 # ──────────────────────────────────────────────────────────────────────
 dir=$(make_sandbox tc16)
@@ -690,6 +711,39 @@ if [ "$HELPER_RC" -eq 0 ] \
 else
   fail "TC-16d (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
   cat "$TEST_DIR/tc16d-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16g (T-04): 統計 3 行が全欠落 → stats_sync=skipped_unreadable + WARNING
+# 1 行も同期できていないのに synced を返すと marker 契約 (LLM への唯一の
+# 機械可読チャネル) が WARNING と矛盾する — 0 行同期は「前サイクル値のまま」
+# なので skipped_unreadable と同義に降ろす
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16g)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+（統計行は手動整理で失われた）
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T10:35:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_unreadable' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && grep -qxF '（統計行は手動整理で失われた）' "$dir/index.md" \
+   && grep -q '2026-08-05T10:35:00+09:00' "$dir/index.md"; then
+  pass "TC-16g 統計 3 行全欠落は skipped_unreadable (0 行同期を synced と偽装しない・行は新設しない)"
+else
+  fail "TC-16g (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -910,6 +964,36 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
+# TC-22 (T-04): 行末区切り欠落の登録行 + description 省略 (summary 保持経路)
+# → exit 1 + 無変更。positional 抽出は先頭・末尾フラグメントが空白のみで
+# あることを検査する — 検査なしだと同定は通るのに抽出が空になり、蓄積
+# サマリーを rc=0 のまま空文字で上書きする (docstring の禁止事項)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc22)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 | high
+EOF
+before=$(cat "$dir/index.md")
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T11:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+after=$(cat "$dir/index.md")
+if [ "$HELPER_RC" -eq 1 ] \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+   && [ "$before" = "$after" ] \
+   && [ "$(grep -c '蓄積サマリー' "$dir/index.md")" -eq 1 ]; then
+  pass "TC-22 行末区切り欠落行の summary 保持抽出は exit 1・無変更 (silent 空文字化しない)"
+else
+  fail "TC-22 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
 # TC-17 (T-06): SKILL.md ステップ 6 の縮退 (grep 検査)
 # ──────────────────────────────────────────────────────────────────────
 if [ ! -f "$INGEST_MD" ]; then
@@ -960,6 +1044,23 @@ printf '%s\n' "$step6_block" | grep -qF -- '--description "$wiu_description"' ||
 printf '%s\n' "$step6_block" | grep -qF -- 'bash "{plugin_root}/hooks/scripts/wiki-index-update.sh"' || { tc17b_ok=0; echo "  (helper 呼び出しコマンド行が無い/形が崩れている)"; }
 printf '%s\n' "$step6_block" | grep -qF -- '--index "$wiki_root/index.md"' || { tc17b_ok=0; echo '  (--index の値が $wiki_root/index.md でない)'; }
 printf '%s\n' "$step6_block" | grep -qF -- '--pages-root "$wiki_root/pages"' || { tc17b_ok=0; echo '  (--pages-root の値が $wiki_root/pages でない)'; }
+# 継続行を 1 論理コマンドへ join して 8 フラグが同一コマンド内に並ぶことを assert する。
+# 行単位断片の grep だけでは継続 backslash の脱落 (行が分断され後続フラグが別コマンド化し
+# 実行時 rc=127 になる Edit 崩れ) が生存する
+step6_joined=$(printf '%s\n' "$step6_block" | awk '{ if (sub(/[[:space:]]*\\$/, " ")) printf "%s", $0; else print }')
+helper_call_line=$(printf '%s\n' "$step6_joined" | grep -F -- 'bash "{plugin_root}/hooks/scripts/wiki-index-update.sh"') || helper_call_line=""
+if [ -z "$helper_call_line" ]; then
+  tc17b_ok=0; echo "  (join 後に helper 呼び出しが 1 論理コマンドに正規化できない)"
+else
+  tc17b_split_flags=""
+  for f in $helper_flags; do
+    case "$helper_call_line" in
+      *"$f "*) ;;
+      *) tc17b_ok=0; tc17b_split_flags="$tc17b_split_flags $f" ;;
+    esac
+  done
+  [ -z "$tc17b_split_flags" ] || echo "  (継続 backslash 脱落等でフラグが呼び出しコマンドの外にある:$tc17b_split_flags)"
+fi
 printf '%s\n' "$step6_block" | grep -qF -- "wiu_title=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (title の quoted heredoc が解除されている)"; }
 printf '%s\n' "$step6_block" | grep -qF -- "wiu_description=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (description の quoted heredoc が解除されている)"; }
 if [ "$tc17b_ok" -eq 1 ]; then

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -368,13 +368,13 @@ run_helper --index "$dir/index.md" --title "Dup NEW" --domain patterns \
 if [ "$HELPER_RC" -eq 0 ] \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=aborted_duplicate' \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'dedup_removed=1' \
-   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF "2 rows register page 'patterns/dup'" \
    && grep -q 'Dup 先発' "$dir/index.md" \
    && ! grep -q 'Dup NEW' "$dir/index.md" \
    && ! grep -q 'Dup 後発' "$dir/index.md"; then
-  pass "TC-10 対象ページ重複で中止 (fallback なし・WARNING) + 3a が後発回収"
+  pass "TC-10 対象ページ重複で中止 (page '{domain}/{slug}' 表記 WARNING) + 3a が後発回収"
 else
-  fail "TC-10 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  fail "TC-10 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -549,6 +549,22 @@ run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
 run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
   --updated $'2026\t08' --confidence high
 [ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (制御文字入り updated が rc=$HELPER_RC)"; }
+# placeholder residue gate: 未置換の {title}/{description}/{updated} は exit 2
+run_helper --index "$dir/index.md" --title '{title}' --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (未置換 {title} が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --description '{description}' --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (未置換 {description} が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated '{updated}' --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (未置換 {updated} が rc=$HELPER_RC)"; }
+# unknown argument arm: フラグ誤記への唯一の fail-loud (silent no-op 退化の検出)
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high --bogus x
+if [ "$HELPER_RC" -ne 2 ] || ! printf '%s\n' "$HELPER_STDERR" | grep -qF 'unknown argument: --bogus'; then
+  tc15_ok=0; echo "  (unknown argument --bogus が rc=$HELPER_RC / ERROR 文言不一致)"
+fi
 after=$(cat "$dir/index.md")
 if [ "$tc15_ok" -eq 1 ] && [ "$before" = "$after" ]; then
   pass "TC-15 invocation error 群 (enum/slug/updated/欠落/制御文字) で exit 2・index.md 無変更"
@@ -939,8 +955,15 @@ printf '%s\n' "$step6_block" | grep -qF -- '--updated "{updated}"' || { tc17b_ok
 printf '%s\n' "$step6_block" | grep -qF -- '--confidence "{confidence}"' || { tc17b_ok=0; echo "  (--confidence の placeholder 対応が崩れている)"; }
 printf '%s\n' "$step6_block" | grep -qF -- '--title "$wiu_title"' || { tc17b_ok=0; echo "  (--title の heredoc 変数対応が崩れている)"; }
 printf '%s\n' "$step6_block" | grep -qF -- '--description "$wiu_description"' || { tc17b_ok=0; echo "  (--description の heredoc 変数対応が崩れている)"; }
+# 呼び出し行の実体 (コマンド語・値の形) も literal で pin する — フラグ名集合の突合だけでは
+# 呼び出し行の削除・helper パス改名・パス値の相対化・quoted heredoc 解除が生存する
+printf '%s\n' "$step6_block" | grep -qF -- 'bash "{plugin_root}/hooks/scripts/wiki-index-update.sh"' || { tc17b_ok=0; echo "  (helper 呼び出しコマンド行が無い/形が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--index "$wiki_root/index.md"' || { tc17b_ok=0; echo '  (--index の値が $wiki_root/index.md でない)'; }
+printf '%s\n' "$step6_block" | grep -qF -- '--pages-root "$wiki_root/pages"' || { tc17b_ok=0; echo '  (--pages-root の値が $wiki_root/pages でない)'; }
+printf '%s\n' "$step6_block" | grep -qF -- "wiu_title=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (title の quoted heredoc が解除されている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- "wiu_description=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (description の quoted heredoc が解除されている)"; }
 if [ "$tc17b_ok" -eq 1 ]; then
-  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応) が helper の case arm と一致"
+  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応 + 呼び出し行 literal) が helper と一致"
 else
   fail "TC-17b"
 fi

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -375,18 +375,25 @@ cat > "$dir/index.md" <<'EOF'
 |--------|---------|---------|--------|--------|
 | [Dup 先発](pages/patterns/dup.md) | patterns | 1本目 | 2026-01-01T00:00:00+09:00 | high |
 | [Dup 後発](pages/patterns/dup.md) | patterns | 2本目 | 2026-01-02T00:00:00+09:00 | low |
+| [Dup 3本目](pages/patterns/dup.md) | patterns | 3本目 | 2026-01-03T00:00:00+09:00 | low |
 EOF
+# 3 行重複にするのは dedup_removed が 0/1 の退化値でしか観測されない状態を避けるため
+# (docstring は「後発行群を削除」と複数形で規定しており、最初の 1 本だけ回収する退行や
+#  カウンタを定数 1 にする退行は 2 行 fixture では検出できない。3 行残ると中止条項が
+#  翌サイクルも発火し、当該ページの更新がもう 1 サイクル失われる)
 run_helper --index "$dir/index.md" --title "Dup NEW" --domain patterns \
   --slug dup --description "中止されるべき更新" --updated "2026-08-05T04:00:00+09:00" \
   --confidence medium --pages-root "$dir/pages"
 if [ "$HELPER_RC" -eq 0 ] \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=aborted_duplicate' \
-   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'dedup_removed=1' \
-   && printf '%s\n' "$HELPER_STDERR" | grep -qF "2 rows register page 'patterns/dup'" \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'dedup_removed=2' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF "3 rows register page 'patterns/dup'" \
+   && [ "$(grep -c 'pages/patterns/dup\.md' "$dir/index.md")" -eq 1 ] \
    && grep -q 'Dup 先発' "$dir/index.md" \
    && ! grep -q 'Dup NEW' "$dir/index.md" \
-   && ! grep -q 'Dup 後発' "$dir/index.md"; then
-  pass "TC-10 対象ページ重複で中止 (page '{domain}/{slug}' 表記 WARNING) + 3a が後発回収"
+   && ! grep -q 'Dup 後発' "$dir/index.md" \
+   && ! grep -q 'Dup 3本目' "$dir/index.md"; then
+  pass "TC-10 対象ページ 3 行重複で中止 + 3a が後発 2 行を回収 (dedup_removed=2・残存 1 行)"
 else
   fail "TC-10 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
 fi
@@ -552,9 +559,9 @@ run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
   --updated "2026-08-05T08:00:00+09:00" --confidence high --pages-root "$dir/pages"
 after=$(cat "$dir/index.md")
 if [ "$HELPER_RC" -eq 1 ] \
-   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF -- "2 '## ページ一覧' headings — ambiguous target, refusing to guess" \
    && [ "$before" = "$after" ]; then
-  pass "TC-14 見出し重複 (想定外構造) で exit 1・部分適用なし"
+  pass "TC-14 見出し重複 (想定外構造) で exit 1・部分適用なし (ガード固有文言 + 件数を識別)"
 else
   fail "TC-14 (rc=$HELPER_RC)"
 fi
@@ -619,9 +626,30 @@ run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
 run_helper --index "$dir/index.md" --title t --domain patterns --slug 'bad/slug' \
   --updated "2026-08-05T09:00:00+09:00" --confidence high
 [ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (不正 slug が rc=$HELPER_RC)"; }
+# 必須引数ガード 4 本すべてを流す。rc だけでは兄弟ガード同士が masking し合う
+# (--index 欠落は rc=1 の not found 経路と紛らわしい) ため、各ガード固有の文言も見る
 run_helper --index "$dir/index.md" --domain patterns --slug s \
   --updated "2026-08-05T09:00:00+09:00" --confidence high
 [ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--title 欠落が rc=$HELPER_RC)"; }
+printf '%s\n' "$HELPER_STDERR" | grep -qF -- '--title is required' \
+  || { tc15_ok=0; echo "  (--title 欠落の診断文言が固有でない)"; }
+run_helper --title t --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--index 欠落が rc=$HELPER_RC)"; }
+printf '%s\n' "$HELPER_STDERR" | grep -qF -- '--index is required' \
+  || { tc15_ok=0; echo "  (--index 欠落の診断文言が固有でない)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--slug 欠落が rc=$HELPER_RC)"; }
+printf '%s\n' "$HELPER_STDERR" | grep -qF -- '--slug is required' \
+  || { tc15_ok=0; echo "  (--slug 欠落の診断文言が固有でない)"; }
+# --updated 欠落: ガードを失うと更新日セルと `- 最終更新:` 行が空のまま
+# rc=0 + stats_sync=synced で書かれる silent corruption になる
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--updated 欠落が rc=$HELPER_RC)"; }
+printf '%s\n' "$HELPER_STDERR" | grep -qF -- '--updated is required' \
+  || { tc15_ok=0; echo "  (--updated 欠落の診断文言が固有でない)"; }
 # 制御文字 reject 経路 (_has_c0_del): 改行入り title / 改行入り description /
 # 制御文字 (TAB) 入り updated はいずれも exit 2 (1 行のテーブル行として表現不能)
 run_helper --index "$dir/index.md" --title $'a\nb' --domain patterns --slug s \
@@ -1065,13 +1093,19 @@ run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
   --slug foo --updated "2026-08-05T11:00:00+09:00" --confidence high \
   --pages-root "$dir/pages"
 after=$(cat "$dir/index.md")
+# 総称 ERROR ではなくガード固有文言で見る (この fixture は行末区切りが欠けており
+# 末尾フラグメントが非空になるため境界フラグメント検査が先に発火する — どちらが
+# 発火したかを test が識別できないと 2 つの ERROR 文言を相互置換する退行が素通りする)。
+# 併せて fail-loud 経路で一時ファイルが index.md と同じディレクトリに残らないことも固定する
+# (残置すると後続の commit が `git add .rite/wiki/` でディレクトリごと stage して wiki ブランチへ混入する)
 if [ "$HELPER_RC" -eq 1 ] \
-   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF -- 'content outside the cell delimiters' \
    && [ "$before" = "$after" ] \
-   && [ "$(grep -c '蓄積サマリー' "$dir/index.md")" -eq 1 ]; then
-  pass "TC-22 行末区切り欠落行の summary 保持抽出は exit 1・無変更 (silent 空文字化しない)"
+   && [ "$(grep -c '蓄積サマリー' "$dir/index.md")" -eq 1 ] \
+   && [ "$(ls -A "$dir" | grep -c '^\.wiki-index-update\.')" -eq 0 ]; then
+  pass "TC-22 行末区切り欠落行は exit 1・無変更・一時ファイル残置なし (ガード固有文言で識別)"
 else
-  fail "TC-22 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
+  fail "TC-22 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR tmp=$(ls -A "$dir" | grep '^\.wiki-index-update\.' | paste -sd, -))"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -1083,11 +1117,17 @@ fi
 # 無効化する変異は summary 列が更新日列以降を飲み込む silent corruption に
 # なるため、この shape が当該ガード単独の識別力を担う
 # ──────────────────────────────────────────────────────────────────────
+# shape と期待文言を対にする。総称 ERROR だと「どちらのガードが発火したか」を
+# 識別できず、2 つの ERROR 文言を相互置換する退行 (shape と診断の対応が入れ替わる)
+# が素通りする — SKILL.md は exit 1 の ERROR を「唯一のシグナル」と規定しており、
+# 誤った診断は運用者の修復先を取り違えさせる
 tc22b_ok=1
-for shape in \
-  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 |' \
-  '| [Foo Pattern](pages/patterns/foo.md) | 蓄積サマリー |' \
-  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 | high | junk1 | junk2'; do
+for entry in \
+  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 |@@fewer cells than the 5-column layout' \
+  '| [Foo Pattern](pages/patterns/foo.md) | 蓄積サマリー |@@fewer cells than the 5-column layout' \
+  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 | high | junk1 | junk2@@content outside the cell delimiters'; do
+  shape="${entry%%@@*}"
+  expected_msg="${entry##*@@}"
   dir=$(make_sandbox "tc22b-$(printf '%s' "$shape" | wc -c)")
   cat > "$dir/index.md" <<EOF
 # Wiki Index
@@ -1103,15 +1143,44 @@ EOF
     --slug foo --updated "2026-08-05T12:00:00+09:00" --confidence high \
     --pages-root "$dir/pages"
   after=$(cat "$dir/index.md")
-  if [ "$HELPER_RC" -ne 1 ] || ! printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+  if [ "$HELPER_RC" -ne 1 ] || ! printf '%s\n' "$HELPER_STDERR" | grep -qF -- "$expected_msg" \
      || [ "$before" != "$after" ] || [ "$(grep -c '蓄積サマリー' "$dir/index.md")" -ne 1 ]; then
-    tc22b_ok=0; echo "  (セル数 $(printf '%s' "$shape" | awk -F'|' '{print NF-2}') の行が rc=$HELPER_RC / 蓄積サマリー残存 $(grep -c '蓄積サマリー' "$dir/index.md"))"
+    tc22b_ok=0; echo "  (セル数 $(printf '%s' "$shape" | awk -F'|' '{print NF-2}') の行が rc=$HELPER_RC / 期待文言 '$expected_msg' 不一致 / 蓄積サマリー残存 $(grep -c '蓄積サマリー' "$dir/index.md"))"
   fi
 done
 if [ "$tc22b_ok" -eq 1 ]; then
-  pass "TC-22b セル数不足 (4/3 セル) + 余剰フラグメント行の summary 保持抽出は exit 1・無変更"
+  pass "TC-22b セル数不足 (4/3 セル) + 余剰フラグメント行は exit 1・無変更 (shape ごとにガード固有文言を識別)"
 else
   fail "TC-22b"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-22d (T-04): malformed 行の診断が index.md の制御バイトを中和して出す
+# SKILL.md ステップ 6 の exit 1 行は「ERROR をそのまま表示」を指示するため、
+# 破損 index の生 ESC / CSI が端末・transcript へ素通しする。同 helper の exit 2 系
+# 診断 (neutralize_ctrl 適用済み) との非対称を殺す
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc22d)
+{
+  printf '# Wiki Index\n\n## ページ一覧\n\n'
+  printf '| ページ | ドメイン | サマリー | 更新日 | 確信度 |\n'
+  printf '|--------|---------|---------|--------|--------|\n'
+  printf '| [Foo Pattern](pages/patterns/foo.md) | patterns | \033[31m蓄積\177サマリー | 2026-01-01T00:00:00+09:00 | high\n'
+} > "$dir/index.md"
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T12:40:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+# ESC (033) と DEL (177) が stderr に残らないこと。バイト単位で検査する
+# (grep の文字クラスはロケール依存で raw 8-bit を取りこぼしうるため od で数える)
+tc22d_esc=$(printf '%s' "$HELPER_STDERR" | od -An -tx1 | tr -d ' \n' | grep -o '1b' | wc -l | tr -d ' ')
+tc22d_del=$(printf '%s' "$HELPER_STDERR" | od -An -tx1 | tr -d ' \n' | grep -o '7f' | wc -l | tr -d ' ')
+if [ "$HELPER_RC" -eq 1 ] \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF -- 'content outside the cell delimiters' \
+   && [ "$tc22d_esc" -eq 0 ] && [ "$tc22d_del" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF -- '蓄積' ; then
+  pass "TC-22d malformed 行の診断は制御バイトを中和 (ESC/DEL 0 バイト・日本語は保持)"
+else
+  fail "TC-22d (rc=$HELPER_RC esc=$tc22d_esc del=$tc22d_del)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -1400,8 +1469,17 @@ for v in title description domain slug updated confidence; do
   printf '%s\n' "$step6_block" | grep -qF -- "wiu_${v}=\$(cat <<'WIU_EOF'" \
     || { tc17b_ok=0; echo "  ($v の quoted heredoc が解除されている)"; }
 done
+# heredoc 終端子衝突の実行前ゲート。quoted heredoc に残る唯一の脱出口 (値の行が
+# `WIU_EOF` と一致すると heredoc が早期終了し残りがコマンド実行される) は block 内の
+# シェルでは parse 前に検査できないため、substitute する LLM 側の責務としてゲート文言が
+# 必要。後続 cycle での脱落を殺すため散文を literal で pin する
+step6_prose=$(printf '%s\n' "$step6" | grep -vF -- '```')
+printf '%s\n' "$step6_prose" | grep -qF -- '終端子 `WIU_EOF` と完全一致' \
+  || { tc17b_ok=0; echo "  (heredoc 終端子衝突の実行前ゲート文言が無い)"; }
+printf '%s\n' "$step6_prose" | grep -qF -- 'この bash を実行してはならない' \
+  || { tc17b_ok=0; echo "  (実行前ゲートの禁止指示が無い)"; }
 if [ "$tc17b_ok" -eq 1 ]; then
-  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応 + 呼び出し行 literal + wiki_root 導出 + 6 値 heredoc) が helper と一致"
+  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応 + 呼び出し行 literal + wiki_root 導出 + 6 値 heredoc + 終端子ゲート) が helper と一致"
 else
   fail "TC-17b"
 fi

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -25,6 +25,13 @@
 #   TC-13 (T-04) index.md 不在 → exit 1 (fail-loud)
 #   TC-14 (T-04) `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
 #   TC-15b (T-04) UTF-8 日本語 title/description の制御文字誤検出なし (rc=0、C1 除外の意図を pin)
+#   TC-12b (T-03) 統計節も不在なら EOF に節新設 (golden)
+#   TC-16b (T-04) pages 一覧 0 件 (*.md ゼロ、find rc=0) → skip + 統計保持
+#   TC-16c (T-04) --pages-root 省略 (統計節あり) → skipped_unreadable + 統計保持
+#   TC-16d (T-04) 統計行の一部欠落 → WARNING + 残存行のみ同期・新設しない (golden)
+#   TC-16e (T-04) 祖先ディレクトリ名がドメイン名と衝突しても内訳が膨張しない
+#   TC-16f (T-03) 節末端より後ろの別節の pages リンク行は不変 (golden)
+#   TC-17b (T-06) SKILL.md ステップ 6 呼び出し契約の invocation-symmetry (フラグ集合突合)
 #   TC-18 (T-01/T-03) 別ドメイン同一 slug は別ページ (同定キー = {domain}/{slug}、golden)
 #   TC-19〜21 (T-03) ヘッダ行・区切り行の欠落補填 (両方欠落 / 区切りのみ / ヘッダのみ、golden)
 #   (T-05 は既存 wiki-lint 系スイートの継続 green で担保 — 本ファイル対象外)
@@ -93,10 +100,10 @@ run_helper() {
 # TC-1 (T-01): 新規行追加 parity
 # ──────────────────────────────────────────────────────────────────────
 dir=$(make_sandbox tc1)
+# description は生パイプ入り (新規追加経路のエスケープ規約 (a) を golden で固定する)
 run_helper --index "$dir/index.md" --title "Bar Heuristic" --domain heuristics \
-  --slug bar --description "bar の説明" --updated "2026-08-04T22:00:00+09:00" \
+  --slug bar --description "bar の説明 | 補足" --updated "2026-08-04T22:00:00+09:00" \
   --confidence medium --pages-root "$dir/pages"
-expected_row='| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 | 2026-08-04T22:00:00+09:00 | medium |'
 # golden 全文比較: grep 断片照合ではなく期待ファイル全文との diff で固定する
 # (ヘッダ二重化・本文欠落・空行過剰削除・節末端誤検出を 1 assert で同時捕捉)
 cat > "$TEST_DIR/tc1-expected.md" <<'EOF'
@@ -109,7 +116,7 @@ cat > "$TEST_DIR/tc1-expected.md" <<'EOF'
 | ページ | ドメイン | サマリー | 更新日 | 確信度 |
 |--------|---------|---------|--------|--------|
 | [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
-| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 | 2026-08-04T22:00:00+09:00 | medium |
+| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 \| 補足 | 2026-08-04T22:00:00+09:00 | medium |
 
 ## 統計
 
@@ -413,17 +420,61 @@ EOF
 run_helper --index "$dir/index.md" --title "First Page" --domain patterns \
   --slug foo --description "最初の登録" --updated "2026-08-05T06:00:00+09:00" \
   --confidence high --pages-root "$dir/pages"
-list_line=$(grep -n '^## ページ一覧' "$dir/index.md" | cut -d: -f1)
-stats_line=$(grep -n '^## 統計' "$dir/index.md" | cut -d: -f1)
+# golden 全文比較: 新設節の形状・位置・見出し literal を固定する
+# (見出し汚染変異は is_list_head が二度と一致せず次サイクルで節が二重化するため)
+cat > "$TEST_DIR/tc12-expected.md" <<'EOF'
+# Wiki Index
+
+本文と HTML コメント。
+<!-- comment -->
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [First Page](pages/patterns/foo.md) | patterns | 最初の登録 | 2026-08-05T06:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 2
+- ドメイン別: patterns=1, heuristics=1, anti-patterns=0
+- 最終更新: 2026-08-05T06:00:00+09:00
+EOF
 if [ "$HELPER_RC" -eq 0 ] \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
-   && [ -n "$list_line" ] && [ -n "$stats_line" ] && [ "$list_line" -lt "$stats_line" ] \
-   && grep -qxF '| ページ | ドメイン | サマリー | 更新日 | 確信度 |' "$dir/index.md" \
-   && grep -qxF '| [First Page](pages/patterns/foo.md) | patterns | 最初の登録 | 2026-08-05T06:00:00+09:00 | high |' "$dir/index.md" \
-   && grep -qx -- '- 総ページ数: 2' "$dir/index.md"; then
-  pass "TC-12 節不在時は統計の直前にヘッダ付きで新設"
+   && diff -u "$TEST_DIR/tc12-expected.md" "$dir/index.md" > "$TEST_DIR/tc12-diff.txt" 2>&1; then
+  pass "TC-12 節不在時は統計の直前にヘッダ付きで新設 (golden)"
 else
-  fail "TC-12 (rc=$HELPER_RC list_line=$list_line stats_line=$stats_line)"
+  fail "TC-12 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc12-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-12b (T-03): 節・統計とも不在 → EOF に新設 (golden)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc12b)
+printf '# Wiki Index\n\n本文。\n' > "$dir/index.md"
+run_helper --index "$dir/index.md" --title "EOF Page" --domain patterns \
+  --slug foo --description "EOF 挿入" --updated "2026-08-05T06:30:00+09:00" \
+  --confidence high --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc12b-expected.md" <<'EOF'
+# Wiki Index
+
+本文。
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [EOF Page](pages/patterns/foo.md) | patterns | EOF 挿入 | 2026-08-05T06:30:00+09:00 | high |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=added; dedup_removed=0; stats_sync=skipped_no_section$' \
+   && diff -u "$TEST_DIR/tc12b-expected.md" "$dir/index.md" > "$TEST_DIR/tc12b-diff.txt" 2>&1; then
+  pass "TC-12b 統計節も不在なら EOF に新設 (golden)"
+else
+  fail "TC-12b (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc12b-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -522,7 +573,7 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
-# TC-16 (T-04): pages 一覧 0 件 → stats skip + 既存統計値保持
+# TC-16 (T-04): pages ディレクトリ不在 (find 非ゼロ終了) → stats skip + 既存統計値保持
 # ──────────────────────────────────────────────────────────────────────
 dir=$(make_sandbox tc16)
 rm -rf "$dir/pages"
@@ -535,9 +586,177 @@ if [ "$HELPER_RC" -eq 0 ] \
    && grep -qx -- '- 総ページ数: 1' "$dir/index.md" \
    && grep -qx -- '- 最終更新: 2026-01-01T00:00:00+09:00' "$dir/index.md" \
    && grep -q '2026-08-05T10:00:00+09:00' "$dir/index.md"; then
-  pass "TC-16 pages 取得不能は WARNING + 統計値保持 (行操作は適用)"
+  pass "TC-16 pages ディレクトリ不在 (find rc 非ゼロ) は WARNING + 統計値保持 (行操作は適用)"
 else
   fail "TC-16 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16b (T-04): pages 一覧 0 件 (ディレクトリは在るが *.md ゼロ) → 同じく skip
+# find は rc=0 で空出力を返すため [ -z "$pages_list" ] guard の実行可能仕様
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16b)
+rm -rf "$dir/pages"
+mkdir -p "$dir/pages/patterns"
+touch "$dir/pages/patterns/.gitkeep"
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T10:10:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_unreadable' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && grep -qx -- '- 総ページ数: 1' "$dir/index.md" \
+   && grep -qx -- '- ドメイン別: patterns=1, heuristics=0, anti-patterns=0' "$dir/index.md" \
+   && grep -qx -- '- 最終更新: 2026-01-01T00:00:00+09:00' "$dir/index.md"; then
+  pass "TC-16b pages 一覧 0 件 (*.md ゼロ) も統計値保持 (誤った 0 で上書きしない)"
+else
+  fail "TC-16b (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16c (T-04): 統計節ありで --pages-root 省略 → skipped_unreadable + 統計保持
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16c)
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T10:20:00+09:00" --confidence high
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_unreadable' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && grep -qx -- '- 総ページ数: 1' "$dir/index.md" \
+   && grep -qx -- '- 最終更新: 2026-01-01T00:00:00+09:00' "$dir/index.md" \
+   && grep -q '2026-08-05T10:20:00+09:00' "$dir/index.md"; then
+  pass "TC-16c --pages-root 省略は WARNING + skipped_unreadable + 統計保持"
+else
+  fail "TC-16c (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16d (T-04): 統計 3 行の一部欠落 → 欠落行を新設せず残存行のみ同期 + WARNING
+# docstring の never invented 不変条件の実行可能仕様 (golden)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16d)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 1
+- 最終更新: 2026-01-01T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T10:30:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc16d-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-08-05T10:30:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 2
+- 最終更新: 2026-08-05T10:30:00+09:00
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=synced' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ドメイン別' \
+   && diff -u "$TEST_DIR/tc16d-expected.md" "$dir/index.md" > "$TEST_DIR/tc16d-diff.txt" 2>&1; then
+  pass "TC-16d 統計行の一部欠落は WARNING (行名明示) + 残存行のみ同期・欠落行は新設しない (golden)"
+else
+  fail "TC-16d (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc16d-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16e (T-04): 祖先ディレクトリ名がドメイン名と衝突しても内訳が膨張しない
+# 前方一致 anchor (実装の case literal 前方一致) の実行可能仕様
+# ──────────────────────────────────────────────────────────────────────
+dir="$TEST_DIR/patterns/tc16e"
+mkdir -p "$dir/pages/patterns" "$dir/pages/heuristics" "$dir/pages/anti-patterns"
+touch "$dir/pages/patterns/p1.md" "$dir/pages/patterns/p2.md" \
+      "$dir/pages/heuristics/h1.md" \
+      "$dir/pages/anti-patterns/a1.md" "$dir/pages/anti-patterns/a2.md" "$dir/pages/anti-patterns/a3.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [P1](pages/patterns/p1.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 0
+- ドメイン別: patterns=0, heuristics=0, anti-patterns=0
+- 最終更新: 2026-01-01T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "P1" --domain patterns \
+  --slug p1 --updated "2026-08-05T10:40:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=synced' \
+   && grep -qx -- '- 総ページ数: 6' "$dir/index.md" \
+   && grep -qx -- '- ドメイン別: patterns=2, heuristics=1, anti-patterns=3' "$dir/index.md"; then
+  pass "TC-16e 祖先 patterns/ ディレクトリ下でも内訳が膨張しない (前方一致 anchor)"
+else
+  fail "TC-16e (rc=$HELPER_RC stdout=$HELPER_STDOUT actual=$(grep 'ドメイン別' "$dir/index.md"))"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16f (T-03): 節末端 — ページ一覧節の後ろの別節にある pages リンク行は不変
+# 「次の ## 見出しまで」述語の実行可能仕様 (golden)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16f)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+## 参考
+
+| リンク | 説明 |
+|--------|------|
+| [Foo Pattern](pages/patterns/foo.md) | 参考リンク |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern v2" --domain patterns \
+  --slug foo --updated "2026-08-05T10:50:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc16f-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern v2](pages/patterns/foo.md) | patterns | 既存 | 2026-08-05T10:50:00+09:00 | high |
+
+## 参考
+
+| リンク | 説明 |
+|--------|------|
+| [Foo Pattern](pages/patterns/foo.md) | 参考リンク |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=updated; dedup_removed=0; stats_sync=skipped_no_section$' \
+   && diff -u "$TEST_DIR/tc16f-expected.md" "$dir/index.md" > "$TEST_DIR/tc16f-diff.txt" 2>&1; then
+  pass "TC-16f 節末端より後ろの別節にある pages リンク行は同定・回収の対象外 (golden)"
+else
+  fail "TC-16f (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc16f-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -696,6 +915,34 @@ if [ "$tc17_ok" -eq 1 ]; then
   pass "TC-17 ステップ 6 は helper 呼び出しへ縮退し操作散文が残っていない"
 else
   fail "TC-17"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-17b (T-06): SKILL.md ステップ 6 呼び出し契約の invocation-symmetry
+# 委譲リファクタの唯一の統合シーム。フラグ集合は helper の case arm から動的抽出して
+# 突合する (create-md-invocation-symmetry.test.sh と同型の契約テスト)
+# ──────────────────────────────────────────────────────────────────────
+step6_block=$(printf '%s\n' "$step6" | awk '/^```bash$/{f=1;next} /^```$/{f=0} f{print}')
+tc17b_ok=1
+[ -n "$step6_block" ] || { tc17b_ok=0; echo "  (ステップ 6 に fenced bash ブロックが無い)"; }
+helper_flags=$(grep -oE '^[[:space:]]+--[a-z-]+\)' "$SCRIPT" | tr -d ' )' | LC_ALL=C sort)
+skill_flags=$(printf '%s\n' "$step6_block" | grep -oE -- '--[a-z-]+' | LC_ALL=C sort -u)
+if [ "$helper_flags" != "$skill_flags" ]; then
+  tc17b_ok=0
+  echo "  (フラグ集合が helper の case arm と不一致)"
+  echo "  helper: $(printf '%s' "$helper_flags" | tr '\n' ' ')"
+  echo "  skill:  $(printf '%s' "$skill_flags" | tr '\n' ' ')"
+fi
+printf '%s\n' "$step6_block" | grep -qF -- '--domain "{domain}"' || { tc17b_ok=0; echo "  (--domain の placeholder 対応が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--slug "{slug}"' || { tc17b_ok=0; echo "  (--slug の placeholder 対応が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--updated "{updated}"' || { tc17b_ok=0; echo "  (--updated の placeholder 対応が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--confidence "{confidence}"' || { tc17b_ok=0; echo "  (--confidence の placeholder 対応が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--title "$wiu_title"' || { tc17b_ok=0; echo "  (--title の heredoc 変数対応が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- '--description "$wiu_description"' || { tc17b_ok=0; echo "  (--description の heredoc 変数対応が崩れている)"; }
+if [ "$tc17b_ok" -eq 1 ]; then
+  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応) が helper の case arm と一致"
+else
+  fail "TC-17b"
 fi
 
 echo ""

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -23,17 +23,21 @@
 #   TC-11 (T-03) `## 統計` 節不在 → stats_sync=skipped_no_section (節を新設しない)
 #   TC-12 (T-03) `## ページ一覧` 節不在 → `## 統計` の直前に template 形で新設
 #   TC-13 (T-04) index.md 不在 → exit 1 (fail-loud)
+#   TC-13b (T-04) index.md 読み取り不能 → exit 1 + 'not readable' 診断 (root では skip)
 #   TC-14 (T-04) `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
+#   TC-14b (T-04) `## 統計` 見出し重複 → stats_sync=skipped_unreadable
+#         (first-match で 1 節目だけ同期して synced を返さない・両節無変更・行操作は適用)
 #   TC-15b (T-04) UTF-8 日本語 title/description の制御文字誤検出なし (rc=0、C1 除外の意図を pin)
 #   TC-15c (T-04) brace 含み正当 title は residue gate に棄却されない (exact 突合の意図を pin)
 #   TC-16g (T-04) 統計 3 行が全欠落 → stats_sync=skipped_unreadable (0 行同期を synced にしない)
 #   TC-22 (T-04) 行末区切り欠落の登録行から summary 保持抽出 → exit 1 + 無変更
 #         (positional 抽出の前提崩れを silent 空文字化させない)
-#   TC-22b (T-04) セル数不足 (4 セル / 3 セル) の登録行から summary 保持抽出 → exit 1 + 無変更
-#         (欠けたセルを特定できないため保持値を確定できない — TC-22 と同じ fail-loud 経路)
+#   TC-22b (T-04) セル数不足 (4/3 セル) + 余剰フラグメント行から summary 保持抽出 → exit 1 + 無変更
+#         (欠損はセル数ガード、余剰は境界フラグメント検査が捕捉 — 各ガード単独の識別力を pin)
 #   TC-22c (T-01) 空サマリーセルの正当な 5 列行は保持経路で rc=0 のまま (境界 pin)
 #   TC-23 (T-03) サマリー欄の相互参照リンクは同定に使われない (FIRST link 述語、golden)
 #   TC-24 (T-03) 新規追加と同時に別ページの重複行を回収 (added × dedup_removed=1)
+#   TC-25 (T-02) リンク構文入り title の同定キー詐称防止 (`]` → &#93; 中和、golden)
 #   TC-12b (T-03) 統計節も不在なら EOF に節新設 (golden)
 #   TC-16b (T-04) pages 一覧 0 件 (*.md ゼロ、find rc=0) → skip + 統計保持
 #   TC-16c (T-04) --pages-root 省略 (統計節あり) → skipped_unreadable + 統計保持
@@ -498,6 +502,31 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
+# TC-13b (T-04): index.md 読み取り不能 → exit 1 + 'not readable' 診断
+# rc=1 だけではガードの識別力がない (-r ガードを退行させても後段の awk 失敗が
+# 原因を取り違えた ERROR で rc=1 を返す) ため、-r ガード固有の診断文言を stderr
+# に対して assert し、無変更も前後比較で確認する
+# ──────────────────────────────────────────────────────────────────────
+if [ "$(id -u)" -eq 0 ]; then
+  skip "TC-13b (root では chmod 000 が read を阻めないため測定不能)"
+else
+  dir=$(make_sandbox tc13b)
+  before=$(cat "$dir/index.md")
+  chmod 000 "$dir/index.md"
+  run_helper --index "$dir/index.md" --title t --domain patterns \
+    --slug s --updated "2026-08-05T07:30:00+09:00" --confidence high
+  chmod 644 "$dir/index.md"
+  after=$(cat "$dir/index.md")
+  if [ "$HELPER_RC" -eq 1 ] \
+     && printf '%s\n' "$HELPER_STDERR" | grep -q 'not readable' \
+     && [ "$before" = "$after" ]; then
+    pass "TC-13b index.md 読み取り不能で exit 1 + 'not readable' 診断 (fail-loud)"
+  else
+    fail "TC-13b (rc=$HELPER_RC stderr=$HELPER_STDERR)"
+  fi
+fi
+
+# ──────────────────────────────────────────────────────────────────────
 # TC-14 (T-04): `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
 # ──────────────────────────────────────────────────────────────────────
 dir=$(make_sandbox tc14)
@@ -524,6 +553,48 @@ if [ "$HELPER_RC" -eq 1 ] \
   pass "TC-14 見出し重複 (想定外構造) で exit 1・部分適用なし"
 else
   fail "TC-14 (rc=$HELPER_RC)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-14b (T-04): `## 統計` 見出し重複 → 統計同期のみ skip (skipped_unreadable)
+# ページ一覧側の見出し重複 (TC-14) と同じ破損クラスだが、行操作 (唯一の重複修復
+# 経路 3a を含む) まで塞ぐのは過剰なため exit 1 ではなく WARNING + 同期 skip。
+# first-match で 1 節目だけ同期して synced を返す縮退 (silent first-match) を殺す
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc14b)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 99
+- ドメイン別: patterns=99, heuristics=0, anti-patterns=0
+- 最終更新: 2020-01-01T00:00:00+09:00
+
+## 統計
+
+- 総ページ数: 77
+- ドメイン別: patterns=77, heuristics=0, anti-patterns=0
+- 最終更新: 2021-01-01T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --description "更新後" --updated "2026-08-05T13:30:00+09:00" \
+  --confidence high --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qF '[CONTEXT] WIKI_INDEX_UPDATE=row_action=updated; dedup_removed=0; stats_sync=skipped_unreadable' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ambiguous sync target' \
+   && grep -q '総ページ数: 99' "$dir/index.md" \
+   && grep -q '総ページ数: 77' "$dir/index.md" \
+   && grep -qxF '| [Foo Pattern](pages/patterns/foo.md) | patterns | 更新後 | 2026-08-05T13:30:00+09:00 | high |' "$dir/index.md"; then
+  pass "TC-14b 統計見出し重複は同期 skip (skipped_unreadable)・両節無変更・行操作は適用"
+else
+  fail "TC-14b (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -970,9 +1041,10 @@ fi
 
 # ──────────────────────────────────────────────────────────────────────
 # TC-22 (T-04): 行末区切り欠落の登録行 + description 省略 (summary 保持経路)
-# → exit 1 + 無変更。positional 抽出は先頭・末尾フラグメントが空白のみで
-# あることを検査する — 検査なしだと同定は通るのに抽出が空になり、蓄積
-# サマリーを rc=0 のまま空文字で上書きする (docstring の禁止事項)
+# → exit 1 + 無変更。この fixture (断片 5 個) は境界フラグメント検査とセル数
+# ガードの両方に該当するため fail-loud 契約全体を pin するが、単独ガードの識別
+# 力は持たない (片方を無効化しても他方が捕捉して緑のまま) — 境界検査だけが
+# 検出できる形状 (余剰フラグメント) は TC-22b の第 3 shape が担う
 # ──────────────────────────────────────────────────────────────────────
 dir=$(make_sandbox tc22)
 cat > "$dir/index.md" <<'EOF'
@@ -999,15 +1071,19 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
-# TC-22b (T-04): セル数不足の登録行 + description 省略 → exit 1 + 無変更
-# 4 セル行は境界フラグメントが両方空白で TC-22 の検査を通過し、3 セル行は
-# 早期脱出する — どちらも欠けたセルを特定できず保持値を確定できないため、
-# silent 空文字化ではなく TC-22 と同じ fail-loud 経路に載せる
+# TC-22b (T-04): セル数不足/過剰の登録行 + description 省略 → exit 1 + 無変更
+# 4 セル行は境界フラグメントが両方空白で境界検査を通過しセル数ガードが捕捉、
+# 3 セル行は早期脱出 — どちらも欠けたセルを特定できず保持値を確定できない。
+# 第 3 shape (末尾に余剰フラグメント 2 つ、行末区切りなし) はセル数ガード
+# (n-2>=4) を通過し境界フラグメント検査だけが捕捉する: 境界検査を単独で
+# 無効化する変異は summary 列が更新日列以降を飲み込む silent corruption に
+# なるため、この shape が当該ガード単独の識別力を担う
 # ──────────────────────────────────────────────────────────────────────
 tc22b_ok=1
 for shape in \
   '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 |' \
-  '| [Foo Pattern](pages/patterns/foo.md) | 蓄積サマリー |'; do
+  '| [Foo Pattern](pages/patterns/foo.md) | 蓄積サマリー |' \
+  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 | high | junk1 | junk2'; do
   dir=$(make_sandbox "tc22b-$(printf '%s' "$shape" | wc -c)")
   cat > "$dir/index.md" <<EOF
 # Wiki Index
@@ -1029,7 +1105,7 @@ EOF
   fi
 done
 if [ "$tc22b_ok" -eq 1 ]; then
-  pass "TC-22b セル数不足 (4 セル / 3 セル) の summary 保持抽出は exit 1・無変更"
+  pass "TC-22b セル数不足 (4/3 セル) + 余剰フラグメント行の summary 保持抽出は exit 1・無変更"
 else
   fail "TC-22b"
 fi
@@ -1140,6 +1216,53 @@ if [ "$HELPER_RC" -eq 0 ] \
   pass "TC-24 新規追加と同時に別ページの重複後発行を回収 (added; dedup_removed=1)"
 else
   fail "TC-24 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-25 (T-02): リンク構文を含む title は同定キーを詐称できない (`]` → &#93; 中和)
+# 中和なしだと生成行の FIRST link が title 内の `](pages/patterns/foo.md)` になり、
+# (a) 追加直後に 3a が既存 foo 行との「重複」として新規行を回収する (added なのに
+#     行が残らず dedup_removed=1)、(b) 以後の foo 更新が詐称行を foo の行として
+# 丸ごと書き換える — いずれも WARNING なし・rc=0・成功 marker のまま。
+# 2 サイクル (詐称 title の追加 → 正規 foo の更新) を回して golden で固定する
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc25)
+touch "$dir/pages/heuristics/beta.md"
+run_helper --index "$dir/index.md" --title 'x ](pages/patterns/foo.md) y' --domain heuristics \
+  --slug beta --description "beta 説明" --updated "2026-08-05T14:00:00+09:00" \
+  --confidence medium --pages-root "$dir/pages"
+tc25_rc1=$HELPER_RC
+tc25_out1=$HELPER_STDOUT
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --description "foo 更新" --updated "2026-08-05T14:10:00+09:00" \
+  --confidence high --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc25-expected.md" <<'EOF'
+# Wiki Index
+
+カタログ本文。
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | foo 更新 | 2026-08-05T14:10:00+09:00 | high |
+| [x &#93;(pages/patterns/foo.md) y](pages/heuristics/beta.md) | heuristics | beta 説明 | 2026-08-05T14:00:00+09:00 | medium |
+
+## 統計
+
+- 総ページ数: 3
+- ドメイン別: patterns=1, heuristics=2, anti-patterns=0
+- 最終更新: 2026-08-05T14:10:00+09:00
+EOF
+if [ "$tc25_rc1" -eq 0 ] \
+   && printf '%s\n' "$tc25_out1" | grep -qF '[CONTEXT] WIKI_INDEX_UPDATE=row_action=added; dedup_removed=0; stats_sync=synced' \
+   && [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && diff -u "$TEST_DIR/tc25-expected.md" "$dir/index.md" > "$TEST_DIR/tc25-diff.txt" 2>&1; then
+  pass "TC-25 リンク構文入り title の同定キー詐称を &#93; 中和で防止 (added 行が回収されず foo 更新も非破壊・golden)"
+else
+  fail "TC-25 (rc1=$tc25_rc1 out1=$tc25_out1 rc2=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc25-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -1,0 +1,515 @@
+#!/bin/bash
+# wiki-index-update.test.sh
+#
+# Tests for wiki-index-update.sh (wiki-ingest SKILL.md ステップ 6 delegation
+# target, Issue #2089). The helper applies the #2047-fixed index.md spec
+# (identification predicate / escaping / duplicate reclamation / stats sync)
+# deterministically; these fixtures pin the behavior the prose era established,
+# including the edge cases PR #2052's review loop surfaced (raw-pipe title,
+# blank lines inside the section, old-format coexistence, duplicate rows).
+#
+# Coverage (IDs map to Issue #2089 Section 6 Test Specification):
+#   TC-1  (T-01) 新規行追加 parity: 行形式・テーブル末尾追加・統計同期
+#   TC-2  (T-01) 既存行更新 parity: description ありで行全体を再生成
+#   TC-3  (T-01) 既存行更新: description 空 → 既存サマリー保持 (空上書き禁止)
+#   TC-4  (T-02) 生パイプ title の既存行を first-link 述語で同定し 5 列へ是正
+#   TC-5  (T-02) エスケープ規約 (a): `\` → `\\` の後 `|` → `\|` (title/description)
+#   TC-6  (T-02) エスケープ規約 (b): 保持サマリーの `\|` を再エスケープしない
+#         (2 サイクル回して `\` が増殖しないことを固定)
+#   TC-7  (T-03) 節内の `|` 行間の空行を除去 (節境界の空行は保持)
+#   TC-8  (T-03) 旧形式箇条書き行の共存維持: 述語対象外・新規追加扱い・無改変
+#   TC-9  (T-03) 重複行回収: 対象外ページの後発行も 3a が削除 (先発保持)
+#   TC-10 (T-03) 対象ページ重複 → aborted_duplicate (中止) + 3a が後発を回収
+#   TC-11 (T-03) `## 統計` 節不在 → stats_sync=skipped_no_section (節を新設しない)
+#   TC-12 (T-03) `## ページ一覧` 節不在 → `## 統計` の直前に template 形で新設
+#   TC-13 (T-04) index.md 不在 → exit 1 (fail-loud)
+#   TC-14 (T-04) `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
+#   TC-15 (T-04) invocation error: domain/confidence enum 違反・`|` 入り updated・
+#         必須引数欠落 → exit 2 + 無変更
+#   TC-16 (T-04) pages 一覧 0 件 → stats_sync=skipped_unreadable + 統計値は既存保持
+#         (行操作自体は適用される — silent ではなく WARNING 付きの部分スキップ)
+#   TC-17 (T-06) SKILL.md ステップ 6 の縮退: helper 呼び出しが存在し、操作
+#         アルゴリズムの散文 (同定・抽出・削除手順の記述) が残っていない
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
+PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
+SCRIPT="$PLUGIN_ROOT/hooks/scripts/wiki-index-update.sh"
+INGEST_MD="$PLUGIN_ROOT/skills/wiki-ingest/SKILL.md"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "ERROR: helper not executable: $SCRIPT" >&2
+  exit 1
+fi
+
+TEST_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ❌ FAIL: $1"; }
+
+# 基本フィクスチャ: 5 列テーブル + 統計節。pages/ には patterns 1 / heuristics 1
+make_sandbox() {
+  local name="$1"
+  local dir="$TEST_DIR/$name"
+  mkdir -p "$dir/pages/patterns" "$dir/pages/heuristics" "$dir/pages/anti-patterns"
+  touch "$dir/pages/patterns/foo.md" "$dir/pages/heuristics/bar.md"
+  cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+カタログ本文。
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 1
+- ドメイン別: patterns=1, heuristics=0, anti-patterns=0
+- 最終更新: 2026-01-01T00:00:00+09:00
+EOF
+  printf '%s' "$dir"
+}
+
+run_helper() {
+  HELPER_STDOUT=$("$SCRIPT" "$@" 2>"$TEST_DIR/stderr.txt")
+  HELPER_RC=$?
+  HELPER_STDERR=$(cat "$TEST_DIR/stderr.txt")
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-1 (T-01): 新規行追加 parity
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc1)
+run_helper --index "$dir/index.md" --title "Bar Heuristic" --domain heuristics \
+  --slug bar --description "bar の説明" --updated "2026-08-04T22:00:00+09:00" \
+  --confidence medium --pages-root "$dir/pages"
+expected_row='| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 | 2026-08-04T22:00:00+09:00 | medium |'
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=synced' \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=added; dedup_removed=0; stats_sync=synced$' \
+   && grep -qxF "$expected_row" "$dir/index.md" \
+   && grep -qx -- '- 総ページ数: 2' "$dir/index.md" \
+   && grep -qx -- '- ドメイン別: patterns=1, heuristics=1, anti-patterns=0' "$dir/index.md" \
+   && grep -qx -- '- 最終更新: 2026-08-04T22:00:00+09:00' "$dir/index.md"; then
+  # 追加位置 = テーブル末尾 (既存 Foo 行の後)
+  if awk '/foo\.md/{f=NR} /bar\.md/{b=NR} END{exit !(f && b && b>f)}' "$dir/index.md"; then
+    pass "TC-1 新規行追加 (行形式・末尾追加・統計同期)"
+  else
+    fail "TC-1 追加位置がテーブル末尾でない"
+  fi
+else
+  fail "TC-1 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-2 (T-01): 既存行更新 (description あり → 行全体再生成)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc2)
+run_helper --index "$dir/index.md" --title "Foo Pattern v2" --domain patterns \
+  --slug foo --description "新サマリー" --updated "2026-08-05T00:00:00+09:00" \
+  --confidence low --pages-root "$dir/pages"
+expected_row='| [Foo Pattern v2](pages/patterns/foo.md) | patterns | 新サマリー | 2026-08-05T00:00:00+09:00 | low |'
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF "$expected_row" "$dir/index.md" \
+   && ! grep -q 'Foo Pattern](pages' "$dir/index.md"; then
+  pass "TC-2 既存行更新 (行全体を新形式で再生成)"
+else
+  fail "TC-2 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-3 (T-01): description 空 → 既存サマリー保持
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc3)
+run_helper --index "$dir/index.md" --title "Foo Pattern v3" --domain patterns \
+  --slug foo --updated "2026-08-06T00:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+expected_row='| [Foo Pattern v3](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-08-06T00:00:00+09:00 | high |'
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF "$expected_row" "$dir/index.md"; then
+  pass "TC-3 description 空で既存サマリー保持 (空文字上書きしない)"
+else
+  fail "TC-3 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-4 (T-02): 生パイプ title の既存行を first-link 述語で同定し是正
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc4)
+touch "$dir/pages/patterns/pipe-page.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [broken | title](pages/patterns/pipe-page.md) | patterns | ズレた行のサマリー | 2026-01-01T00:00:00+09:00 | low |
+EOF
+run_helper --index "$dir/index.md" --title "broken | title" --domain patterns \
+  --slug pipe-page --updated "2026-08-04T23:00:00+09:00" --confidence medium \
+  --pages-root "$dir/pages"
+expected_row='| [broken \| title](pages/patterns/pipe-page.md) | patterns | ズレた行のサマリー | 2026-08-04T23:00:00+09:00 | medium |'
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF "$expected_row" "$dir/index.md"; then
+  pass "TC-4 生パイプ title 行の同定・エスケープ是正・サマリー位置抽出"
+else
+  fail "TC-4 (rc=$HELPER_RC stdout=$HELPER_STDOUT actual=$(grep 'pipe-page' "$dir/index.md"))"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-5 (T-02): エスケープ規約 (a) — `\` を先に、次に `|`
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc5)
+run_helper --index "$dir/index.md" --title 'C:\path | pipe' --domain patterns \
+  --slug foo --description 'literal \| here' --updated "2026-08-04T23:50:00+09:00" \
+  --confidence low --pages-root "$dir/pages"
+expected_row='| [C:\\path \| pipe](pages/patterns/foo.md) | patterns | literal \\\| here | 2026-08-04T23:50:00+09:00 | low |'
+if [ "$HELPER_RC" -eq 0 ] && grep -qxF "$expected_row" "$dir/index.md"; then
+  pass "TC-5 規約 (a): backslash 先行エスケープで literal \\| が GFM 誤読されない"
+else
+  fail "TC-5 (rc=$HELPER_RC actual=$(grep 'foo\.md' "$dir/index.md"))"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-6 (T-02): 規約 (b) — 保持サマリーを再エスケープしない (増殖なし)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc6)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Esc Page](pages/patterns/foo.md) | patterns | 済み \| と生 | の混在 | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Esc Page" --domain patterns \
+  --slug foo --updated "2026-08-05T00:10:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+rc1=$HELPER_RC
+row_cycle1=$(grep 'foo\.md' "$dir/index.md")
+run_helper --index "$dir/index.md" --title "Esc Page" --domain patterns \
+  --slug foo --updated "2026-08-05T00:20:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+row_cycle2=$(grep 'foo\.md' "$dir/index.md")
+expected_summary='済み \| と生 \| の混在'
+expected_cycle2="| [Esc Page](pages/patterns/foo.md) | patterns | $expected_summary | 2026-08-05T00:20:00+09:00 | high |"
+if [ "$rc1" -eq 0 ] && [ "$HELPER_RC" -eq 0 ] \
+   && [ "$row_cycle2" = "$expected_cycle2" ] \
+   && [ "${row_cycle1%|*|*|}" = "${row_cycle2%|*|*|}" ]; then
+  pass "TC-6 規約 (b): 生 | のみエスケープ・既存 \\| は 2 サイクル回しても増殖しない"
+else
+  fail "TC-6 (cycle1=$row_cycle1 cycle2=$row_cycle2)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-7 (T-03): 節内の `|` 行間の空行を除去
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc7)
+touch "$dir/pages/heuristics/late.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+| [Late Row](pages/heuristics/late.md) | heuristics | 空行の後の行 | 2026-01-02T00:00:00+09:00 | low |
+
+## 統計
+
+- 総ページ数: 2
+- ドメイン別: patterns=1, heuristics=1, anti-patterns=0
+- 最終更新: 2026-01-02T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "Late Row" --domain heuristics \
+  --slug late --updated "2026-08-05T01:00:00+09:00" --confidence medium \
+  --pages-root "$dir/pages"
+blank_between=$(awk '/^\|/{p=1} p && /^[ \t]*$/{c++} /^## 統計/{exit} END{print c+0}' "$dir/index.md")
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && [ "$blank_between" -le 1 ] \
+   && grep -q 'Late Row' "$dir/index.md"; then
+  # 空行除去後は Late 行が同定・更新されている (空行があると GFM 上は段落落ちしていた行)
+  if grep -qxF '| [Late Row](pages/heuristics/late.md) | heuristics | 空行の後の行 | 2026-08-05T01:00:00+09:00 | medium |' "$dir/index.md"; then
+    pass "TC-7 節内空行を除去し空行後の登録行も同定対象になる"
+  else
+    fail "TC-7 空行後の行が更新されていない"
+  fi
+else
+  fail "TC-7 (rc=$HELPER_RC blank_between=$blank_between)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-8 (T-03): 旧形式箇条書き行の共存維持
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc8)
+touch "$dir/pages/heuristics/old-style.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+
+- [旧形式ページ](pages/heuristics/old-style.md) - 旧箇条書きの説明
+EOF
+run_helper --index "$dir/index.md" --title "旧形式ページ" --domain heuristics \
+  --slug old-style --description "テーブルへ新規登録" --updated "2026-08-05T02:00:00+09:00" \
+  --confidence medium --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
+   && grep -qxF -- '- [旧形式ページ](pages/heuristics/old-style.md) - 旧箇条書きの説明' "$dir/index.md" \
+   && grep -qxF '| [旧形式ページ](pages/heuristics/old-style.md) | heuristics | テーブルへ新規登録 | 2026-08-05T02:00:00+09:00 | medium |' "$dir/index.md"; then
+  pass "TC-8 旧箇条書き行は述語対象外 (新規追加扱い・旧行は無改変で共存)"
+else
+  fail "TC-8 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-9 (T-03): 対象外ページの重複行も 3a が回収 (先発保持)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc9)
+touch "$dir/pages/patterns/dup.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Dup 先発](pages/patterns/dup.md) | patterns | 1本目 | 2026-01-01T00:00:00+09:00 | high |
+| [Dup 後発](pages/patterns/dup.md) | patterns | 2本目 | 2026-01-02T00:00:00+09:00 | low |
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T03:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'dedup_removed=1' \
+   && grep -q 'Dup 先発' "$dir/index.md" \
+   && ! grep -q 'Dup 後発' "$dir/index.md"; then
+  pass "TC-9 対象外ページの重複も 3a が後発削除 (先発保持)"
+else
+  fail "TC-9 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-10 (T-03): 対象ページ重複 → aborted_duplicate + 3a 回収
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc10)
+touch "$dir/pages/patterns/dup.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Dup 先発](pages/patterns/dup.md) | patterns | 1本目 | 2026-01-01T00:00:00+09:00 | high |
+| [Dup 後発](pages/patterns/dup.md) | patterns | 2本目 | 2026-01-02T00:00:00+09:00 | low |
+EOF
+run_helper --index "$dir/index.md" --title "Dup NEW" --domain patterns \
+  --slug dup --description "中止されるべき更新" --updated "2026-08-05T04:00:00+09:00" \
+  --confidence medium --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=aborted_duplicate' \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'dedup_removed=1' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && grep -q 'Dup 先発' "$dir/index.md" \
+   && ! grep -q 'Dup NEW' "$dir/index.md" \
+   && ! grep -q 'Dup 後発' "$dir/index.md"; then
+  pass "TC-10 対象ページ重複で中止 (fallback なし・WARNING) + 3a が後発回収"
+else
+  fail "TC-10 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-11 (T-03): `## 統計` 節不在 → skip + 節を新設しない
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc11)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T05:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_no_section' \
+   && ! grep -q '^## 統計' "$dir/index.md"; then
+  pass "TC-11 統計節不在は skip し節を新設しない"
+else
+  fail "TC-11 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-12 (T-03): `## ページ一覧` 節不在 → `## 統計` の直前に新設
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc12)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+本文と HTML コメント。
+<!-- comment -->
+
+## 統計
+
+- 総ページ数: 0
+- ドメイン別: patterns=0, heuristics=0, anti-patterns=0
+- 最終更新: 2026-01-01T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "First Page" --domain patterns \
+  --slug foo --description "最初の登録" --updated "2026-08-05T06:00:00+09:00" \
+  --confidence high --pages-root "$dir/pages"
+list_line=$(grep -n '^## ページ一覧' "$dir/index.md" | cut -d: -f1)
+stats_line=$(grep -n '^## 統計' "$dir/index.md" | cut -d: -f1)
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
+   && [ -n "$list_line" ] && [ -n "$stats_line" ] && [ "$list_line" -lt "$stats_line" ] \
+   && grep -qxF '| ページ | ドメイン | サマリー | 更新日 | 確信度 |' "$dir/index.md" \
+   && grep -qxF '| [First Page](pages/patterns/foo.md) | patterns | 最初の登録 | 2026-08-05T06:00:00+09:00 | high |' "$dir/index.md" \
+   && grep -qx -- '- 総ページ数: 2' "$dir/index.md"; then
+  pass "TC-12 節不在時は統計の直前にヘッダ付きで新設"
+else
+  fail "TC-12 (rc=$HELPER_RC list_line=$list_line stats_line=$stats_line)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-13 (T-04): index.md 不在 → exit 1
+# ──────────────────────────────────────────────────────────────────────
+run_helper --index "$TEST_DIR/nonexistent/index.md" --title t --domain patterns \
+  --slug s --updated "2026-08-05T07:00:00+09:00" --confidence high
+if [ "$HELPER_RC" -eq 1 ] && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR'; then
+  pass "TC-13 index.md 不在で exit 1 (fail-loud)"
+else
+  fail "TC-13 (rc=$HELPER_RC stderr=$HELPER_STDERR)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-14 (T-04): `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc14)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+EOF
+before=$(cat "$dir/index.md")
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated "2026-08-05T08:00:00+09:00" --confidence high --pages-root "$dir/pages"
+after=$(cat "$dir/index.md")
+if [ "$HELPER_RC" -eq 1 ] \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+   && [ "$before" = "$after" ]; then
+  pass "TC-14 見出し重複 (想定外構造) で exit 1・部分適用なし"
+else
+  fail "TC-14 (rc=$HELPER_RC)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-15 (T-04): invocation error 群 → exit 2 + 無変更
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc15)
+before=$(cat "$dir/index.md")
+tc15_ok=1
+run_helper --index "$dir/index.md" --title t --domain bogus --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (domain enum 違反が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence urgent
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (confidence enum 違反が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated "2026|08" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (| 入り updated が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug 'bad/slug' \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (不正 slug が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--title 欠落が rc=$HELPER_RC)"; }
+after=$(cat "$dir/index.md")
+if [ "$tc15_ok" -eq 1 ] && [ "$before" = "$after" ]; then
+  pass "TC-15 invocation error 群で exit 2・index.md 無変更"
+else
+  fail "TC-15"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-16 (T-04): pages 一覧 0 件 → stats skip + 既存統計値保持
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc16)
+rm -rf "$dir/pages"
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T10:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_unreadable' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && grep -qx -- '- 総ページ数: 1' "$dir/index.md" \
+   && grep -qx -- '- 最終更新: 2026-01-01T00:00:00+09:00' "$dir/index.md" \
+   && grep -q '2026-08-05T10:00:00+09:00' "$dir/index.md"; then
+  pass "TC-16 pages 取得不能は WARNING + 統計値保持 (行操作は適用)"
+else
+  fail "TC-16 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-17 (T-06): SKILL.md ステップ 6 の縮退 (grep 検査)
+# ──────────────────────────────────────────────────────────────────────
+if [ ! -f "$INGEST_MD" ]; then
+  echo "ERROR: $INGEST_MD not found" >&2
+  exit 1
+fi
+step6=$(awk '/^## ステップ 6:/{f=1} f && /^## ステップ 7/{exit} f{print}' "$INGEST_MD")
+tc17_ok=1
+printf '%s\n' "$step6" | grep -q 'wiki-index-update\.sh' || { tc17_ok=0; echo "  (helper 呼び出しがステップ 6 に無い)"; }
+# 操作アルゴリズムの散文が残っていないこと (各フレーズは旧手順 0-3b の記述に固有)
+for phrase in '最初に現れる' '閉じ括弧までの範囲' '末尾 2 つを更新日列' \
+              '後発行を削除' '空行があれば削除' 'エスケープして substitute' \
+              '見出しの直後（既存の登録行より前）に補う'; do
+  if printf '%s\n' "$step6" | grep -qF "$phrase"; then
+    tc17_ok=0; echo "  (操作散文が残存: $phrase)"
+  fi
+done
+if [ "$tc17_ok" -eq 1 ]; then
+  pass "TC-17 ステップ 6 は helper 呼び出しへ縮退し操作散文が残っていない"
+else
+  fail "TC-17"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -29,6 +29,11 @@
 #   TC-16g (T-04) 統計 3 行が全欠落 → stats_sync=skipped_unreadable (0 行同期を synced にしない)
 #   TC-22 (T-04) 行末区切り欠落の登録行から summary 保持抽出 → exit 1 + 無変更
 #         (positional 抽出の前提崩れを silent 空文字化させない)
+#   TC-22b (T-04) セル数不足 (4 セル / 3 セル) の登録行から summary 保持抽出 → exit 1 + 無変更
+#         (欠けたセルを特定できないため保持値を確定できない — TC-22 と同じ fail-loud 経路)
+#   TC-22c (T-01) 空サマリーセルの正当な 5 列行は保持経路で rc=0 のまま (境界 pin)
+#   TC-23 (T-03) サマリー欄の相互参照リンクは同定に使われない (FIRST link 述語、golden)
+#   TC-24 (T-03) 新規追加と同時に別ページの重複行を回収 (added × dedup_removed=1)
 #   TC-12b (T-03) 統計節も不在なら EOF に節新設 (golden)
 #   TC-16b (T-04) pages 一覧 0 件 (*.md ゼロ、find rc=0) → skip + 統計保持
 #   TC-16c (T-04) --pages-root 省略 (統計節あり) → skipped_unreadable + 統計保持
@@ -991,6 +996,150 @@ if [ "$HELPER_RC" -eq 1 ] \
   pass "TC-22 行末区切り欠落行の summary 保持抽出は exit 1・無変更 (silent 空文字化しない)"
 else
   fail "TC-22 (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-22b (T-04): セル数不足の登録行 + description 省略 → exit 1 + 無変更
+# 4 セル行は境界フラグメントが両方空白で TC-22 の検査を通過し、3 セル行は
+# 早期脱出する — どちらも欠けたセルを特定できず保持値を確定できないため、
+# silent 空文字化ではなく TC-22 と同じ fail-loud 経路に載せる
+# ──────────────────────────────────────────────────────────────────────
+tc22b_ok=1
+for shape in \
+  '| [Foo Pattern](pages/patterns/foo.md) | patterns | 蓄積サマリー | 2026-01-01T00:00:00+09:00 |' \
+  '| [Foo Pattern](pages/patterns/foo.md) | 蓄積サマリー |'; do
+  dir=$(make_sandbox "tc22b-$(printf '%s' "$shape" | wc -c)")
+  cat > "$dir/index.md" <<EOF
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+$shape
+EOF
+  before=$(cat "$dir/index.md")
+  run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+    --slug foo --updated "2026-08-05T12:00:00+09:00" --confidence high \
+    --pages-root "$dir/pages"
+  after=$(cat "$dir/index.md")
+  if [ "$HELPER_RC" -ne 1 ] || ! printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR' \
+     || [ "$before" != "$after" ] || [ "$(grep -c '蓄積サマリー' "$dir/index.md")" -ne 1 ]; then
+    tc22b_ok=0; echo "  (セル数 $(printf '%s' "$shape" | awk -F'|' '{print NF-2}') の行が rc=$HELPER_RC / 蓄積サマリー残存 $(grep -c '蓄積サマリー' "$dir/index.md"))"
+  fi
+done
+if [ "$tc22b_ok" -eq 1 ]; then
+  pass "TC-22b セル数不足 (4 セル / 3 セル) の summary 保持抽出は exit 1・無変更"
+else
+  fail "TC-22b"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-22c (T-01): 空サマリーセルの正当な 5 列行は保持経路で rc=0 (境界 pin)
+# セル数ガードの下限 (5 列ちょうど) を fail-loud 側へ倒しすぎない境界固定
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc22c)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns |  | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
+  --slug foo --updated "2026-08-05T12:10:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF '| [Foo Pattern](pages/patterns/foo.md) | patterns |  | 2026-08-05T12:10:00+09:00 | high |' "$dir/index.md"; then
+  pass "TC-22c 空サマリーセルの正当 5 列行は保持経路で rc=0 (ガードの過剰発火なし)"
+else
+  fail "TC-22c (rc=$HELPER_RC stdout=$HELPER_STDOUT stderr=$HELPER_STDERR)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-23 (T-03): サマリー欄の相互参照リンクは同定に使われない (FIRST link 述語)
+# 述語を「行内の最後のリンク」へ変える drift は Page B の登録行を silent 削除
+# する — 両行保持 + dedup 0 を golden 全文比較で固定
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc23)
+mkdir -p "$dir/pages/patterns"
+touch "$dir/pages/patterns/a.md" "$dir/pages/patterns/b.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Page A](pages/patterns/a.md) | patterns | 詳細は [Page B](pages/patterns/b.md) を参照 | 2026-01-01T00:00:00+09:00 | high |
+| [Page B](pages/patterns/b.md) | patterns | B の説明 | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 2
+- ドメイン別: patterns=2, heuristics=0, anti-patterns=0
+- 最終更新: 2026-01-01T00:00:00+09:00
+EOF
+run_helper --index "$dir/index.md" --title "Page A" --domain patterns \
+  --slug a --updated "2026-08-05T12:20:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc23-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Page A](pages/patterns/a.md) | patterns | 詳細は [Page B](pages/patterns/b.md) を参照 | 2026-08-05T12:20:00+09:00 | high |
+| [Page B](pages/patterns/b.md) | patterns | B の説明 | 2026-01-01T00:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 4
+- ドメイン別: patterns=3, heuristics=1, anti-patterns=0
+- 最終更新: 2026-08-05T12:20:00+09:00
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=updated; dedup_removed=0; stats_sync=synced$' \
+   && diff -u "$TEST_DIR/tc23-expected.md" "$dir/index.md" > "$TEST_DIR/tc23-diff.txt" 2>&1; then
+  pass "TC-23 サマリー欄の相互参照リンクは非同定 (FIRST link 述語・両行保持・golden)"
+else
+  fail "TC-23 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc23-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-24 (T-03): 新規追加と同時に別ページの重複行を回収 (3a は毎回走る)
+# 追加経路だけ回収を止める drift の変異を殺す — added × dedup_removed=1
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc24)
+mkdir -p "$dir/pages/heuristics"
+touch "$dir/pages/heuristics/new.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Dup](pages/patterns/dup.md) | patterns | 先発 | 2026-01-01T00:00:00+09:00 | high |
+| [Dup 重複](pages/patterns/dup.md) | patterns | 後発 | 2026-01-02T00:00:00+09:00 | low |
+EOF
+run_helper --index "$dir/index.md" --title "New Page" --domain heuristics \
+  --slug new --description "追加" --updated "2026-08-05T12:30:00+09:00" \
+  --confidence medium --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qF '[CONTEXT] WIKI_INDEX_UPDATE=row_action=added; dedup_removed=1; stats_sync=skipped_no_section' \
+   && [ "$(grep -c 'pages/patterns/dup\.md' "$dir/index.md")" -eq 1 ] \
+   && grep -q '先発' "$dir/index.md" \
+   && ! grep -q '後発' "$dir/index.md" \
+   && grep -qxF '| [New Page](pages/heuristics/new.md) | heuristics | 追加 | 2026-08-05T12:30:00+09:00 | medium |' "$dir/index.md"; then
+  pass "TC-24 新規追加と同時に別ページの重複後発行を回収 (added; dedup_removed=1)"
+else
+  fail "TC-24 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -37,7 +37,8 @@
 #   TC-22c (T-01) 空サマリーセルの正当な 5 列行は保持経路で rc=0 のまま (境界 pin)
 #   TC-23 (T-03) サマリー欄の相互参照リンクは同定に使われない (FIRST link 述語、golden)
 #   TC-24 (T-03) 新規追加と同時に別ページの重複行を回収 (added × dedup_removed=1)
-#   TC-25 (T-02) リンク構文入り title の同定キー詐称防止 (`]` → &#93; 中和、golden)
+#   TC-25 (T-02) リンク構文入り title の同定キー詐称防止 (`](` の `]` → &#93; 中和、golden)
+#   TC-25b (T-02) `](` を含まない `]` は無改変 (中和の過剰適用で描画を壊さない、golden)
 #   TC-12b (T-03) 統計節も不在なら EOF に節新設 (golden)
 #   TC-16b (T-04) pages 一覧 0 件 (*.md ゼロ、find rc=0) → skip + 統計保持
 #   TC-16c (T-04) --pages-root 省略 (統計節あり) → skipped_unreadable + 統計保持
@@ -495,8 +496,11 @@ fi
 # ──────────────────────────────────────────────────────────────────────
 run_helper --index "$TEST_DIR/nonexistent/index.md" --title t --domain patterns \
   --slug s --updated "2026-08-05T07:00:00+09:00" --confidence high
-if [ "$HELPER_RC" -eq 1 ] && printf '%s\n' "$HELPER_STDERR" | grep -q 'ERROR'; then
-  pass "TC-13 index.md 不在で exit 1 (fail-loud)"
+# rc=1 だけでは識別力がない (`-f` ガードを外しても兄弟の `-r` ガードが同じ rc=1 +
+# ERROR を返し、運用者には "not readable" の誤診断が届く) ため、TC-13b と対で
+# ガード固有の診断文言を assert する
+if [ "$HELPER_RC" -eq 1 ] && printf '%s\n' "$HELPER_STDERR" | grep -q 'not found'; then
+  pass "TC-13 index.md 不在で exit 1 + 'not found' 診断 (fail-loud)"
 else
   fail "TC-13 (rc=$HELPER_RC stderr=$HELPER_STDERR)"
 fi
@@ -734,11 +738,11 @@ run_helper --index "$dir/index.md" --title "Foo Pattern" --domain patterns \
   --slug foo --updated "2026-08-05T10:20:00+09:00" --confidence high
 if [ "$HELPER_RC" -eq 0 ] \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=skipped_unreadable' \
-   && printf '%s\n' "$HELPER_STDERR" | grep -q 'WARNING' \
+   && printf '%s\n' "$HELPER_STDERR" | grep -qF -- '--pages-root was not given' \
    && grep -qx -- '- 総ページ数: 1' "$dir/index.md" \
    && grep -qx -- '- 最終更新: 2026-01-01T00:00:00+09:00' "$dir/index.md" \
    && grep -q '2026-08-05T10:20:00+09:00' "$dir/index.md"; then
-  pass "TC-16c --pages-root 省略は WARNING + skipped_unreadable + 統計保持"
+  pass "TC-16c --pages-root 省略は分岐固有 WARNING + skipped_unreadable + 統計保持"
 else
   fail "TC-16c (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
 fi
@@ -1266,6 +1270,47 @@ else
 fi
 
 # ──────────────────────────────────────────────────────────────────────
+# TC-25b (T-02): `]` を含むが `](` を含まない title は無改変 (中和の過剰適用防止)
+# 詐称は `](pages/…)` の literal 連なりでしか成立しないため、対の `[` を持つ
+# `[CONTEXT]` / `.errors[]` / コードスパン内 `[[:cntrl:]]` まで中和すると
+# リンクテキストの角括弧が不均衡になり GFM がリンク範囲を誤って切る
+# (コードスパン内では実体参照が復元されず literal `&#93;` として描画される)。
+# 実 Wiki に該当 title が複数実在するため golden で無改変を固定する
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc25b)
+touch "$dir/pages/patterns/ctx.md"
+run_helper --index "$dir/index.md" --title 'Bash 境界を跨ぐ値は [CONTEXT] で emit する (`[[:cntrl:]]` / .errors[] も同様)' \
+  --domain patterns --slug ctx --description "角括弧を含む説明 [a] と .errors[]" \
+  --updated "2026-08-05T15:00:00+09:00" --confidence high --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc25b-expected.md" <<'EOF'
+# Wiki Index
+
+カタログ本文。
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
+| [Bash 境界を跨ぐ値は [CONTEXT] で emit する (`[[:cntrl:]]` / .errors[] も同様)](pages/patterns/ctx.md) | patterns | 角括弧を含む説明 [a] と .errors[] | 2026-08-05T15:00:00+09:00 | high |
+
+## 統計
+
+- 総ページ数: 3
+- ドメイン別: patterns=2, heuristics=1, anti-patterns=0
+- 最終更新: 2026-08-05T15:00:00+09:00
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
+   && ! grep -q '&#93;' "$dir/index.md" \
+   && diff -u "$TEST_DIR/tc25b-expected.md" "$dir/index.md" > "$TEST_DIR/tc25b-diff.txt" 2>&1; then
+  pass 'TC-25b `](` を含まない `]` は無改変 (中和の過剰適用なし・golden)'
+else
+  fail "TC-25b (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc25b-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
 # TC-17 (T-06): SKILL.md ステップ 6 の縮退 (grep 検査)
 # ──────────────────────────────────────────────────────────────────────
 if [ ! -f "$INGEST_MD" ]; then
@@ -1305,17 +1350,33 @@ if [ "$helper_flags" != "$skill_flags" ]; then
   echo "  helper: $(printf '%s' "$helper_flags" | tr '\n' ' ')"
   echo "  skill:  $(printf '%s' "$skill_flags" | tr '\n' ' ')"
 fi
-printf '%s\n' "$step6_block" | grep -qF -- '--domain "{domain}"' || { tc17b_ok=0; echo "  (--domain の placeholder 対応が崩れている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- '--slug "{slug}"' || { tc17b_ok=0; echo "  (--slug の placeholder 対応が崩れている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- '--updated "{updated}"' || { tc17b_ok=0; echo "  (--updated の placeholder 対応が崩れている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- '--confidence "{confidence}"' || { tc17b_ok=0; echo "  (--confidence の placeholder 対応が崩れている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- '--title "$wiu_title"' || { tc17b_ok=0; echo "  (--title の heredoc 変数対応が崩れている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- '--description "$wiu_description"' || { tc17b_ok=0; echo "  (--description の heredoc 変数対応が崩れている)"; }
+# frontmatter 由来 6 値はすべて heredoc 変数経由で渡す (placeholder をシェル語へ直接
+# 置換する形が再混入していないことを、変数対応と placeholder 直渡しの不在の両側で pin)
+for v in title description domain slug updated confidence; do
+  printf '%s\n' "$step6_block" | grep -qF -- "--$v \"\$wiu_$v\"" \
+    || { tc17b_ok=0; echo "  (--$v の heredoc 変数対応が崩れている)"; }
+  printf '%s\n' "$step6_block" | grep -qF -- "--$v \"{$v}\"" \
+    && { tc17b_ok=0; echo "  (--$v が placeholder 直渡しへ退行している — command injection 経路)"; }
+done
+# heredoc 本体では placeholder がそのまま現れる (シェル解釈なしで helper へ届く形)
+for v in title description domain slug updated confidence; do
+  printf '%s\n' "$step6_block" | grep -qxF -- "{$v}" \
+    || { tc17b_ok=0; echo "  ($v の heredoc 本体に {$v} が無い)"; }
+done
 # 呼び出し行の実体 (コマンド語・値の形) も literal で pin する — フラグ名集合の突合だけでは
 # 呼び出し行の削除・helper パス改名・パス値の相対化・quoted heredoc 解除が生存する
 printf '%s\n' "$step6_block" | grep -qF -- 'bash "{plugin_root}/hooks/scripts/wiki-index-update.sh"' || { tc17b_ok=0; echo "  (helper 呼び出しコマンド行が無い/形が崩れている)"; }
 printf '%s\n' "$step6_block" | grep -qF -- '--index "$wiki_root/index.md"' || { tc17b_ok=0; echo '  (--index の値が $wiki_root/index.md でない)'; }
 printf '%s\n' "$step6_block" | grep -qF -- '--pages-root "$wiki_root/pages"' || { tc17b_ok=0; echo '  (--pages-root の値が $wiki_root/pages でない)'; }
+# 書き込み先を決める $wiki_root の導出 4 行も pin する。値 pin だけでは routing drift
+# (branch_strategy の literal 改変・分岐条件の破壊・worktree 側代入の消失) が素通りし、
+# helper は exit 1 で loud に落ちるが marker 表がそれを「スキップして続行」に落とすため
+# ingest は完走し続け登録行だけが恒久的に欠落する
+printf '%s\n' "$step6_block" | grep -qF -- 'branch_strategy="{branch_strategy}"' || { tc17b_ok=0; echo "  (branch_strategy の placeholder 代入が無い/崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- 'wiki_wt_abs="{wiki_worktree_abs}"' || { tc17b_ok=0; echo "  (wiki_worktree_abs の placeholder 代入が無い/崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- 'if [ "$branch_strategy" = "separate_branch" ]; then' || { tc17b_ok=0; echo "  (branch_strategy の分岐条件が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- 'wiki_root="${wiki_wt_abs:-.rite/wiki-worktree}/.rite/wiki"' || { tc17b_ok=0; echo "  (separate_branch 側の wiki_root 代入が崩れている)"; }
+printf '%s\n' "$step6_block" | grep -qF -- 'wiki_root=".rite/wiki"' || { tc17b_ok=0; echo "  (same_branch 側の wiki_root 代入が崩れている)"; }
 # 継続行を 1 論理コマンドへ join して 8 フラグが同一コマンド内に並ぶことを assert する。
 # 行単位断片の grep だけでは継続 backslash の脱落 (行が分断され後続フラグが別コマンド化し
 # 実行時 rc=127 になる Edit 崩れ) が生存する
@@ -1333,14 +1394,21 @@ else
   done
   [ -z "$tc17b_split_flags" ] || echo "  (継続 backslash 脱落等でフラグが呼び出しコマンドの外にある:$tc17b_split_flags)"
 fi
-printf '%s\n' "$step6_block" | grep -qF -- "wiu_title=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (title の quoted heredoc が解除されている)"; }
-printf '%s\n' "$step6_block" | grep -qF -- "wiu_description=\$(cat <<'WIU_EOF'" || { tc17b_ok=0; echo "  (description の quoted heredoc が解除されている)"; }
+# frontmatter 由来 6 値はすべて quoted heredoc で受ける (double-quote されたシェル語への
+# 直接置換は値の `"` でクォートが閉じ command injection になる)
+for v in title description domain slug updated confidence; do
+  printf '%s\n' "$step6_block" | grep -qF -- "wiu_${v}=\$(cat <<'WIU_EOF'" \
+    || { tc17b_ok=0; echo "  ($v の quoted heredoc が解除されている)"; }
+done
 if [ "$tc17b_ok" -eq 1 ]; then
-  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応 + 呼び出し行 literal) が helper と一致"
+  pass "TC-17b ステップ 6 呼び出し契約 (8 フラグ + placeholder 対応 + 呼び出し行 literal + wiki_root 導出 + 6 値 heredoc) が helper と一致"
 else
   fail "TC-17b"
 fi
 
 echo ""
-echo "Results: $PASS passed, $FAIL failed"
+# skipped 節は必須 — TC-13b が root 実行で helper 由来の skip() を呼び SKIP を +1 して
+# ⏭️ を出すため、節が無いと run-tests.sh の skip 会計 cross-check (visible_skips vs
+# summary から parse した file_skips) が不一致を検出し run 全体を exit 1 にする
+echo "Results: $PASS passed, $FAIL failed$( [ "$SKIP" -gt 0 ] && printf ", %s skipped" "$SKIP" )"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/rite/hooks/tests/wiki-index-update.test.sh
+++ b/plugins/rite/hooks/tests/wiki-index-update.test.sh
@@ -24,6 +24,10 @@
 #   TC-12 (T-03) `## ページ一覧` 節不在 → `## 統計` の直前に template 形で新設
 #   TC-13 (T-04) index.md 不在 → exit 1 (fail-loud)
 #   TC-14 (T-04) `## ページ一覧` 見出し重複 (想定外構造) → exit 1 + 無変更
+#   TC-15b (T-04) UTF-8 日本語 title/description の制御文字誤検出なし (rc=0、C1 除外の意図を pin)
+#   TC-18 (T-01/T-03) 別ドメイン同一 slug は別ページ (同定キー = {domain}/{slug}、golden)
+#   TC-19〜21 (T-03) ヘッダ行・区切り行の欠落補填 (両方欠落 / 区切りのみ / ヘッダのみ、golden)
+#   (T-05 は既存 wiki-lint 系スイートの継続 green で担保 — 本ファイル対象外)
 #   TC-15 (T-04) invocation error: domain/confidence enum 違反・`|` 入り updated・
 #         必須引数欠落 → exit 2 + 無変更
 #   TC-16 (T-04) pages 一覧 0 件 → stats_sync=skipped_unreadable + 統計値は既存保持
@@ -93,22 +97,33 @@ run_helper --index "$dir/index.md" --title "Bar Heuristic" --domain heuristics \
   --slug bar --description "bar の説明" --updated "2026-08-04T22:00:00+09:00" \
   --confidence medium --pages-root "$dir/pages"
 expected_row='| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 | 2026-08-04T22:00:00+09:00 | medium |'
+# golden 全文比較: grep 断片照合ではなく期待ファイル全文との diff で固定する
+# (ヘッダ二重化・本文欠落・空行過剰削除・節末端誤検出を 1 assert で同時捕捉)
+cat > "$TEST_DIR/tc1-expected.md" <<'EOF'
+# Wiki Index
+
+カタログ本文。
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存サマリー | 2026-01-01T00:00:00+09:00 | high |
+| [Bar Heuristic](pages/heuristics/bar.md) | heuristics | bar の説明 | 2026-08-04T22:00:00+09:00 | medium |
+
+## 統計
+
+- 総ページ数: 2
+- ドメイン別: patterns=1, heuristics=1, anti-patterns=0
+- 最終更新: 2026-08-04T22:00:00+09:00
+EOF
 if [ "$HELPER_RC" -eq 0 ] \
-   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=added' \
-   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'stats_sync=synced' \
    && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=added; dedup_removed=0; stats_sync=synced$' \
-   && grep -qxF "$expected_row" "$dir/index.md" \
-   && grep -qx -- '- 総ページ数: 2' "$dir/index.md" \
-   && grep -qx -- '- ドメイン別: patterns=1, heuristics=1, anti-patterns=0' "$dir/index.md" \
-   && grep -qx -- '- 最終更新: 2026-08-04T22:00:00+09:00' "$dir/index.md"; then
-  # 追加位置 = テーブル末尾 (既存 Foo 行の後)
-  if awk '/foo\.md/{f=NR} /bar\.md/{b=NR} END{exit !(f && b && b>f)}' "$dir/index.md"; then
-    pass "TC-1 新規行追加 (行形式・末尾追加・統計同期)"
-  else
-    fail "TC-1 追加位置がテーブル末尾でない"
-  fi
+   && diff -u "$TEST_DIR/tc1-expected.md" "$dir/index.md" > "$TEST_DIR/tc1-diff.txt" 2>&1; then
+  pass "TC-1 新規行追加 (golden 全文比較: 末尾追加・本文/構造保存・統計同期)"
 else
   fail "TC-1 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc1-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -241,19 +256,31 @@ EOF
 run_helper --index "$dir/index.md" --title "Late Row" --domain heuristics \
   --slug late --updated "2026-08-05T01:00:00+09:00" --confidence medium \
   --pages-root "$dir/pages"
-blank_between=$(awk '/^\|/{p=1} p && /^[ \t]*$/{c++} /^## 統計/{exit} END{print c+0}' "$dir/index.md")
+# golden 全文比較: パイプ行間の空行だけが消え、見出し直後・統計節直前の空行は保持される
+# ことを diff で固定する (過剰削除の変異を捕捉。総ページ数は fixture の実 pages/ = 3)
+cat > "$TEST_DIR/tc7-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+| [Late Row](pages/heuristics/late.md) | heuristics | 空行の後の行 | 2026-08-05T01:00:00+09:00 | medium |
+
+## 統計
+
+- 総ページ数: 3
+- ドメイン別: patterns=1, heuristics=2, anti-patterns=0
+- 最終更新: 2026-08-05T01:00:00+09:00
+EOF
 if [ "$HELPER_RC" -eq 0 ] \
    && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
-   && [ "$blank_between" -le 1 ] \
-   && grep -q 'Late Row' "$dir/index.md"; then
-  # 空行除去後は Late 行が同定・更新されている (空行があると GFM 上は段落落ちしていた行)
-  if grep -qxF '| [Late Row](pages/heuristics/late.md) | heuristics | 空行の後の行 | 2026-08-05T01:00:00+09:00 | medium |' "$dir/index.md"; then
-    pass "TC-7 節内空行を除去し空行後の登録行も同定対象になる"
-  else
-    fail "TC-7 空行後の行が更新されていない"
-  fi
+   && diff -u "$TEST_DIR/tc7-expected.md" "$dir/index.md" > "$TEST_DIR/tc7-diff.txt" 2>&1; then
+  pass "TC-7 節内空行の除去 (golden 全文比較: 空行後の行の同定・境界空行の保持)"
 else
-  fail "TC-7 (rc=$HELPER_RC blank_between=$blank_between)"
+  fail "TC-7 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc7-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -460,11 +487,38 @@ run_helper --index "$dir/index.md" --title t --domain patterns --slug 'bad/slug'
 run_helper --index "$dir/index.md" --domain patterns --slug s \
   --updated "2026-08-05T09:00:00+09:00" --confidence high
 [ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (--title 欠落が rc=$HELPER_RC)"; }
+# 制御文字 reject 経路 (_has_c0_del): 改行入り title / 改行入り description /
+# 制御文字 (TAB) 入り updated はいずれも exit 2 (1 行のテーブル行として表現不能)
+run_helper --index "$dir/index.md" --title $'a\nb' --domain patterns --slug s \
+  --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (改行入り title が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --description $'x\ny' --updated "2026-08-05T09:00:00+09:00" --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (改行入り description が rc=$HELPER_RC)"; }
+run_helper --index "$dir/index.md" --title t --domain patterns --slug s \
+  --updated $'2026\t08' --confidence high
+[ "$HELPER_RC" -eq 2 ] || { tc15_ok=0; echo "  (制御文字入り updated が rc=$HELPER_RC)"; }
 after=$(cat "$dir/index.md")
 if [ "$tc15_ok" -eq 1 ] && [ "$before" = "$after" ]; then
-  pass "TC-15 invocation error 群で exit 2・index.md 無変更"
+  pass "TC-15 invocation error 群 (enum/slug/updated/欠落/制御文字) で exit 2・index.md 無変更"
 else
   fail "TC-15"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-15b (T-04): UTF-8 日本語 title/description は制御文字誤検出しない (rc=0)
+# _has_c0_del が C1 バイト (UTF-8 継続バイトと重複) を検査対象から除外した意図を pin
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc15b)
+run_helper --index "$dir/index.md" --title "日本語タイトルのページ" --domain patterns \
+  --slug foo --description "日本語の説明文です" --updated "2026-08-05T09:30:00+09:00" \
+  --confidence high --pages-root "$dir/pages"
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && grep -qxF '| [日本語タイトルのページ](pages/patterns/foo.md) | patterns | 日本語の説明文です | 2026-08-05T09:30:00+09:00 | high |' "$dir/index.md"; then
+  pass "TC-15b UTF-8 日本語 title/description が制御文字誤検出されない (rc=0)"
+else
+  fail "TC-15b (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────
@@ -484,6 +538,140 @@ if [ "$HELPER_RC" -eq 0 ] \
   pass "TC-16 pages 取得不能は WARNING + 統計値保持 (行操作は適用)"
 else
   fail "TC-16 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-18 (T-01/T-03): 別ドメイン同一 slug は別ページ — 誤同定・誤削除しない
+# 同定キーはページ path ({domain}/{slug})。slug 単独キーだと heuristics/c の行が
+# patterns/c の「重複」と誤判定され silent 削除される (golden 全文比較で両行保持を固定)
+# ──────────────────────────────────────────────────────────────────────
+dir=$(make_sandbox tc18)
+touch "$dir/pages/patterns/c.md" "$dir/pages/heuristics/c.md"
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [C patterns 側](pages/patterns/c.md) | patterns | sA | 2026-01-01T00:00:00+09:00 | high |
+| [C heuristics 側](pages/heuristics/c.md) | heuristics | sB | 2026-01-02T00:00:00+09:00 | medium |
+EOF
+run_helper --index "$dir/index.md" --title "C patterns 側 v2" --domain patterns \
+  --slug c --updated "2026-08-05T14:00:00+09:00" --confidence low \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc18-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [C patterns 側 v2](pages/patterns/c.md) | patterns | sA | 2026-08-05T14:00:00+09:00 | low |
+| [C heuristics 側](pages/heuristics/c.md) | heuristics | sB | 2026-01-02T00:00:00+09:00 | medium |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -q '^\[CONTEXT\] WIKI_INDEX_UPDATE=row_action=updated; dedup_removed=0; stats_sync=skipped_no_section$' \
+   && diff -u "$TEST_DIR/tc18-expected.md" "$dir/index.md" > "$TEST_DIR/tc18-diff.txt" 2>&1; then
+  pass "TC-18 別ドメイン同一 slug は両行保持 (対象ドメインの行のみ更新・dedup 0)"
+else
+  fail "TC-18 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc18-diff.txt" 2>/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# TC-19/20/21 (T-03): ヘッダ行・区切り行の欠落補填 (手順 0) — golden 全文比較
+# 節はあるがヘッダ/区切りが欠けた index を、見出し直後 (既存登録行より前) に補って
+# 正規の 5 列テーブル形へ是正する分岐の実行可能仕様
+# ──────────────────────────────────────────────────────────────────────
+# TC-19: ヘッダ・区切り両方欠落 → 見出し直後に 2 行を挿入
+dir=$(make_sandbox tc19)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern v19" --domain patterns \
+  --slug foo --updated "2026-08-05T11:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc19-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern v19](pages/patterns/foo.md) | patterns | 既存 | 2026-08-05T11:00:00+09:00 | high |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && diff -u "$TEST_DIR/tc19-expected.md" "$dir/index.md" > "$TEST_DIR/tc19-diff.txt" 2>&1; then
+  pass "TC-19 ヘッダ・区切り両方欠落を見出し直後に補填 (golden)"
+else
+  fail "TC-19 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc19-diff.txt" 2>/dev/null
+fi
+
+# TC-20: 区切り行のみ欠落 → ヘッダ行の直後に挿入 (見出し直後ではない)
+dir=$(make_sandbox tc20)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern v20" --domain patterns \
+  --slug foo --updated "2026-08-05T12:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc20-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern v20](pages/patterns/foo.md) | patterns | 既存 | 2026-08-05T12:00:00+09:00 | high |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && diff -u "$TEST_DIR/tc20-expected.md" "$dir/index.md" > "$TEST_DIR/tc20-diff.txt" 2>&1; then
+  pass "TC-20 区切り行のみ欠落をヘッダ行直後に補填 (golden)"
+else
+  fail "TC-20 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc20-diff.txt" 2>/dev/null
+fi
+
+# TC-21: ヘッダ行のみ欠落 → 見出し直後に挿入 (区切り行の前)
+dir=$(make_sandbox tc21)
+cat > "$dir/index.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+
+|--------|---------|---------|--------|--------|
+| [Foo Pattern](pages/patterns/foo.md) | patterns | 既存 | 2026-01-01T00:00:00+09:00 | high |
+EOF
+run_helper --index "$dir/index.md" --title "Foo Pattern v21" --domain patterns \
+  --slug foo --updated "2026-08-05T13:00:00+09:00" --confidence high \
+  --pages-root "$dir/pages"
+cat > "$TEST_DIR/tc21-expected.md" <<'EOF'
+# Wiki Index
+
+## ページ一覧
+| ページ | ドメイン | サマリー | 更新日 | 確信度 |
+|--------|---------|---------|--------|--------|
+| [Foo Pattern v21](pages/patterns/foo.md) | patterns | 既存 | 2026-08-05T13:00:00+09:00 | high |
+EOF
+if [ "$HELPER_RC" -eq 0 ] \
+   && printf '%s\n' "$HELPER_STDOUT" | grep -qx 'row_action=updated' \
+   && diff -u "$TEST_DIR/tc21-expected.md" "$dir/index.md" > "$TEST_DIR/tc21-diff.txt" 2>&1; then
+  pass "TC-21 ヘッダ行のみ欠落を見出し直後 (区切り行の前) に補填 (golden)"
+else
+  fail "TC-21 (rc=$HELPER_RC stdout=$HELPER_STDOUT)"
+  cat "$TEST_DIR/tc21-diff.txt" 2>/dev/null
 fi
 
 # ──────────────────────────────────────────────────────────────────────

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -202,9 +202,10 @@ bash "$plugin_root/hooks/scripts/wiki-ingest-lock.sh" acquire
 | `n_skipped` | 0 | ステップ 4 で「スキップ」決定ごとに +1 |
 | `n_warnings` | 0 | ステップ 8.5 で Lint の検出件数合計（`n_unregistered_raw` を除く 5 カテゴリ）を加算。加えて ステップ 8.3 の Lint 実行異常検出時 `n_warnings += 1` と `n_lint_anomaly += 1` を並行加算 |
 | `n_lint_anomaly` | 0 | ステップ 8.3 step 1/3/4 (ERROR 行検出 / stdout 空 / regex mismatch) でそれぞれ +1。`n_warnings` と並行加算 |
+| `n_dedup_removed` | 0 | ステップ 6 の各 helper 呼び出しが出力する `dedup_removed=` の値を加算 |
 | `n_contradictions` / `n_stale` / `n_orphans` / `n_missing_concept` / `n_unregistered_raw` / `n_broken_refs` | 0 | ステップ 8.3 step 2 (6 フィールド regex match) で Lint stdout から抽出 |
 
-`n_unregistered_raw` は informational 指標で `n_warnings` には加算しない（意図的に経験則化しなかった件数は警告ではない）。`auto_lint=false` 経路で ステップ 8.2-8.5 が skip された場合も、本ステップで 0 初期化されているためステップ 9 完了レポートの placeholder 残留は発生しない。
+`n_unregistered_raw` と `n_dedup_removed` は informational 指標で `n_warnings` には加算しない（意図的に経験則化しなかった件数、および index の自己修復として回収した重複行の件数は、いずれも警告ではない）。`auto_lint=false` 経路で ステップ 8.2-8.5 が skip された場合も、本ステップで 0 初期化されているためステップ 9 完了レポートの placeholder 残留は発生しない。
 
 ### 2.2 候補 Raw Source の列挙 (worktree ベース)
 
@@ -444,7 +445,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
    > **複数 Raw Source からの作成**: page-template.md の `sources:` は単一スロット（`{source_type}`/`{source_ref}` 各 1 個）のみ。multi-cycle PR 等で複数の Raw Source を 1 ページに統合する場合は、Write 後に Edit で `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` エントリを追加する。**追加・置換するすべての `ref` は Raw Source のファイルパス形式 (`raw/{type}/{filename}`)** であり、raw frontmatter の `source_ref` フィールド値（PR 識別子形式）ではない（ステップ 5.3 `{source_ref}` 行の dual-use 警告と同一契約）。
 4. **既存 Wiki ページの更新** (ステップ 4 で更新決定): 対象ページを Read で読み、Edit で `## 詳細` 追記・`updated` 更新・`sources` 配列追記。`n_pages_updated` を +1 する。**`sources` に追記する各 `ref` は必ず Raw Source のファイルパス形式 `raw/{type}/{filename}`**（PR 識別子形式 `pr-NNNN` 禁止。ステップ 4.2 / 5.3 と同一契約）
 5. **スキップ決定の処理** (ステップ 4 で skip 決定): step 2 と同じ手順で `ingested: true` 化し、**さらに当該 raw frontmatter に `ingest_status: skipped` と `skip_reason: "{理由}"` を Edit で追記する**（skip 状態の Source of Truth は raw frontmatter。lint の `wiki-lint-skipped-refs.sh` がこれを走査して `unregistered_raw` を判定する。Issue #1520）。ステップ 7 の log.md には人間向けの Skip エントリ (OKF bullet) も追記する。`n_skipped` を +1 する
-6. **index.md の更新**: ステップ 6 の指示に従い `wiki-index-update.sh` helper を bash で呼び出す（LLM は Edit しない）
+6. **index.md の更新**: **手順 3 / 4 を実施した Raw Source についてのみ**、ステップ 6 の指示に従い `wiki-index-update.sh` helper を bash で呼び出す（LLM は Edit しない）。**skip 決定（手順 5）の Raw Source では実行しない** — helper が必須とする page metadata（title / domain / slug / updated / confidence）が存在せず、raw 由来の値で代用すると実在しないパスを指す登録行が新規追加されて孤児検出のシグナルを汚すため
 7. **log.md への追記**: ステップ 7 の指示に従い Edit で append-only 追加する
 
 ### 5.0.c canonical commit message 契約
@@ -642,7 +643,9 @@ fi
 - `{description}` は frontmatter に `description` が無ければ**空のまま**渡す（helper が既存行のサマリー列を保持する）
 - `{domain}` / `{slug}` は対象ページの**ファイルパス** `pages/{domain}/{slug}.md` から取る（新規経路はステップ 4.1 で決めた値、更新経路はステップ 5.0 手順 4 で Read した既存ファイルの domain ディレクトリ名とファイル名 stem）。`title` からの再導出はしない — ステップ 4.2 は title の書き換えを許容するため、再導出すると既存ファイル名と異なる slug が渡り、実在しないパスを指す登録行が新規追加される（旧行は旧値のまま残る）
 
-**substitute する 6 値はすべて quoted heredoc で受ける**（frontmatter は LLM 生成テキストで引用符・バックスラッシュ・`$(...)` を含みうる。double-quote されたシェル語へ直接置換すると値の `"` でクォートが閉じ、後続テキストがコマンドとして実行される — [`skills/fix/SKILL.md`](../fix/SKILL.md) の同旨規約と同じ理由。quoted heredoc はシェル解釈を完全に抑制する）。値は 1 行のみ — 複数行は helper が reject する:
+**substitute する 6 値はすべて quoted heredoc で受ける**（frontmatter は LLM 生成テキストで引用符・バックスラッシュ・`$(...)` を含みうる。double-quote されたシェル語へ直接置換すると値の `"` でクォートが閉じ、後続テキストがコマンドとして実行される — [`skills/fix/SKILL.md`](../fix/SKILL.md) の同旨規約と同じ理由。quoted heredoc は**終端子行と一致しない限り**シェル解釈を抑制する）。
+
+**実行前ゲート（必須）**: substitute する 6 値のいずれかが**複数行**、またはいずれかの**行が終端子 `WIU_EOF` と完全一致**する場合、**この bash を実行してはならない**。heredoc がその行で早期終了し、値の後続がシェルのコマンドとして実行される（quoted heredoc に残る唯一の脱出口で、6 つの heredoc が同じ終端子を共有するため後続の `wiu_*=$(cat <<'WIU_EOF'` が再度開いて構文が通り、helper 呼び出し行も正常に走るため **rc=0 + 3 marker 揃いの成功に見える**）。値は bash に渡る前の substitute 時点でしか検査できない（block 内のシェルは parse 済みで手遅れ）ため、本ゲートは LLM 側の責務である。該当した場合は当該ページの index 更新をスキップし、ステップ 9 の未完了事項に載せる（marker 表の exit 1 行と同じ扱い）。1 行値であることは helper 側の C0 検査でも担保されるが、それは**この bash を実行できた場合に限る**:
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -689,13 +692,15 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
 |---|---|
 | exit 0 + `row_action=added` / `updated` | 正常。次の処理へ続行（`stats_sync` 軸も併せて評価する） |
 | exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次に当該ページが ingest されるサイクルでは中止条項に掛からない（**本サイクル分の登録行更新は失われ、登録行は旧値のまま残る**）。**helper の WARNING をそのまま表示し、当該ページの登録行が旧値のまま残ることをステップ 9 の未完了事項に含める**（exit 1 行と同じく Lint のどの観点にも載らないため）。続行 |
-| exit 0 + `stats_sync=synced` | 統計同期完了。ただし **stderr に WARNING がある場合**は 3 行のうち一部しか同期できていない（既存行が無い統計行は新設しない仕様）。その WARNING をそのまま表示し、未同期の統計行名をステップ 9 の未完了事項に含める。続行 |
+| exit 0 + `stats_sync=synced` | 統計同期完了。ただし **stderr に `'## 統計' 節に既存行が見つからない統計行があります` を含む WARNING がある場合**は 3 行のうち一部しか同期できていない（既存行が無い統計行は新設しない仕様）。その WARNING をそのまま表示し、未同期の統計行名をステップ 9 の未完了事項に含める。続行（**判別は本 literal で行う** — 同じ呼び出しで重複中止の WARNING も stderr に出るため、WARNING の有無だけで判定すると統計が完全に同期された呼び出しを部分未同期と誤報告する。重複中止は `row_action=aborted_duplicate` 行が受け持つ） |
 | exit 0 + `stats_sync=skipped_no_section` | `## 統計` 節が無い（節は新設しない仕様。総ページ数は `/rite:wiki-lint` のレポートで確認できる）。続行 |
 | exit 0 + `stats_sync=skipped_unreadable` | 統計同期をスキップ（原因は stderr の WARNING に出ているのでそれを表示する。`## 統計` 節は前サイクルの内容のまま）。続行 |
 | exit 0 だが marker が 1 行も出ない | helper 呼び出しが構文レベルで壊れている（上記 bash の継続バックスラッシュ脱落・placeholder 置換崩れ等で、helper に到達せず別コマンドの rc が返っている）。**成功として扱わない** — 実行した bash をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 9 の未完了事項に含め、ステップ 7 へ続行する |
 | exit 2（ERROR 出力） | 引数不正 = 呼び出し側の substitute 漏れ・値の混入。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR が指す引数を substitute し直して**同じ bash を再実行**する（再実行しても exit 2 なら ERROR を表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行） |
 | exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなのでステップ 9 の未完了事項（`{ingest_outstanding_line}`）に必ず含める |
 | 上記以外の非ゼロ exit（helper パスを解決できない 127、signal 中断の 130 / 143 / 129 等。marker は 1 行も出力されない） | helper の出力（あれば）と exit code をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 7 へ続行する。**部分適用は無い**（同上）。exit 1 と同様、表示した内容をステップ 9 の未完了事項に含める |
+
+**全 Raw Source が skip 決定だったサイクルでは本ステップが 1 度も走らない**（ステップ 5.0 手順 6 の条件）。その場合 helper の Procedure 3a（重複登録行の回収）も走らないため、既存の重複は次に page 作成/更新を伴うサイクルまで残る。docstring が 3a を「毎回実行」と規定しているのは**呼び出しごと**の意味であり、呼び出し自体の有無は本ステップの条件が決める。
 
 書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる。パス解決の cwd 依存性は分岐で異なる — `separate_branch` かつ `{wiki_worktree_abs}` が非空なら絶対パス基点で cwd に依存しないが、`same_branch` および `{wiki_worktree_abs}` が空のときの縮退経路は相対パスなので、ステップ 3 の `wiki_index_path` 解決と同じく **dev ツリー root を cwd とする前提**で動く（前提が崩れると helper は index.md 不在の exit 1 で fail-loud に止まる）。
 
@@ -964,12 +969,12 @@ Wiki Ingest が完了しました。
 
 | 系統 | 条件 | 展開 |
 |---|---|---|
-| index 更新 | ステップ 6 が ERROR 表示に至った Raw Source がある（exit 1 / exit 2 の再実行後失敗 / marker 無しの非ゼロ exit / marker 無しの exit 0） | `- ⚠️ index 未更新: pages/{domain}/{slug}.md（{ERROR 1 行目}）` を該当件数ぶん列挙 |
-| index 更新 | `row_action=aborted_duplicate` / `stats_sync=synced` かつ WARNING あり / `stats_sync=skipped_unreadable` の Raw Source がある | `- ⚠️ index 部分未同期: pages/{domain}/{slug}.md（{WARNING 1 行目}）` を該当件数ぶん列挙 |
-| index 更新 | `dedup_removed` の合計が 1 以上 | `- ℹ️ index 重複行を {n} 件回収しました` |
+| index 更新 | ステップ 6 が ERROR 表示 / 実行スキップに至った Raw Source がある（exit 1 / exit 2 の再実行後失敗 / marker 無しの非ゼロ exit / marker 無しの exit 0 / 実行前ゲートによるスキップ） | `- ⚠️ index 未更新: pages/{domain}/{slug}.md（{ステップ 6 で表示した出力の 1 行目}）` を該当件数ぶん列挙。**ERROR 行があるとは限らない** — 127 は bash の `No such file or directory`、signal 中断（130 / 143 / 129）は出力ゼロなので、その場合は `（出力なし、exit code {n}）` と書く（実行前ゲートによるスキップは `（実行前ゲート: 値が複数行または終端子行と一致）`） |
+| index 更新 | `row_action=aborted_duplicate` / `stats_sync=synced` かつ stderr に `'## 統計' 節に既存行が見つからない統計行があります` を含む WARNING あり / `stats_sync=skipped_unreadable` の Raw Source がある | `- ⚠️ index 部分未同期: pages/{domain}/{slug}.md（{WARNING 1 行目}）` を該当件数ぶん列挙（`synced` 側の判別が本 literal に閉じているのはステップ 6 marker 表と同じ理由 — 重複中止 WARNING との二重計上を防ぐ） |
+| index 更新 | `{n_dedup_removed}` が 1 以上 | `- ℹ️ index 重複行を {n_dedup_removed} 件回収しました` |
 | Wiki push | `WIKI_INGEST_PUSH=failed` | `- ⚠️ Wiki push: commit は local wiki branch に landed しましたが origin への push に失敗しました。手動回復: git -C {wiki_worktree_abs} push origin {wiki_branch}（次回 /rite:wiki-ingest 実行時にも自動で flush を試みます）` |
 | Wiki push | marker なし（ステップ 8.6 未到達などの想定外経路） | `- ⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください`（`{wiki_push_line}` の同ケースと同じ扱い — 未確認を「失敗なし」と断定しない） |
-| （両系統） | 上記のいずれにも該当しない（index 更新が全件成功し、push も `ok` / `skipped; reason=same_branch`） | `- なし（非ブロッキングで継続した失敗はありませんでした）` |
+| （両系統） | 上記のいずれにも該当しない（index 更新が全件成功し、回収した重複行が 0 件で、push も `ok` / `skipped; reason=same_branch`） | `- なし（非ブロッキングで継続した失敗はありませんでした）` |
 
 ### 9.1 Return-to-Caller Signal
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -671,6 +671,7 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
 | exit 0 + `stats_sync=skipped_unreadable` | 統計同期をスキップ（原因は stderr の WARNING に出ているのでそれを表示する。`## 統計` 節は前サイクルの内容のまま）。続行 |
 | exit 2（ERROR 出力） | 引数不正 = 呼び出し側の substitute 漏れ・値の混入。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR が指す引数を substitute し直して**同じ bash を再実行**する（再実行しても exit 2 なら ERROR を表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行） |
 | exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなので必ず完了レポートに含める |
+| 上記以外の非ゼロ exit（helper パスを解決できない 127、signal 中断の 130 / 143 / 129 等。marker は 1 行も出力されない） | helper の出力（あれば）と exit code をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 7 へ続行する。**部分適用は無い**（同上）。exit 1 と同様、表示した内容を必ず完了レポートに含める |
 
 書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる — 上記 bash が `{wiki_worktree_abs}` 基点で index.md / pages/ のパスを解決するため、呼び出し時の cwd（セッション worktree / main checkout）に依存しない。
 
@@ -969,6 +970,7 @@ sentinel は grep 可能 (`grep -F '[ingest:returned-to-caller]'`) で rendered 
 | `wiki-worktree-commit.sh --commit-only` exit 3 (git add/commit 失敗、ステップ 5.1) | exit 1 で fail-fast。`git -C .rite/wiki-worktree status` で worktree の状態を確認 |
 | `wiki-worktree-commit.sh --push-only` exit 4 (push 失敗、ステップ 8.6) | 非 fatal で継続。commit は local wiki branch に保持される。`git -C .rite/wiki-worktree push origin {wiki_branch}` で手動回復、または次回 ingest の ステップ 8.6 が自動で flush を試みる |
 | `wiki-worktree-commit.sh` 未知の exit code | exit 1 で fail-fast |
+| `wiki-index-update.sh` 非ゼロ exit（exit 1 / exit 2 / 127 / signal 130・143・129 等、ステップ 6） | 当該 Raw Source の index 更新をスキップして続行（非 fatal）。分岐と対処はステップ 6 の結果 marker 表が SoT |
 | `branch_strategy` が未知の値 | ステップ 5.1 の if/elif/else 末尾 else 分岐で fail-fast (ステップ 5.2 の bash block は same_branch 単独分岐のため未知値はステップ 5.1 の else が catch する。`rite-config.yml` の `wiki.branch_strategy` を確認) |
 | LLM が経験則を抽出できない | 該当 Raw Source の raw frontmatter に `ingest_status: skipped` + `skip_reason` を追記（skip 状態の SoT）、`ingested: true` に変更、log.md に人間向け Skip bullet を追記、`n_skipped` を +1（ステップ 5 step 5 参照） |
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -668,9 +668,9 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
 | exit 0 + `row_action=added` / `updated` | 正常。次の処理へ続行 |
 | exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（WARNING 出力済み。first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次サイクルの ingest で更新が通る。続行 |
 | exit 0 + `stats_sync=skipped_no_section` | `## 統計` 節が無い（節は新設しない仕様。総ページ数は `/rite:wiki-lint` のレポートで確認できる）。続行 |
-| exit 0 + `stats_sync=skipped_unreadable` | pages 一覧を取得できず統計同期をスキップ（WARNING 出力済み。統計 3 行は前サイクル値のまま）。続行 |
+| exit 0 + `stats_sync=skipped_unreadable` | 統計同期をスキップ（原因は stderr の WARNING に出ているのでそれを表示する。`## 統計` 節は前サイクルの内容のまま）。続行 |
 | exit 2（ERROR 出力） | 引数不正 = 呼び出し側の substitute 漏れ・値の混入。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR が指す引数を substitute し直して**同じ bash を再実行**する（再実行しても exit 2 なら ERROR を表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行） |
-| exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する（未登録ページはステップ 8 の Lint が orphans として検出する） |
+| exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなので必ず完了レポートに含める |
 
 書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる — 上記 bash が `{wiki_worktree_abs}` 基点で index.md / pages/ のパスを解決するため、呼び出し時の cwd（セッション worktree / main checkout）に依存しない。
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -400,7 +400,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 | 確信度 | LLM の判定として確信があるもの 1-3 件に絞る（量より質） |
 | index.md との照合 | ステップ 3 で読み込んだ `index_content` の一行サマリーとタイトルから判断する |
 
-**title 規約**: `{related_page_title}` は対象ページの frontmatter `title` フィールドと **literal 一致** させる。独自言い換えは禁止 (index.md ↔ link text の drift 防止)。`index.md` 登録行の link text は同じ値だが、ステップ 6 のセル区切りエスケープ（`|` → `\|`）が適用されている場合がある — **literal 一致の基準は frontmatter `title` の生値**であり、index 側のエスケープは表記上の措置なので転記してはならない。
+**title 規約**: `{related_page_title}` は対象ページの frontmatter `title` フィールドと **literal 一致** させる。独自言い換えは禁止 (index.md ↔ link text の drift 防止)。`index.md` 登録行の link text は同じ値だが、ステップ 6 の 2 種の措置が適用されている場合がある — セル区切りエスケープ（`|` → `\|`）と、リンク構文の中和（`](` の `]` → `&#93;`。同定述語が読む先頭リンクを title が詐称できないようにするため）。**literal 一致の基準は frontmatter `title` の生値**であり、index 側のこれらは表記上の措置なので転記してはならない。
 
 **path 計算規約**: `{related_page_path}` には **page-dir 相対** の path を substitute する。新規 page 格納位置 `.rite/wiki/pages/{domain}/{slug}.md` の page-dir = `.rite/wiki/pages/{domain}/` を起点として相対 path を計算する:
 
@@ -636,7 +636,13 @@ fi
 
 `.rite/wiki/index.md` の `## ページ一覧` 5 列テーブル（列順: ページ / ドメイン / サマリー / 更新日 / 確信度）への登録行の追加/更新・重複行の回収・`## 統計` 3 行の同期を、`{plugin_root}/hooks/scripts/wiki-index-update.sh` の 1 回呼び出しで行う。同定述語・セル区切りエスケープ規約・重複時の中止条項・統計最小形・統計節不在スキップの確定仕様は **helper のヘッダ docstring が Source of Truth** であり、挙動は `hooks/tests/wiki-index-update.test.sh` の fixture が固定する。本ステップは入力の substitute と結果 marker の読み取りのみを担い、index.md への書き換えは helper が atomic に実施する（LLM が Read/Edit で index.md を直接操作してはならない）。
 
-**入力契約**: 対象ページの frontmatter 値を substitute する。`{title}` / `{description}` は**生値のまま**渡す（セル区切りエスケープは helper 内で一元適用。値の言い換えは禁止 — ステップ 4.3 の title 規約が frontmatter `title` との literal 一致を要求する）。`{description}` は frontmatter に `description` が無ければ**空のまま**渡す（helper が既存行のサマリー列を保持する）。`{updated}` / `{confidence}` は page frontmatter の値から YAML の引用符を外して渡す。`{title}` / `{description}` は任意テキスト（引用符・バックスラッシュを含み得る）のため quoted heredoc で受ける（シェル解釈なし。1 行値のみ — 複数行は helper が reject する）:
+**入力契約**: 対象ページの frontmatter 値とファイルパスを substitute する。
+
+- `{title}` / `{description}` / `{updated}` / `{confidence}` は page frontmatter の値から **YAML の引用符を外して**渡す（`title: "…"` の実体は引用符の内側）。**値の加工はそれだけ** — セル区切りエスケープとリンク構文の中和は helper 内で一元適用するので呼び出し側では行わず、言い換えも禁止（ステップ 4.3 の title 規約が frontmatter `title` の生値との literal 一致を要求する）
+- `{description}` は frontmatter に `description` が無ければ**空のまま**渡す（helper が既存行のサマリー列を保持する）
+- `{domain}` / `{slug}` は対象ページの**ファイルパス** `pages/{domain}/{slug}.md` から取る（新規経路はステップ 4.1 で決めた値、更新経路はステップ 5.0 手順 4 で Read した既存ファイルの domain ディレクトリ名とファイル名 stem）。`title` からの再導出はしない — ステップ 4.2 は title の書き換えを許容するため、再導出すると既存ファイル名と異なる slug が渡り、実在しないパスを指す登録行が新規追加される（旧行は旧値のまま残る）
+
+**substitute する 6 値はすべて quoted heredoc で受ける**（frontmatter は LLM 生成テキストで引用符・バックスラッシュ・`$(...)` を含みうる。double-quote されたシェル語へ直接置換すると値の `"` でクォートが閉じ、後続テキストがコマンドとして実行される — [`skills/fix/SKILL.md`](../fix/SKILL.md) の同旨規約と同じ理由。quoted heredoc はシェル解釈を完全に抑制する）。値は 1 行のみ — 複数行は helper が reject する:
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -654,26 +660,44 @@ wiu_description=$(cat <<'WIU_EOF'
 {description}
 WIU_EOF
 )
+wiu_domain=$(cat <<'WIU_EOF'
+{domain}
+WIU_EOF
+)
+wiu_slug=$(cat <<'WIU_EOF'
+{slug}
+WIU_EOF
+)
+wiu_updated=$(cat <<'WIU_EOF'
+{updated}
+WIU_EOF
+)
+wiu_confidence=$(cat <<'WIU_EOF'
+{confidence}
+WIU_EOF
+)
 bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
   --index "$wiki_root/index.md" --pages-root "$wiki_root/pages" \
   --title "$wiu_title" --description "$wiu_description" \
-  --domain "{domain}" --slug "{slug}" \
-  --updated "{updated}" --confidence "{confidence}"
+  --domain "$wiu_domain" --slug "$wiu_slug" \
+  --updated "$wiu_updated" --confidence "$wiu_confidence"
 ```
 
-**結果 marker**（stdout の `row_action=` / `dedup_removed=` / `stats_sync=` と exit code で分岐する）:
+**結果 marker**: helper は 1 回の呼び出しで `row_action=` / `dedup_removed=` / `stats_sync=` の 3 marker を**必ず同時に**出力する。**`row_action` 軸と `stats_sync` 軸は独立で、両軸の該当行をそれぞれ適用する**（ステップ 9 の `{wiki_push_line}` 表のような first-match ではない — 片方で打ち切ると同時に出ている他方の WARNING 表示指示に到達しない）。`dedup_removed=` は分岐を持たず、1 以上なら回収件数をステップ 9 の未完了事項へ載せる状態値である:
 
 | 結果 | アクション |
 |---|---|
-| exit 0 + `row_action=added` / `updated` | 正常。次の処理へ続行 |
-| exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（WARNING 出力済み。first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次サイクルの ingest で更新が通る。続行 |
+| exit 0 + `row_action=added` / `updated` | 正常。次の処理へ続行（`stats_sync` 軸も併せて評価する） |
+| exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次に当該ページが ingest されるサイクルでは中止条項に掛からない（**本サイクル分の登録行更新は失われ、登録行は旧値のまま残る**）。**helper の WARNING をそのまま表示し、当該ページの登録行が旧値のまま残ることをステップ 9 の未完了事項に含める**（exit 1 行と同じく Lint のどの観点にも載らないため）。続行 |
+| exit 0 + `stats_sync=synced` | 統計同期完了。ただし **stderr に WARNING がある場合**は 3 行のうち一部しか同期できていない（既存行が無い統計行は新設しない仕様）。その WARNING をそのまま表示し、未同期の統計行名をステップ 9 の未完了事項に含める。続行 |
 | exit 0 + `stats_sync=skipped_no_section` | `## 統計` 節が無い（節は新設しない仕様。総ページ数は `/rite:wiki-lint` のレポートで確認できる）。続行 |
 | exit 0 + `stats_sync=skipped_unreadable` | 統計同期をスキップ（原因は stderr の WARNING に出ているのでそれを表示する。`## 統計` 節は前サイクルの内容のまま）。続行 |
+| exit 0 だが marker が 1 行も出ない | helper 呼び出しが構文レベルで壊れている（上記 bash の継続バックスラッシュ脱落・placeholder 置換崩れ等で、helper に到達せず別コマンドの rc が返っている）。**成功として扱わない** — 実行した bash をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 9 の未完了事項に含め、ステップ 7 へ続行する |
 | exit 2（ERROR 出力） | 引数不正 = 呼び出し側の substitute 漏れ・値の混入。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR が指す引数を substitute し直して**同じ bash を再実行**する（再実行しても exit 2 なら ERROR を表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行） |
-| exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなので必ず完了レポートに含める |
-| 上記以外の非ゼロ exit（helper パスを解決できない 127、signal 中断の 130 / 143 / 129 等。marker は 1 行も出力されない） | helper の出力（あれば）と exit code をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 7 へ続行する。**部分適用は無い**（同上）。exit 1 と同様、表示した内容を必ず完了レポートに含める |
+| exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなのでステップ 9 の未完了事項（`{ingest_outstanding_line}`）に必ず含める |
+| 上記以外の非ゼロ exit（helper パスを解決できない 127、signal 中断の 130 / 143 / 129 等。marker は 1 行も出力されない） | helper の出力（あれば）と exit code をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 7 へ続行する。**部分適用は無い**（同上）。exit 1 と同様、表示した内容をステップ 9 の未完了事項に含める |
 
-書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる — 上記 bash が `{wiki_worktree_abs}` 基点で index.md / pages/ のパスを解決するため、呼び出し時の cwd（セッション worktree / main checkout）に依存しない。
+書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる。パス解決の cwd 依存性は分岐で異なる — `separate_branch` かつ `{wiki_worktree_abs}` が非空なら絶対パス基点で cwd に依存しないが、`same_branch` および `{wiki_worktree_abs}` が空のときの縮退経路は相対パスなので、ステップ 3 の `wiki_index_path` 解決と同じく **dev ツリー root を cwd とする前提**で動く（前提が崩れると helper は index.md 不在の exit 1 で fail-loud に止まる）。
 
 ---
 
@@ -936,13 +960,16 @@ Wiki Ingest が完了しました。
 | `skipped; reason=same_branch` | `Wiki push: 対象外 (same_branch 戦略。通常の PR push に含まれる)` |
 | marker なし（ステップ 8.6 未到達などの想定外経路） | `⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください` |
 
-`{ingest_outstanding_line}`（Issue #1946: 非ブロッキング失敗の集約 surface。`{wiki_push_line}` と同じ `WIKI_INGEST_PUSH=` marker を再評価するだけで、新しい記録先は持たない — local commit 自体が durable な記録であり、次回 ingest のステップ 8.6 が自動で flush を試みる）:
+`{ingest_outstanding_line}`（Issue #1946: 非ブロッキング失敗の集約 surface。Wiki push については `{wiki_push_line}` と同じ `WIKI_INGEST_PUSH=` marker を再評価するだけで新しい記録先は持たない — local commit 自体が durable な記録であり、次回 ingest のステップ 8.6 が自動で flush を試みる）。**ステップ 6 の index 更新と Wiki push の 2 系統を評価し、該当するものをすべて列挙する**（index 更新の失敗・部分適用は Lint のどの観点にも載らず、ステップ 6 で表示した ERROR / WARNING が唯一のシグナルであるため、その場の表示に加えて本欄へ集約する）:
 
-| `WIKI_INGEST_PUSH=` | 展開 |
-|---|---|
-| `failed` | `- ⚠️ Wiki push: commit は local wiki branch に landed しましたが origin への push に失敗しました。手動回復: git -C {wiki_worktree_abs} push origin {wiki_branch}（次回 /rite:wiki-ingest 実行時にも自動で flush を試みます）` |
-| marker なし（ステップ 8.6 未到達などの想定外経路） | `- ⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください`（`{wiki_push_line}` の同ケースと同じ扱い — 未確認を「失敗なし」と断定しない） |
-| `ok` / `skipped; reason=same_branch` | `- なし（非ブロッキングで継続した失敗はありませんでした）` |
+| 系統 | 条件 | 展開 |
+|---|---|---|
+| index 更新 | ステップ 6 が ERROR 表示に至った Raw Source がある（exit 1 / exit 2 の再実行後失敗 / marker 無しの非ゼロ exit / marker 無しの exit 0） | `- ⚠️ index 未更新: pages/{domain}/{slug}.md（{ERROR 1 行目}）` を該当件数ぶん列挙 |
+| index 更新 | `row_action=aborted_duplicate` / `stats_sync=synced` かつ WARNING あり / `stats_sync=skipped_unreadable` の Raw Source がある | `- ⚠️ index 部分未同期: pages/{domain}/{slug}.md（{WARNING 1 行目}）` を該当件数ぶん列挙 |
+| index 更新 | `dedup_removed` の合計が 1 以上 | `- ℹ️ index 重複行を {n} 件回収しました` |
+| Wiki push | `WIKI_INGEST_PUSH=failed` | `- ⚠️ Wiki push: commit は local wiki branch に landed しましたが origin への push に失敗しました。手動回復: git -C {wiki_worktree_abs} push origin {wiki_branch}（次回 /rite:wiki-ingest 実行時にも自動で flush を試みます）` |
+| Wiki push | marker なし（ステップ 8.6 未到達などの想定外経路） | `- ⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください`（`{wiki_push_line}` の同ケースと同じ扱い — 未確認を「失敗なし」と断定しない） |
+| （両系統） | 上記のいずれにも該当しない（index 更新が全件成功し、push も `ok` / `skipped; reason=same_branch`） | `- なし（非ブロッキングで継続した失敗はありませんでした）` |
 
 ### 9.1 Return-to-Caller Signal
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -384,7 +384,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 - **統合**: 一部矛盾するが新情報の方が確度が高い場合は該当箇所を書き換え（`updated` フィールド更新）
 - **`sources` 配列追記**: 新しい Raw Source への参照を必ず追加する。追加する各エントリは `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` の形式とし、**`ref` は必ず Raw Source のファイルパス形式 (`raw/{type}/{filename}`、wiki-root 起点)** にする。raw frontmatter の `source_ref` フィールド値（PR 識別子形式、例: `pr-1143`）を `ref` に転記してはならない（ステップ 5.3 `{source_ref}` 行の dual-use 警告と同一契約）
 - **`updated` 更新**: 現在の ISO 8601 タイムスタンプに更新
-- **`description` の新設・更新**: 本サイクルで概要が変わった場合は frontmatter `description` を更新する（未設定なら新設してよい）。ステップ 6 手順 2 のサマリー列はこの値を第 1 候補として読むため、ここを更新しないと index のサマリーは既存値が保持される
+- **`description` の新設・更新**: 本サイクルで概要が変わった場合は frontmatter `description` を更新する（未設定なら新設してよい）。ステップ 6 の helper はサマリー列の第 1 候補としてこの値を読むため、ここを更新しないと index のサマリーは既存値が保持される
 
 ### 4.3 関連ページの特定
 
@@ -444,7 +444,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
    > **複数 Raw Source からの作成**: page-template.md の `sources:` は単一スロット（`{source_type}`/`{source_ref}` 各 1 個）のみ。multi-cycle PR 等で複数の Raw Source を 1 ページに統合する場合は、Write 後に Edit で `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` エントリを追加する。**追加・置換するすべての `ref` は Raw Source のファイルパス形式 (`raw/{type}/{filename}`)** であり、raw frontmatter の `source_ref` フィールド値（PR 識別子形式）ではない（ステップ 5.3 `{source_ref}` 行の dual-use 警告と同一契約）。
 4. **既存 Wiki ページの更新** (ステップ 4 で更新決定): 対象ページを Read で読み、Edit で `## 詳細` 追記・`updated` 更新・`sources` 配列追記。`n_pages_updated` を +1 する。**`sources` に追記する各 `ref` は必ず Raw Source のファイルパス形式 `raw/{type}/{filename}`**（PR 識別子形式 `pr-NNNN` 禁止。ステップ 4.2 / 5.3 と同一契約）
 5. **スキップ決定の処理** (ステップ 4 で skip 決定): step 2 と同じ手順で `ingested: true` 化し、**さらに当該 raw frontmatter に `ingest_status: skipped` と `skip_reason: "{理由}"` を Edit で追記する**（skip 状態の Source of Truth は raw frontmatter。lint の `wiki-lint-skipped-refs.sh` がこれを走査して `unregistered_raw` を判定する。Issue #1520）。ステップ 7 の log.md には人間向けの Skip エントリ (OKF bullet) も追記する。`n_skipped` を +1 する
-6. **index.md の更新**: ステップ 6 の指示に従い Edit する
+6. **index.md の更新**: ステップ 6 の指示に従い `wiki-index-update.sh` helper を bash で呼び出す（LLM は Edit しない）
 7. **log.md への追記**: ステップ 7 の指示に従い Edit で append-only 追加する
 
 ### 5.0.c canonical commit message 契約
@@ -634,76 +634,44 @@ fi
 
 ## ステップ 6: index.md の更新
 
-`.rite/wiki/index.md` の `## ページ一覧` セクションにある **5 列 GFM テーブル**（列順: ページ / ドメイン / サマリー / 更新日 / 確信度）を更新する。テーブルの**内側**に別形式の行を挿入すると挿入行以降の構造が崩れるため、テーブル節の中には本ステップが規定するテーブル行だけを置く（節の外にある旧テンプレート由来の箇条書き行は GFM 上テーブルと別ブロックとして共存するので、削除も移送もせずそのまま残す）。
+`.rite/wiki/index.md` の `## ページ一覧` 5 列テーブル（列順: ページ / ドメイン / サマリー / 更新日 / 確信度）への登録行の追加/更新・重複行の回収・`## 統計` 3 行の同期を、`{plugin_root}/hooks/scripts/wiki-index-update.sh` の 1 回呼び出しで行う。同定述語・セル区切りエスケープ規約・重複時の中止条項・統計最小形・統計節不在スキップの確定仕様は **helper のヘッダ docstring が Source of Truth** であり、挙動は `hooks/tests/wiki-index-update.test.sh` の fixture が固定する。本ステップは入力の substitute と結果 marker の読み取りのみを担い、index.md への書き換えは helper が atomic に実施する（LLM が Read/Edit で index.md を直接操作してはならない）。
 
-**セル区切り文字のエスケープ（新規追加・既存更新の両経路に適用）**: 入力の由来で 2 通りに分ける。**(a) frontmatter 由来の生値（`{title}` / `{description}`）**: `\` を `\\` に、続いて `|` を `\|` にエスケープして substitute する（値が literal な `\|` を含む場合に GFM が backslash を消費して区切り文字と誤読するのを防ぐ）。**(b) 手順 2 で既存行から保持したサマリー列の値**: 既にエスケープ済みの表記なので**再エスケープしない**（対象は直前が `\` でない生の `|` のみ。既存の `\|` を再エスケープすると更新サイクルごとに `\` が 1 本ずつ増え、元の本数を復元できないまま蓄積する）。**インラインコード `` ` `` の内側も対象** — GFM はコードスパン内の生 `|` もセル区切りとして解釈するため、エスケープしないと列がずれて 5 列構造が壊れる。値を言い換えて `|` を避けるのは禁止（ステップ 4.3 の title 規約が frontmatter `title` との literal 一致を要求するため）。**エスケープは index 登録行にのみ適用し、page frontmatter の `title` / `description` は改変しない**。残る `{path}` / `{domain}` / `{updated}` / `{confidence}` は slug・enum・ISO 8601 タイムスタンプで `|` を含み得ないため対象外。
+**入力契約**: 対象ページの frontmatter 値を substitute する。`{title}` / `{description}` は**生値のまま**渡す（セル区切りエスケープは helper 内で一元適用。値の言い換えは禁止 — ステップ 4.3 の title 規約が frontmatter `title` との literal 一致を要求する）。`{description}` は frontmatter に `description` が無ければ**空のまま**渡す（helper が既存行のサマリー列を保持する）。`{updated}` / `{confidence}` は page frontmatter の値から YAML の引用符を外して渡す。`{title}` / `{description}` は任意テキスト（引用符・バックスラッシュを含み得る）のため quoted heredoc で受ける（シェル解釈なし。1 行値のみ — 複数行は helper が reject する）:
 
-**登録行の同定述語（手順 1 / 2 / 3 共通）**: 「`## ページ一覧` 見出しから**次の `##` 見出しまでの範囲**にある `|` 始まりの行（ヘッダ行・区切り行を除く）のうち、その行で**最初に現れる** `](pages/{domain}/{slug}.md)` の `{slug}` が対象ページと一致する行」とする。**ページ列は「`|` で分割した最初のセル」ではなく、行頭の `|` からその最初のリンクの閉じ括弧までの範囲**と定義する — `title` に未エスケープの生 `|` を含む行ではリンクが 2 つ目以降のセルへ落ちるため、セル分割を前提にすると実在する登録行を同定できず、手順 1 が重複行を追加したうえ手順 3 の重複削除も同じ述語なので回収できない。「最初に現れる」リンクだけを見ることで、サマリー列に置かれた他ページへの相互参照リンクは自動的に対象外になる（実 index.md にはサマリー列に他ページへのリンクを含む行が複数存在する）。**「GFM がテーブル行として解釈する行」ではなく上記の位置で定義する** — 節内に空行があると GFM は先頭ブロックだけをテーブルとして解釈し、以降の登録行は段落として描画されるため、レンダリング結果を基準にすると実在する登録行の一部が同定対象から漏れて更新サイクルごとに行が増える。**共通なのは同定規則そのものだけで、次の中止条項は手順 1 / 2 に限る**: 同定結果が 2 行以上になった場合は WARNING を出して**当該ページの index 更新を中止する**（1 件目を採る等の fallback は禁止 — 誤った行を silent に書き換える経路が残る）。**手順 3 の重複削除は本中止条項の対象外**で、2 行以上の状態を入力として受け取り後発行を削除する（中止条項を手順 3 にも適用すると、重複が一度できた時点で手順 1 / 2 が永久に中止し続け、唯一の修復経路である手順 3 も同時に塞がって index が自己修復不能になる）。
+```bash
+branch_strategy="{branch_strategy}"
+wiki_wt_abs="{wiki_worktree_abs}"
+if [ "$branch_strategy" = "separate_branch" ]; then
+  wiki_root="${wiki_wt_abs:-.rite/wiki-worktree}/.rite/wiki"
+else
+  wiki_root=".rite/wiki"
+fi
+wiu_title=$(cat <<'WIU_EOF'
+{title}
+WIU_EOF
+)
+wiu_description=$(cat <<'WIU_EOF'
+{description}
+WIU_EOF
+)
+bash {plugin_root}/hooks/scripts/wiki-index-update.sh \
+  --index "$wiki_root/index.md" --pages-root "$wiki_root/pages" \
+  --title "$wiu_title" --description "$wiu_description" \
+  --domain "{domain}" --slug "{slug}" \
+  --updated "{updated}" --confidence "{confidence}"
+```
 
-**手順**（0 → 1 → 2 → 3 の順に実行する。手順 3 も省略可の任意項目ではない）:
+**結果 marker**（stdout の `row_action=` / `dedup_removed=` / `stats_sync=` と exit code で分岐する）:
 
-- **0. テーブル節の用意（無条件・毎回確認する）**: `## ページ一覧` 節が無ければ見出しと下記 2 行を新設する。**挿入位置**は既存の本文・HTML コメントより後で、`## 統計` 節があればその直前、なければファイル末尾とする（位置を自分で決めない）。節が既にありヘッダ行・区切り行が欠けている場合は、見出しの直後（既存の登録行より前）に補う。さらに**節内の `|` 始まりの行の間に空行があれば削除する** — 空行は GFM のテーブルブロックを分断し、以降の登録行がテーブルとして描画されなくなるため（既存 index の是正も兼ねる）:
+| 結果 | アクション |
+|---|---|
+| exit 0 + `row_action=added` / `updated` | 正常。次の処理へ続行 |
+| exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（WARNING 出力済み。first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次サイクルの ingest で更新が通る。続行 |
+| exit 0 + `stats_sync=skipped_no_section` | `## 統計` 節が無い（節は新設しない仕様。総ページ数は `/rite:wiki-lint` のレポートで確認できる）。続行 |
+| exit 0 + `stats_sync=skipped_unreadable` | pages 一覧を取得できず統計同期をスキップ（WARNING 出力済み。統計 3 行は前サイクル値のまま）。続行 |
+| exit 1 / exit 2（ERROR 出力） | fail-loud（index.md 不在・想定外構造・引数不正）。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する |
 
-  ```
-  | ページ | ドメイン | サマリー | 更新日 | 確信度 |
-  |--------|---------|---------|--------|--------|
-  ```
-
-- **1. 新規ページ行の追加**: 上記の同定述語に一致する行が既に存在する場合は追加せず「2. 既存ページ行の更新」へ回す（行の二重化防止）。節の外にある旧形式の箇条書き行は本判定の対象にしない（それしか無いページは新規追加として扱い、旧行はそのまま残す）。存在しなければ `## ページ一覧` テーブルの末尾に次の 1 行を追加する:
-
-  ```
-  | [{title}]({path}) | {domain} | {description} | {updated} | {confidence} |
-  ```
-
-  - 列数 (5) と列順は実 index.md のヘッダ行 `| ページ | ドメイン | サマリー | 更新日 | 確信度 |` と一致させる
-  - `{path}` は `pages/{domain}/{slug}.md` 形式を維持する（孤児検出のリンク grep `](pages/...)` 生存条件、`wiki-lint-orphans.sh`）
-  - `{description}` はステップ 4.1 のサマリー（page frontmatter の `description` と同源、1-2 文）
-  - `{updated}` / `{confidence}` は page frontmatter の値と同じにする（ISO 8601 タイムスタンプ / `high`・`medium`・`low`）。**YAML の引用符は含めない**（frontmatter 側が `updated: "2026-..."` でも index 列は引用符なし）
-- **2. 既存ページ行の更新**: 対象行は上記の同定述語で特定する（節の外にある旧形式の箇条書き行を書き換えてはならない — テーブル行を箇条書きリストの中へ置くと GFM は箇条書きの継続行として literal text にレンダリングする）。同定したら**その 1 行を上記「新規ページ行の追加」と同一形式で丸ごと再生成して置換する**（列位置を数えて特定のセルだけ書き換えることはしない）。`title` / `updated` / `confidence` は更新後の page frontmatter の値（YAML の引用符は外す）を使い、エスケープ規約を適用する。**サマリー列の値は次の順で決める**: (1) frontmatter に `description` があればその値、(2) 無ければ**既存行のサマリー列の値を保持する**（新たに生成し直さないという意味。保持値は既にエスケープ済みの表記なので、上記エスケープ規約は**未エスケープの生 `|`（直前が `\` でないもの）にのみ**適用する。ステップ 4.1 のサマリー生成は新規ページ作成時にしか実行されないため、更新経路では候補にならない）。**既存行のサマリー列は位置で切り出す** — 同定述語で確定したページ列より後ろを `|` で分割し、**分割結果の先頭要素と末尾要素は行頭側・行末側の区切りに由来して必ず空（空白のみ）になるので捨てる**。残った並びの先頭をドメイン列、**末尾 2 つを更新日列・確信度列**、その間に残るすべてを `|` で再結合したものをサマリー列とする。更新日は ISO 8601、確信度は enum でどちらも `|` を含み得ないため、末尾から数える方法はサマリー列に生 `|` が残っている行でも決定的に働く。`description` は schema 上 optional で実際に持たない page が多数あるため、**空文字で上書きしてはならない**（蓄積済みのサマリーが失われる）。これにより、既に未エスケープの生 `|` で列がずれている既存行も当該 page の更新サイクルで正しい 5 列へ是正される。
-- **3. 重複行の回収と統計**（手順 1 / 2 と同じく Raw Source 処理の一部として実行する。繰り返しても結果が変わらない冪等な手順のため、実行タイミングの分岐は持たない）: 本手順は **(3a) 重複登録行の削除** と **(3b) `## 統計` 3 行の同期** からなる。
-
-  **(3a) 重複登録行の削除**: 上記の同定述語（ページ列 anchor 付き）で同一ページを指す行が 2 行以上あるものについて後発行を削除する。同定述語の中止条項が手順 1 / 2 を止めた index を再び通せる唯一の修復経路なので、`## 統計` 節の有無や統計同期の成否に gate しない。未登録ページや節の外に旧形式の箇条書き行で登録されているページについては何もせずステップ 8 の lint に委ねる（今回読んでいない page を投機的に登録・削除すると孤児検出のシグナルが消える）。
-
-  **(3b) `## 統計` 3 行の同期**: `## 統計` 節が存在する場合のみ、**総ページ数 / ドメイン別内訳 / 最終更新**の 3 行を今回の ingest 結果と同期する（節が無ければ何もしない — 節を新設しない）。総ページ数 = `pages/` 配下の **`*.md` ファイル数**（`wiki-init` が置く `.gitkeep` 等の非ページファイルを除く）、ドメイン別 = `patterns` / `heuristics` / `anti-patterns` 各配下の `*.md` 件数、最終更新 = 今回の `{updated}` タイムスタンプ。件数は目視で数えず下記で算出する（ステップ 3 の `wiki_index_path` と同じ基点解決を使う — 素の相対パスは呼び出し時の cwd がセッション worktree / main checkout のとき 0 件になり、統計を silent に 0 で上書きする）:
-
-  ```bash
-  branch_strategy="{branch_strategy}"
-  wiki_wt_abs="{wiki_worktree_abs}"
-  if [ "$branch_strategy" = "separate_branch" ]; then
-    pages_root="${wiki_wt_abs:-.rite/wiki-worktree}/.rite/wiki/pages"
-  else
-    pages_root=".rite/wiki/pages"
-  fi
-  # find の stderr は捨てない (読めないディレクトリがあれば errno がそのまま画面に残る)。
-  # find は 1 つでも読めない経路があると非ゼロ終了するため、rc 検査が部分失敗も拾う。
-  # 内訳は $pages_root を前方一致の anchor にする — 素の "/${d}/" は基点より上のディレクトリ名にも
-  # 一致し、内訳だけが膨張して総数と別の述語になる。判定を case の literal 前方一致で行うのは、
-  # grep だと $pages_root が BRE として解釈され、チェックアウトパスが正規表現メタ文字を含むときに
-  # 内訳だけが誤るため。加えて grep はエラー (rc>=2) で何も出力せず、コマンド置換が空文字になって
-  # そのまま下の同期ゲートを通過し、`- ドメイン別: patterns=` という壊れた行を書き込む。case は
-  # クォートしたパターンを literal 扱いし、n の 0 初期化が 0 件でも 0 を出すので、この 2 経路を
-  # 同時に塞げる。awk の行全体フィールドは使わない — fenced block 内のパラメータ参照は Skill
-  # ローダーが起動引数へ展開し、プログラムがロード時に壊れる (hooks/scripts/dollar-zero-check.sh)。
-  if ! pages_list=$(find "$pages_root" -type f -name '*.md') || [ -z "$pages_list" ]; then
-    echo "WARNING: pages 一覧を取得できないか 0 件です (root=$pages_root)。誤った値で正しい統計を上書きしないため、本サイクルの統計同期をスキップします" >&2
-  else
-    total=$(printf '%s\n' "$pages_list" | wc -l | tr -d ' ')
-    for d in patterns heuristics anti-patterns; do
-      n=0
-      while IFS= read -r p; do
-        case "$p" in "${pages_root}/${d}/"*) n=$((n + 1)) ;; esac
-      done <<< "$pages_list"
-      printf '%s=%s\n' "$d" "$n"
-    done
-    echo "total=$total"
-  fi
-  ```
-
-  ブロックが `total=` とドメイン別件数を出力した場合のみ、3 行を Edit で同期する（WARNING でスキップした場合は既存値を変更しない — 過少計上した値で正しい統計を上書きするより、前サイクルの値が残る方が安全）。3 行の literal 形式は既存行に合わせる（`- 総ページ数: {n}` / `- ドメイン別: patterns={n}, heuristics={n}, anti-patterns={n}` / `- 最終更新: {updated}`）。総ページ数がテーブルのデータ行数と一致しなくても何もしない — 重複行は (3a) が回収済みで、未登録ページはステップ 8 の lint に委ねる。
-
-> **読み手側の対応状況**: `wiki-lint-orphans.sh` は `](pages/...)` リンクの grep ベースで形式非依存に登録判定するため、`{path}` の形式維持だけが孤児検出の必須条件になる。`/rite:wiki-query` の Pass 1 はテーブル行と箇条書き行の両方を parse するため、どちらの形式の index でもキーワード照合が機能する。ページ列に置いた**最初のリンク**が候補のページ指定になる（サマリー列に相互参照リンクを含めても候補は奪われない）。
-
-書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行う。
+書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる — 上記 bash が `{wiki_worktree_abs}` 基点で index.md / pages/ のパスを解決するため、呼び出し時の cwd（セッション worktree / main checkout）に依存しない。
 
 ---
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -669,7 +669,8 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
 | exit 0 + `row_action=aborted_duplicate` | 対象ページの登録行が 2 行以上あり追加/更新を中止（WARNING 出力済み。first-match fallback はしない）。重複の後発行は同呼び出しの回収処理が削除済みのため、次サイクルの ingest で更新が通る。続行 |
 | exit 0 + `stats_sync=skipped_no_section` | `## 統計` 節が無い（節は新設しない仕様。総ページ数は `/rite:wiki-lint` のレポートで確認できる）。続行 |
 | exit 0 + `stats_sync=skipped_unreadable` | pages 一覧を取得できず統計同期をスキップ（WARNING 出力済み。統計 3 行は前サイクル値のまま）。続行 |
-| exit 1 / exit 2（ERROR 出力） | fail-loud（index.md 不在・想定外構造・引数不正）。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する |
+| exit 2（ERROR 出力） | 引数不正 = 呼び出し側の substitute 漏れ・値の混入。**部分適用は無い**（書き込みは全処理成功時の atomic 1 回のみ）。ERROR が指す引数を substitute し直して**同じ bash を再実行**する（再実行しても exit 2 なら ERROR を表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行） |
+| exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する（未登録ページはステップ 8 の Lint が orphans として検出する） |
 
 書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる — 上記 bash が `{wiki_worktree_abs}` 基点で index.md / pages/ のパスを解決するため、呼び出し時の cwd（セッション worktree / main checkout）に依存しない。
 

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -654,7 +654,7 @@ wiu_description=$(cat <<'WIU_EOF'
 {description}
 WIU_EOF
 )
-bash {plugin_root}/hooks/scripts/wiki-index-update.sh \
+bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
   --index "$wiki_root/index.md" --pages-root "$wiki_root/pages" \
   --title "$wiu_title" --description "$wiu_description" \
   --domain "{domain}" --slug "{slug}" \


### PR DESCRIPTION
## 概要

wiki-ingest ステップ 6 の index.md 操作（登録行の同定・行生成・エスケープ・重複回収・統計同期）を、SKILL.md の散文手順からテスト付き helper script `wiki-index-update.sh` へ降ろす。散文手順書が review⇄fix ループの発散基質になることへの根本対策第一弾。挙動は確定仕様の 1:1 移植であり変更しない（表現媒体を散文からコードへ移すのみ）。

## 関連 Issue

Closes #2089

## 変更内容

- `plugins/rite/hooks/scripts/wiki-index-update.sh`（新規）: 手順 0〜3b（節用意・追加/更新・重複回収・統計同期）の決定論的実装。同定述語・エスケープ規約・中止条項の仕様はヘッダ docstring へ移設し Source of Truth 化。書込は tmp→mv の atomic 1 回（部分適用なし）、fail-loud（exit 1/2）。制御文字検査は共有 `contains_ctrl()` ではなくローカル C0+DEL 検査を使用（共有版は C1 バイトをバイト単位で reject するため UTF-8 日本語の title/description に誤検出する — 共有版の in-repo caller は ASCII 前提と明記済み）
- `plugins/rite/hooks/tests/wiki-index-update.test.sh`（新規）: parity fixture テスト 17 TC。生パイプ title の同定・是正、エスケープ規約 (a)/(b)（2 サイクルでの `\` 増殖なし）、節内空行除去、旧形式箇条書き共存、重複回収、fail-loud 群、SKILL.md 縮退の grep 検査（T-06）を固定
- `plugins/rite/skills/wiki-ingest/SKILL.md`: ステップ 6 を helper 呼び出し + 入出力契約 + 結果 marker 表へ縮退（約 70 行の操作散文を置換）。ステップ 5.0 手順 6 と description 規約の対称参照 2 箇所も追従
- `docs/SPEC.md`: Plugin Structure ツリーと helper 一覧表へ `wiki-index-update.sh` を追記

## 検証

- `wiki-index-update.test.sh`: 17/17 PASS
- 既存 wiki 系スイート（wiki-lint-* / wiki-ingest-* / wiki-query-inject）: 全 green（読み手契約の非破壊、AC-5）
- 変更ファイルへの plugin-specific checks（bash-heaviness / dollar-zero / number-ref / comment-journal / orphan-ref / sh-cross-ref / hardcoded-line-number）: 追加分の指摘なし

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

## Known Issues

- lint 未実行（`commands.lint` 未設定のためスキップ。上記のとおり helper 単体テスト・wiki 系スイート・plugin-specific checks は実行済み）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
