### PR TITLE
fix(hooks): WM checklist 統合の no-op success を fail-loud 化し §3.5.2 を実体へ直す

### DIFF
--- a/plugins/rite/hooks/issue-comment-wm-sync.sh
+++ b/plugins/rite/hooks/issue-comment-wm-sync.sh
@@ -24,7 +24,7 @@
 #       --transform append-eof --content-file "${TMPDIR:-/tmp}/completion.md"
 #
 #     bash issue-comment-wm-sync.sh update --issue 42 \
-#       --transform merge-checklist --section 進捗 --content-file "${TMPDIR:-/tmp}/items.md"
+#       --transform merge-checklist --section 進捗サマリー --content-file "${TMPDIR:-/tmp}/items.md"
 #
 # Options:
 #   --issue          Issue number (required)
@@ -41,7 +41,9 @@
 #   status=skipped; reason=no_comment       作業メモリ comment 不在 (初回 fix 等, legitimate no-op)
 #   status=skipped; reason=body_fetch_failed gh api での body 取得失敗 (auth/rate/network/404)
 #   status=skipped; reason=safety_check_failed body 空 / header 欠落 / <50% で PATCH 拒否
-#   status=error; reason=transform_failed   Python transform が非ゼロ exit
+#   status=skipped; reason=section_absent   merge-checklist: 対象 ### section 不在で新規 items を置けず
+#                                           (Python exit 10。items は破棄せず PATCH もしない — Issue #2139)
+#   status=error; reason=transform_failed   Python transform が非ゼロ exit (exit 10 以外)
 #   status=error; reason=patch_failed       jq | gh api PATCH が失敗
 #   skills/fix/SKILL.md ステップ 4.5.2 はこの行を read し、no_comment 以外の skipped/error を
 #   `[CONTEXT] WM_UPDATE_FAILED=1` にマップする (`[fix:pushed-wm-stale]` routing 用)。
@@ -556,6 +558,17 @@ original_length=$(printf '%s' "$current_body" | wc -c)
 # cat のみ確実だが、後続の transform で stdin が pipe 終端であることを期待しているため pipe 形式を保つ。
 transform_status=0
 ( set -o pipefail; cat "$body_tmp" | python3 "$PYTHON_SCRIPT" "$TRANSFORM" "${TRANSFORM_ARGS[@]}" > "$updated_tmp" 2>"$py_err_tmp" ) || transform_status=$?
+
+# merge-checklist: exit 10 = target section absent with new items remaining.
+# Distinguish from transform_failed so caller can show "セクション不在のためスキップ"
+# instead of reporting a successful no-op merge (Issue #2139 AC-1).
+if [ "$transform_status" -eq 10 ]; then
+  py_err=$(cat "$py_err_tmp" 2>/dev/null)
+  echo "WARNING: merge-checklist: target section absent; items not merged. Skipping PATCH. Backup: $backup_file" >&2
+  [ -n "$py_err" ] && echo "  Detail: $py_err" >&2
+  echo "status=skipped; reason=section_absent"
+  exit 0
+fi
 
 if [ "$transform_status" -ne 0 ]; then
   py_err=$(cat "$py_err_tmp" 2>/dev/null)

--- a/plugins/rite/hooks/issue-comment-wm-update.py
+++ b/plugins/rite/hooks/issue-comment-wm-update.py
@@ -25,7 +25,7 @@ Usage:
         --content-file /tmp/completion.md > updated.txt
 
     cat body.txt | python3 issue-comment-wm-update.py merge-checklist \
-        --section 進捗 --content-file /tmp/items.md > updated.txt
+        --section 進捗サマリー --content-file /tmp/items.md > updated.txt
 
     cat body.txt | python3 issue-comment-wm-update.py update-checkboxes \
         --tasks "task1,task2" > updated.txt
@@ -36,6 +36,8 @@ Exit codes:
     0: Success (updated body written to stdout)
     1: Usage error (missing arguments, unknown option)
     2: File read error (content-file or changed-files-file not found)
+    10: Section absent (merge-checklist only: new items remain but target
+       section header is missing — caller must not treat this as success)
 """
 
 import re
@@ -193,6 +195,21 @@ def append_eof(body: str, content: str) -> str:
     return body.rstrip("\n") + "\n\n" + content.rstrip("\n") + "\n"
 
 
+class SectionAbsentError(Exception):
+    """Raised by merge_checklist when new items cannot be placed because the
+    target ``### {section}`` header is missing from the body.
+
+    Distinct from an idempotent no-op (all items already present): the caller
+    must surface this as ``status=skipped; reason=section_absent`` rather than
+    ``status=success``, so that silent drop of checklist items is not reported
+    as a successful merge (fail-loud; Issue #2139).
+    """
+
+    def __init__(self, section_name: str):
+        self.section_name = section_name
+        super().__init__(f"section absent: {section_name}")
+
+
 def merge_checklist(body: str, section_name: str, items: list[str]) -> str:
     """Merge checklist items into the end of a named section, skipping any item
     already present as an exact full line anywhere in the body.
@@ -200,20 +217,30 @@ def merge_checklist(body: str, section_name: str, items: list[str]) -> str:
     Ports the progress-section merge from archive-procedures.md §3.5.2: full-body
     exact-line dedup (matching the original ``grep -qxF``), insertion at the end
     of the section (before the next ``### `` header, or at EOF when the section is
-    last). When the section is absent the items are dropped and the body returned
-    unchanged — matching both the original block and append_section's
-    no-op-on-absent contract. Idempotent: re-running with the same items is a
-    no-op. Trailing-newline state of the input is preserved.
+    last). Idempotent: re-running with the same items is a no-op. Trailing-newline
+    state of the input is preserved.
+
+    When the section is absent **and** there are new items to insert, raises
+    :class:`SectionAbsentError` instead of dropping the items and returning the
+    body unchanged. Callers map that to exit code 10 / ``reason=section_absent``
+    so the skip is visible (Issue #2139). When every item is already present
+    (or the item list is empty), returns the body unchanged with no error —
+    that is a true idempotent no-op, not a silent drop.
     """
     existing = set(body.split("\n"))
     new_items = [item for item in items if item not in existing]
     if not new_items:
         return body
 
+    section_header = "### " + section_name
+    section_found = any(line.rstrip() == section_header for line in body.split("\n"))
+    if not section_found:
+        raise SectionAbsentError(section_name)
+
     result: list[str] = []
     in_section = False
     for line in body.split("\n"):
-        if line.rstrip() == "### " + section_name:
+        if line.rstrip() == section_header:
             in_section = True
             result.append(line)
             continue
@@ -373,7 +400,13 @@ def main():
             sys.exit(1)
         content = read_file_content(opts["content_file"])
         items = [line for line in content.split("\n") if line.strip()]
-        body = merge_checklist(body, opts["section"], items)
+        try:
+            body = merge_checklist(body, opts["section"], items)
+        except SectionAbsentError as exc:
+            # Exit 10 is the contract for section_absent (see module docstring).
+            # Do not write body to stdout — caller must not PATCH a partial body.
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(10)
 
     elif subcommand == "update-checkboxes":
         if "tasks" not in opts:

--- a/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-sync.test.sh
@@ -351,6 +351,80 @@ else
 fi
 echo ""
 
+# ─── TC-011: update merge-checklist section absent → status=section_absent ──
+# AC-1 の公開面: Python exit 10 を shell が status=skipped; reason=section_absent に写像し、
+# PATCH しない。Python 単体テスト (merge-checklist.test.sh TC-004) だけではこのマッピングが
+# 壊れても green のまま残るため、gh shim で update 経路を end-to-end pin する (Issue #2139)。
+echo "TC-011: update merge-checklist section absent → status=skipped; reason=section_absent, no PATCH"
+dir011="$TEST_DIR/tc011"
+mkdir -p "$dir011/bin"
+# body は header を持つが ### 進捗サマリー を持たない（section_absent を起こす）
+# list / body / PATCH を URL 形状で分岐。--jq は shim が丸ごと gh を置換するため適用されない。
+PATCH_MARKER011="$dir011/patch.marker"
+cat > "$dir011/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+# Detect PATCH first (any position of -X PATCH)
+for a in "$@"; do
+  if [ "$a" = "PATCH" ] || [ "$a" = "-X" ]; then
+    # second pass: only mark when -X PATCH pair is present
+    :
+  fi
+done
+case " $* " in
+  *" -X PATCH "*|*" --method PATCH "*)
+    touch "${PATCH_MARKER:?PATCH_MARKER unset}"
+    exit 0
+    ;;
+esac
+case "$1 $2" in
+  "repo view") echo "testowner/testrepo"; exit 0 ;;
+  "api repos/testowner/testrepo/issues/42/comments")
+    # get_comment_id list path — return a bare comment id (shim replaces --jq)
+    echo "555"
+    exit 0
+    ;;
+  "api repos/testowner/testrepo/issues/comments/555")
+    # body fetch (and any cache verify that lands here). Return body only.
+    printf '%s\n' \
+      '## 📜 rite 作業メモリ' \
+      '' \
+      '### 完了情報' \
+      '- **PR**: #1'
+    exit 0
+    ;;
+esac
+exit 0
+GH_SHIM
+chmod +x "$dir011/bin/gh"
+items011="$dir011/items.txt"
+printf '%s\n' "- [x] レビュー完了" "- [x] マージ完了" "- [x] クリーンアップ完了" > "$items011"
+out011=$(cd "$dir011" && PATH="$dir011/bin:$PATH" PATCH_MARKER="$PATCH_MARKER011" \
+  bash "$HOOK" update --issue 42 \
+    --transform merge-checklist --section 進捗サマリー --content-file "$items011" 2>/dev/null) || true
+if printf '%s' "$out011" | grep -qF "status=skipped; reason=section_absent"; then
+  pass "TC-011a: section absent → status=skipped; reason=section_absent"
+else
+  fail "TC-011a: expected section_absent status. out: $out011"
+fi
+if [ ! -f "$PATCH_MARKER011" ]; then
+  pass "TC-011b: PATCH not invoked when section absent"
+else
+  fail "TC-011b: PATCH was invoked despite section_absent"
+fi
+# process must exit 0 (non-blocking skip for cleanup callers)
+set +e
+cd "$dir011" && PATH="$dir011/bin:$PATH" PATCH_MARKER="$PATCH_MARKER011.2" \
+  bash "$HOOK" update --issue 42 \
+    --transform merge-checklist --section 進捗サマリー --content-file "$items011" >/dev/null 2>&1
+rc011=$?
+set -e
+if [ "$rc011" -eq 0 ]; then
+  pass "TC-011c: process exit 0 on section_absent (non-blocking)"
+else
+  fail "TC-011c: expected exit 0, got $rc011"
+fi
+echo ""
+
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then
   exit 1

--- a/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
+++ b/plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
@@ -2,12 +2,13 @@
 # issue-comment-wm-update-merge-checklist.test.sh
 #
 # Pins the `merge-checklist` transform (archive-procedures
-# §3.5.2 progress-merge delegation). Verifies the verbatim-fidelity contract
-# ported from the original inline Python block:
+# §3.5.2 progress-merge delegation). Verifies:
 #   - full-body exact-line dedup (idempotency / partial dedup)
 #   - insertion at the end of the named section (before next `### ` / at EOF)
-#   - section-absent → body unchanged, items dropped
+#   - section-absent + new items → exit 10 (SectionAbsentError; fail-loud, Issue #2139)
+#   - real WM template heading `### 進捗サマリー` accepts the merge (AC-3)
 #   - trailing-newline state of the input preserved
+#   - missing --section → usage error (exit 1; AC-2 pin for required flag)
 #
 # The transform is a pure stdin→stdout text op (no gh API), so it is driven
 # end-to-end here. run-tests.sh auto-discovers this file via the *.test.sh glob.
@@ -31,7 +32,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-# The standard 3 completion items the §3.5.2 caller merges into ### 進捗.
+# The standard 3 completion items the §3.5.2 caller merges into ### 進捗サマリー.
 items_file="$TEST_DIR/items.txt"
 printf '%s\n' "- [x] レビュー完了" "- [x] マージ完了" "- [x] クリーンアップ完了" > "$items_file"
 
@@ -91,15 +92,30 @@ else
 fi
 echo ""
 
-# ─── TC-004: section absent → body unchanged, items dropped ──────────────
-echo "TC-004: section absent → no-op (verbatim with original block)"
+# ─── TC-004: section absent + new items → exit 10 (fail-loud, Issue #2139) ─
+echo "TC-004: section absent → exit 10 (SectionAbsentError; items not silently dropped)"
 body4=$'## 📜 rite 作業メモリ\n\n### 完了情報\n- **PR**: #1\n'
 printf '%s' "$body4" > "$TEST_DIR/body4"
-python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" < "$TEST_DIR/body4" > "$TEST_DIR/out4"
-if cmp -s "$TEST_DIR/body4" "$TEST_DIR/out4"; then
-  pass "TC-004: body unchanged when 進捗 section absent"
+set +e
+python3 "$PY" merge-checklist --section 進捗 --content-file "$items_file" \
+  < "$TEST_DIR/body4" > "$TEST_DIR/out4" 2>"$TEST_DIR/err4"
+rc4=$?
+set -e
+if [ "$rc4" -eq 10 ]; then
+  pass "TC-004a: exit code 10 when section absent with new items"
 else
-  fail "TC-004: body changed despite absent section"
+  fail "TC-004a: expected exit 10, got $rc4"
+fi
+if grep -qF "section absent" "$TEST_DIR/err4"; then
+  pass "TC-004b: stderr names section absent"
+else
+  fail "TC-004b: stderr missing section-absent detail ($(cat "$TEST_DIR/err4"))"
+fi
+# stdout must not carry a body that a caller could PATCH as "success"
+if [ ! -s "$TEST_DIR/out4" ]; then
+  pass "TC-004c: stdout empty (no body to PATCH)"
+else
+  fail "TC-004c: stdout non-empty despite section absent (would enable silent success PATCH)"
 fi
 echo ""
 
@@ -163,6 +179,65 @@ if [ -n "$item_ln8" ] && [ -n "$new_ln" ] && [ -n "$done_ln8" ] \
   pass "TC-008: items inserted at last 進捗 block (after 新しい進捗, before 完了情報)"
 else
   fail "TC-008: insertion at wrong 進捗 block (古い=$old_ln, 新しい=$new_ln, item=$item_ln8, 完了情報=$done_ln8)"
+fi
+echo ""
+
+# ─── TC-009: real WM template ### 進捗サマリー → merge succeeds (AC-3) ───
+echo "TC-009: real init template heading 進捗サマリー accepts merge (AC-3)"
+body9=$'## 📜 rite 作業メモリ\n\n### 進捗サマリー\n\n| 項目 | 状態 | 備考 |\n|------|------|------|\n| 実装 | ✅ 完了 | - |\n| テスト | ✅ 完了 | - |\n| ドキュメント | ✅ 完了 | - |\n\n### 要確認事項\n_確認事項はありません_\n'
+printf '%s' "$body9" | python3 "$PY" merge-checklist --section 進捗サマリー --content-file "$items_file" > "$TEST_DIR/out9"
+if grep -qxF -- "- [x] レビュー完了" "$TEST_DIR/out9" \
+   && grep -qxF -- "- [x] マージ完了" "$TEST_DIR/out9" \
+   && grep -qxF -- "- [x] クリーンアップ完了" "$TEST_DIR/out9"; then
+  pass "TC-009a: 3 items merged into 進捗サマリー"
+else
+  fail "TC-009a: items missing after 進捗サマリー merge"
+fi
+item_ln9=$(grep -nF -- "- [x] クリーンアップ完了" "$TEST_DIR/out9" | head -1 | cut -d: -f1 || true)
+next_ln9=$(grep -nF -- "### 要確認事項" "$TEST_DIR/out9" | head -1 | cut -d: -f1 || true)
+table_ln9=$(grep -nF -- "| ドキュメント |" "$TEST_DIR/out9" | head -1 | cut -d: -f1 || true)
+if [ -n "$item_ln9" ] && [ -n "$next_ln9" ] && [ -n "$table_ln9" ] \
+   && [ "$item_ln9" -gt "$table_ln9" ] && [ "$item_ln9" -lt "$next_ln9" ]; then
+  pass "TC-009b: items after table, before next ### (within 進捗サマリー)"
+else
+  fail "TC-009b: insertion position wrong (table=$table_ln9, item=$item_ln9, next=$next_ln9)"
+fi
+echo ""
+
+# ─── TC-010: missing --section → usage error exit 1 (AC-2 pin) ───────────
+echo "TC-010: missing --section → exit 1 (usage error; example must include --section)"
+body10=$'## 📜 rite 作業メモリ\n\n### 進捗サマリー\n\n| 項目 | 状態 |\n'
+printf '%s' "$body10" > "$TEST_DIR/body10"
+set +e
+python3 "$PY" merge-checklist --content-file "$items_file" \
+  < "$TEST_DIR/body10" > "$TEST_DIR/out10" 2>"$TEST_DIR/err10"
+rc10=$?
+set -e
+if [ "$rc10" -eq 1 ]; then
+  pass "TC-010a: exit 1 when --section omitted"
+else
+  fail "TC-010a: expected exit 1, got $rc10"
+fi
+if grep -qiE "section|required" "$TEST_DIR/err10"; then
+  pass "TC-010b: stderr mentions --section requirement"
+else
+  fail "TC-010b: stderr missing section requirement ($(cat "$TEST_DIR/err10"))"
+fi
+echo ""
+
+# ─── TC-011: section absent + all items already in body → exit 0 no-op ───
+echo "TC-011: section absent but all items already present → idempotent exit 0"
+body11=$'## 📜 rite 作業メモリ\n\n### 完了情報\n- [x] レビュー完了\n- [x] マージ完了\n- [x] クリーンアップ完了\n'
+printf '%s' "$body11" > "$TEST_DIR/body11"
+set +e
+python3 "$PY" merge-checklist --section 進捗サマリー --content-file "$items_file" \
+  < "$TEST_DIR/body11" > "$TEST_DIR/out11" 2>"$TEST_DIR/err11"
+rc11=$?
+set -e
+if [ "$rc11" -eq 0 ] && cmp -s "$TEST_DIR/body11" "$TEST_DIR/out11"; then
+  pass "TC-011: exit 0 + body unchanged when items already present (even without section)"
+else
+  fail "TC-011: expected exit 0 + unchanged body (rc=$rc11)"
 fi
 echo ""
 

--- a/plugins/rite/skills/cleanup/references/archive-procedures.md
+++ b/plugins/rite/skills/cleanup/references/archive-procedures.md
@@ -140,7 +140,7 @@ rm -f "${wm_sync_err:-}"
 
 #### 3.5.2 Update Content
 
-> **委譲状況（完了）**: §3.5.1（`### 完了情報` の `append-eof` 追記）に続き、本節の **進捗チェックリスト merge**（`### 進捗` への dedup 追記）も `issue-comment-wm-sync.sh` の `merge-checklist` transform へ委譲済み。cleanup ステップ 11 が §3.5 全体を実行する経路で wired され、§3.5.1（完了情報）とは独立した fetch→transform→PATCH として走る（touch するセクションが異なるため順序非依存）。
+> **委譲状況（完了）**: §3.5.1（`### 完了情報` の `append-eof` 追記）に続き、本節の **進捗チェックリスト merge**（`### 進捗サマリー` への dedup 追記）も `issue-comment-wm-sync.sh` の `merge-checklist` transform へ委譲済み。cleanup ステップ 11 が §3.5 全体を実行する経路で wired され、§3.5.1（完了情報）とは独立した fetch→transform→PATCH として走る（touch するセクションが異なるため順序非依存）。
 
 Automatically append the following to the work memory:
 
@@ -148,16 +148,21 @@ Automatically append the following to the work memory:
 
 The progress section update in Phase 3.5.2 follows this logic（`merge-checklist` transform 内 Python が担う）:
 
-1. Retrieve the existing progress section
-2. Preserve all existing checklist items
-3. Append new items (`- [x] レビュー完了`, `- [x] マージ完了`, `- [x] クリーンアップ完了`) at the end (do not duplicate if already present anywhere in the body — full-line exact match, 冪等)
+1. Retrieve the existing progress section (`### 進捗サマリー` — 現行 WM テンプレの見出し。SoT: `work-memory-format.md` / init テンプレ)
+2. Preserve all existing content (table rows / checklist items)
+3. Append new items (`- [x] レビュー完了`, `- [x] マージ完了`, `- [x] クリーンアップ完了`) at the end of the section (do not duplicate if already present anywhere in the body — full-line exact match, 冪等)
+4. When the target section is absent **and** new items remain, helper returns `status=skipped; reason=section_absent` (items are **not** dropped silently, and the caller does **not** report success — Issue #2139)
 
 **Example:**
 
 ```markdown
-### 進捗
-- [x] 実装完了
-- [x] PR マージ済み
+### 進捗サマリー
+
+| 項目 | 状態 | 備考 |
+|------|------|------|
+| 実装 | ✅ 完了 | - |
+| テスト | ✅ 完了 | - |
+| ドキュメント | ✅ 完了 | - |
 - [x] レビュー完了           ← Phase 3.5.2 で追加
 - [x] マージ完了             ← Phase 3.5.2 で追加
 - [x] クリーンアップ完了     ← Phase 3.5.2 で追加
@@ -165,7 +170,7 @@ The progress section update in Phase 3.5.2 follows this logic（`merge-checklist
 
 **Bash implementation (helper 委譲):**
 
-進捗チェックリストの完了項目を `merge-checklist` transform で委譲追記する。全文・完全行 dedup（既出項目スキップ＝冪等）・`### 進捗` セクション末尾への挿入・backup・空body/ヘッダー/safety check・PATCH はすべて helper 内部で完結する（§3.5.1 と同じ canonical caller パターン）。
+進捗チェックリストの完了項目を `merge-checklist` transform で委譲追記する。全文・完全行 dedup（既出項目スキップ＝冪等）・`### 進捗サマリー` セクション末尾への挿入・backup・空body/ヘッダー/safety check・PATCH はすべて helper 内部で完結する（§3.5.1 と同じ canonical caller パターン）。`--section` は必須（欠けると Python が usage error → `status=error; reason=transform_failed`）。
 
 ```bash
 # 進捗セクションの完了項目を content-file に生成し merge-checklist transform で委譲追記する。
@@ -182,31 +187,36 @@ printf '%s\n' \
 
 wm_progress_status=$(bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
   --issue {issue_number} \
-  --transform merge-checklist --section 進捗 --content-file "$progress_tmp" 2>"${wm_sync_err:-/dev/null}") || true
+  --transform merge-checklist --section 進捗サマリー --content-file "$progress_tmp" 2>"${wm_sync_err:-/dev/null}") || true
 rm -f "$progress_tmp"
 
 # 非ブロッキング: cleanup は work memory 更新失敗で停止してはならない（§3.5 は automatic final update）。
-# no_comment（作業メモリ不在 = legitimate no-op）以外の skipped/error は WARNING 表示にとどめる。
+# no_comment / section_absent は legitimate skip（success と区別して表示）。その他の skipped/error は WARNING。
 # 失敗時は helper stderr の root-cause（先頭 5 行）も surface し、backup path / API エラー詳細を operator に残す。
 case "$wm_progress_status" in
-  status=success)      echo "作業メモリの進捗セクションを更新しました" ;;
-  *reason=no_comment*) echo "作業メモリ comment が無いため進捗更新をスキップしました" ;;
-  *)                   echo "警告: 作業メモリ進捗更新が完了しませんでした (${wm_progress_status:-no-status})。cleanup は続行します。" >&2
-                       [ -n "$wm_sync_err" ] && [ -s "$wm_sync_err" ] && { echo "  helper stderr (root-cause、先頭 5 行):" >&2; head -5 "$wm_sync_err" | sed 's/^/    /' >&2; } ;;
+  status=success)              echo "作業メモリの進捗セクションを更新しました" ;;
+  *reason=no_comment*)         echo "作業メモリ comment が無いため進捗更新をスキップしました" ;;
+  *reason=section_absent*)     echo "作業メモリに対象セクション（進捗サマリー）が無いため進捗チェックリスト統合をスキップしました" ;;
+  *)                           echo "警告: 作業メモリ進捗更新が完了しませんでした (${wm_progress_status:-no-status})。cleanup は続行します。" >&2
+                               [ -n "$wm_sync_err" ] && [ -s "$wm_sync_err" ] && { echo "  helper stderr (root-cause、先頭 5 行):" >&2; head -5 "$wm_sync_err" | sed 's/^/    /' >&2; } ;;
 esac
 rm -f "${wm_sync_err:-}"
 ```
 
-**Note for Claude**: comment 取得・body 変換（全文 dedup + `### 進捗` セクション末尾挿入）・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない（旧 inline 実装のクロスプロセス変数 `$current_body` 参照制約は解消済み）。`{plugin_root}` はリテラル値で埋め込み、`{issue_number}` を cleanup.md コンテキストの実値で置換すること。`### 進捗` セクション不在時は項目を drop し body を変更しない（既存 §3.5 の no-op 契約。`merge-checklist` transform がこれを保証）。参照: §3.5.1 の canonical caller パターン。
+**Note for Claude**: comment 取得・body 変換（全文 dedup + `### 進捗サマリー` セクション末尾挿入）・safety check・PATCH・backup はすべて helper 内部で完結するため、本ブロックを単一 Bash 呼び出しに収める必要はない。`{plugin_root}` はリテラル値で埋め込み、`{issue_number}` を cleanup.md コンテキストの実値で置換すること。対象セクション不在時は items を破棄せず `status=skipped; reason=section_absent` を返す（`status=success` と報告しない — fail-loud、Issue #2139）。参照: §3.5.1 の canonical caller パターン。
 
-> **適用範囲の注記**: `### 進捗` は **v1 (legacy) WM フォーマット限定**のセクションで、現行 default フォーマットは `### 進捗サマリー` (table) である（SoT: `skills/rite-workflow/references/work-memory-format.md`、init テンプレ: `issue-comment-wm-sync.sh`、v1/v2 分岐: `issue-comment-wm-update.py` の `update_progress` v1 fallback `"### 進捗" in body and "### 進捗サマリー" not in body`）。したがって **v2 WM では本 merge は常に no-op** になり、`### 進捗` を持つ v1 WM が残存する Issue でのみ実効する。これは原 §3.5.2 inline 実装の target section (`### 進捗`) を verbatim 保持した結果であり、`### 進捗サマリー` table 対応への変更は本委譲のスコープ外（§3.5.1 が section-novelty を明記しているのと対称の適用範囲記述）。
+> **適用範囲の注記**: 対象見出しは現行 default WM フォーマットの `### 進捗サマリー`（table + 任意の checklist 追記）である（SoT: `skills/rite-workflow/references/work-memory-format.md`、init テンプレ: `issue-comment-wm-sync.sh`）。v1 legacy の `### 進捗` のみを持つ body では `section_absent` となり skip 表示される（旧「silent no-op success」は廃止）。v1 への互換フォールバックは持たない（実運用の init 経路は常に `進捗サマリー` を生成する）。
 
 **Standard update template:**
 
 ```markdown
-### 進捗
-- [x] 実装完了
-- [x] PR 作成済み
+### 進捗サマリー
+
+| 項目 | 状態 | 備考 |
+|------|------|------|
+| 実装 | ✅ 完了 | - |
+| テスト | ✅ 完了 | - |
+| ドキュメント | ✅ 完了 | - |
 - [x] レビュー完了
 - [x] マージ完了
 - [x] クリーンアップ完了


### PR DESCRIPTION
## 概要

作業メモリ checklist 統合経路（`merge_checklist()` + `archive-procedures.md` §3.5.2）の 3 欠陥を直す。

1. **AC-1**: 対象セクション不在時に items を破棄したまま `status=success` を返す no-op を廃止。`SectionAbsentError` → Python exit 10 → `status=skipped; reason=section_absent`
2. **AC-2**: §3.5.2 呼び出し例が `--section` 必須であることをテストで pin（欠落は exit 1 / transform_failed）
3. **AC-3**: 対象見出しを現行 WM テンプレの `### 進捗サマリー` に揃え、実テンプレ上で統合が成立することをテストで pin

## 関連 Issue

Closes #2139

## 変更内容

| ファイル | 変更 |
|---|---|
| `plugins/rite/hooks/issue-comment-wm-update.py` | `SectionAbsentError` + exit 10 契約 |
| `plugins/rite/hooks/issue-comment-wm-sync.sh` | exit 10 → `status=skipped; reason=section_absent` |
| `plugins/rite/skills/cleanup/references/archive-procedures.md` | §3.5.2 を `進捗サマリー` へ、caller 分岐追加 |
| `plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh` | TC-004 改訂 + TC-009/010/011（19 pass） |

## テスト

```bash
bash plugins/rite/hooks/tests/issue-comment-wm-update-merge-checklist.test.sh
# === Results: 19 passed, 0 failed ===
```

## 受け入れ基準

- [x] AC-1: section 不在 → success と区別可能な skipped/section_absent
- [x] AC-2: `--section` 必須（欠落は transform_failed 系）
- [x] AC-3: 実テンプレ見出し `進捗サマリー` で統合が成立