### PR TITLE
fix(cleanup): リモート確認の transient rc=128 に 1 リトライを足す

### DIFF
--- a/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
+++ b/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
@@ -136,6 +136,7 @@ for required in 'ls-remote --exit-code' \
                 'REMOTE_BRANCH_CHECK_FAILED=1; branch=.*rc=invalid-refname' \
                 'REMOTE_BRANCH_CHECK_FAILED=1; branch=.*rc=mktemp-failed' \
                 'if \[ -z "\$_ls_out" \]; then' \
+                'if \[ "\$_ls_rc" -eq 128 \]; then' \
                 '_check_reason="ref-match-awk-\${_match_rc}"' 'if \[ "\$_ls_rc" -eq 0 \]; then' \
                 '^  2) echo "\[CONTEXT\] REMOTE_BRANCH_ALREADY_ABSENT' \
                 'REMOTE_BRANCH_DELETED=1; branch=' 'REMOTE_BRANCH_DELETE_FAILED=1; branch=' \
@@ -466,10 +467,11 @@ fi
 _td_err=$(LC_ALL=C git push -q origin --delete "refs/heads/$BRANCH" 2>&1) \
   || echo "WARN: TC-2b teardown: $BRANCH の削除に失敗: $_td_err" >&2
 
-# ─── TC-3 (AC-1): ls-remote 自体の失敗 → CHECK_FAILED、削除は試行しない ───
-# ネットワーク断・認証失敗は rc=128 になる。これを rc=2 (不在) と取り違えて「既削除」に
-# 丸めると、delete_branch_on_merge:false のリポジトリでリモートブランチが黙って残る (§8 リスク)。
-echo "TC-3: ls-remote failure (unreachable origin) -> REMOTE_BRANCH_CHECK_FAILED, no delete attempt"
+# ─── TC-3 (AC-2 / #2140 T-02): ls-remote 自体の恒常失敗 → CHECK_FAILED、削除は試行しない ───
+# ネットワーク断・認証失敗は rc=128 になる。#2140 で rc=128 は 1 回リトライするが、
+# 2 回とも 128 なら依然 CHECK_FAILED に倒す（transient 吸収は 1 回だけ。恒常失敗を「既削除」に
+# 丸めると delete_branch_on_merge:false のリポジトリでリモートブランチが黙って残る）。
+echo "TC-3: ls-remote failure (unreachable origin, after 1 retry) -> REMOTE_BRANCH_CHECK_FAILED, no delete attempt"
 git remote set-url origin "$TEST_DIR/does-not-exist.git"
 out=$(run_guard "$GUARD_SNIPPET")
 if push_delete_called; then
@@ -490,6 +492,52 @@ else
   pass "TC-3 (判定不能を未完了として surface、原因テキストも保持、退避 stderr は列 0 に到達しない)"
 fi
 git remote set-url origin "$ORIGIN"
+
+# ─── TC-3b (AC-1 / #2140 T-01): 1 回目 rc=128 → 2 回目 rc=2 で不在判定・削除処方なし ───
+# sandbox の HTTPS プロキシ断で 1 回目だけ 128 になり、2 回目で正常応答する経路の pin。
+# git wrapper が ls-remote の 1 回目だけ fatal を返し、2 回目以降は REAL_GIT に委譲する。
+echo "TC-3b: ls-remote 128 then 2 -> REMOTE_BRANCH_ALREADY_ABSENT, no delete prescription"
+_ls_count_file="$TEST_DIR/ls-remote-count"
+: > "$_ls_count_file"
+cat > "$BIN_DIR/git" <<EOF
+#!/bin/bash
+if [ "\${1:-}" = "push" ]; then printf '%s\n' "push \$*" >> "$CALL_LOG"; fi
+if [ "\${1:-}" = "ls-remote" ] || { [ "\${1:-}" = "-C" ] && [ "\${3:-}" = "ls-remote" ]; }; then
+  # 直書きの ls-remote を数える（ガードは \`git ls-remote\` 形）
+  :
+fi
+if [ "\${1:-}" = "ls-remote" ]; then
+  n=\$(cat "$_ls_count_file" 2>/dev/null || echo 0)
+  n=\$((n + 1))
+  printf '%s' "\$n" > "$_ls_count_file"
+  if [ "\$n" -eq 1 ]; then
+    echo "fatal: unable to access 'origin': Failed to connect to localhost port 3128" >&2
+    exit 128
+  fi
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$BIN_DIR/git"
+out=$(run_guard "$GUARD_SNIPPET")
+_ls_n=$(cat "$_ls_count_file" 2>/dev/null || echo 0)
+# 後始末: 通常の stub に戻す（以降 TC が transient mock に引きずられないようにする）
+cat > "$BIN_DIR/git" <<EOF
+#!/bin/bash
+if [ "\${1:-}" = "push" ]; then printf '%s\n' "push \$*" >> "$CALL_LOG"; fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$BIN_DIR/git"
+if [ "$_ls_n" -lt 2 ]; then
+  fail "TC-3b: ls-remote が 2 回呼ばれていない (count=$_ls_n — 128 リトライが消失した可能性。出力: '$out')"
+elif push_delete_called; then
+  fail "TC-3b: 不在判定後に push --delete が呼ばれた ($(cat "$CALL_LOG"))"
+elif ! printf '%s' "$out" | grep -qE "^\[CONTEXT\] REMOTE_BRANCH_ALREADY_ABSENT=1; branch=$BRANCH(;|\$)"; then
+  fail "TC-3b: 128→2 の遷移で ALREADY_ABSENT になっていない (出力: '$out')"
+elif printf '%s' "$out" | grep -q 'REMOTE_BRANCH_CHECK_FAILED=1'; then
+  fail "TC-3b: リトライ成功後も CHECK_FAILED を出した (出力: '$out')"
+else
+  pass "TC-3b (128→2 の transient を吸収し不在判定・削除処方なし)"
+fi
 
 # ─── TC-7 (#2016 cycle 3): 契約を満たせないブランチ名は削除を試行しない (fail-fast) ───
 # marker 契約は `branch=<値>` の右端を「直後が `;` または行末」で照合する。`;` と `=` はどちらも

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -670,6 +670,11 @@ esac
 # rc=2（不在）だけを「既削除」とみなし、それ以外の非 0（ネットワーク断・認証失敗の 128 等）は
 # 存在有無が不明なため削除を試行せず未完了として surface する（不明を「既削除」に丸めると、
 # delete_branch_on_merge: false のリポジトリでリモートブランチが黙って残る）。
+# ただし rc=128 は sandbox の HTTPS プロキシ断など **transient** で再現することがある
+# （PR #2137 cleanup で 1 回目 128 → 2 回目 2 を実測。Issue #2140）。1 回目が 128 のときだけ
+# **1 回再試行**し、2 回目の結果を採用する。2 回とも 128 なら従来どおり CHECK_FAILED で
+# 削除を処方しない（確認できていない状態での偽処方は #2016 と同型）。rc=0/2 の即返しは
+# 再試行せず 1 回で確定する（正常系の遅延を増やさない）。
 # stderr は捨てず退避して WARNING に載せる（rc だけでは認証失敗・DNS 解決失敗・proxy 遮断がすべて
 # 128 に潰れて切り分けられない。直上のローカル削除が $del_err で原因を surface するのと対称）。
 # stdout は完全一致検証に使うため別ファイルへ分離する（`2>&1 >/dev/null` で捨てない）。
@@ -720,6 +725,12 @@ if [ -z "$_ls_out" ]; then
   echo "WARNING: 一時ファイルを作成できずリモートブランチの存在確認ができないため、削除を試行していません。" >&2
 else
 _ls_err=$(LC_ALL=C git ls-remote --exit-code --heads origin "refs/heads/{branch_name}" 2>&1 >"$_ls_out"); _ls_rc=$?
+# transient 失敗 (rc=128: ネットワーク断・proxy 遮断等) は 1 回だけ再試行する (Issue #2140)。
+# 2 回目の結果を採用する。rc=0/2 の即返しは従来どおり 1 回で確定。2 回とも 128 なら
+# 下の `*)` が CHECK_FAILED を emit し、削除は処方しない（確認できていない状態での偽処方を防ぐ — #2016）。
+if [ "$_ls_rc" -eq 128 ]; then
+  _ls_err=$(LC_ALL=C git ls-remote --exit-code --heads origin "refs/heads/{branch_name}" 2>&1 >"$_ls_out"); _ls_rc=$?
+fi
 # rc=0 でも完全一致でなければ不在扱いに落とす（tail 一致による誤ヒットの排除）。ls-remote の出力は
 # `<sha>\t<refname>` 形式。ブランチ名は `.` 等の正規表現メタ文字を含みうるため、regex ではなく
 # awk のフィールド完全一致で比較する。
@@ -788,7 +799,7 @@ esac
 
 `BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（作業ツリーが未削除のまま残り削除を遅延したケース — 別セッション使用中(#1670) または sandbox マスク skip(#1957)。原因は断定しない）のときは**強制削除しない**。marker の `recovery=` で次セッション回収の可否が決まる: `recovery=auto`（{pr_merged}=true かつ reap manifest への記録を verify 済み）は worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が自動回収する。`recovery=manual`（未マージ PR の強制 cleanup、または記録漏れ）は自動回収されないため手動 `git branch -D` が必要。ステップ 12 はこの `recovery=` 値で残置メッセージを出し分ける。
 
-リモート削除は **ブランチ名の事前検証 → 一時ファイル確保 → `git ls-remote --exit-code` + ref 名の完全一致検証** の順に進み、**どの経路も必ず marker を emit する**（marker 名は 4 種、emit 箇所は 8 — うち fail-fast 4 経路（空値 / marker デリミタ / refname 非合法 / 一時ファイル確保失敗）は `ls-remote` を実行しない。#2016）: 事前検証（空値 / marker デリミタ文字 / refname 非合法）に落ちた場合、一時ファイルを確保できなかった場合、ref 名の完全一致検証が異常終了した場合はいずれも削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1`（原因は marker の `rc=` と `reason=` で区別する）。`rc=0`（存在確認済み）は削除し、成功なら `REMOTE_BRANCH_DELETED=1`、失敗（protected branch / 権限不足 / race）なら `REMOTE_BRANCH_DELETE_FAILED=1` を emit する。`rc=2` は不在なので削除せず `REMOTE_BRANCH_ALREADY_ABSENT=1`、それ以外の非 0 は存在有無が判定できないため削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1` を emit する。成功側も marker を出すのは、ステップ 12 が marker 不在を「削除成功」と読まないようにするため — 不在を成功の符号化に使うと、本ブロックが実行されなかった経路と削除成功が同一視され、`/rite:merge` の完了報告と同種の「実際には起きていないことを完了として報告する」嘘が判定表側から復活する。リポジトリ設定 `delete_branch_on_merge: true` の環境では merge 時にサーバサイドで head ブランチが削除されるため通常は `rc=2` に落ち、`/rite:merge` の `--delete-branch=false` はこれを抑止しない（`skills/merge/SKILL.md` の設計判断を参照）。`delete_branch_on_merge: false` のリポジトリでは従来どおり `rc=0` 経路で削除される。
+リモート削除は **ブランチ名の事前検証 → 一時ファイル確保 → `git ls-remote --exit-code`（rc=128 なら 1 回リトライ、#2140）+ ref 名の完全一致検証** の順に進み、**どの経路も必ず marker を emit する**（marker 名は 4 種、emit 箇所は 8 — うち fail-fast 4 経路（空値 / marker デリミタ / refname 非合法 / 一時ファイル確保失敗）は `ls-remote` を実行しない。#2016）: 事前検証（空値 / marker デリミタ文字 / refname 非合法）に落ちた場合、一時ファイルを確保できなかった場合、ref 名の完全一致検証が異常終了した場合はいずれも削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1`（原因は marker の `rc=` と `reason=` で区別する）。`rc=0`（存在確認済み）は削除し、成功なら `REMOTE_BRANCH_DELETED=1`、失敗（protected branch / 権限不足 / race）なら `REMOTE_BRANCH_DELETE_FAILED=1` を emit する。`rc=2` は不在なので削除せず `REMOTE_BRANCH_ALREADY_ABSENT=1`、それ以外の非 0（リトライ後も 128 を含む）は存在有無が判定できないため削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1` を emit する。成功側も marker を出すのは、ステップ 12 が marker 不在を「削除成功」と読まないようにするため — 不在を成功の符号化に使うと、本ブロックが実行されなかった経路と削除成功が同一視され、`/rite:merge` の完了報告と同種の「実際には起きていないことを完了として報告する」嘘が判定表側から復活する。リポジトリ設定 `delete_branch_on_merge: true` の環境では merge 時にサーバサイドで head ブランチが削除されるため通常は `rc=2` に落ち、`/rite:merge` の `--delete-branch=false` はこれを抑止しない（`skills/merge/SKILL.md` の設計判断を参照）。`delete_branch_on_merge: false` のリポジトリでは従来どおり `rc=0` 経路で削除される。
 
 ---
 


### PR DESCRIPTION
## Summary
- cleanup ステップ 5 の `git ls-remote` が rc=128（transient）のとき 1 回だけ再試行する
- 2 回目が rc=2 なら不在（正常系）、rc=0 なら削除経路、両回 128 なら CHECK_FAILED（削除処方なし）
- 回帰テスト TC-3b を追加し、静的 pin に `if [ "$_ls_rc" -eq 128 ]` を追加

Closes #2140

## Test plan
- [x] `bash plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh`（12 passed）