### PR TITLE
fix(cleanup): 未完了タスク検出の WM 採用を内容検査へ直す

### DIFF
--- a/plugins/rite/hooks/tests/cleanup-wm-source-select.test.sh
+++ b/plugins/rite/hooks/tests/cleanup-wm-source-select.test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# cleanup-wm-source-select.test.sh
+#
+# cleanup/SKILL.md ステップ 3 の WM 正本選定（存在検査 → 内容検査、Issue #2141）を pin する。
+# SKILL.md から選定ブロックを抽出して sandbox で実行し、stub / 実 WM / 両不在の 3 経路を検証する。
+#
+# - T-01 (AC-1): stub（進捗セクションなし）→ stub_fallback → comment 正本 + WARNING
+# - T-02 (AC-2): 進捗セクションありの実 WM → local 採用（comment を呼ばない）
+# - T-03 (AC-3): ローカル WM もコメントも無い → none
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLEANUP_MD="$SCRIPT_DIR/../../skills/cleanup/SKILL.md"
+TEST_DIR=""
+cleanup() { [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"; return 0; }
+trap cleanup EXIT
+TEST_DIR="$(mktemp -d)" || exit 1
+_canon="$(cd "$TEST_DIR" && pwd -P)" || exit 1
+TEST_DIR="$_canon"
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# 選定ブロック抽出: `# WM 正本の選定` 〜 incomplete 抽出の直前まで
+extract_select() {
+  awk '/^# WM 正本の選定/{f=1} f && /^# 未完了タスク抽出/{exit} f{print}' "$CLEANUP_MD" \
+    | sed -e 's|{issue_number}|9999|g' -e 's|{owner}|o|g' -e 's|{repo}|r|g'
+}
+
+SELECT="$TEST_DIR/select.sh"
+extract_select > "$SELECT"
+if [ ! -s "$SELECT" ] || ! grep -q 'WM_SOURCE=stub_fallback' "$SELECT"; then
+  echo "FAIL: cleanup/SKILL.md から WM 正本選定ブロックを抽出できません（#2141 の契約消失）"
+  echo "  抽出: $(wc -l < "$SELECT") 行"
+  exit 1
+fi
+# 静的 pin: 存在検査のみで採用しないこと（-f だけで local に倒さない）
+if ! grep -q '進捗(サマリー)?' "$SELECT" && ! grep -q '進捗' "$SELECT"; then
+  echo "FAIL: 内容検査（進捗セクション）が選定ブロックに無い"
+  exit 1
+fi
+if ! grep -q 'WARNING:.*stub' "$SELECT"; then
+  echo "FAIL: stub fallback 時の WARNING が無い（silent 切替禁止 #2141）"
+  exit 1
+fi
+
+# gh stub: コメント本文を返す / 空
+FAKE_COMMENT=""
+export PATH="$TEST_DIR/bin:$PATH"
+mkdir -p "$TEST_DIR/bin"
+cat > "$TEST_DIR/bin/gh" <<'EOF'
+#!/bin/bash
+# only used for: gh api repos/.../comments --jq ...
+if [ -n "${FAKE_COMMENT:-}" ]; then
+  printf '%s' "$FAKE_COMMENT"
+else
+  printf ''
+fi
+exit 0
+EOF
+chmod +x "$TEST_DIR/bin/gh"
+
+run_select() {
+  ( cd "$1" && FAKE_COMMENT="${2:-}" bash "$SELECT" 2>&1 )
+}
+
+echo "=== cleanup WM source select tests (Issue #2141) ==="
+
+# T-01: stub only
+echo "T-01: stub local WM -> stub_fallback + comment"
+SB1="$TEST_DIR/sb1"
+mkdir -p "$SB1/.rite-work-memory"
+cat > "$SB1/.rite-work-memory/issue-9999.md" <<'EOF'
+---
+phase: init
+issue_number: 9999
+---
+Local work memory auto-created by PostToolUse hook.
+EOF
+FAKE_COMMENT=$'📜 rite 作業メモリ\n\n### 進捗サマリー\n\n- [ ] real task from comment\n'
+out=$(run_select "$SB1" "$FAKE_COMMENT")
+if ! printf '%s' "$out" | grep -q 'WM_SOURCE=stub_fallback'; then
+  fail "T-01: stub_fallback marker 不在 (出力: $out)"
+elif ! printf '%s' "$out" | grep -qi 'WARNING:.*stub'; then
+  fail "T-01: WARNING 不在 (出力: $out)"
+elif ! printf '%s' "$out" | grep -q 'WM_SOURCE=comment'; then
+  fail "T-01: comment fallback 不在 (出力: $out)"
+else
+  pass "T-01 (stub → WARNING + comment fallback)"
+fi
+
+# T-02: real local WM
+echo "T-02: real local WM with progress section -> local"
+SB2="$TEST_DIR/sb2"
+mkdir -p "$SB2/.rite-work-memory"
+cat > "$SB2/.rite-work-memory/issue-9999.md" <<'EOF'
+---
+phase: implement
+---
+### 進捗サマリー
+
+| Step | Status |
+|------|--------|
+| 1    | done   |
+
+- [ ] remaining local task
+EOF
+# comment があっても local を優先すべき
+out=$(run_select "$SB2" $'📜 rite 作業メモリ\n### 進捗サマリー\n- [ ] should not win\n')
+if ! printf '%s' "$out" | grep -q 'WM_SOURCE=local'; then
+  fail "T-02: local 採用されない (出力: $out)"
+elif printf '%s' "$out" | grep -q 'stub_fallback'; then
+  fail "T-02: 実 WM を stub と誤判定 (出力: $out)"
+else
+  pass "T-02 (実 WM を local 採用)"
+fi
+
+# T-03: neither
+echo "T-03: no local WM and no comment -> none"
+SB3="$TEST_DIR/sb3"
+mkdir -p "$SB3"
+out=$(run_select "$SB3" "")
+if ! printf '%s' "$out" | grep -q 'WM_SOURCE=none'; then
+  fail "T-03: none に倒れていない (出力: $out)"
+else
+  pass "T-03 (両不在 → none)"
+fi
+
+# T-02b: v1 heading ### 進捗 also counts as real
+echo "T-02b: v1 ### 進捗 heading counts as content"
+SB2b="$TEST_DIR/sb2b"
+mkdir -p "$SB2b/.rite-work-memory"
+cat > "$SB2b/.rite-work-memory/issue-9999.md" <<'EOF'
+### 進捗
+
+- [x] old step
+EOF
+out=$(run_select "$SB2b" "")
+if ! printf '%s' "$out" | grep -q 'WM_SOURCE=local'; then
+  fail "T-02b: v1 進捗見出しが local にならない (出力: $out)"
+else
+  pass "T-02b (v1 ### 進捗 も内容ありと判定)"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -149,19 +149,58 @@ echo "[DEBUG] parent not detected for issue #{issue_number} — processing as st
 
 関連 Issue が識別できなければステップ 4 へ進む。
 
-`.rite-work-memory/issue-{issue_number}.md` を Read で読む。無ければ Issue コメントから work memory を取得:
+Work Memory の正本を **存在ではなく内容** で選ぶ（Issue #2141）。PostToolUse hook が作る空 stub（`phase: init`・進捗セクションなし）はファイルとして存在するが、存在検査だけだと stub を正本と見なし Issue コメント側 fallback が発火しない（#2127 の「存在と成功の混同」と同族）。進捗セクション見出し（現行 `### 進捗サマリー` / v1 `### 進捗`）が実在するときだけローカル WM を正本とし、stub 判定時はコメント側へ fallback して WARNING で可視化する:
 
 ```bash
-comment_body=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
-  --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | .body // empty')
+# WM 正本の選定（内容検査 — Issue #2141）
+# 進捗セクション: 現行 `### 進捗サマリー` と v1 `### 進捗` の両方を認める
+# （incomplete 抽出が両見出しを拾う契約との整合）
+_wm_local=".rite-work-memory/issue-{issue_number}.md"
+_wm_source=""
+_wm_body=""
+if [ -f "$_wm_local" ]; then
+  _wm_body=$(cat "$_wm_local" 2>/dev/null) || _wm_body=""
+  # 行頭の AT1-3 + 進捗 / 進捗サマリー。stub は frontmatter や phase 行だけでこの見出しを持たない
+  if printf '%s\n' "$_wm_body" | grep -qE '^#{1,3}[[:space:]]*進捗(サマリー)?([[:space:]]|$)'; then
+    _wm_source=local
+    echo "[CONTEXT] WM_SOURCE=local; path=$_wm_local"
+  else
+    echo "WARNING: ローカル WM ($_wm_local) は進捗セクションを持たない stub と判定。Issue コメント側へ fallback します (#2141)" >&2
+    echo "[CONTEXT] WM_SOURCE=stub_fallback; path=$_wm_local"
+    _wm_body=""
+  fi
+fi
+if [ -z "$_wm_source" ] || [ "$_wm_source" = "stub_fallback" ]; then
+  comment_body=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
+    --jq '[.[] | select(.body | contains("📜 rite 作業メモリ"))] | last | .body // empty')
+  if [ -n "$comment_body" ]; then
+    _wm_source=comment
+    _wm_body="$comment_body"
+    echo "[CONTEXT] WM_SOURCE=comment"
+  elif [ "$_wm_source" != "stub_fallback" ]; then
+    _wm_source=none
+    echo "[CONTEXT] WM_SOURCE=none"
+  else
+    # stub でコメントも無い → 検出対象なし（既存の「WM なし」縮退）
+    _wm_source=none
+    echo "[CONTEXT] WM_SOURCE=none; after=stub_fallback"
+  fi
+fi
+# 未完了タスク抽出（親子 Tasklist `- [ ] #XX` は除外）
+incomplete=""
+if [ -n "$_wm_body" ]; then
+  incomplete=$(printf '%s\n' "$_wm_body" | sed -n '/### 進捗/,/### /p' \
+    | grep -E '^\s*- \[ \]' | grep -v -E '^\s*- \[ \] #[0-9]+' | head -10) || incomplete=""
+fi
+echo "incomplete_count=$(printf '%s\n' "$incomplete" | grep -c . 2>/dev/null || echo 0)"
 ```
 
-進捗セクションと Issue 本文の未完了チェックボックス (`- [ ] #XX` の親子 Tasklist は除外) を検出:
-
-```bash
-incomplete=$(printf '%s\n' "$comment_body" | sed -n '/### 進捗/,/### /p' \
-  | grep -E '^\s*- \[ \]' | grep -v -E '^\s*- \[ \] #[0-9]+' | head -10)
-```
+| `WM_SOURCE` | 意味 |
+|---|---|
+| `local` | 進捗セクションを持つ実 WM を正本として採用（AC-2） |
+| `stub_fallback` → 後続で `comment` / `none` | stub を不採用しコメントへ fallback。切替理由は WARNING 済み（AC-1） |
+| `comment` | ローカル WM 不在 or stub 後のコメント正本 |
+| `none` | ローカルもコメントも無い。既存の「WM なし」経路（AC-3） |
 
 未完了タスクがあれば `AskUserQuestion` で「未完了タスクを Issue 化 (推奨) / 無視して続行 / キャンセル」を確認。Issue 化選択時は各タスクを `残作業` label 付きで作成する。
 


### PR DESCRIPTION
## Summary
- cleanup ステップ 3: ローカル WM の採用条件を「ファイル存在」から「進捗セクション実在」へ変更
- stub 判定時は Issue コメントへ fallback し WARNING で可視化
- 回帰テスト `cleanup-wm-source-select.test.sh`（AC-1/2/3 + v1 見出し）

Closes #2141

## Test plan
- [x] `bash plugins/rite/hooks/tests/cleanup-wm-source-select.test.sh`（4 passed）