### PR TITLE
fix(hooks): pr-cycle-cleanup が TMPDIR 配下の detached mutation worktree を回収するようにする

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -627,6 +627,107 @@ if [ -f "$manifest_path" ]; then
 fi
 
 # -----------------------------------------------------------------------
+# Step 4-P: porcelain 走査による TMPDIR 配下 detached worktree 回収 (Issue #2145)。
+#
+# 背景: Step 4 の find は (a) maxdepth 1 で `$TMPDIR/rite-review-mutation-*` しか見ない
+# ため `$TMPDIR/claude-*/rite-review-mutation-*` のような入れ子を取りこぼし、(b) 24h age
+# ガードが同一 review サイクル内の残留 (数分〜数時間) を保護し続けて回収しない。実測で
+# `git worktree list` に `/tmp/claude-1000/rite-review-mutation-*` が 8 個残ったのに
+# `mutation_worktrees=0` と報告された (PR #2142)。
+#
+# 本ステップは `git worktree list --porcelain` を権威として:
+#   - path が `${TMPDIR}/` 配下 (prefix 一致、入れ子可)
+#   - detached HEAD (porcelain の `detached` 行。`branch refs/heads/...` を持つものは除外)
+#   - リポジトリ配下 (`.rite/worktrees/*` / wiki-worktree / main) は除外
+#   - 自セッション live cwd は除外 (worktree-foreign-cwd.sh --self-root $PPID)
+# を満たす worktree を age ガード無しで回収する。reviewer は READ-ONLY で remove できず、
+# cleanup は review 入口 / iterate 終端でのみ走るため、並行 reviewer の in-flight を
+# age で守る必要は無い — 別セッション在席は foreign-cwd が塞ぐ。
+# カウンタは既存 `mutation_worktrees_reaped` を共有する。
+# -----------------------------------------------------------------------
+_tmp_prefix="${TMPDIR:-/tmp}"
+_tmp_prefix="${_tmp_prefix%/}"
+# 正規化: 末尾スラッシュ無しの prefix + "/" で「配下」判定する
+_is_under_tmpdir() {
+  case "$1" in
+    "$_tmp_prefix"|"$_tmp_prefix"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+_is_under_repo() {
+  case "$1" in
+    "$repo_root"|"$repo_root"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+# Step 1 で既に取得した porcelain があれば再利用したいが、Step 1 は失敗時に空、かつ
+# その後の Step 4 find 経路で worktree が変わりうるため、ここで再取得する (失敗は non-blocking)。
+_p_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-pr-cycle-cleanup-porcelain-err-XXXXXX" 2>/dev/null) || _p_list_err=""
+if _p_list=$(git worktree list --porcelain 2>"${_p_list_err:-/dev/null}"); then
+  _p_path=""
+  _p_detached=0
+  _p_flush() {
+    # 1 entry 分を判定して必要なら回収。空 path は no-op。
+    [ -n "$_p_path" ] || return 0
+    if [ "$_p_detached" -eq 1 ] \
+       && _is_under_tmpdir "$_p_path" \
+       && ! _is_under_repo "$_p_path"; then
+      # 自セッション / 別 live セッションの cwd 保護 (self-exclusion 付き)
+      _p_fc_rc=0
+      bash "$SCRIPT_DIR/worktree-foreign-cwd.sh" "$_p_path" --self-root "$PPID" >/dev/null 2>&1 || _p_fc_rc=$?
+      # rc=0 = 別 live セッションが cwd を置く → 見送り / rc=1 = 自のみ or 不在 → 回収 /
+      # rc=2 = 判定不能 → 回収 (Step 4-W と同規約の後方互換)
+      if [ "$_p_fc_rc" -eq 0 ]; then
+        echo "WARNING: 別セッションが detached worktree ($_p_path) を使用中のため回収を見送りました" >&2
+      else
+        # dirty 保護 (Step 4.5 AC-6 と同旨): uncommitted 変更のある worktree は force 削除しない
+        _p_dirty=$(git -C "$_p_path" status --porcelain 2>/dev/null) || _p_dirty="??"
+        if [ -n "$_p_dirty" ]; then
+          echo "WARNING: detached TMPDIR worktree ($_p_path) に未コミット変更があるため回収を見送りました" >&2
+        elif [ "$DRY_RUN" = "1" ]; then
+          echo "[dry-run] would reap detached TMPDIR worktree: $(printf '%s' "$_p_path" | neutralize_ctrl)"
+        else
+          _reap_mutation_worktree "$_p_path"
+        fi
+      fi
+    fi
+    _p_path=""
+    _p_detached=0
+  }
+  while IFS= read -r _p_line; do
+    case "$_p_line" in
+      "worktree "*)
+        _p_flush
+        _p_path="${_p_line#worktree }"
+        _p_detached=0
+        ;;
+      "detached")
+        _p_detached=1
+        ;;
+      "branch "*)
+        # named branch を持つ entry は本ステップの対象外 (Step 1 の責務)
+        _p_detached=0
+        ;;
+      "")
+        _p_flush
+        ;;
+    esac
+  done <<< "$_p_list"
+  _p_flush
+  if [ "$DRY_RUN" = "0" ] && [ "$mutation_reaped_any" = "1" ]; then
+    git worktree prune 2>/dev/null || true
+  fi
+else
+  _p_rc=$?
+  echo "WARNING: Step 4-P git worktree list --porcelain が失敗しました (rc=$_p_rc)。detached TMPDIR 回収を skip します" >&2
+  if [ -n "$_p_list_err" ] && [ -s "$_p_list_err" ]; then
+    head -3 "$_p_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+  fi
+  # non-blocking: errors は増やさない (既存 Step 1 が既に list 失敗を errors++ している場合と二重計上しない)
+fi
+[ -n "$_p_list_err" ] && rm -f "$_p_list_err"
+
+# -----------------------------------------------------------------------
 # Step 5: Lazy reap of orphaned SESSION worktrees (multi-session design §8).
 # 責務分担: 正常系の即時削除は cleanup.md (S7) の責務、本 reap は **異常終了の
 # 残骸回収のみ**。`.rite/worktrees/issue-{N}` (multi_session.worktree_base 配下)

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -618,24 +618,25 @@ rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
-# T-15: age 未満の mutation worktree は保護 (in-flight 誤回収防止)
-# Given: a freshly-created registered `rite-review-mutation-*` worktree (mtime now)
+# T-15: fresh detached TMPDIR worktree は Step 4-P (porcelain) で即回収 (Issue #2145)
+# Given: a freshly-created registered detached worktree under TMPDIR (mtime now)
 # When: Cleanup runs
-# Then: The worktree survives (age guard) and status=noop / mutation_worktrees=0.
-# Core safety assertion: a concurrent reviewer's in-flight mutation worktree is
-# never reaped mid-experiment by another session's cleanup.
+# Then: The worktree is reaped (porcelain path has no 24h age guard) and
+#       mutation_worktrees >= 1. In-flight protection is self-exclusion via
+#       worktree-foreign-cwd (別 live セッション), not age — cleanup only runs at
+#       review entry / iterate end, never mid-parallel-review.
 # -----------------------------------------------------------------------
-echo "T-15: age 未満の mutation worktree は保護 (in-flight 誤回収防止)"
+echo "T-15: fresh detached TMPDIR worktree は Step 4-P で即回収 (Issue #2145)"
 rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
 TEST_REPO=$(make_temp_repo)
 ( cd "$TEST_REPO" && git worktree add --detach -q "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" HEAD )
 t15_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
-if [ -d "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" ] \
-   && echo "$t15_output" | grep -q 'status=noop' \
-   && echo "$t15_output" | grep -q 'mutation_worktrees=0'; then
-  pass "T-15: age 未満の mutation worktree が保護され status=noop"
+t15_mut=$(echo "$t15_output" | sed -n 's/.*mutation_worktrees=\([0-9]*\).*/\1/p' | head -1)
+if [ ! -e "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" ] \
+   && [ "${t15_mut:-0}" -ge 1 ] 2>/dev/null; then
+  pass "T-15: fresh detached TMPDIR worktree が Step 4-P で回収され mutation_worktrees=$t15_mut"
 else
-  fail "T-15: fresh=$([ -d "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" ] && echo present || echo gone). Output: $t15_output"
+  fail "T-15: fresh=$([ -e "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" ] && echo present || echo gone) mut=$t15_mut. Output: $t15_output"
 fi
 ( cd "$TEST_REPO" && git worktree remove --force "$WORKDIR_SCAN_TMP/rite-review-mutation-fresh" 2>/dev/null ) || true
 rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
@@ -993,6 +994,66 @@ if [ "$t29_recorded" = "yes" ] && [ "$t29_rel_rc" -ne 0 ]; then
   pass "T-29: session_worktree type は絶対パスで manifest に記録され、相対パスは拒否される (rc=$t29_rel_rc)"
 else
   fail "T-29: recorded=$t29_recorded, rel_rc=$t29_rel_rc"
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-30: Step 4-P porcelain — 2 fresh detached under nested TMPDIR (AC-1 / Issue #2145)
+# Given: two detached worktrees at $TMPDIR/nested/probe-{1,2} (NOT the name pattern
+#        find-based Step 4 looks for; nested so maxdepth-1 find cannot see them)
+# When: Cleanup runs
+# Then: both gone, mutation_worktrees=2
+# -----------------------------------------------------------------------
+echo "T-30: Step 4-P porcelain が nested TMPDIR の fresh detached を 2 件回収 (AC-1)"
+TEST_REPO=$(make_temp_repo)
+t30_nest="$WORKDIR_SCAN_TMP/nested-claude"
+mkdir -p "$t30_nest"
+( cd "$TEST_REPO" && git worktree add --detach -q "$t30_nest/probe-1" HEAD )
+( cd "$TEST_REPO" && git worktree add --detach -q "$t30_nest/probe-2" HEAD )
+t30_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t30_mut=$(echo "$t30_output" | sed -n 's/.*mutation_worktrees=\([0-9]*\).*/\1/p' | head -1)
+if [ ! -e "$t30_nest/probe-1" ] && [ ! -e "$t30_nest/probe-2" ] \
+   && [ "${t30_mut:-0}" -eq 2 ] 2>/dev/null; then
+  pass "T-30: nested detached 2 件が回収され mutation_worktrees=2"
+else
+  fail "T-30: p1=$([ -e "$t30_nest/probe-1" ] && echo present || echo gone) p2=$([ -e "$t30_nest/probe-2" ] && echo present || echo gone) mut=$t30_mut. Output: $t30_output"
+fi
+( cd "$TEST_REPO" && git worktree remove --force "$t30_nest/probe-1" 2>/dev/null ) || true
+( cd "$TEST_REPO" && git worktree remove --force "$t30_nest/probe-2" 2>/dev/null ) || true
+rm -rf "$t30_nest"
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-31: Step 4-P does NOT reap .rite/worktrees/* (AC-2 / Issue #2145)
+# Given: a detached worktree under $TEST_REPO/.rite/worktrees/issue-N (session path shape)
+# When: Cleanup runs
+# Then: the worktree remains (repo-root exclusion)
+# -----------------------------------------------------------------------
+echo "T-31: Step 4-P は .rite/worktrees/* を回収しない (AC-2)"
+TEST_REPO=$(make_temp_repo)
+t31_wt="$TEST_REPO/.rite/worktrees/issue-t31"
+mkdir -p "$(dirname "$t31_wt")"
+( cd "$TEST_REPO" && git worktree add --detach -q "$t31_wt" HEAD )
+t31_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ -d "$t31_wt" ]; then
+  pass "T-31: .rite/worktrees/issue-t31 が残存"
+else
+  fail "T-31: session-shaped worktree が消えた. Output: $t31_output"
+fi
+( cd "$TEST_REPO" && git worktree remove --force "$t31_wt" 2>/dev/null ) || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-32: Step 4-P 対象 0 件 → mutation_worktrees=0 と status=noop 両立 (AC-3)
+# -----------------------------------------------------------------------
+echo "T-32: Step 4-P 対象 0 件で mutation_worktrees=0 + status=noop (AC-3)"
+TEST_REPO=$(make_temp_repo)
+t32_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if echo "$t32_output" | grep -q 'status=noop' \
+   && echo "$t32_output" | grep -q 'mutation_worktrees=0'; then
+  pass "T-32: 対象 0 件で status=noop / mutation_worktrees=0"
+else
+  fail "T-32: Output: $t32_output"
 fi
 cleanup_temp_repo "$TEST_REPO"
 


### PR DESCRIPTION
## Summary
- `pr-cycle-cleanup.sh` に Step 4-P を追加: `git worktree list --porcelain` で TMPDIR 配下の detached worktree を回収
- find の maxdepth=1 + 24h age ガードでは取りこぼしていた入れ子パス / 同一サイクル残留を捕捉
- 自セッション除外・`.rite/worktrees/*` 除外・dirty 保護を維持

## Test plan
- [x] `bash plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh` PASS 34 / FAIL 0
- [x] T-30 nested TMPDIR 2 件回収 / T-31 session path 保護 / T-32 0 件 noop

Closes #2145