### PR TITLE
fix(hooks): Step 4-P の dirty 保護を到達不能 commit 保護に置換する

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -640,9 +640,15 @@ fi
 #   - detached HEAD (porcelain の `detached` 行。`branch refs/heads/...` を持つものは除外)
 #   - リポジトリ配下 (`.rite/worktrees/*` / wiki-worktree / main) は除外
 #   - 自セッション live cwd は除外 (worktree-foreign-cwd.sh --self-root $PPID)
+#   - HEAD がどの ref からも到達不能な commit の worktree は除外 (Issue #2158)
 # を満たす worktree を age ガード無しで回収する。reviewer は READ-ONLY で remove できず、
 # cleanup は review 入口 / iterate 終端でのみ走るため、並行 reviewer の in-flight を
 # age で守る必要は無い — 別セッション在席は foreign-cwd が塞ぐ。
+#
+# dirty は見送り理由にしない (Issue #2158): mutation worktree は tracked 書き換えと
+# 実験スクリプトが本質であり、status --porcelain 非空は回収対象の性質そのもの。
+# 保護するのは「どの named ref からも到達不能な commit」のみ（使い捨て dirty と
+# 区別する）。判定コマンド失敗時は安全側で見送り + WARNING（silent skip しない）。
 # カウンタは既存 `mutation_worktrees_reaped` を共有する。
 # -----------------------------------------------------------------------
 _tmp_prefix="${TMPDIR:-/tmp}"
@@ -680,10 +686,18 @@ if _p_list=$(git worktree list --porcelain 2>"${_p_list_err:-/dev/null}"); then
       if [ "$_p_fc_rc" -eq 0 ]; then
         echo "WARNING: 別セッションが detached worktree ($_p_path) を使用中のため回収を見送りました" >&2
       else
-        # dirty 保護 (Step 4.5 AC-6 と同旨): uncommitted 変更のある worktree は force 削除しない
-        _p_dirty=$(git -C "$_p_path" status --porcelain 2>/dev/null) || _p_dirty="??"
-        if [ -n "$_p_dirty" ]; then
-          echo "WARNING: detached TMPDIR worktree ($_p_path) に未コミット変更があるため回収を見送りました" >&2
+        # 到達不能 commit 保護 (Issue #2158): mutation worktree は本質的に dirty なので
+        # 未コミット変更は見送り理由にしない。保護するのは「どの named ref からも
+        # 到達不能な commit」のみ。for-each-ref --contains は worktree HEAD
+        # (.git/worktrees/*/HEAD) を列挙しないため、detached 上でだけ作られた
+        # commit は EMPTY になる。判定失敗時は削除せず WARNING で観測可能にする。
+        _p_head=$(git -C "$_p_path" rev-parse HEAD 2>/dev/null) || _p_head=""
+        if [ -z "$_p_head" ]; then
+          echo "WARNING: detached TMPDIR worktree ($_p_path) の HEAD 判定に失敗したため回収を見送りました" >&2
+        elif ! _p_refs=$(git -C "$_p_path" for-each-ref --contains="$_p_head" --format='%(refname)' 2>/dev/null); then
+          echo "WARNING: detached TMPDIR worktree ($_p_path) の到達可能性判定に失敗したため回収を見送りました" >&2
+        elif [ -z "$_p_refs" ]; then
+          echo "WARNING: detached TMPDIR worktree ($_p_path) に到達不能 commit があるため回収を見送りました" >&2
         elif [ "$DRY_RUN" = "1" ]; then
           echo "[dry-run] would reap detached TMPDIR worktree: $(printf '%s' "$_p_path" | neutralize_ctrl)"
         else

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -874,26 +874,29 @@ fi
 rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
-# T-24: dirty manifest worktree is skipped + kept in manifest (AC-6)
+# T-24: dirty manifest worktree is skipped + kept in manifest (AC-6 / Step 4.5)
+# Path is under TEST_REPO (not TMPDIR) so Step 4-P porcelain sweep does not
+# reap it first — Issue #2158 made dirty TMPDIR detached worktrees reaped by
+# Step 4-P, which would otherwise collapse this Step 4.5-only assertion.
 echo "T-24: dirty な manifest worktree は保護 + manifest 保持 (AC-6)"
-rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
 TEST_REPO=$(make_temp_repo)
+t24_wt="$TEST_REPO/mf-wt-dirty"
 (
   cd "$TEST_REPO"
-  git worktree add --detach -q "$WORKDIR_SCAN_TMP/mf-wt-dirty" HEAD
-  echo "uncommitted" > "$WORKDIR_SCAN_TMP/mf-wt-dirty/scratch.txt"   # untracked → dirty
-  bash "$ARTIFACT_HELPER" record --type worktree --id "$WORKDIR_SCAN_TMP/mf-wt-dirty" >/dev/null 2>&1
+  git worktree add --detach -q "$t24_wt" HEAD
+  echo "uncommitted" > "$t24_wt/scratch.txt"   # untracked → dirty
+  bash "$ARTIFACT_HELPER" record --type worktree --id "$t24_wt" >/dev/null 2>&1
 )
 t24_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
 t24_kept=$( { grep -c 'mf-wt-dirty' "$TEST_REPO/.rite/tmp-artifacts.tsv" 2>/dev/null || true; } )
-if [ -e "$WORKDIR_SCAN_TMP/mf-wt-dirty" ] \
+if [ -e "$t24_wt" ] \
    && echo "$t24_output" | grep -q 'manifest=0' \
    && [ "$t24_kept" = "1" ]; then
   pass "T-24: dirty worktree は reap されず manifest=0 + manifest にエントリ保持"
 else
-  fail "T-24: dir=$([ -e "$WORKDIR_SCAN_TMP/mf-wt-dirty" ] && echo present || echo gone), kept=$t24_kept. Output: $t24_output"
+  fail "T-24: dir=$([ -e "$t24_wt" ] && echo present || echo gone), kept=$t24_kept. Output: $t24_output"
 fi
-rm -rf "$WORKDIR_SCAN_TMP"/mf-wt-* 2>/dev/null || true
+( cd "$TEST_REPO" && git worktree remove --force "$t24_wt" 2>/dev/null ) || true
 cleanup_temp_repo "$TEST_REPO"
 
 # T-25: a non-recorded weird-named branch survives (誤削除防止 — manifest reaps only recorded) (AC-3)
@@ -1055,6 +1058,103 @@ if echo "$t32_output" | grep -q 'status=noop' \
 else
   fail "T-32: Output: $t32_output"
 fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-33: Step 4-P — tracked modified (dirty) mutation worktree を回収 (Issue #2158 AC-1)
+# Given: detached TMPDIR worktree with uncommitted modification to a tracked file
+# When: Cleanup runs
+# Then: worktree reaped; mutation_worktrees >= 1 (dirty is NOT a skip reason)
+# -----------------------------------------------------------------------
+echo "T-33: Step 4-P が tracked modified な mutation worktree を回収 (Issue #2158 AC-1)"
+TEST_REPO=$(make_temp_repo)
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+( cd "$TEST_REPO" && git worktree add --detach -q "$WORKDIR_SCAN_TMP/rite-review-mutation-dirty-mod" HEAD )
+echo "mutated" >> "$WORKDIR_SCAN_TMP/rite-review-mutation-dirty-mod/README.md"
+t33_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t33_mut=$(echo "$t33_output" | sed -n 's/.*mutation_worktrees=\([0-9]*\).*/\1/p' | head -1)
+if [ ! -e "$WORKDIR_SCAN_TMP/rite-review-mutation-dirty-mod" ] \
+   && [ "${t33_mut:-0}" -ge 1 ] 2>/dev/null; then
+  pass "T-33: tracked modified worktree が回収され mutation_worktrees=$t33_mut"
+else
+  fail "T-33: dir=$([ -e "$WORKDIR_SCAN_TMP/rite-review-mutation-dirty-mod" ] && echo present || echo gone) mut=$t33_mut. Output: $t33_output"
+fi
+( cd "$TEST_REPO" && git worktree remove --force "$WORKDIR_SCAN_TMP/rite-review-mutation-dirty-mod" 2>/dev/null ) || true
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-34: Step 4-P — untracked のみの dirty worktree を回収 (Issue #2158 AC-2)
+# -----------------------------------------------------------------------
+echo "T-34: Step 4-P が untracked のみの mutation worktree を回収 (Issue #2158 AC-2)"
+TEST_REPO=$(make_temp_repo)
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+( cd "$TEST_REPO" && git worktree add --detach -q "$WORKDIR_SCAN_TMP/rite-review-mutation-untracked" HEAD )
+echo "experiment" > "$WORKDIR_SCAN_TMP/rite-review-mutation-untracked/mutate.py"
+t34_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+t34_mut=$(echo "$t34_output" | sed -n 's/.*mutation_worktrees=\([0-9]*\).*/\1/p' | head -1)
+if [ ! -e "$WORKDIR_SCAN_TMP/rite-review-mutation-untracked" ] \
+   && [ "${t34_mut:-0}" -ge 1 ] 2>/dev/null; then
+  pass "T-34: untracked のみ worktree が回収され mutation_worktrees=$t34_mut"
+else
+  fail "T-34: dir=$([ -e "$WORKDIR_SCAN_TMP/rite-review-mutation-untracked" ] && echo present || echo gone) mut=$t34_mut. Output: $t34_output"
+fi
+( cd "$TEST_REPO" && git worktree remove --force "$WORKDIR_SCAN_TMP/rite-review-mutation-untracked" 2>/dev/null ) || true
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-35: Step 4-P — 到達不能 commit を持つ worktree は WARNING 付きで残存 (Issue #2158 AC-3)
+# Given: detached worktree with a unique commit not reachable from any named ref
+# When: Cleanup runs
+# Then: worktree remains; WARNING mentions 到達不能 commit
+# -----------------------------------------------------------------------
+echo "T-35: Step 4-P が到達不能 commit worktree を WARNING 付きで保護 (Issue #2158 AC-3)"
+TEST_REPO=$(make_temp_repo)
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+( cd "$TEST_REPO" && git worktree add --detach -q "$WORKDIR_SCAN_TMP/rite-review-mutation-orphan-commit" HEAD )
+(
+  cd "$WORKDIR_SCAN_TMP/rite-review-mutation-orphan-commit"
+  echo "unique-only-here" > orphan-payload.txt
+  git add orphan-payload.txt
+  git -c user.email=test@example.com -c user.name=Test commit --quiet -m "orphan-only-on-detached"
+)
+t35_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ -d "$WORKDIR_SCAN_TMP/rite-review-mutation-orphan-commit" ] \
+   && echo "$t35_output" | grep -q '到達不能 commit'; then
+  pass "T-35: 到達不能 commit worktree が WARNING 付きで残存"
+else
+  fail "T-35: dir=$([ -d "$WORKDIR_SCAN_TMP/rite-review-mutation-orphan-commit" ] && echo present || echo gone). Output: $t35_output"
+fi
+( cd "$TEST_REPO" && git worktree remove --force "$WORKDIR_SCAN_TMP/rite-review-mutation-orphan-commit" 2>/dev/null ) || true
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
+# T-36: Step 4-P — 到達可能性判定不能時は安全側で見送り + WARNING (Issue #2158 AC-4)
+# Given: detached worktree whose HEAD cannot be resolved (broken gitdir pointer)
+# When: Cleanup runs
+# Then: worktree remains; WARNING about HEAD 判定失敗
+# -----------------------------------------------------------------------
+echo "T-36: Step 4-P 判定不能時は残存 + WARNING (Issue #2158 AC-4)"
+TEST_REPO=$(make_temp_repo)
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
+t36_wt="$WORKDIR_SCAN_TMP/rite-review-mutation-broken-head"
+( cd "$TEST_REPO" && git worktree add --detach -q "$t36_wt" HEAD )
+# Break worktree gitdir so `git -C wt rev-parse HEAD` fails (判定不能 = 安全側見送り)
+printf 'gitdir: /nonexistent/rite-broken-gitdir\n' > "$t36_wt/.git"
+t36_output=$( cd "$TEST_REPO" && bash "$CLEANUP" 2>&1 )
+if [ -d "$t36_wt" ] \
+   && echo "$t36_output" | grep -qE 'HEAD 判定に失敗|到達可能性判定に失敗'; then
+  pass "T-36: 判定不能 worktree が WARNING 付きで残存"
+else
+  fail "T-36: dir=$([ -d "$t36_wt" ] && echo present || echo gone). Output: $t36_output"
+fi
+# force-remove may fail on broken gitdir; fall back to prune + rm
+( cd "$TEST_REPO" && git worktree remove --force "$t36_wt" 2>/dev/null ) || true
+rm -rf "$t36_wt"
+( cd "$TEST_REPO" && git worktree prune 2>/dev/null ) || true
+rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`pr-cycle-cleanup.sh` Step 4-P が、mutation worktree の本質的 dirty を一律見送りしていたため回収が機能しなかった問題を修正する。保護条件を「どの named ref からも到達不能な commit」に置き換える。

Closes #2158

## 変更内容

- Step 4-P: `status --porcelain` 非空による見送りを廃止し、`git for-each-ref --contains=$HEAD` が空のときのみ見送り + WARNING
- 判定コマンド失敗時は安全側で見送り + WARNING（silent skip しない）
- テスト追加: T-33（tracked modified 回収）/ T-34（untracked 回収）/ T-35（到達不能 commit 保護）/ T-36（判定不能）
- T-24 を Step 4.5 専用に保つため dirty manifest worktree を TMPDIR 外へ配置

## Known Issues

- lint 未実行（`commands.lint` が null）

## チェックリスト

- [x] 受入基準を満たす
- [x] 既存 T-15 / T-30 / T-31 / T-32 および T-24 が green
- [x] 対象外ファイル（worktree-foreign-cwd.sh / cleanup SKILL.md / Step 5 dirty ガード）に未接触
