### PR TITLE
feat(hooks): merge 実行点に review 実在 positive ゲートを追加する

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -586,7 +586,10 @@ fi
 if [ -z "$BLOCKED_PATTERN" ]; then
   _mrg_is_merge=0
   # CLI: `gh pr merge` with flexible whitespace (flags/args may follow).
-  if [[ "$CMD_CHECK" =~ (^|[^[:alnum:]_/-])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
+  # Boundary is (^|non-alnum-non-underscore) so path-prefixed binaries
+  # (`/usr/bin/gh pr merge`) match — excluding `/` from the boundary class
+  # would let absolute-path invocations silent-bypass the gate (measured).
+  if [[ "$CMD_CHECK" =~ (^|[^[:alnum:]_])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
     _mrg_is_merge=1
   # REST merge endpoint (gh api / curl-style path fragment).
   elif [[ "$CMD_CHECK" =~ /pulls/[0-9]+/merge ]]; then

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -16,6 +16,13 @@
 #            remote / update-ref / symbolic-ref) → deny (writes .git/config or
 #            .git refs with no redirect or file verb for (H) to see)
 #        (H) WRITE into a .git dir via redirect / file-mutating verb → deny
+#   5. Merge-point review-result positive gate (Issue #2159) — main-session
+#      (and any session) Bash that issues `gh pr merge` / REST pulls/{n}/merge /
+#      GraphQL mergePullRequest is denied unless `.rite/review-results/{pr}-*.json`
+#      exists with minimum form (schema_version + verdict keys, reviewers array
+#      length >= sole-reviewer guard floor 2). Fail-closed on PR-number
+#      unresolvable / missing / malformed / floor-under JSON. Purpose: block
+#      procedure-omission bypass of /rite:pr-review, not adversarial forgery.
 #
 # Reviewer working-tree mutations (git checkout / reset / commit / branch / ...)
 # are deliberately NOT machine-gated here (Issue #1879). They are visible and
@@ -562,6 +569,161 @@ if [ -z "$BLOCKED_PATTERN" ] && [ "$IS_SUBAGENT" = "1" ]; then
   # Restore the Patterns 1-3 fail-open trap for the shared result-emit section
   # below (it has its own fail-closed fallback for the deny-emit path).
   trap '_rite_btg_pattern13_fail_open' ERR
+fi
+
+# --- Pattern 5: Merge-point review-result positive gate (Issue #2159) ---
+# Blocks merge commands that have not been through /rite:pr-review far enough
+# to leave a qualifying review-results JSON. Applies to any session (not just
+# subagents): the bypass path observed in the wild was main-session batch-run
+# skipping pr-review. Fail direction is CLOSED (inspection failure → deny) so
+# "cannot tell" never becomes "allow merge".
+#
+# Detection surface (CMD_CHECK after heredoc strip, same as Patterns 1-3):
+#   - `gh pr merge` (CLI)
+#   - REST `.../pulls/{n}/merge` (gh api)
+#   - GraphQL `mergePullRequest`
+# Non-merge `gh` / other Bash is untouched.
+if [ -z "$BLOCKED_PATTERN" ]; then
+  _mrg_is_merge=0
+  # CLI: `gh pr merge` with flexible whitespace (flags/args may follow).
+  if [[ "$CMD_CHECK" =~ (^|[^[:alnum:]_/-])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
+    _mrg_is_merge=1
+  # REST merge endpoint (gh api / curl-style path fragment).
+  elif [[ "$CMD_CHECK" =~ /pulls/[0-9]+/merge ]]; then
+    _mrg_is_merge=1
+  # GraphQL merge mutation name (argument forms vary; name is stable).
+  elif [[ "$CMD_CHECK" =~ mergePullRequest ]]; then
+    _mrg_is_merge=1
+  fi
+
+  if [ "$_mrg_is_merge" = "1" ]; then
+    _mrg_pr=""
+
+    # --- PR number resolution (arg first, then flow-state) ---
+    # 1) REST path /pulls/{n}/merge
+    if [[ "$CMD_CHECK" =~ /pulls/([0-9]+)/merge ]]; then
+      _mrg_pr="${BASH_REMATCH[1]}"
+    fi
+    # 2) `gh pr merge` tail: first bare integer token, or /pull/{n} URL form
+    if [ -z "$_mrg_pr" ] && [[ "$CMD_CHECK" =~ gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+(.*) ]]; then
+      _mrg_tail="${BASH_REMATCH[1]}"
+      # shellcheck disable=SC2086  # intentional word-split of merge argv tail
+      for _mrg_tok in $_mrg_tail; do
+        case "$_mrg_tok" in
+          --*) continue ;;  # flag; value may be next token (non-numeric for known flags)
+        esac
+        if [[ "$_mrg_tok" =~ ^[0-9]+$ ]]; then
+          _mrg_pr="$_mrg_tok"
+          break
+        fi
+        if [[ "$_mrg_tok" =~ /pull/([0-9]+)(/|$) ]]; then
+          _mrg_pr="${BASH_REMATCH[1]}"
+          break
+        fi
+      done
+    fi
+    # 3) flow-state pr_number (merge skill often omits the number when cwd is the PR branch)
+    if [ -z "$_mrg_pr" ]; then
+      _mrg_pr=$(bash "$SCRIPT_DIR/flow-state.sh" get --field pr_number --default "" 2>/dev/null) || _mrg_pr=""
+      # treat unset / 0 / non-numeric as unresolved
+      case "$_mrg_pr" in
+        ''|0|*[!0-9]*) _mrg_pr="" ;;
+      esac
+    fi
+
+    if [ -z "$_mrg_pr" ]; then
+      BLOCKED_PATTERN="merge-review-pr-unresolved"
+      BLOCKED_REASON="Cannot resolve PR number for merge (no numeric arg / URL / REST path, and flow-state pr_number is unset). Merge is denied fail-loud rather than allowed without a review-result check."
+      BLOCKED_ALTERNATIVE="Pass the PR number explicitly (gh pr merge {N}) or run inside a rite session with flow-state pr_number set. After /rite:pr-review, re-run merge."
+    else
+      # --- review-results positive check ---
+      _mrg_root=""
+      if [ -n "${RITE_STATE_ROOT:-}" ] && [ -d "${RITE_STATE_ROOT}" ]; then
+        _mrg_root="$RITE_STATE_ROOT"
+      else
+        _mrg_root=$(bash "$SCRIPT_DIR/state-path-resolve.sh" 2>/dev/null) || _mrg_root=""
+      fi
+      _mrg_dir="${_mrg_root:+$_mrg_root/}.rite/review-results"
+      # When state root is empty, still try cwd-relative path (best-effort); empty
+      # root would otherwise look in "/.rite/..." which is wrong.
+      if [ -z "$_mrg_root" ]; then
+        _mrg_dir=".rite/review-results"
+      fi
+
+      _mrg_ok=0
+      _mrg_any=0
+      _mrg_fail_kind="absent"  # absent | parse_error | missing_keys | sole_reviewer
+      # nullglob so a no-match pattern expands to zero words (not the literal glob).
+      _mrg_noglob_was_set=0
+      case "$-" in *f*) _mrg_noglob_was_set=1 ;; esac
+      set +f
+      shopt -s nullglob 2>/dev/null || true
+      _mrg_files=("$_mrg_dir/${_mrg_pr}-"*.json)
+      shopt -u nullglob 2>/dev/null || true
+      [ "$_mrg_noglob_was_set" = "1" ] && set -f || true
+
+      for _mrg_f in "${_mrg_files[@]+"${_mrg_files[@]}"}"; do
+        # Skip if array empty (bash 4.4+ empty-array iterate safety)
+        [ -n "$_mrg_f" ] || continue
+        [ -f "$_mrg_f" ] || continue
+        _mrg_any=1
+        # parse + minimum form in one jq; map outcomes to fail kinds
+        _mrg_check=$(jq -r '
+          if (has("schema_version")|not)
+             or (.schema_version == null)
+             or ((.schema_version | tostring | length) == 0)
+             or (has("verdict")|not)
+             or ((.reviewers | type) != "array")
+            then "missing_keys"
+          elif ((.reviewers | length) < 2)
+            then "sole_reviewer"
+          else "ok"
+          end
+        ' "$_mrg_f" 2>/dev/null) || _mrg_check="parse_error"
+        if [ "$_mrg_check" = "ok" ]; then
+          _mrg_ok=1
+          break
+        fi
+        # Keep the most specific failure seen (prefer sole_reviewer / missing_keys
+        # over a later parse_error so a mixed dir still names the real defect).
+        case "$_mrg_fail_kind:$_mrg_check" in
+          absent:*|parse_error:missing_keys|parse_error:sole_reviewer|missing_keys:sole_reviewer)
+            _mrg_fail_kind="$_mrg_check"
+            ;;
+          *)
+            [ "$_mrg_fail_kind" = "absent" ] && _mrg_fail_kind="$_mrg_check"
+            ;;
+        esac
+      done
+
+      if [ "$_mrg_ok" != "1" ]; then
+        if [ "$_mrg_any" = "0" ]; then
+          BLOCKED_PATTERN="merge-review-json-absent"
+          BLOCKED_REASON="No review-results JSON for PR #${_mrg_pr} under ${_mrg_dir}/${_mrg_pr}-*.json. Merge requires a prior /rite:pr-review result (positive existence + minimum form)."
+          BLOCKED_ALTERNATIVE="Run /rite:pr-review ${_mrg_pr} (or /rite:iterate ${_mrg_pr}) so a qualifying review-results JSON is written, then re-run merge."
+        else
+          case "$_mrg_fail_kind" in
+            sole_reviewer)
+              BLOCKED_PATTERN="merge-review-sole-reviewer"
+              BLOCKED_REASON="Review-results JSON for PR #${_mrg_pr} has reviewers array length below sole-reviewer guard floor (2). A single-reviewer (or empty) result does not satisfy the merge gate."
+              BLOCKED_ALTERNATIVE="Re-run /rite:pr-review ${_mrg_pr} so at least 2 reviewers are recorded, then re-run merge."
+              ;;
+            parse_error)
+              BLOCKED_PATTERN="merge-review-json-parse"
+              BLOCKED_REASON="Review-results JSON for PR #${_mrg_pr} could not be parsed (jq non-zero). A broken file is not treated as a qualifying review."
+              BLOCKED_ALTERNATIVE="Remove or replace the broken ${_mrg_dir}/${_mrg_pr}-*.json and run /rite:pr-review ${_mrg_pr}, then re-run merge."
+              ;;
+            *)
+              BLOCKED_PATTERN="merge-review-json-incomplete"
+              BLOCKED_REASON="Review-results JSON for PR #${_mrg_pr} is missing required keys (schema_version non-empty, verdict present, reviewers array). Minimum form is not satisfied."
+              BLOCKED_ALTERNATIVE="Run /rite:pr-review ${_mrg_pr} to write a complete review-results JSON, then re-run merge."
+              ;;
+          esac
+        fi
+      fi
+      # success: leave BLOCKED_PATTERN empty — no extra output (AC-1)
+    fi
+  fi
 fi
 
 # --- Result ---

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1686,6 +1686,244 @@ assert_main_allow "main-session git config write not blocked by (N)" "git config
 echo ""
 
 # --------------------------------------------------------------------------
+# Pattern 5: Merge-point review-result positive gate (Issue #2159)
+# --------------------------------------------------------------------------
+# Isolates state via RITE_STATE_ROOT so real repo review-results never leak in.
+# Sole-reviewer guard floor = 2 (same constant as pr-review sole-reviewer guard).
+
+_mrg_setup_state() {
+  # $1 = temp root; creates sessions + review-results dirs and a session id file
+  local root="$1"
+  mkdir -p "$root/.rite/sessions" "$root/.rite/review-results"
+  printf '%s\n' "mrg-gate-sess" > "$root/.rite-session-id"
+  cat > "$root/.rite/sessions/mrg-gate-sess.flow-state" <<'EOF'
+{
+  "schema_version": 1,
+  "active": true,
+  "phase": "merge",
+  "issue_number": "2159",
+  "branch": "feat/test",
+  "pr_number": 0,
+  "session_id": "mrg-gate-sess",
+  "next_action": "",
+  "error_count": 0,
+  "updated_at": "2026-08-08T00:00:00Z"
+}
+EOF
+}
+
+_mrg_set_flow_pr() {
+  local root="$1" pr="$2"
+  jq --argjson pr "$pr" '.pr_number = $pr' \
+    "$root/.rite/sessions/mrg-gate-sess.flow-state" > "$root/.rite/sessions/mrg-gate-sess.flow-state.tmp"
+  mv "$root/.rite/sessions/mrg-gate-sess.flow-state.tmp" "$root/.rite/sessions/mrg-gate-sess.flow-state"
+}
+
+_mrg_write_json() {
+  # $1=root $2=filename $3=body
+  printf '%s\n' "$3" > "$1/.rite/review-results/$2"
+}
+
+_mrg_qualifying_json() {
+  # qualifying: schema_version + verdict keys, reviewers length >= 2
+  cat <<'EOF'
+{"schema_version":"1.1.0","verdict":"mergeable","reviewers":["code-quality","security"]}
+EOF
+}
+
+_mrg_run() {
+  # run_guard under RITE_STATE_ROOT; prints stdout, returns hook rc
+  local root="$1" cmd="$2"
+  local rc=0 output
+  output=$(RITE_STATE_ROOT="$root" jq -n --arg tn "Bash" --arg cmd "$cmd" \
+    '{tool_name: $tn, tool_input: {command: $cmd}, cwd: "/tmp"}' \
+    | RITE_STATE_ROOT="$root" bash "$HOOK" 2>"$STDERR_FILE") || rc=$?
+  printf '%s' "$output"
+  return $rc
+}
+
+echo "TC-128 / T-01: qualifying review JSON → gh pr merge N allowed (no extra stdout noise)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "99-good.json" "$(_mrg_qualifying_json)"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 99 --squash") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-128 qualifying JSON allows gh pr merge 99 with empty stdout"
+else
+  fail "TC-128 expected allow (rc=0 empty stdout), got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-129 / T-02: number-less gh pr merge resolves PR via flow-state"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_set_flow_pr "$_mrg_tmp" 77
+_mrg_write_json "$_mrg_tmp" "77-good.json" "$(_mrg_qualifying_json)"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge --squash") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-129 flow-state pr_number=77 allows number-less gh pr merge"
+else
+  fail "TC-129 expected allow via flow-state, got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-130 / T-03: no review JSON → deny + /rite:pr-review guidance"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 55 --squash") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-json-absent"* ]] && [[ "$reason" == *"/rite:pr-review"* ]]; then
+  pass "TC-130 absent JSON denies with merge-review-json-absent and /rite:pr-review"
+else
+  fail "TC-130 expected deny absent+/rite:pr-review, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-131 / T-04: sole-reviewer (reviewers length 1) JSON → deny"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "56-sole.json" \
+  '{"schema_version":1,"verdict":"mergeable","reviewers":["code-quality"]}'
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 56") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-sole-reviewer"* ]]; then
+  pass "TC-131 sole-reviewer JSON denies with merge-review-sole-reviewer"
+else
+  fail "TC-131 expected sole-reviewer deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-132 / T-05: unparseable review JSON → deny"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "57-broken.json" '{not valid json'
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 57") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-json-parse"* ]]; then
+  pass "TC-132 broken JSON denies with merge-review-json-parse"
+else
+  fail "TC-132 expected parse deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-133 / T-06: PR number unresolvable → deny (no arg, flow-state pr_number=0)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"   # pr_number stays 0
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge --squash") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-pr-unresolved"* ]]; then
+  pass "TC-133 unresolvable PR number denies with merge-review-pr-unresolved"
+else
+  fail "TC-133 expected pr-unresolved deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-134 / T-07: non-merge gh commands still allowed (no regression on Pattern 5)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+# No qualifying JSON present — if Pattern 5 false-fired these would deny.
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr view 1 --json title") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-134 gh pr view allowed (Pattern 5 does not false-positive)"
+else
+  fail "TC-134 expected allow for gh pr view, got rc=$rc output=$output"
+fi
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr diff 1") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-134 gh pr diff allowed (Pattern 5 does not false-positive)"
+else
+  fail "TC-134 expected allow for gh pr diff, got rc=$rc output=$output"
+fi
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh api repos/o/r/pulls/1") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-134 gh api non-merge REST allowed"
+else
+  fail "TC-134 expected allow for non-merge gh api, got rc=$rc output=$output"
+fi
+# REST merge endpoint is detected and denied when JSON absent
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh api repos/o/r/pulls/88/merge -X PUT") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-134 REST pulls/88/merge is detected and denied without JSON"
+else
+  fail "TC-134 expected deny for REST merge, got decision=$decision output=$output"
+fi
+# GraphQL mergePullRequest detected
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh api graphql -f query='mutation { mergePullRequest(input:{pullRequestId:\"X\"}) { clientMutationId } }'") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+# GraphQL has no PR number in path → pr-unresolved (or absent if number extracted)
+if [ "$decision" = "deny" ]; then
+  pass "TC-134 GraphQL mergePullRequest is detected and denied"
+else
+  fail "TC-134 expected deny for mergePullRequest, got decision=$decision output=$output"
+fi
+# Existing Pattern 1 still denies
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr diff 1 --stat") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"gh-pr-diff-stat"* ]]; then
+  pass "TC-134 Pattern 1 (gh pr diff --stat) still denies (non-regression)"
+else
+  fail "TC-134 expected Pattern 1 deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-135: missing required keys (no reviewers) → deny incomplete"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "60-incomplete.json" \
+  '{"schema_version":"1.0.0","verdict":"mergeable"}'
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 60") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-json-incomplete"* ]]; then
+  pass "TC-135 incomplete keys deny with merge-review-json-incomplete"
+else
+  fail "TC-135 expected incomplete deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-136: one qualifying + one broken JSON for same PR → allow (any-pass)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "61-broken.json" '{broken'
+_mrg_write_json "$_mrg_tmp" "61-good.json" "$(_mrg_qualifying_json)"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 61") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-136 any qualifying JSON allows merge even if a sibling file is broken"
+else
+  fail "TC-136 expected allow when one file qualifies, got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1923,6 +1923,30 @@ fi
 rm -rf "$_mrg_tmp"
 echo ""
 
+echo "TC-137: path-prefixed /usr/bin/gh pr merge is detected (no absolute-path bypass)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "/usr/bin/gh pr merge 99 --squash") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-json-absent"* ]]; then
+  pass "TC-137 /usr/bin/gh pr merge denies (path-prefixed binary is not a bypass)"
+else
+  fail "TC-137 expected deny for /usr/bin/gh pr merge, got decision=$decision reason=$reason"
+fi
+# hyphen-prefixed path also (Homebrew-style multi-component)
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "/opt/homebrew/bin/gh pr merge 99") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ]; then
+  pass "TC-137 /opt/homebrew/bin/gh pr merge denies"
+else
+  fail "TC-137 expected deny for homebrew gh path, got decision=$decision"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
 # --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`pre-tool-bash-guard` に merge 実行点の review 実在 positive ゲート（Pattern 5）を追加し、`/rite:pr-review` を経由しない merge を hook 層で遮断する。

## 関連 Issue

Closes #2159

## 変更内容

- `plugins/rite/hooks/pre-tool-bash-guard.sh`
  - `gh pr merge` / REST `/pulls/{n}/merge` / GraphQL `mergePullRequest` を検出
  - PR 番号は引数 → flow-state `pr_number` の順で解決（不能なら deny）
  - `{state_root}/.rite/review-results/{pr}-*.json` の positive 検査
    - 必須: `schema_version`（非空）/ `verdict`（キー存在）/ `reviewers` 配列長 ≥ 2
    - 1 件でも合格すれば素通し、合格時は追加出力なし
  - 不合格時は reason に不合格種別と `/rite:pr-review` 誘導を含む 1 行 deny
- `plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`
  - T-01〜T-07 相当（TC-128〜TC-136）を追加
  - 既存スイート含めて 231 passed / 0 failed

## 実装中の判断・計画逸脱

- 判断: `schema_version` は値リストを縛らず非空のみ要求（legacy 数値/文字列両対応）
- 判断: `verdict` はキー存在で足り null も可（古い JSON 互換）
- 判断: 複数 JSON がある場合は 1 件合格で素通し（最新強制なし）

## チェックリスト

- [x] プロジェクト規約に従う
- [x] テスト追加・既存非退行確認
- [x] Non-target（review-save-json-verify / merge・pr-review SKILL）未変更

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
