### PR TITLE
fix(skills): 環境起因の迂回対処を成功時無言・失敗時行動可能な1行へ統一する

### DIFF
--- a/plugins/rite/references/common-error-handling.md
+++ b/plugins/rite/references/common-error-handling.md
@@ -63,6 +63,28 @@ When Projects-related API calls fail, display a warning and continue. Projects o
 {operation} をスキップします
 ```
 
+## Environment Workaround Output Posture (canonical)
+
+<a id="environment-workaround-output-posture"></a>
+
+環境起因の制約への対処（sandbox 迂回・`dangerouslyDisableSandbox` 再実行・egress プロキシ断のリトライ・検証の代替経路など）の **人間向け出力姿勢** を定義する。本文は本セクションのみを SoT とする。各スキルは本規則を複製せず、1 行参照に留める（drift 防止）。
+
+**規則**:
+
+| 条件 | 人間向け出力 |
+|------|-------------|
+| **(a) 成功** — 迂回・リトライ・代替経路の結果、処理が完了した | **無言**。完了報告・進捗表示に迂回の前置き・背景解説・仕組みの説明を含めない（「サンドボックスの制約を先に共有します」等の定型前置きを含む） |
+| **(b) 失敗** — 対処しても失敗が残り、人間の行動が必要 | **行動可能な 1 行のみ**（何をすればよいか）。プロキシの仕組み・診断過程・環境の背景説明は書かない |
+| **(c) 機械可読経路** | `[CONTEXT]` marker は従来どおり emit する（監査・後段 routing 用。本規則は人間向け散文のみを対象とする） |
+
+**不変条件**:
+
+- **fail-loud は不変** — 沈黙化するのは「成功した迂回の説明」であって、失敗の隠蔽ではない
+- **権限ゲート自体は対象外** — `dangerouslyDisableSandbox` の確認 UI 等は Claude Code の管轄。本規則は narration（説明文）のみ
+- **対処の機構は別 Issue** — リトライ回数・代替経路の実装は各スキル / helper が持つ（例: cleanup の ls-remote 1 リトライは Issue #2140）。本規則は「成功後にそれをどう語るか」だけを規定する
+
+**適用対象（優先）**: ネットワーク git / sandbox 迂回を行うスキル（`cleanup` / `merge` / `ready` / `iterate` / `open` / `batch-run` 等）。新規スキルで同様の迂回を行う場合も本セクションを 1 行参照すること。
+
 ## Non-blocking Contract (canonical 定義)
 
 「Non-blocking Contract」とは、特定の sub-phase の失敗が **upstream phase 全体を失敗扱いにしない** ことを保証する設計上の契約。`/rite:pr-review` ステップ 6.1.a (ローカル JSON 保存) や `/rite:cleanup` ステップ 6 (review 結果ファイル削除、旧 Phase 2.5) など複数 phase で参照される。両方とも本セクションの定義を SoT とすること。

--- a/plugins/rite/skills/batch-run/SKILL.md
+++ b/plugins/rite/skills/batch-run/SKILL.md
@@ -35,6 +35,10 @@ argument-hint: "[--merge] <issue_number>..."
 **Output**: 全 Issue 処理完了の完了通知（ステップ 7。デフォルトは draft PR 群、`--merge` は merge/cleanup 完走）、または最初の失敗での停止報告（残り Issue 含む、ステップ 8）
 **自律度**: 完全自律（無確認）。デフォルトは draft PR まで、`--merge` 時は merge を含め確認を挟まない。失敗時のみ停止。
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ## Arguments
 
 | Argument | Description |

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -30,6 +30,10 @@ PR マージ後のクリーンアップを実行する。やることは以下�
 
 `{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md) で解決する。
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ## Arguments
 
 | Argument | Description |

--- a/plugins/rite/skills/iterate/SKILL.md
+++ b/plugins/rite/skills/iterate/SKILL.md
@@ -39,6 +39,10 @@ argument-hint: "<pr_number>"
 **Input**: PR number (required)
 **Output**: 完了通知（`[review:mergeable]` 到達 or `[fix:replied-only]` 終了 or `[fix:cancelled-by-user]` 中断 or サーキットブレーカー発火（`[iterate:max-cycles-reached]` バッチ / `[iterate:max-cycles-stopped]` 対話。いずれも非収束による失敗で、マージには進まない）or Ctrl+C 中断）
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ## Arguments
 
 | Argument | Description |

--- a/plugins/rite/skills/merge/SKILL.md
+++ b/plugins/rite/skills/merge/SKILL.md
@@ -18,6 +18,10 @@ argument-hint: "<pr_number>"
 
 `gh pr merge --squash` を叩いて PR をマージするだけ。**cleanup は走らせない**。マージ後の cleanup (ブランチ削除 / Projects 更新 / Wiki ingest 等) は `/rite:cleanup` を別途実行する。
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ## Arguments
 
 | Argument | Description |

--- a/plugins/rite/skills/open/SKILL.md
+++ b/plugins/rite/skills/open/SKILL.md
@@ -19,6 +19,10 @@ Issue を起点に「準備 → ブランチ → 計画 → 実装 → lint → 
 
 **途中で止まったら**: `/rite:recover` が flow-state ファイル (`.rite/sessions/{session_id}.flow-state`) の phase から復帰する。本コマンドの Step 0 が Resume Dispatch を担う。
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ## Arguments
 
 | Argument | Description |

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -18,6 +18,10 @@ Change PR to Ready for review and update the related Issue's Status
 
 > **Important (responsibility for flow continuation)**: When executed within the end-to-end flow, this Skill outputs a machine-readable output pattern (`[ready:returned-to-caller]` or `[ready:error]`) and **returns control to the caller** (orchestrator — caller-name agnostic). The caller determines the next action based on this output pattern.
 
+## E2E Output Minimization
+
+**環境起因の迂回・リトライの出力姿勢**: [common-error-handling.md#environment-workaround-output-posture](../../references/common-error-handling.md#environment-workaround-output-posture) — 成功時は無言、失敗時は行動可能な 1 行のみ（規則本文はそちら。本スキルは複製しない）。
+
 ---
 
 When this command is executed, run the following phases in order.


### PR DESCRIPTION
## 概要

環境起因の制約への対処（sandbox 迂回・プロキシ断リトライ等）の人間向け出力姿勢を「成功時は無言・失敗時は行動可能な 1 行のみ」に統一する。

## 関連 Issue

Closes #2149

## 変更内容

- `common-error-handling.md` に Environment Workaround Output Posture を単一定義として追加
- cleanup / merge / ready / iterate / open / batch-run の E2E Output Minimization から 1 行参照
- 前置き定型文の残存ゼロを grep 確認済み

## チェックリスト

- [x] 規則本文は common-error-handling の 1 箇所のみ
- [x] スキル側は複製せず参照 1 行
- [x] fail-loud / `[CONTEXT]` marker は不変
