### PR TITLE
fix(hooks): Step 4-P の TMPDIR 判定を symlink 物理パス対応にする

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -636,7 +636,8 @@ fi
 # `mutation_worktrees=0` と報告された (PR #2142)。
 #
 # 本ステップは `git worktree list --porcelain` を権威として:
-#   - path が `${TMPDIR}/` 配下 (prefix 一致、入れ子可)
+#   - path が `${TMPDIR}/` 配下 (論理形・`pwd -P` 物理形の両方で prefix 一致、入れ子可。
+#     macOS の `/var`→`/private/var` 等で porcelain が物理パスを返すケースを含む)
 #   - detached HEAD (porcelain の `detached` 行。`branch refs/heads/...` を持つものは除外)
 #   - リポジトリ配下 (`.rite/worktrees/*` / wiki-worktree / main) は除外
 #   - 自セッション live cwd は除外 (worktree-foreign-cwd.sh --self-root $PPID)
@@ -653,16 +654,37 @@ fi
 # -----------------------------------------------------------------------
 _tmp_prefix="${TMPDIR:-/tmp}"
 _tmp_prefix="${_tmp_prefix%/}"
-# 正規化: 末尾スラッシュ無しの prefix + "/" で「配下」判定する
+# Physical (symlink-resolved) forms for macOS-safe prefix match. Git worktree
+# porcelain typically emits the physical path (`/private/var/folders/...`,
+# `/private/tmp/...`), while `$TMPDIR` / `repo_root` may still be the logical
+# form (`/var/folders/...`, `/tmp`). A string-prefix compare between those two
+# shapes never matches, so Step 4-P reports mutation_worktrees=0 and leaves
+# every detached TMPDIR worktree in place (macOS CI failure on T-15/T-30/T-33+).
+# Resolve once with `cd && pwd -P` (same idiom as the Step 4.5 containment
+# guard; GNU realpath is not assumed — macOS bash 3.2 portability floor).
+_tmp_prefix_phys=$( cd -- "$_tmp_prefix" 2>/dev/null && pwd -P ) || _tmp_prefix_phys="$_tmp_prefix"
+_repo_root_phys=$( cd -- "$repo_root" 2>/dev/null && pwd -P ) || _repo_root_phys="$repo_root"
+# 正規化: 末尾スラッシュ無しの prefix + "/" で「配下」判定する。
+# 論理形・物理形の両方を受け付ける（path が片方だけ解決されているケースを含む）。
 _is_under_tmpdir() {
-  case "$1" in
+  local p="$1" p_phys
+  case "$p" in
     "$_tmp_prefix"|"$_tmp_prefix"/*) return 0 ;;
+  esac
+  p_phys=$( cd -- "$p" 2>/dev/null && pwd -P ) || p_phys="$p"
+  case "$p_phys" in
+    "$_tmp_prefix_phys"|"$_tmp_prefix_phys"/*) return 0 ;;
     *) return 1 ;;
   esac
 }
 _is_under_repo() {
-  case "$1" in
+  local p="$1" p_phys
+  case "$p" in
     "$repo_root"|"$repo_root"/*) return 0 ;;
+  esac
+  p_phys=$( cd -- "$p" 2>/dev/null && pwd -P ) || p_phys="$p"
+  case "$p_phys" in
+    "$_repo_root_phys"|"$_repo_root_phys"/*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -1158,6 +1158,43 @@ rm -rf "$WORKDIR_SCAN_TMP"/rite-review-mutation-* 2>/dev/null || true
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
+# T-37: Step 4-P — TMPDIR がシンボリックリンクでも porcelain 物理パスを回収する
+# (macOS: /var/folders → /private/var/folders、/tmp → /private/tmp)
+# Given: logical TMPDIR is a symlink to a physical dir; detached worktree is
+#        registered under the physical path (git worktree porcelain form)
+# When: Cleanup runs with TMPDIR=logical (unresolved) form
+# Then: worktree is reaped; mutation_worktrees >= 1
+# Without pwd -P normalization, string-prefix match of logical vs physical
+# fails and Step 4-P reports mutation_worktrees=0 (macOS CI T-15/T-30/T-33+).
+# -----------------------------------------------------------------------
+echo "T-37: Step 4-P が TMPDIR シンボリックリンク先の porcelain 物理パスを回収する"
+TEST_REPO=$(make_temp_repo)
+t37_phys=$(mktemp -d "$HOST_TMPDIR/rite-pr-cleanup-t37-phys-XXXXXX")
+TEST_REPOS+=("$t37_phys")
+t37_link=$(mktemp -u "$HOST_TMPDIR/rite-pr-cleanup-t37-link-XXXXXX")
+if ! ln -s "$t37_phys" "$t37_link" 2>/dev/null; then
+  skip "T-37: シンボリックリンクを作成できない環境のためスキップ"
+else
+  TEST_REPOS+=("$t37_link")
+  # git often stores the physical path; put the worktree under the phys dir
+  # while TMPDIR points at the logical (symlink) form — the macOS mismatch.
+  ( cd "$TEST_REPO" && git worktree add --detach -q "$t37_phys/rite-review-mutation-symlink" HEAD )
+  t37_output=$( cd "$TEST_REPO" && TMPDIR="$t37_link" bash "$CLEANUP" 2>&1 )
+  t37_mut=$(echo "$t37_output" | sed -n 's/.*mutation_worktrees=\([0-9]*\).*/\1/p' | head -1)
+  if [ ! -e "$t37_phys/rite-review-mutation-symlink" ] \
+     && [ "${t37_mut:-0}" -ge 1 ] 2>/dev/null; then
+    pass "T-37: シンボリックリンク TMPDIR 越しに porcelain 物理パスを回収 (mut=$t37_mut)"
+  else
+    fail "T-37: dir=$([ -e "$t37_phys/rite-review-mutation-symlink" ] && echo present || echo gone) mut=$t37_mut. Output: $t37_output"
+  fi
+  ( cd "$TEST_REPO" && git worktree remove --force "$t37_phys/rite-review-mutation-symlink" 2>/dev/null ) || true
+  rm -rf "$t37_phys/rite-review-mutation-symlink" 2>/dev/null || true
+  rm -f "$t37_link" 2>/dev/null || true
+  rm -rf "$t37_phys" 2>/dev/null || true
+fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 echo


### PR DESCRIPTION
## 概要

`pr-cycle-cleanup.sh` Step 4-P が macOS CI で detached TMPDIR worktree を一切回収できず、`mutation_worktrees=0` / `status=noop` のまま T-15 / T-30 / T-33–T-36 が失敗していた問題を修正する。

## 原因

macOS では:

- `$TMPDIR` が論理パス（例: `/var/folders/.../T`）
- `git worktree list --porcelain` が物理パス（例: `/private/var/folders/.../T`）

を返す。Step 4-P の「`${TMPDIR}/` 配下」判定が文字列 prefix 一致だけだったため、全 entry がミスマッチ → 回収 0 件。

PR #2171 の macOS job 失敗はこの経路。Linux では論理=物理のため顕在化しなかった。

## 変更

- `_is_under_tmpdir` / `_is_under_repo` を `cd && pwd -P` で物理パスも照合するよう拡張（Step 4.5 の containment と同じ idiom）
- 回帰テスト T-37: シンボリックリンク TMPDIR + porcelain 物理パスでも回収されること

## 検証

- ローカル: `pr-cycle-cleanup.test.sh` 39/39 green（T-37 含む）
- CI: macOS `tests (macos-latest)` の green を必須確認

## 関連

PR #2171 の macOS 失敗への修正。#2085 本体（設計記録）とは独立。
