### PR TITLE
fix(hooks): merge ゲートが変数形 PR 番号で flow-state へフォールバックしないようにする

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -601,8 +601,14 @@ if [ -z "$BLOCKED_PATTERN" ]; then
 
   if [ "$_mrg_is_merge" = "1" ]; then
     _mrg_pr=""
+    # Set when `gh pr merge` tail has a non-flag token that is neither a bare
+    # integer nor a /pull/{n} URL. Variable forms ("$PR", $PR) and flag values
+    # that look like free tokens land here. flow-state fallback must NOT run
+    # in that case — a different session's pr_number must not become the gate
+    # target for an unresolved merge argv (Issue #2173).
+    _mrg_nonflag_unresolved=0
 
-    # --- PR number resolution (arg first, then flow-state) ---
+    # --- PR number resolution (arg first, then flow-state only if flag-only) ---
     # 1) REST path /pulls/{n}/merge
     if [[ "$CMD_CHECK" =~ /pulls/([0-9]+)/merge ]]; then
       _mrg_pr="${BASH_REMATCH[1]}"
@@ -617,16 +623,24 @@ if [ -z "$BLOCKED_PATTERN" ]; then
         esac
         if [[ "$_mrg_tok" =~ ^[0-9]+$ ]]; then
           _mrg_pr="$_mrg_tok"
+          _mrg_nonflag_unresolved=0
           break
         fi
         if [[ "$_mrg_tok" =~ /pull/([0-9]+)(/|$) ]]; then
           _mrg_pr="${BASH_REMATCH[1]}"
+          _mrg_nonflag_unresolved=0
           break
         fi
+        # Non-flag token that did not resolve to a PR number (variable form,
+        # flag value, etc.). Keep scanning in case a later numeric token exists
+        # (e.g. --body msg 2172); if none does, block flow-state fallback.
+        _mrg_nonflag_unresolved=1
       done
     fi
-    # 3) flow-state pr_number (merge skill often omits the number when cwd is the PR branch)
-    if [ -z "$_mrg_pr" ]; then
+    # 3) flow-state pr_number — only when the merge argv has no unresolved
+    # non-flag token. Number-less `gh pr merge --squash` (merge skill on the PR
+    # branch) still falls back; `"$PR"` / `$PR` must deny fail-loud (#2173).
+    if [ -z "$_mrg_pr" ] && [ "$_mrg_nonflag_unresolved" != "1" ]; then
       _mrg_pr=$(bash "$SCRIPT_DIR/flow-state.sh" get --field pr_number --default "" 2>/dev/null) || _mrg_pr=""
       # treat unset / 0 / non-numeric as unresolved
       case "$_mrg_pr" in
@@ -636,8 +650,13 @@ if [ -z "$BLOCKED_PATTERN" ]; then
 
     if [ -z "$_mrg_pr" ]; then
       BLOCKED_PATTERN="merge-review-pr-unresolved"
-      BLOCKED_REASON="Cannot resolve PR number for merge (no numeric arg / URL / REST path, and flow-state pr_number is unset). Merge is denied fail-loud rather than allowed without a review-result check."
-      BLOCKED_ALTERNATIVE="Pass the PR number explicitly (gh pr merge {N}) or run inside a rite session with flow-state pr_number set. After /rite:pr-review, re-run merge."
+      if [ "$_mrg_nonflag_unresolved" = "1" ]; then
+        BLOCKED_REASON="Cannot resolve PR number for merge: a non-flag token is present in the merge argv but is not a numeric PR number or /pull/{n} URL (e.g. variable form \"\$PR\"). flow-state is not used as a fallback for unresolved tokens — a different session PR must not gate this merge."
+        BLOCKED_ALTERNATIVE="Pass the PR number explicitly as a bare integer (gh pr merge {N}) and re-run. Variable or quoted-variable forms are denied fail-loud."
+      else
+        BLOCKED_REASON="Cannot resolve PR number for merge (no numeric arg / URL / REST path, and flow-state pr_number is unset). Merge is denied fail-loud rather than allowed without a review-result check."
+        BLOCKED_ALTERNATIVE="Pass the PR number explicitly (gh pr merge {N}) or run inside a rite session with flow-state pr_number set. After /rite:pr-review, re-run merge."
+      fi
     else
       # --- review-results positive check ---
       _mrg_root=""

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -1948,6 +1948,84 @@ rm -rf "$_mrg_tmp"
 echo ""
 
 # --------------------------------------------------------------------------
+# Issue #2173: variable-form PR token must not fall back to flow-state
+# --------------------------------------------------------------------------
+
+echo "TC-138 / T-01 (#2173): variable-form \"\$PR\" denies even when flow-state has qualifying other PR"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_set_flow_pr "$_mrg_tmp" 77
+_mrg_write_json "$_mrg_tmp" "77-good.json" "$(_mrg_qualifying_json)"
+rc=0
+# Quoted variable form as it appears in tool_input.command after shell expansion
+# has NOT happened (hook sees the literal command string from the tool call).
+output=$(_mrg_run "$_mrg_tmp" 'gh pr merge "$PR" --squash') || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-pr-unresolved"* ]] && [[ "$reason" == *"gh pr merge"* || "$reason" == *"bare integer"* || "$reason" == *"explicitly"* ]]; then
+  pass "TC-138 variable-form \"\$PR\" denies with merge-review-pr-unresolved (no flow-state 77 pass-through)"
+else
+  fail "TC-138 expected pr-unresolved deny (not allow via flow-state 77), got decision=$decision reason=$reason rc=$rc"
+fi
+# Unquoted $PR form
+rc=0
+output=$(_mrg_run "$_mrg_tmp" 'gh pr merge $PR --squash') || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-review-pr-unresolved"* ]]; then
+  pass "TC-138 unquoted \$PR also denies with merge-review-pr-unresolved"
+else
+  fail "TC-138 expected pr-unresolved for unquoted \$PR, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-139 / T-02 (#2173): literal numeric form still allowed (non-regression of TC-128 path)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_write_json "$_mrg_tmp" "99-good.json" "$(_mrg_qualifying_json)"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 99 --squash") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-139 literal gh pr merge 99 still allows with qualifying JSON"
+else
+  fail "TC-139 expected allow for literal 99, got rc=$rc output=$output"
+fi
+# Number after flags
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge --squash 99") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-139 literal after flags (gh pr merge --squash 99) still allows"
+else
+  fail "TC-139 expected allow for --squash 99, got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-140 / T-03 (#2173): flag-only tail still uses flow-state fallback (pin limited retention)"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+_mrg_set_flow_pr "$_mrg_tmp" 77
+_mrg_write_json "$_mrg_tmp" "77-good.json" "$(_mrg_qualifying_json)"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge --squash") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-140 flag-only gh pr merge --squash still resolves via flow-state"
+else
+  fail "TC-140 expected allow via flow-state for flag-only tail, got rc=$rc output=$output"
+fi
+# Multiple flags only
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge --squash --delete-branch") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-140 multi-flag-only tail still uses flow-state"
+else
+  fail "TC-140 expected allow for --squash --delete-branch via flow-state, got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## 概要

merge ゲート（`pre-tool-bash-guard.sh`）の PR 番号解決を fail-loud 化する。`gh pr merge` の argv に非 flag トークンがあるのに数値 / `/pull/{n}` に解決できない場合（変数形 `"$PR"` 等）は、flow-state へフォールバックせず `merge-review-pr-unresolved` で deny する。

## 関連 Issue

Closes #2173

## 変更内容

- `pre-tool-bash-guard.sh`: 非 flag トークン残存 + 解決失敗時は flow-state を見ない。flag のみ tail（`gh pr merge --squash`）は従来どおり flow-state フォールバックを維持
- テスト TC-138〜140: 変数形 deny / リテラル素通し / flag のみ pin

## チェックリスト

- [x] テスト追加・suite green（239 passed）
- [x] Target files のみ変更
- [x] 既存 flag-only / リテラル経路の非退行

## テスト計画

- [x] `bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh` — 239 passed, 0 failed
