### PR TITLE
feat(dev): 3ホスト共通の rite 開発ランチャーを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ Thumbs.db
 .env
 .env.local
 
+# Repository-local Codex dogfooding profile. This isolates the working-tree
+# version of rite from plugins installed under the user's normal CODEX_HOME and
+# may contain authentication/session data.
+.codex-dev/
+
 # Temporary files
 tmp/
 temp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ scripts/rite-dev grok
 
 Additional arguments are forwarded to the selected host. The launcher exports
 `RITE_HOST` and `RITE_PLUGIN_ROOT` for host-neutral workflow code. Claude Code
-loads `plugins/rite` explicitly, Grok Build uses the repository-local plugin
-link, and Codex uses an ignored `.codex-dev/` profile. Its `skills` directory
+loads `plugins/rite` explicitly and disables `rite@rite-marketplace` for that
+process only, without changing the user's settings. Grok Build uses the
+repository-local plugin link, and Codex uses an ignored `.codex-dev/` profile. Its `skills` directory
 keeps Codex-managed state locally and links each rite skill back to
 `plugins/rite/skills`; this prevents `.system` and other mutable Codex files
 from entering the distributed plugin source. The profile may require a separate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,30 @@ Thank you for your interest in contributing to Claude Code Rite Workflow!
 1. Clone the repository
 2. Install dependencies: `jq` (required by hook scripts)
 3. The plugin uses Rite Workflow itself for development (self-hosting)
-4. Set `rite@rite-marketplace: false` in `~/.claude/settings.json` to avoid plugin dual-load collision when developing locally
+4. Launch the host through `scripts/rite-dev` to avoid plugin dual-load collisions
+
+### Unified dogfooding launcher
+
+Use the same entry point from Claude Code, Codex, or Grok Build:
+
+```bash
+scripts/rite-dev claude
+scripts/rite-dev codex
+scripts/rite-dev grok
+```
+
+Additional arguments are forwarded to the selected host. The launcher exports
+`RITE_HOST` and `RITE_PLUGIN_ROOT` for host-neutral workflow code. Claude Code
+loads `plugins/rite` explicitly, Grok Build uses the repository-local plugin
+link, and Codex uses an ignored `.codex-dev/` profile. Its `skills` directory
+keeps Codex-managed state locally and links each rite skill back to
+`plugins/rite/skills`; this prevents `.system` and other mutable Codex files
+from entering the distributed plugin source. The profile may require a separate
+login on first use.
+
+The launcher never replaces an unexpected local link or directory. If an older
+development setup already has `.codex-dev/skills` as a symlink, move or remove
+that local profile explicitly before launching Codex again.
 
 ## How to Contribute
 

--- a/scripts/rite-dev
+++ b/scripts/rite-dev
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/rite-dev <claude|codex|grok> [host arguments...]
+
+Launch an AI coding host against the rite plugin in this working tree.
+
+Examples:
+  scripts/rite-dev claude
+  scripts/rite-dev codex
+  scripts/rite-dev grok
+  scripts/rite-dev codex "inspect the current issue"
+
+The launcher keeps host-global rite installations out of the dogfooding path:
+  claude  loads plugins/rite explicitly with --plugin-dir
+  codex   uses the repository-local .codex-dev profile
+  grok    uses the repository-local .grok configuration and plugin symlink
+EOF
+}
+
+die() {
+  printf 'rite-dev: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+[[ $# -gt 0 ]] || {
+  usage >&2
+  exit 2
+}
+
+host=$1
+shift
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null) || \
+  die "scripts/rite-dev must be run from a git checkout"
+plugin_root="$repo_root/plugins/rite"
+
+[[ -d "$plugin_root/skills" ]] || \
+  die "rite plugin source not found: $plugin_root"
+
+export RITE_HOST="$host"
+export RITE_PLUGIN_ROOT="$plugin_root"
+cd "$repo_root"
+
+case "$host" in
+  claude)
+    command -v claude >/dev/null 2>&1 || die "claude executable not found"
+    exec claude --plugin-dir "$plugin_root" "$@"
+    ;;
+  codex)
+    command -v codex >/dev/null 2>&1 || die "codex executable not found"
+    codex_home="$repo_root/.codex-dev"
+    codex_skills="$codex_home/skills"
+    if [[ -L "$codex_skills" || ( -e "$codex_skills" && ! -d "$codex_skills" ) ]]; then
+      die "expected $codex_skills to be a directory reserved for Codex state"
+    fi
+    mkdir -p "$codex_skills"
+
+    for skill_dir in "$plugin_root"/skills/*; do
+      [[ -f "$skill_dir/SKILL.md" ]] || continue
+      skill_name=${skill_dir##*/}
+      skill_link="$codex_skills/$skill_name"
+      if [[ -e "$skill_link" || -L "$skill_link" ]]; then
+        [[ -L "$skill_link" ]] || \
+          die "expected $skill_link to be a symlink to $skill_dir"
+        linked_skill=$(cd -- "$(dirname -- "$skill_link")" && cd -- "$(readlink -- "$skill_link")" 2>/dev/null && pwd -P) || \
+          die "expected $skill_link to resolve to $skill_dir"
+        [[ "$linked_skill" == "$skill_dir" ]] || \
+          die "expected $skill_link to resolve to $skill_dir"
+      else
+        ln -s "$skill_dir" "$skill_link"
+      fi
+    done
+    export CODEX_HOME="$codex_home"
+    exec codex --cd "$repo_root" "$@"
+    ;;
+  grok)
+    command -v grok >/dev/null 2>&1 || die "grok executable not found"
+    grok_link="$repo_root/.grok/plugins/rite"
+    [[ -f "$repo_root/.grok/config.toml" ]] || \
+      die "Grok development config not found: $repo_root/.grok/config.toml"
+    [[ -L "$grok_link" ]] || die "Grok development plugin link not found: $grok_link"
+    linked_plugin=$(cd -- "$(dirname -- "$grok_link")" && cd -- "$(readlink -- "$grok_link")" 2>/dev/null && pwd -P) || \
+      die "expected $grok_link to resolve to $plugin_root"
+    [[ "$linked_plugin" == "$plugin_root" ]] || \
+      die "expected $grok_link to resolve to $plugin_root"
+    exec grok --cwd "$repo_root" "$@"
+    ;;
+  *)
+    usage >&2
+    die "unknown host '$host' (expected claude, codex, or grok)"
+    ;;
+esac

--- a/scripts/rite-dev
+++ b/scripts/rite-dev
@@ -53,7 +53,8 @@ cd "$repo_root"
 case "$host" in
   claude)
     command -v claude >/dev/null 2>&1 || die "claude executable not found"
-    exec claude --plugin-dir "$plugin_root" "$@"
+    claude_settings='{"enabledPlugins":{"rite@rite-marketplace":false}}'
+    exec claude --settings "$claude_settings" --plugin-dir "$plugin_root" "$@"
     ;;
   codex)
     command -v codex >/dev/null 2>&1 || die "codex executable not found"

--- a/tests/rite-dev.test.sh
+++ b/tests/rite-dev.test.sh
@@ -100,8 +100,8 @@ RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" claude 'two word
 claude_log=$(<"$LOG")
 assert_contains 'Claude host 環境変数を設定' "$claude_log" 'RITE_HOST=claude'
 assert_contains 'Claude plugin root 環境変数を設定' "$claude_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
-assert_contains 'Claude はグローバル rite を無効化' "$claude_log" 'ARG={"enabledPlugins":{"rite@rite-marketplace":false}}'
-assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" "ARG=$REPO/plugins/rite"
+assert_contains 'Claude はグローバル rite を無効化' "$claude_log" $'ARG=--settings\nARG={"enabledPlugins":{"rite@rite-marketplace":false}}'
+assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" $'ARG=--plugin-dir\nARG='"$REPO/plugins/rite"
 assert_contains 'Claude の語境界を保持' "$claude_log" $'ARG=two words\nARG=tail'
 
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" codex 'two words' tail
@@ -109,6 +109,7 @@ codex_log=$(<"$LOG")
 assert_contains 'Codex host 環境変数を設定' "$codex_log" 'RITE_HOST=codex'
 assert_contains 'Codex plugin root 環境変数を設定' "$codex_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
 assert_contains 'Codex は分離 CODEX_HOME を使用' "$codex_log" "CODEX_HOME=$REPO/.codex-dev"
+assert_contains 'Codex は repository cwd を指定' "$codex_log" $'ARG=--cd\nARG='"$REPO"
 assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=tail'
 [[ -d "$REPO/.codex-dev/skills" && ! -L "$REPO/.codex-dev/skills" ]] && \
   pass 'Codex skills root は実ディレクトリ' || fail 'Codex skills root は実ディレクトリ'
@@ -121,7 +122,7 @@ RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" grok 'two words'
 grok_log=$(<"$LOG")
 assert_contains 'Grok host 環境変数を設定' "$grok_log" 'RITE_HOST=grok'
 assert_contains 'Grok plugin root 環境変数を設定' "$grok_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
-assert_contains 'Grok は repository cwd を指定' "$grok_log" "ARG=$REPO"
+assert_contains 'Grok は repository cwd を指定' "$grok_log" $'ARG=--cwd\nARG='"$REPO"
 assert_contains 'Grok の語境界を保持' "$grok_log" $'ARG=two words\nARG=tail'
 
 conflict_repo="$TEST_ROOT/conflict"

--- a/tests/rite-dev.test.sh
+++ b/tests/rite-dev.test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  ✅ %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  ❌ %s\n' "$1"
+}
+
+assert_eq() {
+  local label=$1 expected=$2 actual=$3
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected='$expected' actual='$actual')"
+  fi
+}
+
+assert_contains() {
+  local label=$1 haystack=$2 needle=$3
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$label"
+  else
+    fail "$label (missing '$needle')"
+  fi
+}
+
+make_repo() {
+  local repo=$1
+  mkdir -p "$repo/scripts" "$repo/plugins/rite/skills/open" "$repo/plugins/rite/skills/lint" \
+    "$repo/.grok/plugins"
+  cp "$SCRIPT_UNDER_TEST" "$repo/scripts/rite-dev"
+  chmod +x "$repo/scripts/rite-dev"
+  printf '%s\n' '---' 'name: open' '---' > "$repo/plugins/rite/skills/open/SKILL.md"
+  printf '%s\n' '---' 'name: lint' '---' > "$repo/plugins/rite/skills/lint/SKILL.md"
+  printf '[plugins]\n' > "$repo/.grok/config.toml"
+  ln -s ../../plugins/rite "$repo/.grok/plugins/rite"
+  git -C "$repo" init -q
+}
+
+make_host_stub() {
+  local bin=$1 host=$2
+  mkdir -p "$bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'printf "RITE_HOST=%s\n" "$RITE_HOST" > "$RITE_STUB_LOG"' \
+    'printf "RITE_PLUGIN_ROOT=%s\n" "$RITE_PLUGIN_ROOT" >> "$RITE_STUB_LOG"' \
+    'printf "CODEX_HOME=%s\n" "${CODEX_HOME:-}" >> "$RITE_STUB_LOG"' \
+    'printf "ARG=%s\n" "$@" >> "$RITE_STUB_LOG"' \
+    'if [[ ${RITE_HOST:-} == codex ]]; then mkdir -p "$CODEX_HOME/skills/.system"; fi' \
+    > "$bin/$host"
+  chmod +x "$bin/$host"
+}
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_UNDER_TEST=$(cd -- "$SCRIPT_DIR/.." && pwd)/scripts/rite-dev
+REPO="$TEST_ROOT/repo"
+BIN="$TEST_ROOT/bin"
+LOG="$TEST_ROOT/host.log"
+make_repo "$REPO"
+make_host_stub "$BIN" claude
+make_host_stub "$BIN" codex
+make_host_stub "$BIN" grok
+
+set +e
+no_arg_out=$(cd "$REPO" && "$REPO/scripts/rite-dev" 2>&1)
+no_arg_rc=$?
+unknown_out=$(cd "$REPO" && "$REPO/scripts/rite-dev" unknown 2>&1)
+unknown_rc=$?
+set -e
+assert_eq 'host 未指定は exit 2' 2 "$no_arg_rc"
+assert_contains 'host 未指定は usage を表示' "$no_arg_out" 'Usage: scripts/rite-dev'
+assert_eq '未対応 host は非ゼロ終了' 1 "$unknown_rc"
+assert_contains '未対応 host を診断' "$unknown_out" "unknown host 'unknown'"
+
+MISSING_BIN="$TEST_ROOT/missing-bin"
+mkdir -p "$MISSING_BIN"
+ln -s "$(command -v bash)" "$MISSING_BIN/bash"
+ln -s "$(command -v dirname)" "$MISSING_BIN/dirname"
+ln -s "$(command -v git)" "$MISSING_BIN/git"
+for missing_host in claude codex grok; do
+  set +e
+  missing_out=$(PATH="$MISSING_BIN" "$REPO/scripts/rite-dev" "$missing_host" 2>&1)
+  missing_rc=$?
+  set -e
+  assert_eq "$missing_host 不在は非ゼロ終了" 1 "$missing_rc"
+  assert_contains "$missing_host 不在を診断" "$missing_out" "$missing_host executable not found"
+done
+
+RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" claude 'two words' tail
+claude_log=$(<"$LOG")
+assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" "ARG=$REPO/plugins/rite"
+assert_contains 'Claude の語境界を保持' "$claude_log" $'ARG=two words\nARG=tail'
+
+RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" codex 'two words' tail
+codex_log=$(<"$LOG")
+assert_contains 'Codex は分離 CODEX_HOME を使用' "$codex_log" "CODEX_HOME=$REPO/.codex-dev"
+assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=tail'
+[[ -d "$REPO/.codex-dev/skills" && ! -L "$REPO/.codex-dev/skills" ]] && \
+  pass 'Codex skills root は実ディレクトリ' || fail 'Codex skills root は実ディレクトリ'
+[[ -L "$REPO/.codex-dev/skills/open" && -L "$REPO/.codex-dev/skills/lint" ]] && \
+  pass 'rite スキルを個別リンク' || fail 'rite スキルを個別リンク'
+[[ -d "$REPO/.codex-dev/skills/.system" && ! -e "$REPO/plugins/rite/skills/.system" ]] && \
+  pass 'Codex 管理物は配布ソースへ混入しない' || fail 'Codex 管理物は配布ソースへ混入しない'
+
+RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" grok 'two words' tail
+grok_log=$(<"$LOG")
+assert_contains 'Grok は repository cwd を指定' "$grok_log" "ARG=$REPO"
+assert_contains 'Grok の語境界を保持' "$grok_log" $'ARG=two words\nARG=tail'
+
+conflict_repo="$TEST_ROOT/conflict"
+make_repo "$conflict_repo"
+mkdir -p "$conflict_repo/.codex-dev/skills/open"
+printf 'keep\n' > "$conflict_repo/.codex-dev/skills/open/sentinel"
+set +e
+conflict_out=$(RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$conflict_repo/scripts/rite-dev" codex 2>&1)
+conflict_rc=$?
+set -e
+assert_eq '競合する Codex skill path は非ゼロ終了' 1 "$conflict_rc"
+assert_contains '競合する Codex skill path を診断' "$conflict_out" "$conflict_repo/.codex-dev/skills/open"
+[[ $(<"$conflict_repo/.codex-dev/skills/open/sentinel") == keep ]] && \
+  pass '競合 path を上書きしない' || fail '競合 path を上書きしない'
+
+bad_grok_repo="$TEST_ROOT/bad-grok"
+make_repo "$bad_grok_repo"
+mv "$bad_grok_repo/.grok/plugins/rite" "$bad_grok_repo/.grok/plugins/rite.original"
+ln -s ../wrong "$bad_grok_repo/.grok/plugins/rite"
+set +e
+bad_grok_out=$(RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$bad_grok_repo/scripts/rite-dev" grok 2>&1)
+bad_grok_rc=$?
+set -e
+assert_eq '誤った Grok plugin link は非ゼロ終了' 1 "$bad_grok_rc"
+assert_contains '誤った Grok plugin link を診断' "$bad_grok_out" "$bad_grok_repo/.grok/plugins/rite"
+[[ $(readlink "$bad_grok_repo/.grok/plugins/rite") == ../wrong ]] && \
+  pass '誤った Grok plugin link を上書きしない' || fail '誤った Grok plugin link を上書きしない'
+
+printf '\nPASS: %d, FAIL: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/rite-dev.test.sh
+++ b/tests/rite-dev.test.sh
@@ -98,11 +98,16 @@ done
 
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" claude 'two words' tail
 claude_log=$(<"$LOG")
+assert_contains 'Claude host 環境変数を設定' "$claude_log" 'RITE_HOST=claude'
+assert_contains 'Claude plugin root 環境変数を設定' "$claude_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
+assert_contains 'Claude はグローバル rite を無効化' "$claude_log" 'ARG={"enabledPlugins":{"rite@rite-marketplace":false}}'
 assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" "ARG=$REPO/plugins/rite"
 assert_contains 'Claude の語境界を保持' "$claude_log" $'ARG=two words\nARG=tail'
 
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" codex 'two words' tail
 codex_log=$(<"$LOG")
+assert_contains 'Codex host 環境変数を設定' "$codex_log" 'RITE_HOST=codex'
+assert_contains 'Codex plugin root 環境変数を設定' "$codex_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
 assert_contains 'Codex は分離 CODEX_HOME を使用' "$codex_log" "CODEX_HOME=$REPO/.codex-dev"
 assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=tail'
 [[ -d "$REPO/.codex-dev/skills" && ! -L "$REPO/.codex-dev/skills" ]] && \
@@ -114,6 +119,8 @@ assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=
 
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" grok 'two words' tail
 grok_log=$(<"$LOG")
+assert_contains 'Grok host 環境変数を設定' "$grok_log" 'RITE_HOST=grok'
+assert_contains 'Grok plugin root 環境変数を設定' "$grok_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
 assert_contains 'Grok は repository cwd を指定' "$grok_log" "ARG=$REPO"
 assert_contains 'Grok の語境界を保持' "$grok_log" $'ARG=two words\nARG=tail'
 


### PR DESCRIPTION
## 概要

Claude Code・Codex・Grok Build から同じ入口で作業ツリー版 rite を起動できる開発ランチャーを追加します。ホストごとのグローバル環境は変更せず、Codex の可変管理データも配布スキルから分離します。

## 関連 Issue

Closes #2177

## 変更内容

- `scripts/rite-dev`: 3ホストの選択、環境変数、引数転送、競合検出を実装
- `tests/rite-dev.test.sh`: 正常系・異常系・引数境界・Codex 非汚染を25件で検証
- `CONTRIBUTING.md`: 統一ランチャーとホスト別分離方式を文書化
- `.gitignore`: Codex のリポジトリローカルプロファイルを除外

## 未完了の Issue チェック項目

- [ ] `/rite:pr-review` の品質ゲートを通過する

レビューは後続の `/rite:iterate` で実施します。

## 既知事項

- プロジェクト共通 lint コマンドは未設定
- 実装固有テスト 25/25、`bash -n`、`git diff --check` は成功

## チェックリスト

- [x] プロジェクト規約に従っている
- [x] 実装固有テストが成功している
- [x] 関連ドキュメントを更新した

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
