### PR TITLE
feat(hooks): bash-guard の deny 判定を監査ログへ永続化

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -757,6 +757,9 @@ fi
 # Log block event (stderr + deny-only persistent audit trail)
 CMD_SUMMARY="${COMMAND:0:80}"
 CMD_SUMMARY="${CMD_SUMMARY//\"/\\\"}"
+# Keep one deny event on one physical line. Without this normalization a
+# multiline command could forge a second audit record.
+CMD_SUMMARY=$(printf '%s' "$CMD_SUMMARY" | neutralize_ctrl --c0-only)
 BLOCK_EVENT="[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PATTERN cmd=\"$CMD_SUMMARY\""
 echo "$BLOCK_EVENT" >&2
 

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -754,10 +754,23 @@ if [ -z "$BLOCKED_PATTERN" ]; then
   exit 0
 fi
 
-# Log block event (stderr, for effect measurement)
+# Log block event (stderr + deny-only persistent audit trail)
 CMD_SUMMARY="${COMMAND:0:80}"
 CMD_SUMMARY="${CMD_SUMMARY//\"/\\\"}"
-echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PATTERN cmd=\"$CMD_SUMMARY\"" >&2
+BLOCK_EVENT="[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PATTERN cmd=\"$CMD_SUMMARY\""
+echo "$BLOCK_EVENT" >&2
+
+# Auditing must never interfere with the guard's primary deny contract. Resolve
+# the shared state root when no explicit test/runtime override is present, then
+# make directory creation and append one best-effort operation.
+_audit_root="${RITE_STATE_ROOT:-}"
+if [ -z "$_audit_root" ]; then
+  _audit_root=$(bash "$SCRIPT_DIR/state-path-resolve.sh" 2>/dev/null) || _audit_root=""
+fi
+_audit_log="${_audit_root:+$_audit_root/}.rite/logs/bash-guard.log"
+if ! { mkdir -p "$(dirname "$_audit_log")" && printf '%s\n' "$BLOCK_EVENT" >> "$_audit_log"; } 2>/dev/null; then
+  echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: WARNING: unable to append deny audit log: $_audit_log" >&2
+fi
 
 # Deny with reason and alternative. jq is required to emit the final permission
 # payload; an intermittent jq failure here would silently downgrade the deny to

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -757,9 +757,10 @@ fi
 # Log block event (stderr + deny-only persistent audit trail)
 CMD_SUMMARY="${COMMAND:0:80}"
 CMD_SUMMARY="${CMD_SUMMARY//\"/\\\"}"
-# Keep one deny event on one physical line. Without this normalization a
-# multiline command could forge a second audit record.
-CMD_SUMMARY=$(printf '%s' "$CMD_SUMMARY" | neutralize_ctrl --c0-only)
+# Keep one deny event on one physical line. Use built-in substitutions here so
+# the deny path remains independent from the JSON fallback helper.
+CMD_SUMMARY="${CMD_SUMMARY//$'\n'/?}"
+CMD_SUMMARY="${CMD_SUMMARY//$'\r'/?}"
 BLOCK_EVENT="[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PATTERN cmd=\"$CMD_SUMMARY\""
 echo "$BLOCK_EVENT" >&2
 

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2046,7 +2046,7 @@ fi
 RITE_STATE_ROOT="$_audit_tmp" jq -n --arg cmd $'gh pr diff 99 --stat\n[2099-01-01T00:00:00Z] bash-guard: BLOCKED pattern=forged' \
   '{tool_name:"Bash",tool_input:{command:$cmd}}' \
   | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" >/dev/null 2>/dev/null || true
-if [ "$(wc -l < "$_audit_tmp/.rite/logs/bash-guard.log")" = "2" ] \
+if [ "$(awk 'END { print NR }' "$_audit_tmp/.rite/logs/bash-guard.log")" = "2" ] \
   && ! grep -q '^\[2099-01-01T00:00:00Z\]' "$_audit_tmp/.rite/logs/bash-guard.log"; then
   pass "TC-141 multiline commands cannot forge additional audit records"
 else

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2026,6 +2026,56 @@ rm -rf "$_mrg_tmp"
 echo ""
 
 # --------------------------------------------------------------------------
+# Issue #2174: persist deny-only audit records
+# --------------------------------------------------------------------------
+
+echo "TC-141 / T-01 (#2174): deny appends the stderr event to bash-guard.log"
+_audit_tmp=$(mktemp -d)
+rc=0
+RITE_STATE_ROOT="$_audit_tmp" jq -n --arg cmd "gh pr diff 99 --stat" \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" >/dev/null 2>"$_audit_tmp/stderr" || rc=$?
+if [ "$rc" = "0" ] \
+  && [ -f "$_audit_tmp/.rite/logs/bash-guard.log" ] \
+  && grep -q 'bash-guard: BLOCKED pattern=gh-pr-diff-stat' "$_audit_tmp/.rite/logs/bash-guard.log" \
+  && cmp -s "$_audit_tmp/stderr" "$_audit_tmp/.rite/logs/bash-guard.log"; then
+  pass "TC-141 deny audit record matches the existing stderr event"
+else
+  fail "TC-141 expected matching deny audit record (rc=$rc)"
+fi
+rm -rf "$_audit_tmp"
+echo ""
+
+echo "TC-142 / T-02 (#2174): audit write failure preserves deny JSON and warns"
+_audit_tmp=$(mktemp -d)
+mkdir -p "$_audit_tmp/.rite"
+printf 'not-a-directory\n' > "$_audit_tmp/.rite/logs"
+rc=0
+output=$(jq -n --arg cmd "gh pr diff 99 --stat" \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" 2>"$_audit_tmp/stderr") || rc=$?
+decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+if [ "$decision" = "deny" ] && grep -q 'WARNING: unable to append deny audit log' "$_audit_tmp/stderr"; then
+  pass "TC-142 deny contract survives audit write failure with one WARNING"
+else
+  fail "TC-142 expected deny + audit WARNING, got decision=$decision rc=$rc stderr=$(cat -v "$_audit_tmp/stderr")"
+fi
+rm -rf "$_audit_tmp"
+echo ""
+
+echo "TC-143 / T-03 (#2174): allow does not create an audit log"
+_audit_tmp=$(mktemp -d)
+jq -n --arg cmd "printf safe" '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" >/dev/null 2>"$_audit_tmp/stderr" || true
+if [ ! -e "$_audit_tmp/.rite/logs/bash-guard.log" ]; then
+  pass "TC-143 allow path writes no audit record"
+else
+  fail "TC-143 allow path unexpectedly created bash-guard.log"
+fi
+rm -rf "$_audit_tmp"
+echo ""
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2043,6 +2043,15 @@ if [ "$rc" = "0" ] \
 else
   fail "TC-141 expected matching deny audit record (rc=$rc)"
 fi
+RITE_STATE_ROOT="$_audit_tmp" jq -n --arg cmd $'gh pr diff 99 --stat\n[2099-01-01T00:00:00Z] bash-guard: BLOCKED pattern=forged' \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" >/dev/null 2>/dev/null || true
+if [ "$(wc -l < "$_audit_tmp/.rite/logs/bash-guard.log")" = "2" ] \
+  && ! grep -q '^\[2099-01-01T00:00:00Z\]' "$_audit_tmp/.rite/logs/bash-guard.log"; then
+  pass "TC-141 multiline commands cannot forge additional audit records"
+else
+  fail "TC-141 multiline command broke the one-event-per-line audit contract"
+fi
 rm -rf "$_audit_tmp"
 echo ""
 


### PR DESCRIPTION
## 概要

bash guard の deny 判定を `.rite/logs/bash-guard.log` に追記し、事後監査できるようにします。

Closes #2174

## 変更内容

- 既存 stderr イベントと同内容の deny-only 監査レコードを追記
- ログ作成・追記失敗時も deny JSON を維持し WARNING を出力
- deny、書込失敗、allow 無記録の回帰テストを追加

## チェックリスト

- [x] bash guard テスト（242件）
- [x] `git diff --check`
- [x] bang-backtick gate
