### PR TITLE
fix(hooks): 孤児 review JSON と run-start pin を機械回収

### DIFF
--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -1467,7 +1467,7 @@ if [ "$review_gc_safe" -eq 1 ] && [ -d "$review_dir" ]; then
     case "$review_pr" in ''|*[!0-9]*) continue ;; esac
     case "$active_prs" in *$'\n'"$review_pr"$'\n'*) continue ;; esac
 
-    if nb_count=$(jq -er '(.non_blocking_count // .metrics.non_blocking_count // 0) as $n | if ($n|type)=="number" and ($n|floor)==$n and $n>=0 then $n else error("invalid non_blocking_count") end' "$review_file" 2>/dev/null); then
+    if nb_count=$(jq -er '(.non_blocking_findings // []) as $items | if ($items|type)=="array" then ($items|length) else error("invalid non_blocking_findings") end' "$review_file" 2>/dev/null); then
       :
     else
       echo "WARNING: review JSON '$(printf '%s' "$review_file" | neutralize_ctrl)' を解析できないため保持します" >&2

--- a/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
+++ b/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh
@@ -143,6 +143,9 @@ mutation_worktrees_reaped=0
 session_worktrees_reaped=0
 session_branches_deleted=0
 manifest_reaped=0
+orphan_reviews_deleted=0
+orphan_reviews_archived=0
+orphan_review_pins_deleted=0
 errors=0
 
 # trap + cleanup パターン (canonical: references/bash-trap-patterns.md#signal-specific-trap-template)
@@ -1427,16 +1430,102 @@ if [ -d "$session_wt_root" ]; then
 fi
 
 # -----------------------------------------------------------------------
+# Step 6: Reap orphaned review results and run-start pins.
+# Active flow-state PRs are protected. If any flow-state cannot be read, skip
+# this entire step: an incomplete active set is not safe enough for deletion.
+# -----------------------------------------------------------------------
+review_dir="$repo_root/.rite/review-results"
+session_dir="$repo_root/.rite/sessions"
+active_prs=$'\n'
+review_gc_safe=1
+if [ -d "$session_dir" ]; then
+  while IFS= read -r state_file; do
+    [ -n "$state_file" ] || continue
+    if state_pair=$(jq -r '[.active // false, .pr_number // 0] | @tsv' "$state_file" 2>/dev/null); then
+      state_active=${state_pair%%$'\t'*}
+      state_pr=${state_pair#*$'\t'}
+      if [ "$state_active" = "true" ]; then
+        case "$state_pr" in
+          ''|0|*[!0-9]*) ;;
+          *) active_prs="${active_prs}${state_pr}"$'\n' ;;
+        esac
+      fi
+    else
+      echo "WARNING: flow-state '$(printf '%s' "$state_file" | neutralize_ctrl)' の読取に失敗したため orphan review 回収をスキップします" >&2
+      review_gc_safe=0
+      break
+    fi
+  done < <(find "$session_dir" -maxdepth 1 -type f -name '*.flow-state' -print 2>/dev/null)
+fi
+
+if [ "$review_gc_safe" -eq 1 ] && [ -d "$review_dir" ]; then
+  archive_dir="$review_dir/archive"
+  while IFS= read -r review_file; do
+    [ -n "$review_file" ] || continue
+    review_name=${review_file##*/}
+    review_pr=${review_name%%-*}
+    case "$review_pr" in ''|*[!0-9]*) continue ;; esac
+    case "$active_prs" in *$'\n'"$review_pr"$'\n'*) continue ;; esac
+
+    if nb_count=$(jq -er '(.non_blocking_count // .metrics.non_blocking_count // 0) as $n | if ($n|type)=="number" and ($n|floor)==$n and $n>=0 then $n else error("invalid non_blocking_count") end' "$review_file" 2>/dev/null); then
+      :
+    else
+      echo "WARNING: review JSON '$(printf '%s' "$review_file" | neutralize_ctrl)' を解析できないため保持します" >&2
+      continue
+    fi
+
+    if [ "$DRY_RUN" = "1" ]; then
+      if [ "$nb_count" -gt 0 ]; then
+        echo "[dry-run] would archive orphan review JSON: $review_name"
+      else
+        echo "[dry-run] would delete orphan review JSON: $review_name"
+      fi
+      continue
+    fi
+
+    if [ "$nb_count" -gt 0 ]; then
+      if [ -e "$archive_dir/$review_name" ] || [ -L "$archive_dir/$review_name" ]; then
+        echo "WARNING: orphan review JSON '$review_name' の archive 先が既に存在するため元ファイルを保持します" >&2
+        errors=$((errors + 1))
+        continue
+      elif mkdir -p "$archive_dir" 2>/dev/null && mv "$review_file" "$archive_dir/$review_name" 2>/dev/null; then
+        orphan_reviews_archived=$((orphan_reviews_archived + 1))
+      else
+        echo "WARNING: orphan review JSON '$review_name' の archive に失敗したため元ファイルを保持します" >&2
+        errors=$((errors + 1))
+        continue
+      fi
+    elif rm -f "$review_file" 2>/dev/null; then
+      orphan_reviews_deleted=$((orphan_reviews_deleted + 1))
+    else
+      echo "WARNING: orphan review JSON '$review_name' の削除に失敗しました" >&2
+      errors=$((errors + 1))
+      continue
+    fi
+
+    pin_file="$repo_root/.rite/state/review-run-since-${review_pr}.txt"
+    if [ -e "$pin_file" ] || [ -L "$pin_file" ]; then
+      if rm -f "$pin_file" 2>/dev/null; then
+        orphan_review_pins_deleted=$((orphan_review_pins_deleted + 1))
+      else
+        echo "WARNING: orphan review pin '$(printf '%s' "$pin_file" | neutralize_ctrl)' の削除に失敗しました" >&2
+        errors=$((errors + 1))
+      fi
+    fi
+  done < <(find "$review_dir" -maxdepth 1 -type f -name '[0-9]*-*.json' -print 2>/dev/null)
+fi
+
+# -----------------------------------------------------------------------
 # Status line
 # -----------------------------------------------------------------------
 if [ "$DRY_RUN" = "1" ]; then
   echo "[pr-cycle-cleanup] status=dry-run; pattern=$PATTERN"
 elif [ "$errors" -gt 0 ]; then
-  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped; errors=$errors"
-elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ] && [ "$session_branches_deleted" -eq 0 ] && [ "$manifest_reaped" -eq 0 ]; then
-  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0; session_branches=0; manifest=0"
+  echo "[pr-cycle-cleanup] status=failed; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped; orphan_reviews_deleted=$orphan_reviews_deleted; orphan_reviews_archived=$orphan_reviews_archived; orphan_review_pins=$orphan_review_pins_deleted; errors=$errors"
+elif [ "$worktrees_removed" -eq 0 ] && [ "$branches_deleted" -eq 0 ] && [ "$workdirs_reaped" -eq 0 ] && [ "$mutation_worktrees_reaped" -eq 0 ] && [ "$session_worktrees_reaped" -eq 0 ] && [ "$session_branches_deleted" -eq 0 ] && [ "$manifest_reaped" -eq 0 ] && [ "$orphan_reviews_deleted" -eq 0 ] && [ "$orphan_reviews_archived" -eq 0 ] && [ "$orphan_review_pins_deleted" -eq 0 ]; then
+  echo "[pr-cycle-cleanup] status=noop; worktrees=0; branches=0; workdirs=0; mutation_worktrees=0; session_worktrees=0; session_branches=0; manifest=0; orphan_reviews_deleted=0; orphan_reviews_archived=0; orphan_review_pins=0"
 else
-  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped"
+  echo "[pr-cycle-cleanup] status=cleaned; worktrees=$worktrees_removed; branches=$branches_deleted; workdirs=$workdirs_reaped; mutation_worktrees=$mutation_worktrees_reaped; session_worktrees=$session_worktrees_reaped; session_branches=$session_branches_deleted; manifest=$manifest_reaped; orphan_reviews_deleted=$orphan_reviews_deleted; orphan_reviews_archived=$orphan_reviews_archived; orphan_review_pins=$orphan_review_pins_deleted"
 fi
 
 exit 0

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -1195,6 +1195,36 @@ fi
 cleanup_temp_repo "$TEST_REPO"
 
 # -----------------------------------------------------------------------
+# T-38..42: orphan review JSON / run-start pin machine cleanup (#2175)
+# -----------------------------------------------------------------------
+echo "T-38..42: orphan review JSON / pin cleanup"
+TEST_REPO=$(make_temp_repo)
+mkdir -p "$TEST_REPO/.rite/review-results" "$TEST_REPO/.rite/sessions" "$TEST_REPO/.rite/state"
+printf '{"active":true,"pr_number":700}\n' > "$TEST_REPO/.rite/sessions/live.flow-state"
+printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/701-clean.json"
+printf '{"non_blocking_count":2}\n' > "$TEST_REPO/.rite/review-results/702-notes.json"
+printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/700-active.json"
+printf 'broken\n' > "$TEST_REPO/.rite/review-results/703-broken.json"
+printf '701-clean.json\n' > "$TEST_REPO/.rite/state/review-run-since-701.txt"
+printf '700-active.json\n' > "$TEST_REPO/.rite/state/review-run-since-700.txt"
+t38_output=$(cd "$TEST_REPO" && bash "$CLEANUP" 2>&1)
+if [ ! -e "$TEST_REPO/.rite/review-results/701-clean.json" ] && [ ! -e "$TEST_REPO/.rite/state/review-run-since-701.txt" ]; then pass "T-38 orphan nb=0 JSON + pin deleted"; else fail "T-38 orphan nb=0 residue remained"; fi
+if [ -e "$TEST_REPO/.rite/review-results/archive/702-notes.json" ] && [ ! -e "$TEST_REPO/.rite/review-results/702-notes.json" ]; then pass "T-39 orphan nb>0 JSON archived"; else fail "T-39 nb>0 JSON not archived"; fi
+if [ -e "$TEST_REPO/.rite/review-results/700-active.json" ] && [ -e "$TEST_REPO/.rite/state/review-run-since-700.txt" ]; then pass "T-40 active PR artifacts protected"; else fail "T-40 active PR artifacts changed"; fi
+if [ -e "$TEST_REPO/.rite/review-results/703-broken.json" ] && echo "$t38_output" | grep -q '解析できない'; then pass "T-41 malformed JSON protected with WARNING"; else fail "T-41 malformed JSON was not safely surfaced"; fi
+if echo "$t38_output" | grep -q 'orphan_reviews_deleted=1' && echo "$t38_output" | grep -q 'orphan_reviews_archived=1' && echo "$t38_output" | grep -q 'orphan_review_pins=1'; then pass "T-42 cleanup counters observable"; else fail "T-42 counters missing: $t38_output"; fi
+cleanup_temp_repo "$TEST_REPO"
+
+echo "T-43: unreadable flow-state skips orphan review cleanup"
+TEST_REPO=$(make_temp_repo)
+mkdir -p "$TEST_REPO/.rite/review-results" "$TEST_REPO/.rite/sessions"
+printf 'broken\n' > "$TEST_REPO/.rite/sessions/broken.flow-state"
+printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/704-clean.json"
+t43_output=$(cd "$TEST_REPO" && bash "$CLEANUP" 2>&1)
+if [ -e "$TEST_REPO/.rite/review-results/704-clean.json" ] && echo "$t43_output" | grep -q '回収をスキップ'; then pass "T-43 unreadable flow-state fails safe"; else fail "T-43 flow-state failure did not protect review JSON"; fi
+cleanup_temp_repo "$TEST_REPO"
+
+# -----------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------
 echo

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup.test.sh
@@ -1201,9 +1201,9 @@ echo "T-38..42: orphan review JSON / pin cleanup"
 TEST_REPO=$(make_temp_repo)
 mkdir -p "$TEST_REPO/.rite/review-results" "$TEST_REPO/.rite/sessions" "$TEST_REPO/.rite/state"
 printf '{"active":true,"pr_number":700}\n' > "$TEST_REPO/.rite/sessions/live.flow-state"
-printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/701-clean.json"
-printf '{"non_blocking_count":2}\n' > "$TEST_REPO/.rite/review-results/702-notes.json"
-printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/700-active.json"
+printf '{"non_blocking_findings":[]}\n' > "$TEST_REPO/.rite/review-results/701-clean.json"
+printf '{"non_blocking_findings":[{"id":"F-01"},{"id":"F-02"}]}\n' > "$TEST_REPO/.rite/review-results/702-notes.json"
+printf '{"non_blocking_findings":[]}\n' > "$TEST_REPO/.rite/review-results/700-active.json"
 printf 'broken\n' > "$TEST_REPO/.rite/review-results/703-broken.json"
 printf '701-clean.json\n' > "$TEST_REPO/.rite/state/review-run-since-701.txt"
 printf '700-active.json\n' > "$TEST_REPO/.rite/state/review-run-since-700.txt"
@@ -1219,7 +1219,7 @@ echo "T-43: unreadable flow-state skips orphan review cleanup"
 TEST_REPO=$(make_temp_repo)
 mkdir -p "$TEST_REPO/.rite/review-results" "$TEST_REPO/.rite/sessions"
 printf 'broken\n' > "$TEST_REPO/.rite/sessions/broken.flow-state"
-printf '{"non_blocking_count":0}\n' > "$TEST_REPO/.rite/review-results/704-clean.json"
+printf '{"non_blocking_findings":[]}\n' > "$TEST_REPO/.rite/review-results/704-clean.json"
 t43_output=$(cd "$TEST_REPO" && bash "$CLEANUP" 2>&1)
 if [ -e "$TEST_REPO/.rite/review-results/704-clean.json" ] && echo "$t43_output" | grep -q '回収をスキップ'; then pass "T-43 unreadable flow-state fails safe"; else fail "T-43 flow-state failure did not protect review JSON"; fi
 cleanup_temp_repo "$TEST_REPO"


### PR DESCRIPTION
## 概要

active な flow-state に紐づかない review artifacts を `pr-cycle-cleanup.sh` が安全に回収します。

Closes #2175

## 変更内容

- nb=0 の孤児 review JSON と対応pinを削除
- nb>0 の孤児 JSON を archive へ保全
- active PR、parse不能JSON、flow-state判定不能時をfail-safeで保護
- 回収カウンタと回帰テストを追加

## チェックリスト

- [x] pr-cycle-cleanup tests: 45 passed
- [x] bash syntax / diff check
- [x] 対象外ファイル未変更
