### PR TITLE
chore(ci,dev): rite-dev テストをCI配線し物理パス照合へ統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
         shell: bash
         run: bash plugins/rite/scripts/tests/run-all.sh 2>&1 | tee scripts-tests.log
 
+      - name: Run rite-dev launcher test suite
+        shell: bash
+        run: bash tests/rite-dev.test.sh 2>&1 | tee rite-dev-tests.log
+
       # SHOULD (Issue #2002 AC-5): surface which tests failed and on which OS in
       # the job summary. Runs only when a preceding step failed.
       - name: Summarize test failures
@@ -113,7 +117,7 @@ jobs:
           set +e
           {
             echo "### ❌ Test failures — ${{ matrix.os }}"
-            for log in hooks-tests.log scripts-tests.log; do
+            for log in hooks-tests.log scripts-tests.log rite-dev-tests.log; do
               [ -f "$log" ] || continue
               echo "<details><summary>$log</summary>"
               echo ""

--- a/scripts/rite-dev
+++ b/scripts/rite-dev
@@ -38,9 +38,11 @@ fi
 host=$1
 shift
 
-script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 repo_root=$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null) || \
   die "scripts/rite-dev must be run from a git checkout"
+repo_root=$(cd -- "$repo_root" && pwd -P) || \
+  die "scripts/rite-dev could not resolve the physical repository path"
 plugin_root="$repo_root/plugins/rite"
 
 [[ -d "$plugin_root/skills" ]] || \

--- a/tests/rite-dev.test.sh
+++ b/tests/rite-dev.test.sh
@@ -118,6 +118,24 @@ assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=
 [[ -d "$REPO/.codex-dev/skills/.system" && ! -e "$REPO/plugins/rite/skills/.system" ]] && \
   pass 'Codex 管理物は配布ソースへ混入しない' || fail 'Codex 管理物は配布ソースへ混入しない'
 
+repo_link="$TEST_ROOT/repo-link"
+ln -s "$REPO" "$repo_link"
+RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$repo_link/scripts/rite-dev" codex
+symlink_codex_log=$(<"$LOG")
+assert_contains 'symlink checkout 経由でも Codex 照合が成立' "$symlink_codex_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
+assert_contains 'symlink checkout 経由でも物理 repository cwd を指定' "$symlink_codex_log" $'ARG=--cd\nARG='"$REPO"
+
+wrong_link_repo="$TEST_ROOT/wrong-link"
+make_repo "$wrong_link_repo"
+mkdir -p "$wrong_link_repo/.codex-dev/skills" "$wrong_link_repo/unrelated/open"
+ln -s "$wrong_link_repo/unrelated/open" "$wrong_link_repo/.codex-dev/skills/open"
+set +e
+wrong_link_out=$(RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$wrong_link_repo/scripts/rite-dev" codex 2>&1)
+wrong_link_rc=$?
+set -e
+assert_eq '異実体 Codex skill link は非ゼロ終了' 1 "$wrong_link_rc"
+assert_contains '異実体 Codex skill link を診断' "$wrong_link_out" "$wrong_link_repo/.codex-dev/skills/open"
+
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" grok 'two words' tail
 grok_log=$(<"$LOG")
 assert_contains 'Grok host 環境変数を設定' "$grok_log" 'RITE_HOST=grok'

--- a/tests/rite-dev.test.sh
+++ b/tests/rite-dev.test.sh
@@ -67,6 +67,7 @@ REPO="$TEST_ROOT/repo"
 BIN="$TEST_ROOT/bin"
 LOG="$TEST_ROOT/host.log"
 make_repo "$REPO"
+REPO_PHYS=$(cd -- "$REPO" && pwd -P)
 make_host_stub "$BIN" claude
 make_host_stub "$BIN" codex
 make_host_stub "$BIN" grok
@@ -99,17 +100,17 @@ done
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" claude 'two words' tail
 claude_log=$(<"$LOG")
 assert_contains 'Claude host 環境変数を設定' "$claude_log" 'RITE_HOST=claude'
-assert_contains 'Claude plugin root 環境変数を設定' "$claude_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
+assert_contains 'Claude plugin root 環境変数を設定' "$claude_log" "RITE_PLUGIN_ROOT=$REPO_PHYS/plugins/rite"
 assert_contains 'Claude はグローバル rite を無効化' "$claude_log" $'ARG=--settings\nARG={"enabledPlugins":{"rite@rite-marketplace":false}}'
-assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" $'ARG=--plugin-dir\nARG='"$REPO/plugins/rite"
+assert_contains 'Claude は作業ツリープラグインを指定' "$claude_log" $'ARG=--plugin-dir\nARG='"$REPO_PHYS/plugins/rite"
 assert_contains 'Claude の語境界を保持' "$claude_log" $'ARG=two words\nARG=tail'
 
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" codex 'two words' tail
 codex_log=$(<"$LOG")
 assert_contains 'Codex host 環境変数を設定' "$codex_log" 'RITE_HOST=codex'
-assert_contains 'Codex plugin root 環境変数を設定' "$codex_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
-assert_contains 'Codex は分離 CODEX_HOME を使用' "$codex_log" "CODEX_HOME=$REPO/.codex-dev"
-assert_contains 'Codex は repository cwd を指定' "$codex_log" $'ARG=--cd\nARG='"$REPO"
+assert_contains 'Codex plugin root 環境変数を設定' "$codex_log" "RITE_PLUGIN_ROOT=$REPO_PHYS/plugins/rite"
+assert_contains 'Codex は分離 CODEX_HOME を使用' "$codex_log" "CODEX_HOME=$REPO_PHYS/.codex-dev"
+assert_contains 'Codex は repository cwd を指定' "$codex_log" $'ARG=--cd\nARG='"$REPO_PHYS"
 assert_contains 'Codex の語境界を保持' "$codex_log" $'ARG=two words\nARG=tail'
 [[ -d "$REPO/.codex-dev/skills" && ! -L "$REPO/.codex-dev/skills" ]] && \
   pass 'Codex skills root は実ディレクトリ' || fail 'Codex skills root は実ディレクトリ'
@@ -122,8 +123,8 @@ repo_link="$TEST_ROOT/repo-link"
 ln -s "$REPO" "$repo_link"
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$repo_link/scripts/rite-dev" codex
 symlink_codex_log=$(<"$LOG")
-assert_contains 'symlink checkout 経由でも Codex 照合が成立' "$symlink_codex_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
-assert_contains 'symlink checkout 経由でも物理 repository cwd を指定' "$symlink_codex_log" $'ARG=--cd\nARG='"$REPO"
+assert_contains 'symlink checkout 経由でも Codex 照合が成立' "$symlink_codex_log" "RITE_PLUGIN_ROOT=$REPO_PHYS/plugins/rite"
+assert_contains 'symlink checkout 経由でも物理 repository cwd を指定' "$symlink_codex_log" $'ARG=--cd\nARG='"$REPO_PHYS"
 
 wrong_link_repo="$TEST_ROOT/wrong-link"
 make_repo "$wrong_link_repo"
@@ -139,8 +140,8 @@ assert_contains '異実体 Codex skill link を診断' "$wrong_link_out" "$wrong
 RITE_STUB_LOG="$LOG" PATH="$BIN:$PATH" "$REPO/scripts/rite-dev" grok 'two words' tail
 grok_log=$(<"$LOG")
 assert_contains 'Grok host 環境変数を設定' "$grok_log" 'RITE_HOST=grok'
-assert_contains 'Grok plugin root 環境変数を設定' "$grok_log" "RITE_PLUGIN_ROOT=$REPO/plugins/rite"
-assert_contains 'Grok は repository cwd を指定' "$grok_log" $'ARG=--cwd\nARG='"$REPO"
+assert_contains 'Grok plugin root 環境変数を設定' "$grok_log" "RITE_PLUGIN_ROOT=$REPO_PHYS/plugins/rite"
+assert_contains 'Grok は repository cwd を指定' "$grok_log" $'ARG=--cwd\nARG='"$REPO_PHYS"
 assert_contains 'Grok の語境界を保持' "$grok_log" $'ARG=two words\nARG=tail'
 
 conflict_repo="$TEST_ROOT/conflict"


### PR DESCRIPTION
## 概要

rite-dev launcher suiteをUbuntu/macOS CIへ配線し、symlink成分を含むcheckoutでも物理パス同士で検証します。

Closes #2179

## 変更内容

- CIにpipefail有効のrite-dev test stepを追加
- repository/plugin基準パスを`pwd -P`で物理正規化
- symlink checkout成功と異実体link拒否の回帰テストを追加

## チェックリスト

- [x] rite-dev tests: 37 passed
- [x] git diff check
- [x] 実hostバイナリ不要のstub testを維持
