### PR TITLE
chore(review): レビュー・修正ループの昇格知見を機構化

### DIFF
--- a/plugins/rite/agents/error-handling-reviewer.md
+++ b/plugins/rite/agents/error-handling-reviewer.md
@@ -35,6 +35,7 @@ For each error handler identified in Step 1:
 - **Catch specificity**: Is the catch narrowed to the expected error type, or does it catch all exceptions?
 - **Fallback behavior**: If a default value is returned, is the caller aware that the primary operation failed?
 - **Error propagation**: If the error is re-thrown, is the original cause preserved?
+- **Regression proof for newly added paths**: When the diff introduces a fallback, WARNING, catch/else branch, or other error path, verify that a test enters that exact branch, asserts its observable outcome, and fails when the pre-fix behavior is restored (or an equivalent mutation is applied). Report missing proof as a current-PR finding. See `skills/pr-review/references/promotion-audit-2091.md#new-error-path-regression-gate`.
 
 ### Step 3: Error Message Inspection
 

--- a/plugins/rite/agents/test-reviewer.md
+++ b/plugins/rite/agents/test-reviewer.md
@@ -39,6 +39,7 @@ For each test in the diff:
 For each tested function:
 - Are boundary values tested (empty arrays, zero, null, max values)?
 - Are error paths tested (network failures, invalid input, permission denied)?
+- If the fix adds a fallback, WARNING, catch/else branch, or other error path, require a regression test that enters that exact new branch and asserts the observable outcome. Require a non-vacuity check: reverting the fix (or applying an equivalent mutation) must make the new test fail. See `skills/pr-review/references/promotion-audit-2091.md#new-error-path-regression-gate`.
 - `Grep` for similar test patterns in the codebase to verify consistency of edge case coverage
 
 ### Step 4: Test Isolation and Reliability

--- a/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
@@ -30,7 +30,8 @@ assert_grep 'error-path regression mechanized' "$audit" '| `bugfix-new-error-pat
 
 assert_grep 'scope split detects both scopes' "$review" 'same root cause is assigned both `current-pr` and `follow-up` scope'
 assert_grep 'scope split forbids mechanical collapse' "$review" 'severity の高い側・多数派へ機械統合しない'
-assert_grep 'scope split uses debate first' "$review" 'debate で consensus に至らなければ treatment をユーザーへエスカレート'
+assert_grep 'scope split uses debate for analysis' "$review" 'debate は論点整理と推奨 disposition の生成に使う'
+assert_grep 'scope split always escalates' "$review" 'consensus の有無にかかわらず treatment の最終決定は AskUserQuestion'
 assert_grep 'scope split records decision' "$review" '選択した disposition を Decision Log に記録する'
 assert_grep 'follow-up semantics preserved' "$review" 'durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない'
 assert_grep 'rejection evidence gate wired' "$fix" 'Rejection Evidence Gate (state mutation 前)'
@@ -41,6 +42,15 @@ assert_grep 'counterfactual evidence required' "$fix" 'empirical counterfactual/
 assert_grep 'both rejection artifacts required' "$fix" '両方の artifact を Decision Log に記録する'
 assert_grep 'invalid rejection cannot mutate' "$fix" '`status = acknowledged` override・reply・fingerprint block・commit trailer の**いずれにも到達せず**'
 assert_grep 'user override is not bypass' "$fix" '`user-override` も evidence gate の例外ではない'
+assert_grep 'rendered reason is canonical' "$fix" '`accept_reason_rendered` を `{accept_reason_class}: {accept_reason_detail}`'
+assert_grep 'reply always records class' "$fix" '`; reason: {accept_reason_rendered}`'
+assert_grep 'trailer uses rendered reason' "$fix" 'Step 1 で生成した `accept_reason_rendered`'
+if grep -Fq 'user decision: accept (no reason given)' "$fix"; then
+  printf 'FAIL: stale no-reason acceptance path remains\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: no stale no-reason acceptance path\n'
+fi
 assert_grep 'test reviewer checks new error paths' "$test_reviewer" 'non-vacuity check'
 assert_grep 'test reviewer requires exact branch' "$test_reviewer" 'enters that exact new branch'
 assert_grep 'test reviewer requires observable outcome' "$test_reviewer" 'asserts the observable outcome'
@@ -50,12 +60,19 @@ assert_grep 'error reviewer reports missing proof' "$error_reviewer" 'Report mis
 
 gate_line=$(grep -n 'Rejection Evidence Gate (state mutation 前)' "$fix" | head -1 | cut -d: -f1)
 mutation_line=$(grep -n 'finding state の override' "$fix" | head -1 | cut -d: -f1)
+reply_line=$(grep -n 'reply 投稿' "$fix" | head -1 | cut -d: -f1)
 persist_line=$(grep -n 'accept fingerprint 永続化' "$fix" | head -1 | cut -d: -f1)
+trailer_line=$(grep -n 'Acknowledged-finding trailer (accept' "$fix" | head -1 | cut -d: -f1)
+section_start=$(grep -n '^### 2\.1\.A accept' "$fix" | head -1 | cut -d: -f1)
+section_end=$(awk -v start="$section_start" 'NR > start && /^### / { print NR; exit }' "$fix")
 if [ -n "$gate_line" ] && [ -n "$mutation_line" ] && [ -n "$persist_line" ] \
-  && [ "$gate_line" -lt "$mutation_line" ] && [ "$gate_line" -lt "$persist_line" ]; then
-  printf 'PASS: rejection gate precedes mutation and persistence\n'
+  && [ -n "$reply_line" ] && [ -n "$trailer_line" ] && [ -n "$section_start" ] && [ -n "$section_end" ] \
+  && [ "$section_start" -lt "$gate_line" ] && [ "$gate_line" -lt "$section_end" ] \
+  && [ "$gate_line" -lt "$mutation_line" ] && [ "$gate_line" -lt "$reply_line" ] \
+  && [ "$gate_line" -lt "$persist_line" ] && [ "$gate_line" -lt "$trailer_line" ]; then
+  printf 'PASS: rejection gate precedes all mutation and durable-output steps\n'
 else
-  printf 'FAIL: rejection gate must precede mutation and persistence\n' >&2
+  printf 'FAIL: rejection gate must remain in 2.1.A before mutation, reply, persistence, and trailer\n' >&2
   failures=$((failures + 1))
 fi
 

--- a/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+audit="$ROOT/plugins/rite/skills/pr-review/references/promotion-audit-2091.md"
+review="$ROOT/plugins/rite/skills/pr-review/SKILL.md"
+fix="$ROOT/plugins/rite/skills/fix/SKILL.md"
+test_reviewer="$ROOT/plugins/rite/agents/test-reviewer.md"
+error_reviewer="$ROOT/plugins/rite/agents/error-handling-reviewer.md"
+failures=0
+
+assert_grep() {
+  local label=$1 file=$2 pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+for page in \
+  aggregate-recommendation-label-evasion \
+  fix-induced-drift-in-cumulative-defense \
+  reviewer-likelihood-evidence-omission-induces-mechanical-demotion \
+  convention-escalation-has-no-terminus \
+  differential-scope-review-blind-outside-diff \
+  reviewer-scope-split-escalates-to-user \
+  scope-creep-rejection-empirical-gate \
+  bugfix-new-error-path-needs-regression-test
+do
+  assert_grep "audit decision: $page" "$audit" "$page"
+done
+
+assert_grep 'scope split gate wired' "$review" '5.1.2.S Scope Split Gate'
+assert_grep 'follow-up semantics preserved' "$review" 'durable な follow-up Issue'
+assert_grep 'rejection evidence gate wired' "$fix" '**Rejection Evidence Gate**'
+assert_grep 'counterfactual evidence required' "$fix" 'empirical counterfactual/revert test'
+assert_grep 'test reviewer checks new error paths' "$test_reviewer" 'non-vacuity check'
+assert_grep 'error reviewer checks regression proof' "$error_reviewer" 'Regression proof for newly added paths'
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s contract assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'All review/fix promotion contract assertions passed.\n'

--- a/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/review-fix-promotion-contract.test.sh
@@ -19,25 +19,45 @@ assert_grep() {
   fi
 }
 
-for page in \
-  aggregate-recommendation-label-evasion \
-  fix-induced-drift-in-cumulative-defense \
-  reviewer-likelihood-evidence-omission-induces-mechanical-demotion \
-  convention-escalation-has-no-terminus \
-  differential-scope-review-blind-outside-diff \
-  reviewer-scope-split-escalates-to-user \
-  scope-creep-rejection-empirical-gate \
-  bugfix-new-error-path-needs-regression-test
-do
-  assert_grep "audit decision: $page" "$audit" "$page"
-done
+assert_grep 'aggregate recommendation shelved' "$audit" '| `aggregate-recommendation-label-evasion` | shelve — already mechanized | recommendation classification and disposition gate |'
+assert_grep 'fix drift shelved' "$audit" '| `fix-induced-drift-in-cumulative-defense` | shelve — already mechanized | `review-trend-divergence.sh` and the `iterate` circuit breaker |'
+assert_grep 'likelihood evidence routed to follow-up' "$audit" '| `reviewer-likelihood-evidence-omission-induces-mechanical-demotion` | follow-up — producer enforcement incomplete |'
+assert_grep 'convention escalation shelved' "$audit" '| `convention-escalation-has-no-terminus` | shelve — already mechanized | structured review JSON, helper gates, and fail-loud enum validation |'
+assert_grep 'differential scope routed to follow-up' "$audit" '| `differential-scope-review-blind-outside-diff` | follow-up — post-breaker full pass not enforced |'
+assert_grep 'scope split mechanized' "$audit" '| `reviewer-scope-split-escalates-to-user` | mechanized here | Scope Split Gate below and `pr-review/SKILL.md` |'
+assert_grep 'scope rejection mechanized' "$audit" '| `scope-creep-rejection-empirical-gate` | mechanized here | Rejection Evidence Gate below and `fix/SKILL.md` |'
+assert_grep 'error-path regression mechanized' "$audit" '| `bugfix-new-error-path-needs-regression-test` | mechanized here | New Error-Path Regression Gate in reviewer prompts |'
 
-assert_grep 'scope split gate wired' "$review" '5.1.2.S Scope Split Gate'
-assert_grep 'follow-up semantics preserved' "$review" 'durable な follow-up Issue'
-assert_grep 'rejection evidence gate wired' "$fix" '**Rejection Evidence Gate**'
+assert_grep 'scope split detects both scopes' "$review" 'same root cause is assigned both `current-pr` and `follow-up` scope'
+assert_grep 'scope split forbids mechanical collapse' "$review" 'severity の高い側・多数派へ機械統合しない'
+assert_grep 'scope split uses debate first' "$review" 'debate で consensus に至らなければ treatment をユーザーへエスカレート'
+assert_grep 'scope split records decision' "$review" '選択した disposition を Decision Log に記録する'
+assert_grep 'follow-up semantics preserved' "$review" 'durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない'
+assert_grep 'rejection evidence gate wired' "$fix" 'Rejection Evidence Gate (state mutation 前)'
+assert_grep 'rejection reasons pinned' "$fix" '`scope-creep` / `out-of-scope` / `minor` / `user-override`'
+assert_grep 'rejection classification required' "$fix" '構造化 enum から必ず選択'
+assert_grep 'cross-validation required' "$fix" '別 reviewer の cross-validation'
 assert_grep 'counterfactual evidence required' "$fix" 'empirical counterfactual/revert test'
+assert_grep 'both rejection artifacts required' "$fix" '両方の artifact を Decision Log に記録する'
+assert_grep 'invalid rejection cannot mutate' "$fix" '`status = acknowledged` override・reply・fingerprint block・commit trailer の**いずれにも到達せず**'
+assert_grep 'user override is not bypass' "$fix" '`user-override` も evidence gate の例外ではない'
 assert_grep 'test reviewer checks new error paths' "$test_reviewer" 'non-vacuity check'
+assert_grep 'test reviewer requires exact branch' "$test_reviewer" 'enters that exact new branch'
+assert_grep 'test reviewer requires observable outcome' "$test_reviewer" 'asserts the observable outcome'
+assert_grep 'test reviewer requires mutation failure' "$test_reviewer" 'equivalent mutation) must make the new test fail'
 assert_grep 'error reviewer checks regression proof' "$error_reviewer" 'Regression proof for newly added paths'
+assert_grep 'error reviewer reports missing proof' "$error_reviewer" 'Report missing proof as a current-PR finding'
+
+gate_line=$(grep -n 'Rejection Evidence Gate (state mutation 前)' "$fix" | head -1 | cut -d: -f1)
+mutation_line=$(grep -n 'finding state の override' "$fix" | head -1 | cut -d: -f1)
+persist_line=$(grep -n 'accept fingerprint 永続化' "$fix" | head -1 | cut -d: -f1)
+if [ -n "$gate_line" ] && [ -n "$mutation_line" ] && [ -n "$persist_line" ] \
+  && [ "$gate_line" -lt "$mutation_line" ] && [ "$gate_line" -lt "$persist_line" ]; then
+  printf 'PASS: rejection gate precedes mutation and persistence\n'
+else
+  printf 'FAIL: rejection gate must precede mutation and persistence\n' >&2
+  failures=$((failures + 1))
+fi
 
 if [ "$failures" -ne 0 ]; then
   printf '%s contract assertion(s) failed\n' "$failures" >&2

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -1938,6 +1938,7 @@ Claude は ステップ 1 末尾で skip_file を、`{target_author}` が必要�
 **accept 選択時の処理 (4 つを同期実行)**:
 
 1. **accept reason 分類 (必須、AskUserQuestion)**: accept の根拠を `scope-creep` / `out-of-scope` / `minor` / `user-override` の構造化 enum から必ず選択し、追加説明だけを `accept_reason_detail` の free-text として任意入力する。空値・enum 外・同義の自由記述だけで次へ進んではならない。trailer の `reason` 欄は `{accept_reason_class}: {accept_reason_detail}`（detail 空なら class のみ）とする。
+   `accept_reason_rendered` を `{accept_reason_class}: {accept_reason_detail}`（detail 空なら class のみ）として一度生成し、reply と commit trailer の両方でこの同じ値を使う。class を含まない durable output は禁止する。
 1.5. **Rejection Evidence Gate (state mutation 前)**: 4 分類すべてについて、別 reviewer の cross-validation と reject 対象 scenario の empirical counterfactual/revert test を [promotion-audit-2091.md](../pr-review/references/promotion-audit-2091.md#rejection-evidence-gate) に従って実行し、両方の artifact を Decision Log に記録する。どちらかが欠ける場合はステップ 2 の `status = acknowledged` override・reply・fingerprint block・commit trailer の**いずれにも到達せず**、finding を修正対象へ戻すか AskUserQuestion で accept を取り消す。`user-override` も evidence gate の例外ではない。
 2. **finding state の override**:
    - `status = "acknowledged"` を設定
@@ -1946,7 +1947,7 @@ Claude は ステップ 1 末尾で skip_file を、`{target_author}` が必要�
    ```
    accepted, will not be fixed in this PR. (reviewer scope: {original_scope}; user decision: accept{reason_suffix})
    ```
-   `{reason_suffix}` は `accept_reason` が非空なら `; reason: {accept_reason}`、空なら空文字列
+   `{reason_suffix}` は常に `; reason: {accept_reason_rendered}`。必須 class があるため空 suffix 経路は存在しない
 4. **accept fingerprint 永続化**: `.rite/state/accepted-fingerprints-{pr_number}.txt` に当該 finding の fingerprint を append (詳細は下記 bash block)
 
 **fingerprint 計算式 (ステップ 2.1.A 独自仕様 — accept 抑止専用。cycle 間比較は `pr-review/references/finding-cycling.md` の semantic 判断であり、本 hash はそれとは独立の機械契約)**:
@@ -2603,7 +2604,7 @@ Acknowledged-finding: F-NN (file:line) — reason
 
 - `F-NN`: review-result-schema.md の `findings[].id` (例: `F-01`、100 件以上は `F-100`)
 - `file:line`: 当該 finding の対象ファイル:行 (ステップ 2.1 で表示されたもの)。**`line == null` (anchor finding) の場合は `(file:anchor)` 表記** に正規化する (ステップ 2.1.A bash block の line_no 正規化と統一)
-- `reason`: ステップ 2.1.A Step 1 で取得した `accept_reason` (非空時)、または `user decision: accept (no reason given)` (accept_reason が空の場合) のいずれか。書式例は下記参照
+- `reason`: ステップ 2.1.A Step 1 で生成した `accept_reason_rendered`。必ず `accept_reason_class` を含み、detail が空でも class 単独を記録する。`no reason given` / 空 reason 経路は禁止
 
 **反復生成ルール**:
 
@@ -2616,8 +2617,8 @@ fix(review): レビュー指摘に対応 (acknowledged 含む)
 F-01 の入力バリデーションを追加。F-02 は reviewer の指摘範囲を本 PR scope 外と
 判断し accept として受け流した。
 
-Acknowledged-finding: F-02 (src/foo.ts:42) — reviewer scope: out-of-current-pr; user decision: accept
-Acknowledged-finding: F-05 (src/bar.ts:88) — user decision: accept (no reason given)
+Acknowledged-finding: F-02 (src/foo.ts:42) — out-of-scope: reviewer scope is outside the current PR
+Acknowledged-finding: F-05 (src/bar.ts:88) — user-override
 
 Addresses review comments from @reviewer1
 ```

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -1937,10 +1937,8 @@ Claude は ステップ 1 末尾で skip_file を、`{target_author}` が必要�
 
 **accept 選択時の処理 (4 つを同期実行)**:
 
-1. **accept reason 入力 (任意、AskUserQuestion)**: Other 経由で自由記入を許容する option-based 構造で以下 2 択を提示する:
-   - **「理由を入力 (Other で自由記入)」**: ユーザーが Other 選択時に free-text を入力 → `accept_reason` として retain
-   - **「reason なしで accept」**: `accept_reason = ""` (空文字列、デフォルト)
-   入力値は ステップ 3.2 commit trailer の `reason` 欄に展開される (`accept_reason` が空なら `user decision: accept (no reason given)`、非空なら `{accept_reason}; user decision: accept`)
+1. **accept reason 分類 (必須、AskUserQuestion)**: accept の根拠を `scope-creep` / `out-of-scope` / `minor` / `user-override` の構造化 enum から必ず選択し、追加説明だけを `accept_reason_detail` の free-text として任意入力する。空値・enum 外・同義の自由記述だけで次へ進んではならない。trailer の `reason` 欄は `{accept_reason_class}: {accept_reason_detail}`（detail 空なら class のみ）とする。
+1.5. **Rejection Evidence Gate (state mutation 前)**: 4 分類すべてについて、別 reviewer の cross-validation と reject 対象 scenario の empirical counterfactual/revert test を [promotion-audit-2091.md](../pr-review/references/promotion-audit-2091.md#rejection-evidence-gate) に従って実行し、両方の artifact を Decision Log に記録する。どちらかが欠ける場合はステップ 2 の `status = acknowledged` override・reply・fingerprint block・commit trailer の**いずれにも到達せず**、finding を修正対象へ戻すか AskUserQuestion で accept を取り消す。`user-override` も evidence gate の例外ではない。
 2. **finding state の override**:
    - `status = "acknowledged"` を設定
    - `scope` を `nit-noted` に override (元 scope は `original_scope` として retain — reply 文言で参照)
@@ -2072,8 +2070,6 @@ fi
 **Revocability (AC-5)**: accept は **revocable**。state file (`.rite/state/accepted-fingerprints-{pr_number}.txt`) を手動削除すれば、次 review cycle で当該 finding が再出現した際に suppression が解除され、通常の ステップ 2.1 選択 UI に戻る。手動編集で特定行 (fingerprint) のみ削除しても部分的に revoke 可能。
 
 **fix 対象除外との関係**: accept で `status == "acknowledged"` となった finding は **ステップ 3 (commit) の対象から完全除外** される。これにより accept された finding は fix commit 対象にならない (本 PR で先延ばしの記録だけが残る)。
-
-**Rejection Evidence Gate**: accept 理由が `scope-creep` / `out-of-scope` / `minor` のいずれかなら、fingerprint 永続化より前に [promotion-audit-2091.md](../pr-review/references/promotion-audit-2091.md#rejection-evidence-gate) を適用する。別 reviewer の cross-validation と、reject 対象 scenario の empirical counterfactual/revert test の両方を Decision Log に記録できない限り `acknowledged` へ遷移してはならず、`ACCEPT_FINGERPRINT_PERSISTED` も commit trailer も生成しない。不足時は finding を修正対象へ戻すか AskUserQuestion でユーザー判断へ上げる。
 
 **ステップ 3.2 commit trailer**: 1 commit に複数の accept finding が含まれる場合、commit trailer に `Acknowledged-finding: F-NN (file:line) — reason` 行を **反復生成** する (詳細は ステップ 3.2 セクション参照)。
 

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -2073,6 +2073,8 @@ fi
 
 **fix 対象除外との関係**: accept で `status == "acknowledged"` となった finding は **ステップ 3 (commit) の対象から完全除外** される。これにより accept された finding は fix commit 対象にならない (本 PR で先延ばしの記録だけが残る)。
 
+**Rejection Evidence Gate**: accept 理由が `scope-creep` / `out-of-scope` / `minor` のいずれかなら、fingerprint 永続化より前に [promotion-audit-2091.md](../pr-review/references/promotion-audit-2091.md#rejection-evidence-gate) を適用する。別 reviewer の cross-validation と、reject 対象 scenario の empirical counterfactual/revert test の両方を Decision Log に記録できない限り `acknowledged` へ遷移してはならず、`ACCEPT_FINGERPRINT_PERSISTED` も commit trailer も生成しない。不足時は finding を修正対象へ戻すか AskUserQuestion でユーザー判断へ上げる。
+
 **ステップ 3.2 commit trailer**: 1 commit に複数の accept finding が含まれる場合、commit trailer に `Acknowledged-finding: F-NN (file:line) — reason` 行を **反復生成** する (詳細は ステップ 3.2 セクション参照)。
 
 **`acknowledged` retained flag namespace** (ステップ 2.1.A 独立、ステップ 1.2.0 reason 表とは別 namespace):

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1542,6 +1542,10 @@ Action: 手動で当該 reviewer の出力を確認し、verification テンプ�
 When verification mode AND `allow_new_findings_in_unchanged_code == false`: Check if finding is in incremental diff. Unchanged code: CRITICAL/HIGH → genuine (blocking), MEDIUM/LOW-MEDIUM/LOW → stability_concern (non-blocking, informational).
 **例外**: この stability_concern 分類は、ステップ 4.5.1 の verification テンプレート（Part 2: リグレッションチェック）由来の指摘にのみ適用される。ステップ 4.5 の通常テンプレート（フルレビュー）由来の指摘には適用しない。フルレビュー由来の指摘は 5.1.1 に従い、重要度に関わらず blocking とする。
 
+#### 5.1.2.S Scope Split Gate
+
+ステップ 5.1 で収集した独立 reviewer の指摘を、同じ affected behavior かつ file:line が重なる root cause ごとに照合する。同一 root cause に `current-pr` と `follow-up` が併存した場合、severity の高い側・多数派へ機械統合してはならない。[promotion-audit-2091.md](references/promotion-audit-2091.md#scope-split-gate) に従い AskUserQuestion で treatment をユーザーへエスカレートし、選択した disposition を Decision Log に記録する。`follow-up` を選ぶ場合は durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない。
+
 #### 5.1.2.A Accepted Fingerprint Suppression
 
 **Owner**: ステップ 5.1 finding collection 完了直後。**Condition**: 常に実行 (state file 不在時は skip)。**Purpose**: 前 cycle で `/rite:fix` ステップ 2.1 で `accept (認知のみ)` を選択した finding (status: `acknowledged`) が同 PR の次 review cycle で再出現した場合、JSON output からは削除し Markdown output には audit log として残す。これにより decision-replay 系の同一 finding 再出現を断つ (M5 の核)。

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1542,10 +1542,6 @@ Action: 手動で当該 reviewer の出力を確認し、verification テンプ�
 When verification mode AND `allow_new_findings_in_unchanged_code == false`: Check if finding is in incremental diff. Unchanged code: CRITICAL/HIGH → genuine (blocking), MEDIUM/LOW-MEDIUM/LOW → stability_concern (non-blocking, informational).
 **例外**: この stability_concern 分類は、ステップ 4.5.1 の verification テンプレート（Part 2: リグレッションチェック）由来の指摘にのみ適用される。ステップ 4.5 の通常テンプレート（フルレビュー）由来の指摘には適用しない。フルレビュー由来の指摘は 5.1.1 に従い、重要度に関わらず blocking とする。
 
-#### 5.1.2.S Scope Split Gate
-
-ステップ 5.1 で収集した独立 reviewer の指摘を、同じ affected behavior かつ file:line が重なる root cause ごとに照合する。同一 root cause に `current-pr` と `follow-up` が併存した場合、severity の高い側・多数派へ機械統合してはならない。[promotion-audit-2091.md](references/promotion-audit-2091.md#scope-split-gate) に従い AskUserQuestion で treatment をユーザーへエスカレートし、選択した disposition を Decision Log に記録する。`follow-up` を選ぶ場合は durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない。
-
 #### 5.1.2.A Accepted Fingerprint Suppression
 
 **Owner**: ステップ 5.1 finding collection 完了直後。**Condition**: 常に実行 (state file 不在時は skip)。**Purpose**: 前 cycle で `/rite:fix` ステップ 2.1 で `accept (認知のみ)` を選択した finding (status: `acknowledged`) が同 PR の次 review cycle で再出現した場合、JSON output からは削除し Markdown output には audit log として残す。これにより decision-replay 系の同一 finding 再出現を断つ (M5 の核)。
@@ -1845,7 +1841,7 @@ tech-writer の出力に以下のいずれかの META 行が含まれている�
 ### 5.2 Cross-Validation
 
 **Same file/line check**: Group by `file:line`. 2+ reviewers → mark "High Confidence" + boost severity (LOW→MEDIUM→HIGH→CRITICAL).
-**Contradiction detection**: Two or more reviewers give assessments of the same `file:line` that cannot both be followed — opposite recommendations, or severity judgments so far apart that they imply different handling (per [Trigger Conditions in cross-validation.md](../../skills/reviewers/references/cross-validation.md#trigger-conditions)) → debate phase (5.2.1) if enabled, otherwise prompt user via `AskUserQuestion`.
+**Contradiction detection**: Two or more reviewers give assessments of the same `file:line` that cannot both be followed — opposite recommendations, severity judgments so far apart that they imply different handling, **or the same root cause is assigned both `current-pr` and `follow-up` scope** (per [Trigger Conditions in cross-validation.md](../../skills/reviewers/references/cross-validation.md#trigger-conditions) and [Scope Split Gate](references/promotion-audit-2091.md#scope-split-gate)) → debate phase (5.2.1) if enabled, otherwise prompt user via `AskUserQuestion`.
 **Quality Signal 3 — Cross-validation disagreement**: When reviewers report contradictory assessments of the same `file:line`, the sub-skill treats this as Signal 3 of the four quality signals. The outcome of the deliberation (5.2.1) determines whether Signal 3 fires:
 
 - 検討の結果、合意に至った矛盾 → Signal 3 は**発火しない**（consensus reached）
@@ -1862,6 +1858,7 @@ echo "[CONTEXT] QUALITY_SIGNAL=3_cross_validation_disagreement; file=${file_line
 1. If there are multiple findings for the same `file:line`, compare the assessment content
 2. If matching the contradiction patterns above, flag as a contradiction
 3. Collect all detected contradictions for ステップ 5.2.1 (debate) or direct user resolution
+4. Scope split は severity の高い側・多数派へ機械統合しない。debate で consensus に至らなければ treatment をユーザーへエスカレートし、選択した disposition を Decision Log に記録する。`follow-up` を選ぶ場合は durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない
 
 **When contradictions are detected:**
 

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1858,7 +1858,7 @@ echo "[CONTEXT] QUALITY_SIGNAL=3_cross_validation_disagreement; file=${file_line
 1. If there are multiple findings for the same `file:line`, compare the assessment content
 2. If matching the contradiction patterns above, flag as a contradiction
 3. Collect all detected contradictions for ステップ 5.2.1 (debate) or direct user resolution
-4. Scope split は severity の高い側・多数派へ機械統合しない。debate で consensus に至らなければ treatment をユーザーへエスカレートし、選択した disposition を Decision Log に記録する。`follow-up` を選ぶ場合は durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない
+4. Scope split は severity の高い側・多数派へ機械統合しない。debate は論点整理と推奨 disposition の生成に使うが、consensus の有無にかかわらず treatment の最終決定は AskUserQuestion でユーザーへエスカレートし、選択した disposition を Decision Log に記録する。`follow-up` を選ぶ場合は durable な follow-up Issue / destination が作成または指定されるまで解決済みにしない
 
 **When contradictions are detected:**
 

--- a/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
+++ b/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
@@ -1,0 +1,40 @@
+# Wiki Promotion Audit #2091 — Review/Fix Loop
+
+Issue #2163 audited the eight `promote: rite-plugin` pages from promotion audit
+#2091. This table is the durable routing log. A page is shelved when an existing
+mechanical contract already enforces it; otherwise the named gate is the
+mechanization target.
+
+| Wiki page | Decision | Enforcement pointer |
+|---|---|---|
+| `aggregate-recommendation-label-evasion` | shelve — already mechanized | recommendation classification and disposition gate |
+| `fix-induced-drift-in-cumulative-defense` | shelve — already mechanized | `review-trend-divergence.sh` and the `iterate` circuit breaker |
+| `reviewer-likelihood-evidence-omission-induces-mechanical-demotion` | shelve — already mechanized | `review-measured-gate.sh` and positive save verification |
+| `convention-escalation-has-no-terminus` | shelve — already mechanized | structured review JSON, helper gates, and fail-loud enum validation |
+| `differential-scope-review-blind-outside-diff` | shelve — already mechanized | cycle 1/fail-safe full review and a fresh full run after circuit-breaker reset |
+| `reviewer-scope-split-escalates-to-user` | mechanized here | Scope Split Gate below and `pr-review/SKILL.md` |
+| `scope-creep-rejection-empirical-gate` | mechanized here | Rejection Evidence Gate below and `fix/SKILL.md` |
+| `bugfix-new-error-path-needs-regression-test` | mechanized here | New Error-Path Regression Gate in reviewer prompts |
+
+## Scope Split Gate
+
+After finding collection, group independently reported findings by normalized
+root cause. If one group contains both `current-pr` and `follow-up`, do not
+collapse the scopes by severity or majority vote. Escalate the treatment choice
+to the user and record it. `follow-up` is deferred work, not an alias for
+`current-pr`; accepting it requires a durable follow-up destination.
+
+## Rejection Evidence Gate
+
+Before persisting an `acknowledged` finding whose reason is `scope-creep`,
+`out-of-scope`, or `minor`, require independent reviewer cross-validation and an
+empirical counterfactual/revert test. If either artifact is absent, return the
+finding to fix selection or ask the user; do not persist its accepted fingerprint
+or commit trailer.
+
+## New Error-Path Regression Gate
+
+When a fix adds a fallback, warning, catch/else branch, or other error path, a
+regression test must enter that branch and assert its observable outcome. The
+test must be non-vacuous: restoring the pre-fix behavior, or an equivalent
+mutation, must make it fail.

--- a/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
+++ b/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
@@ -9,9 +9,9 @@ mechanization target.
 |---|---|---|
 | `aggregate-recommendation-label-evasion` | shelve — already mechanized | recommendation classification and disposition gate |
 | `fix-induced-drift-in-cumulative-defense` | shelve — already mechanized | `review-trend-divergence.sh` and the `iterate` circuit breaker |
-| `reviewer-likelihood-evidence-omission-induces-mechanical-demotion` | shelve — already mechanized | `review-measured-gate.sh` and positive save verification |
+| `reviewer-likelihood-evidence-omission-induces-mechanical-demotion` | follow-up — producer enforcement incomplete | existing measured gate records demotion but does not prevent omitted evidence; tracked by Issue #2185 |
 | `convention-escalation-has-no-terminus` | shelve — already mechanized | structured review JSON, helper gates, and fail-loud enum validation |
-| `differential-scope-review-blind-outside-diff` | shelve — already mechanized | cycle 1/fail-safe full review and a fresh full run after circuit-breaker reset |
+| `differential-scope-review-blind-outside-diff` | follow-up — post-breaker full pass not enforced | a manual fresh run is full, but the breaker does not require it; tracked by Issue #2184 |
 | `reviewer-scope-split-escalates-to-user` | mechanized here | Scope Split Gate below and `pr-review/SKILL.md` |
 | `scope-creep-rejection-empirical-gate` | mechanized here | Rejection Evidence Gate below and `fix/SKILL.md` |
 | `bugfix-new-error-path-needs-regression-test` | mechanized here | New Error-Path Regression Gate in reviewer prompts |

--- a/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
+++ b/plugins/rite/skills/pr-review/references/promotion-audit-2091.md
@@ -27,7 +27,7 @@ to the user and record it. `follow-up` is deferred work, not an alias for
 ## Rejection Evidence Gate
 
 Before persisting an `acknowledged` finding whose reason is `scope-creep`,
-`out-of-scope`, or `minor`, require independent reviewer cross-validation and an
+`out-of-scope`, `minor`, or `user-override`, require independent reviewer cross-validation and an
 empirical counterfactual/revert test. If either artifact is absent, return the
 finding to fix selection or ask the user; do not persist its accepted fingerprint
 or commit trailer.


### PR DESCRIPTION
## 概要

Wiki 昇格監査 #2091 で抽出されたレビュー・修正ループ系8件を監査し、既存機構への対応と未配線ゲートをプラグイン内に固定します。

Closes #2163

## 変更内容

- 8件すべての機構化・shelve 判断と enforcement pointer を監査記録へ追加
- reviewer scope split をユーザー判断へ上げる gate を pr-review に追加
- `scope-creep` 等の accept に cross-validation と empirical revert test を要求
- 新設エラーパスに非空虚な回帰テストを要求する reviewer 契約を追加
- 上記配線を固定する contract test を追加

## 検証

- `review-fix-promotion-contract.test.sh`: PASS（14 assertions）
- `git diff --check`: PASS
- rite plugin checks 18種: 今回差分に起因するエラーなし（既存の非ブロッキング警告のみ）

## チェックリスト

- [x] 対象8ページの機構化方針を決定
- [x] 実装・既存機構への pointer を永続化
- [x] 既存機構化済みページの shelve 理由を記録
- [x] 契約テストを追加・実行
