### PR TITLE
chore(pr-create): インライン content 委譲の昇格監査を記録

### DIFF
--- a/plugins/rite/scripts/tests/pr-create-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/pr-create-promotion-contract.test.sh
@@ -31,11 +31,12 @@ assert_grep 'producer passes body by file' "$create" '--title "$pr_title" --body
 assert_grep 'producer guards empty title' "$create" 'if [ -z "$pr_title" ]; then'
 assert_grep 'producer guards empty body' "$create" 'if [ ! -s "$pr_workdir/pr_body.md" ]; then'
 
-assert_grep 'lint signal exists' "$heaviness" 'inline-gh-create-title'
+assert_grep 'lint signal emitter exists' "$heaviness" 'printf "[bash-heaviness] %s:%d: inline-gh-create-title — literal --title in gh {pr,issue} create; delegate the title to a file (Write tool) or a variable to avoid malformed tool-call\n", fname, gh_title_line'
 assert_grep 'lint detects pr and issue create' "$heaviness" '/gh[[:space:]]+(pr|issue)[[:space:]]+create/'
 assert_grep 'lint tracks continued commands' "$heaviness" 'gh_create_active == 1 && line !~ /\\[[:space:]]*$/'
 
-assert_grep 'orphan reaper targets pr workdirs' "$cleanup" 'rite-pr-create-*'
+assert_grep 'orphan reaper targets pr workdirs' "$cleanup" 'reap_orphan_dirs "orphan workdir" "$workdir_tmp_base" '\''rite-pr-create-*'\'' \'
+assert_grep 'orphan reaper invokes workdir callback' "$cleanup" '_reap_workdir "$workdir_find_out" "$workdir_find_err"'
 assert_grep 'orphan reaper has 24-hour guard' "$cleanup" 'readonly WORKDIR_REAP_AGE_MINUTES=1440'
 
 if [ "$failures" -ne 0 ]; then

--- a/plugins/rite/scripts/tests/pr-create-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/pr-create-promotion-contract.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+audit="$ROOT/plugins/rite/skills/pr-create/references/promotion-audit-2091.md"
+create="$ROOT/plugins/rite/skills/pr-create/SKILL.md"
+heaviness="$ROOT/plugins/rite/hooks/scripts/bash-heaviness-check.sh"
+cleanup="$ROOT/plugins/rite/hooks/scripts/pr-cycle-cleanup.sh"
+failures=0
+
+assert_grep() {
+  local label=$1 file=$2 pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_grep 'promotion is shelved as already mechanized' "$audit" \
+  '| `inline-content-delegation-avoids-malformed-toolcall` | shelve — already mechanized |'
+assert_grep 'audit points to producer protocol' "$audit" '`pr-create/SKILL.md` Phase 3.4 three-stage protocol'
+assert_grep 'audit points to prevention signal' "$audit" '`inline-gh-create-title` signal'
+assert_grep 'audit points to lifecycle backstop' "$audit" '`pr-cycle-cleanup.sh` orphan-workdir reaper'
+
+assert_grep 'producer requires three-stage protocol' "$create" '**3 段プロトコル**'
+assert_grep 'producer delegates title and body to Write tool' "$create" '**Write tool** で title / body を raw ファイル化'
+assert_grep 'producer reads title through a variable' "$create" 'pr_title=$(cat "$pr_workdir/pr_title.txt")'
+assert_grep 'producer passes body by file' "$create" '--title "$pr_title" --body-file "$pr_workdir/pr_body.md"'
+assert_grep 'producer guards empty title' "$create" 'if [ -z "$pr_title" ]; then'
+assert_grep 'producer guards empty body' "$create" 'if [ ! -s "$pr_workdir/pr_body.md" ]; then'
+
+assert_grep 'lint signal exists' "$heaviness" 'inline-gh-create-title'
+assert_grep 'lint detects pr and issue create' "$heaviness" '/gh[[:space:]]+(pr|issue)[[:space:]]+create/'
+assert_grep 'lint tracks continued commands' "$heaviness" 'gh_create_active == 1 && line !~ /\\[[:space:]]*$/'
+
+assert_grep 'orphan reaper targets pr workdirs' "$cleanup" 'rite-pr-create-*'
+assert_grep 'orphan reaper has 24-hour guard' "$cleanup" 'readonly WORKDIR_REAP_AGE_MINUTES=1440'
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s contract assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'All PR-create promotion contract assertions passed.\n'

--- a/plugins/rite/skills/pr-create/references/promotion-audit-2091.md
+++ b/plugins/rite/skills/pr-create/references/promotion-audit-2091.md
@@ -1,0 +1,32 @@
+# Wiki Promotion Audit #2091 — Inline Content Delegation
+
+The `promote: rite-plugin` page
+`inline-content-delegation-avoids-malformed-toolcall` is shelved because
+the plugin already enforces the pattern mechanically at both production and
+detection points.
+
+| Wiki page | Decision | Enforcement pointer |
+|---|---|---|
+| `inline-content-delegation-avoids-malformed-toolcall` | shelve — already mechanized | `pr-create/SKILL.md` Phase 3.4 three-stage protocol, `bash-heaviness-check.sh`'s `inline-gh-create-title` signal, and `pr-cycle-cleanup.sh` orphan-workdir reaper |
+
+## Existing mechanical contract
+
+`pr-create/SKILL.md` requires a three-stage protocol: allocate a dedicated
+workdir, write title and body as raw files, then pass the title through a shell
+variable and the body through `--body-file`. Empty title/body guards and
+signal-specific cleanup traps make the delivery path fail loudly and cleanly.
+
+`bash-heaviness-check.sh` rejects literal `--title` arguments in
+`gh pr create` and `gh issue create`, including backslash-continued command
+forms. This prevents future command specifications from reintroducing the
+inline-title trigger.
+
+The protocol spans multiple tool processes, so an interruption between workdir
+allocation and the final shell call cannot be handled by that call's traps.
+`pr-cycle-cleanup.sh` closes this lifecycle gap by reaping
+`rite-pr-create-*` directories only after a 24-hour age guard.
+
+No follow-up is needed: Cause B (inline title/body content) is prevented by the
+producer contract and lint signal, while the distinct transport-level Cause A
+is explicitly scoped out and its only durable residue is covered by the aged
+orphan reaper.


### PR DESCRIPTION
## 概要

Wiki 昇格監査で抽出されたインライン title/body 委譲の知見を監査し、既存の機械的強制点へ対応付けます。

Closes #2164

## 変更内容

- 3段プロトコル、inline title lint、孤児 workdir GCを既機構化として監査記録へ固定
- enforcement pointer の消失を検知する契約テストを追加

## 検証

- `pr-create-promotion-contract.test.sh`: PASS（16 assertions）
- `git diff --check`: PASS
- rite plugin checks 18種: 今回差分に起因するエラーなし（既存の非ブロッキング警告のみ）

## チェックリスト

- [x] 対象ページの機構化方針を決定
- [x] 既機構化として shelve 理由と enforcement pointer を記録
- [x] 契約テストを追加・実行

