### PR TITLE
chore(review): 契約・履歴知見を共通ゲートへ昇格

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -186,6 +186,39 @@ documentation file.
    initialization, imports/functions, prerequisites supplied by the caller, and
    return-value consumption. If intentional abstraction prevents exact equality,
    narrow the claim instead of saying "verbatim" or "identical".
+5. **Consumer portability**: When an instruction mutates a consumer-owned file
+   by matching a literal anchor, prove that the anchor is distributed or
+   created on every supported entrypoint. Otherwise require an exact
+   precondition check and an anchor-independent, user-visible fallback. A
+   literal that exists only in the plugin's dogfooding repository is not a
+   portable mutation contract.
+6. **Aggregation and provenance truthfulness**: When prose claims that a helper
+   centralizes a concern, enumerate what moved behind the helper and what names,
+   schemas, defaults, or callers remain distributed. `Grep` every old inline
+   implementation to verify migration completeness. When a summary attributes
+   several additions to one Issue, PR, or commit, use `git log -S` for each
+   independently introduced literal, compare same-file cross-references, and
+   run a repository-wide propagation scan; do not collapse incremental history
+   into a single provenance claim.
+7. **Counterfactual and executable backing**: Trace every changed claim that an
+   ordering, guard, marker, or invariant changes behavior to its executable
+   producer and consumer. For an ordering justification, write down each
+   branch outcome and verify that swapping the stages really changes the stated
+   result; shared accept or reject outcomes do not prove deterioration. When an
+   invariant is mechanically expressible, require a test that fails when the
+   invariant is broken and treat the test's green result as the contract instead
+   of adding another cross-axis prose mapping.
+8. **Command and query semantics**: Verify changed CLI filters against their
+   actual matching and default-state semantics, not against the visual shape of
+   a sibling command. In particular, do not use wildcard-looking values with an
+   exact-match option; fetch the required state range and filter the returned
+   structured field client-side when substring matching is intended.
+9. **Success-predicate completeness**: A success check over command-substitution
+   output must preserve each producer's exit status and reject empty required
+   values before comparing them. Equality of two empty strings is not evidence
+   of success. When cwd or another prerequisite can disappear during the
+   lifecycle, verify the prerequisite independently as well as hardening the
+   final predicate.
 
 Report a current-PR finding only when the changed explanation, command, citation,
 or sample fails one of these checks and the resulting contradiction or wrong
@@ -196,7 +229,9 @@ target is demonstrable. Record the exact source and consumer in
 
 - [ ] **Documentation fidelity (when triggered)**: Verify pivot/delegation
   references, human-context recovery commands, citation content, and canonical
-  sample blocks against their actual source and execution context.
+  sample blocks against their actual source and execution context. Also verify
+  consumer portability, aggregation/provenance claims, counterfactual and
+  executable backing, command-filter semantics, and complete success predicates.
 
 ## Confidence Scoring
 

--- a/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+audit="$ROOT/plugins/rite/skills/pr-review/references/promotion-audit-2167.md"
+reviewer="$ROOT/plugins/rite/agents/_reviewer-base.md"
+failures=0
+
+assert_grep() {
+  local label=$1 file=$2 pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_grep 'audit records five promotions' "$audit" \
+  'Five pages add missing detection work'
+assert_grep 'audit records three shelves' "$audit" \
+  'Three pages are shelved'
+assert_grep 'anchor portability is promoted' "$audit" \
+  '| `dogfooding-anchor-hardcode` | mechanized here |'
+assert_grep 'helper aggregation is promoted' "$audit" \
+  '| `dry-helper-aggregation-effect-overstate` | mechanized here |'
+assert_grep 'provenance is shelved with enforcement' "$audit" \
+  '| `multi-pr-provenance-aggregation-error` | shelved as already mechanized |'
+assert_grep 'prose-only design is shelved with enforcement' "$audit" \
+  '| `prose-design-without-backing-implementation` | shelved as already mechanized |'
+assert_grep 'counterfactual justification is promoted' "$audit" \
+  '| `result-based-justification-logical-fallacy` | mechanized here |'
+assert_grep 'gh query semantics is promoted' "$audit" \
+  '| `gh-pr-list-related-pr-resolution` | mechanized here |'
+assert_grep 'success predicate is promoted' "$audit" \
+  '| `cwd-corruption-success-check-exit-code-and-nonempty` | mechanized here |'
+assert_grep 'mechanical contracts are shelved with enforcement' "$audit" \
+  '| `mechanical-test-over-declarative-invariant` | shelved as already mechanized |'
+
+assert_grep 'consumer mutation checks distribution' "$reviewer" \
+  'prove that the anchor is distributed or'
+assert_grep 'consumer mutation has portable fallback' "$reviewer" \
+  'anchor-independent, user-visible fallback'
+assert_grep 'aggregation names residual distribution' "$reviewer" \
+  'schemas, defaults, or callers remain distributed'
+assert_grep 'aggregation sweeps old callers' "$reviewer" \
+  'implementation to verify migration completeness'
+assert_grep 'provenance uses pickaxe per literal' "$reviewer" \
+  'use `git log -S` for each'
+assert_grep 'counterfactual compares branch outcomes' "$reviewer" \
+  'branch outcome and verify that swapping the stages'
+assert_grep 'mechanical test must detect breakage' "$reviewer" \
+  'require a test that fails when the'
+assert_grep 'query semantics rejects wildcard exact match' "$reviewer" \
+  'exact-match option; fetch the required state range'
+assert_grep 'query semantics filters structured output' "$reviewer" \
+  'structured field client-side'
+assert_grep 'success preserves producer status' "$reviewer" \
+  "preserve each producer's exit status"
+assert_grep 'success rejects empty required values' "$reviewer" \
+  'values before comparing them. Equality of two empty strings'
+assert_grep 'empty equality is not success' "$reviewer" \
+  'of success. When cwd or another prerequisite can disappear'
+assert_grep 'shared checklist maps all promoted checks' "$reviewer" \
+  'consumer portability, aggregation/provenance claims, counterfactual and'
+assert_grep 'audit keeps measured classification boundary' "$audit" \
+  'classification remains the responsibility of the measured-confirmed gate'
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s contract assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'All contract and provenance promotion assertions passed.\n'

--- a/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
@@ -16,16 +16,26 @@ assert_grep() {
   fi
 }
 
-assert_grep 'audit records five promotions' "$audit" \
-  'Five pages add missing detection work'
-assert_grep 'audit records three shelves' "$audit" \
-  'Three pages are shelved'
+assert_not_grep() {
+  local label=$1 file=$2 pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS: %s\n' "$label"
+  fi
+}
+
+assert_grep 'audit records six promotions' "$audit" \
+  'Six pages add missing detection work'
+assert_grep 'audit records two shelves' "$audit" \
+  'Two pages are shelved'
 assert_grep 'anchor portability is promoted' "$audit" \
   '| `dogfooding-anchor-hardcode` | mechanized here |'
 assert_grep 'helper aggregation is promoted' "$audit" \
   '| `dry-helper-aggregation-effect-overstate` | mechanized here |'
-assert_grep 'provenance is shelved with enforcement' "$audit" \
-  '| `multi-pr-provenance-aggregation-error` | shelved as already mechanized |'
+assert_grep 'provenance is promoted' "$audit" \
+  '| `multi-pr-provenance-aggregation-error` | mechanized here |'
 assert_grep 'prose-only design is shelved with enforcement' "$audit" \
   '| `prose-design-without-backing-implementation` | shelved as already mechanized |'
 assert_grep 'counterfactual justification is promoted' "$audit" \
@@ -50,7 +60,9 @@ assert_grep 'provenance uses pickaxe per literal' "$reviewer" \
 assert_grep 'counterfactual compares branch outcomes' "$reviewer" \
   'branch outcome and verify that swapping the stages'
 assert_grep 'mechanical test must detect breakage' "$reviewer" \
-  'require a test that fails when the'
+  'invariant is mechanically expressible, require a test that fails when the'
+assert_not_grep 'mechanical test requirement is not negated' "$reviewer" \
+  'do not require a test that fails when the invariant is broken'
 assert_grep 'query semantics rejects wildcard exact match' "$reviewer" \
   'exact-match option; fetch the required state range'
 assert_grep 'query semantics filters structured output' "$reviewer" \

--- a/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/contract-provenance-promotion-contract.test.sh
@@ -16,13 +16,17 @@ assert_grep() {
   fi
 }
 
-assert_not_grep() {
-  local label=$1 file=$2 pattern=$3
-  if grep -Fq -- "$pattern" "$file"; then
+assert_section_equals() {
+  local label=$1 file=$2 start=$3 end=$4 expected=$5 actual
+  actual=$(awk -v start="$start" -v end="$end" \
+    'index($0, start) == 1 { capture=1 }
+     capture && index($0, end) == 1 { exit }
+     capture' "$file")
+  if [ "$actual" = "$expected" ]; then
+    printf 'PASS: %s\n' "$label"
+  else
     printf 'FAIL: %s\n' "$label" >&2
     failures=$((failures + 1))
-  else
-    printf 'PASS: %s\n' "$label"
   fi
 }
 
@@ -59,10 +63,18 @@ assert_grep 'provenance uses pickaxe per literal' "$reviewer" \
   'use `git log -S` for each'
 assert_grep 'counterfactual compares branch outcomes' "$reviewer" \
   'branch outcome and verify that swapping the stages'
-assert_grep 'mechanical test must detect breakage' "$reviewer" \
-  'invariant is mechanically expressible, require a test that fails when the'
-assert_not_grep 'mechanical test requirement is not negated' "$reviewer" \
-  'do not require a test that fails when the invariant is broken'
+mechanical_contract=$(printf '%s\n' \
+  '7. **Counterfactual and executable backing**: Trace every changed claim that an' \
+  '   ordering, guard, marker, or invariant changes behavior to its executable' \
+  '   producer and consumer. For an ordering justification, write down each' \
+  '   branch outcome and verify that swapping the stages really changes the stated' \
+  '   result; shared accept or reject outcomes do not prove deterioration. When an' \
+  '   invariant is mechanically expressible, require a test that fails when the' \
+  "   invariant is broken and treat the test's green result as the contract instead" \
+  '   of adding another cross-axis prose mapping.')
+assert_section_equals 'counterfactual and mechanical contract is exact' "$reviewer" \
+  '7. **Counterfactual and executable backing**:' \
+  '8. **Command and query semantics**:' "$mechanical_contract"
 assert_grep 'query semantics rejects wildcard exact match' "$reviewer" \
   'exact-match option; fetch the required state range'
 assert_grep 'query semantics filters structured output' "$reviewer" \

--- a/plugins/rite/skills/pr-review/references/promotion-audit-2167.md
+++ b/plugins/rite/skills/pr-review/references/promotion-audit-2167.md
@@ -1,15 +1,15 @@
 # Wiki Promotion Audit #2167 — Contract and Provenance Fidelity
 
 Issue #2167 audited eight `promote: rite-plugin` pages from promotion audit
-#2091. Five pages add missing detection work to the shared Documentation
-Fidelity Gate. Three pages are shelved because an existing shared gate already
+#2091. Six pages add missing detection work to the shared Documentation
+Fidelity Gate. Two pages are shelved because an existing shared gate already
 mechanizes the complete rule; duplicating them would create another drift site.
 
 | Wiki page | Decision | Enforcement pointer |
 |---|---|---|
 | `dogfooding-anchor-hardcode` | mechanized here | consumer portability requires distributed anchors or an exact precondition plus anchor-independent fallback |
 | `dry-helper-aggregation-effect-overstate` | mechanized here | aggregation truthfulness enumerates centralized and still-distributed state and sweeps every old caller |
-| `multi-pr-provenance-aggregation-error` | shelved as already mechanized | Documentation Fidelity Gate citation content fidelity already requires reading the cited source and exact semantic anchors; its propagation sweep covers contradictory sibling claims |
+| `multi-pr-provenance-aggregation-error` | mechanized here | aggregation and provenance truthfulness requires per-literal `git log -S`, same-file cross-reference comparison, and a repository-wide propagation scan |
 | `prose-design-without-backing-implementation` | shelved as already mechanized | Defense Mechanism Integrity Gate code-level structural enforcement already requires an explicit check and helper-level accept/reject tests |
 | `result-based-justification-logical-fallacy` | mechanized here | counterfactual branch-outcome analysis rejects ordering claims whose swapped stages have identical outcomes |
 | `gh-pr-list-related-pr-resolution` | mechanized here | command semantics rejects wildcard-looking exact-match filters and requires explicit state coverage plus client-side structured-field filtering |
@@ -18,9 +18,9 @@ mechanizes the complete rule; duplicating them would create another drift site.
 
 ## Scope decision
 
-No follow-up is required. The five promoted rules are cross-language review
+No follow-up is required. The six promoted rules are cross-language review
 obligations, so the shared reviewer base is the narrowest durable enforcement
-point. The three shelved pages name behavior already required by an existing
+point. The two shelved pages name behavior already required by an existing
 mandatory gate. Their decision rows retain provenance without copying the same
 contract into another checklist.
 

--- a/plugins/rite/skills/pr-review/references/promotion-audit-2167.md
+++ b/plugins/rite/skills/pr-review/references/promotion-audit-2167.md
@@ -1,0 +1,29 @@
+# Wiki Promotion Audit #2167 — Contract and Provenance Fidelity
+
+Issue #2167 audited eight `promote: rite-plugin` pages from promotion audit
+#2091. Five pages add missing detection work to the shared Documentation
+Fidelity Gate. Three pages are shelved because an existing shared gate already
+mechanizes the complete rule; duplicating them would create another drift site.
+
+| Wiki page | Decision | Enforcement pointer |
+|---|---|---|
+| `dogfooding-anchor-hardcode` | mechanized here | consumer portability requires distributed anchors or an exact precondition plus anchor-independent fallback |
+| `dry-helper-aggregation-effect-overstate` | mechanized here | aggregation truthfulness enumerates centralized and still-distributed state and sweeps every old caller |
+| `multi-pr-provenance-aggregation-error` | shelved as already mechanized | Documentation Fidelity Gate citation content fidelity already requires reading the cited source and exact semantic anchors; its propagation sweep covers contradictory sibling claims |
+| `prose-design-without-backing-implementation` | shelved as already mechanized | Defense Mechanism Integrity Gate code-level structural enforcement already requires an explicit check and helper-level accept/reject tests |
+| `result-based-justification-logical-fallacy` | mechanized here | counterfactual branch-outcome analysis rejects ordering claims whose swapped stages have identical outcomes |
+| `gh-pr-list-related-pr-resolution` | mechanized here | command semantics rejects wildcard-looking exact-match filters and requires explicit state coverage plus client-side structured-field filtering |
+| `cwd-corruption-success-check-exit-code-and-nonempty` | mechanized here | success predicates require producer exit status, non-empty required values, and lifecycle-prerequisite verification |
+| `mechanical-test-over-declarative-invariant` | shelved as already mechanized | Defense Mechanism Integrity Gate already requires helper-level tests for structural claims; the Documentation Fidelity Gate now points to that executable contract instead of duplicating prose mappings |
+
+## Scope decision
+
+No follow-up is required. The five promoted rules are cross-language review
+obligations, so the shared reviewer base is the narrowest durable enforcement
+point. The three shelved pages name behavior already required by an existing
+mandatory gate. Their decision rows retain provenance without copying the same
+contract into another checklist.
+
+The gate remains evidence-gated: reviewers report a current-PR finding only
+when a changed claim or command demonstrably fails a check. Blocking
+classification remains the responsibility of the measured-confirmed gate.


### PR DESCRIPTION
## 概要

Wiki 昇格監査 #2091 の「その他機構化候補」8件を監査し、未機構化の6件を共通 reviewer gate に組み込みました。既存ゲートで完全に機構化済みの2件は、重複実装せず shelve 理由と enforcement pointer を監査記録に残しています。

Closes #2167

## 変更内容

- consumer 固有 anchor、DRY 集約範囲、provenance、反実仮想、CLI filter 意味論、成功述語を Documentation Fidelity Gate に追加
- 8ページすべての昇格・shelve 判断を監査記録へ固定
- gate と監査記録の対応を検証する promotion contract test を追加

## 検証

- `bash plugins/rite/scripts/tests/run-all.sh`
- `git diff --check`
- `shellcheck` は実行環境に未導入のため未実行

## チェックリスト

- [x] 各ページの機構化方針を決定
- [x] 既機構化ページの shelve 理由を記録
- [x] contract test を追加
- [x] 全 script tests を実行