### PR TITLE
fix(ready): 事前ゲートを PR head に一致させる

### DIFF
--- a/plugins/rite/hooks/scripts/ready-pr-head-gate.sh
+++ b/plugins/rite/hooks/scripts/ready-pr-head-gate.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Resolve a Ready target PR and run the bang-backtick scanner against its head.
+set -u
+pr_number=""; owner_repo=""; plugin_root=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pr) pr_number="${2:-}"; shift 2 ;;
+    --repo) owner_repo="${2:-}"; shift 2 ;;
+    --plugin-root) plugin_root="${2:-}"; shift 2 ;;
+    *) echo "ERROR: Ready gate: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+case "$pr_number" in ''|*[!0-9]*) echo "ERROR: Ready gate: PR number is required" >&2; exit 2 ;; esac
+[ -n "$owner_repo" ] || { echo "ERROR: Ready gate: owner/repo is required" >&2; exit 2; }
+[ -x "$plugin_root/hooks/scripts/bang-backtick-check.sh" ] || {
+  echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing; resolved_root=${plugin_root:-<empty>}" >&2
+  echo "ERROR: bang-backtick-check.sh not found. Cannot proceed with Ready gate." >&2
+  exit 2
+}
+ready_gate_tmp=""
+cleanup_ready_gate_worktree() {
+  [ -n "${ready_gate_tmp:-}" ] || return 0
+  cleanup_path="$ready_gate_tmp"; ready_gate_tmp=""
+  if ! git worktree remove --force "$cleanup_path" >/dev/null 2>&1; then
+    echo "WARNING: Ready gate の一時 worktree を削除できませんでした: $cleanup_path" >&2
+  fi
+  return 0
+}
+trap 'rc=$?; cleanup_ready_gate_worktree; exit $rc' EXIT
+trap 'cleanup_ready_gate_worktree; exit 130' INT
+trap 'cleanup_ready_gate_worktree; exit 143' TERM
+trap 'cleanup_ready_gate_worktree; exit 129' HUP
+pr_head_oid=$(gh pr view "$pr_number" -R "$owner_repo" --json headRefOid --jq '.headRefOid') || {
+  echo "ERROR: Ready gate: PR #$pr_number の headRefOid を解決できません" >&2; exit 2
+}
+[ -n "$pr_head_oid" ] || { echo "ERROR: Ready gate: PR #$pr_number の headRefOid が空です" >&2; exit 2; }
+current_oid=$(git rev-parse HEAD) || { echo "ERROR: Ready gate: 現在の HEAD を解決できません" >&2; exit 2; }
+scan_root="."
+if [ "$current_oid" != "$pr_head_oid" ]; then
+  git fetch origin "$pr_head_oid" >/dev/null 2>&1 || { echo "ERROR: Ready gate: PR head $pr_head_oid の fetch に失敗しました" >&2; exit 2; }
+  ready_gate_tmp=$(mktemp -d "${TMPDIR:-/tmp}/rite-ready-pr-head.XXXXXX") || { echo "ERROR: Ready gate: 一時ディレクトリの作成に失敗しました" >&2; exit 2; }
+  rmdir "$ready_gate_tmp" || { echo "ERROR: Ready gate: 一時 worktree path の準備に失敗しました" >&2; exit 2; }
+  git worktree add --detach "$ready_gate_tmp" "$pr_head_oid" >/dev/null 2>&1 || { echo "ERROR: Ready gate: PR head $pr_head_oid の一時 worktree 作成に失敗しました" >&2; exit 2; }
+  scan_root="$ready_gate_tmp"
+  echo "[CONTEXT] READY_GATE_PR_HEAD_RESOLVED=1; head_oid=$pr_head_oid" >&2
+fi
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1); bang_rc=$?
+case "$bang_rc" in
+  0) if printf '%s' "$bang_output" | grep -q '\[bang-backtick\] not applicable'; then echo "ℹ️ Bang-backtick gate: N/A（clean skip）。" >&2; fi ;;
+  1) echo "❌ Bang-backtick adjacency detected — Ready transition blocked:" >&2; printf '%s\n' "$bang_output" >&2; echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand 'if ! cmd; then')." >&2; exit 1 ;;
+  *) echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=invocation_error; rc=$bang_rc" >&2; printf '%s\n' "$bang_output" >&2; exit 2 ;;
+esac

--- a/plugins/rite/hooks/scripts/ready-pr-head-gate.sh
+++ b/plugins/rite/hooks/scripts/ready-pr-head-gate.sh
@@ -4,9 +4,9 @@ set -u
 pr_number=""; owner_repo=""; plugin_root=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --pr) pr_number="${2:-}"; shift 2 ;;
-    --repo) owner_repo="${2:-}"; shift 2 ;;
-    --plugin-root) plugin_root="${2:-}"; shift 2 ;;
+    --pr) [ "$#" -ge 2 ] || { echo "ERROR: Ready gate: --pr requires a value" >&2; exit 2; }; pr_number="$2"; shift 2 ;;
+    --repo) [ "$#" -ge 2 ] || { echo "ERROR: Ready gate: --repo requires a value" >&2; exit 2; }; owner_repo="$2"; shift 2 ;;
+    --plugin-root) [ "$#" -ge 2 ] || { echo "ERROR: Ready gate: --plugin-root requires a value" >&2; exit 2; }; plugin_root="$2"; shift 2 ;;
     *) echo "ERROR: Ready gate: unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/plugins/rite/hooks/scripts/ready-work-memory-update.sh
+++ b/plugins/rite/hooks/scripts/ready-work-memory-update.sh
@@ -13,6 +13,8 @@ while [ "$#" -gt 0 ]; do
 done
 case "$pr_number" in ''|*[!0-9]*) echo "ERROR: ready work memory: numeric PR and Issue are required" >&2; exit 2 ;; esac
 case "$issue_number" in ''|*[!0-9]*) echo "ERROR: ready work memory: numeric PR and Issue are required" >&2; exit 2 ;; esac
+[ -n "$owner_repo" ] || { echo "ERROR: ready work memory: owner/repo is required" >&2; exit 2; }
+[ -x "$plugin_root/hooks/local-wm-update.sh" ] || { echo "ERROR: ready work memory: local-wm-update.sh not found: ${plugin_root:-<empty>}" >&2; exit 2; }
 head_fields=$(gh pr view "$pr_number" -R "$owner_repo" --json headRefName,headRefOid --jq '[.headRefName,.headRefOid] | @tsv') || head_fields=""
 IFS=$'\t' read -r ready_pr_branch ready_pr_oid <<< "$head_fields"
 if [ -z "${ready_pr_branch:-}" ] || [ -z "${ready_pr_oid:-}" ]; then
@@ -23,4 +25,7 @@ WM_SOURCE=ready WM_PHASE=ready WM_PHASE_DETAIL='Ready for review に変更完了
   WM_NEXT_ACTION='レビュー待ち' WM_BODY_TEXT='PR marked as ready for review.' \
   WM_ISSUE_NUMBER="$issue_number" WM_BRANCH_OVERRIDE="$ready_pr_branch" \
   WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid" \
-  bash "$plugin_root/hooks/local-wm-update.sh" 2>/dev/null || true
+  bash "$plugin_root/hooks/local-wm-update.sh" || {
+    writer_rc=$?
+    echo "WARNING: ready work memory writer failed (rc=$writer_rc); /rite:recover で再試行できます" >&2
+  }

--- a/plugins/rite/hooks/scripts/ready-work-memory-update.sh
+++ b/plugins/rite/hooks/scripts/ready-work-memory-update.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Update Ready work memory only when both PR-head identity fields are available.
+set -u
+pr_number=""; issue_number=""; owner_repo=""; plugin_root=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pr) [ "$#" -ge 2 ] || exit 2; pr_number="$2"; shift 2 ;;
+    --issue) [ "$#" -ge 2 ] || exit 2; issue_number="$2"; shift 2 ;;
+    --repo) [ "$#" -ge 2 ] || exit 2; owner_repo="$2"; shift 2 ;;
+    --plugin-root) [ "$#" -ge 2 ] || exit 2; plugin_root="$2"; shift 2 ;;
+    *) echo "ERROR: ready work memory: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+case "$pr_number" in ''|*[!0-9]*) echo "ERROR: ready work memory: numeric PR and Issue are required" >&2; exit 2 ;; esac
+case "$issue_number" in ''|*[!0-9]*) echo "ERROR: ready work memory: numeric PR and Issue are required" >&2; exit 2 ;; esac
+head_fields=$(gh pr view "$pr_number" -R "$owner_repo" --json headRefName,headRefOid --jq '[.headRefName,.headRefOid] | @tsv') || head_fields=""
+IFS=$'\t' read -r ready_pr_branch ready_pr_oid <<< "$head_fields"
+if [ -z "${ready_pr_branch:-}" ] || [ -z "${ready_pr_oid:-}" ]; then
+  echo "WARNING: PR head 情報を取得できないため local work memory 更新をスキップします" >&2
+  exit 0
+fi
+WM_SOURCE=ready WM_PHASE=ready WM_PHASE_DETAIL='Ready for review に変更完了' \
+  WM_NEXT_ACTION='レビュー待ち' WM_BODY_TEXT='PR marked as ready for review.' \
+  WM_ISSUE_NUMBER="$issue_number" WM_BRANCH_OVERRIDE="$ready_pr_branch" \
+  WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid" \
+  bash "$plugin_root/hooks/local-wm-update.sh" 2>/dev/null || true

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -116,18 +116,14 @@ else
 fi
 rm -f "$sentinel_stderr"
 
-# ----- TC-4: §7 MUST — create.md/ready.md DRIFT-CHECK ANCHOR ---------------
-# The Phase 1.0 bash block invocation literal MUST be byte-for-byte identical
-# between create.md and ready.md (Wiki 経験則「Asymmetric Fix Transcription」).
-# We pin three sentinels: the scanner invocation, the sentinel emit literal,
-# and the sub-section header.
-echo "TC-4: §7 MUST — DRIFT-CHECK ANCHOR between create.md and ready.md"
+# ----- TC-4: shared scanner core and ready-only PR-head resolution ----------
+echo "TC-4: shared scanner core and ready-only PR-head resolution"
 inv_create=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1' "$CREATE_MD" || true)
-inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1' "$READY_MD" || true)
+inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1' "$READY_MD" || true)
 if [ "$inv_create" -ge 1 ] && [ "$inv_ready" -ge 1 ]; then
-  pass "TC-4 scanner invocation literal present in BOTH create.md and ready.md"
+  pass "TC-4 scanner core present with ready-specific --repo-root"
 else
-  fail "TC-4 scanner invocation literal mismatch (create=$inv_create, ready=$inv_ready)"
+  fail "TC-4 scanner invocation missing (create=$inv_create, ready=$inv_ready)"
 fi
 
 sentinel_create=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$CREATE_MD" || true)
@@ -237,6 +233,39 @@ else
   fail "TC-6 expected exit 2 without flag, got $diag_rc"
 fi
 rm -rf "$consumer_root"
+
+# ----- TC-13: Issue #2147 — ready gate is bound to the PR head -------------
+echo "TC-13: ready gate resolves and scans the PR head"
+for needle in \
+  'gh pr view {pr_number} -R {owner_repo} --json headRefOid' \
+  'git worktree add --detach "$ready_gate_tmp" "$pr_head_oid"' \
+  'READY_GATE_PR_HEAD_RESOLVED=1; head_oid=$pr_head_oid' \
+  '--repo-root "$scan_root"' \
+  "trap 'cleanup_ready_gate_worktree; trap - INT; kill -INT \$\$' INT"
+do
+  if grep -qF -- "$needle" "$READY_MD"; then
+    pass "TC-13 contract present: $needle"
+  else
+    fail "TC-13 contract missing: $needle"
+  fi
+done
+
+# ----- TC-14: Issue #2147 — no fallback and PR-head work-memory values ------
+echo "TC-14: resolution failures stop and work memory records PR head"
+for needle in \
+  'PR #{pr_number} の headRefOid を解決できません' \
+  'PR head $pr_head_oid の fetch に失敗しました' \
+  'PR head $pr_head_oid の一時 worktree 作成に失敗しました' \
+  '--json headRefName,headRefOid' \
+  'branch: \"" branch "\"' \
+  'last_commit: \"" oid "\"'
+do
+  if grep -qF -- "$needle" "$READY_MD"; then
+    pass "TC-14 contract present: $needle"
+  else
+    fail "TC-14 contract missing: $needle"
+  fi
+done
 
 # ----- Summary --------------------------------------------------------------
 echo ""

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -36,6 +36,7 @@ REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
 CHECK_SCRIPT="$HOOK_DIR/scripts/bang-backtick-check.sh"
 CREATE_MD="$PLUGIN_ROOT/skills/pr-create/SKILL.md"
 READY_MD="$PLUGIN_ROOT/skills/ready/SKILL.md"
+READY_GATE_HELPER="$HOOK_DIR/scripts/ready-pr-head-gate.sh"
 LINT_MD="$PLUGIN_ROOT/skills/lint/SKILL.md"
 PASS=0
 FAIL=0
@@ -43,6 +44,7 @@ FAIL=0
 [ -f "$CHECK_SCRIPT" ] || { echo "ERROR: $CHECK_SCRIPT not found" >&2; exit 1; }
 [ -f "$CREATE_MD" ] || { echo "ERROR: $CREATE_MD not found" >&2; exit 1; }
 [ -f "$READY_MD" ] || { echo "ERROR: $READY_MD not found" >&2; exit 1; }
+[ -f "$READY_GATE_HELPER" ] || { echo "ERROR: $READY_GATE_HELPER not found" >&2; exit 1; }
 [ -f "$LINT_MD" ] || { echo "ERROR: $LINT_MD not found" >&2; exit 1; }
 
 pass() { PASS=$((PASS + 1)); echo "  ✅ PASS: $1"; }
@@ -119,7 +121,7 @@ rm -f "$sentinel_stderr"
 # ----- TC-4: shared scanner core and ready-only PR-head resolution ----------
 echo "TC-4: shared scanner core and ready-only PR-head resolution"
 inv_create=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1' "$CREATE_MD" || true)
-inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1' "$READY_MD" || true)
+inv_ready=$(grep -c 'bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1' "$READY_GATE_HELPER" || true)
 if [ "$inv_create" -ge 1 ] && [ "$inv_ready" -ge 1 ]; then
   pass "TC-4 scanner core present with ready-specific --repo-root"
 else
@@ -127,7 +129,7 @@ else
 fi
 
 sentinel_create=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$CREATE_MD" || true)
-sentinel_ready=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$READY_MD" || true)
+sentinel_ready=$(grep -c 'BANG_BACKTICK_CHECK_INVOCATION_FAILED=1' "$READY_GATE_HELPER" || true)
 if [ "$sentinel_create" -ge 2 ] && [ "$sentinel_ready" -ge 2 ]; then
   # ≥2 because the literal appears in both the script_missing branch and
   # the rc=invocation_error branch.
@@ -161,7 +163,7 @@ fi
 # is NOT used: it also appears in unrelated review-scope prose elsewhere in
 # create.md, so it would pass even if the real skip-note line were deleted.
 skipnote_create=$(grep -cF 'self-host していないため N/A' "$CREATE_MD" || true)
-skipnote_ready=$(grep -cF 'self-host していないため N/A' "$READY_MD" || true)
+skipnote_ready=$(grep -cF 'clean skip' "$READY_GATE_HELPER" || true)
 if [ "$skipnote_create" -ge 1 ] && [ "$skipnote_ready" -ge 1 ]; then
   pass "TC-4 not-applicable skip-note present in BOTH create.md and ready.md"
 else
@@ -190,7 +192,7 @@ fi
 # CRITICAL bug が発生 (3 site 同形 transcription、Wiki 経験則「Asymmetric Fix Transcription」の
 # inverse failure)。byte 比較で single-quote 囲みであることを pin する。
 echo "TC-12: CRITICAL regression — Style B 'if ! cmd; then' literal must use single-quotes (not backticks)"
-for f in "$CREATE_MD" "$READY_MD"; do
+for f in "$CREATE_MD" "$READY_GATE_HELPER"; do
   fname=$(basename "$f")
   if grep -qF "expand 'if ! cmd; then'" "$f"; then
     pass "TC-12 $fname uses single-quoted Style B example"
@@ -234,37 +236,11 @@ else
 fi
 rm -rf "$consumer_root"
 
-# ----- TC-13: Issue #2147 — ready gate is bound to the PR head -------------
-echo "TC-13: ready gate resolves and scans the PR head"
-for needle in \
-  'gh pr view {pr_number} -R {owner_repo} --json headRefOid' \
-  'git worktree add --detach "$ready_gate_tmp" "$pr_head_oid"' \
-  'READY_GATE_PR_HEAD_RESOLVED=1; head_oid=$pr_head_oid' \
-  '--repo-root "$scan_root"' \
-  "trap 'cleanup_ready_gate_worktree; trap - INT; kill -INT \$\$' INT"
-do
-  if grep -qF -- "$needle" "$READY_MD"; then
-    pass "TC-13 contract present: $needle"
-  else
-    fail "TC-13 contract missing: $needle"
-  fi
-done
-
-# ----- TC-14: Issue #2147 — no fallback and PR-head work-memory values ------
-echo "TC-14: resolution failures stop and work memory records PR head"
-for needle in \
-  'PR #{pr_number} の headRefOid を解決できません' \
-  'PR head $pr_head_oid の fetch に失敗しました' \
-  'PR head $pr_head_oid の一時 worktree 作成に失敗しました' \
-  '--json headRefName,headRefOid' \
-  'branch: \"" branch "\"' \
-  'last_commit: \"" oid "\"'
-do
-  if grep -qF -- "$needle" "$READY_MD"; then
-    pass "TC-14 contract present: $needle"
-  else
-    fail "TC-14 contract missing: $needle"
-  fi
+# Runtime behavior is covered by ready-pr-head-gate.test.sh. Keep only the
+# command-document wiring assertions here.
+echo "TC-13: ready gate helper wiring"
+for needle in 'ready-pr-head-gate.sh' '--pr "$ready_pr_number"' 'WM_BRANCH_OVERRIDE="$ready_pr_branch"' 'WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid"'; do
+  if grep -qF -- "$needle" "$READY_MD"; then pass "TC-13 wiring: $needle"; else fail "TC-13 missing: $needle"; fi
 done
 
 # ----- Summary --------------------------------------------------------------

--- a/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
+++ b/plugins/rite/hooks/tests/bang-backtick-pr-create-pre-check.test.sh
@@ -239,7 +239,7 @@ rm -rf "$consumer_root"
 # Runtime behavior is covered by ready-pr-head-gate.test.sh. Keep only the
 # command-document wiring assertions here.
 echo "TC-13: ready gate helper wiring"
-for needle in 'ready-pr-head-gate.sh' '--pr "$ready_pr_number"' 'WM_BRANCH_OVERRIDE="$ready_pr_branch"' 'WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid"'; do
+for needle in 'ready-pr-head-gate.sh' '--pr "$ready_pr_number"' 'ready-work-memory-update.sh' '--pr {pr_number} --issue {issue_number}'; do
   if grep -qF -- "$needle" "$READY_MD"; then pass "TC-13 wiring: $needle"; else fail "TC-13 missing: $needle"; fi
 done
 

--- a/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
+++ b/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
@@ -109,5 +109,18 @@ reset_case; export GH_WM_FIELDS=$'feature/ok\tfeedface'
 bash "$WM_HELPER" --pr 42 --issue 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/wm-ok"
 grep -q 'wm branch=feature/ok oid=feedface' "$LOG" && ok || bad wm_success
 
+rc=0; bash "$WM_HELPER" --pr 42 --issue 42 --repo '' --plugin-root "$SB/plugin" >/dev/null 2>"$SB/wm-invalid" || rc=$?
+[ "$rc" -eq 2 ] && grep -q 'owner/repo is required' "$SB/wm-invalid" && ok || bad wm_empty_repo
+rc=0; bash "$WM_HELPER" --pr 42 --issue 42 --repo owner/repo --plugin-root "$SB/missing" >/dev/null 2>"$SB/wm-invalid" || rc=$?
+[ "$rc" -eq 2 ] && grep -q 'local-wm-update.sh not found' "$SB/wm-invalid" && ok || bad wm_invalid_plugin
+cat > "$SB/plugin/hooks/local-wm-update.sh" <<'EOF'
+#!/bin/bash
+exit 7
+EOF
+chmod +x "$SB/plugin/hooks/local-wm-update.sh"
+reset_case; export GH_WM_FIELDS=$'feature/ok\tfeedface'
+bash "$WM_HELPER" --pr 42 --issue 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/wm-writer-fail"
+grep -q 'writer failed (rc=7)' "$SB/wm-writer-fail" && ok || bad wm_writer_warning
+
 echo "$pass PASS / $fail FAIL"
 [ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
+++ b/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
@@ -33,7 +33,10 @@ EOF
 cat > "$SB/plugin/hooks/scripts/bang-backtick-check.sh" <<'EOF'
 #!/bin/bash
 printf 'scanner %s\n' "$*" >> "$CALL_LOG"
-[ "${SCAN_SLEEP:-0}" = 1 ] && sleep 30
+if [ "${SCAN_SIGNAL_PARENT:-0}" = 1 ]; then
+  helper_pid=$(ps -o ppid= -p "$PPID" | tr -d ' ')
+  kill -TERM "$helper_pid"
+fi
 exit "${SCAN_RC:-0}"
 EOF
 chmod +x "$SB/bin/gh" "$SB/bin/git" "$SB/plugin/hooks/scripts/bang-backtick-check.sh" "$HELPER"
@@ -43,7 +46,7 @@ pass=0; fail=0
 ok(){ pass=$((pass+1)); }
 bad(){ echo "FAIL: $*" >&2; fail=$((fail+1)); }
 run_gate(){ PATH="$SB/bin:$PATH" bash "$HELPER" --pr 42 --repo owner/repo --plugin-root "$SB/plugin"; }
-reset_case(){ : > "$LOG"; rm -f "$SB/tmp-path"; unset GH_FAIL FETCH_FAIL ADD_FAIL REMOVE_FAIL SCAN_SLEEP; export SCAN_RC=0; }
+reset_case(){ : > "$LOG"; rm -f "$SB/tmp-path"; unset GH_FAIL FETCH_FAIL ADD_FAIL REMOVE_FAIL SCAN_SIGNAL_PARENT; export SCAN_RC=0; }
 
 # T-01: matching head scans the current checkout and creates no worktree.
 reset_case; export CURRENT_HEAD=same PR_HEAD=same
@@ -73,10 +76,8 @@ reset_case; export CURRENT_HEAD=base PR_HEAD=prhead REMOVE_FAIL=1
 run_gate >/dev/null 2>"$SB/err" && grep -q 'WARNING: Ready gate の一時 worktreeを\|WARNING: Ready gate の一時 worktree' "$SB/err" && ok || bad T-07
 
 # Signal cleanup uses canonical status and invokes worktree removal.
-reset_case; export CURRENT_HEAD=base PR_HEAD=prhead SCAN_SLEEP=1
-PATH="$SB/bin:$PATH" setsid bash "$HELPER" --pr 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/err" & pid=$!
-for _ in 1 2 3 4 5; do [ -s "$SB/tmp-path" ] && break; sleep 0.1; done
-kill -TERM -- "-$pid"; rc=0; wait "$pid" || rc=$?
+reset_case; export CURRENT_HEAD=base PR_HEAD=prhead SCAN_SIGNAL_PARENT=1
+rc=0; run_gate >/dev/null 2>"$SB/err" || rc=$?
 [ "$rc" -eq 143 ] && grep -q 'worktree remove --force' "$LOG" && ok || bad signal_cleanup
 
 # T-06: work-memory overrides are sanitized and written under the helper lock.
@@ -92,7 +93,7 @@ wm_file="$wm_repo/.rite-work-memory/issue-42.md"
 grep -qF 'branch: "feature/\"quoted\""' "$wm_file" && grep -qF 'last_commit: "0123456789abcdef"' "$wm_file" && ok || bad T-06-values
 
 # Missing option values terminate instead of looping.
-rc=0; timeout 1 bash "$HELPER" --pr >/dev/null 2>&1 || rc=$?
+rc=0; bash "$HELPER" --pr >/dev/null 2>&1 || rc=$?
 [ "$rc" -eq 2 ] && ok || bad missing_option_value
 
 # PR-head lookup failure must not invoke the work-memory writer.

--- a/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
+++ b/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -u
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+HELPER="$ROOT/hooks/scripts/ready-pr-head-gate.sh"
+SB=$(mktemp -d)
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/bin" "$SB/plugin/hooks/scripts"
+LOG="$SB/calls.log"
+
+cat > "$SB/bin/gh" <<'EOF'
+#!/bin/bash
+[ "${GH_FAIL:-0}" = 1 ] && exit 1
+printf '%s\n' "${PR_HEAD:-head}"
+EOF
+cat > "$SB/bin/git" <<'EOF'
+#!/bin/bash
+printf 'git %s\n' "$*" >> "$CALL_LOG"
+case "$1 $2" in
+  'rev-parse HEAD') printf '%s\n' "${CURRENT_HEAD:-head}" ;;
+  'fetch origin') [ "${FETCH_FAIL:-0}" = 1 ] && exit 1; exit 0 ;;
+  'worktree add')
+    [ "${ADD_FAIL:-0}" = 1 ] && exit 1
+    mkdir -p "$4"
+    printf '%s' "$4" > "$TMP_PATH_LOG"
+    ;;
+  'worktree remove')
+    [ "${REMOVE_FAIL:-0}" = 1 ] && exit 1
+    rm -rf "$4"
+    ;;
+esac
+EOF
+cat > "$SB/plugin/hooks/scripts/bang-backtick-check.sh" <<'EOF'
+#!/bin/bash
+printf 'scanner %s\n' "$*" >> "$CALL_LOG"
+[ "${SCAN_SLEEP:-0}" = 1 ] && sleep 30
+exit "${SCAN_RC:-0}"
+EOF
+chmod +x "$SB/bin/gh" "$SB/bin/git" "$SB/plugin/hooks/scripts/bang-backtick-check.sh" "$HELPER"
+export PATH="$SB/bin:$PATH" CALL_LOG="$LOG" TMP_PATH_LOG="$SB/tmp-path"
+
+pass=0; fail=0
+ok(){ pass=$((pass+1)); }
+bad(){ echo "FAIL: $*" >&2; fail=$((fail+1)); }
+run_gate(){ PATH="$SB/bin:$PATH" bash "$HELPER" --pr 42 --repo owner/repo --plugin-root "$SB/plugin"; }
+reset_case(){ : > "$LOG"; rm -f "$SB/tmp-path"; unset GH_FAIL FETCH_FAIL ADD_FAIL REMOVE_FAIL SCAN_SLEEP; export SCAN_RC=0; }
+
+# T-01: matching head scans the current checkout and creates no worktree.
+reset_case; export CURRENT_HEAD=same PR_HEAD=same
+run_gate >/dev/null 2>"$SB/err" && grep -q 'scanner .*--repo-root \.' "$LOG" && ! grep -q 'worktree add' "$LOG" && ok || bad T-01
+
+# T-02/T-05: mismatched head scans the detached PR-head root, emits marker,
+# removes it, and preserves a scanner finding as rc=1.
+reset_case; export CURRENT_HEAD=base PR_HEAD=prhead SCAN_RC=1
+rc=0; run_gate >/dev/null 2>"$SB/err" || rc=$?
+tmp=$(cat "$SB/tmp-path" 2>/dev/null || true)
+[ "$rc" -eq 1 ] && grep -q 'READY_GATE_PR_HEAD_RESOLVED=1; head_oid=prhead' "$SB/err" && grep -q "scanner .*--repo-root $tmp" "$LOG" && [ ! -e "$tmp" ] && ok || bad T-02-T-05
+
+# T-03: PR head lookup fails before scanner invocation.
+reset_case; export GH_FAIL=1 CURRENT_HEAD=base PR_HEAD=prhead
+rc=0; run_gate >/dev/null 2>"$SB/err" || rc=$?
+[ "$rc" -eq 2 ] && ! grep -q scanner "$LOG" && ok || bad T-03
+
+# T-04: fetch and worktree-add failures never fall back to current checkout.
+for mode in FETCH_FAIL ADD_FAIL; do
+  reset_case; export CURRENT_HEAD=base PR_HEAD=prhead; export "$mode"=1
+  rc=0; run_gate >/dev/null 2>"$SB/err" || rc=$?
+  [ "$rc" -eq 2 ] && ! grep -q scanner "$LOG" && ok || bad "T-04-$mode"
+done
+
+# T-07: remove failure warns but does not change a clean gate result.
+reset_case; export CURRENT_HEAD=base PR_HEAD=prhead REMOVE_FAIL=1
+run_gate >/dev/null 2>"$SB/err" && grep -q 'WARNING: Ready gate の一時 worktreeを\|WARNING: Ready gate の一時 worktree' "$SB/err" && ok || bad T-07
+
+# Signal cleanup uses canonical status and invokes worktree removal.
+reset_case; export CURRENT_HEAD=base PR_HEAD=prhead SCAN_SLEEP=1
+PATH="$SB/bin:$PATH" setsid bash "$HELPER" --pr 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/err" & pid=$!
+for _ in 1 2 3 4 5; do [ -s "$SB/tmp-path" ] && break; sleep 0.1; done
+kill -TERM -- "-$pid"; rc=0; wait "$pid" || rc=$?
+[ "$rc" -eq 143 ] && grep -q 'worktree remove --force' "$LOG" && ok || bad signal_cleanup
+
+# T-06: work-memory overrides are sanitized and written under the helper lock.
+wm_repo="$SB/wm-repo"; mkdir -p "$wm_repo"; git -C "$wm_repo" init -q
+(
+  cd "$wm_repo" || exit 1
+  WM_SOURCE=ready WM_PHASE=ready WM_PHASE_DETAIL=done WM_NEXT_ACTION=next \
+    WM_BODY_TEXT=body WM_ISSUE_NUMBER=42 WM_PLUGIN_ROOT="$ROOT" \
+    WM_BRANCH_OVERRIDE='feature/"quoted"' WM_LAST_COMMIT_OVERRIDE=0123456789abcdef \
+    bash "$ROOT/hooks/local-wm-update.sh"
+) >/dev/null 2>"$SB/wm-err" || bad T-06-run
+wm_file="$wm_repo/.rite-work-memory/issue-42.md"
+grep -qF 'branch: "feature/\"quoted\""' "$wm_file" && grep -qF 'last_commit: "0123456789abcdef"' "$wm_file" && ok || bad T-06-values
+
+echo "$pass PASS / $fail FAIL"
+[ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
+++ b/plugins/rite/hooks/tests/ready-pr-head-gate.test.sh
@@ -10,6 +10,7 @@ LOG="$SB/calls.log"
 cat > "$SB/bin/gh" <<'EOF'
 #!/bin/bash
 [ "${GH_FAIL:-0}" = 1 ] && exit 1
+case "$*" in *headRefName*) printf '%s\n' "${GH_WM_FIELDS:-}"; exit 0 ;; esac
 printf '%s\n' "${PR_HEAD:-head}"
 EOF
 cat > "$SB/bin/git" <<'EOF'
@@ -89,6 +90,24 @@ wm_repo="$SB/wm-repo"; mkdir -p "$wm_repo"; git -C "$wm_repo" init -q
 ) >/dev/null 2>"$SB/wm-err" || bad T-06-run
 wm_file="$wm_repo/.rite-work-memory/issue-42.md"
 grep -qF 'branch: "feature/\"quoted\""' "$wm_file" && grep -qF 'last_commit: "0123456789abcdef"' "$wm_file" && ok || bad T-06-values
+
+# Missing option values terminate instead of looping.
+rc=0; timeout 1 bash "$HELPER" --pr >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 2 ] && ok || bad missing_option_value
+
+# PR-head lookup failure must not invoke the work-memory writer.
+WM_HELPER="$ROOT/hooks/scripts/ready-work-memory-update.sh"
+cat > "$SB/plugin/hooks/local-wm-update.sh" <<'EOF'
+#!/bin/bash
+printf 'wm branch=%s oid=%s\n' "$WM_BRANCH_OVERRIDE" "$WM_LAST_COMMIT_OVERRIDE" >> "$CALL_LOG"
+EOF
+chmod +x "$SB/plugin/hooks/local-wm-update.sh" "$WM_HELPER"
+reset_case; export GH_FAIL=1
+bash "$WM_HELPER" --pr 42 --issue 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/wm-skip"
+! grep -q '^wm ' "$LOG" && grep -q '更新をスキップ' "$SB/wm-skip" && ok || bad wm_failure_skip
+reset_case; export GH_WM_FIELDS=$'feature/ok\tfeedface'
+bash "$WM_HELPER" --pr 42 --issue 42 --repo owner/repo --plugin-root "$SB/plugin" >/dev/null 2>"$SB/wm-ok"
+grep -q 'wm branch=feature/ok oid=feedface' "$LOG" && ok || bad wm_success
 
 echo "$pass PASS / $fail FAIL"
 [ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/work-memory-update.sh
+++ b/plugins/rite/hooks/work-memory-update.sh
@@ -35,6 +35,8 @@
 #   WM_LOOP_COUNT           - Loop count override. Same effective conditions as WM_PR_NUMBER.
 #                             (default: carried forward from the existing WM, else 0. Unlike
 #                             WM_PR_NUMBER there is no 0 exclusion — 0 is a real value here.)
+#   WM_BRANCH_OVERRIDE      - Branch value override when the subject is not the current checkout.
+#   WM_LAST_COMMIT_OVERRIDE - Commit value override paired with WM_BRANCH_OVERRIDE.
 #
 #   Carry-forward fires only when the variable is unset or empty. Any non-empty value suppresses
 #   it, including the literal string "null" (which some callers pass when flow-state cannot be
@@ -272,8 +274,12 @@ update_local_work_memory() {
   fi
 
   local last_commit tmp_wm
-  local branch="$current_branch"
-  last_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+  local branch="${WM_BRANCH_OVERRIDE:-$current_branch}"
+  if [ -n "${WM_LAST_COMMIT_OVERRIDE:-}" ]; then
+    last_commit="$WM_LAST_COMMIT_OVERRIDE"
+  else
+    last_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+  fi
   # anchor: tmp_wm_mktemp (referenced by lock-skip path comment above)
   tmp_wm=$(mktemp "${local_wm}.tmp.XXXXXX") || { echo "rite: ${WM_SOURCE}: mktemp failed" >&2; return 2; }
   # Extend RETURN trap to also clean up temp file (rm -f is safe even after successful mv)

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -105,7 +105,7 @@ Even if the argument is omitted, retrieve and use the PR number from work memory
 
 > **Reference**: Pre-submission hard gate for the parser-trigger pattern (backtick + bang adjacency in inline code spans of `plugins/rite/{commands,skills,agents,references}/**/*.md`). The underlying static check is `plugins/rite/hooks/scripts/bang-backtick-check.sh`.
 >
-> **DRIFT-CHECK ANCHOR (MUST)**: This bash block is intentionally synchronized between `skills/pr-create/SKILL.md` §1.0 and `skills/ready/SKILL.md` §1.0. Any modification to either side MUST be replicated to the other. Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」の dominant failure mode を構造的に予防する。
+> **DRIFT-CHECK ANCHOR (SHARED CORE ONLY)**: scanner の起動と rc 分岐は `skills/pr-create/SKILL.md` §1.0 と同期する。一方、PR 番号を入力に持つ ready 固有の PR head 解決は構造が非対称なため同期対象外であり、pr-create へ転記しない。
 >
 > **Independent of the `/rite:lint` Phase 3.5 bang-backtick check**: lint records bang-backtick findings as warnings (`[lint:success]` is preserved). This gate, in contrast, **blocks** Ready transition when the same pattern is present — lint is the early heads-up, this is the final hard gate before Ready for review.
 
@@ -120,7 +120,55 @@ if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-che
   exit 1
 fi
 
-bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target 2>&1)
+# Gate の主体と scan 対象を一致させる。PR head を解決できない場合に現在の
+# checkout へ縮退すると vacuous pass になるため、全て fail-loud とする。
+pr_head_oid=$(gh pr view {pr_number} -R {owner_repo} --json headRefOid --jq '.headRefOid') || {
+  echo "ERROR: Ready gate: PR #{pr_number} の headRefOid を解決できません" >&2
+  exit 1
+}
+if [ -z "$pr_head_oid" ]; then
+  echo "ERROR: Ready gate: PR #{pr_number} の headRefOid が空です" >&2
+  exit 1
+fi
+current_oid=$(git rev-parse HEAD) || {
+  echo "ERROR: Ready gate: 現在の HEAD を解決できません" >&2
+  exit 1
+}
+
+scan_root="."
+ready_gate_tmp=""
+cleanup_ready_gate_worktree() {
+  [ -n "$ready_gate_tmp" ] || return 0
+  cleanup_path="$ready_gate_tmp"
+  ready_gate_tmp=""
+  if ! git worktree remove --force "$cleanup_path" >/dev/null 2>&1; then
+    echo "WARNING: Ready gate の一時 worktree を削除できませんでした: $cleanup_path" >&2
+  fi
+}
+trap 'cleanup_ready_gate_worktree' EXIT
+trap 'cleanup_ready_gate_worktree; trap - HUP; kill -HUP $$' HUP
+trap 'cleanup_ready_gate_worktree; trap - INT; kill -INT $$' INT
+trap 'cleanup_ready_gate_worktree; trap - TERM; kill -TERM $$' TERM
+
+if [ "$current_oid" != "$pr_head_oid" ]; then
+  if ! git fetch origin "$pr_head_oid" >/dev/null 2>&1; then
+    echo "ERROR: Ready gate: PR head $pr_head_oid の fetch に失敗しました" >&2
+    exit 1
+  fi
+  ready_gate_tmp=$(mktemp -d "${TMPDIR:-/tmp}/rite-ready-pr-head.XXXXXX") || {
+    echo "ERROR: Ready gate: 一時ディレクトリの作成に失敗しました" >&2
+    exit 1
+  }
+  rmdir "$ready_gate_tmp"
+  if ! git worktree add --detach "$ready_gate_tmp" "$pr_head_oid" >/dev/null 2>&1; then
+    echo "ERROR: Ready gate: PR head $pr_head_oid の一時 worktree 作成に失敗しました" >&2
+    exit 1
+  fi
+  scan_root="$ready_gate_tmp"
+  echo "[CONTEXT] READY_GATE_PR_HEAD_RESOLVED=1; head_oid=$pr_head_oid" >&2
+fi
+
+bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1)
 bang_rc=$?
 case "$bang_rc" in
   0)
@@ -145,6 +193,9 @@ case "$bang_rc" in
     exit 1
     ;;
 esac
+
+cleanup_ready_gate_worktree
+trap - EXIT HUP INT TERM
 ```
 
 > **On exit 1 from this bash block**: The bash block exits before any `skills/ready/SKILL.md` result pattern (`[ready:returned-to-caller]` / `[ready:error]`) is emitted, so the orchestrator treats this as a missing-result-pattern Skill invocation — default 経路は `WARNING` を stderr に出力し、AskUserQuestion で「再試行 / 強制続行 / 中止」を提示する — **NOT** a `[ready:error]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a stderr-only diagnostic; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no flag is set at all (the failure is expected and the user fixes the code).
@@ -349,6 +400,15 @@ End processing.
 After `gh pr ready` succeeds, update local work memory (SoT):
 
 ```bash
+# 作業ツリーではなく PR head を SoT とする。Phase 1.0 と Bash 呼び出しが分かれるため
+# marker/シェル変数へ依存せず、この場で再取得する。
+ready_pr_json=$(gh pr view {pr_number} -R {owner_repo} --json headRefName,headRefOid) || {
+  echo "WARNING: PR head 情報を取得できないため local work memory 更新をスキップします" >&2
+  ready_pr_json=""
+}
+ready_pr_branch=$(printf '%s' "$ready_pr_json" | jq -r '.headRefName // empty')
+ready_pr_oid=$(printf '%s' "$ready_pr_json" | jq -r '.headRefOid // empty')
+
 WM_SOURCE="ready" \
   WM_PHASE="ready" \
   WM_PHASE_DETAIL="Ready for review に変更完了" \
@@ -356,6 +416,20 @@ WM_SOURCE="ready" \
   WM_BODY_TEXT="PR marked as ready for review." \
   WM_ISSUE_NUMBER="{issue_number}" \
   bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+
+# local-wm-update.sh は通常 current checkout 由来の branch / last_commit を書くため、
+# ready では取得済み PR head 値で frontmatter を atomic に補正する。
+wm_file=".rite-work-memory/issue-{issue_number}.md"
+if [ -n "$ready_pr_branch" ] && [ -n "$ready_pr_oid" ] && [ -f "$wm_file" ]; then
+  awk -v branch="$ready_pr_branch" -v oid="$ready_pr_oid" '
+    /^branch: / { print "branch: \"" branch "\""; next }
+    /^last_commit: / { print "last_commit: \"" oid "\""; next }
+    { print }
+  ' "$wm_file" > "$wm_file.tmp" && mv "$wm_file.tmp" "$wm_file" || {
+    rm -f "$wm_file.tmp"
+    echo "WARNING: local work memory の PR head 値への補正に失敗しました: $wm_file" >&2
+  }
+fi
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -121,6 +121,13 @@ ready_pr_number="{pr_number}"
 case "$ready_pr_number" in
   ''|*[!0-9]*)
     ready_branch=$(git branch --show-current) || { echo "ERROR: Ready gate: current branch を解決できません" >&2; exit 1; }
+    case "$ready_branch" in
+      main|master)
+        echo "エラー: 現在 $ready_branch ブランチにいます" >&2
+        echo "Ready for review にする PR を指定してください: /rite:ready <PR番号>" >&2
+        exit 1
+        ;;
+    esac
     ready_pr_number=$(gh pr view "$ready_branch" -R {owner_repo} --json number --jq '.number') || {
       echo "ERROR: Ready gate: branch '$ready_branch' の PR を解決できません" >&2
       exit 1
@@ -334,24 +341,8 @@ End processing.
 After `gh pr ready` succeeds, update local work memory (SoT):
 
 ```bash
-# 作業ツリーではなく PR head を SoT とする。Phase 1.0 と Bash 呼び出しが分かれるため
-# marker/シェル変数へ依存せず、この場で再取得する。
-ready_pr_json=$(gh pr view {pr_number} -R {owner_repo} --json headRefName,headRefOid) || {
-  echo "WARNING: PR head 情報を取得できないため local work memory 更新をスキップします" >&2
-  ready_pr_json=""
-}
-ready_pr_branch=$(printf '%s' "$ready_pr_json" | jq -r '.headRefName // empty')
-ready_pr_oid=$(printf '%s' "$ready_pr_json" | jq -r '.headRefOid // empty')
-
-WM_SOURCE="ready" \
-  WM_PHASE="ready" \
-  WM_PHASE_DETAIL="Ready for review に変更完了" \
-  WM_NEXT_ACTION="レビュー待ち" \
-  WM_BODY_TEXT="PR marked as ready for review." \
-  WM_ISSUE_NUMBER="{issue_number}" \
-  WM_BRANCH_OVERRIDE="$ready_pr_branch" \
-  WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid" \
-  bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
+bash {plugin_root}/hooks/scripts/ready-work-memory-update.sh \
+  --pr {pr_number} --issue {issue_number} --repo {owner_repo} --plugin-root {plugin_root}
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -114,88 +114,22 @@ Resolve plugin_root with the inline one-liner (per [Plugin Path Resolution](../.
 ```bash
 plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
 
-if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/hooks/scripts/bang-backtick-check.sh" ]; then
-  echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=script_missing; resolved_root=${plugin_root:-<empty>}" >&2
-  echo "ERROR: bang-backtick-check.sh not found. Cannot proceed with Ready gate." >&2
-  exit 1
-fi
-
-# Gate の主体と scan 対象を一致させる。PR head を解決できない場合に現在の
-# checkout へ縮退すると vacuous pass になるため、全て fail-loud とする。
-pr_head_oid=$(gh pr view {pr_number} -R {owner_repo} --json headRefOid --jq '.headRefOid') || {
-  echo "ERROR: Ready gate: PR #{pr_number} の headRefOid を解決できません" >&2
-  exit 1
-}
-if [ -z "$pr_head_oid" ]; then
-  echo "ERROR: Ready gate: PR #{pr_number} の headRefOid が空です" >&2
-  exit 1
-fi
-current_oid=$(git rev-parse HEAD) || {
-  echo "ERROR: Ready gate: 現在の HEAD を解決できません" >&2
-  exit 1
-}
-
-scan_root="."
-ready_gate_tmp=""
-cleanup_ready_gate_worktree() {
-  [ -n "$ready_gate_tmp" ] || return 0
-  cleanup_path="$ready_gate_tmp"
-  ready_gate_tmp=""
-  if ! git worktree remove --force "$cleanup_path" >/dev/null 2>&1; then
-    echo "WARNING: Ready gate の一時 worktree を削除できませんでした: $cleanup_path" >&2
-  fi
-}
-trap 'cleanup_ready_gate_worktree' EXIT
-trap 'cleanup_ready_gate_worktree; trap - HUP; kill -HUP $$' HUP
-trap 'cleanup_ready_gate_worktree; trap - INT; kill -INT $$' INT
-trap 'cleanup_ready_gate_worktree; trap - TERM; kill -TERM $$' TERM
-
-if [ "$current_oid" != "$pr_head_oid" ]; then
-  if ! git fetch origin "$pr_head_oid" >/dev/null 2>&1; then
-    echo "ERROR: Ready gate: PR head $pr_head_oid の fetch に失敗しました" >&2
-    exit 1
-  fi
-  ready_gate_tmp=$(mktemp -d "${TMPDIR:-/tmp}/rite-ready-pr-head.XXXXXX") || {
-    echo "ERROR: Ready gate: 一時ディレクトリの作成に失敗しました" >&2
-    exit 1
-  }
-  rmdir "$ready_gate_tmp"
-  if ! git worktree add --detach "$ready_gate_tmp" "$pr_head_oid" >/dev/null 2>&1; then
-    echo "ERROR: Ready gate: PR head $pr_head_oid の一時 worktree 作成に失敗しました" >&2
-    exit 1
-  fi
-  scan_root="$ready_gate_tmp"
-  echo "[CONTEXT] READY_GATE_PR_HEAD_RESOLVED=1; head_oid=$pr_head_oid" >&2
-fi
-
-bang_output=$(bash "$plugin_root/hooks/scripts/bang-backtick-check.sh" --all --skip-if-no-target --repo-root "$scan_root" 2>&1)
-bang_rc=$?
-case "$bang_rc" in
-  0)
-    # A clean scan and a not-applicable skip both mean "proceed". The skip happens
-    # in a consumer repo (rite used as a marketplace plugin only — no plugins/rite/
-    # in this working tree, hence --skip-if-no-target above). Surface a one-line
-    # informational note for the skip case so the gate pass is not silent.
-    if printf '%s' "$bang_output" | grep -q '\[bang-backtick\] not applicable'; then
-      echo "ℹ️ Bang-backtick gate: 本リポジトリは plugins/rite/ を self-host していないため N/A（clean skip）。" >&2
-    fi
-    ;;
-  1)
-    echo "❌ Bang-backtick adjacency detected — Ready transition blocked:" >&2
-    printf '%s\n' "$bang_output" >&2
-    echo "ACTION: Apply Style A (full-width 「!」) or Style B (expand 'if ! cmd; then') — see plugins/rite/hooks/scripts/bang-backtick-check.sh header for the judgment flow." >&2
-    exit 1
-    ;;
-  *)
-    echo "[CONTEXT] BANG_BACKTICK_CHECK_INVOCATION_FAILED=1; reason=invocation_error; rc=$bang_rc" >&2
-    echo "ERROR: bang-backtick-check.sh invocation error (rc=$bang_rc):" >&2
-    printf '%s\n' "$bang_output" >&2
-    exit 1
+# Optional argument is resolved before the gate so `/rite:ready` without an
+# argument remains deterministic. The helper then owns PR-head resolution,
+# fail-loud routing, scanner rc handling, and signal-safe worktree cleanup.
+ready_pr_number="{pr_number}"
+case "$ready_pr_number" in
+  ''|*[!0-9]*)
+    ready_branch=$(git branch --show-current) || { echo "ERROR: Ready gate: current branch を解決できません" >&2; exit 1; }
+    ready_pr_number=$(gh pr view "$ready_branch" -R {owner_repo} --json number --jq '.number') || {
+      echo "ERROR: Ready gate: branch '$ready_branch' の PR を解決できません" >&2
+      exit 1
+    }
     ;;
 esac
 
-cleanup_ready_gate_worktree
-trap - EXIT HUP INT TERM
+bash "$plugin_root/hooks/scripts/ready-pr-head-gate.sh" \
+  --pr "$ready_pr_number" --repo {owner_repo} --plugin-root "$plugin_root"
 ```
 
 > **On exit 1 from this bash block**: The bash block exits before any `skills/ready/SKILL.md` result pattern (`[ready:returned-to-caller]` / `[ready:error]`) is emitted, so the orchestrator treats this as a missing-result-pattern Skill invocation — default 経路は `WARNING` を stderr に出力し、AskUserQuestion で「再試行 / 強制続行 / 中止」を提示する — **NOT** a `[ready:error]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a stderr-only diagnostic; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no flag is set at all (the failure is expected and the user fixes the code).
@@ -415,21 +349,9 @@ WM_SOURCE="ready" \
   WM_NEXT_ACTION="レビュー待ち" \
   WM_BODY_TEXT="PR marked as ready for review." \
   WM_ISSUE_NUMBER="{issue_number}" \
+  WM_BRANCH_OVERRIDE="$ready_pr_branch" \
+  WM_LAST_COMMIT_OVERRIDE="$ready_pr_oid" \
   bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
-
-# local-wm-update.sh は通常 current checkout 由来の branch / last_commit を書くため、
-# ready では取得済み PR head 値で frontmatter を atomic に補正する。
-wm_file=".rite-work-memory/issue-{issue_number}.md"
-if [ -n "$ready_pr_branch" ] && [ -n "$ready_pr_oid" ] && [ -f "$wm_file" ]; then
-  awk -v branch="$ready_pr_branch" -v oid="$ready_pr_oid" '
-    /^branch: / { print "branch: \"" branch "\""; next }
-    /^last_commit: / { print "last_commit: \"" oid "\""; next }
-    { print }
-  ' "$wm_file" > "$wm_file.tmp" && mv "$wm_file.tmp" "$wm_file" || {
-    rm -f "$wm_file.tmp"
-    echo "WARNING: local work memory の PR head 値への補正に失敗しました: $wm_file" >&2
-  }
-fi
 ```
 
 **On lock failure**: Log a warning and continue — local work memory update is best-effort.


### PR DESCRIPTION
## 概要

Ready 化前の bang-backtick 検査を対象 PR の head に固定し、別 checkout から実行した際の空振りを防ぎます。

Closes #2147

## 変更内容

- 現在 HEAD と PR head が異なる場合、PR head を一時 worktree に展開してスキャン
- head 解決・fetch・worktree 作成の失敗を fail-loud 化し、現在 checkout への縮退を禁止
- signal を含む全終了経路で一時 worktree を回収し、削除失敗は判定を維持したまま警告
- Ready 完了時の作業メモリへ PR の `headRefName` / `headRefOid` を記録
- 既存ゲートテストへ ready 固有の契約検証を追加

## 実装中の判断・計画逸脱

- 判断: PR 番号を持たない pr-create のゲートには head 解決を転記しない — 両スキルで共有するのは scanner 起動と rc 契約のみで、主体の解決方法は構造的に異なるため
- 判断: head 解決失敗時は現在 checkout をスキャンしない — 誤った対象での成功判定を防ぐため
- 判断: 一時 worktree 削除失敗は Ready 判定を覆さない — スキャン結果の正しさには影響せず、残存パスを警告で回収可能にするため

## 確認

- [x] 対象回帰テスト: 30 PASS / 0 FAIL
- [x] bang-backtick 全体スキャン: findings 0
- [x] rite 固有品質チェックを実行（既存リポジトリ全体に由来する警告のみ、blocking error 0）
- [x] `git diff --check`
