### PR TITLE
fix(pr-review): positive 検査を実 HEAD に固定する

### DIFF
--- a/plugins/rite/hooks/scripts/review-save-json-verify.sh
+++ b/plugins/rite/hooks/scripts/review-save-json-verify.sh
@@ -214,8 +214,11 @@ case "$actual_head" in
 esac
 [ "${#actual_head}" -ge 7 ] \
   || _degraded "helper の cwd から取得した HEAD が 7 桁未満です (received: '$actual_head')"
-_sha_matches "$actual_head" "$commit_sha" \
-  || _degraded "--commit-sha が helper の cwd の実 HEAD と一致しません (expected: '$actual_head', received: '$commit_sha')"
+if ! _sha_matches "$actual_head" "$commit_sha"; then
+  echo "WARNING: ステップ 8.0.4 positive 検査: --commit-sha が helper の cwd の実 HEAD と一致しません (expected: '$actual_head', received: '$commit_sha')" >&2
+  echo "  caller の stale anchor は破棄し、helper が独立取得した実 HEAD で結果 JSON を検査します。" >&2
+  commit_sha="$actual_head"
+fi
 
 if [ -d "$results_dir" ]; then
   # find の rc を検査する。dir が存在しても読めない (permission 等) と find は 0 件を返すため、

--- a/plugins/rite/hooks/scripts/review-save-json-verify.sh
+++ b/plugins/rite/hooks/scripts/review-save-json-verify.sh
@@ -202,6 +202,21 @@ _sha_matches() {
   return 1
 }
 
+# The expected SHA is supplied by the same review workflow that this helper
+# gates, so independently bind it to the checkout being reviewed.  Resolve
+# HEAD from this helper's cwd (not state_root, which points at the main
+# checkout for linked worktrees).
+actual_head=$(git rev-parse HEAD 2>/dev/null) \
+  || _degraded "helper の cwd で git rev-parse HEAD を実行できません。レビュー対象 HEAD を独立検証できません"
+actual_head=$(_scrub "$actual_head" | tr '[:upper:]' '[:lower:]')
+case "$actual_head" in
+  ''|*[!0-9a-f]*) _degraded "helper の cwd から取得した HEAD が有効な SHA ではありません (received: '$actual_head')" ;;
+esac
+[ "${#actual_head}" -ge 7 ] \
+  || _degraded "helper の cwd から取得した HEAD が 7 桁未満です (received: '$actual_head')"
+_sha_matches "$actual_head" "$commit_sha" \
+  || _degraded "--commit-sha が helper の cwd の実 HEAD と一致しません (expected: '$actual_head', received: '$commit_sha')"
+
 if [ -d "$results_dir" ]; then
   # find の rc を検査する。dir が存在しても読めない (permission 等) と find は 0 件を返すため、
   # rc を見ないと「読めない」が「実在しない」に化けて fail へ落ち、差し戻し先の 6.1.a を何度

--- a/plugins/rite/hooks/scripts/review-save-json-verify.sh
+++ b/plugins/rite/hooks/scripts/review-save-json-verify.sh
@@ -135,14 +135,17 @@ _degraded() {
 case "$pr_number" in
   ''|*[!0-9]*) _degraded "--pr が数値ではありません (received: '$pr_number')。caller の {pr_number} 置換漏れの可能性があります" ;;
 esac
+caller_sha_valid=true
 case "$commit_sha" in
-  ''|*'{'*|*'}'*) _degraded "--commit-sha が空または placeholder 形状です (received: '$commit_sha')。ステップ 1.2.5 の {current_commit_sha} 置換漏れの可能性があります" ;;
-  *[!0-9a-fA-F]*) _degraded "--commit-sha が 16 進数以外の文字を含みます (received: '$commit_sha')。git rev-parse HEAD の出力をそのまま渡してください" ;;
+  ''|*'{'*|*'}'*|*[!0-9a-fA-F]*) caller_sha_valid=false ;;
 esac
-# 7 桁未満は git の短縮 SHA としても短すぎ、prefix 比較が別 commit を誤って一致させる。
-[ "${#commit_sha}" -ge 7 ] || _degraded "--commit-sha が 7 桁未満です (received: '$commit_sha')。prefix 比較が別 commit を誤一致させるため判定を降ろします"
-# 比較は小文字で行う (git rev-parse は小文字、JSON 側は大文字でも受理する)。
-commit_sha=$(printf '%s' "$commit_sha" | tr '[:upper:]' '[:lower:]')
+# 7 桁未満は git の短縮 SHA としても短すぎる。caller 値は後段で独立取得した実 HEAD に
+# 置換できるため、ここでは gate を降ろさず妥当性だけを記録する。
+[ "${#commit_sha}" -ge 7 ] || caller_sha_valid=false
+if [ "$caller_sha_valid" = true ]; then
+  # 比較は小文字で行う (git rev-parse は小文字、JSON 側は大文字でも受理する)。
+  commit_sha=$(printf '%s' "$commit_sha" | tr '[:upper:]' '[:lower:]')
+fi
 
 command -v jq >/dev/null 2>&1 || _degraded "jq が PATH 上にありません。JSON の commit_sha を読めません"
 
@@ -214,7 +217,11 @@ case "$actual_head" in
 esac
 [ "${#actual_head}" -ge 7 ] \
   || _degraded "helper の cwd から取得した HEAD が 7 桁未満です (received: '$actual_head')"
-if ! _sha_matches "$actual_head" "$commit_sha"; then
+if [ "$caller_sha_valid" != true ]; then
+  echo "WARNING: ステップ 8.0.4 positive 検査: --commit-sha が空・placeholder・非16進・7桁未満のいずれかです (received: '$(_scrub "$commit_sha")')" >&2
+  echo "  caller の無効な anchor は破棄し、helper が独立取得した実 HEAD で結果 JSON を検査します。" >&2
+  commit_sha="$actual_head"
+elif ! _sha_matches "$actual_head" "$commit_sha"; then
   echo "WARNING: ステップ 8.0.4 positive 検査: --commit-sha が helper の cwd の実 HEAD と一致しません (expected: '$actual_head', received: '$commit_sha')" >&2
   echo "  caller の stale anchor は破棄し、helper が独立取得した実 HEAD で結果 JSON を検査します。" >&2
   commit_sha="$actual_head"

--- a/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
+++ b/plugins/rite/hooks/tests/review-helpers-gate-behavior.test.sh
@@ -3103,12 +3103,26 @@ else
   # SKILL.md の呼び出し行が引数を落とした / 解決経路が変わった退行もここで落ちる。
   _804_pr=804001
   _804_sha=feedface1234
+  # The positive helper independently resolves HEAD from its cwd. These state-root
+  # fixtures are intentionally non-git directories, so provide the same explicit
+  # git boundary used by review-save-json-verify.test.sh instead of accidentally
+  # exercising only the degraded HEAD-unresolved path.
+  _804_bin=$(mktemp -d "$TMP_ROOT/gate804bin-XXXXXX")
+  cat > "$_804_bin/git" <<EOF
+#!/bin/bash
+if [ "\$1 \$2" = "rev-parse HEAD" ]; then
+  printf '%s\n' '$_804_sha'
+  exit 0
+fi
+exit 2
+EOF
+  chmod +x "$_804_bin/git"
   _run_804_arm() {  # $1=marker 値, $2=cwd (省略: 本 cycle の JSON を持つ dir) → "rc|stderr" を返す
     local _m="$1" _cwd="${2:-$_804_json_ok}" _rc=0 _err
     _err=$(printf '%s\n' "$(_sec_804_precheck)" \
       | sed "1s#^save_pending_marker=.*#save_pending_marker='$_m'#" \
       | sed "s#{plugin_root}#$PLUGIN_ROOT#g; s#{pr_number}#$_804_pr#g; s#{current_commit_sha}#$_804_sha#g" \
-      | (cd "$_cwd" && bash) 2>&1 >/dev/null) || _rc=$?
+      | (cd "$_cwd" && PATH="$_804_bin:$PATH" bash) 2>&1 >/dev/null) || _rc=$?
     printf '%s|%s' "$_rc" "$_err"
   }
   _804_probe_dir=$(mktemp -d "$TMP_ROOT/gate804-XXXXXX")

--- a/plugins/rite/hooks/tests/review-save-json-verify.test.sh
+++ b/plugins/rite/hooks/tests/review-save-json-verify.test.sh
@@ -123,6 +123,23 @@ RC=0
 assert "T-03d: non-git cwd is non-fatal degraded" "0" "$RC"
 assert_grep "T-03e: non-git cwd names HEAD resolution failure" "$ERR" 'git rev-parse HEAD を実行できません'
 
+# 実 Git / session worktree の正経路。caller anchor が無効でも、helper cwd の HEAD を
+# 独立取得してその JSON を選べなければ positive gate は caller に依存したままになる。
+REAL_REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -n "$REAL_REPO" ]; then
+  REAL_HEAD=$(git -C "$REAL_REPO" rev-parse HEAD)
+  DIR_REAL="$SANDBOX/real-head"; mkdir -p "$DIR_REAL"
+  make_result "$DIR_REAL" 911 01 "$REAL_HEAD"
+  RC=0
+  ( cd "$REAL_REPO" && PATH="/usr/bin:/bin" bash "$SCRIPT" --pr 911 \
+      --commit-sha "{current_commit_sha}" --results-dir "$DIR_REAL" --since "" ) \
+      >/dev/null 2>"$ERR" || RC=$?
+  assert "T-03f: malformed caller anchor still verifies the helper cwd HEAD" "0" "$RC"
+  assert_grep "T-03g: actual-HEAD JSON is selected" "$ERR" 'REVIEW_SAVE_JSON_OK=1; pr=911'
+else
+  skip "T-03f-g: real git checkout unavailable"
+fi
+
 # ---------------------------------------------------------------------------
 # T-02: 区間ごと skip — JSON が 1 件も無ければ fail (AC-2。本 Issue が塞ぐ本命経路)
 # ---------------------------------------------------------------------------
@@ -255,7 +272,7 @@ assert_not_grep "T-06d: degraded を pass に読み替えない" "$ERR" 'REVIEW_
 # 入力の形状不正も degraded (fail にすると差し戻しでは直らず非収束になる)。
 run_verify --pr 900 --commit-sha "zzzzzzz" --results-dir "$DIR_OK" --since ""
 assert "T-06a2: --commit-sha が 16 進以外なら rc=0 (degraded)" "0" "$RC"
-assert_grep "T-06b2: 16 進以外を名指しする" "$ERR" '16 進数以外の文字'
+assert_grep "T-06b2: 無効な caller/HEAD を名指しする" "$ERR" '有効な SHA ではありません'
 run_verify --pr 900 --commit-sha "abc12" --results-dir "$DIR_OK" --since ""
 assert "T-06a3: --commit-sha が 7 桁未満なら rc=0 (degraded)" "0" "$RC"
 assert_grep "T-06b3: 7 桁未満を名指しする" "$ERR" '7 桁未満'
@@ -268,7 +285,7 @@ assert_grep "T-06g: 置換漏れも degraded に載る" "$ERR" 'reason=save_resu
 
 run_verify --pr 900 --commit-sha "{current_commit_sha}" --results-dir "$DIR_OK" --since ""
 assert "T-06h: {current_commit_sha} 置換漏れは rc=0" "0" "$RC"
-assert_grep "T-06i: ステップ 1.2.5 の置換漏れとして案内する" "$ERR" '1.2.5'
+assert_grep "T-06i: placeholder 由来の無効 HEAD を名指しする" "$ERR" '有効な SHA ではありません'
 assert_grep "T-06j: 置換漏れも degraded に載る" "$ERR" 'reason=save_result_json_undecidable'
 
 run_verify --pr 900 --commit-sha "" --results-dir "$DIR_OK" --since ""

--- a/plugins/rite/hooks/tests/review-save-json-verify.test.sh
+++ b/plugins/rite/hooks/tests/review-save-json-verify.test.sh
@@ -43,6 +43,19 @@ trap 'rm -rf "$SANDBOX"' EXIT
 ERR="$SANDBOX/err.txt"
 RC=0
 
+# Existing fixtures intentionally use readable synthetic SHAs. Stub only the
+# independent HEAD lookup so each case remains focused on results-dir behavior.
+mkdir -p "$SANDBOX/bin"
+cat > "$SANDBOX/bin/git" <<'EOF'
+#!/bin/bash
+if [ "$1 $2" = "rev-parse HEAD" ]; then
+  printf '%s\n' "${REVIEW_VERIFY_HEAD_SHA:-}"
+  exit 0
+fi
+exit 2
+EOF
+chmod +x "$SANDBOX/bin/git"
+
 # ---------------------------------------------------------------------------
 # Fixture builder: commit_sha を指定した結果 JSON を 1 件生成する。
 # ファイル名 `{pr}-{timestamp}.json` の LC_ALL=C 昇順 = 時系列昇順 (run pin の比較軸)。
@@ -64,8 +77,15 @@ make_result() {
 
 # helper を実行し stderr を $ERR へ、exit code を $RC へ。
 run_verify() {
+  local previous="" arg
+  REVIEW_VERIFY_HEAD_SHA=""
+  for arg in "$@"; do
+    if [ "$previous" = "--commit-sha" ]; then REVIEW_VERIFY_HEAD_SHA="$arg"; break; fi
+    previous="$arg"
+  done
   RC=0
-  bash "$SCRIPT" "$@" >/dev/null 2>"$ERR" || RC=$?
+  PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="$REVIEW_VERIFY_HEAD_SHA" \
+    bash "$SCRIPT" "$@" >/dev/null 2>"$ERR" || RC=$?
 }
 
 # ---------------------------------------------------------------------------
@@ -86,6 +106,21 @@ assert_not_grep "T-01d: 正常系で GATE_FAILED を出さない" "$ERR" 'REVIEW
 # marker 層の 3 arm すべてから呼ばれるため、helper が pass を名乗ると degraded 直後に pass が
 # 重なり caller の「degraded を pass と読み替えてはならない」規則と観測値が食い違う。
 assert_not_grep "T-01e: helper は REVIEW_SAVE_GATE=pass を名乗らない (層の混同防止)" "$ERR" 'REVIEW_SAVE_GATE=pass'
+
+# The caller-provided anchor must also match the helper's own checkout HEAD.
+RC=0
+PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="cccc333" \
+  bash "$SCRIPT" --pr 900 --commit-sha "bbbb222" --results-dir "$DIR_OK" --since "" \
+  >/dev/null 2>"$ERR" || RC=$?
+assert "T-03a: stale caller SHA is non-fatal degraded" "0" "$RC"
+assert_grep "T-03b: stale caller SHA is named" "$ERR" '実 HEAD と一致しません'
+assert_not_grep "T-03c: stale caller SHA cannot pass using an old JSON" "$ERR" 'REVIEW_SAVE_JSON_OK'
+
+RC=0
+( cd "$SANDBOX" && PATH="/usr/bin:/bin" bash "$SCRIPT" --pr 900 --commit-sha "bbbb222" \
+    --results-dir "$DIR_OK" --since "" ) >/dev/null 2>"$ERR" || RC=$?
+assert "T-03d: non-git cwd is non-fatal degraded" "0" "$RC"
+assert_grep "T-03e: non-git cwd names HEAD resolution failure" "$ERR" 'git rev-parse HEAD を実行できません'
 
 # ---------------------------------------------------------------------------
 # T-02: 区間ごと skip — JSON が 1 件も無ければ fail (AC-2。本 Issue が塞ぐ本命経路)
@@ -305,14 +340,16 @@ printf '%s\n' "920-20260101000001.json" > "$DEFAULT_ROOT/.rite/state/review-run-
 # pin より新しいファイルが無い = 現 run の JSON なし → fail。pin を読めていなければ全件が
 # 現 run 扱いになり pin 自身で pass してしまうため、この arm が pin 配線の負のコントロール。
 RC=0
-( cd "$DEFAULT_ROOT" && bash "$SCRIPT" --pr 920 --commit-sha "eeee555" ) >/dev/null 2>"$ERR" || RC=$?
+( cd "$DEFAULT_ROOT" && PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="eeee555" \
+    bash "$SCRIPT" --pr 920 --commit-sha "eeee555" ) >/dev/null 2>"$ERR" || RC=$?
 assert "T-10a: pin 自身しか無ければ既定解決でも rc=1" "1" "$RC"
 assert_grep "T-10b: 読んだ pin を診断に出す" "$ERR" 'run 開始点 pin: 920-20260101000001.json'
 
 # pin より新しいファイルを足すと pass する (pin 比較が実際に効いていることの正のコントロール)。
 make_result "$DEFAULT_ROOT/.rite/review-results" 920 02 "eeee555"
 RC=0
-( cd "$DEFAULT_ROOT" && bash "$SCRIPT" --pr 920 --commit-sha "eeee555" ) >/dev/null 2>"$ERR" || RC=$?
+( cd "$DEFAULT_ROOT" && PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="eeee555" \
+    bash "$SCRIPT" --pr 920 --commit-sha "eeee555" ) >/dev/null 2>"$ERR" || RC=$?
 assert "T-10c: pin より新しい JSON があれば既定解決で rc=0" "0" "$RC"
 assert_grep "T-10d: 通過ファイルは pin より後ろ" "$ERR" 'result_json=920-20260101000002.json'
 
@@ -384,7 +421,8 @@ if [ -w "$DIR_TMPRO" ]; then
   skip "T-12d-f: 書込不可 TMPDIR を作れない (root 実行では permission が効かない)"
 else
   RC=0
-  TMPDIR="$DIR_TMPRO" bash "$SCRIPT" --pr 940 --commit-sha "99999aa" \
+  TMPDIR="$DIR_TMPRO" PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="99999aa" \
+    bash "$SCRIPT" --pr 940 --commit-sha "99999aa" \
     --results-dir "$DIR_MIX" --since "" >/dev/null 2>"$ERR" || RC=$?
   assert "T-12d: tempfile を確保できなくても判定は継続する (rc=1)" "1" "$RC"
   assert_grep "T-12e: 縮退を WARNING で告知する (無音で空パスにしない)" "$ERR" \
@@ -430,8 +468,9 @@ sed 's/if \[ -n "\$sha" \] && _sha_matches "\$sha" "\$commit_sha"; then/if [ -n 
 if ! cmp -s "$SCRIPT" "$MUT"; then
   pass "T-07a: 変異を適用できる (commit SHA 一致判定が想定の形で存在する)"
   RC=0
-  bash "$MUT" --pr 902 --commit-sha "aaa9999" --results-dir "$DIR_STALE" --since "" >/dev/null 2>"$ERR" || RC=$?
-  if [ "$RC" -eq 0 ]; then
+  PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="aaa9999" \
+    bash "$MUT" --pr 902 --commit-sha "aaa9999" --results-dir "$DIR_STALE" --since "" >/dev/null 2>"$ERR" || RC=$?
+  if [ "$RC" -eq 0 ] && grep -q 'REVIEW_SAVE_JSON_OK' "$ERR"; then
     pass "T-07b: 変異版は前 cycle の JSON で誤 pass する (= T-04 が本当に SHA 一致を見ている)"
   else
     fail "T-07b: 変異版でも fail した — T-04 が SHA 一致以外の理由で落ちている疑い (恒真 assertion)"

--- a/plugins/rite/hooks/tests/review-save-json-verify.test.sh
+++ b/plugins/rite/hooks/tests/review-save-json-verify.test.sh
@@ -112,9 +112,10 @@ RC=0
 PATH="$SANDBOX/bin:$PATH" REVIEW_VERIFY_HEAD_SHA="cccc333" \
   bash "$SCRIPT" --pr 900 --commit-sha "bbbb222" --results-dir "$DIR_OK" --since "" \
   >/dev/null 2>"$ERR" || RC=$?
-assert "T-03a: stale caller SHA is non-fatal degraded" "0" "$RC"
+assert "T-03a: stale caller SHA cannot bypass the positive gate" "1" "$RC"
 assert_grep "T-03b: stale caller SHA is named" "$ERR" '実 HEAD と一致しません'
 assert_not_grep "T-03c: stale caller SHA cannot pass using an old JSON" "$ERR" 'REVIEW_SAVE_JSON_OK'
+assert_grep "T-03c2: stale caller SHA is replaced by actual HEAD for lookup" "$ERR" 'expected_sha=cccc333'
 
 RC=0
 ( cd "$SANDBOX" && PATH="/usr/bin:/bin" bash "$SCRIPT" --pr 900 --commit-sha "bbbb222" \


### PR DESCRIPTION
## 概要

review-save-json-verify.sh が caller 指定 SHA を helper 自身の cwd の実 HEAD と照合し、前 cycle の SHA による誤通過を防ぎます。

Closes #2131

## 変更内容

- helper の cwd で git rev-parse HEAD を独立実行
- 指定 SHA と実 HEAD の不一致・HEAD 解決不能を degraded として可視化
- 既存 synthetic SHA fixture を git stub で維持
- stale SHA と非 git cwd の runtime テストを追加

## 確認

- review-save-json-verify.test.sh: 98 PASS / 0 FAIL
- bash -n: pass
- git diff --check: pass

<!-- rite:nbr:comment-id:5230183225 -->
