### PR TITLE
fix(review): Likelihood-Evidence producer gate を追加

### DIFF
--- a/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
+++ b/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -u
+
+# Validate the producer contract before reviewer output reaches aggregation.
+# rc=0: every finding has a valid evidence anchor (or an explicit allowed
+#       Hypothetical exception); rc=1: retryable contract violation; rc=2: usage.
+
+reviewer_type=""
+input=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --reviewer-type) reviewer_type="${2:-}"; shift 2 ;;
+    --input) input="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$reviewer_type" ] || [ -z "$input" ] || [ ! -r "$input" ]; then
+  echo "ERROR: --reviewer-type and readable --input are required" >&2
+  exit 2
+fi
+
+case "$reviewer_type" in
+  security|devops|dependencies) exception_category=1 ;;
+  *) exception_category=0 ;;
+esac
+
+stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$reviewer_type" '
+  BEGIN { in_findings=0; findings=0; missing=0 }
+  /^###[[:space:]]*(指摘事項|Findings)[[:space:]]*$/ { in_findings=1; next }
+  in_findings && /^###[[:space:]]/ { in_findings=0 }
+  !in_findings || $0 !~ /^[[:space:]]*\|/ { next }
+  /^\|[[:space:]]*(-+:?|-*[[:space:]]*#)[[:space:]]*\|/ { next }
+  /^\|[[:space:]]*(重要度|Severity)[[:space:]]*\|/ { next }
+  /^\|[[:space:]]*(なし|None)[[:space:]]*\|/ { next }
+  {
+    findings++
+    evidence = ($0 ~ /Likelihood-Evidence:[[:space:]]*(existing_call_site|new_call_site|entrypoint_connection|runtime_observation)[[:space:]]+[^|[:space:]]/)
+    hypothetical = ($0 ~ /Likelihood:[[:space:]]*Hypothetical[[:space:]]*\(例外カテゴリ:[[:space:]]*[^)]+\)/)
+    migration = (reviewer_type == "application" && $0 ~ /例外カテゴリ:[[:space:]]*database migration/)
+    if (!evidence && !((exception_category || migration) && hypothetical)) missing++
+  }
+  END { printf "%d\t%d\n", findings, missing }
+' "$input") || {
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=parse_failed; reviewer=$reviewer_type" >&2
+  exit 2
+}
+
+IFS=$'\t' read -r findings missing <<EOF
+$stats
+EOF
+if [ "$missing" -gt 0 ]; then
+  echo "ERROR: reviewer output contains $missing finding(s) without a valid Likelihood-Evidence anchor" >&2
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=anchor_missing; reviewer=$reviewer_type; findings=$findings; missing=$missing" >&2
+  exit 1
+fi
+
+echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE=passed; reviewer=$reviewer_type; findings=$findings"

--- a/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
+++ b/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
@@ -51,7 +51,7 @@ stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$revie
     separator_columns = split($0, separator_cell, "|")
     separator_valid = (separator_columns == 7)
     for (i = 2; i <= 6 && separator_valid; i++) {
-      if (trim(separator_cell[i]) !~ /^:?-+:?$/) separator_valid=0
+      if (trim(separator_cell[i]) !~ /^:?---+:?$/) separator_valid=0
     }
     if (separator_valid) saw_separator=1
     else malformed++

--- a/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
+++ b/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
@@ -41,7 +41,12 @@ stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$revie
   /^###[[:space:]]*(指摘事項|Findings)[[:space:]]*$/ { in_findings=1; saw_heading=1; next }
   in_findings && /^###[[:space:]]/ { in_findings=0 }
   !in_findings || $0 !~ /^[[:space:]]*\|/ { next }
-  /^\|[[:space:]]*(重要度|Severity)[[:space:]]*\|/ { saw_header=1; next }
+  /^\|[[:space:]]*(重要度|Severity)[[:space:]]*\|/ {
+    header_columns = split($0, header_cell, "|")
+    if (header_columns == 7 && trim(header_cell[5]) ~ /^(内容|Description)$/) saw_header=1
+    else malformed++
+    next
+  }
   /^\|[[:space:]]*(-+:?|-*[[:space:]]*#)[[:space:]]*\|/ { next }
   /^\|[[:space:]]*(なし|None)[[:space:]]*\|/ { next }
   {

--- a/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
+++ b/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
@@ -36,7 +36,7 @@ case "$reviewer_type" in
 esac
 
 stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$reviewer_type" '
-  BEGIN { in_findings=0; saw_heading=0; saw_header=0; findings=0; missing=0; malformed=0 }
+  BEGIN { in_findings=0; saw_heading=0; saw_header=0; saw_separator=0; findings=0; missing=0; malformed=0 }
   function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
   /^###[[:space:]]*(指摘事項|Findings)[[:space:]]*$/ { in_findings=1; saw_heading=1; next }
   in_findings && /^###[[:space:]]/ { in_findings=0 }
@@ -47,7 +47,16 @@ stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$revie
     else malformed++
     next
   }
-  /^\|[[:space:]]*(-+:?|-*[[:space:]]*#)[[:space:]]*\|/ { next }
+  /^\|[[:space:]]*:?-+/ {
+    separator_columns = split($0, separator_cell, "|")
+    separator_valid = (separator_columns == 7)
+    for (i = 2; i <= 6 && separator_valid; i++) {
+      if (trim(separator_cell[i]) !~ /^:?-+:?$/) separator_valid=0
+    }
+    if (separator_valid) saw_separator=1
+    else malformed++
+    next
+  }
   /^\|[[:space:]]*(なし|None)[[:space:]]*\|/ { next }
   {
     columns = split($0, cell, "|")
@@ -59,13 +68,13 @@ stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$revie
     hypothetical = (exception_category != "" && index(content, "Likelihood: Hypothetical (例外カテゴリ: " exception_category ")") > 0)
     if (!evidence && !hypothetical) missing++
   }
-  END { printf "%d\t%d\t%d\t%d\t%d\n", findings, missing, malformed, saw_heading, saw_header }
+  END { printf "%d\t%d\t%d\t%d\t%d\t%d\n", findings, missing, malformed, saw_heading, saw_header, saw_separator }
 ' "$input") || {
   echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=parse_failed; reviewer=$reviewer_type" >&2
   exit 2
 }
 
-IFS=$'\t' read -r findings missing malformed saw_heading saw_header <<EOF
+IFS=$'\t' read -r findings missing malformed saw_heading saw_header saw_separator <<EOF
 $stats
 EOF
 if [ "$saw_heading" -ne 1 ]; then
@@ -76,6 +85,11 @@ fi
 if [ "$saw_header" -ne 1 ]; then
   echo "ERROR: reviewer output is missing the canonical five-column findings table header" >&2
   echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=table_header_missing; reviewer=$reviewer_type" >&2
+  exit 1
+fi
+if [ "$saw_separator" -ne 1 ]; then
+  echo "ERROR: reviewer output is missing a canonical five-column table separator" >&2
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=table_malformed; reviewer=$reviewer_type; malformed=$malformed" >&2
   exit 1
 fi
 if [ "$malformed" -gt 0 ]; then

--- a/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
+++ b/plugins/rite/hooks/scripts/review-likelihood-evidence-gate.sh
@@ -9,8 +9,15 @@ reviewer_type=""
 input=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --reviewer-type) reviewer_type="${2:-}"; shift 2 ;;
-    --input) input="${2:-}"; shift 2 ;;
+    --reviewer-type|--input)
+      option="$1"
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: $option requires a value" >&2
+        exit 2
+      fi
+      value="$2"
+      [ "$option" = "--reviewer-type" ] && reviewer_type="$value" || input="$value"
+      shift 2 ;;
     *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -21,34 +28,56 @@ if [ -z "$reviewer_type" ] || [ -z "$input" ] || [ ! -r "$input" ]; then
 fi
 
 case "$reviewer_type" in
-  security|devops|dependencies) exception_category=1 ;;
-  *) exception_category=0 ;;
+  security) exception_category="security" ;;
+  devops) exception_category="devops infra" ;;
+  dependencies) exception_category="dependencies" ;;
+  application) exception_category="database migration" ;;
+  *) exception_category="" ;;
 esac
 
 stats=$(awk -v exception_category="$exception_category" -v reviewer_type="$reviewer_type" '
-  BEGIN { in_findings=0; findings=0; missing=0 }
-  /^###[[:space:]]*(指摘事項|Findings)[[:space:]]*$/ { in_findings=1; next }
+  BEGIN { in_findings=0; saw_heading=0; saw_header=0; findings=0; missing=0; malformed=0 }
+  function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+  /^###[[:space:]]*(指摘事項|Findings)[[:space:]]*$/ { in_findings=1; saw_heading=1; next }
   in_findings && /^###[[:space:]]/ { in_findings=0 }
   !in_findings || $0 !~ /^[[:space:]]*\|/ { next }
+  /^\|[[:space:]]*(重要度|Severity)[[:space:]]*\|/ { saw_header=1; next }
   /^\|[[:space:]]*(-+:?|-*[[:space:]]*#)[[:space:]]*\|/ { next }
-  /^\|[[:space:]]*(重要度|Severity)[[:space:]]*\|/ { next }
   /^\|[[:space:]]*(なし|None)[[:space:]]*\|/ { next }
   {
+    columns = split($0, cell, "|")
+    # Canonical reviewer finding table: leading/trailing pipe plus five cells.
+    if (columns != 7) { malformed++; next }
+    content = trim(cell[5])
     findings++
-    evidence = ($0 ~ /Likelihood-Evidence:[[:space:]]*(existing_call_site|new_call_site|entrypoint_connection|runtime_observation)[[:space:]]+[^|[:space:]]/)
-    hypothetical = ($0 ~ /Likelihood:[[:space:]]*Hypothetical[[:space:]]*\(例外カテゴリ:[[:space:]]*[^)]+\)/)
-    migration = (reviewer_type == "application" && $0 ~ /例外カテゴリ:[[:space:]]*database migration/)
-    if (!evidence && !((exception_category || migration) && hypothetical)) missing++
+    evidence = (content ~ /Likelihood-Evidence:[[:space:]]*(existing_call_site|new_call_site|entrypoint_connection|runtime_observation)[[:space:]]+[^[:space:]]/)
+    hypothetical = (exception_category != "" && index(content, "Likelihood: Hypothetical (例外カテゴリ: " exception_category ")") > 0)
+    if (!evidence && !hypothetical) missing++
   }
-  END { printf "%d\t%d\n", findings, missing }
+  END { printf "%d\t%d\t%d\t%d\t%d\n", findings, missing, malformed, saw_heading, saw_header }
 ' "$input") || {
   echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=parse_failed; reviewer=$reviewer_type" >&2
   exit 2
 }
 
-IFS=$'\t' read -r findings missing <<EOF
+IFS=$'\t' read -r findings missing malformed saw_heading saw_header <<EOF
 $stats
 EOF
+if [ "$saw_heading" -ne 1 ]; then
+  echo "ERROR: reviewer output is missing the canonical findings heading" >&2
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=findings_heading_missing; reviewer=$reviewer_type" >&2
+  exit 1
+fi
+if [ "$saw_header" -ne 1 ]; then
+  echo "ERROR: reviewer output is missing the canonical five-column findings table header" >&2
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=table_header_missing; reviewer=$reviewer_type" >&2
+  exit 1
+fi
+if [ "$malformed" -gt 0 ]; then
+  echo "ERROR: reviewer output contains $malformed malformed finding table row(s); expected exactly five columns" >&2
+  echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=table_malformed; reviewer=$reviewer_type; malformed=$malformed" >&2
+  exit 1
+fi
 if [ "$missing" -gt 0 ]; then
   echo "ERROR: reviewer output contains $missing finding(s) without a valid Likelihood-Evidence anchor" >&2
   echo "[CONTEXT] LIKELIHOOD_EVIDENCE_GATE_FAILED=1; reason=anchor_missing; reviewer=$reviewer_type; findings=$findings; missing=$missing" >&2

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -3,6 +3,10 @@ set -u
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 HELPER="$ROOT/hooks/scripts/review-likelihood-evidence-gate.sh"
+SKILL="$ROOT/skills/pr-review/SKILL.md"
+SCRIPT_DIR="$ROOT/hooks/tests"
+# shellcheck source=_test-helpers.sh
+source "$SCRIPT_DIR/_test-helpers.sh"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 pass=0 fail=0
@@ -26,8 +30,11 @@ check bash -c '! "$1" --reviewer-type security --input "$2" >/dev/null 2>&1' _ "
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing-heading.md"
 check "$HELPER" --reviewer-type application --input "$TMP/empty.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-empty.md"
-check bash -c 'timeout 1 "$1" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
-check bash -c 'timeout 1 "$1" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
+check bash -c 'source "$1"; _timeout 1 "$2" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
+check bash -c 'source "$1"; _timeout 1 "$2" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
+for reason in anchor_missing findings_heading_missing table_header_missing table_malformed; do
+  check grep -q "$reason" "$SKILL"
+done
 
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -20,6 +20,7 @@ printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 
 printf '%s\n' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect without anchor | fix |' > "$TMP/missing-heading.md"
 printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' > "$TMP/empty.md"
 printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' > "$TMP/malformed-empty.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|' > "$TMP/malformed-separator.md"
 
 check "$HELPER" --reviewer-type application --input "$TMP/valid.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing.md"
@@ -30,6 +31,7 @@ check bash -c '! "$1" --reviewer-type security --input "$2" >/dev/null 2>&1' _ "
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing-heading.md"
 check "$HELPER" --reviewer-type application --input "$TMP/empty.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-empty.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-separator.md"
 check bash -c 'source "$1"; _timeout 1 "$2" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
 check bash -c 'source "$1"; _timeout 1 "$2" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
 for reason in anchor_missing findings_heading_missing table_header_missing table_malformed; do

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -8,14 +8,24 @@ trap 'rm -rf "$TMP"' EXIT
 pass=0 fail=0
 check() { if "$@"; then pass=$((pass+1)); else fail=$((fail+1)); fi; }
 
-printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | defect. Likelihood-Evidence: existing_call_site a.sh:1 |' > "$TMP/valid.md"
-printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | defect without anchor |' > "$TMP/missing.md"
-printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | risk. Likelihood: Hypothetical (例外カテゴリ: security) |' > "$TMP/hypothetical.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect. Likelihood-Evidence: existing_call_site a.sh:1 | fix |' > "$TMP/valid.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect without anchor | fix |' > "$TMP/missing.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | risk. Likelihood: Hypothetical (例外カテゴリ: security) | mitigate |' > "$TMP/hypothetical.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect without anchor | add Likelihood-Evidence: existing_call_site a.sh:1 |' > "$TMP/wrong-column.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | risk. Likelihood: Hypothetical (例外カテゴリ: banana) | mitigate |' > "$TMP/wrong-category.md"
+printf '%s\n' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect without anchor | fix |' > "$TMP/missing-heading.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' > "$TMP/empty.md"
 
 check "$HELPER" --reviewer-type application --input "$TMP/valid.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing.md"
 check "$HELPER" --reviewer-type security --input "$TMP/hypothetical.md"
 check bash -c '! "$1" --reviewer-type test --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/hypothetical.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/wrong-column.md"
+check bash -c '! "$1" --reviewer-type security --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/wrong-category.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing-heading.md"
+check "$HELPER" --reviewer-type application --input "$TMP/empty.md"
+check bash -c 'timeout 1 "$1" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
+check bash -c 'timeout 1 "$1" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
 
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -21,6 +21,8 @@ printf '%s\n' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨�
 printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' > "$TMP/empty.md"
 printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' > "$TMP/malformed-empty.md"
 printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|' > "$TMP/malformed-separator.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|-|--|-|--|-|' > "$TMP/short-separator.md"
+printf '%s\n' '### Findings' '| Severity | Scope | File:Line | Description | Recommendation |' '|:---|---:|:---:|----|-----|' > "$TMP/aligned-empty.md"
 
 check "$HELPER" --reviewer-type application --input "$TMP/valid.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing.md"
@@ -32,6 +34,8 @@ check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' 
 check "$HELPER" --reviewer-type application --input "$TMP/empty.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-empty.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-separator.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/short-separator.md"
+check "$HELPER" --reviewer-type application --input "$TMP/aligned-empty.md"
 check bash -c 'source "$1"; _timeout 1 "$2" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
 check bash -c 'source "$1"; _timeout 1 "$2" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$SCRIPT_DIR/_test-helpers.sh" "$HELPER"
 for reason in anchor_missing findings_heading_missing table_header_missing table_malformed; do

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+HELPER="$ROOT/hooks/scripts/review-likelihood-evidence-gate.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+pass=0 fail=0
+check() { if "$@"; then pass=$((pass+1)); else fail=$((fail+1)); fi; }
+
+printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | defect. Likelihood-Evidence: existing_call_site a.sh:1 |' > "$TMP/valid.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | defect without anchor |' > "$TMP/missing.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' '| HIGH | a.sh:1 | risk. Likelihood: Hypothetical (例外カテゴリ: security) |' > "$TMP/hypothetical.md"
+
+check "$HELPER" --reviewer-type application --input "$TMP/valid.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing.md"
+check "$HELPER" --reviewer-type security --input "$TMP/hypothetical.md"
+check bash -c '! "$1" --reviewer-type test --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/hypothetical.md"
+
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
+++ b/plugins/rite/hooks/tests/review-likelihood-evidence-gate.test.sh
@@ -15,6 +15,7 @@ printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 
 printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | risk. Likelihood: Hypothetical (例外カテゴリ: banana) | mitigate |' > "$TMP/wrong-category.md"
 printf '%s\n' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' '| HIGH | current-pr | a.sh:1 | defect without anchor | fix |' > "$TMP/missing-heading.md"
 printf '%s\n' '### 指摘事項' '| 重要度 | スコープ | ファイル:行 | 内容 | 推奨対応 |' '|---|---|---|---|---|' > "$TMP/empty.md"
+printf '%s\n' '### 指摘事項' '| 重要度 | ファイル:行 | 内容 |' '|---|---|---|' > "$TMP/malformed-empty.md"
 
 check "$HELPER" --reviewer-type application --input "$TMP/valid.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing.md"
@@ -24,6 +25,7 @@ check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' 
 check bash -c '! "$1" --reviewer-type security --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/wrong-category.md"
 check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/missing-heading.md"
 check "$HELPER" --reviewer-type application --input "$TMP/empty.md"
+check bash -c '! "$1" --reviewer-type application --input "$2" >/dev/null 2>&1' _ "$HELPER" "$TMP/malformed-empty.md"
 check bash -c 'timeout 1 "$1" --input >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
 check bash -c 'timeout 1 "$1" --reviewer-type >/dev/null 2>&1; [ "$?" -eq 2 ]' _ "$HELPER"
 

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1447,6 +1447,28 @@ For **every** item in the "### 推奨事項" section (regardless of `別 Issue` 
 **Investigation suggestion collection**: Extract items from each reviewer's "### 調査推奨" section. Retain these as `investigation_suggestions` in the conversation context (reviewer_type, file, concern_description, notes). These are NOT findings and NOT Issue candidates — they do not affect the assessment, finding counts, or merge decision, and are never auto-Issue-ified by ステップ 7. They are collected solely for ステップ 5.4 "調査推奨" section rendering so the user may optionally run `/rite:investigate {file}` afterwards. A reviewer writing nothing in this section is the common case (blocking-worthy issues should go into findings, out-of-scope recommendations with Issue keywords into 推奨事項).
 **Demoted findings collection (ステップ 5.3.0 safety net)**: After collecting findings, scan each finding's `内容` column for the `Likelihood-Evidence:` anchor defined in [`_reviewer-base.md`](../../agents/_reviewer-base.md#demonstrable-proof-of-burden). Findings lacking the anchor AND whose `reviewer_type` is NOT in the Hypothetical Exception Categories (security/devops/dependencies; `application` は migration 関連 finding — `Likelihood: Hypothetical (例外カテゴリ: database migration)` 表記を伴うもの — に限り Database migration 例外カテゴリを継承する) are candidates for ステップ 5.3.0 mechanical demotion. Retain these as `demoted_findings` in the conversation context (reviewer_type, severity, file_line, description, demotion_destination) for ステップ 5.3.0 processing and ステップ 5.4 "Observed Likelihood 降格結果" section rendering. The `demotion_destination` is `推奨事項` (CRITICAL/HIGH/MEDIUM/LOW-MEDIUM) or `（削除）` (LOW).
 
+##### 5.1.0.L Likelihood-Evidence Producer Post-Condition
+
+Before aggregation or the 5.3.0 safety-net demotion, write each raw reviewer output unchanged to a tempfile and invoke:
+
+```bash
+bash {plugin_root}/hooks/scripts/review-likelihood-evidence-gate.sh \
+  --reviewer-type "{reviewer_type}" --input "{raw_reviewer_output_file}"
+```
+
+The helper validates every row under `### 指摘事項` / `### Findings`. A normal finding must contain a canonical `Likelihood-Evidence:` label. Security, devops, and dependencies may instead use the explicit `Likelihood: Hypothetical (例外カテゴリ: ...)` form; application receives that exception only for `database migration`. An empty findings table passes.
+
+Route the result mechanically per reviewer:
+
+| Result | Action |
+|---|---|
+| rc=0 + `LIKELIHOOD_EVIDENCE_GATE=passed` | Accept the raw output and continue |
+| rc=1 + `reason=anchor_missing`, first occurrence | Retry that reviewer once with the original review prompt plus the missing-count diagnostic and the strict requirement to add a canonical anchor to every realistic finding; replace the original output with the retry output and rerun this helper |
+| rc=1 after the one retry | Mark the reviewer `incomplete`, set `likelihood_evidence_post_condition=error`, and stop this review with `[review:error]`; do not pass the output to aggregation or 5.3.0 |
+| rc=2, or a missing success marker | Treat as producer-gate infrastructure failure and stop with `[review:error]` |
+
+Maintain `likelihood_evidence_retry_count` as a per-reviewer dict initialized to `{}`. Only a completed retry increments the corresponding value from 0 to 1. This gate deliberately runs before hypothetical demotion: omission by a realistic-finding producer is a retryable contract violation, while an explicitly marked exception remains a legitimate hypothetical finding.
+
 #### 5.1.1 Verification Mode Findings Collection
 
 When `review_mode == "verification"`, classify: NOT_FIXED/PARTIAL/REGRESSION/MISSED_CRITICAL (all blocking). FIXED findings recorded in Fix Verification Summary only.

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1463,8 +1463,8 @@ Route the result mechanically per reviewer:
 | Result | Action |
 |---|---|
 | rc=0 + `LIKELIHOOD_EVIDENCE_GATE=passed` | Accept the raw output and continue |
-| rc=1 + `reason=anchor_missing`, first occurrence | Retry that reviewer once with the original review prompt plus the missing-count diagnostic and the strict requirement to add a canonical anchor to every realistic finding; replace the original output with the retry output and rerun this helper |
-| rc=1 after the one retry | Mark the reviewer `incomplete`, set `likelihood_evidence_post_condition=error`, and stop this review with `[review:error]`; do not pass the output to aggregation or 5.3.0 |
+| rc=1 + `reason ∈ {anchor_missing, findings_heading_missing, table_header_missing, table_malformed}`, first occurrence | Retry that reviewer once with the original review prompt plus the reason-specific diagnostic and the strict requirement to emit the canonical five-column findings table with a canonical anchor in every realistic finding's `内容` cell; replace the original output with the retry output and rerun this helper |
+| rc=1 with any producer-contract reason after the one retry | Mark the reviewer `incomplete`, set `likelihood_evidence_post_condition=error`, and stop this review with `[review:error]`; do not pass the output to aggregation or 5.3.0 |
 | rc=2, or a missing success marker | Treat as producer-gate infrastructure failure and stop with `[review:error]` |
 
 Maintain `likelihood_evidence_retry_count` as a per-reviewer dict initialized to `{}`. Only a completed retry increments the corresponding value from 0 to 1. This gate deliberately runs before hypothetical demotion: omission by a realistic-finding producer is a retryable contract violation, while an explicitly marked exception remains a legitimate hypothetical finding.


### PR DESCRIPTION
## 概要

reviewer 出力を集約する前に Likelihood-Evidence 契約を機械検査し、欠落を downstream demotion へ流さず retry / fail-loud へ戻します。

Closes #2185

## 変更内容

- raw reviewer Markdown の finding 行を検査する helper を追加
- 通常 finding の canonical anchor 欠落を rc=1 で検出
- security/devops/dependencies と application migration の明示 Hypothetical 例外を維持
- reviewer ごとの 1 回 retry と再欠落時の review:error routing を pr-review 契約へ追加

## 確認

- review-likelihood-evidence-gate.test.sh: 4 PASS / 0 FAIL
- review-measured-gate.test.sh: 100 PASS / 0 FAIL
- review-fix-promotion-contract.test.sh: PASS
- bash -n / git diff --check: PASS