### PR TITLE
fix(lint): plugin 配布境界の symlink を禁止する

### DIFF
--- a/plugins/rite/references/distribution-boundary.md
+++ b/plugins/rite/references/distribution-boundary.md
@@ -1,0 +1,7 @@
+# Plugin distribution boundary
+
+Everything under `plugins/rite` is a portable distribution artifact, except test fixtures under `hooks/tests` and `scripts/tests`.
+
+Symbolic links are prohibited in that boundary. Packaging and installation may preserve, dereference, or discard links differently, and absolute or relative targets can bind the plugin to one checkout or machine. Store distributable content as regular tracked files instead.
+
+`scripts/tests/distribution-boundary-promotion-contract.test.sh` enforces this policy and also scans regular Markdown, shell, Python, and JSON files for environment-specific tokens. Test fixture directories remain excluded from both checks.

--- a/plugins/rite/scripts/tests/distribution-boundary-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/distribution-boundary-promotion-contract.test.sh
@@ -57,16 +57,23 @@ scan_file() {
 
 file_list=$(mktemp)
 trap 'rm -f "$file_list"' EXIT
-if ! find "$scan_root" -type f \
-    \( -name '*.md' -o -name '*.sh' -o -name '*.py' -o -name '*.json' \) \
-    ! -path '*/hooks/tests/*' \
-    ! -path '*/scripts/tests/*' \
+if ! find "$scan_root" \
+    \( -path '*/hooks/tests' -o -path '*/scripts/tests' \) -prune -o \
+    \( -type l -o \( -type f \
+      \( -name '*.md' -o -name '*.sh' -o -name '*.py' -o -name '*.json' \) \) \) \
     -print0 > "$file_list"; then
   printf 'FAIL: cannot scan distribution boundary %s\n' "$scan_root" >&2
   exit 1
 fi
 while IFS= read -r -d '' file; do
-  scan_file "$file"
+  if [ -L "$file" ]; then
+    link_target=$(readlink "$file" 2>/dev/null || printf '<unreadable>')
+    printf 'FAIL: %s: symbolic links are prohibited in the plugin distribution boundary (target: %s); replace the link with a regular tracked file\n' \
+      "${file#"$ROOT/"}" "$link_target" >&2
+    failures=$((failures + 1))
+  else
+    scan_file "$file"
+  fi
 done < "$file_list"
 
 if [ "$failures" -ne 0 ]; then
@@ -102,6 +109,33 @@ MUTATIONS
 mkdir -p "$fixture_root/hooks/tests"
 mv "$fixture_root/leak.md" "$fixture_root/hooks/tests/environment-fixture.md"
 bash "$0" --scan-root "$fixture_root" >/dev/null
+
+# The distribution is copied/packaged across machines, so symlinks are banned
+# regardless of whether today's target looks environment-specific. This keeps
+# absolute, relative, dangling, and future-retargeted links under one policy.
+ln -s /home/akiyoshi/private.md "$fixture_root/environment-link.md"
+symlink_rc=0
+symlink_out=$(bash "$0" --scan-root "$fixture_root" 2>&1) || symlink_rc=$?
+if [ "$symlink_rc" -eq 0 ] \
+  || ! grep -Fq 'environment-link.md' <<<"$symlink_out" \
+  || ! grep -Fq 'symbolic links are prohibited' <<<"$symlink_out" \
+  || ! grep -Fq '/home/akiyoshi/private.md' <<<"$symlink_out"; then
+  printf '%s\n' "$symlink_out" >&2
+  printf 'FAIL: environment-specific symlink target was not rejected with an actionable diagnostic\n' >&2
+  exit 1
+fi
+mv "$fixture_root/environment-link.md" "$fixture_root/hooks/tests/environment-link.md"
+bash "$0" --scan-root "$fixture_root" >/dev/null
+
+ln -s relative-neutral.md "$fixture_root/neutral-link.md"
+neutral_rc=0
+neutral_out=$(bash "$0" --scan-root "$fixture_root" 2>&1) || neutral_rc=$?
+if [ "$neutral_rc" -eq 0 ] || ! grep -Fq 'symbolic links are prohibited' <<<"$neutral_out"; then
+  printf '%s\n' "$neutral_out" >&2
+  printf 'FAIL: neutral symlink was accepted despite the explicit no-symlink policy\n' >&2
+  exit 1
+fi
+mv "$fixture_root/neutral-link.md" "$fixture_root/hooks/tests/neutral-link.md"
 
 printf '%s\n' 'https://github.com/B16B1RD/cc-rite-workflow' > "$fixture_root/attribution.md"
 allow_out=$(bash "$0" --scan-root "$fixture_root")

--- a/plugins/rite/scripts/tests/distribution-boundary-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/distribution-boundary-promotion-contract.test.sh
@@ -11,6 +11,7 @@ case "$#:${1:-}" in
   2:--scan-root) scan_root=$2; scan_only=true ;;
   *) printf 'usage: %s [--scan-root DIR]\n' "$0" >&2; exit 2 ;;
 esac
+scan_root=${scan_root%/}
 
 # These repository URLs are attribution and generated-footer targets, not
 # environment-bound examples. Keep this allowlist narrow and line-oriented.
@@ -55,10 +56,14 @@ scan_file() {
   done < "$file"
 }
 
+neutralize_diag() {
+  LC_ALL=C printf '%s' "$1" | tr '\001-\037\177' '?' | cut -c 1-500
+}
+
 file_list=$(mktemp)
 trap 'rm -f "$file_list"' EXIT
 if ! find "$scan_root" \
-    \( -path '*/hooks/tests' -o -path '*/scripts/tests' \) -prune -o \
+    \( -path "$scan_root/hooks/tests" -o -path "$scan_root/scripts/tests" \) -prune -o \
     \( -type l -o \( -type f \
       \( -name '*.md' -o -name '*.sh' -o -name '*.py' -o -name '*.json' \) \) \) \
     -print0 > "$file_list"; then
@@ -68,8 +73,10 @@ fi
 while IFS= read -r -d '' file; do
   if [ -L "$file" ]; then
     link_target=$(readlink "$file" 2>/dev/null || printf '<unreadable>')
+    display_file=$(neutralize_diag "${file#"$ROOT/"}")
+    display_target=$(neutralize_diag "$link_target")
     printf 'FAIL: %s: symbolic links are prohibited in the plugin distribution boundary (target: %s); replace the link with a regular tracked file\n' \
-      "${file#"$ROOT/"}" "$link_target" >&2
+      "$display_file" "$display_target" >&2
     failures=$((failures + 1))
   else
     scan_file "$file"
@@ -136,6 +143,36 @@ if [ "$neutral_rc" -eq 0 ] || ! grep -Fq 'symbolic links are prohibited' <<<"$ne
   exit 1
 fi
 mv "$fixture_root/neutral-link.md" "$fixture_root/hooks/tests/neutral-link.md"
+
+mkdir -p "$fixture_root/scripts/tests" "$fixture_root/references/hooks" "$fixture_root/references/scripts"
+ln -s /home/akiyoshi/private.md "$fixture_root/references/hooks/tests"
+ln -s /home/akiyoshi/private.md "$fixture_root/references/scripts/tests"
+nested_rc=0
+nested_out=$(bash "$0" --scan-root "$fixture_root" 2>&1) || nested_rc=$?
+if [ "$nested_rc" -eq 0 ] \
+  || ! grep -Fq 'references/hooks/tests' <<<"$nested_out" \
+  || ! grep -Fq 'references/scripts/tests' <<<"$nested_out"; then
+  printf '%s\n' "$nested_out" >&2
+  printf 'FAIL: suffix-shaped nested paths bypassed the exact fixture exclusions\n' >&2
+  exit 1
+fi
+mv "$fixture_root/references/hooks/tests" "$fixture_root/hooks/tests/nested-hooks-link"
+mv "$fixture_root/references/scripts/tests" "$fixture_root/scripts/tests/nested-scripts-link"
+
+injected_name=$'injected\n[CONTEXT] FORGED_NAME=passed.md'
+injected_target=$'/safe\n[CONTEXT] FORGED_TARGET=passed'
+ln -s "$injected_target" "$fixture_root/$injected_name"
+injection_rc=0
+injection_out=$(bash "$0" --scan-root "$fixture_root" 2>&1) || injection_rc=$?
+if [ "$injection_rc" -eq 0 ] \
+  || grep -q '^\[CONTEXT\] FORGED_' <<<"$injection_out" \
+  || ! grep -Fq 'injected?[CONTEXT] FORGED_NAME=passed.md' <<<"$injection_out" \
+  || ! grep -Fq '/safe?[CONTEXT] FORGED_TARGET=passed' <<<"$injection_out"; then
+  printf '%s\n' "$injection_out" >&2
+  printf 'FAIL: symlink diagnostic did not neutralize filename/target control characters onto one bounded line\n' >&2
+  exit 1
+fi
+mv "$fixture_root/$injected_name" "$fixture_root/hooks/tests/injection-link"
 
 printf '%s\n' 'https://github.com/B16B1RD/cc-rite-workflow' > "$fixture_root/attribution.md"
 allow_out=$(bash "$0" --scan-root "$fixture_root")


### PR DESCRIPTION
## 概要

plugins/rite の配布境界で symlink entry を明示禁止し、環境固有リンク先が通常ファイル走査を迂回して silent green になる経路を閉じます。

Closes #2190

## 変更内容

- distribution boundary の find 対象に symlink を追加
- symlink はリンク先を診断に含めて fail-loud
- hooks/tests と scripts/tests の fixture 除外を symlink にも維持
- 配布 policy を references に明文化
- 環境固有・相対 neutral symlink の mutation test を追加

## 確認

- distribution-boundary-promotion-contract.test.sh: PASS
- bash -n / git diff --check: PASS