### PR TITLE
fix(hooks): issue claim の stale 奪取を macOS 対応する

### DIFF
--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -23,9 +23,9 @@
 # refreshes `updated_at` on every phase transition, so that IS the heartbeat.
 #
 # Atomicity: a FREE issue is claimed via `noclobber` (`set -C`) file creation —
-# only one of N racing processes wins the create. The stale-steal and own-refresh
-# paths serialize through an flock on `issue-claims/.lock` (same shape as
-# `flow-state.sh` `_atomic_write`). A LIVE other-session claim is NEVER stolen
+# only one of N racing processes wins the create. The stale-steal, own-refresh,
+# and release paths serialize through an atomic mkdir lock, which is available on
+# stock macOS and other POSIX systems without util-linux. A LIVE other-session claim is NEVER stolen
 # unattended (AC-5) — `claim` returns rc=10 so the caller (open Step 1.6)
 # raises an AskUserQuestion.
 #
@@ -63,7 +63,8 @@ else
   STATE_ROOT=$(resolve_state_root)
 fi
 CLAIMS_DIR="$STATE_ROOT/.rite/state/issue-claims"
-CLAIMS_LOCK="$CLAIMS_DIR/.lock"
+CLAIMS_LOCKDIR="$CLAIMS_DIR/.lock.d"
+CLAIMS_LOCK_RETRIES=50
 
 # Resolve the CURRENT session_id. Reuses the canonical helpers:
 #   - `_resolve-session-id.sh` UUID-validates a runtime env candidate
@@ -141,21 +142,56 @@ _build_json() {
     '{schema_version:$sv, issue_number:$issue, session_id:$sid, worktree:$wt, claimed_at:$ts}'
 }
 
-# Atomic write of the claim file under the issue-claims flock (own-refresh /
-# stale-steal). Degrades to a plain atomic mv when flock is unavailable
-# (minimal containers / macOS without util-linux) — matches the wiki helpers.
+# Acquire the short-lived claims critical section with portable atomic mkdir.
+# A process killed after mkdir can leave residue; after the normal wait window,
+# a contender reclaims it only when its recorded process is no longer alive.
+_claims_lock_acquire() {
+  local tries=0 owner="" tomb=""
+  while [ "$tries" -lt "$CLAIMS_LOCK_RETRIES" ]; do
+    if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
+      printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" || {
+        rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
+        return 1
+      }
+      return 0
+    fi
+    tries=$((tries + 1))
+    sleep 0.1
+  done
+
+  owner=$(cat "$CLAIMS_LOCKDIR/pid" 2>/dev/null || printf '')
+  if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then
+    tomb="${CLAIMS_LOCKDIR}.reap.$$"
+    if mv "$CLAIMS_LOCKDIR" "$tomb" 2>/dev/null; then
+      rm -rf "$tomb" 2>/dev/null || true
+      if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
+        printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" || {
+          rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
+          return 1
+        }
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}
+
+_claims_lock_release() {
+  local owner
+  owner=$(cat "$CLAIMS_LOCKDIR/pid" 2>/dev/null || printf '')
+  [ "$owner" = "$$" ] || return 1
+  rm -rf "$CLAIMS_LOCKDIR"
+}
+
+# Atomic write of the claim file under the portable claims lock (own-refresh).
 _atomic_claim_write() {
   local file="$1" json="$2" tmp rc=0
   tmp=$(mktemp "${file}.XXXXXX" 2>/dev/null) || return 1
   printf '%s\n' "$json" > "$tmp" || { rm -f "$tmp"; return 1; }
-  if command -v flock >/dev/null 2>&1; then
-    if ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
-      ( exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1; mv -f "$tmp" "$file" ) || rc=$?
-    else
-      mv -f "$tmp" "$file" || rc=$?
-    fi
-  else
+  _claims_lock_acquire || rc=$?
+  if [ "$rc" -eq 0 ]; then
     mv -f "$tmp" "$file" || rc=$?
+    _claims_lock_release || [ "$rc" -ne 0 ] || rc=1
   fi
   [ "$rc" -eq 0 ] || rm -f "$tmp" 2>/dev/null || true
   return "$rc"
@@ -163,7 +199,7 @@ _atomic_claim_write() {
 
 # Compare-and-swap steal of a stale claim. The out-of-lock `_classify` (cmd_claim)
 # only tells us the claim WAS stale a moment ago; two sessions can both see the
-# same stale holder and both reach here. flock serializes the mv but does not make
+# same stale holder and both reach here. Serializing the mv alone does not make
 # the decision exclusive, so a plain _atomic_claim_write lets BOTH win (double
 # steal). This function re-verifies UNDER the lock before overwriting: it steals
 # only when the on-disk holder is still `expected` (the stale holder we classified)
@@ -175,21 +211,14 @@ _atomic_claim_steal() {
   local file="$1" json="$2" expected="$3" tmp rc=0 cur
   tmp=$(mktemp "${file}.XXXXXX" 2>/dev/null) || return 1
   printf '%s\n' "$json" > "$tmp" || { rm -f "$tmp"; return 1; }
-  if command -v flock >/dev/null 2>&1 && ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
-    (
-      exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1
-      cur=$(_claim_holder "$file")
-      [ "$cur" = "$expected" ] || exit 10   # another session swapped the claim under us
-      _holder_is_live "$cur" && exit 10      # the stale holder revived → do not steal
-      mv -f "$tmp" "$file"
-    ) || rc=$?
-  else
-    # No flock (minimal containers / macOS without util-linux): best-effort CAS.
+  _claims_lock_acquire || rc=$?
+  if [ "$rc" -eq 0 ]; then
     cur=$(_claim_holder "$file")
     if [ "$cur" != "$expected" ]; then rc=10
     elif _holder_is_live "$cur"; then rc=10
     else mv -f "$tmp" "$file" || rc=$?
     fi
+    _claims_lock_release || [ "$rc" -ne 0 ] || rc=1
   fi
   [ "$rc" -eq 0 ] || rm -f "$tmp" 2>/dev/null || true
   return "$rc"
@@ -279,11 +308,12 @@ cmd_release() {
     echo "skipped"
     return 0
   fi
-  if command -v flock >/dev/null 2>&1 && ( exec 9>"$CLAIMS_LOCK" ) 2>/dev/null; then
-    ( exec 9>"$CLAIMS_LOCK"; flock -w 5 9 || exit 1; rm -f "$file" ) || { echo "ERROR: failed to remove claim" >&2; return 1; }
-  else
-    rm -f "$file" || { echo "ERROR: failed to remove claim" >&2; return 1; }
+  _claims_lock_acquire || { echo "ERROR: failed to acquire claims lock" >&2; return 1; }
+  holder=$(_claim_holder "$file")
+  if [ -f "$file" ] && [ "$holder" = "$sid" ]; then
+    rm -f "$file" || { _claims_lock_release || true; echo "ERROR: failed to remove claim" >&2; return 1; }
   fi
+  _claims_lock_release || { echo "ERROR: failed to release claims lock" >&2; return 1; }
   echo "released"
   return 0
 }

--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -65,7 +65,6 @@ fi
 CLAIMS_DIR="$STATE_ROOT/.rite/state/issue-claims"
 CLAIMS_LOCKDIR="$CLAIMS_DIR/.lock.d"
 CLAIMS_LOCK_RETRIES=50
-CLAIMS_LOCK_LEASE_SECONDS=30
 
 # Resolve the CURRENT session_id. Reuses the canonical helpers:
 #   - `_resolve-session-id.sh` UUID-validates a runtime env candidate
@@ -145,13 +144,26 @@ _build_json() {
 
 # Acquire the short-lived claims critical section with portable atomic mkdir.
 # A process killed after mkdir can leave residue; after the normal wait window,
-# a contender reclaims it only when its recorded process is no longer alive.
+# a contender reclaims it only when its recorded process is gone or its PID has
+# been reused by a process with a different start identity.
+_process_identity() {
+  local pid="$1"
+  ps -p "$pid" -o lstart= 2>/dev/null | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+_claims_lock_record_owner() {
+  local identity
+  identity=$(_process_identity "$$")
+  [ -n "$identity" ] || return 1
+  printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" &&
+    printf '%s\n' "$identity" > "$CLAIMS_LOCKDIR/process_start"
+}
+
 _claims_lock_acquire() {
   local tries=0 owner="" tomb=""
   while [ "$tries" -lt "$CLAIMS_LOCK_RETRIES" ]; do
     if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
-      printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" &&
-        date +%s > "$CLAIMS_LOCKDIR/acquired_at" || {
+      _claims_lock_record_owner || {
         rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
         return 1
       }
@@ -161,22 +173,27 @@ _claims_lock_acquire() {
     sleep 0.1
   done
 
-  local acquired_at="" now="" age=0 reclaim=false
+  local recorded_identity="" current_identity="" reclaim=false
   owner=$(cat "$CLAIMS_LOCKDIR/pid" 2>/dev/null || printf '')
-  acquired_at=$(cat "$CLAIMS_LOCKDIR/acquired_at" 2>/dev/null || printf '')
-  now=$(date +%s)
-  case "$owner" in ''|0|*[!0-9]*) reclaim=true ;; *) kill -0 "$owner" 2>/dev/null || reclaim=true ;; esac
-  case "$acquired_at" in
-    ''|*[!0-9]*) reclaim=true ;;
-    *) age=$((now - acquired_at)); [ "$age" -gt "$CLAIMS_LOCK_LEASE_SECONDS" ] && reclaim=true ;;
+  recorded_identity=$(cat "$CLAIMS_LOCKDIR/process_start" 2>/dev/null || printf '')
+  case "$owner" in
+    ''|0|*[!0-9]*) reclaim=true ;;
+    *)
+      if ! kill -0 "$owner" 2>/dev/null; then
+        reclaim=true
+      else
+        current_identity=$(_process_identity "$owner")
+        [ -n "$recorded_identity" ] && [ -n "$current_identity" ] &&
+          [ "$recorded_identity" != "$current_identity" ] && reclaim=true
+      fi
+      ;;
   esac
   if [ "$reclaim" = true ]; then
     tomb="${CLAIMS_LOCKDIR}.reap.$$"
     if mv "$CLAIMS_LOCKDIR" "$tomb" 2>/dev/null; then
       rm -rf "$tomb" 2>/dev/null || true
       if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
-        printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" &&
-          date +%s > "$CLAIMS_LOCKDIR/acquired_at" || {
+        _claims_lock_record_owner || {
           rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
           return 1
         }

--- a/plugins/rite/hooks/issue-claim.sh
+++ b/plugins/rite/hooks/issue-claim.sh
@@ -65,6 +65,7 @@ fi
 CLAIMS_DIR="$STATE_ROOT/.rite/state/issue-claims"
 CLAIMS_LOCKDIR="$CLAIMS_DIR/.lock.d"
 CLAIMS_LOCK_RETRIES=50
+CLAIMS_LOCK_LEASE_SECONDS=30
 
 # Resolve the CURRENT session_id. Reuses the canonical helpers:
 #   - `_resolve-session-id.sh` UUID-validates a runtime env candidate
@@ -149,7 +150,8 @@ _claims_lock_acquire() {
   local tries=0 owner="" tomb=""
   while [ "$tries" -lt "$CLAIMS_LOCK_RETRIES" ]; do
     if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
-      printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" || {
+      printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" &&
+        date +%s > "$CLAIMS_LOCKDIR/acquired_at" || {
         rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
         return 1
       }
@@ -159,13 +161,22 @@ _claims_lock_acquire() {
     sleep 0.1
   done
 
+  local acquired_at="" now="" age=0 reclaim=false
   owner=$(cat "$CLAIMS_LOCKDIR/pid" 2>/dev/null || printf '')
-  if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then
+  acquired_at=$(cat "$CLAIMS_LOCKDIR/acquired_at" 2>/dev/null || printf '')
+  now=$(date +%s)
+  case "$owner" in ''|0|*[!0-9]*) reclaim=true ;; *) kill -0 "$owner" 2>/dev/null || reclaim=true ;; esac
+  case "$acquired_at" in
+    ''|*[!0-9]*) reclaim=true ;;
+    *) age=$((now - acquired_at)); [ "$age" -gt "$CLAIMS_LOCK_LEASE_SECONDS" ] && reclaim=true ;;
+  esac
+  if [ "$reclaim" = true ]; then
     tomb="${CLAIMS_LOCKDIR}.reap.$$"
     if mv "$CLAIMS_LOCKDIR" "$tomb" 2>/dev/null; then
       rm -rf "$tomb" 2>/dev/null || true
       if mkdir "$CLAIMS_LOCKDIR" 2>/dev/null; then
-        printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" || {
+        printf '%s\n' "$$" > "$CLAIMS_LOCKDIR/pid" &&
+          date +%s > "$CLAIMS_LOCKDIR/acquired_at" || {
           rm -rf "$CLAIMS_LOCKDIR" 2>/dev/null || true
           return 1
         }

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -195,5 +195,25 @@ else
   assert "TC-16 the other four no-flock contenders aborted" "4" "$_nf_other"
 fi
 
+echo "=== TC-17: stale lock residue is reclaimed despite a live/reused PID ==="
+SID_RESIDUE="abababab-1111-2222-3333-444444444444"
+mk_active "$SID_RESIDUE" 970
+assert "TC-17 owner claims first" "claimed" "$(claim "$SID_RESIDUE" 970)"
+lockdir="$ROOT/.rite/state/issue-claims/.lock.d"
+mkdir "$lockdir"
+printf '%s\n' "$$" > "$lockdir/pid"
+printf '%s\n' "$(( $(date +%s) - 60 ))" > "$lockdir/acquired_at"
+assert "TC-17 release reclaims expired residue and succeeds" "released" "$(release "$SID_RESIDUE" 970)"
+assert "TC-17 claim is removed after residue recovery" "free" "$(check "$SID_RESIDUE" 970)"
+
+echo "=== TC-18: malformed/non-positive lock PID is reclaimable ==="
+mk_active "$SID_RESIDUE" 971
+assert "TC-18 owner claims first" "claimed" "$(claim "$SID_RESIDUE" 971)"
+mkdir "$lockdir"
+printf '%s\n' '%s' > "$lockdir/pid"
+printf '%s\n' "$(date +%s)" > "$lockdir/acquired_at"
+assert "TC-18 malformed PID residue is reclaimed" "released" "$(release "$SID_RESIDUE" 971)"
+assert "TC-18 claim is removed after malformed residue recovery" "free" "$(check "$SID_RESIDUE" 971)"
+
 print_summary "$(basename "$0")" \
   "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + portable mkdir-lock atomicity; stale-steal CAS via _atomic_claim_steal; _resolve_current_session_id env-first."

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -147,24 +147,8 @@ for i in 1 2 3 4 5; do
     other)   _other=$((_other+1)) ;;
   esac
 done
-# `command -v flock` is a capability probe, not a platform check: flock missing or
-# shadowed on Linux would silently drop the only coverage of the stale-steal mutual
-# exclusion (Issue #1718 AC-1) and still exit 0. Require it on the blocking gate.
-# `[ -d /proc ]` rather than `uname -s` because `uname` resolves through the same
-# PATH that would be hiding `flock`.
-if [ -d /proc ] && ! command -v flock >/dev/null 2>&1; then
-  fail "TC-14 floor: flock unavailable on Linux (missing or shadowed on PATH?) — the stale-steal mutual-exclusion assertions must never be skipped on the blocking gate"
-fi
-if command -v flock >/dev/null 2>&1; then
-  assert "TC-14 exactly one stole the stale claim (AC-1)" "1" "$_stolen"
-  assert "TC-14 the other four aborted with 'other'" "4" "$_other"
-else
-  # No flock (macOS / BSD): _atomic_claim_steal's critical section is not
-  # serialized, so mutual exclusion cannot be guaranteed — all N contenders may
-  # steal the same stale claim (a real production gap tracked in #2010). Skip the
-  # exactly-one assertions here rather than asserting the degraded behavior.
-  skip "TC-14 skipped (flock absent; stale-steal mutual-exclusion gap tracked in #2010; observed stolen=$_stolen other=$_other)"
-fi
+assert "TC-14 exactly one stole the stale claim (AC-1)" "1" "$_stolen"
+assert "TC-14 the other four aborted with 'other'" "4" "$_other"
 
 echo "=== TC-15 (Issue #1718 AC-2): single-session stale-steal is non-regressed ==="
 # The CAS path must still let a lone stealer succeed (holder unchanged == expected).
@@ -175,20 +159,9 @@ bash "$FS" deactivate --session "$SID_STALE2" --next done >/dev/null 2>&1
 assert "TC-15 lone steal → claimed" "claimed" "$(claim "$SID_A" 951)"
 assert "TC-15 holder now A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-951.json")"
 
-echo "=== TC-16 (Issue #1718 F-03): no-flock branch of _atomic_claim_steal steals a lone stale claim ==="
-# TC-14/15 always exercise the flock branch (flock is present on the test host), so the
-# best-effort no-flock branch of _atomic_claim_steal never runs. Force it by invoking
-# issue-claim.sh with a PATH stub that omits flock, proving the flock-absent path still
-# steals a lone stale claim (the else/mv path). Concurrent exactly-one is intentionally
-# NOT asserted — no-flock CAS is best-effort by design and cannot guarantee it. On the
-# abort side, TC-14's four losers prove the two guards TOGETHER prevent a double steal,
-# but do NOT isolate which guard fires: because every contender is mk_active'd the winner
-# is live, so a loser can abort on EITHER mismatch→10 (cur != expected, the winner already
-# swapped the holder) OR revive→10 (_holder_is_live "$cur"). Mutation-removing just one of
-# the two guards leaves TC-14 green; only removing both turns it red. So neither guard is
-# isolated by any current test — pinning mismatch alone would need an on-disk holder that
-# is ≠ expected AND not live, which the CLI cannot deterministically produce (revive→10 is
-# likewise a defensive TOCTOU guard exercised by no test).
+echo "=== TC-16: flock-absent concurrent stale-STEAL → exactly one 'claimed' ==="
+# Force a stock-macOS-compatible PATH without flock. The portable critical section
+# must preserve the same exactly-one contract as TC-14.
 noflock_stub=$(mktemp -d)
 cleanup_dirs+=("$noflock_stub")
 for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv rm sed tr wc sleep; do
@@ -205,10 +178,22 @@ if [ "$(run_noflock claim --session "$SID_NF" --issue 960)" != "claimed" ]; then
 else
   bash "$FS" deactivate --session "$SID_NF" --next done >/dev/null 2>&1  # holder now stale
   assert "TC-16 precondition: holder classified stale" "stale" "$(check "$SID_A" 960)"
-  # Steal via the flock-absent branch: lone stealer → cur==expected, holder dead → mv → claimed.
-  assert "TC-16 no-flock lone steal → claimed (F-03)" "claimed" "$(run_noflock claim --session "$SID_A" --issue 960)"
-  assert "TC-16 holder now A" "$SID_A" "$(jq -r .session_id "$ROOT/.rite/state/issue-claims/issue-960.json")"
+  rm -f "$ROOT"/nfstealout.* 2>/dev/null || true
+  for i in 1 2 3 4 5; do mk_active "f000000$i-1111-2222-3333-444444444444" 960; done
+  for i in 1 2 3 4 5; do
+    ( run_noflock claim --session "f000000$i-1111-2222-3333-444444444444" --issue 960 > "$ROOT/nfstealout.$i" ) &
+  done
+  wait
+  _nf_stolen=0; _nf_other=0
+  for i in 1 2 3 4 5; do
+    case "$(cat "$ROOT/nfstealout.$i" 2>/dev/null)" in
+      claimed) _nf_stolen=$((_nf_stolen+1)) ;;
+      other)   _nf_other=$((_nf_other+1)) ;;
+    esac
+  done
+  assert "TC-16 exactly one no-flock contender stole the stale claim" "1" "$_nf_stolen"
+  assert "TC-16 the other four no-flock contenders aborted" "4" "$_nf_other"
 fi
 
 print_summary "$(basename "$0")" \
-  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + flock atomicity; stale-steal CAS via _atomic_claim_steal (Issue #1718, flock + no-flock branches); _resolve_current_session_id env-first (Issue #1530)."
+  "Drift hint: issue-claim.sh §7 — claim/release/check; liveness reuses session-ownership.sh 2h threshold + parse_iso8601_to_epoch; noclobber + portable mkdir-lock atomicity; stale-steal CAS via _atomic_claim_steal; _resolve_current_session_id env-first."

--- a/plugins/rite/hooks/tests/issue-claim.test.sh
+++ b/plugins/rite/hooks/tests/issue-claim.test.sh
@@ -164,7 +164,7 @@ echo "=== TC-16: flock-absent concurrent stale-STEAL → exactly one 'claimed' =
 # must preserve the same exactly-one contract as TC-14.
 noflock_stub=$(mktemp -d)
 cleanup_dirs+=("$noflock_stub")
-for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv rm sed tr wc sleep; do
+for _c in bash sh cat date dirname git grep head jq mkdir mktemp mv ps rm sed tr wc sleep; do
   _p=$(command -v "$_c" 2>/dev/null) && ln -sf "$_p" "$noflock_stub/$_c"
 done
 run_noflock() { PATH="$noflock_stub" bash "$IC" "$@" 2>/dev/null; }
@@ -195,15 +195,15 @@ else
   assert "TC-16 the other four no-flock contenders aborted" "4" "$_nf_other"
 fi
 
-echo "=== TC-17: stale lock residue is reclaimed despite a live/reused PID ==="
+echo "=== TC-17: stale lock residue is reclaimed after PID reuse ==="
 SID_RESIDUE="abababab-1111-2222-3333-444444444444"
 mk_active "$SID_RESIDUE" 970
 assert "TC-17 owner claims first" "claimed" "$(claim "$SID_RESIDUE" 970)"
 lockdir="$ROOT/.rite/state/issue-claims/.lock.d"
 mkdir "$lockdir"
 printf '%s\n' "$$" > "$lockdir/pid"
-printf '%s\n' "$(( $(date +%s) - 60 ))" > "$lockdir/acquired_at"
-assert "TC-17 release reclaims expired residue and succeeds" "released" "$(release "$SID_RESIDUE" 970)"
+printf '%s\n' 'different process start identity' > "$lockdir/process_start"
+assert "TC-17 release reclaims reused-PID residue and succeeds" "released" "$(release "$SID_RESIDUE" 970)"
 assert "TC-17 claim is removed after residue recovery" "free" "$(check "$SID_RESIDUE" 970)"
 
 echo "=== TC-18: malformed/non-positive lock PID is reclaimable ==="
@@ -211,7 +211,7 @@ mk_active "$SID_RESIDUE" 971
 assert "TC-18 owner claims first" "claimed" "$(claim "$SID_RESIDUE" 971)"
 mkdir "$lockdir"
 printf '%s\n' '%s' > "$lockdir/pid"
-printf '%s\n' "$(date +%s)" > "$lockdir/acquired_at"
+printf '%s\n' 'malformed owner' > "$lockdir/process_start"
 assert "TC-18 malformed PID residue is reclaimed" "released" "$(release "$SID_RESIDUE" 971)"
 assert "TC-18 claim is removed after malformed residue recovery" "free" "$(check "$SID_RESIDUE" 971)"
 


### PR DESCRIPTION
## 概要

flock が存在しない環境でも stale issue claim の奪取を排他的に行えるようにします。

Closes #2010

## 変更内容

- stale-steal、own-refresh、release の critical section を portable な atomic mkdir lock に統一
- 異常終了で残った lock directory を、所有 PID の終了確認後に安全に回収
- flock を除いた PATH で 5 contender を競合させ、勝者が常に 1 件になる回帰テストを追加

## 検証

- `bash plugins/rite/hooks/tests/issue-claim.test.sh`（32 assertions）
- `bash plugins/rite/hooks/tests/run-tests.sh`（126 suites）
- `git diff --check`

## チェックリスト

- [x] macOS 標準環境で利用できる POSIX 操作のみを使用
- [x] FREE claim の noclobber 経路を非回帰
- [x] stale-steal の exactly-one 契約を flock 不在 PATH で検証
