### PR TITLE
fix(hooks): macOS の live cwd 判定を修正する

### DIFF
--- a/plugins/rite/hooks/scripts/worktree-live-cwd.sh
+++ b/plugins/rite/hooks/scripts/worktree-live-cwd.sh
@@ -77,11 +77,10 @@ _rite_probe_proc() {
 # processes whose working directory is at or under <dir>; any hit means a live cwd.
 # Returns 2 (undeterminable) when lsof itself is unavailable.
 _rite_probe_lsof() {
+  local out
   command -v lsof >/dev/null 2>&1 || return 2
-  if lsof -a -d cwd +D "$target_canon" >/dev/null 2>&1; then
-    return 0
-  fi
-  return 1
+  out=$(lsof -a -d cwd +D "$target_canon" 2>/dev/null) || true
+  [ -n "$out" ]
 }
 
 case "$probe" in

--- a/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
+++ b/plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh
@@ -296,11 +296,6 @@ case "$out" in *"session_worktrees=1"*) pass "T-06 status reports session_worktr
 # gap by reading the OS's own per-process cwd, independent of flow-state.
 # ===========================================================================
 echo "=== T-07 (Issue #1544): a live process standing in a clean+stale worktree → NOT reaped (live-cwd guard) ==="
-# The OS-level live-cwd guard resolves to /proc on Linux but lsof on macOS, and
-# the lsof path has an exit-code false-negative (#2011) that reaps a live tree.
-# Guard behind /proc so the macOS leg skips this rather than failing on the known
-# lsof bug (Issue #2008 Family B). T-08 (no live cwd → reaped) stays platform-agnostic.
-if [ -d /proc ]; then
 R=$(make_repo 80); cleanup_dirs+=("$R")
 # Fully drift flow-state so neither flow-state-based guard protects issue-80:
 # `deactivate` sets SID_A's flow-state active=false, so the worktree liveness
@@ -321,9 +316,6 @@ assert "T-07 claim file survives (not reaped)" "1" "$( [ -f "$R/.rite/state/issu
 assert_grep "T-07 live-cwd guard WARNING on stderr" "$R/pcc.err" "live-cwd guard"
 case "$out" in *"session_worktrees=0"*) pass "T-07 status reports session_worktrees=0" ;; *) fail "T-07 status: $out" ;; esac
 kill "$_h80" 2>/dev/null || true; wait "$_h80" 2>/dev/null || true
-else
-  skip "T-07 skipped (no /proc: OS-level live-cwd guard uses lsof; exit-code false-negative reaps live tree, tracked in #2011)"
-fi
 
 echo "=== T-08 (Issue #1544 non-regression): same clean+stale worktree with NO live cwd → reaped ==="
 R=$(make_repo 81); cleanup_dirs+=("$R")

--- a/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
+++ b/plugins/rite/hooks/tests/worktree-live-cwd.test.sh
@@ -52,19 +52,11 @@ sleep 0.3
 assert "TC-3 held dir → rc 0" "0" "$(probe_rc "$D")"
 
 echo "=== TC-4: a process holds cwd nested under dir → rc 0 ==="
-# Without /proc the auto backend falls back to lsof, whose exit-code-based
-# detection is a false-negative for a dir that has subdirectories (a real bug
-# tracked in #2011). Guard behind /proc so the macOS leg skips this rather than
-# asserting the broken result (Issue #2008 Family B).
-if [ -d /proc ]; then
 D2=$(mktemp -d); cleanup_dirs+=("$D2")
 mkdir -p "$D2/sub/deep"
 ( cd "$D2/sub/deep" && sleep 30 ) & holders+=("$!")
 sleep 0.3
 assert "TC-4 nested-held dir → rc 0" "0" "$(probe_rc "$D2")"
-else
-  skip "TC-4 skipped (no /proc: auto backend → lsof; lsof exit-code false-negative on nested dirs tracked in #2011)"
-fi
 
 echo "=== TC-5: sibling-prefix dir must not false-match (issue-1 vs issue-12) ==="
 D3=$(mktemp -d); cleanup_dirs+=("$D3")
@@ -117,6 +109,10 @@ if command -v lsof >/dev/null 2>&1; then
   ( cd "$D7" && sleep 30 ) & holders+=("$!")
   sleep 0.3
   assert "TC-10 probe=lsof held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
+  mkdir -p "$D7/sub/deep"
+  ( cd "$D7/sub/deep" && sleep 30 ) & holders+=("$!")
+  sleep 0.3
+  assert "TC-10 probe=lsof nested-held dir → rc 0" "0" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
 else
   # lsof absent → the lsof backend reports undeterminable (rc 2), not a false negative.
   assert "TC-10 probe=lsof w/o lsof → rc 2" "2" "$(RITE_WORKTREE_LIVE_CWD_PROBE=lsof bash "$PROBE" "$D7" >/dev/null 2>&1; echo $?)"
@@ -127,19 +123,12 @@ echo "=== TC-11: canonicalization matches a symlinked parent (pwd -P / readlink 
 # physical. A holder entering via a symlinked path must still match both the real
 # and the linked target — pins the canonicalization contract against a future
 # realpath swap.
-# Guard behind /proc: the auto backend uses lsof without /proc, whose exit-code
-# false-negative on dirs-with-subdirs ($Dreal/wt has /sub) makes both asserts
-# fail on macOS — the #2011 lsof bug, not a canonicalization regression (Family B).
-if [ -d /proc ]; then
 Dreal=$(mktemp -d); cleanup_dirs+=("$Dreal"); mkdir -p "$Dreal/wt/sub"
 Dlink=$(mktemp -d); cleanup_dirs+=("$Dlink"); ln -s "$Dreal/wt" "$Dlink/wtlink"
 ( cd "$Dlink/wtlink/sub" && sleep 30 ) & holders+=("$!")
 sleep 0.3
 assert "TC-11 real path → rc 0" "0" "$(probe_rc "$Dreal/wt")"
 assert "TC-11 symlinked path → rc 0" "0" "$(probe_rc "$Dlink/wtlink")"
-else
-  skip "TC-11 skipped (no /proc: auto backend → lsof; exit-code false-negative tracked in #2011)"
-fi
 
 if ! print_summary "$(basename "$0")" "worktree-live-cwd.sh の OS 接地 liveness 判定 (Issue #1544)"; then
   exit 1


### PR DESCRIPTION
## 概要

lsof がマッチ行を出しながら exit 1 を返す場合でも、live な worktree cwd を検出します。

Closes #2011

## 変更内容

- lsof の終了コードではなく stdout の有無で live cwd を判定
- forced-lsof nested holder テストを追加
- macOS で skip していた nested/symlink/reaper integration を有効化

## 検証

- `bash plugins/rite/hooks/tests/worktree-live-cwd.test.sh`（17 assertions）
- `bash plugins/rite/hooks/tests/pr-cycle-cleanup-session-reap.test.sh`（137 assertions）
- `bash plugins/rite/hooks/tests/run-tests.sh`（126 suites）
