### PR TITLE
fix(hooks): symlink 下の wiki content-file 判定を修正する

### DIFF
--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -669,6 +669,32 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
+# TC-034b: symlink component in $PWD + regular content-file → exit 0 (#2012)
+# --------------------------------------------------------------------------
+echo "TC-034b: symlink component in \$PWD + regular content-file → exit 0"
+dir34b_real="$TEST_DIR/tc34b-real"
+dir34b_link="$TEST_DIR/tc34b-link"
+mkdir -p "$dir34b_real"
+ln -s "$dir34b_real" "$dir34b_link"
+cat > "$dir34b_real/rite-config.yml" <<'EOF'
+wiki:
+  enabled: true
+EOF
+echo "content below logical cwd" > "$dir34b_real/body.md"
+( cd -L "$dir34b_link" && bash "$HOOK" --type reviews --source-ref pr-2012 --content-file body.md > out.log 2>err.log ) && rc=0 || rc=$?
+if [ $rc -eq 0 ]; then
+  target_path34b=$(tr -d '[:space:]' < "$dir34b_real/out.log")
+  if [ -n "$target_path34b" ] && [ -f "$dir34b_real/$target_path34b" ]; then
+    pass "Canonical content path is accepted below symlinked \$PWD"
+  else
+    fail "Symlinked \$PWD → rc=0 but output file not found (path='$target_path34b')"
+  fi
+else
+  fail "Expected rc=0 below symlinked \$PWD, got rc=$rc, stderr=$(cat "$dir34b_real/err.log")"
+fi
+echo ""
+
+# --------------------------------------------------------------------------
 # TC-035: Control character in --source-ref → exit 1 (F-14)
 # --------------------------------------------------------------------------
 echo "TC-035: Control character in --source-ref → exit 1"

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -208,6 +208,11 @@ resolved_content=$(realpath -- "$CONTENT_FILE") || {
   echo "  hint: ensure the file exists and realpath is available (coreutils)" >&2
   exit 1
 }
+# Compare canonical paths on both sides. A logical $PWD can retain symlink
+# components (notably macOS /var -> /private/var), while realpath above always
+# returns the physical content path. Falling back to $PWD preserves the
+# existing fail-closed boundary when the cwd itself cannot be canonicalized.
+resolved_pwd=$(realpath -- "$PWD" 2>/dev/null) || resolved_pwd="$PWD"
 # /tmp/* → /tmp/rite-* に限定して exfiltration 経路を縮小。macOS では realpath が
 # /tmp → /private/tmp に symlink 解決するため /private/tmp/rite-* も同じ信頼境界
 # (owner-managed /tmp/rite-* namespace) として allowlist に含める。
@@ -224,7 +229,7 @@ if [[ -n "${TMPDIR:-}" ]]; then
   }
 fi
 case "$resolved_content" in
-  "$PWD"/*|/tmp/rite-*|/private/tmp/rite-*)
+  "$resolved_pwd"/*|/tmp/rite-*|/private/tmp/rite-*)
     : # allowed ($PWD 配下 / /tmp/rite-* / /private/tmp/rite-* — 後者は macOS realpath 解決後)
     ;;
   *)


### PR DESCRIPTION
## Summary

- canonicalize `$PWD` before comparing it with the resolved content-file path
- preserve the existing containment boundary and fail-closed fallback
- add a regression test using a logical cwd with a symlink component

## Test plan

- `bash plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh` (60 passed)
- `bash plugins/rite/hooks/tests/run-tests.sh` (126/126 passed)
- `bash --posix -n plugins/rite/hooks/wiki-ingest-trigger.sh plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh`

Closes #2012