### PR TITLE
fix(hooks): edit path と BLOCKED log の解釈差を塞ぐ

### DIFF
--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -761,6 +761,8 @@ CMD_SUMMARY="${CMD_SUMMARY//\"/\\\"}"
 # the deny path remains independent from the JSON fallback helper.
 CMD_SUMMARY="${CMD_SUMMARY//$'\n'/?}"
 CMD_SUMMARY="${CMD_SUMMARY//$'\r'/?}"
+CMD_SUMMARY=$(printf '%s' "$CMD_SUMMARY" | neutralize_ctrl --c0-only) \
+  || CMD_SUMMARY="[control-neutralization-failed]"
 BLOCK_EVENT="[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] bash-guard: BLOCKED pattern=$BLOCKED_PATTERN cmd=\"$CMD_SUMMARY\""
 echo "$BLOCK_EVENT" >&2
 

--- a/plugins/rite/hooks/pre-tool-edit-guard.sh
+++ b/plugins/rite/hooks/pre-tool-edit-guard.sh
@@ -145,9 +145,8 @@ fi
 # guarantee that /rite:open → implement.md Edit/Write is unaffected (AC-4).
 [ "$IS_SUBAGENT" = "1" ] || exit 0
 
-# --- Absolute path resolution (join relative against cwd; do NOT collapse `..` lexically) ---
-# `..` is resolved PHYSICALLY by `git -C` / `[ -d ]` below, never by string munging. A lexical
-# collapse (or a raw substring match) would let a reviewer forge an isolation path —
+# --- Absolute path resolution (join relative against cwd, then normalize lexically) ---
+# A raw substring match would let a reviewer forge an isolation path —
 # `<repo>/rite-review-mutation-x/../plugins/rite/hooks.json` re-enters a tracked file, and
 # `<repo>/src/rite-review-mutation-hack.py` embeds the token in a filename — both empirically
 # bypassed the old substring allowlist (Issue #1860 review cycle 1).
@@ -155,6 +154,28 @@ case "$FILE_PATH" in
   /*) ABS_PATH="$FILE_PATH" ;;
   *)  ABS_PATH="${CWD%/}/$FILE_PATH" ;;
 esac
+
+# Match the lexical normalization performed by file-writing clients before
+# they open a path. Do this byte-exactly with parameter expansion: external
+# dirname/readlink-style command substitutions would strip trailing LF bytes.
+# Empty and "." components disappear; ".." pops one component without ever
+# consulting the filesystem. Physical ownership is still resolved below by
+# `[ -d ]` and `git -C`, so symlink components are not canonicalized here.
+_path_rest=${ABS_PATH#/}
+_path_norm=""
+while :; do
+  case "$_path_rest" in
+    */*) _path_component=${_path_rest%%/*}; _path_rest=${_path_rest#*/}; _path_more=1 ;;
+    *)   _path_component=$_path_rest; _path_rest=""; _path_more=0 ;;
+  esac
+  case "$_path_component" in
+    ""|.) ;;
+    ..) _path_norm=${_path_norm%/*} ;;
+    *)  _path_norm="$_path_norm/$_path_component" ;;
+  esac
+  [ "$_path_more" = "1" ] || break
+done
+ABS_PATH=${_path_norm:-/}
 
 # --- Dereference a FINAL-element symlink before isolation scoping (Issue #1864 AC-2) ---
 # The _tdir walk below resolves INTERMEDIATE dirs physically (via `[ -d ]` / `git -C`), but the
@@ -166,12 +187,11 @@ esac
 # here so such a write lands on the real parent .git (→ git-dir deny below) instead.
 #
 # The retarget is LEXICAL on purpose (`readlink` + absolutize a relative target against the
-# link's own directory); it deliberately does NOT canonicalize `..` or intermediate symlinks.
-# That is safe because the _tdir walk immediately below does the physical resolution: `[ -d ]`
-# and `git -C` both chdir, so a target carrying `..` or a directory symlink lands on the REAL
-# tree that owns it — the same property that closes the `..` re-entry forgery for non-symlink
-# targets. So a forged `..` cannot escape here either, and nothing downstream of the walk needs
-# a canonical ABS_PATH — it is only reported (the deny reason and the BLOCKED stderr log); the
+# link's own directory); it does not canonicalize intermediate symlinks. The normalized input
+# has removed `.` / `..`; a relative readlink target may introduce them again, and the _tdir
+# walk immediately below performs that physical resolution: `[ -d ]` and `git -C` both chdir,
+# so a directory symlink or readlink target with `..` lands on the REAL tree
+# that owns it. Nothing downstream needs a canonical ABS_PATH — it is only reported; the
 # decision is made on TARGET_ROOT, which `git -C` produces already-resolved.
 #
 # Why not `realpath` (Issue #2014): it is the one step that would need the target to EXIST.
@@ -246,9 +266,11 @@ fi
 # and resolve `..` physically, so a path carrying a non-existent `..` segment lands on the real
 # parent repo (→ deny), not on a forged isolation dir. Walking to the nearest existing ancestor
 # also covers a brand-new file in a not-yet-created dir (the ancestor still resolves to the repo).
-_tdir=$(dirname "$ABS_PATH")
+_tdir=${ABS_PATH%/*}
+[ -n "$_tdir" ] || _tdir="/"
 while [ -n "$_tdir" ] && [ "$_tdir" != "/" ] && [ ! -d "$_tdir" ]; do
-  _tdir=$(dirname "$_tdir")
+  _tdir=${_tdir%/*}
+  [ -n "$_tdir" ] || _tdir="/"
 done
 [ -d "$_tdir" ] || _tdir="${CWD:-.}"
 # git -C chdir's to the resolved ancestor and reports the worktree toplevel that owns it.

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2052,6 +2052,14 @@ if [ "$(awk 'END { print NR }' "$_audit_tmp/.rite/logs/bash-guard.log")" = "2" ]
 else
   fail "TC-141 multiline command broke the one-event-per-line audit contract"
 fi
+RITE_STATE_ROOT="$_audit_tmp" jq -n --arg cmd $'gh pr diff 1 --stat\t\033X' \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | RITE_STATE_ROOT="$_audit_tmp" bash "$HOOK" >/dev/null 2>/dev/null || true
+if grep -Fq 'cmd="gh pr diff 1 --stat??X"' "$_audit_tmp/.rite/logs/bash-guard.log"; then
+  pass "TC-141 remaining C0 controls are neutralized in audit records"
+else
+  fail "TC-141 audit record retained raw TAB/ESC controls: $(tail -1 "$_audit_tmp/.rite/logs/bash-guard.log" | cat -v)"
+fi
 rm -rf "$_audit_tmp"
 echo ""
 

--- a/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-edit-guard.test.sh
@@ -370,6 +370,36 @@ assert_deny "isolation symlink into parent working tree resolved & blocked" "$ou
 rm -f "$ISO_MUT_DIR/evil-into-tree"
 echo ""
 
+# Intermediate directory names ending in LF must survive the ancestor split
+# byte-for-byte. A command substitution around dirname strips that LF and scopes
+# the isolation worktree instead of the parent tree reached by the symlink.
+echo "TC-SYMLINK-lf-intermediate: LF directory symlink into parent tree → deny"
+lf_intermediate=$'dir-link\n'
+mkdir -p "$TEST_REPO/lf-target-dir"
+ln -s "$TEST_REPO/lf-target-dir" "$ISO_MUT_DIR/$lf_intermediate"
+ln -s "$ISO_MUT_DIR/$lf_intermediate/newfile.py" "$ISO_MUT_DIR/evil-lf-intermediate"
+out=$(run_edit_guard "Write" "$ISO_MUT_DIR/evil-lf-intermediate" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+assert_deny "LF-terminated intermediate directory is preserved and blocked" "$out"
+rm -f "$ISO_MUT_DIR/evil-lf-intermediate" "$ISO_MUT_DIR/$lf_intermediate"
+rmdir "$TEST_REPO/lf-target-dir" || fail "LF intermediate fixture cleanup failed"
+echo ""
+
+# Write-style lexical normalization removes these spellings before opening the
+# path. The hook must make the same decision before testing the final symlink,
+# or it scopes the isolation tree while the normalized write reaches .git.
+echo "TC-SYMLINK-lexical-spellings: trailing /, /. and missing/../ forms → deny"
+ln -s "$TEST_REPO/.git/hooks/pre-commit" "$ISO_MUT_DIR/evil-lexical"
+for lexical_path in \
+  "$ISO_MUT_DIR/evil-lexical/" \
+  "$ISO_MUT_DIR/evil-lexical/." \
+  "$ISO_MUT_DIR/missing/../evil-lexical"
+do
+  out=$(run_edit_guard "Write" "$lexical_path" "$ISO_MUT_DIR" "$SUBAGENT_TRANSCRIPT") || true
+  assert_deny_gitdir "lexically normalized symlink spelling blocked: $lexical_path" "$out"
+done
+rm -f "$ISO_MUT_DIR/evil-lexical"
+echo ""
+
 # A two-link chain: resolving only ONE hop would leave ABS_PATH at `$ISO_MUT_DIR/hop`,
 # landing _tdir back on the isolation root → allow. Pins the loop against a future
 # "just dereference once" simplification (Issue #2014).


### PR DESCRIPTION
## Summary

- normalize Edit/Write paths lexically before final-symlink and repository scoping
- preserve LF-terminated path components with parameter expansion in the ancestor walk
- neutralize all remaining C0 controls in bash-guard BLOCKED audit summaries
- add blocking regressions for LF directory symlinks, trailing `/`, `/.`, missing `..`, and TAB/ESC audit injection

## Test plan

- `pre-tool-edit-guard.test.sh` (49 passed)
- `pre-tool-bash-guard.test.sh` (244 passed)
- full hooks `run-tests.sh` (126/126 passed)
- `bash --posix -n` on the four changed shell files

Note: local shellcheck binary is unavailable; CI shellcheck is the authoritative gate.

Closes #2018