### PR TITLE
fix(hooks): 診断中和 parity sweep を scripts へ拡張

### DIFF
--- a/plugins/rite/hooks/control-char-neutralize.sh
+++ b/plugins/rite/hooks/control-char-neutralize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # rite workflow - Control Character Neutralization (shared)
 # Provides the single source of truth for the "control chars → ?" diagnostic
-# neutralization convention shared by all hooks/ diagnostic snippet emission
+# neutralization convention shared by all hooks/ and scripts/ diagnostic snippet emission
 # sites (`head -3 "$err_file" | neutralize_ctrl --keep-newline | sed ... >&2`
 # — the parity is pinned by
 # tests/diag-snippet-neutralize-parity.test.sh), by stop-loop-continuation.sh

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -139,8 +139,8 @@ echo "=== TC-3: head -c byte 指向 embed site は全て neutralize_ctrl を経�
 # (mutation 検証で実証)。そのため head -c 全行を sweep し、非 emission の
 # 既知 site のみ明示 allowlist で除外する fail-closed 設計とする。新規の head -c が
 # 非 emission 用途なら本 allowlist に追記すること。
-violations_c=$(grep -rnE 'head -c [0-9]+' "$HOOKS_DIR" --include='*.sh' \
-  | grep -v "$HOOKS_DIR/tests/" \
+violations_c=$(grep -rnE 'head -c [0-9]+' "${SWEEP_DIRS[@]}" --include='*.sh' \
+  | grep -v '/tests/' \
   | grep -v 'neutralize_ctrl' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   | grep -v 'work-memory-lock.sh:.*lock_pid=' \
@@ -190,8 +190,8 @@ echo "=== TC-4: cat full-file 直接 emission site は全て neutralize_ctrl を
 #     現状 hooks の **stderr 向け cat heredoc** は全て redirect-first のため実害はない
 #     (stdout / tmpfile 向けの body-first heredoc は主 regex の `>&2` 要件で元々マッチしない。
 #     追加で stderr 向け body-first heredoc を書く場合は本 allowlist を拡張する)。
-violations_cat=$(grep -rnE '(^[[:space:]]*|[;|&{][[:space:]]*)cat [^|;&]*(1)?>&2' "$HOOKS_DIR" --include='*.sh' \
-  | grep -v "$HOOKS_DIR/tests/" \
+violations_cat=$(grep -rnE '(^[[:space:]]*|[;|&{][[:space:]]*)cat [^|;&]*(1)?>&2' "${SWEEP_DIRS[@]}" --include='*.sh' \
+  | grep -v '/tests/' \
   | grep -v 'neutralize_ctrl' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   | grep -vE 'cat [^|;&]*(1)?>&2[[:space:]]*<<' \

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -4,7 +4,7 @@
 #
 # Purpose:
 #   flow-state.sh で導入された「診断スニペットは
-#   neutralize_ctrl を経由して emit する」規約を、hooks/ 配下の全
+#   neutralize_ctrl を経由して emit する」規約を、hooks/ と scripts/ 配下の全
 #   `head -3` emission site に対称適用したことを保証する
 #   (Wiki 経験則 Asymmetric Fix Transcription — 対称位置への伝播漏れ防止)。
 #   sweep は `head -3` 限定ではなく `head -N` / `head -n N` (任意行数・両綴り)
@@ -15,7 +15,7 @@
 #   場合も TC-1 が検出する。
 #
 # Test cases:
-#   TC-1: hooks/ 配下 (tests/ 除く) に neutralize_ctrl を経由しない
+#   TC-1: hooks/ と scripts/ 配下 (tests/ 除く) に neutralize_ctrl を経由しない
 #         `head -N` 行指向 emission site が存在しない (コメント行は除外)
 #   TC-2: neutralize_ctrl を call する全 hook ファイルが
 #         control-char-neutralize.sh を source している
@@ -30,6 +30,8 @@
 #         構造的死角は TC-4 ブロックのコメント参照 (fail-open 余地の閉塞)
 #   TC-5: `>&2` が log() / surface_git_warnings() 等の関数内部に隠れる emission
 #         経路は静的 sweep で構造的に検出不能のため、既知 site を個別に pin する
+#   TC-6: scripts/ の是正 site を実行し、ESC/C1 を含む複数行 stderr が
+#         制御文字を残さず、行ごとの indent を維持する
 #
 # Usage: bash plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
 set -euo pipefail
@@ -38,11 +40,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_test-helpers.sh"
 PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
 HOOKS_DIR="$PLUGIN_ROOT/hooks"
+SCRIPTS_DIR="$PLUGIN_ROOT/scripts"
+SWEEP_DIRS=("$HOOKS_DIR" "$SCRIPTS_DIR")
 
-if [ ! -d "$HOOKS_DIR" ]; then
-  echo "ERROR: $HOOKS_DIR not found" >&2
-  exit 1
-fi
+for sweep_dir in "${SWEEP_DIRS[@]}"; do
+  if [ ! -d "$sweep_dir" ]; then
+    echo "ERROR: $sweep_dir not found" >&2
+    exit 1
+  fi
+done
 
 echo "=== TC-1: head/tail -N emission site は全て neutralize_ctrl を経由 ==="
 # 除外: tests/ (fixture/assertion 内の出現)、コメント行、定義元 helper の usage コメント
@@ -57,9 +63,9 @@ echo "=== TC-1: head/tail -N emission site は全て neutralize_ctrl を経由 =
 # sweep 正規表現は floor guard と共有する。literal を二重に持つと、片方だけ腕を落とす変異を
 # もう片方が検出できない (初版の floor guard が実際にそうだった)。
 SWEEP_RE='(head|tail) (-[0-9]+|-n +[0-9]+) '
-violations=$(grep -rnE "$SWEEP_RE" "$HOOKS_DIR" --include='*.sh' \
+violations=$(grep -rnE "$SWEEP_RE" "${SWEEP_DIRS[@]}" --include='*.sh' \
   | grep '>&2' \
-  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v '/tests/' \
   | grep -v 'neutralize_ctrl' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   || true)
@@ -72,9 +78,9 @@ fi
 # sweep 正規表現が tail site を実際に拾えていることを pin (TC-2 の floor guard と同型)。
 # TC-1 は violations が空であることだけを assert する fail-closed sweep なので、式から tail が
 # 落ちても Green のまま通る。$SWEEP_RE を共有して数えることで腕の消失が本 guard の失敗になる。
-tail_pop=$(grep -rnE "$SWEEP_RE" "$HOOKS_DIR" --include='*.sh' \
+tail_pop=$(grep -rnE "$SWEEP_RE" "${SWEEP_DIRS[@]}" --include='*.sh' \
   | grep '>&2' \
-  | grep -v "$HOOKS_DIR/tests/" \
+  | grep -v '/tests/' \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
   | grep -c 'tail ') || tail_pop=0
 case "$tail_pop" in ''|*[!0-9]*) tail_pop=0 ;; esac
@@ -84,12 +90,27 @@ else
   fail "TC-1 floor: tail 腕のカバー site が 0 件 — 正規表現から tail が落ちても violations は空のままで回帰が不可視になる"
 fi
 
+# scripts/ を sweep 根から外す変異を、violations の偶然の空集合に依存せず検出する。
+# TC-1 と同じ正規表現・emission 条件で scripts/ の実 site 母集団を数えるため、
+# SWEEP_DIRS から "$SCRIPTS_DIR" を削ると 0 件になり loud に落ちる。
+scripts_pop=$(grep -rnE "$SWEEP_RE" "${SWEEP_DIRS[@]}" --include='*.sh' \
+  | grep '>&2' \
+  | grep -v '/tests/' \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+  | grep -cF "$SCRIPTS_DIR/") || scripts_pop=0
+case "$scripts_pop" in ''|*[!0-9]*) scripts_pop=0 ;; esac
+if [ "$scripts_pop" -ge 1 ]; then
+  pass "TC-1 floor: scripts/ sweep が実 site を $scripts_pop 件カバーしている"
+else
+  fail "TC-1 floor: scripts/ のカバー site が 0 件 — SWEEP_DIRS から scripts/ を外す回帰が不可視になる"
+fi
+
 echo ""
 echo "=== TC-2: neutralize_ctrl の caller は helper を source 済み ==="
 # `neutralize_ctrl` / `contains_ctrl` を実行コードとして含むファイル一覧 (コメント行のみの言及は除外)
 # 収集側も両関数対応にする — contains_ctrl のみを使う hook が将来追加された場合の検査漏れ防止
-caller_files=$(grep -rlE 'neutralize_ctrl|contains_ctrl' "$HOOKS_DIR" --include='*.sh' \
-  | grep -v "$HOOKS_DIR/tests/" \
+caller_files=$(grep -rlE 'neutralize_ctrl|contains_ctrl' "${SWEEP_DIRS[@]}" --include='*.sh' \
+  | grep -v '/tests/' \
   | grep -v '/control-char-neutralize.sh$' \
   || true)
 checked=0
@@ -189,8 +210,46 @@ assert_grep "TC-5: wiki-ingest-commit.sh surface_git_warnings" \
   "$HOOKS_DIR/scripts/wiki-ingest-commit.sh" \
   'grep -iE .\^\(warning\|hint\|error\):. \| neutralize_ctrl --keep-newline'
 
+echo ""
+echo "=== TC-6: scripts/ 実 site は制御文字を中和し複数行 indent を維持 ==="
+tc6_dir=$(mktemp -d "${TMPDIR:-/tmp}/rite-diag-parity-tc6-XXXXXX")
+tc6_cleanup() { rm -rf -- "$tc6_dir"; }
+trap tc6_cleanup EXIT
+mkdir -p "$tc6_dir/bin" "$tc6_dir/repo/.git"
+cat > "$tc6_dir/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$tc6_dir/bin/gh" <<'SH'
+#!/bin/bash
+printf 'gh-esc\033one\ngh-c1\302\233two\ngh-raw\233three\n' >&2
+exit 1
+SH
+chmod +x "$tc6_dir/bin/gh"
+set +e
+(cd "$tc6_dir/repo" && PATH="$tc6_dir/bin:$PATH" \
+  bash "$SCRIPTS_DIR/watchdog-status-mismatch.sh" >"$tc6_dir/stdout" 2>"$tc6_dir/stderr")
+tc6_rc=$?
+set -e
+assert "TC-6: watchdog failure contract preserved" "1" "$tc6_rc"
+tc6_ctrl_hex=$(LC_ALL=C od -An -tx1 "$tc6_dir/stderr" | tr -d ' \n' \
+  | grep -oE '(1b|9b)' || true)
+assert "TC-6: ESC/C1 bytes are absent" "" "$tc6_ctrl_hex"
+assert_grep "TC-6: ESC line remains indented" "$tc6_dir/stderr" '^  gh-esc\?one$'
+tc6_stderr_hex=$(LC_ALL=C od -An -tx1 "$tc6_dir/stderr" | tr -d ' \n')
+if [[ "$tc6_stderr_hex" == *"202067682d6331c23f74776f0a"* ]]; then
+  pass "TC-6: UTF-8 C1 line remains indented"
+else
+  fail "TC-6: UTF-8 C1 line lost byte-wise replacement or indentation"
+fi
+assert_grep "TC-6: raw C1 line remains indented" "$tc6_dir/stderr" '^  gh-raw\?three$'
+tc6_cleanup
+trap - EXIT
+
 if ! print_summary "$(basename "$0")" \
-  "診断スニペット emission site を hook に追加するときは control-char-neutralize.sh を source し、emission site の構造に応じて中和を挿入すること: \
+  "診断スニペット emission site を hooks/ または scripts/ に追加するときは control-char-neutralize.sh を source し、emission site の構造に応じて中和を挿入すること: \
 TC-1 (head/tail -N 行指向) は直後に '| neutralize_ctrl --keep-newline'; \
 TC-3 (head -c byte 指向 embed) は '| tr '\\''\\n'\\'' '\\'' '\\'' | neutralize_ctrl --c0-only'; \
 TC-4 (cat full-file 直接 emission) は 'neutralize_ctrl --keep-newline < \"\$file\" >&2' へ置換; \

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -148,7 +148,7 @@ violations_c=$(grep -rnE 'head -c [0-9]+' "${SWEEP_DIRS[@]}" --include='*.sh' \
   || true)
 assert "TC-3: un-neutralized head -c emission sites" "" "$violations_c"
 if [ -n "$violations_c" ]; then
-  echo "  検出された未中和 site (head -c の直後に '| tr '\\''\\n'\\'' '\\'' '\\'' | neutralize_ctrl --c0-only' を挿入すること):"
+  echo "  検出された未中和 site (診断値を emission 前に default 'neutralize_ctrl' へ通すこと。新規 --c0-only は使用しない):"
   printf '%s\n' "$violations_c" | sed 's/^/    /'
 fi
 
@@ -251,7 +251,7 @@ trap - EXIT
 if ! print_summary "$(basename "$0")" \
   "診断スニペット emission site を hooks/ または scripts/ に追加するときは control-char-neutralize.sh を source し、emission site の構造に応じて中和を挿入すること: \
 TC-1 (head/tail -N 行指向) は直後に '| neutralize_ctrl --keep-newline'; \
-TC-3 (head -c byte 指向 embed) は '| tr '\\''\\n'\\'' '\\'' '\\'' | neutralize_ctrl --c0-only'; \
+TC-3 (head -c byte 指向 embed) は改行を整形後に default '| neutralize_ctrl' (新規 --c0-only は禁止); \
 TC-4 (cat full-file 直接 emission) は 'neutralize_ctrl --keep-newline < \"\$file\" >&2' へ置換; \
 TC-5 (log()/surface_git_warnings() 等の関数内 >&2) は静的 sweep で検出不能のため中和適用後に本テストへ個別 pin を追記すること"; then
   exit 1

--- a/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
@@ -171,6 +171,33 @@ else
 fi
 
 echo ""
+echo "[T-9g] Behavioral: head -c preview neutralizes ESC/C1 bytes"
+real_jq=$(command -v jq)
+cat > "$T9F_DIR/repo/bin/jq" <<'JQ_SHIM'
+#!/bin/bash
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = ".[]" ]; then
+  printf 'bad\033esc\302\233utf8\233raw\n'
+  exit 0
+fi
+exec "__REAL_JQ__" "$@"
+JQ_SHIM
+sed -i.bak "s|__REAL_JQ__|$real_jq|" "$T9F_DIR/repo/bin/jq"
+chmod +x "$T9F_DIR/repo/bin/jq"
+set +e
+(cd "$T9F_DIR/repo" && PATH="$T9F_DIR/repo/bin:$PATH" \
+  bash "$WATCHDOG_SH" --dry-run >"$T9F_DIR/t9g-stdout" 2>"$T9F_DIR/t9g-stderr")
+t9g_rc=$?
+set -e
+t9g_hex=$(LC_ALL=C od -An -tx1 "$T9F_DIR/t9g-stderr" | tr -d ' \n')
+if [ "$t9g_rc" -eq 0 ] && [[ "$t9g_hex" != *"1b"* ]] && [[ "$t9g_hex" != *"9b"* ]] \
+  && grep -qF 'pr_entry preview: bad?esc' "$T9F_DIR/t9g-stderr"; then
+  PASS=$((PASS + 1)); echo "  ✓ preview preserves exit contract and replaces ESC/UTF-8 C1/raw C1"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-9g: preview leaked control bytes or changed exit contract")
+  echo "  ✗ preview leaked control bytes or changed exit contract" >&2
+fi
+
+echo ""
 echo "==============================="
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
+++ b/plugins/rite/hooks/tests/watchdog-status-mismatch.test.sh
@@ -188,9 +188,11 @@ set +e
   bash "$WATCHDOG_SH" --dry-run >"$T9F_DIR/t9g-stdout" 2>"$T9F_DIR/t9g-stderr")
 t9g_rc=$?
 set -e
-t9g_hex=$(LC_ALL=C od -An -tx1 "$T9F_DIR/t9g-stderr" | tr -d ' \n')
-if [ "$t9g_rc" -eq 0 ] && [[ "$t9g_hex" != *"1b"* ]] && [[ "$t9g_hex" != *"9b"* ]] \
-  && grep -qF 'pr_entry preview: bad?esc' "$T9F_DIR/t9g-stderr"; then
+t9g_preview_hex=$(LC_ALL=C grep -aF 'pr_entry preview:' "$T9F_DIR/t9g-stderr" \
+  | od -An -tx1 | tr -d ' \n')
+if [ "$t9g_rc" -eq 0 ] && [[ "$t9g_preview_hex" != *"1b"* ]] \
+  && [[ "$t9g_preview_hex" != *"9b"* ]] \
+  && [[ "$t9g_preview_hex" == *"6261643f657363c23f757466383f726177"* ]]; then
   PASS=$((PASS + 1)); echo "  ✓ preview preserves exit contract and replaces ESC/UTF-8 C1/raw C1"
 else
   FAIL=$((FAIL + 1)); FAILURES+=("T-9g: preview leaked control bytes or changed exit contract")

--- a/plugins/rite/scripts/migrate-review-state-to-1.1.sh
+++ b/plugins/rite/scripts/migrate-review-state-to-1.1.sh
@@ -32,6 +32,10 @@
 # `set -uo pipefail` と同パターン)。pipefail は維持して pipeline 失敗を捕捉する。
 set -uo pipefail
 
+_mig_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$_mig_script_dir/../hooks/control-char-neutralize.sh"
+
 # --- Signal-specific trap setup ---
 # canonical pattern: references/bash-trap-patterns.md#signal-specific-trap-template
 # SIGINT/SIGTERM/SIGHUP で中断時に per-file mktemp tempfile (`${file}.XXXXXX`) を残さない。
@@ -62,7 +66,6 @@ esac
 # どおり優先。git repo 外では resolver を呼ばず (非 git cwd でも cwd を正常出力するため)、
 # 従来どおり下の ERROR ガードで fail-fast させる。
 if [ -z "${REPO_ROOT:-}" ] && git rev-parse --show-toplevel >/dev/null 2>&1; then
-  _mig_script_dir="$(dirname "${BASH_SOURCE[0]}")"
   if _mig_state_root=$("$_mig_script_dir/../hooks/state-path-resolve.sh" 2>/dev/null) && [ -n "$_mig_state_root" ]; then
     REPO_ROOT="$_mig_state_root"
   else
@@ -176,7 +179,7 @@ migrate_file() {
   if ! jq "$MIGRATE_FILTER" "$file" > "$tmp" 2>"${_jq_err:-/dev/null}"; then
     local _jq_rc=$?
     echo "[rite] ERROR: jq migration filter failed for $file (rc=$_jq_rc)" >&2
-    [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | sed 's/^/  /' >&2
+    [ -n "$_jq_err" ] && [ -s "$_jq_err" ] && head -3 "$_jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     [ -n "$_jq_err" ] && rm -f "$_jq_err"
     rm -f "$tmp"
     FAILED_COUNT=$((FAILED_COUNT + 1))
@@ -203,7 +206,7 @@ migrate_file() {
   else
     _mig_mv_rc=$?
     echo "[rite] ERROR: atomic mv failed for $file (rc=$_mig_mv_rc, tmp=$tmp left behind for inspection)" >&2
-    [ -n "$_mig_mv_err" ] && [ -s "$_mig_mv_err" ] && head -3 "$_mig_mv_err" | sed 's/^/  /' >&2
+    [ -n "$_mig_mv_err" ] && [ -s "$_mig_mv_err" ] && head -3 "$_mig_mv_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     [ -n "$_mig_mv_err" ] && rm -f "$_mig_mv_err"
     FAILED_COUNT=$((FAILED_COUNT + 1))
     FAILED_FILES+=("$file (tmp=$tmp)")

--- a/plugins/rite/scripts/review-cycle-scope.sh
+++ b/plugins/rite/scripts/review-cycle-scope.sh
@@ -79,6 +79,8 @@ set -uo pipefail
 _rcs_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../hooks/scripts/lib/tempfile.sh
 source "$_rcs_dir/../hooks/scripts/lib/tempfile.sh"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$_rcs_dir/../hooks/control-char-neutralize.sh"
 
 PR_NUMBER=""
 RESULTS_DIR=""
@@ -162,7 +164,7 @@ if [ "$RUN_SINCE_SET" -eq 0 ]; then
     rite_tempfile_new pin_err "rcs-pin-err" || emit_full run_pin_unreadable
     if ! RUN_SINCE=$(head -1 "$_rcs_pin" 2>"$pin_err"); then
       echo "WARNING: review-cycle-scope: run 開始点 pin を読めません: $_rcs_pin" >&2
-      head -3 "$pin_err" | sed 's/^/  /' >&2
+      head -3 "$pin_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       emit_full run_pin_unreadable
     fi
   fi
@@ -180,7 +182,7 @@ mapfile -t cs_files < <(find "$RESULTS_DIR" -maxdepth 1 -type f -name "${PR_NUMB
 # cycle 1 扱いになる。loud な prev_json_unreadable として区別する。
 if [ -s "$find_err" ]; then
   echo "WARNING: review-cycle-scope: $RESULTS_DIR/ の探索でエラーが発生しました:" >&2
-  head -3 "$find_err" | sed 's/^/  /' >&2
+  head -3 "$find_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full prev_json_unreadable
 fi
 
@@ -207,7 +209,7 @@ rite_tempfile_new probe_err "rcs-probe-err" || emit_full prev_json_unreadable
 
 if ! jq empty "$prev_json" 2>"$probe_err"; then
   echo "WARNING: review-cycle-scope: 前回レビュー JSON を parse できません: $prev_json" >&2
-  head -3 "$probe_err" | sed 's/^/  /' >&2
+  head -3 "$probe_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full prev_json_unreadable
 fi
 
@@ -216,7 +218,7 @@ fi
 # 破損が旧形式互換の顔をして運用者に無視される。診断も他 4 経路と同じ形で surface する。
 if ! base_sha=$(jq -r '.commit_sha // empty' "$prev_json" 2>"$probe_err"); then
   echo "WARNING: review-cycle-scope: commit_sha を抽出できません: $prev_json" >&2
-  head -3 "$probe_err" | sed 's/^/  /' >&2
+  head -3 "$probe_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full prev_json_unreadable
 fi
 if [ -z "$base_sha" ]; then
@@ -231,13 +233,13 @@ fi
 # 巻き込むが、失敗方向は「差分が広くなる」= 安全側のため許容する。
 if ! git cat-file -e "${base_sha}^{commit}" 2>"$probe_err"; then
   echo "WARNING: review-cycle-scope: 起点 commit を解決できません (base_sha=$base_sha)" >&2
-  head -3 "$probe_err" | sed 's/^/  /' >&2
+  head -3 "$probe_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full commit_sha_unreachable
 fi
 
 diff_names=$(git diff --name-only "${base_sha}..HEAD" 2>"$probe_err") || {
   echo "WARNING: review-cycle-scope: 差分を取得できません (${base_sha}..HEAD)" >&2
-  head -3 "$probe_err" | sed 's/^/  /' >&2
+  head -3 "$probe_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full diff_failed
 }
 
@@ -304,7 +306,7 @@ scope_probe=$(jq -r '
     end
 ' "$prev_json" 2>"$probe_err") || {
   echo "WARNING: review-cycle-scope: 前回 finder を抽出できません: $prev_json" >&2
-  head -3 "$probe_err" | sed 's/^/  /' >&2
+  head -3 "$probe_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   emit_full prev_json_unreadable
 }
 

--- a/plugins/rite/scripts/review-findings-maps.sh
+++ b/plugins/rite/scripts/review-findings-maps.sh
@@ -59,6 +59,10 @@
 # global `set -e` を使わない。verbatim 移植のため本 helper も同様。
 set -u
 
+_rfm_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$_rfm_dir/../hooks/control-char-neutralize.sh"
+
 review_source=""
 review_source_path=""
 REPO_ROOT=""
@@ -230,7 +234,7 @@ if duplicate_keys=$(jq -r '[.findings[] | (.file + ":" + (if .line == null or .l
 else
   jq_dup_rc=$?
   echo "WARNING: 重複 file:line 検出用 jq が失敗しました (rc=$jq_dup_rc) — silent data loss 検出を skip します" >&2
-  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  影響: 同一 file:line の重複 severity 警告が出ないため、後段で最後勝ち畳み込みが silent に発生する可能性があります" >&2
   echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=jq_duplicate_check_failed; rc=$jq_dup_rc" >&2
   # severity_map 構築は続行する (重複警告の喪失は non-blocking 失敗として扱う)
@@ -242,7 +246,7 @@ if severity_map_json=$(jq -c '[.findings[] | {key: (.file + ":" + (if .line == n
 else
   jq_smap_rc=$?
   echo "ERROR: severity_map 構築用 jq が失敗しました (rc=$jq_smap_rc)" >&2
-  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "  対処: review-result JSON ($review_source_path) の内容と jq バイナリを確認してください" >&2
   echo "  影響: severity_map が空のまま後段に流れ、指摘 0 件と誤認される silent regression を防ぐため fail-fast します" >&2
   echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=severity_map_build_failed; rc=$jq_smap_rc" >&2
@@ -260,7 +264,7 @@ if scope_map_json=$(jq -c '[.findings[] | {key: (.file + ":" + (if .line == null
 else
   jq_scmap_rc=$?
   echo "WARNING: scope_map 構築用 jq が失敗しました (rc=$jq_scmap_rc) — scope-based routing が無効化されます (legacy blocking 扱い)" >&2
-  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | sed 's/^/  /' >&2
+  [ -n "$jq_err" ] && [ -s "$jq_err" ] && head -3 "$jq_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   echo "[CONTEXT] FIX_FALLBACK_FAILED=1; reason=scope_map_build_failed; rc=$jq_scmap_rc" >&2
   scope_map_json="{}"
 fi

--- a/plugins/rite/scripts/review-measured-gate.sh
+++ b/plugins/rite/scripts/review-measured-gate.sh
@@ -144,6 +144,10 @@
 # (sibling の scripts/review-findings-maps.sh と同方針)。
 set -u
 
+_rmg_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$_rmg_script_dir/../hooks/control-char-neutralize.sh"
+
 input=""
 reject_preset=0
 
@@ -191,7 +195,7 @@ _fail() {
   #  hard-stop 経路で原因が消える)。
   echo "ERROR: $2" >&2
   if [ -n "${diag_file:-}" ] && [ -s "${diag_file:-}" ]; then
-    head -5 "$diag_file" | sed 's/^/  /' >&2
+    head -5 "$diag_file" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   echo "[CONTEXT] MEASURED_GATE_FAILED=1; reason=$1" >&2
   exit 1
@@ -458,7 +462,8 @@ if [ "$scope_unknown" -gt 0 ]; then
   # 1 行の JSON literal に畳む — id / file / scope は LLM 生成の自由記述で、raw 改行を
   # 埋めれば本 script 自身の `[CONTEXT]` marker とバイト同一の行を偽造でき、その marker は
   # caller (pr-review step 3) の routing 入力そのものになる。ANSI/OSC も同時に潰れる。
-  printf '%s\n' "$result" | jq -r '.stats.scope_unknown_list[]' 2>"${diag_file:-/dev/null}" | head -10 >&2
+  printf '%s\n' "$result" | jq -r '.stats.scope_unknown_list[]' 2>"${diag_file:-/dev/null}" \
+    | head -10 | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   if [ "$scope_unknown" -gt 10 ]; then
     echo "  ... (残り $((scope_unknown - 10)) 件は省略)" >&2
   fi

--- a/plugins/rite/scripts/review-source-resolve.sh
+++ b/plugins/rite/scripts/review-source-resolve.sh
@@ -58,6 +58,10 @@
 # abort してはならない。`set -o pipefail` のみ block 本体で有効化する (旧 block と同一)。
 set -uo pipefail
 
+_rsr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$_rsr_dir/../hooks/control-char-neutralize.sh"
+
 # --- bash 4+ compat guard (mapfile builtin; Priority 2 で使用) ---
 # fix.md ステップ 1.0.1 の canonical guard と対称。helper は独立プロセスのため
 # defense-in-depth として再掲する。bash 3.2 (macOS default) では mapfile が無く
@@ -179,7 +183,7 @@ _rite_rename_corrupt_file() {
     echo "  WARNING: ${label} file の rename に失敗 (rc=$mv_rc)。次回 fix で同じ WARNING が再発します" >&2
     if [ -n "$mv_err" ] && [ -s "$mv_err" ]; then
       echo "    詳細 (mv stderr):" >&2
-      head -3 "$mv_err" | sed 's/^/      /' >&2
+      head -3 "$mv_err" | neutralize_ctrl --keep-newline | sed 's/^/      /' >&2
     fi
     echo "    対処: permission denied / read-only filesystem / cross-filesystem / target exists のいずれかを確認" >&2
     echo "    手動削除: rm \"$target\"" >&2
@@ -212,7 +216,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
     review_source_path=""
   elif jq_val_err_p0=$(mktemp "${TMPDIR:-/tmp}/rite-jq-val-err-p0-XXXXXX" 2>/dev/null) || true; ! jq empty "$review_file_path" 2>"${jq_val_err_p0:-/dev/null}"; then
     echo "エラー: --review-file で指定されたファイルが有効な JSON ではありません: $review_file_path" >&2
-    [ -n "${jq_val_err_p0:-}" ] && [ -s "$jq_val_err_p0" ] && head -3 "$jq_val_err_p0" | sed 's/^/  /' >&2
+    [ -n "${jq_val_err_p0:-}" ] && [ -s "$jq_val_err_p0" ] && head -3 "$jq_val_err_p0" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=explicit_file_parse" >&2
     rm -f "${jq_val_err_p0:-}"
     review_source="fallback"
@@ -248,7 +252,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
       # rc>=2 は jq 自身の失敗 (ランタイムエラー / バイナリ異常 / IO)。型崩れと同じ reason に
       # 融合すると、verification を持たない JSON にも type_invalid が付いて診断が事実とずれる。
       echo "エラー: --review-file の verification 型ガード実行中に jq が失敗しました (rc=$vg_rc_p0)" >&2
-      [ -n "$vg_err_p0" ] && [ -s "$vg_err_p0" ] && head -3 "$vg_err_p0" | sed 's/^/  /' >&2
+      [ -n "$vg_err_p0" ] && [ -s "$vg_err_p0" ] && head -3 "$vg_err_p0" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       echo "  原因候補: findings 要素が object でない / jq バイナリ異常 / OOM / ファイル IO エラー" >&2
       echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=explicit_file_verification_guard_jq_failed; rc=$vg_rc_p0" >&2
     fi
@@ -324,7 +328,7 @@ if [ -n "$review_file_path" ] && [ "$review_file_path" != "__RITE_UNSET__" ]; th
         else
           jq_p0_commit_sha_rc=$?
           echo "WARNING: --review-file の commit_sha 抽出で jq が失敗 (rc=$jq_p0_commit_sha_rc)" >&2
-          [ -n "$json_commit_sha_err" ] && [ -s "$json_commit_sha_err" ] && head -3 "$json_commit_sha_err" | sed 's/^/  /' >&2
+          [ -n "$json_commit_sha_err" ] && [ -s "$json_commit_sha_err" ] && head -3 "$json_commit_sha_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
           echo "[CONTEXT] REVIEW_SOURCE_STALE_CHECK_FAILED=1; reason=jq_error_on_commit_sha; priority=0" >&2
           json_commit_sha=""
         fi
@@ -471,7 +475,7 @@ if [ -z "$review_source" ]; then
 
     if [ -n "$find_err" ] && [ -s "$find_err" ]; then
       echo "WARNING: $_p2_results_dir/ 検索時にエラー発生:" >&2
-      head -3 "$find_err" | sed 's/^/  /' >&2
+      head -3 "$find_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
       echo "  Priority 2 を IO エラーにより skip し、Priority 3 (PR コメント) に明示 routing します" >&2
       echo "[CONTEXT] REVIEW_SOURCE_FIND_FAILED=1; reason=local_file_find_io_error" >&2
       review_source="pr_comment"
@@ -515,7 +519,7 @@ if [ -z "$review_source" ]; then
       jq_val_err_p2=$(mktemp "${TMPDIR:-/tmp}/rite-jq-val-err-p2-XXXXXX" 2>/dev/null) || jq_val_err_p2=""
       if ! jq empty "$latest_file" 2>"${jq_val_err_p2:-/dev/null}"; then
         echo "WARNING: $latest_file は有効な JSON ではありません。Priority 3 (PR コメント) に routing します。" >&2
-        [ -n "${jq_val_err_p2:-}" ] && [ -s "$jq_val_err_p2" ] && head -3 "$jq_val_err_p2" | sed 's/^/  /' >&2
+        [ -n "${jq_val_err_p2:-}" ] && [ -s "$jq_val_err_p2" ] && head -3 "$jq_val_err_p2" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
         echo "[CONTEXT] REVIEW_SOURCE_PARSE_FAILED=1; reason=local_file_json_parse_failure" >&2
         # verified-review M-6 (M10) 対応: corrupted file を .corrupt-{epoch} にリネームし、
         # 次回の lexicographic sort で選ばれないようにする。WARNING を出すだけで corrupted file を
@@ -551,7 +555,7 @@ if [ -z "$review_source" ]; then
           # rc>=2 は jq 自身の失敗。ファイルが壊れている証拠がないため rename しない
           # (破壊的操作を conflated signal で駆動しない)。routing だけ Priority 3 へ倒す。
           echo "WARNING: $latest_file の verification 型ガード実行中に jq が失敗しました (rc=$vg_rc_p2)。Priority 3 に routing します。" >&2
-          [ -n "$vg_err_p2" ] && [ -s "$vg_err_p2" ] && head -3 "$vg_err_p2" | sed 's/^/  /' >&2
+          [ -n "$vg_err_p2" ] && [ -s "$vg_err_p2" ] && head -3 "$vg_err_p2" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
           echo "  原因候補: findings 要素が object でない / jq バイナリ異常 / OOM / ファイル IO エラー" >&2
           echo "  注: 破損が未証明のため .corrupt-{epoch} rename は行いません" >&2
           echo "  対処: /rite:pr-review を再実行すれば新しい timestamp のファイルが生成され本ファイルは選ばれなくなります (即時解消は手動削除: rm \"$latest_file\")" >&2
@@ -622,7 +626,7 @@ if [ -z "$review_source" ]; then
             else
               jq_p2_commit_sha_rc=$?
               echo "WARNING: $latest_file の commit_sha 抽出で jq が失敗 (rc=$jq_p2_commit_sha_rc)" >&2
-              [ -n "$json_commit_sha_err" ] && [ -s "$json_commit_sha_err" ] && head -3 "$json_commit_sha_err" | sed 's/^/  /' >&2
+              [ -n "$json_commit_sha_err" ] && [ -s "$json_commit_sha_err" ] && head -3 "$json_commit_sha_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
               echo "[CONTEXT] REVIEW_SOURCE_STALE_CHECK_FAILED=1; reason=jq_error_on_commit_sha; priority=2" >&2
               json_commit_sha=""
             fi

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -85,6 +85,8 @@ fi
 # --- Locate rite-config.yml ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+# shellcheck source=../hooks/control-char-neutralize.sh
+source "$SCRIPT_DIR/../hooks/control-char-neutralize.sh"
 
 # Find repo root (look upward for rite-config.yml or .git)
 CWD="$(pwd)"
@@ -149,10 +151,10 @@ if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
   if ! REPO_INFO=$(gh repo view --json owner,name 2>"${repo_view_err:-/dev/null}"); then
     echo "ERROR: gh repo view failed" >&2
     if [ -n "$repo_view_err" ] && [ -s "$repo_view_err" ]; then
-      head -5 "$repo_view_err" | sed 's/^/  /' >&2
+      head -5 "$repo_view_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
     fi
     if [ -n "$git_remote_err" ] && [ -s "$git_remote_err" ]; then
-      head -3 "$git_remote_err" | sed 's/^/  git-remote: /' >&2
+      head -3 "$git_remote_err" | neutralize_ctrl --keep-newline | sed 's/^/  git-remote: /' >&2
     fi
     echo "  対処: gh auth status / network 接続を確認してください" >&2
     exit 1
@@ -174,7 +176,7 @@ pr_list_err=$(mktemp "${TMPDIR:-/tmp}/rite-watchdog-pr-list-err-XXXXXX") || pr_l
 if ! PR_LIST=$(gh pr list --repo "$REPO_OWNER/$REPO_NAME" --state open --limit "$LIMIT" --json number,isDraft,body,headRefName 2>"${pr_list_err:-/dev/null}"); then
   echo "ERROR: gh pr list failed" >&2
   if [ -n "$pr_list_err" ] && [ -s "$pr_list_err" ]; then
-    head -5 "$pr_list_err" | sed 's/^/  /' >&2
+    head -5 "$pr_list_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
   fi
   echo "  対処: gh auth status / network 接続 / repository 権限を確認してください" >&2
   exit 1

--- a/plugins/rite/scripts/watchdog-status-mismatch.sh
+++ b/plugins/rite/scripts/watchdog-status-mismatch.sh
@@ -206,7 +206,7 @@ while IFS= read -r pr_entry; do
   head_ref=$(printf '%s' "$pr_entry" | jq -r '.headRefName // empty' 2>/dev/null) || head_ref=""
   if [ -z "$pr_number" ] || [ -z "$is_draft" ]; then
     if [ "$QUIET" != "true" ]; then
-      echo "[watchdog] ⚠️ jq parse failed for PR entry, skipping (pr_entry preview: $(printf '%s' "$pr_entry" | head -c 80))" >&2
+      echo "[watchdog] ⚠️ jq parse failed for PR entry, skipping (pr_entry preview: $(printf '%s' "$pr_entry" | head -c 80 | neutralize_ctrl))" >&2
     fi
     continue
   fi
@@ -256,8 +256,8 @@ query($owner: String!, $repo: String!, $number: Int!) {
     # gh / jq pipeline 失敗 — silent skip せず warnings に記録 (debug 可能性向上)
     # 4-site stderr root cause attribution: gh_stderr と jq_stderr を独立表示
     if [ "$QUIET" != "true" ]; then
-      gql_err_oneline=$(head -c 200 "${gql_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
-      jq_err_oneline=$(head -c 200 "${jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ')
+      gql_err_oneline=$(head -c 200 "${gql_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl)
+      jq_err_oneline=$(head -c 200 "${jq_err:-/dev/null}" 2>/dev/null | tr '\n' ' ' | neutralize_ctrl)
       echo "[watchdog] ⚠️ gh api graphql or jq failed for Issue #$issue_number (gh_stderr=$gql_err_oneline, jq_stderr=$jq_err_oneline)" >&2
     fi
     current_status=""
@@ -287,7 +287,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       else
         RECONCILE_FAILURES=$((RECONCILE_FAILURES + 1))
         if [ -n "$reconcile_err" ] && [ -s "$reconcile_err" ]; then
-          reconcile_stderr_oneline=$(head -c 200 "$reconcile_err" | tr '\n' ' ')
+          reconcile_stderr_oneline=$(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl)
           if [ "$QUIET" != "true" ]; then
             echo "[watchdog] ⚠️ reconcile failed for Issue #$issue_number: $reconcile_stderr_oneline" >&2
           fi


### PR DESCRIPTION
## Summary

診断スニペットの制御文字中和 parity sweep を `plugins/rite/scripts/` へ拡張し、露出した emission site を共通 helper 経由へ統一します。

## Related Issue

Closes #2144

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- hooks/scripts 横断の head/tail 診断 sweep と scripts 母集団 floor pin を追加
- scripts 配下 6 ファイルの診断出力を `neutralize_ctrl --keep-newline` へ統一
- ESC/C1/複数行 stderr を実 site に流す動的回帰テストを追加
- helper header の保証範囲を hooks/scripts に同期

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)