### PR TITLE
docs(contributing): guard hook判定契約を実装と同期

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,12 @@ fi
 - Always use `set -euo pipefail` at the top
 - Read JSON input from stdin using `INPUT=$(cat)` and parse with `jq`
 - Use `state-path-resolve.sh` to resolve the state root directory
-- For guard hooks (e.g., `pre-tool-bash-guard.sh`): exit code `0` means "allow", non-zero means "block"
+- For PreToolUse guard hooks such as `pre-tool-bash-guard.sh` and
+  `pre-tool-edit-guard.sh`, read the decision from stdout JSON:
+  `hookSpecificOutput.permissionDecision: "deny"` means block. A normal allow is
+  exit `0` with no stdout; a normal deny may also exit `0` because the JSON is the
+  primary decision channel. Scope-confirmed fail-closed error paths emit the same
+  deny JSON and exit `2`. Do not infer allow/block from the exit code alone.
 - For non-guard hooks (e.g., `session-start.sh`, `session-end.sh`): exit code `0` indicates successful execution
 - For a new hook that needs temporary files, source `hooks/scripts/lib/tempfile.sh` rather than writing `mktemp` + `trap` by hand: call `rite_tempfile_init`, then `rite_tempfile_new <outvar> [tag]` (or `rite_tempdir_new`). A hook that already owns any of the EXIT / INT / TERM / HUP handlers passes `--caller-traps` to `rite_tempfile_init` and calls `rite_tempfile_cleanup` from its own handler. The rule, the refusal conditions, and why the lib beats a hand-written `trap 'rm -f "$tmpfile"' EXIT` are specified in `plugins/rite/skills/rite-workflow/references/coding-principles.md` "Shell Helper Conventions" — the SoT
 - Keep hooks fast — they run on every matching event


### PR DESCRIPTION
## Summary

Hook Conventions の guard hook 判定説明を、PreToolUse hook の実際の stdout JSON + exit code 契約へ同期します。

## Related Issue

Closes #2019

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

- allowはexit 0 + stdoutなしと明記
- denyの一次判定はpermissionDecision JSONであり通常denyもexit 0になり得ると明記
- scope確定後のfail-closed denyはJSON + exit 2と明記
- exit code単独でallow/blockを推論しないよう注意を追加

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [ ] CHANGELOG.md updated

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)