### PR TITLE
docs(config): review.loop commentsを現行仕様へ同期

### DIFF
--- a/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
+++ b/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Dogfooding 用 rite-config.yml の review.loop コメントを現行契約へ固定する (Issue #2107)。
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CONFIG="$ROOT_DIR/rite-config.yml"
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local name="$1" pattern="$2"
+  if LC_ALL=C grep -qE -- "$pattern" "$CONFIG"; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_grep() {
+  local name="$1" pattern="$2"
+  if LC_ALL=C grep -qE -- "$pattern" "$CONFIG"; then
+    echo "FAIL: $name"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_grep "normal exit is zero blocking findings with the severity SoT" \
+  '正常出口は 0 blocking findings のみ.*plugins/rite/references/severity-levels\.md.*§実測必須ゲート'
+assert_grep "circuit breaker documents trend divergence" \
+  '収束トレンドの発散'
+assert_grep "circuit breaker documents max_review_cycles backstop" \
+  'safety\.max_review_cycles 到達（backstop）'
+assert_grep "convergence_monitoring is scaffolding only with no runtime effect" \
+  'convergence_monitoring: true.*Scaffolding only.*runtime effect はない'
+assert_not_grep "obsolete four-signal escalation design is absent" \
+  '以下の 4 品質シグナル|root-cause 不明 fix|cross-validation 不一致|finding quality gate 不通過'
+assert_not_grep "obsolete semantic-cycle description is absent" \
+  '同一 finding 循環の semantic 検知'
+
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
+++ b/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
@@ -6,13 +6,23 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 CONFIG="$ROOT_DIR/rite-config.yml"
+LOOP_BLOCK="$(mktemp "${TMPDIR:-/tmp}/rite-review-loop-comments.XXXXXX")"
+trap 'rm -f -- "$LOOP_BLOCK"' EXIT
+
+# `review.loop` は 2-space indent、配下のキーは 4-space indent。次の同レベル
+# mapping key の直前までに限定し、同じ文言が別 section にあっても通さない。
+awk '
+  /^  loop:[[:space:]]*$/ { in_loop = 1 }
+  in_loop && seen_loop && /^  [[:alnum:]_]+:/ { exit }
+  in_loop { print; seen_loop = 1 }
+' "$CONFIG" > "$LOOP_BLOCK"
 
 PASS=0
 FAIL=0
 
 assert_grep() {
   local name="$1" pattern="$2"
-  if LC_ALL=C grep -qE -- "$pattern" "$CONFIG"; then
+  if LC_ALL=C grep -qE -- "$pattern" "$LOOP_BLOCK"; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
@@ -23,7 +33,7 @@ assert_grep() {
 
 assert_not_grep() {
   local name="$1" pattern="$2"
-  if LC_ALL=C grep -qE -- "$pattern" "$CONFIG"; then
+  if LC_ALL=C grep -qE -- "$pattern" "$LOOP_BLOCK"; then
     echo "FAIL: $name"
     FAIL=$((FAIL + 1))
   else
@@ -32,6 +42,7 @@ assert_not_grep() {
   fi
 }
 
+assert_grep "review.loop block was extracted" '^  loop:[[:space:]]*$'
 assert_grep "normal exit is zero blocking findings with the severity SoT" \
   '正常出口は 0 blocking findings のみ.*plugins/rite/references/severity-levels\.md.*§実測必須ゲート'
 assert_grep "circuit breaker documents trend divergence" \

--- a/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
+++ b/plugins/rite/hooks/tests/review-loop-config-comments.test.sh
@@ -9,10 +9,13 @@ CONFIG="$ROOT_DIR/rite-config.yml"
 LOOP_BLOCK="$(mktemp "${TMPDIR:-/tmp}/rite-review-loop-comments.XXXXXX")"
 trap 'rm -f -- "$LOOP_BLOCK"' EXIT
 
-# `review.loop` は 2-space indent、配下のキーは 4-space indent。次の同レベル
-# mapping key の直前までに限定し、同じ文言が別 section にあっても通さない。
+# top-level `review:` の内側にある 2-space indent の `loop:` だけを対象にし、
+# 次の同レベル mapping key の直前までに限定する。同じ文言や `loop:` block が
+# 別 section にあっても通さない。
 awk '
-  /^  loop:[[:space:]]*$/ { in_loop = 1 }
+  /^review:[[:space:]]*$/ { in_review = 1; print; next }
+  in_review && /^[[:alnum:]_]+:/ { exit }
+  in_review && /^  loop:[[:space:]]*$/ { in_loop = 1 }
   in_loop && seen_loop && /^  [[:alnum:]_]+:/ { exit }
   in_loop { print; seen_loop = 1 }
 ' "$CONFIG" > "$LOOP_BLOCK"
@@ -42,7 +45,8 @@ assert_not_grep() {
   fi
 }
 
-assert_grep "review.loop block was extracted" '^  loop:[[:space:]]*$'
+assert_grep "review parent was extracted" '^review:[[:space:]]*$'
+assert_grep "review.loop child was extracted" '^  loop:[[:space:]]*$'
 assert_grep "normal exit is zero blocking findings with the severity SoT" \
   '正常出口は 0 blocking findings のみ.*plugins/rite/references/severity-levels\.md.*§実測必須ゲート'
 assert_grep "circuit breaker documents trend divergence" \

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -74,9 +74,9 @@ review:
   loop:
     verification_mode: false                       # 前回レビューコメントがある場合に検証モードを有効化
     allow_new_findings_in_unchanged_code: false    # 未変更コードへの新規指摘を blocking 扱いにするか
-    # 正常出口は 0 findings のみ。以下の 4 品質シグナルのいずれかで escalate する:
-    # 同一 finding 循環 / root-cause 不明 fix / cross-validation 不一致 / finding quality gate 不通過
-    convergence_monitoring: true          # 同一 finding 循環の semantic 検知
+    # 正常出口は 0 blocking findings のみ。circuit breaker は次のいずれかで発火する:
+    # 収束トレンドの発散 / safety.max_review_cycles 到達（backstop）
+    convergence_monitoring: true          # Scaffolding only（収束監視は circuit breaker の trend check が担い、このキーに runtime effect はない）
     auto_propagation_scan: true           # Fix 後の類似パターン伝播スキャン
     pre_commit_drift_check: true          # コミット前に review-schema-version-check を実行
   security_reviewer:

--- a/rite-config.yml
+++ b/rite-config.yml
@@ -74,7 +74,8 @@ review:
   loop:
     verification_mode: false                       # 前回レビューコメントがある場合に検証モードを有効化
     allow_new_findings_in_unchanged_code: false    # 未変更コードへの新規指摘を blocking 扱いにするか
-    # 正常出口は 0 blocking findings のみ。circuit breaker は次のいずれかで発火する:
+    # 正常出口は 0 blocking findings のみ（定義: plugins/rite/references/severity-levels.md §実測必須ゲート）。
+    # circuit breaker は次のいずれかで発火する:
     # 収束トレンドの発散 / safety.max_review_cycles 到達（backstop）
     convergence_monitoring: true          # Scaffolding only（収束監視は circuit breaker の trend check が担い、このキーに runtime effect はない）
     auto_propagation_scan: true           # Fix 後の類似パターン伝播スキャン


### PR DESCRIPTION
## Summary
- `rite-config.yml` の正常終了条件を 0 blocking findings と明記
- circuit breaker の現行2発火条件へコメントを更新
- `convergence_monitoring` が scaffolding only であることを明記

## Verification
- `git diff --check`
- Ruby YAML parse
- 旧コメント3種の残存確認

Closes #2107