### PR TITLE
fix(lint): exclude backlink checker across worktrees

### DIFF
--- a/plugins/rite/hooks/scripts/backlink-format-check.sh
+++ b/plugins/rite/hooks/scripts/backlink-format-check.sh
@@ -133,15 +133,12 @@ if [ "$USE_ALL" -eq 1 ]; then
       TARGETS+=("$f")
     done < <(find "$skills_dir" -type f -name '*.md' 2>/dev/null | sort)
   fi
-  # Self-exclusion: the awk regex literals in this script would match
-  # themselves when scanned. Compute the script's own path relative to
-  # REPO_ROOT and skip it in --all mode. --target still accepts explicit
-  # self-reference so test harnesses can verify behaviour deliberately.
-  self_abs="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
-  self_rel=""
-  case "$self_abs" in
-    "$REPO_ROOT"/*) self_rel="${self_abs#"$REPO_ROOT"/}" ;;
-  esac
+  # Self-exclusion: the awk regex literals in this script would match the copy
+  # inside the scanned tree. Identify that copy by its canonical path under the
+  # target scripts directory, not by the executable's absolute path: /rite:lint
+  # may invoke a plugin-root copy while --repo-root points at a session worktree.
+  # --target still accepts explicit self-reference for deliberate checks.
+  self_rel="$scripts_dir/$(basename "$0")"
   if [ -d "$scripts_dir" ]; then
     while IFS= read -r f; do
       if [ -n "$self_rel" ] && [ "$f" = "$self_rel" ]; then

--- a/plugins/rite/hooks/tests/backlink-format-check.test.sh
+++ b/plugins/rite/hooks/tests/backlink-format-check.test.sh
@@ -72,4 +72,21 @@ else
   fail "P2 finding tag missing: $p2_out"
 fi
 
+# --- Cross-tree --all self-exclusion -----------------------------------------
+# /rite:lint can execute the checker from plugin_root while scanning a separate
+# session worktree. The scanned tree contains its own same-path copy, whose awk
+# regex literal would be a P2 false positive unless exclusion is tree-relative.
+mkdir -p "$SANDBOX/plugins/rite/hooks/scripts"
+cp "$SCRIPT" "$SANDBOX/plugins/rite/hooks/scripts/backlink-format-check.sh"
+printf '%s\n' '#!/usr/bin/env bash' \
+  > "$SANDBOX/plugins/rite/hooks/scripts/clean.sh"
+assert "external checker excludes scanned-tree self copy" "0" \
+  "$(bash "$SCRIPT" --repo-root "$SANDBOX" --all --quiet >/dev/null 2>&1; echo $?)"
+
+# Excluding self must not suppress sibling findings in the scanned tree.
+printf '%s\n' '<!-- Downstream reference: lint.md Phase 8.3 -->' \
+  > "$SANDBOX/plugins/rite/hooks/scripts/violation.sh"
+assert "cross-tree --all still scans sibling scripts" "1" \
+  "$(bash "$SCRIPT" --repo-root "$SANDBOX" --all --quiet >/dev/null 2>&1; echo $?)"
+
 print_summary "backlink-format-check.sh"


### PR DESCRIPTION
## Summary

- identify the scanned-tree backlink checker by its canonical relative path
- keep explicit --target self-checks unchanged
- add cross-tree --all coverage for self exclusion and sibling violation detection

## Verification

- backlink-format-check.test.sh (10 pass, 0 fail)
- bash -n
- git diff --check

Closes #2050