### PR TITLE
test(lint): kill comment journal mutation survivors

### DIFF
--- a/plugins/rite/hooks/scripts/comment-journal-check.sh
+++ b/plugins/rite/hooks/scripts/comment-journal-check.sh
@@ -111,9 +111,12 @@
 #   X2 inline code span— `` `refs #204` `` 等。X1 と同じ理由。span は削除ではなく `_` へ
 #                        置換する: 削除するとキーワードと後続番号が隣接して偽の一致を
 #                        作り出すため。
-#   X3 `## ソース` 節   — Wiki ページの provenance リンクラベル (`- [PR #N review results](...)`)
+#   X3 `## ソース` 節   — `.rite/wiki/` 配下の Wiki ページに限定。provenance リンクラベル
+#                        (`- [PR #N review results](...)`)
 #                        は出所の監査証跡として維持対象。走査すると当該節を持つ全ページが
-#                        誤検出になる。除外は**節スコープ** (見出しから次の `##` 見出しの手前まで)
+#                        誤検出になる。`docs/` / `plugins/rite/` の同名見出しは除外を開始せず、
+#                        以降の参照を検出し続ける。Wiki 内の除外は**節スコープ**
+#                        (見出しから次の `##` 見出しの手前まで)
 #                        で、ファイル末尾までではない。判定はフェンス状態の更新後に行うため、
 #                        コードフェンス内に引用された `## ソース` では発火しない。見出しは
 #                        `## ソース（追記分）` 等の接尾辞を許容する (wiki-ingest の生成形)。
@@ -269,7 +272,7 @@ check_file() {
     return 0
   fi
   awk -v F="$file" '
-    FNR == 1 { infence = 0; insources = 0 }
+    FNR == 1 { infence = 0; insources = 0; wiki_file = (F ~ /^\.rite\/wiki\//) }
     {
       line = $0
       # コードフェンスと `## ソース` 節の状態は、どの `next` よりも先に更新する。
@@ -281,8 +284,8 @@ check_file() {
       # 判定はフェンス状態の更新後に置く — フェンス内に引用された `## ソース` で誤発火しない。
       # 見出しは接尾辞を許容する (`## ソース（追記分）` 等)。厳密一致だと揺れた見出しが
       # 節の開始として認識されないまま次の見出しとしては認識され、直前の節の除外を打ち切る。
-      if (!infence && line ~ /^##[[:space:]]+ソース([[:space:]]*$|[（(])/) insources = 1
-      else if (!infence && insources && line ~ /^##[[:space:]]/) insources = 0
+      if (wiki_file && !infence && line ~ /^##[[:space:]]+ソース([[:space:]]*$|[（(])/) insources = 1
+      else if (wiki_file && !infence && insources && line ~ /^##[[:space:]]/) insources = 0
 
       # Whitelist: any line carrying an "example:" marker is skipped wholesale.
       if (line ~ /(<!--[[:space:]]*example:|#[[:space:]]+example:|\/\/[[:space:]]+example:)/) next

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -234,6 +234,24 @@ assert_file_exists_or_fail() {
   return 0
 }
 
+# Mutation-test precondition: require a generated mutant to differ from its
+# source before interpreting behavioral equality/difference. This keeps sed/awk
+# selector drift from turning a mutation assertion into a vacuous green test.
+# The helper records only failure (matching the historical local helpers); the
+# caller's behavioral assertion records the PASS when the mutant is meaningful.
+assert_mutant_changed() {
+  local label="$1"
+  local original="$2"
+  local mutant="$3"
+  if ! assert_file_exists_or_fail "$label source" "$original"; then return 1; fi
+  if ! assert_file_exists_or_fail "$label mutant" "$mutant"; then return 1; fi
+  if diff -q "$original" "$mutant" >/dev/null 2>&1; then
+    fail "$label (mutant is identical to source; mutation selector matched nothing)"
+    return 1
+  fi
+  return 0
+}
+
 # Section-scoped pattern presence assertion.
 # Extracts an awk address-range section ([start_pattern, end_pattern]) from `file`
 # into a private tempfile, runs `grep -qE grep_pattern` against it, then self-cleans.

--- a/plugins/rite/hooks/tests/_test-helpers.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.sh
@@ -245,11 +245,23 @@ assert_mutant_changed() {
   local mutant="$3"
   if ! assert_file_exists_or_fail "$label source" "$original"; then return 1; fi
   if ! assert_file_exists_or_fail "$label mutant" "$mutant"; then return 1; fi
+  local diff_rc
   if diff -q "$original" "$mutant" >/dev/null 2>&1; then
-    fail "$label (mutant is identical to source; mutation selector matched nothing)"
-    return 1
+    diff_rc=0
+  else
+    diff_rc=$?
   fi
-  return 0
+  case "$diff_rc" in
+    0)
+      fail "$label (mutant is identical to source; mutation selector matched nothing)"
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      fail "$label (diff could not compare source and mutant; rc=$diff_rc)"
+      return 1
+      ;;
+  esac
 }
 
 # Section-scoped pattern presence assertion.

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -111,7 +111,8 @@ echo
 echo "TC-4: assert_grep / assert_not_grep"
 
 tmpfile=$(mktemp)
-trap 'rm -f "$tmpfile"' EXIT
+mutant_file="${tmpfile}.mutant"
+trap 'rm -f "$tmpfile" "$mutant_file"' EXIT
 printf 'hello world\nfoo bar\n' > "$tmpfile"
 
 grep_state=$(bash -c "
@@ -605,6 +606,21 @@ if echo "$no_skip_state" | grep -q 'SKIP:'; then
   outer_fail "TC-15.2: print_summary printed a SKIP line with SKIP=0 (should be omitted): $(printf '%s' "$no_skip_state" | tr '\n' '|')"
 else
   outer_pass "TC-15.2: print_summary omits the SKIP line when nothing was skipped"
+fi
+
+# === TC-16: shared mutation precondition ===
+printf 'original\n' > "$tmpfile"
+printf 'changed\n' > "$mutant_file"
+if bash -c "source '$HELPERS'; assert_mutant_changed changed '$tmpfile' '$mutant_file'" >/dev/null; then
+  outer_pass "TC-16.1: assert_mutant_changed accepts a real mutation"
+else
+  outer_fail "TC-16.1: assert_mutant_changed rejected different files"
+fi
+printf 'original\n' > "$mutant_file"
+if bash -c "source '$HELPERS'; assert_mutant_changed identical '$tmpfile' '$mutant_file'" >/dev/null; then
+  outer_fail "TC-16.2: assert_mutant_changed accepted an identical mutant"
+else
+  outer_pass "TC-16.2: assert_mutant_changed rejects a no-op mutation"
 fi
 
 # === Summary ===

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -626,6 +626,10 @@ fi
 mkdir -p "$diff_shim_dir"
 printf '%s\n' '#!/bin/sh' 'exit 2' > "$diff_shim_dir/diff"
 chmod +x "$diff_shim_dir/diff"
+# Keep inputs different: without the shim the real diff returns 1 and the helper
+# accepts them, so this assertion specifically discriminates the injected rc=2
+# path instead of passing through the identical-mutant rejection branch.
+printf 'changed-again\n' > "$mutant_file"
 if PATH="$diff_shim_dir:$PATH" bash -c "source '$HELPERS'; assert_mutant_changed compare-error '$tmpfile' '$mutant_file'" >/dev/null; then
   outer_fail "TC-16.3: assert_mutant_changed accepted a diff comparison error"
 else

--- a/plugins/rite/hooks/tests/_test-helpers.test.sh
+++ b/plugins/rite/hooks/tests/_test-helpers.test.sh
@@ -112,7 +112,8 @@ echo "TC-4: assert_grep / assert_not_grep"
 
 tmpfile=$(mktemp)
 mutant_file="${tmpfile}.mutant"
-trap 'rm -f "$tmpfile" "$mutant_file"' EXIT
+diff_shim_dir="${tmpfile}.diff-shim"
+trap 'rm -f "$tmpfile" "$mutant_file"; rm -rf "$diff_shim_dir"' EXIT
 printf 'hello world\nfoo bar\n' > "$tmpfile"
 
 grep_state=$(bash -c "
@@ -621,6 +622,14 @@ if bash -c "source '$HELPERS'; assert_mutant_changed identical '$tmpfile' '$muta
   outer_fail "TC-16.2: assert_mutant_changed accepted an identical mutant"
 else
   outer_pass "TC-16.2: assert_mutant_changed rejects a no-op mutation"
+fi
+mkdir -p "$diff_shim_dir"
+printf '%s\n' '#!/bin/sh' 'exit 2' > "$diff_shim_dir/diff"
+chmod +x "$diff_shim_dir/diff"
+if PATH="$diff_shim_dir:$PATH" bash -c "source '$HELPERS'; assert_mutant_changed compare-error '$tmpfile' '$mutant_file'" >/dev/null; then
+  outer_fail "TC-16.3: assert_mutant_changed accepted a diff comparison error"
+else
+  outer_pass "TC-16.3: assert_mutant_changed rejects diff rc>=2"
 fi
 
 # === Summary ===

--- a/plugins/rite/hooks/tests/comment-journal-check.test.sh
+++ b/plugins/rite/hooks/tests/comment-journal-check.test.sh
@@ -24,7 +24,11 @@
 #   TC-16  語彙の大小文字対称性と左語境界 (prefs / hrefs の語尾一致を弾く)
 #   TC-17  「PR #N で別途対応」が P5/P6 で二重報告されない
 #
-# NOT covered (environment-dependent): mktemp failure on a read-only /tmp.
+# Diagnostic neutralization/head emission is covered repository-wide by
+# diag-snippet-neutralize-parity.test.sh. This suite pins --quiet via TC-11;
+# duplicating injected IO failures here would test the shared diagnostic policy,
+# not this checker's detection contract. mktemp failure on read-only /tmp remains
+# environment-dependent and is not reproduced here.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -56,6 +60,12 @@ scan() {
 # count: number of findings; pat_count: findings matching a pattern
 count() { scan "$1" | grep -c . ; }
 pat_count() { scan "$1" | grep -cE "$2" || true ; }
+wiki_pat_count() {
+  mkdir -p "$SBX/.rite/wiki/pages"
+  printf '%s\n' "$1" > "$SBX/.rite/wiki/pages/source-scope.md"
+  ( cd "$SBX" && bash "$SCRIPT" --target .rite/wiki/pages/source-scope.md --repo-root "$SBX" --quiet ) 2>/dev/null \
+    | grep -cE "$2" || true
+}
 
 echo "== comment-journal-check.sh (P5/P6 拡張と除外) =="
 
@@ -74,6 +84,17 @@ assert "TC-7 Closes #N が hit"     "1" "$(count 'Closes #1148 で閉じた')"
 assert "TC-7 refs #N が hit"       "1" "$(count '(refs #1150) の括弧形')"
 assert "TC-7 詳細は #N が hit"      "1" "$(count '詳細は #1151')"
 assert "TC-7 #N で別途対応 が hit"  "1" "$(count '#1152 で別途対応')"
+assert "TC-7 lowercase see member is pinned" "1" "$(count 'see #1153 for context')"
+assert "TC-7 Fixes member is pinned"        "1" "$(count 'Fixes #1154')"
+assert "TC-7 Related to member is pinned"   "1" "$(count 'Related to #1155')"
+
+# P3/P4 regexes and each supported example-marker dialect are individually
+# pinned so deleting one alternation member cannot survive behind aggregate counts.
+assert "TC-7 P3 regex member is pinned" "1" "$(pat_count 'PR #123 cycle 4 fix' '\[P3\]')"
+assert "TC-7 P4 regex member is pinned" "1" "$(pat_count 'cycle 4 F-2 で導入' '\[P4\]')"
+assert "TC-7 HTML example marker skips line" "0" "$(count '<!-- example: PR #1200 -->')"
+assert "TC-7 hash example marker skips line" "0" "$(count '# example: PR #1201')"
+assert "TC-7 slash example marker skips line" "0" "$(count '// example: PR #1202')"
 
 # ---- TC-8 意図的な非対象 ----------------------------------------------------
 assert "TC-8 キーワードなし裸 #N は hit しない" "0" "$(count '#1234 の単独形は対象外')"
@@ -102,10 +123,15 @@ assert "TC-10 フェンス内でも P1 は従来どおり検出される" "1" "$
 
 # ---- TC-2 `## ソース` 節 ----------------------------------------------------
 src=$(printf '# t\n\nPR #1300 は本文の参照\n\n## ソース\n\n- [PR #1300 review results](../../raw/reviews/a.md)\n- [Issue #1284 fix results](../../raw/fixes/b.md)\n')
-assert "TC-2 ソース節より前の本文は hit する" "1" "$(pat_count "$src" '\[P5\]')"
+mkdir -p "$SBX/.rite/wiki/pages"
+printf '%s\n' "$src" > "$SBX/.rite/wiki/pages/source-scope.md"
+wiki_src_out=$( ( cd "$SBX" && bash "$SCRIPT" --target .rite/wiki/pages/source-scope.md --repo-root "$SBX" --quiet ) 2>/dev/null )
+assert "TC-2 wiki ソース節より前の本文は hit する" "1" "$(printf '%s' "$wiki_src_out" | grep -c '\[P5\]' || true)"
 # 行番号ではなく総 findings 数で測る (fixture が 1 行ずれると行番号 assert は vacuous になる)。
 # ソース節の除外が外れると本文 1 件 + ラベル 2 件 = 3 件になり確実に落ちる。
-assert "TC-2 ソース節配下の provenance ラベルは hit しない (総数 1 件)" "1" "$(count "$src")"
+assert "TC-2 wiki ソース節配下の provenance ラベルは hit しない" "1" "$(printf '%s' "$wiki_src_out" | grep -c . || true)"
+# X3 is a Wiki provenance convention, not a repository-wide heading escape.
+assert "TC-2 docs の ## ソース節は除外せず全参照を検出" "3" "$(count "$src")"
 
 # ---- TC-6 語境界 -------------------------------------------------------------
 b=$(scan 'PR #2047 の語境界')
@@ -148,17 +174,10 @@ assert "TC-11 target 指定なし → exit 2" "2" "$?"
 assert "TC-11 未知の引数 → exit 2" "2" "$?"
 
 # ---- TC-12 / TC-13 MUTATION --------------------------------------------------
-# mutant は `sed` で作る。パターンが一致せず no-op のまま「差が出なかった」と読むと
-# mutation test が無言で vacuous になるため、実行前に必ず元との差分を確認する。
-# sed は BRE のため `?` と `|` は literal 文字として扱われる (パターンを素の文字列で書ける)。
 make_mutant() {
   local label="$1" out="$2" expr="$3"
   sed "$expr" "$SCRIPT" > "$out"
-  if diff -q "$SCRIPT" "$out" >/dev/null 2>&1; then
-    fail "$label (mutant が元と同一 — sed パターンが一致していない。この assert は無効)"
-    return 1
-  fi
-  return 0
+  assert_mutant_changed "$label" "$SCRIPT" "$out"
 }
 
 # 拡張で語彙に足した裸の Issue / PR を取り除いた mutant では、裸形が落ちる。
@@ -250,16 +269,16 @@ assert "TC-14 --all で検出器 test の fixture が hit しない" "0" "$exclu
 # 見出し以降 EOF まで打ち切ると、後続の本文節が丸ごと盲点になる。またフェンス内に引用された
 # `## ソース` で走査が止まると、そのファイルの以降が無言で検出対象外になる。
 post_src=$(printf '# t\n\n## ソース\n\n- [PR #1400 review results](../../raw/reviews/a.md)\n\n## 補強: 節\n\nPR #1500 はソース節の後の本文\n')
-assert "TC-15 ソース節の後に続く本文は hit する (節スコープ)" "1" "$(pat_count "$post_src" '\[P5\]')"
+assert "TC-15 ソース節の後に続く本文は hit する (節スコープ)" "1" "$(wiki_pat_count "$post_src" '\[P5\]')"
 # wiki-ingest が生成する `## ソース（追記分）` / `## ソース(追記分 N)` も節として認識する。
 # 厳密一致だと節の開始として認識されないまま「次の見出し」としては認識され、直前の節の
 # 除外を打ち切って provenance ラベルを走査対象に戻す。
 appendix_src=$(printf '# t\n\n## ソース\n\n- [PR #1400 review](../../raw/a.md)\n\n## ソース（追記分）\n\n- [PR #1500 review](../../raw/b.md)\n\n## ソース(追記分 2)\n\n- [PR #1600 review](../../raw/c.md)\n')
-assert "TC-15 追記分ソース節の provenance ラベルも hit しない (全角・半角括弧)" "0" "$(pat_count "$appendix_src" '\[P5\]')"
+assert "TC-15 追記分ソース節の provenance ラベルも hit しない (全角・半角括弧)" "0" "$(wiki_pat_count "$appendix_src" '\[P5\]')"
 appendix_then=$(printf '# t\n\n## ソース（追記分）\n\n- [PR #1500 review](../../raw/b.md)\n\n## 補強: 節\n\nPR #1700 は追記分ソース節の後の本文\n')
-assert "TC-15 追記分ソース節の後の本文は hit する" "1" "$(pat_count "$appendix_then" '\[P5\]')"
+assert "TC-15 追記分ソース節の後の本文は hit する" "1" "$(wiki_pat_count "$appendix_then" '\[P5\]')"
 fenced_src=$(printf '# t\n\n```markdown\n## ソース\n```\n\nPR #1300 はフェンス後の本文\n')
-assert "TC-15 フェンス内の ## ソース では走査が止まらない" "1" "$(pat_count "$fenced_src" '\[P5\]')"
+assert "TC-15 フェンス内の ## ソース では走査が止まらない" "1" "$(wiki_pat_count "$fenced_src" '\[P5\]')"
 
 # ---- TC-16: 語彙の大小文字対称性と左語境界 ----------------------------------
 assert "TC-16 小文字 issue #N も hit する"  "1" "$(count 'issue #55 の話')"

--- a/plugins/rite/hooks/tests/wiki-lint-descriptive-refs.test.sh
+++ b/plugins/rite/hooks/tests/wiki-lint-descriptive-refs.test.sh
@@ -170,12 +170,7 @@ assert "TC-1/2/3/4/5 hits=8 (対象のみ)" "8" "$hits"
 # ---- MUTATION の前提: mutant が実際に元と違うことを先に確かめる ---------------
 # 生成が no-op のまま「差が出なかった」と読むと mutation test が無言で vacuous になる。
 assert_mutated() {
-  local label="$1" mutant="$2"
-  if diff -q "$SCRIPT" "$mutant" >/dev/null 2>&1; then
-    fail "$label (mutant が元と同一 — 変換パターンが一致していない。この assert は無効)"
-    return 1
-  fi
-  return 0
+  assert_mutant_changed "$1" "$SCRIPT" "$2"
 }
 
 # ---- 除外の識別力を「フィルタを外した版」との差で測る (TC-16 の測定基盤) -------


### PR DESCRIPTION
## Summary

- pin individual P3/P4, vocabulary, and example-whitelist mutation survivors
- scope the `## ソース` exclusion to `.rite/wiki/` provenance sections
- share the mutation precondition helper across both mutation-heavy suites
- document why shared diagnostic-policy coverage is not duplicated here

## Verification

- comment-journal-check.test.sh: 63 pass, 0 fail
- wiki-lint-descriptive-refs.test.sh: 184 pass, 0 fail
- _test-helpers.test.sh: 40 pass, 0 fail
- P1-P4 output: 37 findings, byte-identical before/after
- bash -n; git diff --check

Closes #2067