### PR TITLE
refactor(hooks): .gitignore 同梱処理を共有化する

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -189,7 +189,7 @@ rite-workflow/
 │ ├── pre-compact.sh / post-compact.sh
 │ ├── pre-tool-bash-guard.sh / pre-tool-edit-guard.sh / post-tool-wm-sync.sh
 │ ├── stop-loop-continuation.sh # Stop hook: review↔fix loop continuation + terminal finalize
-│ ├── hook-preamble.sh / state-path-resolve.sh / control-char-neutralize.sh # Shared helpers
+│ ├── hook-preamble.sh / state-path-resolve.sh / control-char-neutralize.sh / gitignore-ensure.sh # Shared helpers
 │ ├── _resolve-session-id.sh / _resolve-session-id-from-file.sh # Private session-id resolution helpers
 │ ├── _resolve-cross-session-guard.sh # Private legacy-state takeover classifier
 │ ├── _validate-helpers.sh / _validate-state-root.sh / _mktemp-stderr-guard.sh # Private fail-fast validators
@@ -1278,7 +1278,7 @@ Lifecycle-incomplete detection for the legacy `create_*` / `cleanup_*` phases no
 
 Shared library sourced by the lifecycle hooks for multi-session conflict prevention. With the per-session state structure, ownership is **structurally guaranteed** by the file naming (`.rite/sessions/{session_id}.flow-state`); this library now serves as a path/entry resolution layer rather than a runtime guard.
 
-> **Canonical SoT for sourcing callers**: actual `source` directives in `plugins/rite/hooks/*.sh` (verify with `grep -rn "source.*session-ownership.sh" plugins/rite/hooks/ --include='*.sh' | grep -v tests/`). At present this resolves to: `session-start.sh` / `session-end.sh` / `pre-compact.sh` / `post-tool-wm-sync.sh`. (`flow-state.sh` is NOT a `source` caller of this library — it sources only `state-path-resolve.sh` and `control-char-neutralize.sh`. `stop-guard.sh` has been removed; `post-compact.sh` does not source this library directly. `pre-tool-bash-guard.sh` sources only `hook-preamble.sh`, does not participate in flow-state path resolution, and has never been a `source` caller of this library.)
+> **Canonical SoT for sourcing callers**: actual `source` directives in `plugins/rite/hooks/*.sh` (verify with `grep -rn "source.*session-ownership.sh" plugins/rite/hooks/ --include='*.sh' | grep -v tests/`). At present this resolves to: `session-start.sh` / `session-end.sh` / `pre-compact.sh` / `post-tool-wm-sync.sh`. (`flow-state.sh` is NOT a `source` caller of this library — it sources `state-path-resolve.sh`, `control-char-neutralize.sh`, and `gitignore-ensure.sh`. `stop-guard.sh` has been removed; `post-compact.sh` does not source this library directly. `pre-tool-bash-guard.sh` sources only `hook-preamble.sh`, does not participate in flow-state path resolution, and has never been a `source` caller of this library.)
 
 **Provided Functions:**
 

--- a/plugins/rite/hooks/flow-state.sh
+++ b/plugins/rite/hooks/flow-state.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/state-path-resolve.sh"
 # shellcheck source=control-char-neutralize.sh
 source "$SCRIPT_DIR/control-char-neutralize.sh"
+# shellcheck source=gitignore-ensure.sh
+source "$SCRIPT_DIR/gitignore-ensure.sh"
 
 # Callers may pre-resolve STATE_ROOT (e.g., session-start.sh resolves it from
 # the hook payload's `cwd` field, which differs from flow-state.sh's own CWD)
@@ -203,7 +205,6 @@ _append_phase_transition() {
   local from="$1" to="$2" sid="$3" issue="$4" pr="$5" ts="$6"
   local log_dir="$STATE_ROOT/.rite/logs"
   local log_file="$log_dir/phase-transitions.log"
-  local _gi_err
   # Every runtime-derived value below goes through `neutralize_ctrl` before landing in
   # a WARNING: `$log_dir` / `$log_file` carry `$STATE_ROOT`, `$from` comes from the state
   # file and `$to` straight from `--phase`, and a raw 0x9b in any of them is read as a CSI
@@ -220,17 +221,9 @@ _append_phase_transition() {
   # A failure is announced rather than swallowed — a missing exclusion is the exact
   # path by which the log reaches a public repo. Same form as review-result-save.sh
   # and review-results-archive-or-rm.sh. Still non-blocking: the append runs either way.
-  if [ ! -s "$log_dir/.gitignore" ]; then
-    # `LC_ALL=C` sits on the failing command, not on the neutralizer. bash localizes
-    # its own redirect-setup diagnostic, and `neutralize_ctrl` blanks 0x80-0x9f one
-    # byte at a time, so under ja_JP the errno arrives as `?` runs and the cause —
-    # the only thing the indented line adds over the WARNING above — is lost. Forcing
-    # the upstream message to ASCII leaves the neutralizer fully intact (it merely
-    # becomes a no-op here); `--c0-only` would instead blank 0x0a and break the indent.
-    if ! _gi_err=$( { LC_ALL=C printf '*\n' > "$log_dir/.gitignore"; } 2>&1 ); then
+  if ! _ensure_dir_gitignore "$log_dir"; then
       echo "WARNING: flow-state.sh: cannot create $(printf '%s' "$log_dir" | neutralize_ctrl)/.gitignore; verify by hand that this directory is excluded from git" >&2
-      [ -n "$_gi_err" ] && printf '%s\n' "$_gi_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
-    fi
+      [ -n "$_RITE_GITIGNORE_ERROR" ] && printf '%s\n' "$_RITE_GITIGNORE_ERROR" | sed 's/^/  /' >&2
   fi
   # `--argjson` keeps the two numeric fields as JSON numbers; both values already
   # survived the identical `--argjson` in the state write above, so anything it would
@@ -284,7 +277,7 @@ cmd_set() {
   esac; done
   [ -z "$phase" ] && { echo "ERROR: --phase is required" >&2; return 1; }
   [ -z "$next" ] && { echo "ERROR: --next is required" >&2; return 1; }
-  _phase_is_valid "$phase" || echo "WARNING: unknown phase: $phase (allowed: $PHASE_ENUM_V3)" >&2
+  _phase_is_valid "$phase" || echo "WARNING: unknown phase: $(printf '%s' "$phase" | neutralize_ctrl) (allowed: $PHASE_ENUM_V3)" >&2
   local sid path; sid=$(_resolve_session_id "$session") || return 1
   path=$(_state_path "$sid")
   if [ $if_exists -eq 1 ] && [ ! -f "$path" ]; then

--- a/plugins/rite/hooks/gitignore-ensure.sh
+++ b/plugins/rite/hooks/gitignore-ensure.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Shared primitive for self-contained runtime directories that must carry `*`.
+# Contract: non-empty files are left untouched; missing/empty files are rewritten.
+# On failure, return 1 and expose a control-character-neutralized, C-locale cause in
+# `_RITE_GITIGNORE_ERROR`. Callers own their WARNING/marker policy.
+
+_rite_gitignore_source="${BASH_SOURCE[0]}"
+case "$_rite_gitignore_source" in
+  */*) _rite_gitignore_dir="${_rite_gitignore_source%/*}" ;;
+  *) _rite_gitignore_dir="." ;;
+esac
+if ! declare -F neutralize_ctrl >/dev/null 2>&1; then
+  # shellcheck source=control-char-neutralize.sh
+source "$_rite_gitignore_dir/control-char-neutralize.sh"
+fi
+
+_RITE_GITIGNORE_ERROR=""
+_ensure_dir_gitignore() {
+  local dir="$1" raw_error=""
+  _RITE_GITIGNORE_ERROR=""
+  [ -n "$dir" ] || { _RITE_GITIGNORE_ERROR="empty directory path"; return 1; }
+  [ -s "$dir/.gitignore" ] && return 0
+  if ! raw_error=$( { LC_ALL=C printf '*\n' > "$dir/.gitignore"; } 2>&1 ); then
+    _RITE_GITIGNORE_ERROR=$(printf '%s' "$raw_error" | neutralize_ctrl --keep-newline)
+    return 1
+  fi
+}

--- a/plugins/rite/hooks/review-result-save.sh
+++ b/plugins/rite/hooks/review-result-save.sh
@@ -82,6 +82,8 @@
 set -uo pipefail
 # shellcheck source=control-char-neutralize.sh
 source "$(dirname "${BASH_SOURCE[0]}")/control-char-neutralize.sh"
+# shellcheck source=gitignore-ensure.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gitignore-ensure.sh"
 
 # --- Argument parsing ---
 PR_NUMBER=""
@@ -296,7 +298,8 @@ fi
 # 除外されていないと `git add -A` で公開リポジトリへ入る。root の .gitignore に頼ると
 # セットアップ履歴・`--upgrade` 経路・設定の drift の 3 つに同時に依存するが、同梱方式は
 # そのすべてから独立する (consuming repo の `/rite:setup` 生成 .gitignore は
-# `.rite/sessions/` と `.rite/worktrees/` しかカバーせず、`--upgrade` は追記 Phase を通らない)。
+# `.rite/sessions/` / `.rite/worktrees/` / `.rite/review-results/` をカバーするが、
+# `--upgrade` は追記 Phase を通らない)。
 # 非ブロッキング: 書けなくても保存は続行する。ただし黙って続行はしない — 除外の欠落は
 # 全文が公開面へ出る経路そのものなので WARNING と marker で loud にする。
 # 守りたいのは「除外が効いている」ことなので、guard は存在 (`-f`) ではなく中身 (`-s`) を見る。
@@ -306,12 +309,10 @@ fi
 # stderr は捨てずに捕捉する。`{ ...; } 2>&1` の**グループ**スコープにするのは、単純コマンドの
 # `printf ... > f 2>&1` だと bash が redirect 自身の失敗 (EACCES) を 2>&1 適用**前**に報告し、
 # 原因が最も要る側だけが捕捉から漏れて列 0 へ素通しするため (session-start.sh の先例と同型)。
-if [ ! -s "$REVIEW_RESULTS_DIR/.gitignore" ]; then
-  if ! gitignore_err=$( { printf '*\n' > "$REVIEW_RESULTS_DIR/.gitignore"; } 2>&1 ); then
+if ! _ensure_dir_gitignore "$REVIEW_RESULTS_DIR"; then
     echo "WARNING: $REVIEW_RESULTS_DIR/.gitignore を作成できませんでした。本ディレクトリが git の追跡対象から除外されているか手動で確認してください (非実測指摘の全文が含まれます)" >&2
-    [ -n "$gitignore_err" ] && printf '%s\n' "$gitignore_err" | neutralize_ctrl --keep-newline | sed 's/^/  /' >&2
+    [ -n "$_RITE_GITIGNORE_ERROR" ] && printf '%s\n' "$_RITE_GITIGNORE_ERROR" | sed 's/^/  /' >&2
     echo "[CONTEXT] LOCAL_SAVE_GITIGNORE_FAILED=1; dir=$REVIEW_RESULTS_DIR" >&2
-  fi
 fi
 
 # mktemp stderr 退避 (失敗原因 disk full / permission / readonly を可視化)。

--- a/plugins/rite/hooks/scripts/review-results-archive-or-rm.sh
+++ b/plugins/rite/hooks/scripts/review-results-archive-or-rm.sh
@@ -71,6 +71,10 @@
 #   [review-results-archive-or-rm] archived=<n>; removed=<n>; failed=<n>; pr=<n>
 set -uo pipefail
 
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+# shellcheck source=../gitignore-ensure.sh
+source "$SCRIPT_DIR/../gitignore-ensure.sh"
+
 STATE_ROOT=""
 PR_NUMBER=""
 # reason / メッセージの prefix。唯一の caller が単一の artifact 種別しか渡さないため定数。
@@ -121,12 +125,10 @@ failed=0
 # 張られる。ループ内に置くと (b) で保護が一度も発火しないまま `git add -A` が全文を
 # 拾う経路が残る。guard が存在 (`-f`) ではなく中身 (`-s`) なのと、`{ ...; } 2>&1` の
 # グループスコープで捕捉する理由は保存経路 (hooks/review-result-save.sh) と同一。
-if [ -d "$results_dir" ] && [ ! -s "$results_dir/.gitignore" ]; then
-  if ! gi_err=$( { printf '*\n' > "$results_dir/.gitignore"; } 2>&1 ); then
+if [ -d "$results_dir" ] && ! _ensure_dir_gitignore "$results_dir"; then
     echo "WARNING: ${LABEL} の保存先に .gitignore を作成できません (PR #${PR_NUMBER}): $results_dir/.gitignore — 退避した非実測指摘の全文が git の追跡対象に入る恐れがあります" >&2
-    [ -n "$gi_err" ] && printf '%s\n' "$gi_err" | sed 's/^/  /' >&2
+    [ -n "$_RITE_GITIGNORE_ERROR" ] && printf '%s\n' "$_RITE_GITIGNORE_ERROR" | sed 's/^/  /' >&2
     echo "[CONTEXT] REVIEW_CLEANUP_PARTIAL_FAILURE=1; reason=${LABEL}_gitignore_failure; pr=${PR_NUMBER}" >&2
-  fi
 fi
 
 for f in "$results_dir/${PR_NUMBER}"-*.json*; do

--- a/plugins/rite/hooks/session-start.sh
+++ b/plugins/rite/hooks/session-start.sh
@@ -19,6 +19,8 @@ fi
 source "$SCRIPT_DIR/session-ownership.sh" 2>/dev/null || true
 # shellcheck source=control-char-neutralize.sh
 source "$SCRIPT_DIR/control-char-neutralize.sh"
+# shellcheck source=gitignore-ensure.sh
+source "$SCRIPT_DIR/gitignore-ensure.sh"
 
 # jq is a hard dependency: .rite-flow-state is created by jq, so if jq is
 # missing the state file won't exist and the hook exits at the -f check below.
@@ -376,8 +378,9 @@ RITE_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/flow-state.sh" migrate >/dev/nul
 # manifest-bypass WARNINGs) were previously unobservable and slowed diagnosis
 # (#1966's investigation). A self-contained `.gitignore` (`*`) is written into
 # the log dir on first creation so it never leaks into the repo even in
-# downstream consuming repos, where /rite:setup's generated .gitignore only
-# covers `.rite/sessions/` and `.rite/worktrees/` (not `.rite/logs/`) and this
+# downstream consuming repos, where /rite:setup's generated .gitignore covers
+# `.rite/sessions/`, `.rite/worktrees/`, and `.rite/review-results/` (not
+# `.rite/logs/`) and this
 # repo's own root `*.log` rule doesn't apply. If the dir can't be created,
 # fall back to discarding output — this hook must never block session start on
 # a log-write failure.
@@ -389,7 +392,10 @@ if [ "$CWD" = "$STATE_ROOT" ]; then
   # degrading to discard. The truncate below doubles as the "overwritten each
   # run" reset, so the reap output is appended after it.
   if mkdir -p "$_reap_log_dir" 2>/dev/null && { : > "$_reap_log_dir/pr-cycle-cleanup.log"; } 2>/dev/null; then
-    [ -f "$_reap_log_dir/.gitignore" ] || { printf '*\n' > "$_reap_log_dir/.gitignore"; } 2>/dev/null || true
+    if ! _ensure_dir_gitignore "$_reap_log_dir"; then
+      echo "WARNING: session-start.sh: cannot create $(printf '%s' "$_reap_log_dir" | neutralize_ctrl)/.gitignore; verify by hand that this directory is excluded from git" >&2
+      [ -n "$_RITE_GITIGNORE_ERROR" ] && printf '%s\n' "$_RITE_GITIGNORE_ERROR" | sed 's/^/  /' >&2
+    fi
     ( cd "$CWD" && bash "$SCRIPT_DIR/scripts/pr-cycle-cleanup.sh" ) >>"$_reap_log_dir/pr-cycle-cleanup.log" 2>&1 || true
   else
     ( cd "$CWD" && bash "$SCRIPT_DIR/scripts/pr-cycle-cleanup.sh" ) >/dev/null 2>&1 || true

--- a/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
+++ b/plugins/rite/hooks/tests/diag-snippet-neutralize-parity.test.sh
@@ -209,6 +209,9 @@ echo "=== TC-5: 関数内 >&2 経由の既知 emission site は個別 pin ==="
 assert_grep "TC-5: wiki-ingest-commit.sh surface_git_warnings" \
   "$HOOKS_DIR/scripts/wiki-ingest-commit.sh" \
   'grep -iE .\^\(warning\|hint\|error\):. \| neutralize_ctrl --keep-newline'
+assert_grep "TC-5: flow-state unknown phase inline value is neutralized" \
+  "$HOOKS_DIR/flow-state.sh" \
+  'unknown phase: .*"\$phase" \| neutralize_ctrl\)'
 
 echo ""
 echo "=== TC-6: scripts/ 実 site は制御文字を中和し複数行 indent を維持 ==="

--- a/plugins/rite/hooks/tests/flow-state.test.sh
+++ b/plugins/rite/hooks/tests/flow-state.test.sh
@@ -1712,13 +1712,15 @@ rm -f "$stderr_2115_10"
 # a newline inside `--phase` splits this WARNING, forging a second one at column 0.
 # The same sandbox works — the log path is still a directory, so the append still
 # fails and `$to` still reaches the message. Count only the append line: the
-# `unknown phase` WARNING interpolates the same value raw and would mask the check.
+# Both the enum WARNING and append WARNING must neutralize the same runtime value.
 stderr_2115_10b="$(mktemp)"
 set +e
 (cd "$d" && bash "$HOOK" set --phase "$(printf 'plan\nWARNING: forged')" --issue 15 --pr 0 --next "n") 2>"$stderr_2115_10b"
 set -e
 assert "TC-2115-10: a newline in --phase cannot split the append WARNING" "1" \
   "$(LC_ALL=C grep -cE 'phase-transition log not writable.*not recorded$' "$stderr_2115_10b" || true)"
+assert "TC-2121: a newline in --phase cannot forge any column-zero WARNING" "0" \
+  "$(LC_ALL=C grep -c '^WARNING: forged$' "$stderr_2115_10b" || true)"
 rm -f "$stderr_2115_10b"
 
 if ! print_summary "$(basename "$0")" "flow-state.sh PR 2a refactor + silent-failure fixes + security/observability hardening + handoff marker + consume-handoff corrupt-read WARNING + jq stderr snippet control-char neutralization + C1 8-bit coverage via shared neutralize_ctrl + --worktree merge-preserve field + clear-worktree surgical del (Issue #1524) + non-UUID acceptance (Layer 1 format-agnostic contract pin) + phase-transition append log (#2115)"; then

--- a/plugins/rite/hooks/tests/gitignore-ensure.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-ensure.test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_test-helpers.sh"
+source "$SCRIPT_DIR/../gitignore-ensure.sh"
+
+SBX=$(make_plain_sandbox); trap 'rm -rf -- "$SBX"' EXIT
+target="$SBX/runtime"; mkdir -p "$target"
+
+_ensure_dir_gitignore "$target"
+assert "missing exclusion is created" "*" "$(cat "$target/.gitignore")"
+
+: > "$target/.gitignore"
+_ensure_dir_gitignore "$target"
+assert "empty exclusion is repaired" "*" "$(cat "$target/.gitignore")"
+
+printf '%s\n' '!keep' > "$target/.gitignore"
+_ensure_dir_gitignore "$target"
+assert "non-empty caller policy is preserved" "!keep" "$(cat "$target/.gitignore")"
+
+mkdir -p "$SBX/not-a-dir"
+printf '%s' occupied > "$SBX/not-a-dir/.gitignore"
+_ensure_dir_gitignore "$SBX/not-a-dir/.gitignore" >/dev/null 2>&1; rc=$?
+assert "write failure is returned" "1" "$rc"
+assert "write failure exposes a cause" "0" "$([ -n "$_RITE_GITIGNORE_ERROR" ]; echo $?)"
+
+print_summary "gitignore-ensure.sh"

--- a/plugins/rite/hooks/tests/gitignore-ensure.test.sh
+++ b/plugins/rite/hooks/tests/gitignore-ensure.test.sh
@@ -24,4 +24,18 @@ _ensure_dir_gitignore "$SBX/not-a-dir/.gitignore" >/dev/null 2>&1; rc=$?
 assert "write failure is returned" "1" "$rc"
 assert "write failure exposes a cause" "0" "$([ -n "$_RITE_GITIGNORE_ERROR" ]; echo $?)"
 
+HOOKS_DIR="$SCRIPT_DIR/.."
+callers=(
+  "$HOOKS_DIR/session-start.sh"
+  "$HOOKS_DIR/review-result-save.sh"
+  "$HOOKS_DIR/scripts/review-results-archive-or-rm.sh"
+  "$HOOKS_DIR/flow-state.sh"
+)
+for caller in "${callers[@]}"; do
+  assert "$(basename "$caller") uses the shared primitive exactly once" "1" \
+    "$(grep -c '_ensure_dir_gitignore ' "$caller" || true)"
+done
+raw_writers=$(LC_ALL=C grep -nF "printf '*\\n'" "${callers[@]}" 2>/dev/null || true)
+assert "production callers contain no private star-only writer" "" "$raw_writers"
+
 print_summary "gitignore-ensure.sh"

--- a/plugins/rite/hooks/tests/review-result-state-root.test.sh
+++ b/plugins/rite/hooks/tests/review-result-state-root.test.sh
@@ -39,6 +39,7 @@ mkdir -p "$REPO/hooks" "$REPO/scripts"
 cp "$HOOKS_DIR/review-result-save.sh" "$REPO/hooks/"
 cp "$HOOKS_DIR/state-path-resolve.sh" "$REPO/hooks/"
 cp "$HOOKS_DIR/control-char-neutralize.sh" "$REPO/hooks/"
+cp "$HOOKS_DIR/gitignore-ensure.sh" "$REPO/hooks/"
 cp "$HOOKS_DIR/../scripts/review-source-resolve.sh" "$REPO/scripts/"
 # review-cycle-scope.sh は同じ state-root 契約の 3 番目の参加者 (書込 = review-result-save.sh /
 # 読取 = review-source-resolve.sh Priority 2 / 読取 = 本 helper の既定 results dir)。
@@ -179,6 +180,7 @@ nogit_dir="$TEST_DIR/nogit"
 mkdir -p "$nogit_dir/hooks"
 cp "$HOOKS_DIR/review-result-save.sh" "$nogit_dir/hooks/"
 cp "$HOOKS_DIR/control-char-neutralize.sh" "$nogit_dir/hooks/"
+cp "$HOOKS_DIR/gitignore-ensure.sh" "$nogit_dir/hooks/"
 # state-path-resolve.sh を意図的に置かない (解決失敗経路)
 content5="$TEST_DIR/body5.json"
 json_body > "$content5"

--- a/plugins/rite/hooks/tests/session-start.test.sh
+++ b/plugins/rite/hooks/tests/session-start.test.sh
@@ -780,6 +780,7 @@ cp "$src_hook_dir/session-start.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/hook-preamble.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/state-path-resolve.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/control-char-neutralize.sh" "$sandbox_hook_dir/"
+cp "$src_hook_dir/gitignore-ensure.sh" "$sandbox_hook_dir/"
 cp "$src_hook_dir/flow-state.sh" "$sandbox_hook_dir/"
 # Sandbox に canonical mktemp helper を含める (silent suppress 禁止 — sibling cp と同じ fail-fast)
 cp "$src_hook_dir/_mktemp-stderr-guard.sh" "$sandbox_hook_dir/"
@@ -823,6 +824,7 @@ cp "$src_hook_dir_b/session-start.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/hook-preamble.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/state-path-resolve.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/control-char-neutralize.sh" "$sandbox_hook_dir_b/"
+cp "$src_hook_dir_b/gitignore-ensure.sh" "$sandbox_hook_dir_b/"
 cp "$src_hook_dir_b/flow-state.sh" "$sandbox_hook_dir_b/"
 # canonical mktemp helper を sandbox に同期コピーする (silent suppress 禁止 — sibling cp と同じ fail-fast)
 cp "$src_hook_dir_b/_mktemp-stderr-guard.sh" "$sandbox_hook_dir_b/"
@@ -1218,7 +1220,7 @@ _mk_wt_sandbox() {
   mkdir -p "$dir/sandbox/hooks"
   sbx="$dir/sandbox/hooks"
   src="$(cd "$SCRIPT_DIR/.." && pwd)"
-  for f in session-start.sh hook-preamble.sh state-path-resolve.sh control-char-neutralize.sh flow-state.sh _mktemp-stderr-guard.sh; do
+  for f in session-start.sh hook-preamble.sh state-path-resolve.sh control-char-neutralize.sh gitignore-ensure.sh flow-state.sh _mktemp-stderr-guard.sh; do
     cp "$src/$f" "$sbx/"
   done
   cat > "$sbx/session-ownership.sh" <<'STUB_EOF'


### PR DESCRIPTION
## Summary

- centralize the four self-contained runtime `.gitignore` writers in one fail-loud helper
- preserve caller-specific warning and marker contracts while standardizing empty-file repair, C-locale diagnostics, and control-character neutralization
- correct stale setup coverage prose and neutralize the remaining unknown-phase diagnostic

## Verification

- gitignore-ensure: 5 PASS / 0 FAIL
- flow-state: 209 PASS / 0 FAIL
- review-results archive: 74 PASS / 0 FAIL
- review-result state-root: 10 PASS / 0 FAIL
- session-start: 72 PASS / 0 FAIL
- diagnostic parity: 50 PASS / 0 FAIL

Closes #2121