### PR TITLE
fix(cleanup): harden branch delete guards

### DIFF
--- a/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
+++ b/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
@@ -15,8 +15,8 @@
 # delete_branch_on_merge: true の環境 (merge 時にサーバサイドで head が削除済み) では
 # cleanup が完全に成功しているのに `error: unable to delete ...` を 2 行出していた。
 #
-# TC 対応 (Issue #2016 Section 7)。実行順は TC-0 → 1 → 2 → 2b → 3 → 4 → 6 → 5 で、TC-5 だけ
-# 番号順から外れる (precondition が「対象ブランチが origin に不在」で前段 TC の後始末に依存する)。
+# TC 対応 (Issue #2016 / #2027)。実行順は TC-0 → 1 → 2 → 2b → 3 → 3b → 7 → 7b → 7c →
+# 8 → 9 → 4 → 6 → 5。TC-5 は precondition が前段 TC の後始末に依存するため最後に置く。
 # - TC-0              : git ls-remote --heads が ref 不在でも rc=0 を返す前提の pin
 #                      (修正前の && ガードが常に成立していたことの根拠)
 # - TC-1 = T-01 (AC-1): ref 不在 → push --delete を呼ばず REMOTE_BRANCH_ALREADY_ABSENT を emit
@@ -35,6 +35,8 @@
 #                      (emitter だけ検証して consumer が無防備になる穴を塞ぐ)
 # - TC-7       (#2016 cycle 3): marker のデリミタ文字 (`;` `=`) や空値を含むブランチ名は
 #                      fail-fast で弾き、削除を試行せず sentinel marker で fallback へ倒す
+# - TC-7b/7c   (#2027): remote の非 canonical/非合法名、mktemp 失敗、awk 異常終了を実行時に pin
+# - TC-8/9     (#2027): local の削除未試行、非 canonical 名、存在判定不能を実行時に pin
 # - TC-5 = T-04       : 抽出した実物のガードから完全一致検証を弱めた mutant で TC-1 相当が
 #                      落ちる (完全一致検証が load-bearing であることの実証)
 #
@@ -73,8 +75,10 @@ BRANCH="fix/issue-2016-sample"
 # デリミタ検査 → 存在確認 → rc 分岐)、最初の `^esac$` で切ると内側の case までしか取れず
 # `fi ;; esac` が落ちて構文エラーになる。fence 終端なら入れ子の深さに依存しない。
 extract_guard_as() {
+  local _replacement
+  _replacement=$(printf '%s' "$1" | sed 's/[&|\\]/\\&/g')
   awk '/^# リモートブランチ削除/{f=1} f && /^```$/{exit} f{print}' "$CLEANUP_MD" \
-    | sed -e "s|{branch_name}|$1|g"
+    | sed -e "s|{branch_name}|$_replacement|g"
 }
 extract_guard() { extract_guard_as "$BRANCH"; }
 # ローカル削除ブロックの抽出。リモート側と別アンカーが要る — `# リモートブランチ削除` を開始
@@ -86,8 +90,10 @@ extract_local_guard_raw() {
   awk '/^## ステップ 5: ローカル \/ リモートブランチを削除/{s=1} s && /^```bash$/{f=1; next} f && /^# リモートブランチ削除/{exit} f{print}' "$CLEANUP_MD"
 }
 extract_local_guard_as() {
+  local _replacement
+  _replacement=$(printf '%s' "$1" | sed 's/[&|\\]/\\&/g')
   extract_local_guard_raw \
-    | sed -e "s|{branch_name}|$1|g" -e "s|{pr_merged}|true|g" -e "s|{plugin_root}|$TEST_DIR/no-plugin|g"
+    | sed -e "s|{branch_name}|$_replacement|g" -e "s|{pr_merged}|true|g" -e "s|{plugin_root}|$TEST_DIR/no-plugin|g"
 }
 GUARD_SNIPPET="$TEST_DIR/guard.sh"
 extract_guard > "$GUARD_SNIPPET"
@@ -248,7 +254,7 @@ CALL_LOG="$TEST_DIR/git-calls.log"
 mkdir -p "$BIN_DIR"
 cat > "$BIN_DIR/git" <<EOF
 #!/bin/bash
-if [ "\${1:-}" = "push" ]; then printf '%s\n' "push \$*" >> "$CALL_LOG"; fi
+if [ "\${1:-}" = "push" ] || [ "\${1:-}" = "branch" ]; then printf '%s\n' "\$*" >> "$CALL_LOG"; fi
 exec "$REAL_GIT" "\$@"
 EOF
 chmod +x "$BIN_DIR/git"
@@ -270,6 +276,7 @@ push_delete_called() {
     *) echo "FATAL: CALL_LOG の grep が IO エラー (rc=$rc): $CALL_LOG" >&2; exit 1 ;;
   esac
 }
+branch_delete_called() { grep -qE '^branch -[dD]( | -- )' "$CALL_LOG"; }
 
 # 退避 stderr のデリミタ区間が **列 0 に到達していない** ことを検査する。SKILL.md は
 # 「デリミタは可読性の補助であり、data 自身が終端行を騙る経路を塞ぐ security boundary は
@@ -280,10 +287,10 @@ push_delete_called() {
 delimited_block_indented() {
   local _text="$1" _label="$2"
   printf '%s\n' "$_text" | awk -v b="--- $_label stderr begin ---" -v e="--- $_label stderr end ---" '
-    index($0, b) { f = 1; next }
-    index($0, e) { f = 0; next }
+    index($0, b) { f = 1; begin_count++; next }
+    index($0, e) { f = 0; end_count++; next }
     f && /^[^[:space:]]/ { bad = 1 }
-    END { exit bad }
+    END { exit (bad || begin_count != 1 || end_count != 1 || f) }
   '
 }
 # Positive control。本検査は negative assertion (列 0 の行が無ければ PASS) のため、検出器が壊れると
@@ -292,6 +299,11 @@ delimited_block_indented() {
 _indent_probe=$'--- push stderr begin ---\nnot-indented\n--- push stderr end ---'
 if delimited_block_indented "$_indent_probe" "push"; then
   echo "FAIL: インデント検出器が既知の違反 (列 0 の行) を報告しません — 以降のインデント検査は vacuous です"
+  exit 1
+fi
+_missing_delimiter_probe=$'not-indented'
+if delimited_block_indented "$_missing_delimiter_probe" "push"; then
+  echo "FAIL: インデント検出器がデリミタ不在を PASS しました — 区間検査が vacuous です"
   exit 1
 fi
 
@@ -559,6 +571,42 @@ else
   pass "TC-7 (契約外のブランチ名は削除を試行せず sentinel で fallback へ倒す)"
 fi
 
+echo "TC-7b: remote invalid/non-canonical names and mktemp failure are fail-fast"
+tc7b_fail=""
+for _bad in "fix/trailing " "origin/foo"; do
+  _bad_snippet="$TEST_DIR/guard-bad-${RANDOM}.sh"
+  extract_guard_as "$_bad" > "$_bad_snippet"
+  out=$(run_guard "$_bad_snippet")
+  printf '%s' "$out" | grep -q '^\[CONTEXT\] REMOTE_BRANCH_CHECK_FAILED=1' \
+    || tc7b_fail="remote bad name が CHECK_FAILED にならない: $_bad (出力: '$out')"
+  [ -z "$tc7b_fail" ] && push_delete_called && tc7b_fail="remote bad name で push delete が呼ばれた: $_bad"
+done
+if [ -z "$tc7b_fail" ]; then
+  : > "$CALL_LOG"
+  out=$(TMPDIR="$TEST_DIR/does-not-exist" PATH="$BIN_DIR:$PATH" bash "$GUARD_SNIPPET" 2>&1)
+  printf '%s' "$out" | grep -q 'rc=mktemp-failed' || tc7b_fail="mktemp 失敗が marker で surface されない (出力: '$out')"
+  [ -z "$tc7b_fail" ] && push_delete_called && tc7b_fail="mktemp 失敗時に push delete が呼ばれた"
+fi
+if [ -n "$tc7b_fail" ]; then fail "TC-7b: $tc7b_fail"; else pass "TC-7b (remote preflight/mktemp failure は削除未試行)"; fi
+
+echo "TC-7c: exact-ref awk failure is CHECK_FAILED, not ALREADY_ABSENT"
+cat > "$BIN_DIR/awk" <<'EOF'
+#!/bin/bash
+exit 2
+EOF
+chmod +x "$BIN_DIR/awk"
+out=$(run_guard "$GUARD_SNIPPET")
+rm -f "$BIN_DIR/awk"
+if ! printf '%s' "$out" | grep -q 'reason=ref-match-awk-2'; then
+  fail "TC-7c: awk rc=2 が reason 付き CHECK_FAILED にならない (出力: '$out')"
+elif printf '%s' "$out" | grep -q 'REMOTE_BRANCH_ALREADY_ABSENT'; then
+  fail "TC-7c: awk 異常終了を既削除へ丸めた"
+elif push_delete_called; then
+  fail "TC-7c: awk 異常終了時に push delete が呼ばれた"
+else
+  pass "TC-7c (awk 異常終了を判定不能として surface)"
+fi
+
 # ─── TC-8 (#2016 cycle 4): ローカル削除ブロックの事前検証と存在確認 rc 分岐 ───
 # ローカルブロックは cycle 3 まで抽出対象外で、fail-fast と rc 3 分岐のどちらも無検証だった
 # (実測で両方を revert しても全 TC 緑)。emitter 側を実行して pin する。
@@ -576,6 +624,7 @@ printf '%s' "$out" | grep -q '^\[CONTEXT\] BRANCH_CHECK_FAILED=1; branch=<unsupp
   || tc8_fail="デリミタ含みの名前で sentinel marker が行頭に出ていない (出力: '$out')"
 [ -z "$tc8_fail" ] && { printf '%s' "$out" | grep -q 'branch=fix/issue-2016;branch=other' \
   && tc8_fail="marker 行に実ブランチ名が載っている (誤帰属経路が開いたまま)"; }
+[ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="デリミタ含み入力で git branch delete が呼ばれた"
 # (b) 空名 -> sentinel。必ず失敗する処方 (`git branch -D ""`) を出さない
 if [ -z "$tc8_fail" ]; then
   out=$(run_local "")
@@ -591,8 +640,16 @@ if [ -z "$tc8_fail" ]; then
     || tc8_fail="refname 非合法な名前が invalid-refname として surface されていない (出力: '$out')"
   [ -z "$tc8_fail" ] && { printf '%s' "$out" | grep -q 'BRANCH_ALREADY_ABSENT' \
     && tc8_fail="refname 非合法な名前を「既削除 = 正常系」に丸めた (削除していないのに完了と報告する)"; }
+  [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="refname 非合法入力で git branch delete が呼ばれた"
 fi
-# (d) 本当に不在 -> 正常系
+# (d) remote/ref prefix は syntactically valid でも PR head の短い名前ではない
+if [ -z "$tc8_fail" ]; then
+  out=$(run_local "origin/foo")
+  printf '%s' "$out" | grep -q 'rc=non-canonical-branch-name' \
+    || tc8_fail="origin/ prefix が non-canonical として拒否されていない (出力: '$out')"
+  [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="non-canonical 入力で git branch delete が呼ばれた"
+fi
+# (e) 本当に不在 -> 正常系
 if [ -z "$tc8_fail" ]; then
   out=$(run_local "fix/definitely-absent")
   printf '%s' "$out" | grep -q '^\[CONTEXT\] BRANCH_ALREADY_ABSENT=1; branch=fix/definitely-absent' \

--- a/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
+++ b/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
@@ -619,6 +619,19 @@ fi
 # (実測で両方を revert しても全 TC 緑)。emitter 側を実行して pin する。
 echo "TC-8: local delete block -> fail-fast on invalid names, rc=1 only means absent"
 LOCAL_RUN="$TEST_DIR/local-run.sh"
+# TC-3/3b の retry fixture が git stub を上書きするため、local 検査前に canonical call logger を復元する。
+cat > "$BIN_DIR/git" <<EOF
+#!/bin/bash
+if [ "\${1:-}" = "push" ] || [ "\${1:-}" = "branch" ]; then printf '%s\n' "\$*" >> "$CALL_LOG"; fi
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$BIN_DIR/git"
+: > "$CALL_LOG"
+PATH="$BIN_DIR:$PATH" git branch -D -- definitely-not-a-real-branch >/dev/null 2>&1 || true
+if ! branch_delete_called; then
+  echo "FATAL: branch delete call logger が既知の delete probe を記録しません — TC-8 の negative assertions は vacuous です"
+  exit 1
+fi
 run_local() {
   : > "$CALL_LOG"
   extract_local_guard_as "$1" > "$LOCAL_RUN"

--- a/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
+++ b/plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh
@@ -78,7 +78,7 @@ extract_guard_as() {
   local _replacement
   _replacement=$(printf '%s' "$1" | sed 's/[&|\\]/\\&/g')
   awk '/^# リモートブランチ削除/{f=1} f && /^```$/{exit} f{print}' "$CLEANUP_MD" \
-    | sed -e "s|{branch_name}|$_replacement|g"
+    | sed -e "s|{branch_name}|$_replacement|g" -e 's|{branch_identity_verified}|true|g'
 }
 extract_guard() { extract_guard_as "$BRANCH"; }
 # ローカル削除ブロックの抽出。リモート側と別アンカーが要る — `# リモートブランチ削除` を開始
@@ -93,7 +93,7 @@ extract_local_guard_as() {
   local _replacement
   _replacement=$(printf '%s' "$1" | sed 's/[&|\\]/\\&/g')
   extract_local_guard_raw \
-    | sed -e "s|{branch_name}|$_replacement|g" -e "s|{pr_merged}|true|g" -e "s|{plugin_root}|$TEST_DIR/no-plugin|g"
+    | sed -e "s|{branch_name}|$_replacement|g" -e "s|{pr_merged}|true|g" -e 's|{branch_identity_verified}|true|g' -e "s|{plugin_root}|$TEST_DIR/no-plugin|g"
 }
 GUARD_SNIPPET="$TEST_DIR/guard.sh"
 extract_guard > "$GUARD_SNIPPET"
@@ -573,7 +573,7 @@ fi
 
 echo "TC-7b: remote invalid/non-canonical names and mktemp failure are fail-fast"
 tc7b_fail=""
-for _bad in "fix/trailing " "origin/foo"; do
+for _bad in "fix/trailing "; do
   _bad_snippet="$TEST_DIR/guard-bad-${RANDOM}.sh"
   extract_guard_as "$_bad" > "$_bad_snippet"
   out=$(run_guard "$_bad_snippet")
@@ -586,6 +586,13 @@ if [ -z "$tc7b_fail" ]; then
   out=$(TMPDIR="$TEST_DIR/does-not-exist" PATH="$BIN_DIR:$PATH" bash "$GUARD_SNIPPET" 2>&1)
   printf '%s' "$out" | grep -q 'rc=mktemp-failed' || tc7b_fail="mktemp 失敗が marker で surface されない (出力: '$out')"
   [ -z "$tc7b_fail" ] && push_delete_called && tc7b_fail="mktemp 失敗時に push delete が呼ばれた"
+fi
+if [ -z "$tc7b_fail" ]; then
+  _unverified="$TEST_DIR/guard-unverified.sh"
+  sed 's/\[ "true" != "true" \]/[ "false" != "true" ]/' "$GUARD_SNIPPET" > "$_unverified"
+  out=$(run_guard "$_unverified")
+  printf '%s' "$out" | grep -q 'rc=branch-identity-unverified' || tc7b_fail="identity 未確認が拒否されない"
+  [ -z "$tc7b_fail" ] && push_delete_called && tc7b_fail="identity 未確認で push delete が呼ばれた"
 fi
 if [ -n "$tc7b_fail" ]; then fail "TC-7b: $tc7b_fail"; else pass "TC-7b (remote preflight/mktemp failure は削除未試行)"; fi
 
@@ -632,6 +639,7 @@ if [ -z "$tc8_fail" ]; then
     || tc8_fail="空ブランチ名で sentinel marker が行頭に出ていない (出力: '$out')"
   [ -z "$tc8_fail" ] && { printf '%s' "$out" | grep -q 'git branch -D ""' \
     && tc8_fail="空ブランチ名に対して必ず失敗する処方 git branch -D \"\" を提示している"; }
+  [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="空ブランチ名で git branch delete が呼ばれた"
 fi
 # (c) refname 非合法 (末尾空白) -> 「既削除」に丸めない
 if [ -z "$tc8_fail" ]; then
@@ -642,12 +650,13 @@ if [ -z "$tc8_fail" ]; then
     && tc8_fail="refname 非合法な名前を「既削除 = 正常系」に丸めた (削除していないのに完了と報告する)"; }
   [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="refname 非合法入力で git branch delete が呼ばれた"
 fi
-# (d) remote/ref prefix は syntactically valid でも PR head の短い名前ではない
+# (d) identity 未確認は名前の形に依存せず拒否
 if [ -z "$tc8_fail" ]; then
-  out=$(run_local "origin/foo")
-  printf '%s' "$out" | grep -q 'rc=non-canonical-branch-name' \
-    || tc8_fail="origin/ prefix が non-canonical として拒否されていない (出力: '$out')"
-  [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="non-canonical 入力で git branch delete が呼ばれた"
+  extract_local_guard_as "upstream/foo" | sed 's/\[ "true" != "true" \]/[ "false" != "true" ]/' > "$LOCAL_RUN"
+  : > "$CALL_LOG"; out=$(PATH="$BIN_DIR:$PATH" bash "$LOCAL_RUN" 2>&1)
+  printf '%s' "$out" | grep -q 'rc=branch-identity-unverified' \
+    || tc8_fail="identity 未確認入力が拒否されていない (出力: '$out')"
+  [ -z "$tc8_fail" ] && branch_delete_called && tc8_fail="identity 未確認入力で git branch delete が呼ばれた"
 fi
 # (e) 本当に不在 -> 正常系
 if [ -z "$tc8_fail" ]; then
@@ -676,6 +685,21 @@ elif ! delimited_block_indented "$out" "show-ref"; then
   fail "TC-9: 退避 stderr の行が列 0 から始まっている (出力: '$out')"
 else
   pass "TC-9 (判定不能を未完了として surface、原因テキストも列 0 に到達しない)"
+fi
+
+echo "TC-9b: broken loose ref warning -> BRANCH_CHECK_FAILED, no delete"
+mkdir -p .git/refs/heads
+printf 'bad\n' > .git/refs/heads/broken
+out=$(run_local "broken")
+rm -f .git/refs/heads/broken
+if ! printf '%s' "$out" | grep -q 'rc=ref-store-0'; then
+  fail "TC-9b: for-each-ref rc=0 + warning を判定不能として surface しない (出力: '$out')"
+elif printf '%s' "$out" | grep -q 'BRANCH_ALREADY_ABSENT'; then
+  fail "TC-9b: broken ref を既削除へ丸めた"
+elif branch_delete_called; then
+  fail "TC-9b: broken ref で git branch delete が呼ばれた"
+else
+  pass "TC-9b (ref-store warning を判定不能として surface、削除未試行)"
 fi
 
 # ─── TC-4 (T-03 / AC-3): merge/SKILL.md の設計判断が保証を主張していない ───

--- a/plugins/rite/references/bash-trap-patterns.md
+++ b/plugins/rite/references/bash-trap-patterns.md
@@ -9,7 +9,7 @@
 各 bash block の冒頭では本ファイルへの anchor 参照を pointer コメントとして置く。
 
 > **⚠️ コード層との境界**: rationale / 説明文は本ファイル 1 箇所に集約されるが、cleanup 関数本体と
-> 4 行 trap (`EXIT`/`INT`/`TERM`/`HUP`) は対象 5 ファイル各 site にコードとして存在する。signal 動作
+> 4 行 trap (`EXIT`/`INT`/`TERM`/`HUP`) は各採用 site にコードとして存在する。signal 動作
 > そのものの変更 (HUP 追加、TERM exit code 変更等) は本ファイル更新後に全採用 site の
 > 4 行 trap を同時更新すること。
 
@@ -295,5 +295,5 @@ indent 一貫性を確認する。
 # (rationale: signal 別 exit code、race window 回避、rc=$? capture、${var:-} safety、関数契約)
 ```
 
-signal 動作そのものを変更する場合は、本ファイル更新後に対象 5 ファイル全 site の 4 行 trap を
+signal 動作そのものを変更する場合は、本ファイル更新後に全採用 site の 4 行 trap を
 Instantiation Checklist に従って同時更新すること。

--- a/plugins/rite/references/bash-trap-patterns.md
+++ b/plugins/rite/references/bash-trap-patterns.md
@@ -2,13 +2,15 @@
 
 > **Charter**: Subject to [Simplification Charter](../skills/rite-workflow/references/simplification-charter.md). Runtime に効かない経緯記述は書かない。
 
-対象 6 ファイル: `pr/fix.md` / `pr/pr-review.md` / `pr/open.md` / `pr/merge.md` / `wiki/lint.md` / `wiki/ingest.md`。
+採用 site は `skills/fix/SKILL.md` / `skills/pr-review/SKILL.md` / `skills/open/SKILL.md` /
+`skills/merge/SKILL.md` / `skills/wiki-lint/SKILL.md` / `skills/wiki-ingest/SKILL.md` /
+`skills/cleanup/SKILL.md` ステップ 5。旧 `commands/` 時代の path は対象外。
 本ファイルは **signal-specific trap + cleanup function パターン**の canonical 定義と根拠を集約する。
 各 bash block の冒頭では本ファイルへの anchor 参照を pointer コメントとして置く。
 
 > **⚠️ コード層との境界**: rationale / 説明文は本ファイル 1 箇所に集約されるが、cleanup 関数本体と
 > 4 行 trap (`EXIT`/`INT`/`TERM`/`HUP`) は対象 5 ファイル各 site にコードとして存在する。signal 動作
-> そのものの変更 (HUP 追加、TERM exit code 変更等) は本ファイル更新後に対象 5 ファイル全 site の
+> そのものの変更 (HUP 追加、TERM exit code 変更等) は本ファイル更新後に全採用 site の
 > 4 行 trap を同時更新すること。
 
 ---

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -622,6 +622,9 @@ case "{branch_name}" in
   *[\;=]*)
     echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=marker-delimiter-in-branch-name" >&2
     echo "WARNING: ブランチ名に marker のデリミタ文字 (; =) が含まれるため、ローカルブランチの削除を試行していません。手動で削除してください: git branch -D \"{branch_name}\"" >&2 ;;
+  origin/*|refs/*)
+    echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=non-canonical-branch-name" >&2
+    echo "WARNING: remote/ref prefix を含む名前はローカル head 名として扱えないため削除を試行していません。PR の headRefName を確認してください。" >&2 ;;
   *)
 # rc を捕捉して **rc=1（不在）だけ**を「既削除」に倒す。否定付き if の短絡形だと rc=128（リポジトリ外での
 # 実行等）まで「不在」に丸め、ローカルブランチが残ったまま完了と報告される（リモート側が rc=0/2
@@ -640,12 +643,21 @@ if [ "$_cf_rc" -ne 0 ]; then
   echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch={branch_name}; rc=invalid-refname" >&2
   echo "WARNING: ブランチ名が refname として非合法なため、ローカルブランチの存在を判定できず削除を試行していません (git check-ref-format rc=${_cf_rc})。" >&2
 elif [ "$_sr_rc" -eq 1 ]; then
+  # show-ref の rc=1 は不在だけでなく ref store 障害でも返りうる。全 local heads の走査が正常完了
+  # した場合だけ不在と確定し、走査不能は CHECK_FAILED へ倒す。
+  _fr_err=$(LC_ALL=C git for-each-ref --format='%(refname)' refs/heads 2>&1 >/dev/null); _fr_rc=$?
+  if [ "$_fr_rc" -ne 0 ]; then
+    echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch={branch_name}; rc=ref-store-${_fr_rc}" >&2
+    echo "WARNING: ローカル ref store を走査できないため削除を試行していません:" >&2
+    printf '%s\n' "$_fr_err" | tr -d '\r' | sed 's/^/  /' >&2
+  else
   # 既に不在（cleanup の再実行 / 別セッションで削除済み）は正常系。存在確認せず `git branch -d` に
   # 渡すと "branch not found" で失敗して下の `*)` に落ち、BRANCH_DELETE_FAILED として
   # 「削除に失敗。`git branch -D` で手動削除」という**必ず失敗する処方**を出す。これはリモート側で
   # REMOTE_BRANCH_ALREADY_ABSENT として正常系に倒した症状と同型で、ローカル側だけ残っていた
   # （#2016）。git の診断メッセージ文字列に依存しないよう show-ref で判定する。
   echo "[CONTEXT] BRANCH_ALREADY_ABSENT=1; branch={branch_name}"
+  fi
 elif [ "$_sr_rc" -ne 0 ]; then
   # 存在有無が不明。削除を試行せず未完了として surface する（安全側）。
   echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch={branch_name}; rc=${_sr_rc}" >&2
@@ -653,7 +665,7 @@ elif [ "$_sr_rc" -ne 0 ]; then
   echo "--- show-ref stderr begin ---" >&2
   printf '%s\n' "${_sr_err}" | tr -d '\r' | sed 's/^/  /' >&2
   echo "--- show-ref stderr end ---" >&2
-elif del_err=$(LC_ALL=C git branch -d {branch_name} 2>&1); then
+elif del_err=$(LC_ALL=C git branch -d -- "{branch_name}" 2>&1); then
   echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}"
 else
   case "$del_err" in
@@ -674,7 +686,7 @@ else
     *"not fully merged"*)
       if [ "{pr_merged}" = "true" ]; then
         # squash merge の残渣 — PR は merged 済みなので強制削除して安全。
-        LC_ALL=C git branch -D {branch_name} >/dev/null 2>&1 \
+        LC_ALL=C git branch -D -- "{branch_name}" >/dev/null 2>&1 \
           && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=squash-merged" \
           || echo "[CONTEXT] BRANCH_DELETE_FAILED=1; branch={branch_name}" >&2
       else
@@ -730,6 +742,9 @@ case "{branch_name}" in
     echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=marker-delimiter-in-branch-name" >&2
     echo "WARNING: ブランチ名に marker のデリミタ文字 (; =) が含まれるため、リモート削除の自動判定を行いません。手動で削除してください: git push origin --delete \"refs/heads/{branch_name}\"" >&2
     ;;
+  origin/*|refs/*)
+    echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=non-canonical-branch-name" >&2
+    echo "WARNING: remote/ref prefix を含む名前は PR head の短い branch 名ではないためリモート削除を試行していません。" >&2 ;;
   *)
 # refname 非合法な値は ls-remote の完全一致検証が決して一致せず「既削除 = 正常系」へ倒れるため、
 # ローカル側と対称に先に弾く（削除していないのに完了と報告するのを防ぐ）。

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -73,10 +73,14 @@ git branch --show-current
 > 以降の実行スニペットの `-R {owner_repo}` は、[Owner/Repo Resolution](../../references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe)（ステップ 1.4 と同一の canonical 手順）で解決した owner/repo（slash 形式）をリテラル置換する（SSH host alias 環境対応。値が未解決ならステップ 1.4 の解決スニペットを先に実行して確定する）。
 
 ```bash
-gh pr list -R {owner_repo} --head {branch_name} --state all --json number,title,state,mergedAt,url
+gh pr list -R {owner_repo} --head {branch_name} --state all --json number,title,state,mergedAt,url,headRefName
 ```
 
 PR 未検出: `AskUserQuestion` で「ブランチを削除して続行 / キャンセル」を確認。未マージ PR: 「キャンセル (推奨) / 強制クリーンアップ」を確認。
+
+PR 検出時は返却された `headRefName` と `{branch_name}` の完全一致時だけ `{branch_identity_verified}=true`
+とする。不一致は削除対象 identity が確定しないため中断する。PR 未検出でユーザーが「ブランチを削除して続行」
+を明示選択した場合だけ承認済み入力として `true`、それ以外は `false`。prefix denylist で identity を推測しない。
 
 `mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。これによりステップ 4-W / ステップ 5 のすべての分岐で `{pr_merged}` が必ず literal substitute 可能になる（未定義値参照を防ぐ）。ステップ 4-W の worktree パス manifest 記録（Issue #1945）、およびステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
 
@@ -613,6 +617,10 @@ fi
 # （Fail-Fast First）。sentinel は空白を含めて refname として非合法にし、実在ブランチとの衝突を
 # 構造的に排除する。リモート削除ブロックも同じ検査を独立に持つ（各ブロックが単体で抽出・実行
 # されうるため、ガードもブロック単位で自己完結させる）。
+if [ "{branch_identity_verified}" != "true" ]; then
+  echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=branch-identity-unverified" >&2
+  echo "WARNING: 削除対象が PR head と一致すると確認できないためローカル削除を試行していません。" >&2
+else
 case "{branch_name}" in
   '')
     # 空値は処方を出さない。存在しないブランチに対する `git branch -D ""` は必ず失敗するため、
@@ -622,9 +630,6 @@ case "{branch_name}" in
   *[\;=]*)
     echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=marker-delimiter-in-branch-name" >&2
     echo "WARNING: ブランチ名に marker のデリミタ文字 (; =) が含まれるため、ローカルブランチの削除を試行していません。手動で削除してください: git branch -D \"{branch_name}\"" >&2 ;;
-  origin/*|refs/*)
-    echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=non-canonical-branch-name" >&2
-    echo "WARNING: remote/ref prefix を含む名前はローカル head 名として扱えないため削除を試行していません。PR の headRefName を確認してください。" >&2 ;;
   *)
 # rc を捕捉して **rc=1（不在）だけ**を「既削除」に倒す。否定付き if の短絡形だと rc=128（リポジトリ外での
 # 実行等）まで「不在」に丸め、ローカルブランチが残ったまま完了と報告される（リモート側が rc=0/2
@@ -632,9 +637,9 @@ case "{branch_name}" in
 # ただし rc=1 は「本当に不在」だけを意味しない — refname として非合法な値（末尾空白 / `:` 混入 /
 # `..` や制御文字の混入等）でも rc=1 になり、同じく「既削除 = 正常系」へ倒れて削除していないのに
 # 完了と報告する。そこで **refname 構文に起因する rc=1 を分離する**ために先に合法性を検査する。
-# **これは rc=1 の多義性を解消しない** — `origin/foo` のように構文的には合法だが対象と別物の値、
-# および ref store 側の障害（ref ファイル不可読 / 破損）はこの検査を素通りし、依然として
-# 「不在」として扱われる。塞げていない範囲を「塞いだ」と書かないための注記。
+# 構文的に合法だが対象と別物の値は、ステップ 1.3 の `headRefName` 完全一致で排除する。
+# ref store 側の障害は show-ref rc=1 後の for-each-ref positive control で、非 0 rc または stderr warning
+# のどちらも `ref-store-*` として判定不能へ倒す。
 # stderr は退避して WARNING に載せる（rc=128 の原因が消えると認証失敗・リポジトリ外・破損が
 # 区別できない。リモート側が $_ls_err で原因を surface するのと対称）。
 LC_ALL=C git check-ref-format "refs/heads/{branch_name}" >/dev/null 2>&1; _cf_rc=$?
@@ -646,7 +651,7 @@ elif [ "$_sr_rc" -eq 1 ]; then
   # show-ref の rc=1 は不在だけでなく ref store 障害でも返りうる。全 local heads の走査が正常完了
   # した場合だけ不在と確定し、走査不能は CHECK_FAILED へ倒す。
   _fr_err=$(LC_ALL=C git for-each-ref --format='%(refname)' refs/heads 2>&1 >/dev/null); _fr_rc=$?
-  if [ "$_fr_rc" -ne 0 ]; then
+  if [ "$_fr_rc" -ne 0 ] || [ -n "$_fr_err" ]; then
     echo "[CONTEXT] BRANCH_CHECK_FAILED=1; branch={branch_name}; rc=ref-store-${_fr_rc}" >&2
     echo "WARNING: ローカル ref store を走査できないため削除を試行していません:" >&2
     printf '%s\n' "$_fr_err" | tr -d '\r' | sed 's/^/  /' >&2
@@ -705,6 +710,7 @@ else
 fi
     ;;
 esac
+fi
 # リモートブランチ削除（#2016）。`git ls-remote --heads` は ref 不在でも rc=0（空 stdout）を返すため、
 # `&&` では「存在するときだけ削除する」ガードにならない。--exit-code で ref 不在を rc=2 として
 # 判別する。リポジトリ設定 delete_branch_on_merge: true では merge 時にサーバサイドで head が
@@ -729,6 +735,10 @@ esac
 # ブランチ名が marker のデリミタ文字（`;` `=`）を含む場合は、`branch=` フィールドの右端境界を騙って
 # 別ブランチの判定ルールに一致しうる（`;` `=` はいずれも合法な refname 文字）。エンコード規約を
 # emitter/consumer の両側に増やすより、契約を満たせない入力を fail-fast で弾く（Fail-Fast First）。
+if [ "{branch_identity_verified}" != "true" ]; then
+  echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=branch-identity-unverified" >&2
+  echo "WARNING: 削除対象が PR head と一致すると確認できないためリモート削除を試行していません。" >&2
+else
 case "{branch_name}" in
   '')
     echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=empty-branch-name" >&2
@@ -742,9 +752,6 @@ case "{branch_name}" in
     echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=marker-delimiter-in-branch-name" >&2
     echo "WARNING: ブランチ名に marker のデリミタ文字 (; =) が含まれるため、リモート削除の自動判定を行いません。手動で削除してください: git push origin --delete \"refs/heads/{branch_name}\"" >&2
     ;;
-  origin/*|refs/*)
-    echo "[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=<unsupported branch name>; rc=non-canonical-branch-name" >&2
-    echo "WARNING: remote/ref prefix を含む名前は PR head の短い branch 名ではないためリモート削除を試行していません。" >&2 ;;
   *)
 # refname 非合法な値は ls-remote の完全一致検証が決して一致せず「既削除 = 正常系」へ倒れるため、
 # ローカル側と対称に先に弾く（削除していないのに完了と報告するのを防ぐ）。
@@ -838,8 +845,10 @@ case "$_ls_rc" in
 esac
 trap - EXIT INT TERM HUP
 fi
-fi ;;
+fi
+  ;;
 esac
+fi
 ```
 
 `BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（作業ツリーが未削除のまま残り削除を遅延したケース — 別セッション使用中(#1670) または sandbox マスク skip(#1957)。原因は断定しない）のときは**強制削除しない**。marker の `recovery=` で次セッション回収の可否が決まる: `recovery=auto`（{pr_merged}=true、reap manifest の記録を verify 済み、かつ対象 worktree が reaper と同じ filtered dirty gate を通過）は worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が自動回収する。`recovery=manual`（未マージ PR の強制 cleanup、記録漏れ、dirty または判定不能な worktree）は自動回収されない。実パスを解決できた場合は `BRANCH_DELETE_DEFERRED_WORKTREE` marker の shell-escaped `path_q=` を用いて status を確認し、変更を commit / stash / copy して clean にした後だけ、非 force の `git worktree remove` → prune → branch delete を実行する。解決不能時は `git worktree list --porcelain` で先に実パスを特定する。ステップ 12 はこの `recovery=` 値で残置メッセージを出し分ける。


### PR DESCRIPTION
Closes #2027

## Summary
- reject non-canonical branch identifiers and quote local deletion targets
- distinguish local ref-store failures from confirmed absence
- add executable pins for deletion suppression, invalid inputs, mktemp/awk failures, and delimiter non-vacuity
- refresh trap-pattern adoption documentation

## Verification
- bash plugins/rite/hooks/tests/remote-branch-delete-guard.test.sh