### PR TITLE
fix(lint): board drift 検出から closure reason の限定を外す

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -225,7 +225,7 @@ rite-workflow/
 │ │ ├── settings-local-rite-hook-cleanup.sh / settings-local-rite-hook-cleanup.py # legacy hook entry 掃除 (.sh wrapper + .py 実体)
 │ │ ├── reviewer-registry-drift-check.sh # lint Phase 3.5 reviewer registry 3-way 同期検証
 │ │ ├── gitignore-health-check.sh
-│ │ ├── projects-board-drift-check.sh # lint Phase 3.18 CLOSED+COMPLETED board≠Done 検出
+│ │ ├── projects-board-drift-check.sh # lint Phase 3.18 CLOSED かつ board≠Done 検出
 │ │ ├── number-reference-check.sh # lint Phase 3.5 Issue/PR 番号参照 (#NNN) 検出 (CHANGELOG + lint.md)
 │ │ ├── sentinel-contract-check.sh # lint Phase 3.5 sentinel SoT / emitter / consumer 同期検証
 │ │ ├── tmp-hardcode-check.sh # lint Phase 3.5 sandbox 非互換パターン (mktemp+/tmp テンプレート・/tmp 直書き・push の upstream -u) 検出
@@ -1321,7 +1321,7 @@ Non-hook helper scripts invoked either directly from orchestrator skills or by o
 | `bang-backtick-check.sh` | Detect bash history-expansion pitfalls in generated content | — |
 | `reviewer-registry-drift-check.sh` | `/rite:lint` Phase 3.5 — detect reviewer registry drift across `agents/*-reviewer.md` and the 2 tables in `skills/reviewers/SKILL.md` (edit procedure: CONTRIBUTING.md "Adding a New Reviewer") | — |
 | `gitignore-health-check.sh` | Verify the `.rite/wiki/` last-line-of-defense `.gitignore` rule, emit `gitignore_drift` sentinel on mismatch | — |
-| `projects-board-drift-check.sh` | `/rite:lint` Phase 3.18 — detect CLOSED+COMPLETED Issues whose Projects board Status is not `Done` (NOT_PLANNED excluded), optionally reconcile via `--reconcile` | — |
+| `projects-board-drift-check.sh` | `/rite:lint` Phase 3.18 — detect CLOSED Issues whose Projects board Status is not `Done` (closure reason not consulted), optionally reconcile via `--reconcile` | — |
 | `number-reference-check.sh` | `/rite:lint` Phase 3.5 — detect Issue/PR number references (`#NNN` / `Issue #NNN` / `PR #NNN`) that crept back into the number-free documentation surface (`CHANGELOG.md` / `CHANGELOG.ja.md` / `lint.md`) | — |
 | `sentinel-contract-check.sh` | `/rite:lint` Phase 3.5 — verify the sentinel SoT against emitter and consumer skill files, and detect undeclared sentinel-shaped literals | Canonical contract: `references/sentinel-contract.md` |
 | `tmp-hardcode-check.sh` | `/rite:lint` Phase 3.5 — detect sandbox-incompatible patterns (`mktemp` + `/tmp` template, fixed `/tmp` path hardcode, `git push` upstream `-u`) in `plugins/rite/**/*.{md,sh}` + `docs/**/*.md` (test harnesses / error-catalog / self excluded) | — |

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -270,10 +270,11 @@ if [ -n "$DRIFT_TSV" ]; then
                 echo "projects-board-drift: reconcile #$issue_number: $(printf '%s' "$w" | neutralize_ctrl --c0-only)" >&2
               done
         fi
-        # reconcile_err に中身が入るのは helper を exec できなかった場合のみ (handled failure は
-        # 上の .warnings[] が担う)。両方空なら理由不明として exec 失敗の可能性を示す。
+        # reconcile_err には helper 自身の stderr が入る (exec 不能・helper 内の set -e abort 等)。
+        # helper は handled failure では stderr へ書かないので、ここに中身があるのは helper が
+        # JSON を出す前に落ちた場合。原因は断定せず、捕捉した stderr をそのまま見せる。
         if [ "$QUIET" != "true" ] && [ -n "$reconcile_err" ] && [ -s "$reconcile_err" ]; then
-          echo "projects-board-drift: reconcile exec failed for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
+          echo "projects-board-drift: reconcile helper stderr for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
         fi
       fi
       [ -n "$reconcile_err" ] && rm -f "$reconcile_err"; reconcile_err=""

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 # rite workflow - Projects Board "Done" Drift Check
 #
-# Reconciliation drift-guard for the "CLOSED+COMPLETED but board != Done" gap.
+# Reconciliation drift-guard for the "CLOSED but board != Done" gap.
 # A Done transition is only wired into /rite:cleanup and /rite:issue-close, but
 # GitHub auto-closes Issues via a PR body "Closes #N" the moment the PR merges. When
 # /rite:cleanup is not run afterwards, the board freezes at its last value (In Review
 # for a ready Issue, Todo for an untouched one). No reconciliation picks these back up.
 #
-# This script scans recently-updated CLOSED Issues and reports the ones whose closure
-# reason is COMPLETED yet whose GitHub Projects board Status is not "Done". It is a
-# read-only detector by default (matching the other hooks/scripts/*-check.sh lint
-# checks); with --reconcile it drives scripts/projects-status-update.sh to set Status
-# to Done.
+# This script scans recently-updated CLOSED Issues and reports the ones whose GitHub
+# Projects board Status is not "Done". It is a read-only detector by default (matching
+# the other hooks/scripts/*-check.sh lint checks); with --reconcile it drives
+# scripts/projects-status-update.sh to set Status to Done.
 #
-# Closure-reason policy (AC-2): only stateReason == COMPLETED is considered. NOT_PLANNED
-# (wontfix / duplicate) Issues are intentionally left alone — their board state is not a
-# drift to correct.
+# Closure-reason policy: the closure reason is not consulted. The board's Status field
+# has no Cancelled-equivalent terminal option, so a wontfix / duplicate closure has
+# nowhere to land other than Done — leaving it filtered out only strands it in a
+# non-terminal column that no reconciler ever revisits.
 #
 # On-board policy: an Issue that is not on the project board (no projectItem for the
 # configured project_number) is NOT a drift — there is no board Status to reconcile.
@@ -71,8 +71,8 @@ while [ $# -gt 0 ]; do
       cat <<'USAGE_EOF'
 projects-board-drift-check.sh - Projects Board "Done" Drift Check
 
-Scans recently-updated CLOSED Issues and reports the ones whose closure reason is
-COMPLETED yet whose GitHub Projects board Status is not "Done" — the symptom of a
+Scans recently-updated CLOSED Issues and reports the ones whose GitHub Projects board
+Status is not "Done" — the symptom of a closure that never reached the board, such as a
 merge that auto-closed an Issue without /rite:cleanup running to set Done.
 
 Usage:
@@ -191,7 +191,7 @@ gql_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-gql-err-XXXXXX") || gql_err="
 jq_err=$(mktemp "${TMPDIR:-/tmp}/rite-board-drift-jq-err-XXXXXX") || jq_err=""
 
 # jq emits one TSV line per drifted Issue: number<TAB>status<TAB>title
-# Drift = stateReason COMPLETED AND on board (projectItem for $pn) AND Status != "Done".
+# Drift = on board (projectItem for $pn) AND Status != "Done".
 if ! DRIFT_TSV=$(set -o pipefail; gh api graphql -f query='
 query($owner: String!, $repo: String!, $first: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -199,7 +199,6 @@ query($owner: String!, $repo: String!, $first: Int!) {
       nodes {
         number
         title
-        stateReason
         projectItems(first: 10) {
           nodes {
             project { number }
@@ -221,7 +220,7 @@ query($owner: String!, $repo: String!, $first: Int!) {
       .data.repository.issues.nodes[]
       | . as $i
       | (([$i.projectItems.nodes[] | select(.project.number == $pn)][0]) // null) as $pitem
-      | select($i.stateReason == "COMPLETED" and $pitem != null)
+      | select($pitem != null)
       | (([$pitem.fieldValues.nodes[] | select(.field.name == "Status") | .name][0]) // "<no-status>") as $st
       | select($st != "Done")
       | "\($i.number)\t\($st)\t\($i.title)"
@@ -269,7 +268,7 @@ if [ -n "$DRIFT_TSV" ]; then
     fi
 
     echo "[projects-board-drift] #$issue_number \"$title\" status=\"$status\" (expected Done)$reconcile_suffix"
-    [ "$QUIET" = "true" ] || echo "projects-board-drift: WARNING #$issue_number CLOSED/COMPLETED but board Status=\"$status\" (expected Done)" >&2
+    [ "$QUIET" = "true" ] || echo "projects-board-drift: WARNING #$issue_number CLOSED but board Status=\"$status\" (expected Done)" >&2
   done <<< "$DRIFT_TSV"
 fi
 

--- a/plugins/rite/hooks/scripts/projects-board-drift-check.sh
+++ b/plugins/rite/hooks/scripts/projects-board-drift-check.sh
@@ -260,8 +260,20 @@ if [ -n "$DRIFT_TSV" ]; then
       else
         RECONCILE_FAILURES=$((RECONCILE_FAILURES + 1))
         reconcile_suffix=" -> reconcile FAILED ($reconcile_result)"
+        # projects-status-update.sh は non_blocking=true の handled failure では自身の stderr へ
+        # 何も書かず、診断を stdout JSON の .warnings[] にのみ載せる。.result だけを読むと失敗理由が
+        # どこにも出ないため、ここで .warnings[] を stderr へ転記する (skills/ready と同じ契約)。
+        if [ "$QUIET" != "true" ] && [ -n "$reconcile_json" ]; then
+          printf '%s' "$reconcile_json" | jq -r '.warnings[]? // empty' 2>/dev/null \
+            | while IFS= read -r w; do
+                [ -n "$w" ] || continue
+                echo "projects-board-drift: reconcile #$issue_number: $(printf '%s' "$w" | neutralize_ctrl --c0-only)" >&2
+              done
+        fi
+        # reconcile_err に中身が入るのは helper を exec できなかった場合のみ (handled failure は
+        # 上の .warnings[] が担う)。両方空なら理由不明として exec 失敗の可能性を示す。
         if [ "$QUIET" != "true" ] && [ -n "$reconcile_err" ] && [ -s "$reconcile_err" ]; then
-          echo "projects-board-drift: reconcile failed for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
+          echo "projects-board-drift: reconcile exec failed for #$issue_number: $(head -c 200 "$reconcile_err" | tr '\n' ' ' | neutralize_ctrl --c0-only)" >&2
         fi
       fi
       [ -n "$reconcile_err" ] && rm -f "$reconcile_err"; reconcile_err=""

--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -10,9 +10,13 @@
 #   T-6: config-aware no-op (projects disabled / rite-config absent) exits 0 with a
 #        0-findings summary line — exercised offline, no gh required (AC-4)
 #   T-7: behavioral fixture — the jq detection pipeline (extracted from source, not a
-#        copy) classifies all six cases correctly (drift / Done / NOT_PLANNED /
-#        not-on-board / other-project / <no-status>), catching semantic breaks that
-#        preserve jq literals but flip scoping (offline, jq-only, no gh)
+#        copy) classifies all six cases correctly (COMPLETED drift / NOT_PLANNED drift /
+#        Done / not-on-board / other-project / <no-status>), catching semantic breaks
+#        that preserve jq literals but flip scoping (offline, jq-only, no gh)
+#   T-9: behavioral — --reconcile drives the Status update helper to "Done" for a
+#        closure reason that used to be excluded (offline, gh shim records the item-edit)
+#  T-10: behavioral — a failing GraphQL scan exits 2 with a diagnostic, so lint never
+#        misreads an invocation/API error as "drift detected" (exit 1)
 #
 # Usage: bash plugins/rite/hooks/tests/projects-board-drift-check.test.sh
 set -euo pipefail
@@ -49,6 +53,16 @@ assert_absent() {
   local haystack="$1" needle="$2" description="$3"
   if printf '%s\n' "$haystack" | grep -qF -- "$needle"; then
     FAIL=$((FAIL + 1)); FAILURES+=("$description"); echo "  ✗ $description" >&2
+  else
+    PASS=$((PASS + 1)); echo "  ✓ $description"
+  fi
+}
+
+# Inverse of assert_file_contains: the pattern must NOT appear anywhere in the file.
+assert_file_lacks() {
+  local file="$1" pattern="$2" description="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    FAIL=$((FAIL + 1)); FAILURES+=("$description (pattern: $pattern)"); echo "  ✗ $description" >&2
   else
     PASS=$((PASS + 1)); echo "  ✓ $description"
   fi
@@ -120,10 +134,12 @@ assert_file_contains "$DRIFT_SH" '\-\-limit\)' "case clause handles --limit flag
 assert_file_contains "$DRIFT_SH" '\-\-quiet\)' "case clause handles --quiet flag"
 assert_file_contains "$DRIFT_SH" 'Reconciliation drift-guard' "header documents drift-guard purpose"
 # Detection: anchor asserts to the load-bearing jq predicates (with quotes), NOT to the header
-# comments (which spell COMPLETED/Done without the jq quoting), so deleting the detection logic
-# actually fails the suite. The quoted `stateReason == "COMPLETED"` predicate also pins the AC-2
-# NOT_PLANNED exclusion: rewriting it to a wrong form (e.g. `!= "NOT_PLANNED"`) drops this literal.
-assert_file_contains "$DRIFT_SH" 'stateReason == "COMPLETED"' "AC-2: includes only COMPLETED (NOT_PLANNED excluded)"
+# comments (which spell Done without the jq quoting), so deleting the detection logic actually
+# fails the suite. Board membership is the only remaining inclusion gate, so pin its exact form;
+# the companion absence assert keeps a closure-reason filter from creeping back into the source
+# (the board has no terminal Status other than Done, so no closure reason may be filtered out).
+assert_file_contains "$DRIFT_SH" 'select\(\$pitem != null\)' "board 掲載のみで絞る (closure reason 非依存)"
+assert_file_lacks "$DRIFT_SH" 'stateReason' "closure reason への依存が残っていない"
 assert_file_contains "$DRIFT_SH" 'select.*\$st.*!= "Done"' "AC-1: drift when board Status != Done"
 assert_file_contains "$DRIFT_SH" 'projectItems' "queries projectItems for board membership"
 # AC-4: projects-enabled gate
@@ -184,8 +200,11 @@ else
   PASS=$((PASS + 1)); echo "  ✓ extracted jq detection program from source"
   # GraphQL-shaped fixture (models `gh api graphql` output) covering all six cases.
   # project_number ($pn) = 6. Titles are unique so present/absent asserts key on them.
-  # #101 / #106 are drift; #102 / #103 / #104 / #105 must be excluded. The bare {} node
-  # in #101 mirrors GraphQL emitting non-single-select fieldValues as empty objects.
+  # #101 / #103 / #106 are drift; #102 / #104 / #105 must be excluded. The stateReason
+  # values are retained (the query no longer selects the field) so the two closure reasons
+  # sit side by side and a reintroduced closure-reason filter drops #103 and fails here.
+  # The bare {} node in #101 mirrors GraphQL emitting non-single-select fieldValues as
+  # empty objects.
   fixture=$(cat <<'JSON'
 { "data": { "repository": { "issues": { "nodes": [
   { "number": 101, "title": "drift case", "stateReason": "COMPLETED",
@@ -194,9 +213,9 @@ else
   { "number": 102, "title": "done excluded", "stateReason": "COMPLETED",
     "projectItems": { "nodes": [ { "project": { "number": 6 },
       "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "Done" } ] } } ] } },
-  { "number": 103, "title": "not_planned excluded", "stateReason": "NOT_PLANNED",
+  { "number": 103, "title": "not_planned drift", "stateReason": "NOT_PLANNED",
     "projectItems": { "nodes": [ { "project": { "number": 6 },
-      "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "In Review" } ] } } ] } },
+      "fieldValues": { "nodes": [ { "field": { "name": "Status" }, "name": "Todo" } ] } } ] } },
   { "number": 104, "title": "not on board", "stateReason": "COMPLETED",
     "projectItems": { "nodes": [] } },
   { "number": 105, "title": "other project", "stateReason": "COMPLETED",
@@ -216,13 +235,13 @@ JSON
   else
     FAIL=$((FAIL + 1)); FAILURES+=("jq pipeline errored (rc=$jq_rc)"); echo "  ✗ jq pipeline errored (rc=$jq_rc)" >&2
   fi
-  # Exactly two drift rows — guards over-detection (e.g. a broken on-board scope letting
+  # Exactly three drift rows — guards over-detection (e.g. a broken on-board scope letting
   # not-on-board / other-project issues through). Count lines carrying a TAB separator.
   line_count=$(printf '%s\n' "$actual" | grep -c $'\t' || true)
-  if [ "$line_count" -eq 2 ]; then
-    PASS=$((PASS + 1)); echo "  ✓ exactly 2 drift rows emitted"
+  if [ "$line_count" -eq 3 ]; then
+    PASS=$((PASS + 1)); echo "  ✓ exactly 3 drift rows emitted"
   else
-    FAIL=$((FAIL + 1)); FAILURES+=("expected 2 drift rows, got $line_count"); echo "  ✗ expected 2 drift rows, got $line_count" >&2
+    FAIL=$((FAIL + 1)); FAILURES+=("expected 3 drift rows, got $line_count"); echo "  ✗ expected 3 drift rows, got $line_count" >&2
   fi
   # Case 1: COMPLETED + on-board(6) + Status="In Review" -> drift, status carried through.
   assert_present "$actual" "$(printf '101\tIn Review\tdrift case')" "case1: COMPLETED on-board non-Done -> drift row"
@@ -230,8 +249,8 @@ JSON
   assert_present "$actual" "$(printf '106\t<no-status>\tno-status boundary')" "case6: on-board without Status field -> <no-status> drift"
   # Case 2: Status already Done -> excluded.
   assert_absent "$actual" "done excluded" "case2: Status=Done excluded (AC-1)"
-  # Case 3: NOT_PLANNED closure -> excluded.
-  assert_absent "$actual" "not_planned excluded" "case3: NOT_PLANNED excluded (AC-2)"
+  # Case 3: NOT_PLANNED closure on a non-Done board row -> drift, same as COMPLETED.
+  assert_present "$actual" "$(printf '103\tTodo\tnot_planned drift')" "case3: NOT_PLANNED on-board non-Done -> drift row"
   # Case 4: not on the board (empty projectItems) -> excluded.
   assert_absent "$actual" "not on board" "case4: not-on-board excluded"
   # Case 5: on a different project (number != pn) -> excluded.
@@ -292,6 +311,110 @@ if grep -qE 'MOCK ASSERTION FAILED|gh repo view failed' "$T8_DIR/stderr.txt" 2>/
   echo "  ✗ wrong owner/repo value or gh repo view fallback was hit" >&2
 else
   PASS=$((PASS + 1)); echo "  ✓ exact owner=o repo=r threaded to graphql, gh repo view never consulted"
+fi
+
+echo ""
+echo "[T-9] Behavioral: --reconcile drives Status -> Done for a wontfix/duplicate closure"
+# The reconcile path hands off to scripts/projects-status-update.sh, which is invoked by
+# absolute path and cannot be shimmed — so the assertion is made at the gh boundary that
+# helper drives. The shim answers both graphql shapes (the drift scan is the one carrying
+# `states: CLOSED`), serves the Status field options, and records the item-edit arguments.
+T9_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-board-drift-t9-XXXXXX")
+trap 'rm -rf "${tmpd:-}" "$T8_DIR" "$T9_DIR"' EXIT
+mkdir -p "$T9_DIR/repo/bin"
+( cd "$T9_DIR/repo" && git init -q && git remote add origin "git@github.com:o/r.git" ) >/dev/null 2>&1
+cat > "$T9_DIR/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$T9_DIR/repo/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "api graphql")
+    if printf '%s\n' "$*" | grep -q 'states: CLOSED'; then
+      cat <<'SCAN'
+{"data":{"repository":{"issues":{"nodes":[
+  {"number":103,"title":"closed as duplicate",
+   "projectItems":{"nodes":[{"project":{"number":1},
+     "fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"Todo"}]}}]}}
+]}}}}
+SCAN
+    else
+      cat <<'ITEM'
+{"data":{"repository":{"issue":{"url":"https://github.com/o/r/issues/103",
+  "projectItems":{"nodes":[{"id":"ITEM_103","project":{"id":"PROJ_1","number":1}}]}}}}}
+ITEM
+    fi ;;
+  "project field-list")
+    echo '{"fields":[{"id":"FIELD_STATUS","name":"Status","options":[{"id":"OPT_TODO","name":"Todo"},{"id":"OPT_DONE","name":"Done"}]}]}' ;;
+  "project item-edit")
+    printf '%s\n' "$*" > "$GH_ITEM_EDIT_LOG" ;;
+  *) exit 0 ;;
+esac
+GH_SHIM
+chmod +x "$T9_DIR/repo/bin/gh"
+set +e
+t9_out=$(cd "$T9_DIR/repo" && PATH="$T9_DIR/repo/bin:$PATH" GH_ITEM_EDIT_LOG="$T9_DIR/item-edit.args" \
+  bash "$DRIFT_SH" --reconcile --quiet 2>"$T9_DIR/stderr.txt")
+t9_rc=$?
+set -e
+# exit 1 = drift detected (reconcile does not clear the finding); the summary proves the
+# helper reported success rather than a swallowed failure.
+if [ "$t9_rc" -eq 1 ] && printf '%s' "$t9_out" | grep -q 'reconcile summary: 1 updated, 0 failed'; then
+  PASS=$((PASS + 1)); echo "  ✓ reconcile reports 1 updated, 0 failed (exit 1 = drift detected)"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-9: expected exit 1 + '1 updated, 0 failed', got rc=$t9_rc; stdout: $(printf '%s' "$t9_out" | tr '\n' ' ' | head -c 300)")
+  echo "  ✗ reconcile summary wrong (exit $t9_rc)" >&2
+fi
+assert_present "$t9_out" "-> reconciled to Done" "T-9: finding row carries the reconciled marker"
+if [ -f "$T9_DIR/item-edit.args" ] && grep -q -- '--single-select-option-id OPT_DONE' "$T9_DIR/item-edit.args"; then
+  PASS=$((PASS + 1)); echo "  ✓ item-edit called with the Done option id"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-9: item-edit not called with Done option id (args: $(cat "$T9_DIR/item-edit.args" 2>/dev/null | head -c 300))")
+  echo "  ✗ item-edit not called with the Done option id" >&2
+fi
+
+echo ""
+echo "[T-10] Behavioral: a failing scan exits 2 with a diagnostic (never 1 = 'drift detected')"
+# lint Phase 3.18 reads exit 1 as a drift warning, so an API/pipeline failure must not
+# borrow that code — it exits 2 and says why.
+T10_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-board-drift-t10-XXXXXX")
+trap 'rm -rf "${tmpd:-}" "$T8_DIR" "$T9_DIR" "$T10_DIR"' EXIT
+mkdir -p "$T10_DIR/repo/bin"
+( cd "$T10_DIR/repo" && git init -q && git remote add origin "git@github.com:o/r.git" ) >/dev/null 2>&1
+cat > "$T10_DIR/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$T10_DIR/repo/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "api graphql")
+    echo "HTTP 502: Bad gateway" >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+GH_SHIM
+chmod +x "$T10_DIR/repo/bin/gh"
+set +e
+(cd "$T10_DIR/repo" && PATH="$T10_DIR/repo/bin:$PATH" bash "$DRIFT_SH" --quiet >"$T10_DIR/stdout.txt" 2>"$T10_DIR/stderr.txt")
+t10_rc=$?
+set -e
+if [ "$t10_rc" -eq 2 ]; then
+  PASS=$((PASS + 1)); echo "  ✓ graphql failure exits 2 (invocation error, not drift)"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-10: expected exit 2, got $t10_rc"); echo "  ✗ expected exit 2, got $t10_rc" >&2
+fi
+if grep -q 'ERROR: gh api graphql or jq pipeline failed' "$T10_DIR/stderr.txt" && \
+   grep -q 'gh: HTTP 502' "$T10_DIR/stderr.txt"; then
+  PASS=$((PASS + 1)); echo "  ✓ stderr carries the ERROR line and the captured gh diagnostic"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-10: missing ERROR line or gh diagnostic: $(head -c 300 "$T10_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ stderr missing the ERROR line or the gh diagnostic" >&2
 fi
 
 echo ""

--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -370,8 +370,9 @@ else
   FAIL=$((FAIL + 1)); FAILURES+=("T-9: expected exit 1 + '1 updated, 0 failed', got rc=$t9_rc; stdout: $(printf '%s' "$t9_out" | tr '\n' ' ' | head -c 300)")
   echo "  ✗ reconcile summary wrong (exit $t9_rc)" >&2
 fi
-# findings 行は行まるごと固定する。部分一致だけだと script L270 の書式が壊れても通ってしまい、
-# 契約が「現行のまま維持する」と規定した唯一の出力を誰も守らなくなる。
+# findings 行は行まるごと固定する。部分一致だけだと script の findings 行を emit する echo
+# (`[projects-board-drift] #N ...`) の書式が壊れても通ってしまい、契約が「現行のまま維持する」と
+# 規定した唯一の出力を誰も守らなくなる。
 assert_present "$t9_out" "$(printf '[projects-board-drift] #103 "closed as duplicate" status="Todo" (expected Done) -> reconciled to Done')" \
   "T-9: findings 行形式が維持されている"
 # lint Phase 3.18 が機械読みする件数 sentinel。0 固定などの退行は exit 1 と矛盾したまま

--- a/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
+++ b/plugins/rite/hooks/tests/projects-board-drift-check.test.sh
@@ -17,6 +17,8 @@
 #        closure reason that used to be excluded (offline, gh shim records the item-edit)
 #  T-10: behavioral — a failing GraphQL scan exits 2 with a diagnostic, so lint never
 #        misreads an invocation/API error as "drift detected" (exit 1)
+#  T-11: behavioral — a failed reconcile surfaces the Status-update helper's warnings on
+#        stderr (the helper puts them only in its stdout JSON), exercising the non-quiet path
 #
 # Usage: bash plugins/rite/hooks/tests/projects-board-drift-check.test.sh
 set -euo pipefail
@@ -368,7 +370,14 @@ else
   FAIL=$((FAIL + 1)); FAILURES+=("T-9: expected exit 1 + '1 updated, 0 failed', got rc=$t9_rc; stdout: $(printf '%s' "$t9_out" | tr '\n' ' ' | head -c 300)")
   echo "  ✗ reconcile summary wrong (exit $t9_rc)" >&2
 fi
-assert_present "$t9_out" "-> reconciled to Done" "T-9: finding row carries the reconciled marker"
+# findings 行は行まるごと固定する。部分一致だけだと script L270 の書式が壊れても通ってしまい、
+# 契約が「現行のまま維持する」と規定した唯一の出力を誰も守らなくなる。
+assert_present "$t9_out" "$(printf '[projects-board-drift] #103 "closed as duplicate" status="Todo" (expected Done) -> reconciled to Done')" \
+  "T-9: findings 行形式が維持されている"
+# lint Phase 3.18 が機械読みする件数 sentinel。0 固定などの退行は exit 1 と矛盾したまま
+# 「drift なし」と読ませるため、実件数まで含めて固定する。
+assert_present "$t9_out" '==> Total projects-board-drift findings: 1' \
+  "T-9: 件数 sentinel が実件数を報告する"
 if [ -f "$T9_DIR/item-edit.args" ] && grep -q -- '--single-select-option-id OPT_DONE' "$T9_DIR/item-edit.args"; then
   PASS=$((PASS + 1)); echo "  ✓ item-edit called with the Done option id"
 else
@@ -415,6 +424,67 @@ if grep -q 'ERROR: gh api graphql or jq pipeline failed' "$T10_DIR/stderr.txt" &
 else
   FAIL=$((FAIL + 1)); FAILURES+=("T-10: missing ERROR line or gh diagnostic: $(head -c 300 "$T10_DIR/stderr.txt" | tr '\n' ' ')")
   echo "  ✗ stderr missing the ERROR line or the gh diagnostic" >&2
+fi
+
+echo ""
+echo "[T-11] Behavioral: a failed reconcile surfaces the helper's warnings on stderr"
+# projects-status-update.sh は non_blocking の handled failure で自身の stderr へ何も書かず、
+# 診断を stdout JSON の .warnings[] にのみ載せる。呼び出し側が .result しか読まないと失敗理由が
+# 全出力から消えるため、その転記経路を pin する。--quiet を付けずに走らせるのは、非 quiet の
+# stderr 経路がどのテストからも踏まれていなかったため。
+T11_DIR=$(mktemp -d "${TMPDIR:-/tmp}/rite-board-drift-t11-XXXXXX")
+trap 'rm -rf "${tmpd:-}" "$T8_DIR" "$T9_DIR" "$T10_DIR" "$T11_DIR"' EXIT
+mkdir -p "$T11_DIR/repo/bin"
+( cd "$T11_DIR/repo" && git init -q && git remote add origin "git@github.com:o/r.git" ) >/dev/null 2>&1
+cat > "$T11_DIR/repo/rite-config.yml" <<'YAML'
+github:
+  projects:
+    enabled: true
+    project_number: 1
+YAML
+cat > "$T11_DIR/repo/bin/gh" <<'GH_SHIM'
+#!/bin/bash
+case "$1 $2" in
+  "api graphql")
+    if printf '%s\n' "$*" | grep -q 'states: CLOSED'; then
+      cat <<'SCAN'
+{"data":{"repository":{"issues":{"nodes":[
+  {"number":103,"title":"closed as duplicate",
+   "projectItems":{"nodes":[{"project":{"number":1},
+     "fieldValues":{"nodes":[{"field":{"name":"Status"},"name":"Todo"}]}}]}}
+]}}}}
+SCAN
+    else
+      cat <<'ITEM'
+{"data":{"repository":{"issue":{"url":"https://github.com/o/r/issues/103",
+  "projectItems":{"nodes":[{"id":"ITEM_103","project":{"id":"PROJ_1","number":1}}]}}}}}
+ITEM
+    fi ;;
+  "project field-list")
+    echo '{"fields":[{"id":"FIELD_STATUS","name":"Status","options":[{"id":"OPT_TODO","name":"Todo"},{"id":"OPT_DONE","name":"Done"}]}]}' ;;
+  "project item-edit")
+    echo "HTTP 403: Resource not accessible by integration" >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+GH_SHIM
+chmod +x "$T11_DIR/repo/bin/gh"
+set +e
+t11_out=$(cd "$T11_DIR/repo" && PATH="$T11_DIR/repo/bin:$PATH" bash "$DRIFT_SH" --reconcile 2>"$T11_DIR/stderr.txt")
+t11_rc=$?
+set -e
+if [ "$t11_rc" -eq 1 ] && printf '%s' "$t11_out" | grep -q 'reconcile summary: 0 updated, 1 failed'; then
+  PASS=$((PASS + 1)); echo "  ✓ failed reconcile is counted (0 updated, 1 failed) and still exits 1"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-11: expected exit 1 + '0 updated, 1 failed', got rc=$t11_rc; stdout: $(printf '%s' "$t11_out" | tr '\n' ' ' | head -c 300)")
+  echo "  ✗ reconcile failure summary wrong (exit $t11_rc)" >&2
+fi
+if grep -q 'projects-board-drift: reconcile #103:' "$T11_DIR/stderr.txt" && \
+   grep -q 'HTTP 403' "$T11_DIR/stderr.txt"; then
+  PASS=$((PASS + 1)); echo "  ✓ helper warnings (with the underlying gh error) reach stderr"
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("T-11: helper warnings missing from stderr: $(head -c 300 "$T11_DIR/stderr.txt" | tr '\n' ' ')")
+  echo "  ✗ helper warnings did not reach stderr" >&2
 fi
 
 echo ""

--- a/plugins/rite/skills/lint/references/plugin-checks-rationale.md
+++ b/plugins/rite/skills/lint/references/plugin-checks-rationale.md
@@ -93,7 +93,9 @@ A block is flagged only when it exhibits **2 or more** of these signals (a singl
 
 ## Projects board drift check (projects-board-drift-check.sh)
 
-Detects the "CLOSED+COMPLETED but board != Done" reconciliation gap. A `Done` transition is only wired into `/rite:cleanup` (ステップ8 → `skills/cleanup/references/archive-procedures.md` Phase 3.2) and `/rite:issue-close` (Shared: Projects Status → Done), but GitHub auto-closes an Issue the moment a PR carrying `Closes #N` merges. When `/rite:cleanup` is not run afterwards, the board freezes at its last value (In Review for a ready Issue, Todo for an untouched one) and no reconciler picks it back up. The check scans recently-updated CLOSED Issues whose `stateReason` is `COMPLETED` and reports those that are on the project board with Status != "Done". Closure reason `NOT_PLANNED` (wontfix / duplicate) is intentionally excluded, and Issues that are not on the board are not drift (no board Status to reconcile).
+Detects the "CLOSED but board != Done" reconciliation gap. A `Done` transition is only wired into `/rite:cleanup` (ステップ8 → `skills/cleanup/references/archive-procedures.md` Phase 3.2) and `/rite:issue-close` (Shared: Projects Status → Done), but GitHub auto-closes an Issue the moment a PR carrying `Closes #N` merges. When `/rite:cleanup` is not run afterwards, the board freezes at its last value (In Review for a ready Issue, Todo for an untouched one) and no reconciler picks it back up. The check scans recently-updated CLOSED Issues and reports those that are on the project board with Status != "Done".
+
+The closure reason is deliberately not consulted. The board's Status field carries no Cancelled-equivalent terminal option (Todo / In Progress / In Review / Done), so a `NOT_PLANNED` closure — wontfix, duplicate — has nowhere to land other than Done; filtering it out only strands it in a non-terminal column that nothing else revisits. Issues that are not on the board remain outside the check (there is no board Status to reconcile), which is what keeps `--reconcile` from quietly adding rows to the board.
 
 ## Number reference check (number-reference-check.sh)
 


### PR DESCRIPTION
## 概要

`projects-board-drift-check.sh` の検出条件から closure reason の限定を外し、board 上に存在して Status != Done の CLOSED Issue を、`stateReason` の値に関わらず drift として検出・reconcile する。

board の Status フィールドには Cancelled 相当の終端値が無く（Todo / In Progress / In Review / Done の 4 つ）、wontfix / 重複としてクローズした Issue の行き先も Done しかない。にもかかわらず検出条件が COMPLETED に限定されていたため、そうした Issue は Todo 列に滞留したまま自動チェックの対象外になり、手動棚卸しでしか拾えなかった。

## 関連 Issue

Closes #2226

## 変更内容

- `plugins/rite/hooks/scripts/projects-board-drift-check.sh`
  - jq 検出 filter を `select($i.stateReason == "COMPLETED" and $pitem != null)` から `select($pitem != null)` へ変更
  - 参照しなくなった GraphQL query の `stateReason` フィールドを削除
  - ヘッダ / usage / jq 直前コメント / 検出時 WARNING（`CLOSED/COMPLETED but board Status=` → `CLOSED but board Status=`）を closure reason 非依存の表現へ更新
- `plugins/rite/hooks/tests/projects-board-drift-check.test.sh`
  - T-5 の静的アサーションを新 filter 形（`select($pitem != null)`）の検査へ差し替え、`stateReason` がソースに残っていないことの absence アサーションを追加
  - T-7 fixture の NOT_PLANNED ケース（#103）を除外ケースから検出ケースへ移し、期待 drift 行数を 2 → 3 へ
  - T-9 を追加: `--reconcile` が wontfix / 重複クローズに対して Status 更新 helper を Done option id で駆動することを、gh shim が記録した `item-edit` 引数で検証
  - T-10 を追加: GraphQL 失敗時に exit 2（lint が drift 警告と読む exit 1 ではない）と診断出力が維持されることを検証
- `plugins/rite/skills/lint/references/plugin-checks-rationale.md`: 該当節から除外の記述を削除し、board に終端値が 1 つしか無いことを根拠とする rationale へ書き換え
- `docs/SPEC.md`: ディレクトリツリーのコメントと hooks/scripts 一覧の説明を新仕様へ同期

CLI インターフェース（`--dry-run` / `--reconcile` / `--quiet` / `--limit`）、stdout の findings 行形式、`Total projects-board-drift findings: N` の sentinel はいずれも不変のため、lint 側の result pattern は変更していない。

## 実装中の判断・計画逸脱

- 逸脱: Issue の Target Files に無い `docs/SPEC.md` を更新した — 同ファイルの 2 箇所が旧仕様（`CLOSED+COMPLETED` / `NOT_PLANNED excluded`）を記述しており、ドキュメント影響調査で stale と判定したため同一コミットで同期した
- 判断: 追加テストは新規ファイルを作らず既存 suite（`projects-board-drift-check.test.sh`）へ追記した — Complexity S レーンの生産量制約に従い、検証は既存 suite への assert 追加で行うため
- 判断: T-7 fixture の `stateReason` フィールドは query から消えた後も残した — 2 つの closure reason が並んで検出されることが、限定を再導入した際に fixture が落ちる根拠になるため

## 検証

- `bash plugins/rite/hooks/tests/run-tests.sh` — 133/133 通過
- `bash plugins/rite/hooks/tests/projects-board-drift-check.test.sh` — 37/37 通過（変更前は該当 4 アサーションが Red）
- プラグイン固有チェック 19 件を実行し、本 PR の変更ファイルを指す findings が 0 件であることを確認。`projects-board-drift-check` 自身は実 board に対して 0 findings（新 filter の過検出なし）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)

<!-- rite:nbr:comment-id:5235693915 -->
