### PR TITLE
fix(wiki): 日本語タイトルの C1 誤検出を修正

### DIFF
--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1199,20 +1199,39 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-050: C1 8-bit byte (0x9b CSI) in --title → exit 1
+# TC-050: Japanese UTF-8 title whose continuation bytes overlap C1 → exit 0
 # --------------------------------------------------------------------------
-# TC-018 (newline in title) と対になる C1 側 pin。SOURCE_REF / TITLE は隣接する
-# YAML キーに着地するため、検出範囲も対称であることを保証する。
-echo "TC-050: C1 0x9b in --title → exit 1"
+# 静 (E9 9D 99) / 的 (E7 9A 84) の UTF-8 継続バイトは 0x80-0x9f と
+# 重なる。TITLE は human-readable text なので C0 + DEL だけを拒否する。
+echo "TC-050: Japanese UTF-8 in --title → exit 0"
 dir50="$TEST_DIR/tc50"
 mkdir -p "$dir50"
 echo "x" > "$dir50/body.md"
-( cd "$dir50" && bash "$HOOK" --type reviews --source-ref pr-1 --content-file body.md --title $'foo\x9bbar' >/dev/null 2>err.log ) && rc=0 || rc=$?
-if [ $rc -eq 1 ] && grep -q 'control characters' "$dir50/err.log"; then
-  pass "C1 0x9b in title → exit 1 (SOURCE_REF と対称の C1 reject)"
+( cd "$dir50" && bash "$HOOK" --type reviews --source-ref pr-1 --content-file body.md --title '静的 pin' >out.log 2>err.log ) && rc=0 || rc=$?
+target_path50=$(cat "$dir50/out.log" 2>/dev/null || true)
+if [ $rc -eq 0 ] && [ -f "$dir50/$target_path50" ] && grep -q '^title: "静的 pin"$' "$dir50/$target_path50"; then
+  pass "Japanese UTF-8 title → exit 0 + title preserved"
 else
-  fail "Expected exit 1 'control characters', got rc=$rc, stderr=$(cat "$dir50/err.log")"
+  fail "Expected Japanese title to succeed and be preserved, got rc=$rc, stderr=$(cat "$dir50/err.log")"
 fi
+echo ""
+
+# --------------------------------------------------------------------------
+# TC-050b: C0 controls in --title remain rejected
+# --------------------------------------------------------------------------
+echo "TC-050b: C0 controls in --title → exit 1"
+for control_name in tab soh; do
+  dir50b="$TEST_DIR/tc50b-$control_name"
+  mkdir -p "$dir50b"
+  echo "x" > "$dir50b/body.md"
+  if [ "$control_name" = tab ]; then bad_title=$'foo\tbar'; else bad_title=$'foo\x01bar'; fi
+  ( cd "$dir50b" && bash "$HOOK" --type reviews --source-ref pr-1 --content-file body.md --title "$bad_title" >/dev/null 2>err.log ) && rc=0 || rc=$?
+  if [ $rc -eq 1 ] && grep -q 'control characters' "$dir50b/err.log"; then
+    pass "$control_name in title → exit 1"
+  else
+    fail "Expected $control_name in title to be rejected, got rc=$rc, stderr=$(cat "$dir50b/err.log")"
+  fi
+done
 echo ""
 
 # ==========================================================================

--- a/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
+++ b/plugins/rite/hooks/tests/wiki-ingest-trigger.test.sh
@@ -1217,16 +1217,21 @@ fi
 echo ""
 
 # --------------------------------------------------------------------------
-# TC-050b: C0 controls in --title remain rejected
+# TC-050b: C0/C1 controls and invalid UTF-8 in --title remain rejected
 # --------------------------------------------------------------------------
-echo "TC-050b: C0 controls in --title → exit 1"
-for control_name in tab soh; do
+echo "TC-050b: C0/C1 controls and invalid UTF-8 in --title → exit 1"
+for control_name in tab soh c1-codepoint raw-c1; do
   dir50b="$TEST_DIR/tc50b-$control_name"
   mkdir -p "$dir50b"
   echo "x" > "$dir50b/body.md"
-  if [ "$control_name" = tab ]; then bad_title=$'foo\tbar'; else bad_title=$'foo\x01bar'; fi
+  case "$control_name" in
+    tab) bad_title=$'foo\tbar' ;;
+    soh) bad_title=$'foo\x01bar' ;;
+    c1-codepoint) bad_title=$'foo\xc2\x9bbar' ;;
+    raw-c1) bad_title=$'foo\x9bbar' ;;
+  esac
   ( cd "$dir50b" && bash "$HOOK" --type reviews --source-ref pr-1 --content-file body.md --title "$bad_title" >/dev/null 2>err.log ) && rc=0 || rc=$?
-  if [ $rc -eq 1 ] && grep -q 'control characters' "$dir50b/err.log"; then
+  if [ $rc -eq 1 ] && grep -qE 'control characters|valid UTF-8' "$dir50b/err.log"; then
     pass "$control_name in title → exit 1"
   else
     fail "Expected $control_name in title to be rejected, got rc=$rc, stderr=$(cat "$dir50b/err.log")"

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -163,13 +163,20 @@ if [[ -n "$ISSUE_NUMBER" ]]; then
   esac
 fi
 
-# TITLE is human-readable UTF-8 text. Rejecting C1 byte values here would also
-# reject valid UTF-8 continuation bytes (for example, 静 contains 0x9d). C0 and
-# DEL are sufficient to keep the one-line YAML value intact; SOURCE_REF remains
-# on the stricter byte-oriented identifier policy above.
+# TITLE is human-readable UTF-8 text. Validate the encoding before checking C1
+# as its UTF-8 code-point encoding (C2 80-9F); testing those byte values alone
+# would reject ordinary continuation bytes (for example, 静 contains 0x9d).
 if [[ -n "$TITLE" ]]; then
-  if contains_ctrl "$TITLE" --c0-only; then
-    echo "ERROR: --title must not contain control characters (newlines, tabs, or other C0/DEL control bytes)" >&2
+  if ! command -v iconv >/dev/null 2>&1; then
+    echo "ERROR: --title validation requires iconv" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$TITLE" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+    echo "ERROR: --title must be valid UTF-8" >&2
+    exit 1
+  fi
+  if contains_ctrl "$TITLE" --c0-only || printf '%s' "$TITLE" | LC_ALL=C grep -q $'\302[\200-\237]'; then
+    echo "ERROR: --title must not contain control characters (C0/DEL/C1 code points)" >&2
     exit 1
   fi
   # reject odd trailing backslashes (escape ambiguity)

--- a/plugins/rite/hooks/wiki-ingest-trigger.sh
+++ b/plugins/rite/hooks/wiki-ingest-trigger.sh
@@ -163,14 +163,13 @@ if [[ -n "$ISSUE_NUMBER" ]]; then
   esac
 fi
 
-# Mirror the SOURCE_REF control-char rejection on TITLE — the two fields land
-# in adjacent YAML keys, so an asymmetric guard would leak the same injection
-# class through whichever side is unprotected. Byte-wise C1 detection also
-# rejects multibyte (e.g. Japanese) titles via their 0x80-0x9f continuation
-# bytes — accepted: all in-repo callers pass ASCII-fixed titles.
+# TITLE is human-readable UTF-8 text. Rejecting C1 byte values here would also
+# reject valid UTF-8 continuation bytes (for example, 静 contains 0x9d). C0 and
+# DEL are sufficient to keep the one-line YAML value intact; SOURCE_REF remains
+# on the stricter byte-oriented identifier policy above.
 if [[ -n "$TITLE" ]]; then
-  if contains_ctrl "$TITLE"; then
-    echo "ERROR: --title must not contain control characters (newlines, tabs, or other C0/DEL/C1 control bytes)" >&2
+  if contains_ctrl "$TITLE" --c0-only; then
+    echo "ERROR: --title must not contain control characters (newlines, tabs, or other C0/DEL control bytes)" >&2
     exit 1
   fi
   # reject odd trailing backslashes (escape ambiguity)


### PR DESCRIPTION
## 概要

`wiki-ingest-trigger.sh` の `--title` 検証を、UTF-8 の通常文字と実際の C1 制御コードポイントを区別できる方式へ変更しました。

## 変更内容

- `iconv` で title の UTF-8 妥当性を書き込み前に fail-fast 検証
- C0/DEL と UTF-8 符号化された U+0080–U+009F を拒否
- SOURCE_REF の厳格な C0/DEL/C1 バイト検査は維持
- `静的 pin` の保持と、C0・DEL・U+009B・raw C1 の拒否を回帰テストで固定

## 検証

- `wiki-ingest-trigger.test.sh` — 64 passed, 0 failed
- `control-char-neutralize.test.sh` — 36 passed, 0 failed
- Bash 構文検査、`git diff --check`
- Application / Test / Error Handling の3レビューで 0 findings

## Known Issues

- lint コマンド未設定のため、プロジェクト lint は未実行

Closes #2233
