### PR TITLE
feat(setup): GitHub 認証フローを Phase 1.3 に統合

### DIFF
--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -134,13 +134,34 @@ Display warning and continue (python3 is required for work memory parsing but no
 gh auth status
 ```
 
-If not authenticated, show:
+If not authenticated, use AskUserQuestion to ask whether to authenticate now.
+
+- If the user chooses to authenticate, show the following command and ask them to run it with Claude Code's `!` prefix so the interactive login owns the user's TTY:
+
+  ```text
+  ! gh auth login --web --scopes project
+  ```
+
+  If the `!` prefix is unavailable in the current environment, show `gh auth login --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
+- After the user reports that login is complete, run `gh auth status` again. Continue to Phase 1.4 only when it succeeds.
+- If verification still fails, show the command output and use AskUserQuestion to offer retrying authentication or stopping setup. On retry, repeat the login guidance and verification above; do not poll in a Bash loop.
+- If the user declines authentication, show:
+
 ```
 GitHub に認証されていません
 
-認証コマンド: `gh auth login`
+認証コマンド: `gh auth login --web --scopes project`
 ```
-and exit.
+
+  and exit without an error.
+
+If already authenticated, verify that the active token includes the `project` scope:
+
+```bash
+gh auth status --json hosts --jq '[.hosts[][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
+```
+
+If the result is not `true`, show `gh auth refresh -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
 
 ### 1.4 Retrieve Repository Information
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -139,10 +139,10 @@ If not authenticated, use AskUserQuestion to ask whether to authenticate now.
 - If the user chooses to authenticate, show the following command and ask them to run it with Claude Code's `!` prefix so the interactive login owns the user's TTY:
 
   ```text
-  ! gh auth login --web --scopes project
+  ! gh auth login --hostname github.com --web --scopes project
   ```
 
-  If the `!` prefix is unavailable in the current environment, show `gh auth login --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
+  If the `!` prefix is unavailable in the current environment, show `gh auth login --hostname github.com --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
 - After the user reports that login is complete, run `gh auth status` again. Continue to Phase 1.4 only when it succeeds.
 - If verification still fails, show the command output and use AskUserQuestion to offer retrying authentication or stopping setup. On retry, repeat the login guidance and verification above; do not poll in a Bash loop.
 - If the user declines authentication, show:
@@ -150,7 +150,7 @@ If not authenticated, use AskUserQuestion to ask whether to authenticate now.
 ```
 GitHub に認証されていません
 
-認証コマンド: `gh auth login --web --scopes project`
+認証コマンド: `gh auth login --hostname github.com --web --scopes project`
 ```
 
   and exit without an error.
@@ -158,10 +158,10 @@ GitHub に認証されていません
 If already authenticated, verify that the active token includes the `project` scope:
 
 ```bash
-gh auth status --json hosts --jq '[.hosts[][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
+gh auth status --json hosts --jq '[.hosts["github.com"][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
 ```
 
-If the result is not `true`, show `gh auth refresh -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
+If the result is not `true`, show `gh auth refresh --hostname github.com -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
 
 ### 1.4 Retrieve Repository Information
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -131,7 +131,7 @@ Display warning and continue (python3 is required for work memory parsing but no
 ### 1.3 Verify GitHub Authentication Status
 
 ```bash
-gh auth status
+gh auth status --active --hostname github.com
 ```
 
 If not authenticated, use AskUserQuestion to ask whether to authenticate now.
@@ -143,7 +143,7 @@ If not authenticated, use AskUserQuestion to ask whether to authenticate now.
   ```
 
   If the `!` prefix is unavailable in the current environment, show `gh auth login --hostname github.com --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
-- After the user reports that login is complete, run `gh auth status` again. Continue to Phase 1.4 only when it succeeds.
+- After the user reports that login is complete, run `gh auth status --active --hostname github.com` again. Continue to Phase 1.4 only when it succeeds.
 - If verification still fails, show the command output and use AskUserQuestion to offer retrying authentication or stopping setup. On retry, repeat the login guidance and verification above; do not poll in a Bash loop.
 - If the user declines authentication, show:
 
@@ -158,10 +158,10 @@ GitHub に認証されていません
 If already authenticated, verify that the active token includes the `project` scope:
 
 ```bash
-gh auth status --json hosts --jq '[.hosts["github.com"][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
+gh auth status --hostname github.com --json hosts --jq '[.hosts["github.com"][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
 ```
 
-If the result is not `true`, show `gh auth refresh --hostname github.com -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
+If the result is not `true`, show `gh auth refresh --hostname github.com -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status --active --hostname github.com` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
 
 ### 1.4 Retrieve Repository Information
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -136,13 +136,13 @@ gh auth status --active --hostname github.com
 
 If not authenticated, use AskUserQuestion to ask whether to authenticate now.
 
-- If the user chooses to authenticate, show the following command and ask them to run it with Claude Code's `!` prefix so the interactive login owns the user's TTY:
+- If the user chooses to authenticate, show the following command and ask them to run it with Claude Code's ！ prefix so the interactive login owns the user's TTY:
 
   ```text
   ! gh auth login --hostname github.com --web --scopes project
   ```
 
-  If the `!` prefix is unavailable in the current environment, show `gh auth login --hostname github.com --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
+  If the ！ prefix is unavailable in the current environment, show `gh auth login --hostname github.com --web --scopes project` for execution in another terminal and end setup with instructions to rerun `/rite:setup` after authentication.
 - After the user reports that login is complete, run `gh auth status --active --hostname github.com` again. Continue to Phase 1.4 only when it succeeds.
 - If verification still fails, show the command output and use AskUserQuestion to offer retrying authentication or stopping setup. On retry, repeat the login guidance and verification above; do not poll in a Bash loop.
 - If the user declines authentication, show:
@@ -161,7 +161,7 @@ If already authenticated, verify that the active token includes the `project` sc
 gh auth status --hostname github.com --json hosts --jq '[.hosts["github.com"][] | select(.active == true) | .scopes | split(",")[] | ltrimstr(" ")] | any(. == "project")'
 ```
 
-If the result is not `true`, show `gh auth refresh --hostname github.com -s project` and ask the user to run it (with `! ` when available). After the user reports completion, run `gh auth status --active --hostname github.com` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
+If the result is not `true`, show `gh auth refresh --hostname github.com -s project` and ask the user to run it (with the ！ prefix when available). After the user reports completion, run `gh auth status --active --hostname github.com` and the scope check again. Continue to Phase 1.4 only when both succeed. If verification fails, show the failure and use AskUserQuestion to offer retrying the refresh or stopping setup; do not poll in a Bash loop.
 
 ### 1.4 Retrieve Repository Information
 


### PR DESCRIPTION
## 概要

`/rite:setup` の Phase 1.3 で GitHub CLI の認証と `project` スコープを検証し、不足時は対話的な login / refresh と再検証へ案内します。

Closes #1994

## 変更内容

- 未認証時に `! gh auth login --web --scopes project` を案内
- TTY 起動が使えない環境では外部ターミナル実行と setup 再実行へフォールバック
- 認証済みトークンの `project` スコープを機械検査
- login / refresh 後の再検証と retry / stop 分岐を追加
- Bash の無限ポーリングを避け、ユーザーの完了合図で進行

## チェックリスト

- [x] MUST 要件を実装
- [x] Acceptance Criteria を確認
- [x] `git diff --check` 成功
- [x] 変更対象を Phase 1.3 のみに限定
