### PR TITLE
feat(setup): Phase 1.4 にリポジトリ作成フローを統合

### DIFF
--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -167,10 +167,59 @@ If the result is not `true`, show `gh auth refresh --hostname github.com -s proj
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) — 下記 snippet の `git-remote.sh` 呼び出しで使用する（未解決のまま実行すると git-remote.sh 経路が silent に失敗し、SSH host alias 環境で fallback の `gh repo view` も失敗する）。
 
+First classify the local repository before attempting GitHub resolution:
+
+```bash
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git_initialized=true
+  if [ -n "$(git remote -v 2>/dev/null)" ]; then remotes_present=true; else remotes_present=false; fi
+else
+  git_initialized=false
+  remotes_present=false
+fi
+echo "[CONTEXT] REPO_LOCAL_STATE; git_initialized=$git_initialized; remotes_present=$remotes_present"
+```
+
+Route by this marker:
+
+- `git_initialized=false`: use AskUserQuestion to confirm `git init`. If declined, show `GitHub リポジトリではありません` and exit without an error. If approved, run `git init`, verify success, then continue below.
+- `git_initialized=true; remotes_present=false`: continue below.
+- `remotes_present=true`: skip repository creation entirely and use the existing resolution path below. A remote that cannot be resolved may use an SSH host alias and MUST NOT be treated as an empty repository.
+
+Before creating an initial commit, check for an existing commit:
+
+```bash
+git rev-parse --verify HEAD >/dev/null 2>&1
+```
+
+If no commit exists, display the number and list of files that `git add -A` would include, then use AskUserQuestion to confirm the initial commit. If declined, exit without an error. If approved, run `git add -A` followed by `git commit -m "chore: initial commit"`; stop and show the command error if either operation fails. Do not create a commit when `HEAD` already exists.
+
+When `remotes_present=false`, use AskUserQuestion to collect the owner, repository name (default: current directory name), and exactly one visibility (`public`, `private`, or `internal`). Then use a separate AskUserQuestion to confirm the repository creation before running:
+
+```bash
+gh repo create "{owner}/{repo-name}" --source . --{visibility} --remote origin --push
+```
+
+The visibility flag is mandatory; never invoke the interactive form. If creation or push fails, display gh's stderr and use AskUserQuestion to offer retrying the same command or stopping. For a name collision, stop after showing these manual commands; do not execute them automatically:
+
+```text
+git remote add origin <existing-repository-url>
+git push -u origin <current-branch>
+```
+
+After successful creation, always display:
+
+```bash
+git remote get-url origin
+```
+
+If existing remotes in other local repositories or `~/.ssh/config` indicate a GitHub SSH alias, also show an informational `git remote set-url origin git@{alias}:{owner}/{repo-name}.git` example. Do not rewrite the URL automatically.
+
+For an existing remote, or after repository creation succeeds, resolve the repository through the existing SSH-alias-safe path:
+
 ```bash
 # owner/repo は SSH host alias 環境でも解決できる git-remote.sh を優先し、
-# id/url は解決済み repo を明示指定した gh repo view で取得する（明示指定なら alias 環境でも動く。
-# canonical: references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe）
+# id/url は解決済み repo を明示指定した gh repo view で取得する。
 owner_repo=$(bash {plugin_root}/hooks/scripts/lib/git-remote.sh resolve-owner-repo 2>/dev/null) || owner_repo=""
 owner=""; repo=""
 [ -n "$owner_repo" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo"
@@ -181,11 +230,7 @@ else
 fi
 ```
 
-If not a Git repository or not a GitHub repository, show:
-```
-GitHub リポジトリではありません
-```
-and exit.
+If this resolution fails while `remotes_present=true`, show `GitHub リポジトリではありません` and exit. Do not propose `gh repo create` on this path.
 
 ---
 

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -192,19 +192,28 @@ Before creating an initial commit, check for an existing commit:
 git rev-parse --verify HEAD >/dev/null 2>&1
 ```
 
-If no commit exists, display the number and list of files that `git add -A` would include, then use AskUserQuestion to confirm the initial commit. If declined, exit without an error. If approved, run `git add -A` followed by `git commit -m "chore: initial commit"`; stop and show the command error if either operation fails. Do not create a commit when `HEAD` already exists.
+If no commit exists, display the number and list of files that `git add -A` would include. Before asking for approval, scan those paths for likely sensitive files (`.env` and `.env.*`, private keys, `*.pem`, `*.p12`, credentials, and token/secret-named files). If any are found, do not stage or commit; show the paths and require the user to exclude or move them before rerunning setup. Never override this gate for a public repository. When the scan is clean, use AskUserQuestion to confirm the exact initial-commit file list. If declined, exit without an error. If approved, run `git add -A` followed by `git commit -m "chore: initial commit"`; stop and show the command error if either operation fails. Do not create a commit when `HEAD` already exists.
 
-When `remotes_present=false`, use AskUserQuestion to collect the owner, repository name (default: current directory name), and exactly one visibility (`public`, `private`, or `internal`). Then use a separate AskUserQuestion to confirm the repository creation before running:
+When `remotes_present=false`, use AskUserQuestion to collect the owner, repository name (default: current directory name), and exactly one visibility (`public`, `private`, or `internal`). Validate the owner against `^[A-Za-z0-9][A-Za-z0-9-]{0,38}$`, the repository name against `^[A-Za-z0-9._-]+$`, and the visibility against the three-value allowlist. Reject invalid values and ask again without executing a shell command. Map the selected visibility to one fixed flag; do not interpolate arbitrary text as an option. Bind the validated owner and repository name to shell variables and pass `"$owner/$repo_name"` as one argument. Then use a separate AskUserQuestion to confirm the repository creation before running:
 
 ```bash
-gh repo create "{owner}/{repo-name}" --source . --{visibility} --remote origin --push
+owner="{validated-owner}"
+repo_name="{validated-repo-name}"
+visibility_flag="{--public|--private|--internal}"
+gh repo create "$owner/$repo_name" --source . "$visibility_flag" --remote origin --push
 ```
 
-The visibility flag is mandatory; never invoke the interactive form. If creation or push fails, display gh's stderr and use AskUserQuestion to offer retrying the same command or stopping. For a name collision, stop after showing these manual commands; do not execute them automatically:
+The visibility flag is mandatory; never invoke the interactive form. If the command fails, display gh's stderr and probe both `gh repo view "$owner/$repo_name"` and `git remote get-url origin` before choosing recovery:
+
+- If neither repository nor origin exists, the create step failed before side effects. Use AskUserQuestion to offer retrying the create command or stopping.
+- If the repository and origin exist, treat this as a partial success in the push step. Resolve `current_branch=$(git branch --show-current)` and fail loudly if it is empty. Use AskUserQuestion to offer retrying only `git push -u origin "$current_branch"` or stopping; never rerun `gh repo create` on this path.
+- If only one of repository/origin exists, show the observed state and stop for manual recovery rather than guessing.
+
+For a name collision, resolve `current_branch=$(git branch --show-current)` and the existing repository URL with `gh repo view "$owner/$repo_name" --json url --jq .url`. Fail loudly if either is empty. Then stop after showing these commands with the resolved values; do not execute them automatically:
 
 ```text
-git remote add origin <existing-repository-url>
-git push -u origin <current-branch>
+git remote add origin {resolved-existing-repository-url}
+git push -u origin {resolved-current-branch}
 ```
 
 After successful creation, always display:


### PR DESCRIPTION
## 概要

`/rite:setup` Phase 1.4 に、git 未初期化または remote 空のプロジェクトを GitHub へ登録する対話フローを追加します。

Closes #1995

## 変更内容

- git 未初期化・remote 空・既存 remote の3状態を明確に分類
- 初回コミット前のファイル確認と承認を追加
- owner、repository name、visibility、作成実行の確認を追加
- `gh repo create --source . --push` の成功後に origin URL を表示
- SSH alias の既存 remote は作成候補にせず、alias URL 変更は案内のみに限定
- 名前衝突時の自動接続を禁止し、手動復旧コマンドだけを表示

## チェックリスト

- [x] MUST 要件を実装
- [x] Phase 1.4 のみに変更を限定
- [x] bang-backtick gate 成功
- [x] `git diff --check` 成功
