### PR TITLE
docs(getting-started): setup自動化への案内に薄化

### DIFF
--- a/plugins/rite/skills/getting-started/SKILL.md
+++ b/plugins/rite/skills/getting-started/SKILL.md
@@ -51,7 +51,7 @@ Required:
   ✓ gh CLI version ≥2.x
   ✓ git (any recent version)
   ✓ GitHub repository with Issues enabled
-  ✓ GitHub authentication (gh auth login)
+  ✓ GitHub authentication (`/rite:setup` guides login when needed)
 
 Optional:
   ○ GitHub Projects (recommended for workflow visualization)
@@ -91,13 +91,12 @@ gh auth status
 ```
 ⚠️ GitHub authentication required
 
-Please run:
-  gh auth login
-
-Then run this guide again.
+`/rite:setup` guides you through GitHub login and verifies the required
+permissions before continuing. You do not need to run a separate login
+command from this guide.
 ```
 
-Stop here if not authenticated.
+Continue the guide; Phase 3 directs the user to `/rite:setup`.
 
 ### 2.4 Verify Repository
 
@@ -119,11 +118,15 @@ gh repo view --json owner,name
 
 rite workflow requires a GitHub repository with Issues enabled.
 
-If this is a local repository, push it to GitHub first:
-  gh repo create --source . --push
+`/rite:setup` detects an uninitialized local directory or a repository with no
+remote and guides you through initialization, the first commit, repository
+creation, and push. You do not need to duplicate those commands here.
 ```
 
-Stop here if not a valid repository.
+Continue the guide; Phase 3 directs the user to `/rite:setup`. If a remote is
+already configured but cannot be resolved as GitHub, keep the SSH host alias
+note above as the troubleshooting path; setup does not propose creating a new
+repository for a non-empty remote.
 
 ---
 


### PR DESCRIPTION
## Summary

Getting Started の GitHub 認証・リポジトリ作成手順を `/rite:setup` への案内に薄化します。

Closes #1997

## Changes

- GitHub 未認証時の手動 `gh auth login` 手順を `/rite:setup` の案内へ置換
- GitHub リポジトリ未作成時の手動作成・push 手順を `/rite:setup` の案内へ置換
- SSH host alias 利用時の既存注意事項を維持

## Verification

- [x] `gh auth login` の手動コマンドが残っていないことを確認
- [x] `gh repo create --source` の手動コマンドが残っていないことを確認
- [x] Markdown の禁止パターン検査を通過
