### PR TITLE
fix(skills): 可逆な推奨判断を自律処理する

### DIFF
--- a/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
@@ -17,6 +17,18 @@ assert_grep() {
   fi
 }
 
+assert_not_grep() {
+  local label=$1
+  local file=$2
+  local pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'not ok - %s\n' "$label" >&2
+    failures=$((failures + 1))
+  else
+    printf 'ok - %s\n' "$label"
+  fi
+}
+
 assert_grep 'audit routes all pages to the shared gate' "$audit" \
   'All four are mechanized by the shared Documentation Fidelity Gate'
 assert_grep 'pivot page mechanized' "$audit" \
@@ -96,6 +108,14 @@ assert_grep 'review auto-records reversible recommendations' \
   "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'Decision Log への記録である候補は可逆なので質問せず推奨で処理'
 assert_grep 'review legacy gate covers automatic disposition' \
   "$ROOT/plugins/rite/skills/pr-review/SKILL.md" '自動 Decision Log 経路でも emit する'
+assert_not_grep 'iterate overview does not restore review error questions' \
+  "$ROOT/plugins/rite/skills/iterate/SKILL.md" 'その他 → AskUserQuestion'
+assert_not_grep 'iterate overview does not restore fix error questions' \
+  "$ROOT/plugins/rite/skills/iterate/SKILL.md" '`[fix:error]` → AskUserQuestion'
+assert_not_grep 'fix fallback does not offer a second review run' \
+  "$ROOT/plugins/rite/skills/fix/SKILL.md" '- レビュー実行: /rite:pr-review を起動してレビュー結果を生成する'
+assert_not_grep 'review overview does not require recommendation questions' \
+  "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'recommendations AskUserQuestion 等の処理本体'
 
 if [ "$failures" -ne 0 ]; then
   printf '%s contract assertion(s) failed\n' "$failures" >&2

--- a/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
 audit="$ROOT/plugins/rite/skills/pr-review/references/promotion-audit-2166.md"
 reviewer="$ROOT/plugins/rite/agents/_reviewer-base.md"
+principles="$ROOT/plugins/rite/skills/rite-workflow/references/coding-principles.md"
 failures=0
 
 assert_grep() {
@@ -67,6 +68,34 @@ assert_grep 'shared checklist maps the gate' "$reviewer" \
   '**Documentation fidelity (when triggered)**'
 assert_grep 'audit leaves blocking classification to measured gate' "$audit" \
   'classification remains the responsibility of the measured-confirmed gate'
+
+assert_grep 'question policy defines the two allowed classes' "$principles" \
+  'ユーザー固有の意思決定、または (b) merge、Issue close、外部公開、削除など不可逆操作'
+assert_grep 'question policy defaults reversible recommendations' "$principles" \
+  '質問せず推奨案で続行する'
+assert_grep 'question policy reuses existing records' "$principles" \
+  '新しい様式や marker を作らず'
+
+for skill in iterate fix ready merge cleanup pr-review; do
+  assert_grep "$skill points to the shared question policy" \
+    "$ROOT/plugins/rite/skills/$skill/SKILL.md" \
+    '[question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously)'
+done
+
+assert_grep 'iterate retries reversible review errors automatically' \
+  "$ROOT/plugins/rite/skills/iterate/SKILL.md" '可逆な再試行を推奨として 1 回だけ自動実行'
+assert_grep 'fix regenerates a missing review source automatically' \
+  "$ROOT/plugins/rite/skills/fix/SKILL.md" '推奨として `/rite:pr-review {pr_number}` を 1 回自動実行'
+assert_grep 'ready preserves standalone publication confirmation' \
+  "$ROOT/plugins/rite/skills/ready/SKILL.md" 'Ready 化は外部公開状態を変えるため、standalone 確認は維持する'
+assert_grep 'merge preserves irreversible approval boundary' \
+  "$ROOT/plugins/rite/skills/merge/SKILL.md" 'merge 自体は不可逆操作として既存の承認境界を維持する'
+assert_grep 'cleanup preserves destructive confirmation' \
+  "$ROOT/plugins/rite/skills/cleanup/SKILL.md" '削除・close・新規 Issue 公開は不可逆操作として確認を維持する'
+assert_grep 'review auto-records reversible recommendations' \
+  "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'Decision Log への記録である候補は可逆なので質問せず推奨で処理'
+assert_grep 'review legacy gate covers automatic disposition' \
+  "$ROOT/plugins/rite/skills/pr-review/SKILL.md" '自動 Decision Log 経路でも emit する'
 
 if [ "$failures" -ne 0 ]; then
   printf '%s contract assertion(s) failed\n' "$failures" >&2

--- a/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
+++ b/plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh
@@ -29,6 +29,18 @@ assert_not_grep() {
   fi
 }
 
+assert_grep_count() {
+  local label=$1 file=$2 pattern=$3 expected=$4
+  local actual
+  actual=$(grep -Fc -- "$pattern" "$file" || true)
+  if [ "$actual" = "$expected" ]; then
+    printf 'ok - %s\n' "$label"
+  else
+    printf 'not ok - %s (expected=%s actual=%s)\n' "$label" "$expected" "$actual" >&2
+    failures=$((failures + 1))
+  fi
+}
+
 assert_grep 'audit routes all pages to the shared gate' "$audit" \
   'All four are mechanized by the shared Documentation Fidelity Gate'
 assert_grep 'pivot page mechanized' "$audit" \
@@ -116,6 +128,19 @@ assert_not_grep 'fix fallback does not offer a second review run' \
   "$ROOT/plugins/rite/skills/fix/SKILL.md" '- レビュー実行: /rite:pr-review を起動してレビュー結果を生成する'
 assert_not_grep 'review overview does not require recommendation questions' \
   "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'recommendations AskUserQuestion 等の処理本体'
+assert_not_grep 'fix handoff does not restore caller questions' \
+  "$ROOT/plugins/rite/skills/fix/SKILL.md" 'after AskUserQuestion'
+assert_not_grep 'review retryable errors are not user prompts' \
+  "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'Retries are not performed automatically'
+
+# 対象 6 スキルの質問点を棚卸した inventory。新しい AskUserQuestion を追加すると
+# 文言が異なっても fail し、2 類型のどちらかへの分類と inventory 更新を必須化する。
+assert_grep_count 'iterate question inventory is unchanged' "$ROOT/plugins/rite/skills/iterate/SKILL.md" 'AskUserQuestion' 5
+assert_grep_count 'fix question inventory is unchanged' "$ROOT/plugins/rite/skills/fix/SKILL.md" 'AskUserQuestion' 13
+assert_grep_count 'ready question inventory is unchanged' "$ROOT/plugins/rite/skills/ready/SKILL.md" 'AskUserQuestion' 2
+assert_grep_count 'merge question inventory is unchanged' "$ROOT/plugins/rite/skills/merge/SKILL.md" 'AskUserQuestion' 2
+assert_grep_count 'cleanup question inventory is unchanged' "$ROOT/plugins/rite/skills/cleanup/SKILL.md" 'AskUserQuestion' 4
+assert_grep_count 'pr-review question inventory is unchanged' "$ROOT/plugins/rite/skills/pr-review/SKILL.md" 'AskUserQuestion' 35
 
 if [ "$failures" -ne 0 ]; then
   printf '%s contract assertion(s) failed\n' "$failures" >&2

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[branch_name]"
 
 # /rite:cleanup
 
+> **質問規律**: すべての質問・削除判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。PR/Issue/branch の削除・close・新規 Issue 公開は不可逆操作として確認を維持する。
+
 PR マージ後のクリーンアップを実行する。やることは以下のシーケンシャルなタスク列:
 
 0. flow-state を `phase=cleanup, active=true` に初期化

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -3600,7 +3600,7 @@ The `fix` flow-state write below records the v3 phase so a `/rite:recover` start
 **Handoff マーカー**: 結果に応じて 3 種類に分岐する (Stop hook による consume・再注入の機構解説: [stop-loop-continuation-contract.md#mechanism](../../references/stop-loop-continuation-contract.md#mechanism))。
 - **継続** (`[fix:pushed]` / `[fix:pushed-wm-stale]`): `--handoff "/rite:pr-review {pr_number}"` で**ループ継続マーカー**をセットする。
 - **正常終了** (`[fix:replied-only]`): `--handoff "FINALIZE:fix:replied-only:{pr_number}"` で**終了通知マーカー (FINALIZE handoff)** をセットする。
-- **エラー** (`[fix:error]`): `--handoff` を**付けない** (handoff はデフォルトクリア)。`[fix:error]` は clean terminal ではなく caller (`/rite:iterate` ステップ4) で AskUserQuestion (再試行/中止) に分岐するため、完了通知を強制してはならない。
+- **エラー** (`[fix:error]`): `--handoff` を**付けない** (handoff はデフォルトクリア)。`[fix:error]` は clean terminal ではなく caller (`/rite:iterate` ステップ4) で1回自動再試行し、再失敗時に停止するため、完了通知を強制してはならない。
 
 判定は本ステップ時点で**既に確定している入力**で行う (sentinel 評価テーブルより前だが、push 状態・fatal フラグ・本 cycle 内の accept 発生有無は ステップ 4.6 / 4.5 / 2.4 / 2.1.A / 1.0.1 で既知): **(`プッシュ: 完了` または 本 cycle 内で accept 決定が発生) かつ fatal フラグ (`FIX_FALLBACK_FAILED` / `REPLY_POST_FAILED` / `REPORT_POST_FAILED`) が context に未 set なら継続 = `--handoff "/rite:pr-review {pr_number}"`**。push 無し かつ 本 cycle 内で accept 決定なし かつ fatal フラグ未 set なら正常終了 = `--handoff "FINALIZE:fix:replied-only:{pr_number}"`。fatal フラグ有り (`[fix:error]`) なら `--handoff` なし。`WM_UPDATE_FAILED` は `[fix:pushed-wm-stale]` (= 継続) に縮退するため継続 handoff を打ち消さない。「本 cycle 内で accept 決定が発生」の判定条件（具体的な context マーカー、および累計値を使ってはならない理由）は ステップ 5.1 Output Pattern テーブル row 4/5 の直後の注記を**唯一の真実の源**として参照すること（重複記述はしない）。
 
@@ -3611,7 +3611,7 @@ The `fix` flow-state write below records the v3 phase so a `/rite:recover` start
 bash {plugin_root}/hooks/flow-state.sh set \
   --phase "fix" \
   --active true \
-  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上 after AskUserQuestion) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
+  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
   --handoff "/rite:pr-review {pr_number}" \
   --if-exists
 
@@ -3619,7 +3619,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 bash {plugin_root}/hooks/flow-state.sh set \
   --phase "fix" \
   --active true \
-  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上 after AskUserQuestion) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
+  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
   --handoff "FINALIZE:fix:replied-only:{pr_number}" \
   --if-exists
 
@@ -3627,7 +3627,7 @@ bash {plugin_root}/hooks/flow-state.sh set \
 bash {plugin_root}/hooks/flow-state.sh set \
   --phase "fix" \
   --active true \
-  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上 after AskUserQuestion) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
+  --next "rite:fix completed. Check recent result pattern in context: [fix:pushed]->caller の review-fix loop (/rite:pr-review を起動。範囲は 1.2.4 が cycle に応じて決定し、指摘の採否基準の緩和は禁止). [fix:pushed-wm-stale]->caller の review-fix loop (同上) with WM stale warning (work memory was not updated, manual intervention recommended). [fix:replied-only]->caller の Ready & 完結 step. Do NOT stop." \
   --if-exists
 ```
 

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -10,6 +10,8 @@ user-invocable: false
 
 # /rite:fix
 
+> **質問規律**: すべての質問・fallback 判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。
+
 PR レビューコメントを取得・整理し、指摘への対応を効率的に支援する。やることは以下のシーケンシャルなタスク列:
 
 0. Work Memory のロード (E2E フロー時のみ)
@@ -716,7 +718,7 @@ fi
 
 > **Acceptance Criteria anchor**: AC-6 (全ソース欠落時に `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示する)。
 
-`{review_source}=fallback` (Priority 0-3 が全て不可) の場合、`AskUserQuestion` で 3 択を提示する:
+`{review_source}=fallback` (Priority 0-3 が全て不可) の場合、レビュー再実行は可逆かつ自己解決可能なので推奨として `/rite:pr-review {pr_number}` を 1 回自動実行し、その判断と欠落 source を既存 work memory の決定事項へ記録する。再実行後も source が得られない場合だけ、ユーザー固有の入力であるファイルパス指定または中止を `AskUserQuestion` で確認する:
 
 ```
 レビュー結果が見つかりませんでした

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -716,7 +716,7 @@ fi
 
 #### 1.2.0.1 Interactive Fallback (when all sources missing) <!-- AC-6 -->
 
-> **Acceptance Criteria anchor**: AC-6 (全ソース欠落時に `AskUserQuestion` で「レビュー実行 / ファイルパス指定 / 中止」を提示する)。
+> **Acceptance Criteria anchor**: AC-6 (全ソース欠落時はレビューを 1 回自動再生成し、再度欠落した場合のみ `AskUserQuestion` で「ファイルパス指定 / 中止」を提示する)。
 
 `{review_source}=fallback` (Priority 0-3 が全て不可) の場合、レビュー再実行は可逆かつ自己解決可能なので推奨として `/rite:pr-review {pr_number}` を 1 回自動実行し、その判断と欠落 source を既存 work memory の決定事項へ記録する。再実行後も source が得られない場合だけ、ユーザー固有の入力であるファイルパス指定または中止を `AskUserQuestion` で確認する:
 
@@ -729,7 +729,6 @@ fi
 どうしますか？
 
 オプション:
-- レビュー実行: /rite:pr-review を起動してレビュー結果を生成する
 - ファイルパス指定: 既存の JSON ファイルパスを入力する (Other で自由入力)
 - 中止: /rite:fix の処理を終了する
 ```
@@ -738,7 +737,6 @@ fi
 
 | User Choice | Action |
 |-------------|--------|
-| **レビュー実行** (Recommended) | `skill: "rite:pr-review", args: "{pr_number}"` を invoke し、完了後 ステップ 1.2 を再入する。再入時は会話コンテキストに新鮮な review があるため Priority 1 が `use` で発火する |
 | **ファイルパス指定** | ユーザー入力パスで ステップ 1.2.0 Priority 0 を **1 回だけ** 再実行する。再実行でも invalid なら `[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_file_path_invalid` を emit して `[fix:error]` で terminate する (リトライループなし) |
 | **中止** | `[CONTEXT] FIX_FALLBACK_FAILED=1; reason=user_cancelled` を emit し `[fix:error]` を出力して terminate する。ステップ 2+ のロジックは一切実行しない |
 

--- a/plugins/rite/skills/iterate/SKILL.md
+++ b/plugins/rite/skills/iterate/SKILL.md
@@ -17,9 +17,9 @@ argument-hint: "<pr_number>"
 0. flow-state から issue_number / branch_name を復元
 0.6. cycle counter を初期化（fresh は 0 にリセット / resume は継続）+ `safety.max_review_cycles` を読込・検証
 1. 発火条件チェック（収束トレンドの発散 / `max_review_cycles` 到達）→ 不成立なら counter を +1 して `/rite:pr-review` を invoke / 成立なら サーキットブレーカー（ステップ 6）へ
-2. review sentinel を判定（`[review:mergeable]` → 終了 / `[review:fix-needed:N]` → ステップ 3 / その他 → AskUserQuestion）
+2. review sentinel を判定（`[review:mergeable]` → 終了 / `[review:fix-needed:N]` → ステップ 3 / error・不在 → 1 回自動再試行、再失敗時は停止）
 3. `/rite:fix` を invoke
-4. fix sentinel を判定（`[fix:pushed]` → ステップ 1 に戻る / `[fix:replied-only]` `[fix:cancelled-by-user]` → 終了 / `[fix:error]` → AskUserQuestion）
+4. fix sentinel を判定（`[fix:pushed]` → ステップ 1 に戻る / `[fix:replied-only]` `[fix:cancelled-by-user]` → 終了 / error・不在 → 1 回自動再試行、再失敗時は停止）
 5. 完了通知を出す
 6. （発火時のみ）サーキットブレーカー: run 境界を更新して post-breaker full review を 1 回実行し、結果を通常の review routing へ戻す。full review 自体が完了できない場合のみ、batch は `[iterate:max-cycles-reached]`、対話は `[iterate:max-cycles-stopped]` で従来どおり停止する
 

--- a/plugins/rite/skills/iterate/SKILL.md
+++ b/plugins/rite/skills/iterate/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "<pr_number>"
 
 # /rite:iterate
 
+> **質問規律**: すべての質問・再試行判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。
+
 `/rite:pr-review` ↔ `/rite:fix` を **blocking 指摘ゼロ（mergeable）になるまでループ** する（blocking の定義は [severity-levels.md §実測必須ゲート](../../references/severity-levels.md#実測必須ゲート-measured-confirmed-gate) が SoT。実測なし（`measured=false`）と判定された指摘は non-blocking として記録されたまま残存し、その状態で正常出口に到達しうる）。ただし **サーキットブレーカー** を備え、reviewer の非決定的な振動や非収束 PR による無限ループを構造的に防ぐ。やることは以下のシーケンシャルなタスク列:
 
 0. flow-state から issue_number / branch_name を復元
@@ -507,8 +509,8 @@ args: "{pr_number}"
 |---------|-----------|
 | `[review:mergeable]` | **ループ終了**（完了通知へ） |
 | `[review:fix-needed:N]` | ステップ 3 (fix invoke) へ |
-| `[review:error]` | AskUserQuestion で「再試行 / 中止」を提示 (sentinel 不在とは別経路で reviewer 側エラーを明示) |
-| sentinel 不在 | AskUserQuestion で「再試行 / 中止」を提示 |
+| `[review:error]` | 可逆な再試行を推奨として 1 回だけ自動実行し、work memory の既存決定事項へ理由を記録する。再失敗なら停止 |
+| sentinel 不在 | 可逆な再試行を推奨として 1 回だけ自動実行し、期待 sentinel と直近出力を既存 work memory へ記録する。再度不在なら停止 |
 
 ---
 
@@ -537,8 +539,8 @@ args: "{pr_number}"
 | `[fix:pushed-wm-stale]` | ステップ 1 に戻る (WM stale 警告は表示するが loop は継続。上限チェックはステップ 1 が実施) |
 | `[fix:replied-only]` | **ループ終了**（reply のみで完結） |
 | `[fix:cancelled-by-user]` | **ループ終了**（ユーザーが fix.md 内 cancel 経路 — ステップ 1.4 Cancel option / Fast Path Cancel handoff 等 — で中止選択。`/rite:recover` で再開可） |
-| `[fix:error]` | AskUserQuestion で「再試行 / 中止」を提示 |
-| sentinel 不在 | AskUserQuestion で「再試行 / 中止」を提示 (どの sentinel が期待されていたか、直近の fix 出力 100 行、flow-state phase を表示) |
+| `[fix:error]` | 可逆な再試行を推奨として 1 回だけ自動実行し、work memory の既存決定事項へ理由を記録する。再失敗なら停止 |
+| sentinel 不在 | 可逆な再試行を推奨として 1 回だけ自動実行し、期待 sentinel・直近の fix 出力 100 行・flow-state phase を既存 work memory へ記録する。再度不在なら停止 |
 
 ---
 
@@ -918,7 +920,7 @@ handoff 迂回のリスクは (b) には含めない。**counter reset の失敗
 ## エラー時の方針
 
 - ユーザーが Ctrl+C で中断した場合: flow-state に現 phase (review or fix) が残るので `/rite:recover` で本コマンドが再起動する (詳細な phase → command routing は [skills/recover/SKILL.md](../recover/SKILL.md) Phase 5.3 を参照)
-- `[fix:error]` 時: 自動継続せず必ず AskUserQuestion で確認 (silent regression 防止)
+- `[fix:error]` 時: [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従い 1 回だけ自動再試行し、再失敗時は停止する
 - reviewer が non-deterministic に振動 (毎 cycle で別の指摘) する場合: 収束トレンドの発散判定が先に発火し、それをすり抜けた場合も `safety.max_review_cycles`（既定 15）到達でサーキットブレーカーが発火する（ステップ 6）。発火後は人間に問わず full review を 1 回実行し、mergeable / fix-needed を通常 routing へ戻す。前処理失敗・`[review:error]`・sentinel 不在の場合のみ、batch は `[iterate:max-cycles-reached]` で当該 Issue を failed 扱いにして次へ進み、対話は `[iterate:max-cycles-stopped]` で停止する。Ctrl+C による手動中断も従来どおり可能
 
 ---

--- a/plugins/rite/skills/merge/SKILL.md
+++ b/plugins/rite/skills/merge/SKILL.md
@@ -11,6 +11,8 @@ argument-hint: "[--force-ci] <pr_number>"
 
 # /rite:merge
 
+> **質問規律**: すべての質問・再判定判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。merge 自体は不可逆操作として既存の承認境界を維持する。
+
 ## Contract
 
 **Input**: `[--force-ci]` + PR number (required)
@@ -91,7 +93,7 @@ echo "[CONTEXT] MERGE_CHECKS_STATE=$checks_state"
 | 状態 | アクション |
 |------|-----------|
 | `isDraft == true` | `[merge:not-ready]` emit + 「先に `/rite:ready {pr_number}` を実行してください」案内 + 終了 |
-| `mergeable != "MERGEABLE"` | `[merge:not-ready]` emit + 原因 (`mergeStateStatus`) 表示 + AskUserQuestion で「再判定 (`mergeStateStatus` を再取得して ステップ 1 をもう一度実行、1 回のみ) / 中止」を提示 |
+| `mergeable != "MERGEABLE"` | 再判定は可逆なので、原因 (`mergeStateStatus`) を表示・既存 work memory に記録して 1 回だけ自動再判定する。再度非 MERGEABLE なら `[merge:not-ready]` を emit して終了 |
 | `mergeable == "MERGEABLE"` + checks 0 件 | CI 未設定リポジトリとして従来どおりステップ 2 へ |
 | `mergeable == "MERGEABLE"` + checks が pending + `force_ci == false` | `[merge:not-ready]` emit + 「checks の完了を待って再実行」と表示して終了。待機・自動 retry はしない |
 | checks が pending + `force_ci == true` | 未完了 check の一覧を表示した後、ステップ 2 へ |

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -10,6 +10,8 @@ user-invocable: false
 
 # /rite:pr-review
 
+> **質問規律**: すべての質問・disposition 判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。
+
 PR の変更内容を解析し、専門家スキルを動的にロードしてマルチレビュアー方式でレビューを行う。やることは以下のシーケンシャルなタスク列:
 
 0. Work Memory のロード (E2E フロー時のみ)
@@ -48,7 +50,7 @@ bash 4.0+ 必須 (`mapfile` builtin の存在を bash 4+ 判定に使用。ス�
 | ステップ 4 (Sub-Agent Execution) | Full execution | **Full execution** — sub-agents MUST run in parallel for every review cycle (including verification mode). No shortcut allowed. |
 | ステップ 5 (Consolidation) | Full findings table | Result pattern + summary counts only。**例外 1: ステップ 5.4 の `### レビュー範囲（cycle 2+ 差分スコープ）` section は `REVIEW_CYCLE_SCOPE == incremental` のとき E2E でも省略禁止** (cycle 2+ は E2E からしか発生しないため、ここを minimize すると「スキップした reviewer を記録する」要求が空文になる — SoT: [cycle-scope.md](references/cycle-scope.md#選抜結果の記録を-e2e-で省略しない理由))。**例外 2: ステップ 5.4 の `### 実測なし指摘 (non-blocking)` section は `non_blocking_count > 0` のとき E2E でも省略禁止** (ステップ 7 AskUserQuestion と同じ identity 制約 — 既定 `post_comment: false` ではこの出力が非実測指摘を人間が見る唯一の同期経路であり、省略は「非実測指摘を破棄しない」という記録契約の喪失に直結する)。**例外 3: ステップ 5.4 の `### レビューレーン（XS/S 軽量レーン）` section は `COMPLEXITY_LANE == light` のとき E2E でも省略禁止** (軽量レーンが動機づけられた Scenario 1「XS が 1 サイクル収束して自律マージされる」は E2E ループでしか起きず、そこを minimize すると観測性の MUST が主対象シナリオでだけ空文になる — SoT: [complexity-lane.md](references/complexity-lane.md#選抜結果の記録を-e2e-で省略しない理由))。**例外 4: ステップ 5.4 の `### Guardrail 監査ログ` section は `guardrail_audit_count > 0` のとき E2E でも省略禁止** (既定 `post_comment: false` でも Category #2 の filter 判断を人間が確認できる同期経路を維持するため)。**例外 5: ステップ 5.4 の `### 総合評価` にある `**起動の直列化**` の 1 行は `SPAWN_SPREAD` が `serialized` / `undetermined` / 欠落を伴う `parallel` のとき E2E でも省略禁止** (直列化が起きるのは長時間 E2E セッションであり、そこを minimize すると本行が到達する経路が消える。既定 `post_comment: false` では統合レポートは PR にも載らないため、省略すると本行が主対象シナリオで空文になる。`serialized` / 欠落を伴う `parallel` では helper の stderr WARNING と結果 JSON のフラグが残るが、**`undetermined` では helper がフラグをキーごと書かない**ため、計測不能の**理由** (`reason=`) は揮発する stderr WARNING にしか残らない — 省略が最も高くつくのはこの条件。`reviewer_timings[]` はステップ 4.6 の timings ファイルが present のときだけ結果 JSON へ転記される) |
 | ステップ 6 (PR Comment) | Full comment + display | Post comment silently, output pattern only |
-| ステップ 7 (Triage) | Full report + guidance | **Recommendations only** — detect scope-irrelevant recommendations (findings/recommendations containing 別 Issue / スコープ外 keywords). **Always** prompt `AskUserQuestion` for each candidate (no E2E skip). Only when `[review:mergeable]`. |
+| ステップ 7 (Triage) | Full report + guidance | **Recommendations only** — detect scope-irrelevant recommendations (findings/recommendations containing 別 Issue / スコープ外 keywords). Decision Log 記録の推奨は可逆なので自動処理し、ユーザー固有・不可逆な disposition だけ `AskUserQuestion` で確認する。Only when `[review:mergeable]`. |
 
 E2E output format (ステップ 6, replaces full display):
 
@@ -3191,7 +3193,7 @@ Claude determines the invocation source from the conversation context:
 **Step 1: Process recommendation-based Issue candidates (ステップ 7)**
 Before outputting the result pattern, execute ステップ 7.1-7.4 to process recommendation-based Issue candidates:
 - Extract candidates per ステップ 7.1 (Source A scope-irrelevant findings and Source B recommendations — Source A findings not flagged as scope-irrelevant are handled by the fix loop)
-- If candidates exist: **always** invoke `AskUserQuestion` per ステップ 7.2-7.3 (E2E no longer skips user confirmation — user must approve each candidate)
+- If candidates exist: ステップ 7.2-7.3 で推奨を分類し、可逆な Decision Log 記録は自動処理、ユーザー固有・不可逆な候補だけ `AskUserQuestion` を invoke する
 - If no candidates: skip silently
 
 **Condition**: Execute only when the review result is `[review:mergeable]`. When `[review:fix-needed:N]`, skip ステップ 7 (the fix loop will continue; ステップ 7 will run on the eventual mergeable review to avoid duplicate Issue creation).
@@ -3231,7 +3233,7 @@ Extract candidates from **two sources**:
 **`candidate_count` assignment**:
 
 ステップ 7.1 deduplication 完了後、Source A + Source B 合算の最終 candidate 数を `candidate_count` として会話コンテキストに保持する。本値は:
-- ステップ 7.2 sentinel emit (`[CONTEXT] PHASE_7_ASKUSER_INVOKED=1; candidates={N}` の `{N}`) に literal substitute される
+- ステップ 7.2 disposition-entry sentinel emit (`[CONTEXT] PHASE_7_ASKUSER_INVOKED=1; candidates={N}` の `{N}`) に literal substitute される（marker 名は後方互換で維持し、自動 Decision Log 経路でも emit する）
 - ステップ 7.7 post-condition gate / ステップ 8.0.2 cross-reference の trigger 条件 (`candidate_count >= 1`) で参照される
 
 
@@ -3241,7 +3243,7 @@ Deduplicate across sources: if the same file:line appears in both Source A and S
 
 ### 7.2-7.3 推奨決定 + User Confirmation
 
-If 0 candidates: Skip ステップ 7 (and **skip ステップ 7.7 post-condition gate** — see 7.7 below). If 1+: **Always** confirm with `AskUserQuestion` — this confirmation is mandatory in both standalone and E2E flow. User must explicitly approve each candidate.
+If 0 candidates: Skip ステップ 7 (and **skip ステップ 7.7 post-condition gate** — see 7.7 below). If 1+: 推奨機械決定表の推奨が既存 Decision Log への記録である候補は可逆なので質問せず推奨で処理し、根拠を同じ Decision Log に残す。別 Issue 作成・本 PR への scope 追加・無視など外部公開またはユーザー固有の優先判断を伴う候補だけ `AskUserQuestion` で確認する。
 **推奨機械決定表**（裁量禁止。エージェントは自分の作業量を減らす目的で「別 Issue 作成」を推奨してはならない — 各候補の推奨は以下の表から機械的に決まる）:
 
 | 候補の性質 | 推奨 |
@@ -3251,9 +3253,9 @@ If 0 candidates: Skip ステップ 7 (and **skip ステップ 7.7 post-condition
 
 `{source_issue_number}`（ステップ 7.1 で解決）が空の候補は「Decision Log に記録」選択肢自体を非表示にする（3 択: 別 Issue 作成 / 本 PR で対応 / 無視。この場合は推奨を付与しない）。
 
-**MANDATORY — ステップ 7.2 sentinel emit**:
+**MANDATORY — ステップ 7.2 disposition-entry sentinel emit**:
 
-Immediately before invoking `AskUserQuestion`, emit the following sentinel to the conversation context so ステップ 7.7 post-condition gate can mechanically verify that ステップ 7.2 was executed:
+候補の disposition 処理を開始する直前（自動 Decision Log 経路では記録直前、質問経路では `AskUserQuestion` 直前）に、以下の既存 sentinel を emit してステップ 7.7 が実行を検証できるようにする。marker 名は互換性のため変更しない:
 
 ```bash
 # LLM (Claude) は以下を Bash tool で実行する前に literal 置換すること:
@@ -3263,7 +3265,7 @@ Immediately before invoking `AskUserQuestion`, emit the following sentinel to th
 echo "[CONTEXT] PHASE_7_ASKUSER_INVOKED=1; candidates={N}; iteration_id={iteration_id}" >&2
 ```
 
-Where `{N}` is the total count of candidates extracted in ステップ 7.1 (Source A + Source B, post-deduplication). `{iteration_id}` is a unique identifier per review iteration (recommended format: `${pr_number}-$(date +%s)`) so a later iteration of a review-fix loop does NOT false-positive match an earlier iteration's sentinel. This sentinel is consumed by ステップ 7.7 (post-condition gate) and ステップ 8.0.2 (gate reference) to verify that the LLM did NOT skip ステップ 7.2 when `candidate_count >= 1`. The sentinel MUST be emitted on stderr (not stdout) and MUST be included in the response text (stderr emit は Bash tool が transcript に取り込んで会話コンテキストに自動載せるが、grep 検出は response text 内の literal を直接参照するため LLM が response 内にも verbatim で含めることが SHOULD レベルの defensive practice として推奨される)。
+Where `{N}` is the total count of candidates extracted in ステップ 7.1 (Source A + Source B, post-deduplication). `{iteration_id}` is a unique identifier per review iteration (recommended format: `${pr_number}-$(date +%s)`) so a later iteration of a review-fix loop does NOT false-positive match an earlier iteration's sentinel. This sentinel is consumed by ステップ 7.7 (post-condition gate) and ステップ 8.0.2 (gate reference) to verify that the LLM did NOT skip disposition handling when `candidate_count >= 1`. The legacy name does not imply that every candidate was asked. The sentinel MUST be emitted on stderr (not stdout) and MUST be included in the response text (stderr emit は Bash tool が transcript に取り込んで会話コンテキストに自動載せるが、grep 検出は response text 内の literal を直接参照するため LLM が response 内にも verbatim で含めることが SHOULD レベルの defensive practice として推奨される)。
 
 **AskUserQuestion prompt text**:
 
@@ -3284,7 +3286,7 @@ Where `{N}` is the total count of candidates extracted in ステップ 7.1 (Sour
 - **Severity in Issue body**: `推奨事項（重要度なし）`
 - **File:line**: Use mentioned path if available; otherwise `特定ファイルなし`
 
-**E2E flow behavior**: Same as standalone — **always** present `AskUserQuestion` and wait for explicit user approval per candidate. Do NOT auto-decide disposition (Issue 作成 or Decision Log 記録) without user confirmation, even in E2E. Previous behavior (auto-create under E2E) has been removed to enforce user control over scope-irrelevant disposition.
+**E2E flow behavior**: Same as standalone. Decision Log 記録の推奨は可逆判断として自動実行し、Issue 作成・scope 追加・無視はユーザー固有または不可逆の判断として明示承認を待つ。Issue 作成を自動決定してはならない。
 
 ### 7.4 Disposition Execution
 
@@ -3529,7 +3531,7 @@ Post Issue list to PR comment (`mktemp` + `--body-file`). Decision Log に記録
 
 ### 7.7 Post-condition Gate — Recommendation Disposition Enforcement
 
-本 gate は **mechanical gate**。ステップ 7.1 で 1+ candidate 抽出時に ステップ 7.2 (`AskUserQuestion` for candidate_count) を実行せず `[review:mergeable]` / `[review:fix-needed:{n}]` (ステップ 8.1) を emit する silent skip を遮断する (prose-only enforcement の置換)。
+本 gate は **mechanical gate**。ステップ 7.1 で 1+ candidate 抽出時に ステップ 7.2 の disposition handling（自動 Decision Log または必要な `AskUserQuestion`）を実行せず `[review:mergeable]` / `[review:fix-needed:{n}]` (ステップ 8.1) を emit する silent skip を遮断する (prose-only enforcement の置換)。
 **Execution condition**: Always execute when ステップ 7 was entered (i.e., `candidate_count >= 1` (ステップ 7.1 Source A + Source B 合算、post-deduplication) was true). Skip silently when ステップ 7.1 yielded 0 candidates (ステップ 7.2 is legitimately not invoked).
 
 **Step 1 — Determine candidate count**:
@@ -3560,8 +3562,8 @@ Where `{N}` MUST be a positive integer matching the candidate count from Step 1,
 ```
 ERROR: ステップ 7.7 post-condition gate failed.
 candidate_count = {N} (>= 1) but no [CONTEXT] PHASE_7_ASKUSER_INVOKED sentinel found.
-This means ステップ 7.2 (AskUserQuestion) was NOT executed — silent skip of recommendation disposition.
-ACTION: Return to ステップ 7.2, emit the sentinel, invoke AskUserQuestion for each candidate, then re-enter ステップ 7.7.
+This means ステップ 7.2 disposition handling was NOT executed — silent skip of recommendation disposition.
+ACTION: Return to ステップ 7.2, emit the sentinel, auto-record reversible Decision Log recommendations and ask only user-specific/irreversible candidates, then re-enter ステップ 7.7.
 ⚠️ LLM MUST NOT output [review:mergeable] or [review:fix-needed:{n}] until ステップ 7.2 has been executed and the sentinel is emitted.
 ANTI-PATTERN reference: This gate enforces the prohibition declared in
 .rite/wiki/pages/anti-patterns/aggregate-recommendation-label-evasion.md
@@ -3698,8 +3700,8 @@ ACTION: Return to ステップ 6.5.W and execute the Wiki Ingest Trigger before 
 ```
 ERROR: ステップ 8.0.2 ステップ 7 Post-condition Gate failed.
 candidate_count = {N} (>= 1) but no current-cycle [CONTEXT] PHASE_7_ASKUSER_INVOKED sentinel found.
-This means ステップ 7 (entire procedure 7.1 candidate extraction → 7.2 AskUserQuestion → 7.7 gate) was NOT executed in the current review cycle.
-ACTION: Return to ステップ 7.1, extract candidates, invoke AskUserQuestion (ステップ 7.2), emit sentinel, then re-enter ステップ 8.0.
+This means ステップ 7 (entire procedure 7.1 candidate extraction → 7.2 disposition handling → 7.7 gate) was NOT executed in the current review cycle.
+ACTION: Return to ステップ 7.1, extract candidates, handle reversible recommendations automatically and ask only user-specific/irreversible candidates, emit sentinel, then re-enter ステップ 8.0.
 ⚠️ LLM MUST NOT output [review:mergeable] or [review:fix-needed:{n}] until ステップ 7 has been executed for the current cycle.
 ```
 

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -1294,7 +1294,7 @@ Determine the error type from the Task tool result. Claude analyzes the Task too
  - Proceed to ステップ 5 and generate the integrated report with only other reviewers' results
  - Include "{reviewer_type}: レビュー失敗" in the integrated report
 
-**Note**: Retries are not performed automatically. On error, prompt the user with AskUserQuestion to choose between retry or skip.
+**Note**: Timeout / network error / invalid output format は可逆で表の推奨が一意なため、質問せず 1 回だけ自動再試行する。再失敗後は当該 reviewer を incomplete として統合を続け、全 reviewer が resolution failure となる等、品質低下・中止に関するユーザー固有の判断が必要な場合だけ AskUserQuestion を使う。
 
 ### 4.5 Review Instruction Format
 

--- a/plugins/rite/skills/pr-review/SKILL.md
+++ b/plugins/rite/skills/pr-review/SKILL.md
@@ -41,8 +41,8 @@ bash 4.0+ 必須 (`mapfile` builtin の存在を bash 4+ 判定に使用。ス�
 
 ## E2E Output Minimization
 
-`/rite:iterate` E2E flow から呼ばれた時、ステップ 4 (sub-agent execution) は **full execution**、ステップ 5-7 の **人間向け出力** のみ minimize する。minimize されるのは出力のみで、sub-agent parallel execution / PR コメント投稿 / recommendations AskUserQuestion 等の処理本体は standalone と同等に実行する (時間・context を理由にした sub-agent 省略 / parallel 直列化 は identity 違反)。
-**AskUserQuestion の扱いは 2 種を区別する（#1861）**: ステップ 7 の recommendations トリアージ（結果整合性 = 未解決指摘・スコープ外指摘の握り潰し防止）は E2E でも **skip 禁止**（省略は identity 違反）。一方 ステップ 3.3 の pre-flight レビュアー構成確認は E2E で **skip 可**（iterate の自律ループ設計に合わせ flow-state ベース判定で機械的に skip する。詳細はステップ 3.3）。いずれの場合も `起動 reviewer {count} 名` サマリ行・省略された reviewer 表示・ステップ 4 のフルレビュー実行は省略しない。
+`/rite:iterate` E2E flow から呼ばれた時、ステップ 4 (sub-agent execution) は **full execution**、ステップ 5-7 の **人間向け出力** のみ minimize する。minimize されるのは出力のみで、sub-agent parallel execution / PR コメント投稿 / recommendation disposition 等の処理本体は standalone と同等に実行する (時間・context を理由にした sub-agent 省略 / parallel 直列化 は identity 違反)。
+**AskUserQuestion の扱いは 2 種を区別する（#1861）**: ステップ 7 の recommendations トリアージ（結果整合性 = 未解決指摘・スコープ外指摘の握り潰し防止）は E2E でも処理自体の **skip 禁止**（省略は identity 違反）だが、Decision Log への可逆な記録は自動処理し、ユーザー固有・不可逆な disposition だけ質問する。一方 ステップ 3.3 の pre-flight レビュアー構成確認は E2E で **skip 可**（iterate の自律ループ設計に合わせ flow-state ベース判定で機械的に skip する。詳細はステップ 3.3）。いずれの場合も `起動 reviewer {count} 名` サマリ行・省略された reviewer 表示・ステップ 4 のフルレビュー実行は省略しない。
 
 | Phase | Standalone | E2E Flow |
 |-------|-----------|----------|

--- a/plugins/rite/skills/ready/SKILL.md
+++ b/plugins/rite/skills/ready/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[pr_number]"
 
 # /rite:ready
 
+> **質問規律**: すべての質問・強制続行判断は [question_resolution](../rite-workflow/references/coding-principles.md#question_resolution-resolve-recommended-reversible-decisions-autonomously) に従う。Ready 化は外部公開状態を変えるため、standalone 確認は維持する。
+
 ## Contract
 **Input**: PR number (or auto-detected), flow state (optional, e2e flow)
 **Output**: `[ready:returned-to-caller]` | `[ready:error]`
@@ -139,7 +141,7 @@ bash "$plugin_root/hooks/scripts/ready-pr-head-gate.sh" \
   --pr "$ready_pr_number" --repo {owner_repo} --plugin-root "$plugin_root"
 ```
 
-> **On exit 1 from this bash block**: The bash block exits before any `skills/ready/SKILL.md` result pattern (`[ready:returned-to-caller]` / `[ready:error]`) is emitted, so the orchestrator treats this as a missing-result-pattern Skill invocation — default 経路は `WARNING` を stderr に出力し、AskUserQuestion で「再試行 / 強制続行 / 中止」を提示する — **NOT** a `[ready:error]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a stderr-only diagnostic; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no flag is set at all (the failure is expected and the user fixes the code).
+> **On exit 1 from this bash block**: The bash block exits before any `skills/ready/SKILL.md` result pattern (`[ready:returned-to-caller]` / `[ready:error]`) is emitted. Invocation failure is a reversible diagnostic action, so the orchestrator retries the gate once and records the reason in the existing work memory; a second failure emits `[ready:error]` and stops. It never offers an unverified force-continue path. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a stderr-only diagnostic. For finding detection (rc=1 — a normal "fix the code" feedback path), no flag is set at all (the failure is expected and the user fixes the code).
 
 ### 1.1 Check Arguments
 

--- a/plugins/rite/skills/rite-workflow/references/coding-principles.md
+++ b/plugins/rite/skills/rite-workflow/references/coding-principles.md
@@ -22,6 +22,7 @@ The `knowledge_routing` principle additionally draws on t-wada's four quadrants 
 | `no_speculative_structure` | No Speculative Structure | Phase 5.1, PR Review |
 | `reference_discovery` | Discover Reference Implementations | Phase 3 |
 | `question_self_check` | Self-Check Before Asking | All Phases |
+| `question_resolution` | Resolve Recommended Reversible Decisions Autonomously | All Phases |
 | `documentation_consistency` | Sync Documentation with Specification Changes | Phase 5.1 |
 | `knowledge_routing` | Route Knowledge to Its Durable Medium | Phase 5.1, PR Review |
 
@@ -90,6 +91,16 @@ The `knowledge_routing` principle additionally draws on t-wada's four quadrants 
 **Summary**: Self-check whether the question is truly necessary before asking.
 
 **Details**: See the `question_self_check` section in [common-principles.md](./common-principles.md).
+
+### question_resolution (Resolve Recommended Reversible Decisions Autonomously)
+
+**Summary**: 人間への質問は、ユーザーの頭の中にしかない意思決定と不可逆操作に限定する。セッション自身が推奨を明記できる可逆判断は、その推奨で続行する。
+
+**Rules**:
+1. `AskUserQuestion` が許されるのは、(a) 優先順位・UX 方針・トレードオフなどユーザー固有の意思決定、または (b) merge、Issue close、外部公開、削除など不可逆操作の承認だけである。
+2. コード編集、commit、PR コメント、再試行などブランチ内で取り消せる判断についてセッション自身が推奨を明記した場合は、質問せず推奨案で続行する。
+3. 自律続行した判断と根拠は、新しい様式や marker を作らず、既存の work memory の決定事項・計画逸脱ログ、PR コメント、または commit body のうち、その phase が既に使用する記録先へ残す。
+4. 推奨を決められない可逆判断でも、まず探索・検証で自己解決する。探索後も複数案の優先がユーザー固有の価値判断に依存するときだけ (a) として質問する。
 
 ### documentation_consistency (Sync Documentation with Specification Changes)
 


### PR DESCRIPTION
## 概要

セッションが推奨を明記できる可逆判断では確認待ちを挟まず、人間への質問をユーザー固有の意思決定と不可逆操作に限定します。

## 関連 Issue

Closes #2247

## 変更内容

- `question_resolution` を共有 SoT として追加し、質問可能な 2 類型・既定続行・既存様式への記録義務を定義
- iterate / fix / ready / merge / cleanup / pr-review から共有規律を参照し、bounded retry・review source 再生成・Decision Log 記録を自動化
- Ready、merge、close、削除、新規 Issue 公開など不可逆・外部公開の承認境界を維持
- 既存 contract test に SoT、6 スキルのポインタ、代表分岐、不可逆側の非退行を追加

## 実装中の判断・計画逸脱

- 判断: v0.10.0 リリース後ではなく v0.10.0 に取り込む — ユーザーから着手条件の変更指示を受けたため
- 判断: S レーンでは新規テストファイルを作らない — 既存 contract suite に静的 pin を追加して検証範囲を維持したため
- 判断: `PHASE_7_ASKUSER_INVOKED` は後方互換のため名称を維持 — 新 marker を作らず disposition-entry gate として自動 Decision Log 経路も検証するため

## 検証

- `bash plugins/rite/scripts/tests/run-all.sh`
- `bash plugins/rite/scripts/tests/documentation-fidelity-promotion-contract.test.sh`
- `git diff --check`
- plugin-specific checks 19 種（既存 warning は non-blocking）

## チェックリスト

- [x] コード・スキル記述がプロジェクト規約に従っている
- [x] 全 script tests が通過している
- [x] 仕様変更と関連スキル文書を同一 PR で更新している

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
