### PR TITLE
feat(issue-implement): 契約字義性 mandate を全 Complexity に導入

### DIFF
--- a/plugins/rite/hooks/tests/complexity-lane-contract.test.sh
+++ b/plugins/rite/hooks/tests/complexity-lane-contract.test.sh
@@ -183,12 +183,16 @@ assert_grep "implement owns the all-Complexity contract-literalism mandate" "$IM
   '^### 5\.0\.L Contract Literalism Mandate（全 Complexity 共通）$'
 assert_grep "contract literalism rejects structures not justified by the Issue contract" "$IMPLEMENT" \
   'Target Files、Scope、MUST / MUST NOT、Non-goal.*オプション・パラメータ・guard・一般化・予約フィールドは実装しない'
+assert_grep "contract literalism chooses the smaller implementation when the contract is ambiguous" "$IMPLEMENT" \
+  '迷った場合は小さい実装を選ぶ'
 assert_grep "contract literalism returns out-of-contract needs to the Issue instead of implementing them" "$IMPLEMENT" \
   '契約外の必要性に気付いた場合は実装せず、既存の Issue コメントへ必要性と根拠を記録して差し戻す'
 assert_grep "contract literalism applies to every declared Complexity" "$IMPLEMENT" \
   'XS / S / M / L / XL の全 Complexity に適用する'
 assert_grep "complexity-lane references the mandate without redefining it" "$LANE" \
   '全 Complexity 共通 mandate の定義は .*issue-implement/SKILL\.md §5\.0\.L.*唯一の所有位置'
+assert_not_grep "complexity-lane does not duplicate the mandate's normative definition" "$LANE" \
+  'Target Files、Scope、MUST / MUST NOT、Non-goal.*オプション・パラメータ・guard・一般化・予約フィールド'
 assert_grep "implement resolves the lane through the shared helper" "$IMPLEMENT" \
   'scripts/issue-complexity-lane\.sh --issue \{issue_number\}'
 assert_grep "implement declares the production-constraint step" "$IMPLEMENT" \

--- a/plugins/rite/hooks/tests/complexity-lane-contract.test.sh
+++ b/plugins/rite/hooks/tests/complexity-lane-contract.test.sh
@@ -179,6 +179,16 @@ assert_grep "5.1.0.1 excludes the fail-safe path from 'M or above'" "$IMPLEMENT"
   '^\| Complexity M or above \|.*かつ `complexity=` を伴う.*`COMPLEXITY_LANE_FALLBACK=1` を伴う fail-safe 経路は満たさない'
 
 echo "=== implement の生産量制約 (AC-3 / T-03) ==="
+assert_grep "implement owns the all-Complexity contract-literalism mandate" "$IMPLEMENT" \
+  '^### 5\.0\.L Contract Literalism Mandate（全 Complexity 共通）$'
+assert_grep "contract literalism rejects structures not justified by the Issue contract" "$IMPLEMENT" \
+  'Target Files、Scope、MUST / MUST NOT、Non-goal.*オプション・パラメータ・guard・一般化・予約フィールドは実装しない'
+assert_grep "contract literalism returns out-of-contract needs to the Issue instead of implementing them" "$IMPLEMENT" \
+  '契約外の必要性に気付いた場合は実装せず、既存の Issue コメントへ必要性と根拠を記録して差し戻す'
+assert_grep "contract literalism applies to every declared Complexity" "$IMPLEMENT" \
+  'XS / S / M / L / XL の全 Complexity に適用する'
+assert_grep "complexity-lane references the mandate without redefining it" "$LANE" \
+  '全 Complexity 共通 mandate の定義は .*issue-implement/SKILL\.md §5\.0\.L.*唯一の所有位置'
 assert_grep "implement resolves the lane through the shared helper" "$IMPLEMENT" \
   'scripts/issue-complexity-lane\.sh --issue \{issue_number\}'
 assert_grep "implement declares the production-constraint step" "$IMPLEMENT" \

--- a/plugins/rite/skills/issue-implement/SKILL.md
+++ b/plugins/rite/skills/issue-implement/SKILL.md
@@ -22,6 +22,14 @@ Perform actual implementation work following the implementation plan approved in
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing bash hook commands in this file.
 
+### 5.0.L Contract Literalism Mandate（全 Complexity 共通）
+
+実装は Issue 契約の字義に限定する。契約の根拠として使えるのは Target Files、Scope、MUST / MUST NOT、Non-goal であり、これらで必要性を説明できないオプション・パラメータ・guard・一般化・予約フィールドは実装しない。迷った場合は小さい実装を選ぶ。
+
+契約外の必要性に気付いた場合は実装せず、既存の Issue コメントへ必要性と根拠を記録して差し戻す。拡張は実需を記した別 Issue の契約として扱い、現在の実装へ先回りして含めない。
+
+本 mandate は **XS / S / M / L / XL の全 Complexity に適用する**。Complexity レーンは儀式コストと生産量制約だけを変え、本 mandate の適用有無を変えない。
+
 ### 5.0.C Complexity Lane Determination (XS/S 軽量レーン)
 
 実装を始める前に、対象 Issue の**宣言 Complexity** からレーンを決める。同じ helper が 5.1.0.1 の並列実装ゲートと 5.1.0.8 の生産量制約の両方に供給する（Complexity の読み取りを 1 箇所に集約する）:

--- a/plugins/rite/skills/pr-review/references/complexity-lane.md
+++ b/plugins/rite/skills/pr-review/references/complexity-lane.md
@@ -2,6 +2,8 @@
 
 > **Source of Truth**: 本ファイルは Issue の宣言 Complexity に応じて儀式コスト（reviewer の幅と検証の深さ、implement の生産量）を比例させる **XS/S 軽量レーン**の設計根拠・fail-safe 規約・合成規則を定義する。実行時に必要な分岐表・reason 表・marker 名は `SKILL.md` ステップ 1.3.2 / ステップ 3.2.1 / ステップ 4.5 本体と `skills/issue-implement/SKILL.md` 5.0.C / 5.1.0.8 に置き、本ファイルは rationale を持つ。
 
+> **Contract literalism**: 契約外構造を実装しない全 Complexity 共通 mandate の定義は [issue-implement/SKILL.md §5.0.L](../../issue-implement/SKILL.md#50l-contract-literalism-mandate全-complexity-共通) が唯一の所有位置である。本レーンは適用範囲や文言を再定義せず、儀式コストと XS/S 生産量制約だけを扱う。
+
 ## なぜレーンを設けるのか
 
 収束性（実測必須ゲート・発散検出）と churn 抑制（帰結クラス・pin 政策）が解決した後に残った構造問題は、**どの工程も変更の大きさを知らない**ことである。1 行の設定変更でも、9 reviewer がフル装備で起動し、implement が説明的な派生散文を新設し、その散文が次サイクルの churn の燃料になる。工程の固定費が diff サイズと無関係に積み上がる。


### PR DESCRIPTION
## 概要

Issue 契約で説明できないオプション、パラメータ、guard、一般化、予約構造を実装しない契約字義性 mandate を追加します。契約外の必要性は実装へ先回りせず、根拠を Issue コメントへ記録して差し戻します。

Closes #2252

## 変更内容

- `issue-implement` に全 Complexity 共通の契約字義性 mandate を単一定義
- Complexity Lane の SoT から mandate 所有位置への参照を追加
- 既存 contract suite に適用範囲、差し戻し経路、単一所有位置の静的 pin を追加

## 検証

- `bash plugins/rite/hooks/tests/complexity-lane-contract.test.sh`（PASS 85 / FAIL 0）
- `bash plugins/rite/scripts/tests/issue-complexity-lane.test.sh`（PASS 83 / FAIL 0）
- plugin 固有チェック 19 種を実行（新規 blocking error なし、既存の non-blocking findings のみ）

## チェックリスト

- [x] 契約字義性 mandate が全 Complexity に適用される
- [x] 契約外の必要性を実装せず Issue へ差し戻す経路が明記される
- [x] mandate の定義は単一所有位置で、lane SoT は参照のみ
- [x] 既存 suite が green
