### PR TITLE
fix(fix): finding 対応を最小差分に限定

### DIFF
--- a/plugins/rite/agents/_reviewer-base.md
+++ b/plugins/rite/agents/_reviewer-base.md
@@ -77,6 +77,17 @@ All reviewers MUST adopt these principles:
 - **Evidence-based reporting**: Every finding must cite a specific file:line and explain both WHAT is wrong and WHY it matters. "Looks wrong" is not a finding.
 - **Thoroughness on every cycle**: Apply the same depth and rigor on every review cycle — first pass, re-review, or verification. Do not self-censor findings because "I should have caught this earlier." If you see a real problem now, report it now. Withholding a valid finding to avoid appearing inconsistent is worse than reporting it late.
 
+### Over-fix Check
+
+When reviewing a fix cycle, compare each change with the finding it addresses. An
+**over-fix** is a change that exceeds the finding's named scope and increases net
+surface area (code, guards, fallbacks, or explanatory comments) without the
+finding requiring new behavior or a new contract. Also flag additive fixes when
+removing the excessive structure would resolve the finding with less surface
+area. Report demonstrable over-fix as at least non-blocking; classify it as
+blocking only when the added surface creates a concrete current-PR defect under
+the normal confidence and evidence gates.
+
 ## Cross-File Impact Check
 
 **Mandatory final step in every Detection Process.** After completing domain-specific checks, verify cross-file consistency:

--- a/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
+++ b/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
@@ -25,6 +25,21 @@ assert_grep 'fix prefers deletion when deletion resolves the finding' "$fix_skil
 assert_grep 'fix limits additive defenses and explanation' "$fix_skill" \
   '新 guard / fallback / 説明コメントの追加は finding が新挙動・新契約を要求する場合のみ'
 
+# Pin the complete fix-cycle range and its numeric persistence. In particular,
+# HEAD~1 would silently shrink a multi-commit cycle to its final commit.
+assert_grep 'fix records the pre-commit cycle baseline' "$fix_skill" \
+  'fix_cycle_base_sha=$(git rev-parse HEAD)'
+assert_grep 'fix uses the cycle baseline for numstat' "$fix_skill" \
+  'git diff --numstat "$commit_sha_before"..HEAD'
+assert_grep 'fix excludes binary additions from line totals' "$fix_skill" \
+  '$1 ~ /^[0-9]+$/ { added += $1 }'
+assert_grep 'fix excludes binary deletions from line totals' "$fix_skill" \
+  '$2 ~ /^[0-9]+$/ { deleted += $2 }'
+assert_grep 'fix persists additions as a JSON number' "$fix_skill" \
+  '"lines_added": $added'
+assert_grep 'fix persists deletions as a JSON number' "$fix_skill" \
+  '"lines_deleted": $deleted'
+
 assert_grep 'reviewer defines over-fix' "$reviewer" \
   '**over-fix** is a change that exceeds the finding'
 assert_grep 'over-fix covers net surface area' "$reviewer" \

--- a/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
+++ b/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
@@ -28,7 +28,11 @@ assert_grep 'fix limits additive defenses and explanation' "$fix_skill" \
 # Pin the complete fix-cycle range and its numeric persistence. In particular,
 # HEAD~1 would silently shrink a multi-commit cycle to its final commit.
 assert_grep 'fix records the pre-commit cycle baseline' "$fix_skill" \
-  'fix_cycle_base_sha=$(git rev-parse HEAD)'
+  'FIX_CYCLE_BASE_SHA=%s'
+assert_grep 'fix consumes the retained cycle baseline' "$fix_skill" \
+  'commit_sha_before="{fix_cycle_base_sha_from_context}"'
+assert_grep 'fix rejects an invalid or unexpanded baseline' "$fix_skill" \
+  'git cat-file -e "${commit_sha_before}^{commit}"'
 assert_grep 'fix uses the cycle baseline for numstat' "$fix_skill" \
   'git diff --numstat "$commit_sha_before"..HEAD'
 assert_grep 'fix excludes binary additions from line totals' "$fix_skill" \
@@ -36,8 +40,12 @@ assert_grep 'fix excludes binary additions from line totals' "$fix_skill" \
 assert_grep 'fix excludes binary deletions from line totals' "$fix_skill" \
   '$2 ~ /^[0-9]+$/ { deleted += $2 }'
 assert_grep 'fix persists additions as a JSON number' "$fix_skill" \
-  '"lines_added": $added'
+  '--argjson added "$lines_added"'
 assert_grep 'fix persists deletions as a JSON number' "$fix_skill" \
+  '--argjson deleted "$lines_deleted"'
+assert_grep 'fix maps the numeric additions into the cycle entry' "$fix_skill" \
+  '"lines_added": $added'
+assert_grep 'fix maps the numeric deletions into the cycle entry' "$fix_skill" \
   '"lines_deleted": $deleted'
 
 assert_grep 'reviewer defines over-fix' "$reviewer" \

--- a/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
+++ b/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+fix_skill="$ROOT/plugins/rite/skills/fix/SKILL.md"
+reviewer="$ROOT/plugins/rite/agents/_reviewer-base.md"
+failures=0
+
+assert_grep() {
+  local label=$1 file=$2 pattern=$3
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# Keep the three fix-side mandates independent: removing or weakening any one
+# must fail this contract even when the surrounding section remains present.
+assert_grep 'fix stays within the finding named scope' "$fix_skill" \
+  'finding が名指しした範囲の最小差分'
+assert_grep 'fix prefers deletion when deletion resolves the finding' "$fix_skill" \
+  '削除で解消できる finding は削除で直す'
+assert_grep 'fix limits additive defenses and explanation' "$fix_skill" \
+  '新 guard / fallback / 説明コメントの追加は finding が新挙動・新契約を要求する場合のみ'
+
+assert_grep 'reviewer defines over-fix' "$reviewer" \
+  '**over-fix** is a change that exceeds the finding'
+assert_grep 'over-fix covers net surface area' "$reviewer" \
+  'surface area (code, guards, fallbacks, or explanatory comments)'
+assert_grep 'reviewer checks deletion as the smaller fix' "$reviewer" \
+  'removing the excessive structure would resolve the finding with less surface'
+assert_grep 'over-fix can be reported as non-blocking' "$reviewer" \
+  'Report demonstrable over-fix as at least non-blocking'
+assert_grep 'blocking still requires a concrete defect' "$reviewer" \
+  'blocking only when the added surface creates a concrete current-PR defect'
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s contract assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'All minimal-fix contract assertions passed.\n'

--- a/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
+++ b/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
@@ -33,6 +33,12 @@ assert_grep 'fix consumes the retained cycle baseline' "$fix_skill" \
   'commit_sha_before="{fix_cycle_base_sha_from_context}"'
 assert_grep 'fix rejects an invalid or unexpanded baseline' "$fix_skill" \
   'git cat-file -e "${commit_sha_before}^{commit}"'
+assert_grep 'invalid cycle baseline fails closed' "$fix_skill" \
+  'if ! git cat-file -e "${commit_sha_before}^{commit}" 2>/dev/null; then
+  echo "ERROR: FIX_CYCLE_BASE_SHA が未展開または無効です: $commit_sha_before" >&2
+  echo "[fix:error]"
+  exit 1
+fi'
 assert_grep 'fix uses the cycle baseline for numstat' "$fix_skill" \
   'git diff --numstat "$commit_sha_before"..HEAD'
 assert_grep 'fix excludes binary additions from line totals' "$fix_skill" \

--- a/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
+++ b/plugins/rite/scripts/tests/minimal-fix-contract.test.sh
@@ -16,6 +16,17 @@ assert_grep() {
   fi
 }
 
+assert_block() {
+  local label=$1 file=$2 pattern=$3 content
+  content=$(<"$file")
+  if [[ "$content" == *"$pattern"* ]]; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label" >&2
+    failures=$((failures + 1))
+  fi
+}
+
 # Keep the three fix-side mandates independent: removing or weakening any one
 # must fail this contract even when the surrounding section remains present.
 assert_grep 'fix stays within the finding named scope' "$fix_skill" \
@@ -33,7 +44,7 @@ assert_grep 'fix consumes the retained cycle baseline' "$fix_skill" \
   'commit_sha_before="{fix_cycle_base_sha_from_context}"'
 assert_grep 'fix rejects an invalid or unexpanded baseline' "$fix_skill" \
   'git cat-file -e "${commit_sha_before}^{commit}"'
-assert_grep 'invalid cycle baseline fails closed' "$fix_skill" \
+assert_block 'invalid cycle baseline fails closed' "$fix_skill" \
   'if ! git cat-file -e "${commit_sha_before}^{commit}" 2>/dev/null; then
   echo "ERROR: FIX_CYCLE_BASE_SHA が未展開または無効です: $commit_sha_before" >&2
   echo "[fix:error]"

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -2487,7 +2487,7 @@ EOF
 
 ### 3.1 Verify Changes
 
-**前置ガード — fix commit 不要 PR の skip (全経路共通)**: ステップ 3 に入る前に必ず評価する。**working tree が無変更**の場合 — nit-only / **non-blocking (実測なし) のみ** / reply-only、およびこれらの混在 — は**ステップ 3 全体 (3.1〜3.5) を skip** し、ステップ 4.2 (完了報告系) へ直行する (空 `git commit` の失敗と、3.3.1 が `HEAD~1..HEAD` = 前 cycle の commit を「本 cycle の fix」として fix-cycle-state に誤記録するのを防ぐ)。本ガードはステップ 2 の出口に相当し、2.4.N を経由しない non-blocking-only 経路でも必ず評価される (ステップ 2.4.N Loop termination の分岐は本ガードへの参照)。
+**前置ガード — fix commit 不要 PR の skip (全経路共通)**: ステップ 3 に入る前に必ず評価する。**working tree が無変更**の場合 — nit-only / **non-blocking (実測なし) のみ** / reply-only、およびこれらの混在 — は**ステップ 3 全体 (3.1〜3.5) を skip** し、ステップ 4.2 (完了報告系) へ直行する (空 `git commit` の失敗と、3.3.1 が前 cycle の commit を「本 cycle の fix」として fix-cycle-state に誤記録するのを防ぐ)。本ガードはステップ 2 の出口に相当し、2.4.N を経由しない non-blocking-only 経路でも必ず評価される (ステップ 2.4.N Loop termination の分岐は本ガードへの参照)。
 
 判定には **`git-status-filtered.sh` を使う** (raw `git status --porcelain` を使ってはならない — sandbox 内の Bash 呼び出しでは write-block bind mount が `??` エントリとして必ず現れるため raw 版は恒に非空になり、**ガードが一度も発火しない**。本 helper はその ghost-mount エントリを除去する。同型の理由で `pr-review/SKILL.md` ステップ 4.0.A も helper 経由にしている):
 
@@ -2507,6 +2507,12 @@ fi
 ```
 
 `FIX_COMMIT_GUARD=skip` ならステップ 3 全体を skip して ステップ 4.2 へ、`proceed` なら以下を通常どおり実行する。
+
+`proceed` の場合、最初の fix commit より前の `HEAD` を `fix_cycle_base_sha` として記録する。ステップ 3.2 で複数コミットを選んでも、3.3.1 ではこの同じ SHA を `{fix_cycle_base_sha}` に literal substitute し、cycle 全体の基準点として使う。
+
+```bash
+fix_cycle_base_sha=$(git rev-parse HEAD)
+```
 
 Once all findings have been addressed, verify the changes:
 
@@ -2701,11 +2707,11 @@ mkdir -p "$_state_root/.rite/fix-cycle-state"
 pr_number="{pr_number}"
 state_file="$_state_root/.rite/fix-cycle-state/${pr_number}.json"
 commit_sha_after=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-commit_sha_before=$(git rev-parse HEAD~1 2>/dev/null || echo "unknown")
+commit_sha_before="{fix_cycle_base_sha}"
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S")
-files_changed=$(git diff --name-only HEAD~1..HEAD 2>/dev/null | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo '[]')
-# 既存の cycle state に当該 fix commit の行数差分を記録する。バイナリの `-` は行数に含めない。
-diff_stats=$(git diff --numstat HEAD~1..HEAD 2>/dev/null | awk '
+files_changed=$(git diff --name-only "$commit_sha_before"..HEAD 2>/dev/null | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo '[]')
+# 既存の cycle state に当該 fix cycle 全体の行数差分を記録する。バイナリの `-` は行数に含めない。
+diff_stats=$(git diff --numstat "$commit_sha_before"..HEAD 2>/dev/null | awk '
   $1 ~ /^[0-9]+$/ { added += $1 }
   $2 ~ /^[0-9]+$/ { deleted += $2 }
   END { printf "%d %d", added, deleted }

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -2508,10 +2508,11 @@ fi
 
 `FIX_COMMIT_GUARD=skip` ならステップ 3 全体を skip して ステップ 4.2 へ、`proceed` なら以下を通常どおり実行する。
 
-`proceed` の場合、最初の fix commit より前の `HEAD` を `fix_cycle_base_sha` として記録する。ステップ 3.2 で複数コミットを選んでも、3.3.1 ではこの同じ SHA を `{fix_cycle_base_sha}` に literal substitute し、cycle 全体の基準点として使う。
+`proceed` の場合、最初の fix commit より前の `HEAD` を marker に出力して会話コンテキストへ保持する。ステップ 3.2 で複数コミットを選んでも、3.3.1 では marker の値を `{fix_cycle_base_sha_from_context}` に literal substitute し、cycle 全体の基準点として使う。
 
 ```bash
-fix_cycle_base_sha=$(git rev-parse HEAD)
+fix_cycle_base_sha=$(git rev-parse HEAD) || { echo "[fix:error]"; exit 1; }
+printf '[CONTEXT] FIX_CYCLE_BASE_SHA=%s\n' "$fix_cycle_base_sha"
 ```
 
 Once all findings have been addressed, verify the changes:
@@ -2707,7 +2708,12 @@ mkdir -p "$_state_root/.rite/fix-cycle-state"
 pr_number="{pr_number}"
 state_file="$_state_root/.rite/fix-cycle-state/${pr_number}.json"
 commit_sha_after=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-commit_sha_before="{fix_cycle_base_sha}"
+commit_sha_before="{fix_cycle_base_sha_from_context}"
+if ! git cat-file -e "${commit_sha_before}^{commit}" 2>/dev/null; then
+  echo "ERROR: FIX_CYCLE_BASE_SHA が未展開または無効です: $commit_sha_before" >&2
+  echo "[fix:error]"
+  exit 1
+fi
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S")
 files_changed=$(git diff --name-only "$commit_sha_before"..HEAD 2>/dev/null | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo '[]')
 # 既存の cycle state に当該 fix cycle 全体の行数差分を記録する。バイナリの `-` は行数に含めない。

--- a/plugins/rite/skills/fix/SKILL.md
+++ b/plugins/rite/skills/fix/SKILL.md
@@ -1848,6 +1848,12 @@ rm -f "${TMPDIR:-/tmp}/rite-fix-target-body-{pr_number}-{target_comment_id}.txt"
 
 ### Simplification-First Response Principle（追加より削除を先に検討）
 
+以下はすべての fix finding に適用する mandate であり、config で opt-out できない:
+
+- **MUST**: finding が名指しした範囲の最小差分に留める。
+- **MUST**: 削除で解消できる finding は削除で直す。原因が過剰構造ならその構造を除去する。
+- **MUST NOT**: 新 guard / fallback / 説明コメントの追加は finding が新挙動・新契約を要求する場合のみに限定する。
+
 指摘に対する修正方針を決定する前に、以下のチェックリストを必ず通過させること（Fail-Fast Response Principle と同様、config での opt-out は不可）:
 
 - [ ] 機構の**追加**（新しい分岐・ガード・規約・注記・例外条項）ではなく、既存機構の**削除・単純化**（分岐の統合、規則の一般化、複製の一本化）で指摘を解消できないか検討したか
@@ -2698,6 +2704,14 @@ commit_sha_after=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 commit_sha_before=$(git rev-parse HEAD~1 2>/dev/null || echo "unknown")
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S")
 files_changed=$(git diff --name-only HEAD~1..HEAD 2>/dev/null | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null || echo '[]')
+# 既存の cycle state に当該 fix commit の行数差分を記録する。バイナリの `-` は行数に含めない。
+diff_stats=$(git diff --numstat HEAD~1..HEAD 2>/dev/null | awk '
+  $1 ~ /^[0-9]+$/ { added += $1 }
+  $2 ~ /^[0-9]+$/ { deleted += $2 }
+  END { printf "%d %d", added, deleted }
+')
+lines_added=${diff_stats%% *}
+lines_deleted=${diff_stats##* }
 
 # Read existing state or initialize
 if [ -f "$state_file" ]; then
@@ -2714,6 +2728,8 @@ new_cycle=$(jq -n \
   --argjson fixed "{findings_fixed_count}" \
   --argjson propagated "{propagation_applied_count}" \
   --argjson files "$files_changed" \
+  --argjson added "$lines_added" \
+  --argjson deleted "$lines_deleted" \
   '{
     "cycle": 0,
     "timestamp": $ts,
@@ -2722,6 +2738,8 @@ new_cycle=$(jq -n \
     "findings_fixed": $fixed,
     "findings_new_from_fix": 0,
     "files_changed_by_fix": $files,
+    "lines_added": $added,
+    "lines_deleted": $deleted,
     "propagation_applied": $propagated
   }')
 


### PR DESCRIPTION
Closes #2251

- fix mandate に最小差分・削除優先・追加条件を追加
- cycle state に追加/削除行数を記録
- reviewer 共通原則に over-fix 観点を追加
- contract test で規則を pin