### PR TITLE
fix(media): assemble.sh の -P を現行シーン構成へ追随

### DIFF
--- a/media/intro-video-v2/PROVENANCE.md
+++ b/media/intro-video-v2/PROVENANCE.md
@@ -92,9 +92,7 @@ BGM を用意した後、2 本のカットを連結する。
 
 ```bash
 # フルカット（M1〜M7、約 55.0 秒）
-./assemble.sh -o out/rite-intro-v2-full.mp4 -t 0.5 -b bombinsound-technology-tech-technology-90-second-499581.mp3 \
-  out/01-problem.mp4 out/02-unknowns.mp4 out/03-loop.mp4 out/04-gates.mp4 \
-  out/05-wiki.mp4 out/06-second-lap.mp4 out/07-closing.mp4
+./assemble.sh -P -o out/rite-intro-v2-full.mp4
 
 # SNS カット（M1 + M3 + M5 + M7、約 31.5 秒）
 ./assemble.sh -o out/rite-intro-v2-sns.mp4 -t 0.5 -b bombinsound-technology-tech-technology-90-second-499581.mp3 \
@@ -104,9 +102,5 @@ BGM を用意した後、2 本のカットを連結する。
 完成動画は楽曲単体ではなく映像・タイポグラフィ・アニメーションを組み合わせた新たな制作物として
 配布する。
 
-> `assemble.sh` の `-P`（プリセット）は Issue #2240 当時の 5 シーン構成（`01-problem` /
-> `02-loop` / `03-terminal` / `04-gates` / `05-closing`）と Pixabay 曲名を既定値に持ったままで、
-> 現構成では使えない（実測: `assemble: シーンが見つかりません: out/02-loop.mp4` で終了する）。
-> 同スクリプトの usage 文言も「レンダ済み 5 シーンと既定 BGM」と旧構成のままである。
-> `assemble.sh` は Issue #2258 の変更対象外だったため据え置いており、上記のシーン明示形を正とする。
-> `-P` の新構成対応（または撤去）は Issue #2259 で扱う。
+`-P` は現行のフルカット（M1〜M7）と上記の既定 BGM を選ぶ。SNS カットは
+フルカットとシーン構成が異なるため、意図が見える上記のシーン明示形を正とする。

--- a/media/intro-video-v2/assemble.sh
+++ b/media/intro-video-v2/assemble.sh
@@ -11,7 +11,7 @@ usage: assemble.sh [-P] -o <out.mp4> [-t <xfade_sec>] [-b <bgm.mp3>] <scene1.mp4
   -o  出力 mp4（必須）
   -t  シーン間クロスフェード秒（既定: 0.5）
   -b  BGM 音声ファイル（任意。指定時は fade in/out を付けて合成する）
-  -P  intro-video-v2 プリセット（レンダ済み 5 シーンと既定 BGM を順番どおり使用）
+  -P  intro-video-v2 フルカットプリセット（M1〜M7 と既定 BGM を使用）
 EOF
   exit 1
 }
@@ -36,10 +36,12 @@ if [ "$preset" = true ]; then
   [ "$#" -eq 0 ] || { echo "assemble: -P とシーン引数は同時に指定できません" >&2; exit 1; }
   scenes=(
     "out/01-problem.mp4"
-    "out/02-loop.mp4"
-    "out/03-terminal.mp4"
+    "out/02-unknowns.mp4"
+    "out/03-loop.mp4"
     "out/04-gates.mp4"
-    "out/05-closing.mp4"
+    "out/05-wiki.mp4"
+    "out/06-second-lap.mp4"
+    "out/07-closing.mp4"
   )
   [ -n "$bgm" ] || bgm="bombinsound-technology-tech-technology-90-second-499581.mp3"
 else

--- a/media/intro-video-v2/check-contract.sh
+++ b/media/intro-video-v2/check-contract.sh
@@ -82,6 +82,21 @@ fi
 
 # -P は現行のフルカット M1〜M7 をその順序で連結する。同じ素材を使い回すことで、
 # プリセットのファイル名契約と 7 本連結の両方を実行経路で pin する。
+preset_scenes="$(awk '
+  /scenes=\(/ { in_scenes=1; next }
+  in_scenes && /^[[:space:]]*\)/ { exit }
+  in_scenes { gsub(/^[[:space:]]*"|"[[:space:]]*$/, ""); print }
+' "$here/assemble.sh")"
+expected_preset_scenes="$(printf '%s\n' \
+  out/01-problem.mp4 out/02-unknowns.mp4 out/03-loop.mp4 out/04-gates.mp4 \
+  out/05-wiki.mp4 out/06-second-lap.mp4 out/07-closing.mp4)"
+if [ "$preset_scenes" = "$expected_preset_scenes" ]; then
+  echo "契約 OK [full-preset-order]: M1〜M7 の順序が一致"
+else
+  echo "契約 NG [full-preset-order]: -P のシーン順序が M1〜M7 と一致しません" >&2
+  failures=$((failures + 1))
+fi
+
 preset_work="$work/preset"
 mkdir -p "$preset_work/out"
 for scene in 01-problem 02-unknowns 03-loop 04-gates 05-wiki 06-second-lap 07-closing; do

--- a/media/intro-video-v2/check-contract.sh
+++ b/media/intro-video-v2/check-contract.sh
@@ -80,6 +80,30 @@ else
   failures=$((failures + 1))
 fi
 
+# -P は現行のフルカット M1〜M7 をその順序で連結する。同じ素材を使い回すことで、
+# プリセットのファイル名契約と 7 本連結の両方を実行経路で pin する。
+preset_work="$work/preset"
+mkdir -p "$preset_work/out"
+for scene in 01-problem 02-unknowns 03-loop 04-gates 05-wiki 06-second-lap 07-closing; do
+  cp "$work/audibility-scene.mp4" "$preset_work/out/$scene.mp4"
+done
+ffmpeg -loglevel error -y -f lavfi -i sine=frequency=1000:duration=12:sample_rate=48000 \
+  -af volume=2 -c:a libmp3lame \
+  "$preset_work/bombinsound-technology-tech-technology-90-second-499581.mp3"
+if preset_log="$(cd "$preset_work" && "$here/assemble.sh" -P -o out/preset.mp4 2>&1)"; then
+  if printf '%s\n' "$preset_log" | grep -q 'assembled 7 scenes'; then
+    echo "契約 OK [full-preset]: M1〜M7 を連結"
+  else
+    echo "契約 NG [full-preset]: 7 シーン連結の完了診断がありません" >&2
+    printf '%s\n' "$preset_log" | tail -3 | sed 's/^/  /' >&2
+    failures=$((failures + 1))
+  fi
+else
+  echo "契約 NG [full-preset]: -P が現行シーン構成を連結できません" >&2
+  printf '%s\n' "$preset_log" | tail -3 | sed 's/^/  /' >&2
+  failures=$((failures + 1))
+fi
+
 if [ "$failures" -ne 0 ]; then
   echo "契約チェック: $failures 件失敗" >&2
   exit 1


### PR DESCRIPTION
## Summary

- `assemble.sh -P` を現行フルカット M1〜M7 に更新
- プリセットの7シーン連結を実行する契約テストを追加
- `PROVENANCE.md` のフル/SNSカット手順とプリセット境界を更新

## Testing

- `cd media/intro-video-v2 && npm run check`
  - 全契約テスト成功
  - fixture と M1〜M7 の各2回レンダで MD5 一致

Closes #2259