### PR TITLE
fix(release): リリース昇格マージを安全に完走可能にする

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -207,7 +207,9 @@ gh pr create \
   --body "Closes #{PREP_ISSUE_NUMBER}"
 ```
 
-`AskUserQuestion` でユーザーに PR を確認してマージしてよいか確認し、承認後にマージ:
+`/rite:iterate {PREP_PR_NUMBER}` を実行し、`[review:mergeable]` を確認する。レビューが
+収束しない場合はマージせず停止する。その後、`AskUserQuestion` でユーザーに PR を確認して
+マージしてよいか確認し、承認後にマージ:
 
 ```bash
 gh pr merge --merge
@@ -263,11 +265,31 @@ gh pr create \
   --body "Merge develop into main for v{VERSION} release. Closes #{RELEASE_ISSUE_NUMBER}"
 ```
 
-`AskUserQuestion` でユーザーに main へのマージを確認し、承認後にマージ:
+昇格 PR の全コミットが既にマージ済み PR 経由であることを検証する。helper は PR が
+`develop -> main` であることも確認し、merge gate 用のアテステーションを保存する:
 
 ```bash
-gh pr merge --merge
+VERIFIED_HEAD_OID=$(bash plugins/rite/hooks/release-promotion-verify.sh {RELEASE_PR_NUMBER})
 ```
+
+検証失敗時は fail-loud で停止する。成功後、`AskUserQuestion` でユーザーに main へのマージを
+確認し、承認後に、出力された SHA を下記の `{VERIFIED_HEAD_OID}` に**リテラル置換**してマージする
+（変数形式のまま実行しない）:
+
+```bash
+gh pr merge {RELEASE_PR_NUMBER} --merge --match-head-commit {VERIFIED_HEAD_OID}
+```
+
+#### 3.2.1 Decision Log
+
+昇格マージは base/head の形状だけでは許可しない。`release-promotion-verify.sh` が差分内の
+各 commit SHA について、同じ SHA を merge commit とする既マージ PR の存在を検証し、検証時の
+head SHA をアテステーションへ記録する。merge gate はそのアテステーションと
+`--match-head-commit` の SHA が一致するときだけレビュー結果 JSON の代替として扱う。
+
+この方式により、通常の実装 PR は従来どおり review-results JSON が必須のまま、直接 push を含む
+昇格と検証後に head が変わった昇格は `merge-release-promotion-unverified` で fail-loud に停止する。
+単なる `base=main` / `head=develop` 判定は、未レビュー commit を区別できないため採用しない。
 
 ### 3.3 タグ作成 + GitHub Release
 
@@ -340,6 +362,7 @@ git pull origin develop
 | CHANGELOG の形式不備 | 既存エントリのパターンに合わせて修正 |
 | main マージ前に Release を作成してしまった | Release を削除 → main マージ → Release 再作成 |
 | PR マージ衝突 | 衝突を解消してから再試行 |
+| 昇格コミットの PR 検証失敗 | 直接 push を取り除くか、対象 commit を通常 PR 経由で develop に取り込み直してから検証を再実行 |
 | Projects 登録失敗 | `gh project item-add` を再実行。`--limit` を増やして Item ID を再取得 |
 | ステータス更新失敗 | Field ID / Option ID を再取得して `gh project item-edit` を再実行 |
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -286,6 +286,8 @@ gh pr merge {RELEASE_PR_NUMBER} --merge --match-head-commit {VERIFIED_HEAD_OID}
 各 commit SHA について、同じ SHA を merge commit とする既マージ PR の存在を検証し、検証時の
 head SHA をアテステーションへ記録する。merge gate はそのアテステーションと
 `--match-head-commit` の SHA が一致するときだけレビュー結果 JSON の代替として扱う。
+GitHub API が返したコミット件数は PR metadata の総コミット数と照合し、API 上限等で完全な一覧を
+取得できない場合はアテステーションを作らず停止する。
 
 この方式により、通常の実装 PR は従来どおり review-results JSON が必須のまま、直接 push を含む
 昇格と検証後に head が変わった昇格は `merge-release-promotion-unverified` で fail-loud に停止する。

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -20,7 +20,9 @@
 #      (and any session) Bash that issues `gh pr merge` / REST pulls/{n}/merge /
 #      GraphQL mergePullRequest is denied unless `.rite/review-results/{pr}-*.json`
 #      exists with minimum form (schema_version + verdict keys, reviewers array
-#      length >= sole-reviewer guard floor 2). Fail-closed on PR-number
+#      length >= sole-reviewer guard floor 2), or a release-promotion attestation
+#      proves a develop -> main PR contains only already-reviewed merge commits
+#      and pins the verified head with --match-head-commit. Fail-closed on PR-number
 #      unresolvable / missing / malformed / floor-under JSON. Purpose: block
 #      procedure-omission bypass of /rite:pr-review, not adversarial forgery.
 #
@@ -718,8 +720,38 @@ if [ -z "$BLOCKED_PATTERN" ]; then
         esac
       done
 
+      # A release promotion has no new implementation diff to re-review. It may
+      # pass only with a verifier-produced attestation and an exact head pin in
+      # the merge command; shape-only recognition would allow direct pushes.
       if [ "$_mrg_ok" != "1" ]; then
-        if [ "$_mrg_any" = "0" ]; then
+        _mrg_promotion_file="${_mrg_root:+$_mrg_root/}.rite/release-promotions/${_mrg_pr}.json"
+        [ -n "$_mrg_root" ] || _mrg_promotion_file=".rite/release-promotions/${_mrg_pr}.json"
+        _mrg_head_arg=""
+        if [[ "$CMD_CHECK" =~ --match-head-commit[[:space:]]+([0-9a-fA-F]{40})([[:space:]]|$) ]]; then
+          _mrg_head_arg="${BASH_REMATCH[1]}"
+        fi
+        if [ -f "$_mrg_promotion_file" ] && [ -n "$_mrg_head_arg" ]; then
+          _mrg_attested_head=$(jq -r --argjson pr "$_mrg_pr" '
+            if .schema_version == "1.0.0"
+               and .pr_number == $pr
+               and .base == "main"
+               and .head == "develop"
+               and (.head_oid | type == "string" and test("^[0-9a-fA-F]{40}$"))
+               and (.commits | type == "array" and length > 0)
+              then .head_oid else empty end
+          ' "$_mrg_promotion_file" 2>/dev/null) || _mrg_attested_head=""
+          if [ -n "$_mrg_attested_head" ] && [ "$_mrg_attested_head" = "$_mrg_head_arg" ]; then
+            _mrg_ok=1
+          fi
+        fi
+      fi
+
+      if [ "$_mrg_ok" != "1" ]; then
+        if [ -f "${_mrg_promotion_file:-}" ]; then
+          BLOCKED_PATTERN="merge-release-promotion-unverified"
+          BLOCKED_REASON="Release-promotion attestation for PR #${_mrg_pr} is invalid, or the merge command does not pin its verified head with --match-head-commit. Promotion merge is denied fail-loud."
+          BLOCKED_ALTERNATIVE="Re-run release-promotion-verify.sh ${_mrg_pr}, then merge with the exact verified head SHA as --match-head-commit."
+        elif [ "$_mrg_any" = "0" ]; then
           BLOCKED_PATTERN="merge-review-json-absent"
           BLOCKED_REASON="No review-results JSON for PR #${_mrg_pr} under ${_mrg_dir}/${_mrg_pr}-*.json. Merge requires a prior /rite:pr-review result (positive existence + minimum form)."
           BLOCKED_ALTERNATIVE="Run /rite:pr-review ${_mrg_pr} (or /rite:iterate ${_mrg_pr}) so a qualifying review-results JSON is written, then re-run merge."

--- a/plugins/rite/hooks/pre-tool-bash-guard.sh
+++ b/plugins/rite/hooks/pre-tool-bash-guard.sh
@@ -603,6 +603,7 @@ if [ -z "$BLOCKED_PATTERN" ]; then
 
   if [ "$_mrg_is_merge" = "1" ]; then
     _mrg_pr=""
+    _mrg_cli_argv=""
     # Set when `gh pr merge` tail has a non-flag token that is neither a bare
     # integer nor a /pull/{n} URL. Variable forms ("$PR", $PR) and flag values
     # that look like free tokens land here. flow-state fallback must NOT run
@@ -618,6 +619,16 @@ if [ -z "$BLOCKED_PATTERN" ]; then
     # 2) `gh pr merge` tail: first bare integer token, or /pull/{n} URL form
     if [ -z "$_mrg_pr" ] && [[ "$CMD_CHECK" =~ gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+(.*) ]]; then
       _mrg_tail="${BASH_REMATCH[1]}"
+      # Limit security-sensitive argv inspection to this simple command. A pin
+      # in a later `;`, `&&`, pipe, newline, or comment must not authenticate an
+      # earlier unpinned merge. Conservative truncation is fail-closed for rare
+      # quoted metacharacters in unrelated flag values.
+      _mrg_cli_argv="$_mrg_tail"
+      _mrg_cli_argv="${_mrg_cli_argv%%;*}"
+      _mrg_cli_argv="${_mrg_cli_argv%%&*}"
+      _mrg_cli_argv="${_mrg_cli_argv%%|*}"
+      _mrg_cli_argv="${_mrg_cli_argv%%$'\n'*}"
+      _mrg_cli_argv="${_mrg_cli_argv%%#*}"
       # shellcheck disable=SC2086  # intentional word-split of merge argv tail
       for _mrg_tok in $_mrg_tail; do
         case "$_mrg_tok" in
@@ -727,7 +738,7 @@ if [ -z "$BLOCKED_PATTERN" ]; then
         _mrg_promotion_file="${_mrg_root:+$_mrg_root/}.rite/release-promotions/${_mrg_pr}.json"
         [ -n "$_mrg_root" ] || _mrg_promotion_file=".rite/release-promotions/${_mrg_pr}.json"
         _mrg_head_arg=""
-        if [[ "$CMD_CHECK" =~ --match-head-commit[[:space:]]+([0-9a-fA-F]{40})([[:space:]]|$) ]]; then
+        if [[ "$_mrg_cli_argv" =~ --match-head-commit[[:space:]]+([0-9a-fA-F]{40})([[:space:]]|$) ]]; then
           _mrg_head_arg="${BASH_REMATCH[1]}"
         fi
         if [ -f "$_mrg_promotion_file" ] && [ -n "$_mrg_head_arg" ]; then

--- a/plugins/rite/hooks/release-promotion-verify.sh
+++ b/plugins/rite/hooks/release-promotion-verify.sh
@@ -23,6 +23,8 @@ head_oid=$(jq -r '.headRefOid // empty' <<< "$pr_json")
 commits_output=$(gh api --paginate -H 'Accept: application/vnd.github+json' \
   "repos/$owner/$repo/pulls/$PR_NUMBER/commits" --jq '.[].sha')
 mapfile -t commits <<< "$commits_output"
+expected_commit_count=$(gh api -H 'Accept: application/vnd.github+json' \
+  "repos/$owner/$repo/pulls/$PR_NUMBER" --jq '.commits')
 
 if [ "$base" != "main" ] || [ "$head" != "develop" ]; then
   echo "ERROR: release promotion must be develop -> main (actual: $head -> $base)" >&2
@@ -30,6 +32,11 @@ if [ "$base" != "main" ] || [ "$head" != "develop" ]; then
 fi
 if [[ ! "$head_oid" =~ ^[0-9a-fA-F]{40}$ ]] || [ -z "$commits_output" ] || [ "${#commits[@]}" -eq 0 ]; then
   echo "ERROR: release promotion PR head/commit list could not be verified" >&2
+  exit 4
+fi
+case "$expected_commit_count" in ''|*[!0-9]*) echo "ERROR: release promotion total commit count could not be verified" >&2; exit 4 ;; esac
+if [ "${#commits[@]}" -ne "$expected_commit_count" ]; then
+  echo "ERROR: release promotion commit list is incomplete (${#commits[@]}/$expected_commit_count); merge denied" >&2
   exit 4
 fi
 

--- a/plugins/rite/hooks/release-promotion-verify.sh
+++ b/plugins/rite/hooks/release-promotion-verify.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Verify that a develop -> main promotion contains only commits already merged
+# through pull requests, then persist a short-lived merge-gate attestation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_NUMBER="${1:-}"
+case "$PR_NUMBER" in ''|*[!0-9]*) echo "ERROR: release promotion PR number must be numeric" >&2; exit 2 ;; esac
+
+owner_repo_tab=$(bash "$SCRIPT_DIR/scripts/lib/git-remote.sh" resolve-owner-repo 2>/dev/null) || owner_repo_tab=""
+owner=""; repo=""
+[ -n "$owner_repo_tab" ] && IFS=$'\t' read -r owner repo <<< "$owner_repo_tab"
+if [ -z "$owner" ] || [ -z "$repo" ]; then
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+fi
+owner_repo="$owner/$repo"
+
+pr_json=$(gh pr view "$PR_NUMBER" -R "$owner_repo" --json baseRefName,headRefName,headRefOid,commits)
+base=$(jq -r '.baseRefName // empty' <<< "$pr_json")
+head=$(jq -r '.headRefName // empty' <<< "$pr_json")
+head_oid=$(jq -r '.headRefOid // empty' <<< "$pr_json")
+mapfile -t commits < <(jq -r '.commits[].oid' <<< "$pr_json")
+
+if [ "$base" != "main" ] || [ "$head" != "develop" ]; then
+  echo "ERROR: release promotion must be develop -> main (actual: $head -> $base)" >&2
+  exit 3
+fi
+if [[ ! "$head_oid" =~ ^[0-9a-fA-F]{40}$ ]] || [ "${#commits[@]}" -eq 0 ]; then
+  echo "ERROR: release promotion PR head/commit list could not be verified" >&2
+  exit 4
+fi
+
+for oid in "${commits[@]}"; do
+  pulls=$(gh api -H 'Accept: application/vnd.github+json' "repos/$owner/$repo/commits/$oid/pulls")
+  if ! jq -e --arg oid "$oid" 'any(.[]; .merged_at != null and .merge_commit_sha == $oid)' <<< "$pulls" >/dev/null; then
+    echo "ERROR: release promotion contains commit without a merged PR: $oid" >&2
+    exit 5
+  fi
+done
+
+if [ -n "${RITE_STATE_ROOT:-}" ] && [ -d "$RITE_STATE_ROOT" ]; then
+  state_root="$RITE_STATE_ROOT"
+else
+  state_root=$(bash "$SCRIPT_DIR/state-path-resolve.sh")
+fi
+attestation_dir="$state_root/.rite/release-promotions"
+mkdir -p "$attestation_dir"
+attestation="$attestation_dir/$PR_NUMBER.json"
+now=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+jq -n --argjson pr "$PR_NUMBER" --arg base "$base" --arg head "$head" \
+  --arg head_oid "$head_oid" --arg verified_at "$now" --argjson commits "$(printf '%s\n' "${commits[@]}" | jq -R . | jq -s .)" \
+  '{schema_version:"1.0.0",pr_number:$pr,base:$base,head:$head,head_oid:$head_oid,commits:$commits,verified_at:$verified_at}' \
+  > "$attestation.tmp"
+mv "$attestation.tmp" "$attestation"
+printf '%s\n' "$head_oid"

--- a/plugins/rite/hooks/release-promotion-verify.sh
+++ b/plugins/rite/hooks/release-promotion-verify.sh
@@ -16,17 +16,19 @@ if [ -z "$owner" ] || [ -z "$repo" ]; then
 fi
 owner_repo="$owner/$repo"
 
-pr_json=$(gh pr view "$PR_NUMBER" -R "$owner_repo" --json baseRefName,headRefName,headRefOid,commits)
+pr_json=$(gh pr view "$PR_NUMBER" -R "$owner_repo" --json baseRefName,headRefName,headRefOid)
 base=$(jq -r '.baseRefName // empty' <<< "$pr_json")
 head=$(jq -r '.headRefName // empty' <<< "$pr_json")
 head_oid=$(jq -r '.headRefOid // empty' <<< "$pr_json")
-mapfile -t commits < <(jq -r '.commits[].oid' <<< "$pr_json")
+commits_output=$(gh api --paginate -H 'Accept: application/vnd.github+json' \
+  "repos/$owner/$repo/pulls/$PR_NUMBER/commits" --jq '.[].sha')
+mapfile -t commits <<< "$commits_output"
 
 if [ "$base" != "main" ] || [ "$head" != "develop" ]; then
   echo "ERROR: release promotion must be develop -> main (actual: $head -> $base)" >&2
   exit 3
 fi
-if [[ ! "$head_oid" =~ ^[0-9a-fA-F]{40}$ ]] || [ "${#commits[@]}" -eq 0 ]; then
+if [[ ! "$head_oid" =~ ^[0-9a-fA-F]{40}$ ]] || [ -z "$commits_output" ] || [ "${#commits[@]}" -eq 0 ]; then
   echo "ERROR: release promotion PR head/commit list could not be verified" >&2
   exit 4
 fi

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2060,6 +2060,45 @@ fi
 rm -rf "$_mrg_tmp"
 echo ""
 
+echo "TC-140a / T-04 (#2269): verified develop -> main promotion with pinned head is allowed"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+mkdir -p "$_mrg_tmp/.rite/release-promotions"
+_promotion_oid="0123456789abcdef0123456789abcdef01234567"
+jq -n --arg oid "$_promotion_oid" \
+  '{schema_version:"1.0.0",pr_number:88,base:"main",head:"develop",head_oid:$oid,commits:[$oid],verified_at:"2026-08-12T00:00:00Z"}' \
+  > "$_mrg_tmp/.rite/release-promotions/88.json"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 88 --merge --match-head-commit $_promotion_oid") || rc=$?
+if [ "$rc" = "0" ] && [ -z "$output" ]; then
+  pass "TC-140a verified promotion allows merge with exact head pin"
+else
+  fail "TC-140a expected verified promotion allow, got rc=$rc output=$output"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
+echo "TC-140b / T-05 (#2269): stale or unpinned promotion attestation denies fail-loud"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+mkdir -p "$_mrg_tmp/.rite/release-promotions"
+_promotion_oid="0123456789abcdef0123456789abcdef01234567"
+_stale_oid="fedcba9876543210fedcba9876543210fedcba98"
+jq -n --arg oid "$_promotion_oid" \
+  '{schema_version:"1.0.0",pr_number:89,base:"main",head:"develop",head_oid:$oid,commits:[$oid],verified_at:"2026-08-12T00:00:00Z"}' \
+  > "$_mrg_tmp/.rite/release-promotions/89.json"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 89 --merge --match-head-commit $_stale_oid") || rc=$?
+decision=$(extract_hook_field "$output" permissionDecision)
+reason=$(extract_hook_field "$output" permissionDecisionReason)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-release-promotion-unverified"* ]]; then
+  pass "TC-140b stale promotion head denies with distinct failure class"
+else
+  fail "TC-140b expected promotion-unverified deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
 # --------------------------------------------------------------------------
 # Why: persist deny-only audit records
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
+++ b/plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh
@@ -2099,6 +2099,26 @@ fi
 rm -rf "$_mrg_tmp"
 echo ""
 
+echo "TC-140c / T-06 (#2269): pin in a later shell command cannot authenticate the merge"
+_mrg_tmp=$(mktemp -d)
+_mrg_setup_state "$_mrg_tmp"
+mkdir -p "$_mrg_tmp/.rite/release-promotions"
+_promotion_oid="0123456789abcdef0123456789abcdef01234567"
+jq -n --arg oid "$_promotion_oid" \
+  '{schema_version:"1.0.0",pr_number:91,base:"main",head:"develop",head_oid:$oid,commits:[$oid],verified_at:"2026-08-12T00:00:00Z"}' \
+  > "$_mrg_tmp/.rite/release-promotions/91.json"
+rc=0
+output=$(_mrg_run "$_mrg_tmp" "gh pr merge 91 --merge; echo --match-head-commit $_promotion_oid") || rc=$?
+decision=$(extract_hook_field "$output" permissionDecision)
+reason=$(extract_hook_field "$output" permissionDecisionReason)
+if [ "$decision" = "deny" ] && [[ "$reason" == *"merge-release-promotion-unverified"* ]]; then
+  pass "TC-140c unrelated later pin is rejected"
+else
+  fail "TC-140c expected promotion-unverified deny, got decision=$decision reason=$reason"
+fi
+rm -rf "$_mrg_tmp"
+echo ""
+
 # --------------------------------------------------------------------------
 # Why: persist deny-only audit records
 # --------------------------------------------------------------------------

--- a/plugins/rite/hooks/tests/release-promotion-verify.test.sh
+++ b/plugins/rite/hooks/tests/release-promotion-verify.test.sh
@@ -12,11 +12,16 @@ cat > "$TMP_ROOT/bin/gh" <<'EOF'
 if [ "$1 $2" = "pr view" ]; then
   jq -n --arg base "${MOCK_BASE:-main}" --arg head "${MOCK_HEAD:-develop}" \
     --arg oid "0123456789abcdef0123456789abcdef01234567" \
-    '{baseRefName:$base,headRefName:$head,headRefOid:$oid,commits:[{oid:$oid}]}'
+    '{baseRefName:$base,headRefName:$head,headRefOid:$oid}'
 elif [ "$1" = "api" ]; then
   oid="0123456789abcdef0123456789abcdef01234567"
-  if [ "${MOCK_UNREVIEWED:-0}" = 1 ]; then printf '[]\n'
-  else jq -n --arg oid "$oid" '[{merged_at:"2026-08-01T00:00:00Z",merge_commit_sha:$oid}]'; fi
+  case " $* " in
+    *"/pulls/"*"/commits"*) printf '%s\n' "$oid" ;;
+    *)
+      if [ "${MOCK_UNREVIEWED:-0}" = 1 ]; then printf '[]\n'
+      else jq -n --arg oid "$oid" '[{merged_at:"2026-08-01T00:00:00Z",merge_commit_sha:$oid}]'; fi
+      ;;
+  esac
 else
   exit 64
 fi

--- a/plugins/rite/hooks/tests/release-promotion-verify.test.sh
+++ b/plugins/rite/hooks/tests/release-promotion-verify.test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOKS_DIR="$SCRIPT_DIR/.."
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/state/.rite"
+
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/bin/bash
+if [ "$1 $2" = "pr view" ]; then
+  jq -n --arg base "${MOCK_BASE:-main}" --arg head "${MOCK_HEAD:-develop}" \
+    --arg oid "0123456789abcdef0123456789abcdef01234567" \
+    '{baseRefName:$base,headRefName:$head,headRefOid:$oid,commits:[{oid:$oid}]}'
+elif [ "$1" = "api" ]; then
+  oid="0123456789abcdef0123456789abcdef01234567"
+  if [ "${MOCK_UNREVIEWED:-0}" = 1 ]; then printf '[]\n'
+  else jq -n --arg oid "$oid" '[{merged_at:"2026-08-01T00:00:00Z",merge_commit_sha:$oid}]'; fi
+else
+  exit 64
+fi
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+# Keep repository resolution deterministic while isolating state output.
+export PATH="$TMP_ROOT/bin:$PATH"
+export RITE_STATE_ROOT="$TMP_ROOT/state"
+
+head_oid=$(bash "$HOOKS_DIR/release-promotion-verify.sh" 88)
+test "$head_oid" = "0123456789abcdef0123456789abcdef01234567"
+jq -e '.pr_number == 88 and .base == "main" and .head == "develop" and (.commits | length == 1)' \
+  "$TMP_ROOT/state/.rite/release-promotions/88.json" >/dev/null
+
+if MOCK_UNREVIEWED=1 bash "$HOOKS_DIR/release-promotion-verify.sh" 89 >/dev/null 2>&1; then
+  echo "FAIL: unreviewed commit was accepted" >&2
+  exit 1
+fi
+if MOCK_BASE=develop MOCK_HEAD=feature bash "$HOOKS_DIR/release-promotion-verify.sh" 90 >/dev/null 2>&1; then
+  echo "FAIL: non-promotion PR shape was accepted" >&2
+  exit 1
+fi
+
+echo "release-promotion-verify tests passed"

--- a/plugins/rite/hooks/tests/release-promotion-verify.test.sh
+++ b/plugins/rite/hooks/tests/release-promotion-verify.test.sh
@@ -17,6 +17,7 @@ elif [ "$1" = "api" ]; then
   oid="0123456789abcdef0123456789abcdef01234567"
   case " $* " in
     *"/pulls/"*"/commits"*) printf '%s\n' "$oid" ;;
+    *"/pulls/"*) printf '%s\n' "${MOCK_COMMIT_COUNT:-1}" ;;
     *)
       if [ "${MOCK_UNREVIEWED:-0}" = 1 ]; then printf '[]\n'
       else jq -n --arg oid "$oid" '[{merged_at:"2026-08-01T00:00:00Z",merge_commit_sha:$oid}]'; fi
@@ -43,6 +44,10 @@ if MOCK_UNREVIEWED=1 bash "$HOOKS_DIR/release-promotion-verify.sh" 89 >/dev/null
 fi
 if MOCK_BASE=develop MOCK_HEAD=feature bash "$HOOKS_DIR/release-promotion-verify.sh" 90 >/dev/null 2>&1; then
   echo "FAIL: non-promotion PR shape was accepted" >&2
+  exit 1
+fi
+if MOCK_COMMIT_COUNT=251 bash "$HOOKS_DIR/release-promotion-verify.sh" 91 >/dev/null 2>&1; then
+  echo "FAIL: incomplete capped commit list was accepted" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 概要

リリース工程と merge review gate の衝突を解消します。

Closes #2269

## 変更内容

- リリース準備 PR に `/rite:iterate` を組み込み、通常変更のレビューを必須化
- develop→main 昇格の全コミットが既マージ PR 経由か検証する helper を追加
- 検証済み head SHA を `--match-head-commit` で固定した昇格だけ merge gate で許可
- 通常 PR の review-results 必須条件と昇格検証失敗の fail-loud をテストで固定

## テスト

- `bash plugins/rite/hooks/tests/release-promotion-verify.test.sh`
- `bash plugins/rite/hooks/tests/pre-tool-bash-guard.test.sh`（247 passed）
- `bash plugins/rite/hooks/tests/run-tests.sh`（137 suites passed）
- `git diff --check`

## チェックリスト

- [x] リリース準備 PR がレビューを経る
- [x] 検証済み昇格を CLI でマージできる
- [x] 未レビューの通常 PR は引き続き遮断される
- [x] 直接 push・stale head は別 failure class で遮断される
