### PR TITLE
fix(release): Phase 2.5 の staging を sandbox 安全にする

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -197,6 +197,14 @@ git add .claude-plugin/marketplace.json \
   plugins/rite/.claude-plugin/plugin.json \
   README.md README.ja.md docs/SPEC.md CHANGELOG.md CHANGELOG.ja.md
 git status --short --untracked-files=no
+expected_staged=$(printf '%s\n' \
+  .claude-plugin/marketplace.json plugins/rite/.claude-plugin/plugin.json \
+  README.md README.ja.md docs/SPEC.md CHANGELOG.md CHANGELOG.ja.md | sort)
+actual_staged=$(git diff --cached --name-only | sort)
+if [ "$actual_staged" != "$expected_staged" ]; then
+  echo "ERROR: release staging が期待する7ファイルと一致しません" >&2
+  exit 1
+fi
 git commit -m "chore: v{VERSION} バージョンバンプ + CHANGELOG 更新"
 git push -u origin HEAD
 ```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -193,7 +193,10 @@ grep -rn "{OLD_VERSION}" .claude-plugin/ plugins/rite/.claude-plugin/ README.md 
 ### 2.5 コミット・PR 作成・マージ
 
 ```bash
-git add -A
+git add .claude-plugin/marketplace.json \
+  plugins/rite/.claude-plugin/plugin.json \
+  README.md README.ja.md docs/SPEC.md CHANGELOG.md CHANGELOG.ja.md
+git status --short --untracked-files=no
 git commit -m "chore: v{VERSION} バージョンバンプ + CHANGELOG 更新"
 git push -u origin HEAD
 ```


### PR DESCRIPTION
## 概要

リリース準備で `git add -A` が sandbox のマスク対象を拾って失敗する問題を解消します。

## 関連 Issue

Closes #2268

## 変更内容

- Phase 2.5 の staging 対象を更新対象の7ファイルへ限定
- staging 直後に tracked changes の範囲を確認する手順を追加

## 確認

- [x] 明示パスの staging 対象が Phase 2.3 / 2.4 の更新対象と一致
- [x] `git status --short --untracked-files=no` で staging 範囲を確認
- [x] `git diff --check` 成功

## Known Issues

- lint 未実行（lint コマンドが設定されていません）
