### PR TITLE
refactor(skills): SKILL 記述ダイエット第 2 波を大型 4 本へ適用

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -154,7 +154,7 @@ rite-workflow/
 │ ├── fix/ # /rite:fix (review 指摘対応; + references/) — sub-skill
 │ ├── ready/ # /rite:ready (Ready for review 化)
 │ ├── merge/ # /rite:merge (squash merge)
-│ ├── cleanup/ # /rite:cleanup (+ references/archive-procedures.md)
+│ ├── cleanup/ # /rite:cleanup (+ references/archive-procedures.md; + references/rationale.md)
 │ ├── batch-run/ # /rite:batch-run (複数 Issue 順次 open→iterate; --merge で ready→merge→cleanup まで)
 │ ├── pr-create/ # /rite:pr-create (draft PR 作成) — sub-skill
 │ # --- Issue 管理 ---
@@ -167,10 +167,10 @@ rite-workflow/
 │ # --- Wiki ---
 │ ├── wiki-init/ # /rite:wiki-init
 │ ├── wiki-query/ # /rite:wiki-query
-│ ├── wiki-ingest/ # /rite:wiki-ingest (+ references/wiki-troubleshooting.md)
-│ ├── wiki-lint/ # /rite:wiki-lint (+ references/: broken-ref-resolution / bash-cross-boundary-state-transfer / descriptive-refs-rationale)
+│ ├── wiki-ingest/ # /rite:wiki-ingest (+ references/wiki-troubleshooting.md; + references/rationale.md)
+│ ├── wiki-lint/ # /rite:wiki-lint (+ references/: broken-ref-resolution / bash-cross-boundary-state-transfer / descriptive-refs-rationale; + references/rationale.md)
 │ # --- meta / top-level ---
-│ ├── setup/ # /rite:setup (+ --upgrade)
+│ ├── setup/ # /rite:setup (+ --upgrade; + references/rationale.md)
 │ ├── getting-started/ # /rite:getting-started
 │ ├── workflow/ # /rite:workflow (rite ワークフロー全体ガイド)
 │ ├── unknowns/ # /rite:unknowns (実装前探索: ブラインドスポット/ブレスト/プロトタイプ/インタビュー; + references/feedback-mode.html)

--- a/plugins/rite/skills/cleanup/SKILL.md
+++ b/plugins/rite/skills/cleanup/SKILL.md
@@ -84,7 +84,8 @@ PR 検出時は返却された `headRefName` と `{branch_name}` の完全一致
 とする。不一致は削除対象 identity が確定しないため中断する。PR 未検出でユーザーが「ブランチを削除して続行」
 を明示選択した場合だけ承認済み入力として `true`、それ以外は `false`。prefix denylist で identity を推測しない。
 
-`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。これによりステップ 4-W / ステップ 5 のすべての分岐で `{pr_merged}` が必ず literal substitute 可能になる（未定義値参照を防ぐ）。ステップ 4-W の worktree パス manifest 記録、およびステップ 5 のブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）で参照する。
+`mergedAt` が非 null（= PR が merge 済み）なら `{pr_merged}=true` として保持する。**それ以外のすべての経路**（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んで続行した経路など）は `{pr_merged}=false` を既定とする。ステップ 4-W / ステップ 5 の全分岐で `{pr_merged}` を literal substitute する。
+rationale: references/rationale.md#pr-merged-default
 
 ### 1.4 リポジトリ情報取得
 
@@ -124,7 +125,8 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }' -f owner="{owner}" -f repo="{repo}" -F number={issue_number}
 ```
 
-Tasklist fallback では、GitHub code search の `[`/`]` が不安定（リテラルを無視しほぼ全 Issue を返す）なため、`--jq '.[0]'` で先頭を盲目採用すると standalone closing Issue が自分自身や無関係 Issue を親と誤検出する。複数候補を取得し、自己マッチ除外＋候補 body の tasklist 行再検証を経た候補のみ採用する（#1629 で close.md / projects-integration.md §2.4.7.1 に導入したループと同一方針。検証ループ本体（自己除外・再検証 regex・`--limit 10`）は close.md Phase 4.5.1 / projects-integration.md §2.4.7.1 と揃える。`--state` は cleanup が `--state open`（子マージ直後で親は通常 open）を使い、これは projects-integration.md §2.4.7.1 と一致する。差異は close.md Phase 4.5.1 が `--state all`（closing Issue の親が既に closed の可能性）を使う点のみ）:
+Tasklist fallback では、複数候補を取得し、自己マッチ除外＋候補 body の tasklist 行再検証を経た候補のみ採用する。検証ループ本体（自己除外・再検証 regex・`--limit 10`）は close.md Phase 4.5.1 / projects-integration.md §2.4.7.1 と揃える。`--state` は cleanup が `--state open`（子マージ直後で親は通常 open）を使い、これは projects-integration.md §2.4.7.1 と一致する。差異は close.md Phase 4.5.1 が `--state all`（closing Issue の親が既に closed の可能性）を使う点のみ:
+rationale: references/rationale.md#tasklist-parent-verify
 
 ```bash
 # GitHub code search は `[`/`]` を無視する緩いマッチのため、複数候補を取得して検証する
@@ -159,7 +161,8 @@ echo "[DEBUG] parent not detected for issue #{issue_number} — processing as st
 
 関連 Issue が識別できなければステップ 4 へ進む。
 
-Work Memory の正本を **存在ではなく内容** で選ぶ。PostToolUse hook が作る空 stub（`phase: init`・進捗セクションなし）はファイルとして存在するが、存在検査だけだと stub を正本と見なし Issue コメント側 fallback が発火しない（存在と成功を同一視しないため）。進捗セクション見出し（現行 `### 進捗サマリー` / v1 `### 進捗`）が実在するときだけローカル WM を正本とし、stub 判定時はコメント側へ fallback して WARNING で可視化する:
+Work Memory の正本を **存在ではなく内容** で選ぶ。進捗セクション見出し（現行 `### 進捗サマリー` / v1 `### 進捗`）が実在するときだけローカル WM を正本とし、stub 判定時はコメント側へ fallback して WARNING で可視化する:
+rationale: references/rationale.md#wm-source-content
 
 ```bash
 # WM 正本の選定（候補の存在ではなく内容を検査する）
@@ -344,7 +347,8 @@ case "$project_reg" in
 esac
 ```
 
-汎用的な argument structure・mapping 表は [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md) を参照。`source: "cleanup"` 引数は本 caller の識別子として必須 (将来 metrics 集計で起点 caller を区別するため)。`残作業` label は **step 0 で `gh label create 残作業` を冪等に事前作成する** ことが必須 (`gh issue create --label X` は X 未存在時に fail するため。`2>/dev/null || true` で既存ラベル時のエラーを無視)。
+汎用的な argument structure・mapping 表は [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md) を参照。`source: "cleanup"` 引数は本 caller の識別子として必須。`残作業` label は **step 0 で `gh label create 残作業` を冪等に事前作成する** ことが必須 (`gh issue create --label X` は X 未存在時に fail するため。`2>/dev/null || true` で既存ラベル時のエラーを無視)。
+rationale: references/rationale.md#cleanup-source-label
 
 ---
 
@@ -409,14 +413,15 @@ esac
 
 **分岐の基準は「worktree 内か」ではなく「`ExitWorktree` で main checkout へ退出できるか」**（#2133）。`in_worktree` は EnterWorktree 管理下で退出でき、`in_worktree_unrecorded` は path 入場で `ExitWorktree` が no-op になる — 後者では main checkout 操作が harness の worktree 隔離ガードに拒否されるため、実行せず委譲する。
 
-> **ガードが拒否する形（実測）**: harness が拒否するのは **Bash ツール呼び出しのコマンド文字列に直接 `cd {main_root}` / `git -C {main_root}` を書く形**（および worktree 外を向くか検証不能な複合ブロック）であり、helper スクリプト内部の `cd` は拒否されない（ステップ 7 の `pr-cycle-cleanup.sh` は内部で main checkout へ `cd` して `git worktree remove` / `git branch -d` を実行できている）。本 SKILL.md のステップ 4 / 4-W / 5 / 9 はいずれも前者の形を取るため委譲対象になる。helper へ閉じ込めれば自動化できる余地は残るが、それは「worktree 内から全項目を完走させる」という現行設計の Non-goal。
+> **ガードが拒否する形（実測）**: harness が拒否するのは **Bash ツール呼び出しのコマンド文字列に直接 `cd {main_root}` / `git -C {main_root}` を書く形**（および worktree 外を向くか検証不能な複合ブロック）であり、helper スクリプト内部の `cd` は拒否されない。
+rationale: references/rationale.md#exitworktree-delegation
 
 - `CLEANUP_WT=in_worktree_unrecorded`（EnterWorktree 非経由の path 入場 = ユーザーがセッションを worktree ディレクトリで開いた場合。`ExitWorktree` が no-op で main checkout へ戻れない）: **下記の手順 1〜4 を実行しない**（`CLEANUP_DELEGATED=1`）。main checkout 操作を要する 4 項目（base 更新 = ステップ 4 / worktree 削除 = 本 4-W / ブランチ削除 = ステップ 5 / wiki ingest = ステップ 9）は**試行せず**、ステップ 12 が未完了として列挙し委譲する。worktree 内で完結する項目（PR-specific state 削除・Projects Status 更新・Issue クローズ・作業メモリ更新・flow state リセット）は通常どおり実行する。ガードを迂回する複合コマンド（main checkout への `cd` / `git -C` リダイレクト）は**試みない** — ガードは正当に機能しており、迂回は設計違反。
   **委譲先は main checkout での `/rite:cleanup {pr_number}` 再実行**（1 系統）。再実行セッションでは flow-state に worktree 記録が無いため 4-W は `CLEANUP_WT=none` を返し、`CLEANUP_DELEGATED` を emit せずステップ 4 / 5 / 9 が通常実行される。base 更新・wiki ingest・リモートブランチ削除はそこで直接完了し、worktree 削除とローカルブランチ削除は**ステップ 5 が `branch` エントリを reap manifest に記録する**ことで次回セッション開始時の自動回収を arm する（`{pr_merged}=true`、manifest への記録を verify 済み、かつ対象 worktree が reaper と同じ filtered dirty gate を通過したときだけ `recovery=auto` になる。未マージ PR の強制 cleanup・記録漏れ・dirty または判定不能な worktree は `recovery=manual` に倒れ手動回復が必要 — 出し分けはステップ 12 の `{local_branch_check}` 判定に規定済み。既存配線で、本ステップから追加の記録は行わない）。
 - `CLEANUP_WT=in_worktree`（EnterWorktree 管理下 = `/rite:batch-run` 経由の通常経路。`ExitWorktree` で退出できる）:
   1. `dirty=yes` なら **AskUserQuestion**（「`git stash push` して続行 / 中止」）。説明文は上記 `--- dirty files begin/end ---` デリミタ内に出力された生パス一覧を**引用**する（要約・創作しない）。stash は common git dir に格納されるため worktree 削除後も `git stash pop` 可能（完了報告の stash 案内は従来文面を流用）。
   2. `ExitWorktree` ツールを `action: "keep"` で呼び出し、main checkout に復帰する（path 入場した worktree は remove でも消えない仕様のため**常に keep**）。
-  3. main から worktree を削除する。**削除前に self-exclusion 付き live-cwd guardを通す**: **別の**セッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、削除せず遅延回収へ委譲する。一方、cleanup を実行している**自セッション自身**（ハーネス = この Bash の親 `$PPID` の process subtree）は除外する — これを除外しないと、ステップ 2 の `ExitWorktree(keep)` が no-op / 失敗に終わった経路で自セッションを「live」と誤検出し、cleanup 自身を理由に削除をブロックする自己ブロッキングが起きる。判定は self-exclusion を内蔵した `worktree-foreign-cwd.sh` に委譲する（全プロセスを列挙する `worktree-live-cwd.sh` 自体は変更しない）:
+  3. main から worktree を削除する。**削除前に self-exclusion 付き live-cwd guardを通す**: **別の**セッションの harness cwd がまだこの worktree に立っている場合に削除すると、そのセッションの `/clear` が `Path does not exist` で失敗するため、削除せず遅延回収へ委譲する。cleanup を実行している**自セッション自身**（ハーネス = この Bash の親 `$PPID` の process subtree）は除外する。判定は self-exclusion を内蔵した `worktree-foreign-cwd.sh` に委譲する（全プロセスを列挙する `worktree-live-cwd.sh` 自体は変更しない）:
      ```bash
      # rc 0 = 別の live セッションが cwd を置く → 削除を遅延 / rc 1 = 自セッションだけ or 不在
      #        → 削除 / rc 2 = 判定不能（/proc 無し）→ 削除（従来 worktree-live-cwd.sh rc=2 と同じ後方互換）。
@@ -486,17 +491,19 @@ esac
        git worktree prune 2>/dev/null || true
      fi
      ```
-     > 通常の `in_worktree` 経路ではステップ 2 の `ExitWorktree(keep)` で自セッションの harness cwd が main に退避済みのため、worktree には自他いずれの cwd も無く `worktree-foreign-cwd.sh` は rc=1（削除）を返す。`ExitWorktree(keep)` が no-op / 失敗に終わった経路でも、残る live cwd は自セッションのハーネス（`$PPID` subtree）だけなので self-exclusion により rc=1（削除）となり、自己ブロッキングしない。rc=0（遅延）になるのは別セッションのハーネスが実際にこの worktree 内に cwd を持つ場合のみ。`/proc` の無い環境では rc=2 となり従来どおり削除を実行する（後方互換）。
-  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（AC-5）。`WORKTREE_REMOVE_FAILED` / `WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` は `{pr_merged}=true` のときのみ reap manifest（`.rite/tmp-artifacts.tsv`）へ `session_worktree` type でパスを記録する（`worktree` type ではない — Step 4.5 の ephemeral tmp artifact 専用 ungated reap と混ぜないため）。corpse 化（admin dir 半壊で git がツリーを認識できなくなる状態）した場合、checkout 中 branch が解決不能でブランチ名 bypassが構造的に効かないため、パス自体の記録で `pr-cycle-cleanup.sh` Step 5 の corpse age guard（24h 待ち）をバイパスさせ、mount 解放後の次回セッションで即座に回収できるようにする。
+     > 通常の `in_worktree` 経路ではステップ 2 の `ExitWorktree(keep)` で自セッションの harness cwd が main に退避済みのため、`worktree-foreign-cwd.sh` は rc=1（削除）を返す。`ExitWorktree(keep)` が no-op / 失敗でも、残る live cwd は自セッションだけなので self-exclusion により rc=1。rc=0（遅延）は別セッションのハーネスがこの worktree 内に cwd を持つ場合のみ。`/proc` の無い環境では rc=2 となり従来どおり削除を実行する（後方互換）。
+rationale: references/rationale.md#live-cwd-self-exclusion
+  4. 削除失敗（`WORKTREE_REMOVE_FAILED`）、live-cwd skip（`WORKTREE_REMOVE_SKIPPED_LIVE_CWD`）、または sandbox マスク skip（`WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` — remove 試行自体が admin dir を半壊させるため試行せず委譲）は **WARNING を表示して続行**（non-blocking。`pr-cycle-cleanup.sh` の遅延 reap へ委譲。ステップ 12 報告に失敗/skip と手動コマンドを表示）。busy 失敗時は上記の sandbox 干渉 WARNING も追加表示される（AC-5）。`WORKTREE_REMOVE_FAILED` / `WORKTREE_REMOVE_SKIPPED_SANDBOX_MASK` は `{pr_merged}=true` のときのみ reap manifest（`.rite/tmp-artifacts.tsv`）へ `session_worktree` type でパスを記録する（`worktree` type ではない）。corpse 化した場合、パス記録で `pr-cycle-cleanup.sh` Step 5 の corpse age guard（24h 待ち）をバイパスさせ、mount 解放後の次回セッションで即座に回収できるようにする。
+rationale: references/rationale.md#session-worktree-reap
 - `CLEANUP_WT=in_main`（resume 等で既に main 復帰済み）: 上記 1〜2 をスキップ。worktree が残っていれば 3 を実行（既削除なら 3 もスキップ = 冪等）。in_main では所有セッションが別セッションの可能性があるため、3 の self-exclusion 付き live-cwd guard が特に重要（live-cwd guard による遅延は別セッション在席時。これに加え sandbox マスク検知時（sandbox マスク）も削除を試行せず遅延する）。
 - `CLEANUP_WT=none`（multi_session 無効、または worktree 関連なし = 物理 cwd も当該 Issue の worktree でない）: 4-W 全体を no-op でスキップ。**注**: flow-state 未記録でも物理 cwd が当該 Issue の worktree なら `in_worktree_unrecorded` に分類されここには落ちない（#1622）。
 
 > **復旧: `/clear` が `Path does not exist` で失敗する場合**
-> セッション worktree（`.rite/worktrees/issue-{N}`）が遅延 reap または手動削除で消えた後、所有セッションをハーネスが resume すると cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗することがある。`pr-cycle-cleanup.sh` の worktree liveness guardはこれを予防するが、ハーネスの cwd レコード自体は rite から intercept できないため、万一発生した場合は次のいずれかで復旧する:
+> セッション worktree（`.rite/worktrees/issue-{N}`）が遅延 reap または手動削除で消えた後、所有セッションをハーネスが resume すると cwd 復元先が無く `/clear` が `Error: Path "...worktrees/issue-{N}" does not exist` で失敗することがある。ハーネスの cwd レコード自体は rite から intercept できないため、万一発生した場合は次のいずれかで復旧する:
 > 1. リポジトリ root（main checkout）で**新しいセッションを開始**する（cwd が有効になり `/clear` が機能する）。
 > 2. 作業を続けるなら、有効なディレクトリで `/rite:recover {issue_number}` を実行する（worktree が消えていれば再構築経路に入る）。
 > 3. 残骸が残っていれば `git worktree prune` で参照を整理する。
-> session-start hook の挙動は 2 経路に分かれる（相互排他、同一フック実行内では片方のみ発火、いずれも非blocking）: (a) cwd 自体が消えた session worktree を指す場合は上記ガイドを stderr に表示してその場で `exit 0` する、(b) cwd は有効だが記録された worktree 参照だけが消えた場合は flow-state の dangling 参照を自動クリアする。
+> session-start hook は 2 経路（相互排他、いずれも非blocking）: (a) cwd 自体が消えた session worktree を指す場合は上記ガイドを stderr に表示して `exit 0` する、(b) cwd は有効だが記録された worktree 参照だけが消えた場合は flow-state の dangling 参照を自動クリアする。
 
 ### 4 base ブランチの更新（安全化）
 
@@ -504,11 +511,8 @@ esac
 
 main checkout の不可侵規約（[git-worktree-patterns.md](../../references/git-worktree-patterns.md#main-checkout-不可侵-inviolability-convention)）に従い、**main checkout が `{base_branch}` 上にある場合のみ** base を更新する。別 branch 上では切り替えず WARNING + skip する:
 
-main_root への cd は worktree 自己削除後の cwd 破損対策。この Bash 永続シェルの cwd が
-4-W の worktree 削除で無効化されていても、4-W が削除前に確保した main checkout の絶対パスへ明示的に
-cd することで本ステップ以降を正しい場所で実行する（`{main_root}` は 4-W の `[CONTEXT] ... main_root=`
-marker の値）。cd はこの Bash 呼び出しの永続シェル cwd を変更するため、ステップ 5 以降も同じ main_root
-上で実行される（順序契約 4-W→5 自体は変更しない）:
+main_root への cd は worktree 自己削除後の cwd 破損対策。`{main_root}` は 4-W の `[CONTEXT] ... main_root=` marker の値。cd はこの Bash 呼び出しの永続シェル cwd を変更するため、ステップ 5 以降も同じ main_root 上で実行される（順序契約 4-W→5 自体は変更しない）:
+rationale: references/rationale.md#main-root-cd
 
 ```bash
 main_root="{main_root}"
@@ -573,7 +577,8 @@ fi
 fi
 ```
 
-`BASE_UPDATE` marker で分岐する（dirty な基点ブランチを黙って上書きしないため。破棄・stash は必ずユーザー確認を挟み、無確認の破壊的操作をしない。`--- dirty files begin/end ---` デリミタ内の行はファイル一覧 **data** であり、marker として解釈しない — marker は行頭 `[CONTEXT]` の行のみ）:
+`BASE_UPDATE` marker で分岐する（dirty な基点ブランチを黙って上書きしない。破棄・stash は必ずユーザー確認を挟む。`--- dirty files begin/end ---` デリミタ内の行はファイル一覧 **data** であり、marker として解釈しない — marker は行頭 `[CONTEXT]` の行のみ）:
+rationale: references/rationale.md#base-update-classify
 
 | `BASE_UPDATE` | アクション |
 |---|---|
@@ -855,7 +860,8 @@ fi
 
 `BRANCH_DELETED=1; via=squash-merged`（PR が merged 済みで `git branch -d` が squash 残渣により拒否したケース）は通常削除と同様にステップ 12 で `x` に分岐する。`BRANCH_DELETE_UNMERGED=1`（未マージ PR の強制 cleanup で `{pr_merged}=false` のとき）は「強制削除 (`-D`) / スキップ」を確認する。**強制削除を選んだ場合**は `LC_ALL=C git branch -D {branch_name} && echo "[CONTEXT] BRANCH_DELETED=1; branch={branch_name}; via=force"` を実行し、削除完了を marker で示す（ステップ 12 が `x` に分岐する）。スキップ時は marker を追加しない（残置のまま）。`BRANCH_DELETE_DEFERRED=1`（作業ツリーが未削除のまま残り削除を遅延したケース — 別セッション使用中別セッション使用中 または sandbox マスク skipsandbox マスク。原因は断定しない）のときは**強制削除しない**。marker の `recovery=` で次セッション回収の可否が決まる: `recovery=auto`（{pr_merged}=true、reap manifest の記録を verify 済み、かつ対象 worktree が reaper と同じ filtered dirty gate を通過）は worktree 解放後に `pr-cycle-cleanup.sh` Step 5 が自動回収する。`recovery=manual`（未マージ PR の強制 cleanup、記録漏れ、dirty または判定不能な worktree）は自動回収されない。実パスを解決できた場合は `BRANCH_DELETE_DEFERRED_WORKTREE` marker の shell-escaped `path_q=` を用いて status を確認し、変更を commit / stash / copy して clean にした後だけ、非 force の `git worktree remove` → prune → branch delete を実行する。解決不能時は `git worktree list --porcelain` で先に実パスを特定する。ステップ 12 はこの `recovery=` 値で残置メッセージを出し分ける。
 
-リモート削除は **ブランチ名の事前検証 → 一時ファイル確保 → `git ls-remote --exit-code`（rc=128 なら 1 回リトライ、#2140）+ ref 名の完全一致検証** の順に進み、**どの経路も必ず marker を emit する**（marker 名は 4 種、emit 箇所は 8 — うち fail-fast 4 経路（空値 / marker デリミタ / refname 非合法 / 一時ファイル確保失敗）は `ls-remote` を実行しない。#2016）: 事前検証（空値 / marker デリミタ文字 / refname 非合法）に落ちた場合、一時ファイルを確保できなかった場合、ref 名の完全一致検証が異常終了した場合はいずれも削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1`（原因は marker の `rc=` と `reason=` で区別する）。`rc=0`（存在確認済み）は削除し、成功なら `REMOTE_BRANCH_DELETED=1`、失敗（protected branch / 権限不足 / race）なら `REMOTE_BRANCH_DELETE_FAILED=1` を emit する。`rc=2` は不在なので削除せず `REMOTE_BRANCH_ALREADY_ABSENT=1`、それ以外の非 0（リトライ後も 128 を含む）は存在有無が判定できないため削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1` を emit する。成功側も marker を出すのは、ステップ 12 が marker 不在を「削除成功」と読まないようにするため — 不在を成功の符号化に使うと、本ブロックが実行されなかった経路と削除成功が同一視され、`/rite:merge` の完了報告と同種の「実際には起きていないことを完了として報告する」嘘が判定表側から復活する。リポジトリ設定 `delete_branch_on_merge: true` の環境では merge 時にサーバサイドで head ブランチが削除されるため通常は `rc=2` に落ち、`/rite:merge` の `--delete-branch=false` はこれを抑止しない（`skills/merge/SKILL.md` の設計判断を参照）。`delete_branch_on_merge: false` のリポジトリでは従来どおり `rc=0` 経路で削除される。
+リモート削除は **ブランチ名の事前検証 → 一時ファイル確保 → `git ls-remote --exit-code`（rc=128 なら 1 回リトライ、#2140）+ ref 名の完全一致検証** の順に進み、**どの経路も必ず marker を emit する**（marker 名は 4 種、emit 箇所は 8 — うち fail-fast 4 経路（空値 / marker デリミタ / refname 非合法 / 一時ファイル確保失敗）は `ls-remote` を実行しない。#2016）: 事前検証（空値 / marker デリミタ文字 / refname 非合法）に落ちた場合、一時ファイルを確保できなかった場合、ref 名の完全一致検証が異常終了した場合はいずれも削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1`（原因は marker の `rc=` と `reason=` で区別する）。`rc=0`（存在確認済み）は削除し、成功なら `REMOTE_BRANCH_DELETED=1`、失敗（protected branch / 権限不足 / race）なら `REMOTE_BRANCH_DELETE_FAILED=1` を emit する。`rc=2` は不在なので削除せず `REMOTE_BRANCH_ALREADY_ABSENT=1`、それ以外の非 0（リトライ後も 128 を含む）は存在有無が判定できないため削除を試行せず `REMOTE_BRANCH_CHECK_FAILED=1` を emit する。成功側も marker を出す。リポジトリ設定 `delete_branch_on_merge: true` の環境では merge 時にサーバサイドで head ブランチが削除されるため通常は `rc=2` に落ち、`/rite:merge` の `--delete-branch=false` はこれを抑止しない（`skills/merge/SKILL.md` の設計判断を参照）。`delete_branch_on_merge: false` のリポジトリでは従来どおり `rc=0` 経路で削除される。
+rationale: references/rationale.md#remote-delete-markers
 
 ---
 
@@ -924,9 +930,11 @@ rite_rm accepted_fingerprints "$_state_root/.rite/state/accepted-fingerprints-${
 rite_rm review_run_since "$_state_root/.rite/state/review-run-since-${pr_number}.txt"
 ```
 
-`review-run-since-{pr}.txt` は `/rite:iterate` の収束トレンド判定が現 run の境界に使う pin (ステップ 0.6 が書き、ステップ 1 が `--since` で helper へ渡す)。直上で削除する `review-results/` と同じライフサイクルのため同列挙で掃除する。残しても次 run の開始時に上書きされるので害はないが、参照先が消えた孤児を PR ごとに積み上げない。
+`review-run-since-{pr}.txt` は `/rite:iterate` の収束トレンド判定が現 run の境界に使う pin。直上で削除する `review-results/` と同じライフサイクルのため同列挙で掃除する。
+rationale: references/rationale.md#review-run-since-sweep
 
-`.rite/wiki-worktree/` は永続 worktree のため削除しない (再作成コストが高く各 PR cycle を跨いで保持する)。手動削除が必要なら `git worktree remove .rite/wiki-worktree && git worktree prune`。
+`.rite/wiki-worktree/` は永続 worktree のため削除しない。手動削除が必要なら `git worktree remove .rite/wiki-worktree && git worktree prune`。
+rationale: references/rationale.md#wiki-worktree-persist
 
 ---
 
@@ -944,7 +952,8 @@ bash {plugin_root}/hooks/scripts/pr-cycle-cleanup.sh 2>&1 || true
 
 **Critical**: Do NOT skip this step. `rite-config.yml.github.projects.enabled: true` かつステップ 2 で関連 Issue が識別できている場合のみ実行し、結果を `projects_status_updated` (true/false) として context に保持してステップ 12 の表示で参照する（`{projects_enabled}` / `{project_number}` / `{owner}` / `{repo}` / `{issue_number}` はステップ 1.4 / 2 / Placeholder Legend で確定済みの値をそのまま使う）。無効化・Issue 未識別の場合はステップ 9 へ進む。
 
-> **Source of truth**: `plugins/rite/scripts/projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と共通）。過去に multi-stage inline pipeline で LLM の attention が sub-step 間で途切れ Status 更新が silent skip する事象が確認されている（`skills/ready/SKILL.md` Phase 4.2 と同一原因）ため、参照のみに留めず本ステップに直接 inline する。
+> **Source of truth**: `plugins/rite/scripts/projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と共通）。参照のみに留めず本ステップに直接 inline する。
+rationale: references/rationale.md#projects-status-inline
 
 ```bash
 status_json_args=$(jq -n \
@@ -1052,8 +1061,7 @@ skill return 後、出力から以下のいずれかの sentinel を発火させ
 - push 失敗併存 (ingest 出力に `push=failed`): 上記 + `[CONTEXT] WIKI_INGEST_PUSH_FAILED=1; source=cleanup_step9`
 - 並行 ingest スキップ (ingest 出力に `WIKI_INGEST_SKIPPED reason=concurrent_ingest`): `[CONTEXT] WIKI_INGEST_SKIPPED=1; reason=concurrent_ingest`（別 live セッションが ingest 中。pending raw は wiki branch に残り次回 ingest が冪等回収する — multi-session §9）
 - 失敗: `[CONTEXT] WIKI_INGEST_FAILED=1; reason=ingest_error`
-
-> **#1941 wiki push batch/defer**: ingest.md はページ更新のたびに push していた旧挙動を、raw source ごとに commit のみ行い ingest フロー末尾（ステップ 8.6）で 1 回だけ push する方式に変更した（AC-1）。`push=failed` 部分文字列検出はそのまま機能する — 集約 push が失敗した場合も、その 1 回の push 結果として ingest の stdout に同じ文字列が現れるため、本ステップの検出ロジック自体の変更は不要（ローカル commit は保持され、次回 ingest のステップ 8.6 が自動で flush を試みる — AC-2 / SHOULD）。
+rationale: references/rationale.md#wiki-push-batch
 
 ingest の成否（skip 含む）に関わらずステップ 10 へ進む。
 
@@ -1078,7 +1086,8 @@ ingest の成否（skip 含む）に関わらずステップ 10 へ進む。
 - **Work Memory final update セクション** (= `### 3.5`): Issue comment への完了マーク追記 (gh API PATCH)
 - **State reset セクション** (= `## Phase 4: Reset State and Delete Local Work Memory`): `cleanup-work-memory.sh` 実行による local `.rite-work-memory/issue-*.md` ファイル削除 + flow state `active: false` リセット
 
-両方を実行しないと、Issue comment は最終化されるがローカル file は永続蓄積し `post-tool-wm-sync.sh` が次セッションで file を再生成する race 経路が開く。
+両方実行する（片方だけではローカル file が残り `post-tool-wm-sync.sh` が再生成する）。
+rationale: references/rationale.md#wm-dual-finalize
 
 あわせて Issue claim を解放する（`multi_session.enabled` に依らず常時実行。claim 取得は /rite:open Step 1.6）。`issue-claim.sh release` は flow-state を変更しないため、ステップ 9 の `WIKICHAIN:` handoff 契約（ステップ 9〜12 間で `flow-state.sh set` を挟まない）に抵触しない:
 
@@ -1150,14 +1159,16 @@ Status: {projects_status_result}
       すぐに消したい場合: git worktree remove --force '{flow_wt}' && git worktree prune
       （上記コマンドが「Device or resource busy」で失敗する場合、Step 4-W の sandbox 干渉 WARNING を参照し、sandbox 外のシェルで実行してください）
     ```
-  - `[CONTEXT] WORKTREE_REMOVE_*` のいずれの行も無い（削除成功）とき: `x`。**marker family でスコープすること** — 無条件の「いずれの `[CONTEXT]` 行も無いとき」はステップ 5 の `BRANCH_DELETED=1` 等が正常系でも必ず存在するため常に偽になり、本 check の判定オペランドが未定義になる（#2016）。ステップ 4-W は削除成功時に marker を出さないため、本 check に限り marker 不在は削除成功を意味してよい（ステップ 5 の全経路が marker を出す設計とは前提が異なる）
+  - `[CONTEXT] WORKTREE_REMOVE_*` のいずれの行も無い（削除成功）とき: `x`。**marker family でスコープすること**。ステップ 4-W は削除成功時に marker を出さないため、本 check に限り marker 不在は削除成功を意味してよい
 - `{local_branch_check}`: ステップ 5 の `[CONTEXT]` 行で判定する。本チェックはローカルとリモートの 2 つの削除を 1 行で表すため、**ローカル側判定とリモート側判定を独立に評価し、両方が `x` 相当のときだけ `x`** とする（どちらか一方でも未完了なら ` ` にし、未完了だった側の付記をすべて列挙する）。ローカル成功をリモート失敗より先に評価して `x` に丸めると、リモート側の残作業が silent に消える（#2016）。
 
-  **marker 名は `[CONTEXT] ` prefix 込みで一致させる（部分文字列一致させない）**: リモート側 marker `REMOTE_BRANCH_DELETE_FAILED` はローカル側 marker `BRANCH_DELETE_FAILED` を部分文字列として含むため、非アンカーで照合すると `[CONTEXT] REMOTE_BRANCH_DELETE_FAILED=1` の行にローカル側ルールが先に一致し、リモートの残渣に対してローカル削除コマンドを案内する誤処方になる（#2016）。`[CONTEXT] ` の直後から一致させれば `REMOTE_` が間に入るため衝突しない。本規約は `{base_update_check}` の `[CONTEXT] BASE_UPDATE=` 行 と同形で、今後 `REMOTE_` 系の marker を追加しても同じ衝突を構造的に防ぐ。
+  **marker 名は `[CONTEXT] ` prefix 込みで一致させる（部分文字列一致させない）**: リモート側 marker `REMOTE_BRANCH_DELETE_FAILED` はローカル側 marker `BRANCH_DELETE_FAILED` を部分文字列として含むため、非アンカーで照合すると `[CONTEXT] REMOTE_BRANCH_DELETE_FAILED=1` の行にローカル側ルールが先に一致し、リモートの残渣に対してローカル削除コマンドを案内する誤処方になる。`[CONTEXT] ` の直後から一致させれば `REMOTE_` が間に入るため衝突しない。
 
-  **さらに marker は `branch={branch_name}` までスコープして照合する**: `/rite:batch-run --merge` は同一セッション内で Issue ごとに `/rite:cleanup` をループ invoke するため、先行 Issue が残した `[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch=A` 等が後続 Issue の判定時にも文脈へ残る。marker 名までしか一致条件に含めないと、リモート側は失敗ルールを先頭に評価する設計上、**stale な失敗が自分の成功 marker を必ず上書きする**（既削除の B に対して「削除に失敗しました。手動削除してください」と処方し、実行すれば本 Issue が消したはずの `error:` が再び出る）。評価順序の入れ替えは解にならない — 成功を先頭にすると今度は stale な成功が実失敗を握り潰し、本 Issue が塞いだ false-success そのものになる。ステップ 5 は各 marker に `; branch={branch_name}` を付けて emit している（ブランチ名が契約を満たせない fail-fast 経路のみ、実ブランチ名を載せず sentinel `branch=<unsupported branch name>` を出してどのルールにも一致させず fallback へ倒す）ので、照合側でスコープすれば **Issue 間の**衝突は消える（#2016）。**`branch=` の値は直後が `;` または行末であることまで含めて一致させる** — 前方一致だけだと `branch=fix/issue-1-a` が `branch=fix/issue-1-a-v2` の行にも一致し、左端で塞いだのと同型の包含衝突が右端に残る。ただし `branch=` は**同一ブランチに対する cleanup 再実行**を識別できない（1 回目がネットワーク断で `CHECK_FAILED` を残し、原因解消後の 2 回目が `ALREADY_ABSENT` を出す場合、両者の `branch=` は一致する）。そのため **同一 marker family で複数行が一致したときは最後の出現を採用する**（recency）。この選択は**各側の判定ルールを評価する前**に行う（下記の 2 段手順を参照）。これがないと失敗ルール先頭評価の設計上、前回実行の失敗が今回の成功を決定的に上書きし、既削除ブランチに「削除に失敗しました。手動削除してください」と誤処方する — AC-4 が禁じた症状そのものになる。recency はローカル側・リモート側の両判定に適用する。
+  **さらに marker は `branch={branch_name}` までスコープして照合する**: `/rite:batch-run --merge` は同一セッション内で Issue ごとに `/rite:cleanup` をループ invoke するため、先行 Issue の marker が後続の判定文脈に残る。ステップ 5 は各 marker に `; branch={branch_name}` を付けて emit する（fail-fast 経路のみ sentinel `branch=<unsupported branch name>` でどのルールにも一致させず fallback へ倒す）。**`branch=` の値は直後が `;` または行末であることまで含めて一致させる**。`branch=` は**同一ブランチに対する cleanup 再実行**を識別できないため、**同一 marker family で複数行が一致したときは最後の出現を採用する**（recency）。この選択は**各側の判定ルールを評価する前**に行う。recency はローカル側・リモート側の両判定に適用する。
+rationale: references/rationale.md#marker-scope-recency
 
-  **さらに prefix は行頭から一致させ、デリミタ内は data として無視する**: ステップ 5 は `$_ls_err` / `$_push_err` に退避した git の stderr を WARNING に載せるため、marker と同じ出力ストリームに**外部由来の複数行テキスト**が流れる。行頭一致だけでは足りない — 複数行テキストの 2 行目以降は列 0 に着地するため、その中の `[CONTEXT] ` 行は行頭一致を突破する。そこでステップ 5 は退避 stderr を `--- {source} stderr begin ---` / `--- {source} stderr end ---` で囲んで出力する（ステップ 4 の dirty ファイル一覧が `--- dirty files begin/end ---` で data と marker を分離しているのと同形）。**照合側は `--- ... begin ---` と `--- ... end ---` に挟まれた区間を、`{source}` が何であれ一律 data として扱い、marker として解釈しない**（現在の退避サイトは branch delete / push / ls-remote の 3 箇所だが、照合規約はサイト列挙ではなくこの形で定義する — サイトを増やすたびに列挙更新を忘れて契約とコードが drift するのを構造的に防ぐ）。**退避テキストの各行は 2 スペースでインデントして出力する** — デリミタは可読性の補助であり、data 自身が終端行を騙る経路を塞ぐ security boundary はインデント（列 0 に到達しないこと）の側にある。照合側は**列 0 から始まる行だけを marker 候補とする**。以下のルールで「行があるとき」「行がいずれも無いとき」と書いた判定は、**肯定・否定とも行頭一致**で行う（fallback を非アンカーで判定すると先行ルールの否定にならず、行中に marker 断片が現れた入力でどのルールにも一致しない未定義状態が生じる）。
+  **さらに prefix は行頭から一致させ、デリミタ内は data として無視する**: ステップ 5 は git の stderr を WARNING に載せるため、marker と同じ出力ストリームに**外部由来の複数行テキスト**が流れる。ステップ 5 は退避 stderr を `--- {source} stderr begin ---` / `--- {source} stderr end ---` で囲む。**照合側は `--- ... begin ---` と `--- ... end ---` に挟まれた区間を、`{source}` が何であれ一律 data として扱い、marker として解釈しない**。**退避テキストの各行は 2 スペースでインデントして出力する**。照合側は**列 0 から始まる行だけを marker 候補とする**。以下のルールで「行があるとき」「行がいずれも無いとき」と書いた判定は、**肯定・否定とも行頭一致**で行う。
+rationale: references/rationale.md#marker-data-delimiter
 
   **ローカル側**（**2 段で判定する**: まず `[CONTEXT] ` 行頭一致 + marker family + `branch={branch_name}` に該当する行を集め、**その中の最後の出現 1 行だけを対象に選ぶ**。次にその 1 行に対して以下のルールを上から評価し最初に一致したものを採用する。段の順序を入れ替えてはならない — ルールを先に評価すると、蓄積した stale marker のうち上位ルールに当たるものが最新の行より先に一致し、recency が働かない）:
   - `[CONTEXT] BRANCH_DELETE_DEFERRED=1; branch={branch_name}` 行があるとき（作業ツリーが未削除のまま残っていて削除を見送った — 別セッション使用中しまたは sandbox マスク skip（sandbox マスク）。原因は断定しない）。**marker の `recovery=` フィールドで文面を出し分ける**（記録できていない経路で「自動回収」と偽らないため — AC-6）: ` ` + 以下を付記
@@ -1174,14 +1185,14 @@ Status: {projects_status_result}
   - `[CONTEXT] BRANCH_CHECK_FAILED=1; branch={branch_name}` 行があるとき（ブランチ名の事前検証に落ちた、または `git show-ref` が rc=0/1 以外で失敗して存在を判定できなかったため削除を試行していない。原因は marker の `rc=` で区別する。リモート側 `REMOTE_BRANCH_CHECK_FAILED` と対称）: ` ` + 「ローカルブランチ {branch_name} の存在確認に失敗したため削除を試行していません。`git branch --list {branch_name}` で確認し、残っていれば `git branch -D {branch_name}` で手動削除」を付記
   - `[CONTEXT] BRANCH_DELETE_FAILED=1; branch={branch_name}` 行があるとき: ` ` + 「ローカルブランチ {branch_name} の削除に失敗。`git branch -D {branch_name}` で手動削除（作業ツリーで使用中なら解放後）」を付記
   - `[CONTEXT] BRANCH_DELETE_UNMERGED=1; branch={branch_name}` 行があるとき（= 未マージ PR の強制 cleanup でユーザーが skip 選択。強制削除で解決した場合は上位の `BRANCH_DELETED=1` 行で既に `x` 評価済みのため、ここに到達するのは skip 時のみ）: ` ` + 「ローカルブランチ {branch_name} は未マージのため保留。`git branch -D {branch_name}` で手動削除」を付記
-  - `[CONTEXT] BRANCH_DELETED` / `[CONTEXT] BRANCH_DELETE_*` / `[CONTEXT] BRANCH_ALREADY_ABSENT` / `[CONTEXT] BRANCH_CHECK_FAILED` かつ `branch={branch_name}` の行がいずれも無いとき: ` ` + 「ローカルブランチ {branch_name} の削除結果を確認できませんでした。`git branch --list {branch_name}` で確認し、残っていれば `git branch -D {branch_name}` で手動削除」を付記。**marker 不在を「削除成功」と読んではならない**（#2016） — ステップ 5 はローカル側 6 marker（`BRANCH_ALREADY_ABSENT` / `BRANCH_DELETED` / `BRANCH_DELETE_DEFERRED` / `BRANCH_DELETE_UNMERGED` / `BRANCH_DELETE_FAILED` / `BRANCH_CHECK_FAILED`）のいずれかを必ず emit するため、不在が意味するのは削除成功ではなく「ステップ 5 の bash block が実行されなかった」「出力が compact で失われた」等の**実行結果を確認できていない状態**である。リモート側 fallback と同一の到達条件・同一の意味に揃える（片側だけ `x` に倒すと、同じ条件に正反対の意味を割り当てる矛盾になる）。**marker family でスコープすること** — 無条件の「いずれの `[CONTEXT]` 行も無いとき」はリモート側 marker の存在で偽になり判定が破綻する
+  - `[CONTEXT] BRANCH_DELETED` / `[CONTEXT] BRANCH_DELETE_*` / `[CONTEXT] BRANCH_ALREADY_ABSENT` / `[CONTEXT] BRANCH_CHECK_FAILED` かつ `branch={branch_name}` の行がいずれも無いとき: ` ` + 「ローカルブランチ {branch_name} の削除結果を確認できませんでした。`git branch --list {branch_name}` で確認し、残っていれば `git branch -D {branch_name}` で手動削除」を付記。**marker 不在を「削除成功」と読んではならない** — 不在は「ステップ 5 の bash block が実行されなかった」「出力が compact で失われた」等の**実行結果を確認できていない状態**である。**marker family でスコープすること**
 
   **リモート側**（**2 段で判定する**: まず `[CONTEXT] ` 行頭一致 + marker family + `branch={branch_name}` に該当する行を集め、**その中の最後の出現 1 行だけを対象に選ぶ**。次にその 1 行に対して以下のルールを上から評価し最初に一致したものを採用する。段の順序を入れ替えてはならない — ルールを先に評価すると、蓄積した stale marker のうち上位ルールに当たるものが最新の行より先に一致し、recency が働かない。#2016）:
   - `[CONTEXT] REMOTE_BRANCH_DELETE_FAILED=1; branch={branch_name}` 行があるとき（`rc=0` 経路で `git push origin --delete` を実行したが失敗した — protected branch / 権限不足 / race。リモートブランチは残存している）: ` ` + 「リモートブランチ {branch_name} の削除に失敗しました。`git push origin --delete "refs/heads/{branch_name}"` で手動削除」を付記
-  - `[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch={branch_name}` 行があるとき（`git ls-remote` が rc=0/2 以外で失敗した、またはブランチ名の事前検証・一時ファイル確保・ref 名の完全一致検証のいずれかが失敗して存在確認自体を完了できなかったため、削除を試行していない）: ` ` + 「リモートブランチ {branch_name} の存在確認に失敗したため削除を試行していません。`git ls-remote --exit-code --heads origin "refs/heads/{branch_name}"` で確認し、残っていれば `git push origin --delete "refs/heads/{branch_name}"` で手動削除」を付記（案内する確認コマンドにも `--exit-code` を付ける — 本 Issue が「ガードとして機能しない」と特定した `--heads` 単体の形をユーザーに処方すると、同じ誤判定を再生産する）
+  - `[CONTEXT] REMOTE_BRANCH_CHECK_FAILED=1; branch={branch_name}` 行があるとき（`git ls-remote` が rc=0/2 以外で失敗した、またはブランチ名の事前検証・一時ファイル確保・ref 名の完全一致検証のいずれかが失敗して存在確認自体を完了できなかったため、削除を試行していない）: ` ` + 「リモートブランチ {branch_name} の存在確認に失敗したため削除を試行していません。`git ls-remote --exit-code --heads origin "refs/heads/{branch_name}"` で確認し、残っていれば `git push origin --delete "refs/heads/{branch_name}"` で手動削除」を付記（案内する確認コマンドにも `--exit-code` を付ける）
   - `[CONTEXT] REMOTE_BRANCH_ALREADY_ABSENT=1; branch={branch_name}` 行があるとき（`delete_branch_on_merge: true` によるサーバサイド auto-delete などで既に不在。**正常系であり残作業ではない** — AC-4）: `x`
   - `[CONTEXT] REMOTE_BRANCH_DELETED=1; branch={branch_name}` 行があるとき（`rc=0` 経路で `git push origin --delete` を実行し成功した = 通常削除。`delete_branch_on_merge: false` のリポジトリの正常系）: `x`
-  - `[CONTEXT] REMOTE_BRANCH_*` かつ `branch={branch_name}` の行がいずれも無いとき: ` ` + 「リモートブランチ {branch_name} の削除結果を確認できませんでした。`git ls-remote --exit-code --heads origin "refs/heads/{branch_name}"` で確認し、残っていれば `git push origin --delete "refs/heads/{branch_name}"` で手動削除」を付記。**marker 不在を「削除成功」と読んではならない**（#2016） — ステップ 5 はリモート側 4 marker（`REMOTE_BRANCH_DELETED` / `REMOTE_BRANCH_DELETE_FAILED` / `REMOTE_BRANCH_ALREADY_ABSENT` / `REMOTE_BRANCH_CHECK_FAILED`）のいずれかを必ず emit するため、不在が意味するのは削除成功ではなく「ステップ 5 の bash block が実行されなかった」「出力が compact で失われた」等の**実行結果を確認できていない状態**である。ここを `x` に倒すと、`{base_update_check}` が marker 不在を「実行結果が確認できませんでした」として扱う規約と正反対になり、同 Issue が塞いだ false-success を判定表側から復活させる。**marker family でスコープすること** — 無条件の「いずれの `[CONTEXT]` 行も無いとき」は正常系でもローカル側の `BRANCH_DELETED=1` が必ず存在するため常に偽になり、リモート側の判定オペランドが未定義になる
+  - `[CONTEXT] REMOTE_BRANCH_*` かつ `branch={branch_name}` の行がいずれも無いとき: ` ` + 「リモートブランチ {branch_name} の削除結果を確認できませんでした。`git ls-remote --exit-code --heads origin "refs/heads/{branch_name}"` で確認し、残っていれば `git push origin --delete "refs/heads/{branch_name}"` で手動削除」を付記。**marker 不在を「削除成功」と読んではならない** — 不在は「ステップ 5 の bash block が実行されなかった」「出力が compact で失われた」等の**実行結果を確認できていない状態**である。**marker family でスコープすること**
 - `{projects_status_result}` / `{projects_check}`: 以下を**上から評価し最初に一致したもの**を採用する（`{wiki_ingest_check}` の legitimate-skip 区別パターンと統一。ステップ8 は `projects_enabled=false` または Issue 未識別のとき丸ごと skip され `[CONTEXT] PROJECTS_STATUS_UPDATED=` を emit しないため、この legitimate skip と本物の更新失敗を区別する）:
   - `{projects_enabled}`（Placeholder Legend の定義、`rite-config.yml` → `github.projects.enabled`）が `false` のとき: `{projects_status_result}` = `（Projects 連携無効）`、`{projects_check}` = `x`（警告ではなく informational — Wiki ingest の `reason=disabled` と同型）
   - ステップ 2 で関連 Issue が識別できなかった（`{issue_number}` 空）とき: `{projects_status_result}` = `（関連 Issue 未識別のためスキップ）`、`{projects_check}` = `x`
@@ -1195,7 +1206,8 @@ Status: {projects_status_result}
   | `reason=review_results_undecidable; cause=jq_missing` がある | ` ` | `⚠️ jq が見つからず全レビュー結果 JSON を無判定で archive/ へ退避しました。jq を導入してください` |
   | `reason=review_results_undecidable` がある（`cause=jq_rc_<n>`） | `x` | `ℹ️ 一部のレビュー結果 JSON は中身を判定できず削除せず archive/ へ退避しました (本 cycle での対応は不要)` |
 
-  行を presence 検査にしてあるので「上から評価し最初の一致」が実際に効く（実失敗と判定不能が同一 run で共起しても 1 行目が先に一致する）。`_gitignore_failure` は `cause=jq_rc_<n>` と同じく summary の `failed` には数えられない（ファイル自体は処理済み）が、1 行目の実失敗側に置く — 除外の欠落は退避した全文が `git add -A` で公開リポジトリへ入る経路そのもので、放置してよい informational ではない。`cause=jq_rc_<n>` を `x` に倒すのは、helper がこれを「退避自体は成功しうるので `failed` には数えない」と定義し summary も `failed=0` を返すため。`.corrupt-*` を「判定不能 → 退避」経路へ載せた以上 corrupt を持つ PR は毎回この reason を出すので、失敗扱いのままだと存在しない手動対応を促し続ける。一方 `cause=jq_missing` は環境不備で、放置すると本来削除されるべき JSON まで無判定で退避され続けるため実失敗側に置く。
+  行を presence 検査にしてあるので「上から評価し最初の一致」が実際に効く。`_gitignore_failure` は 1 行目の実失敗側に置く。`cause=jq_rc_<n>` を `x` に倒すのは helper が退避成功を `failed` に数えないため。`cause=jq_missing` は環境不備のため実失敗側に置く。
+rationale: references/rationale.md#review-cleanup-reasons
 - `{wiki_ingest_check}`: 以下の sentinel を上から評価し最初の一致を採用 (`WIKI_INGEST_DONE` + `WIKI_INGEST_PUSH_FAILED` が併存しうるため順序重要):
 
   | Sentinel | check | 表示 |
@@ -1218,7 +1230,8 @@ Status: {projects_status_result}
 
 `{outstanding_items_block}`（非ブロッキング失敗の集約欄）: 上記チェックリストの `{base_update_check}` / `{session_worktree_check}` / `{local_branch_check}` / `{projects_check}` / `{wiki_ingest_check}` / `{review_cleanup_check}` のうち、**チェックボックスが `x` ではなく空欄（未チェック）として描画されたもの**があれば、そのチェックボックス直下の付記文をそのまま箇条書きで列挙する（各チェックボックス直下の付記と同じ文言をここにも重複表示する — チェックリストは一覧性、本節は見落とし防止のための集約であり、両立させる。AC-1 / AC-2）。
 
-判定基準を「⚠️/ℹ️ 等の絵文字 prefix 一致」ではなく「チェックボックスの空欄/`x`」に統一する: 6 check の判定ルール（上記）はいずれも「実失敗・残作業のときのみ空欄 ` ` を割り当て、成功時および legitimate な informational skip（`{wiki_ingest_check}` の `reason=disabled`/`auto_ingest_off`/`no_pending`/`concurrent_ingest` 等）は `x` を割り当てる」という契約を既に持つ。付記文の絵文字 prefix は表示上の飾りに過ぎず（`{local_branch_check}` の `BRANCH_DELETE_FAILED`/`BRANCH_DELETE_UNMERGED` のように prefix を伴わない実失敗付記も存在する）、チェックボックス自体の空欄/`x`こそが「未完了か否か」の一次情報である。この統一により、prefix の有無に関わらず全 check の実失敗・残作業を漏れなく拾い、かつ legitimate skip（`x` 判定）は自然に除外される（追加の除外ルールは不要）。
+判定基準を「⚠️/ℹ️ 等の絵文字 prefix 一致」ではなく「チェックボックスの空欄/`x`」に統一する: 6 check の判定ルールはいずれも「実失敗・残作業のときのみ空欄 ` ` を割り当て、成功時および legitimate な informational skip は `x` を割り当てる」。付記文の絵文字 prefix は飾りに過ぎず、チェックボックス自体の空欄/`x`こそが「未完了か否か」の一次情報である。
+rationale: references/rationale.md#outstanding-checkbox
 
 いずれの check も `x`（すべて成功、または legitimate skip）の場合は次の 1 行のみを出力する:
 
@@ -1265,7 +1278,7 @@ stash した変更があれば「復元する (`git stash pop`) / 後で手動�
 1. `/rite:issue-list` で次の Issue を確認
 2. `/rite:open <issue_number>` で新しい作業を開始 <!-- [cleanup:outstanding:{n}] --> <!-- skill return signal: caller must continue next step --> <!-- [cleanup:returned-to-caller] -->
 
-> **Why `returned-to-caller` (not `completed`)**: 旧 `cleanup:completed` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、cleanup → wiki-ingest → wiki-lint のネストで lint 直後に turn が暗黙終了する事象が複数回再発した。`returned-to-caller` で terminal vocabulary を構造的に排除する。
+rationale: references/rationale.md#returned-to-caller
 
 最後に flow state を terminal state に落とす:
 
@@ -1275,6 +1288,7 @@ bash {plugin_root}/hooks/flow-state.sh set --phase "cleanup" --next "none" --act
 ```
 
 この set は `--handoff` を持たないため、ステップ 9 でセットした `WIKICHAIN:cleanup:{pr_number}` handoff を default-clear する (チェーン完走 = gate 解除)。チェーン途中で turn が閉じた場合のみ Stop hook が handoff を consume して継続を差し戻す。
+rationale: references/rationale.md#wikichain-terminal-clear
 
 ---
 

--- a/plugins/rite/skills/cleanup/references/rationale.md
+++ b/plugins/rite/skills/cleanup/references/rationale.md
@@ -1,0 +1,174 @@
+# /rite:cleanup — 設計理由
+
+`skills/cleanup/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。
+
+## pr-merged-default
+
+`{pr_merged}` を全経路で既定するのは、ステップ 4-W の worktree パス manifest 記録とステップ 5 の
+ブランチ削除（squash 残渣の強制削除 / 遅延ブランチの manifest 記録）が未定義値を参照しないため。
+`mergedAt` 非 null 以外（未マージ PR の強制クリーンアップ、PR 未検出でブランチ削除を選んだ経路）を
+`false` に倒すのは、未マージ作業を reap 対象に混ぜないため。
+
+## tasklist-parent-verify
+
+GitHub code search は `[` / `]` を無視しほぼ全 Issue を返す。`--jq '.[0]'` で先頭を盲目採用すると
+standalone closing Issue が自分自身や無関係 Issue を親と誤検出する。複数候補 + 自己除外 + body
+再検証は #1629 で close.md / projects-integration.md §2.4.7.1 に入ったループと同じ方針。
+
+## wm-source-content
+
+PostToolUse hook が作る空 stub（`phase: init`・進捗セクションなし）はファイルとして存在する。
+存在検査だけだと stub を正本と見なし Issue コメント側 fallback が発火しない（存在と成功を同一視
+しないため）。#2141。
+
+## cleanup-source-label
+
+`source: "cleanup"` は将来 metrics 集計で起点 caller を区別するための識別子。`残作業` label の
+事前作成は `gh issue create --label X` が X 未存在時に Issue creation 自体を fail させるため。
+
+## exitworktree-delegation
+
+分岐の基準を「worktree 内か」ではなく ExitWorktree 可否にしたのは #2133。path 入場
+（`in_worktree_unrecorded`）では ExitWorktree が no-op になり、main checkout 操作が harness の
+worktree 隔離ガードに拒否される（実測）。ガードが拒否するのは Bash ツール呼び出しのコマンド文字列
+に直接 `cd` / `git -C` を書く形であり、helper 内部の `cd` は拒否されない（ステップ 7 の
+`pr-cycle-cleanup.sh` は内部で main checkout へ `cd` できている）。helper へ閉じ込めれば自動化
+できる余地は残るが、それは「worktree 内から全項目を完走させる」という現行設計の Non-goal。
+ガード迂回は設計違反 — ガードは正当に機能している。
+
+## live-cwd-self-exclusion
+
+自セッションを live-cwd から除外しないと、ステップ 2 の `ExitWorktree(keep)` が no-op / 失敗に
+終わった経路で自セッションを「live」と誤検出し、cleanup 自身を理由に削除をブロックする。
+全プロセスを列挙する `worktree-live-cwd.sh` 自体は変えず、self-exclusion は
+`worktree-foreign-cwd.sh` に閉じる。
+
+## session-worktree-reap
+
+`--type session_worktree`（`worktree` ではない）にするのは、`worktree` type が Step 4.5 の
+ungated reap（dirty チェックのみ、claim / self-exclusion / live-cwd ガード無し）の EPHEMERAL
+tmp artifact 専用契約を持つため。session worktree のパスを混ぜると Step 4.5 が Step 5 の保護
+ゲートを経ずに生存中の worktree を reap しうる。`session_worktree` type の Step 4.5 arm は
+reap せず、消滅済みなら stale 参照を drop し、存在すれば verbatim 保持して Step 5 に委ねる。
+実 reap の消費は Step 5 の gated bypass のみ。
+
+admin dir 半壊（corpse）では checkout 中 branch を git で解決できず、pr-cycle-cleanup.sh Step 5
+のブランチ名 manifest bypass（#1966）が構造的に効かない。パス自体を事前記録すれば corpse age
+guard が 24h 待ちをバイパスできる。記録は `{pr_merged}=true` のときのみ（AC-4: 未マージ PR の
+強制 cleanup では記録しない）。record 自体は non-blocking 契約（rite-tmp-artifact.sh）。
+
+## main-root-cd
+
+worktree 自己削除後は harness の cwd 追跡のみが main へ移り、この Bash 永続シェルの cwd は削除
+済み worktree に残る。ステップ 4 の base 更新はこの main_root へ明示的に cd して実行する必要が
+ある。`git worktree list --porcelain` の先頭 worktree entry は常に main checkout（git の仕様上
+保証）なので、削除がまだ起きていない 4-W 時点で取得すれば cwd の状態に関わらず正しい値が取れる。
+
+## base-update-classify
+
+dirty な基点ブランチを黙って上書きしないため。破棄・stash は必ずユーザー確認を挟み、無確認の
+破壊的操作をしない。分類を安全側（divergent）へ倒す根拠 — staged / untracked は working tree
+比較で内容検証できない、tree 全体比較はマージが追加した無関係ファイルまで D として数える、
+非 -z 出力は quotePath が pathspec 不一致を引き起こす — はステップ 4 bash 内コメントが SoT。
+
+## remote-delete-markers
+
+成功側も positive marker を出すのは、marker 不在を「削除成功」の符号化に使わないため（#2016）。
+不在を成功と読むと、本ブロックがそもそも実行されなかった経路・出力が compact で失われた経路と
+削除成功が区別できず、consumer が不在を根拠に完了と断定する。全経路が marker を持てば、marker
+不在は「実行結果を確認できていない」という別の意味だけを持つ（`{base_update_check}` と同形）。
+
+`git ls-remote --heads` は ref 不在でも rc=0（空 stdout）を返すため `&&` では「存在するときだけ
+削除する」ガードにならない。`--exit-code` で不在を rc=2 として判別する。pattern は full refname
+でも tail 一致であり、rc=0 のあとに stdout の ref 名が完全一致することを検証しないと、対象が
+不在でも削除経路へ入り偽の残作業と必ず失敗する処方を報告する。削除先も namespace 修飾する —
+非修飾の dst は remote の全 namespace に解決され、同名タグを削除しうる（実測。共有リモートの
+タグ削除は不可逆）。
+
+## review-run-since-sweep
+
+`review-run-since-{pr}.txt` は `/rite:iterate` の収束トレンド判定が現 run の境界に使う pin
+（iterate ステップ 0.6 が書き、ステップ 1 が `--since` で helper へ渡す）。残しても次 run の
+開始時に上書きされるので害はないが、参照先が消えた孤児を PR ごとに積み上げない。
+
+## wiki-worktree-persist
+
+`.rite/wiki-worktree/` は再作成コストが高く各 PR cycle を跨いで保持する永続 worktree。
+
+## projects-status-inline
+
+過去に multi-stage inline pipeline で LLM の attention が sub-step 間で途切れ Status 更新が
+silent skip する事象が確認されている（`skills/ready/SKILL.md` Phase 4.2 と同一原因）。参照のみ
+に留めず本ステップに直接 inline する。
+
+## wiki-push-batch
+
+ingest.md はページ更新のたびに push していた旧挙動を、raw source ごとに commit のみ行い ingest
+フロー末尾で 1 回だけ push する方式に変更した（#1941 / AC-1）。`push=failed` 部分文字列検出は
+そのまま機能する — 集約 push が失敗した場合も、その 1 回の push 結果として ingest の stdout に
+同じ文字列が現れるため、本ステップの検出ロジック自体の変更は不要（ローカル commit は保持され、
+次回 ingest が自動で flush を試みる — AC-2 / SHOULD）。
+
+## wm-dual-finalize
+
+ステップ 11 で Work Memory final update と State reset の両方を実行しないと、Issue comment は
+最終化されるがローカル file は永続蓄積し `post-tool-wm-sync.sh` が次セッションで file を再生成
+する race 経路が開く。
+
+## returned-to-caller
+
+旧 `cleanup:completed` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、
+cleanup → wiki-ingest → wiki-lint のネストで lint 直後に turn が暗黙終了する事象が複数回再発
+した。`returned-to-caller` で terminal vocabulary を構造的に排除する。
+
+## marker-scope-recency
+
+`/rite:batch-run --merge` は同一セッション内で Issue ごとに `/rite:cleanup` をループ invoke
+するため、先行 Issue が残した marker が後続 Issue の判定時にも文脈へ残る。marker 名までしか
+一致条件に含めないと、リモート側は失敗ルールを先頭に評価する設計上、stale な失敗が自分の成功
+marker を必ず上書きする。評価順序の入れ替えは解にならない — 成功を先頭にすると今度は stale な
+成功が実失敗を握り潰し、塞いだ false-success そのものになる。
+
+`branch=` は同一ブランチに対する cleanup 再実行を識別できない（1 回目がネットワーク断で
+`CHECK_FAILED` を残し、原因解消後の 2 回目が `ALREADY_ABSENT` を出す場合、両者の `branch=` は
+一致する）。recency（最後の出現をルール評価より前に選ぶ）が無いと、失敗ルール先頭評価の設計上、
+前回実行の失敗が今回の成功を決定的に上書きする。
+
+## marker-data-delimiter
+
+行頭一致だけでは足りない — 複数行テキストの 2 行目以降は列 0 に着地するため、その中の
+`[CONTEXT] ` 行は行頭一致を突破する。照合規約をサイト列挙ではなく begin/end 形で定義するのは、
+サイトを増やすたびに列挙更新を忘れて契約とコードが drift するのを防ぐため。デリミタは可読性の
+補助であり、data 自身が終端行を騙る経路を塞ぐ security boundary はインデント（列 0 に到達しない
+こと）の側にある。fallback を非アンカーで判定すると先行ルールの否定にならず、行中に marker
+断片が現れた入力でどのルールにも一致しない未定義状態が生じる。
+
+## review-cleanup-reasons
+
+行を presence 検査にしてあるので「上から評価し最初の一致」が実際に効く（実失敗と判定不能が同一
+run で共起しても 1 行目が先に一致する）。`_gitignore_failure` は `cause=jq_rc_<n>` と同じく
+summary の `failed` には数えられない（ファイル自体は処理済み）が、除外の欠落は退避した全文が
+`git add -A` で公開リポジトリへ入る経路そのもので、放置してよい informational ではない。
+`cause=jq_rc_<n>` を `x` に倒すのは、helper がこれを「退避自体は成功しうるので `failed` には
+数えない」と定義し summary も `failed=0` を返すため。`.corrupt-*` を「判定不能 → 退避」経路へ
+載せた以上 corrupt を持つ PR は毎回この reason を出すので、失敗扱いのままだと存在しない手動
+対応を促し続ける。一方 `cause=jq_missing` は環境不備で、放置すると本来削除されるべき JSON まで
+無判定で退避され続ける。
+
+## outstanding-checkbox
+
+付記文の絵文字 prefix は表示上の飾りに過ぎず（`{local_branch_check}` の
+`BRANCH_DELETE_FAILED` / `BRANCH_DELETE_UNMERGED` のように prefix を伴わない実失敗付記も
+存在する）、チェックボックス自体の空欄/`x`こそが「未完了か否か」の一次情報である。prefix 一致
+方式は bare-text 付記を取りこぼす。この統一により、prefix の有無に関わらず全 check の実失敗・
+残作業を漏れなく拾い、かつ legitimate skip（`x` 判定）は自然に除外される。
+
+## wikichain-terminal-clear
+
+ステップ 12 末尾の set は `--handoff` を持たないため、ステップ 9 でセットした
+`WIKICHAIN:cleanup:{pr_number}` handoff を default-clear する。チェーン完走 = gate 解除。
+チェーン途中で turn が閉じた場合のみ Stop hook が handoff を consume して継続を差し戻す。

--- a/plugins/rite/skills/setup/SKILL.md
+++ b/plugins/rite/skills/setup/SKILL.md
@@ -26,9 +26,8 @@ When `--upgrade` is specified, skip to [Phase 4.1.3 (Upgrade)](#413-upgrade-exis
 
 ### 1.0 Verify Core Dependencies (bash ≥4 / jq / flock)
 
-rite の hook / スクリプト群は bash 4+ / jq に依存し、flow-state のロックに flock を使う。導入時点でこれらを検査し、欠落があれば OS 別のインストール案内を出す（macOS stock bash 3.2 のまま pr-review 系が不可解に失敗する事故の予防）。**この検査は non-blocking**（欠落があっても setup は継続し、`exit 1` しない）。全依存 OK のときは 1 行サマリのみで邪魔をしない。
-
-> **検査基準（Decision D-01）**: bash は「実行中の bash の `BASH_VERSION`」を基準にする。macOS での PATH 解決（Homebrew bash か `/bin/bash` 3.2 か）が環境依存で不確実なため、実行コンテキスト自身を測るのが最も正確。
+bash 4+ / jq / flock を検査し、欠落時は OS 別インストール案内を出す。**この検査は non-blocking**（欠落しても `exit 1` しない）。全依存 OK なら 1 行サマリのみ。
+rationale: references/rationale.md#dep-check-nonblocking
 
 ```bash
 # OS 検出（uname -s ベース。テスト時は uname() 関数を定義して shadow 可能）
@@ -91,7 +90,8 @@ fi
 echo "[CONTEXT] DEP_CHECK; bash=$dep_bash; jq=$dep_jq; flock=$dep_flock; os=$os_kind"
 ```
 
-この bash ブロックは **常に exit 0** で終わる（依存欠落を理由に setup を停止しない）。`[CONTEXT] DEP_CHECK` marker の各フィールド（`bash=ok|old|nonbash` / `jq=ok|missing` / `flock=ok|missing` / `os=macos|linux|windows|unknown`）は data contract / observability として全ケースで emit するが、現状どの bash フェーズも機械 parse しない（jq 案内の重複排除は Phase 4.5.0 の NO_JQ メッセージが Phase 1.0 を文言で参照して達成しており、marker の消費には依存しない）。出力を読んだうえで、欠落があってもそのまま 1.1 へ続行する。
+この bash ブロックは **常に exit 0** で終わる。`[CONTEXT] DEP_CHECK` の各フィールド（`bash=ok|old|nonbash` / `jq=ok|missing` / `flock=ok|missing` / `os=macos|linux|windows|unknown`）は全ケースで emit する。欠落があっても 1.1 へ続行する。
+rationale: references/rationale.md#dep-check-nonblocking
 
 ### 1.1 Verify gh CLI Installation
 
@@ -165,7 +165,8 @@ If the result is not `true`, show `gh auth refresh --hostname github.com -s proj
 
 ### 1.4 Retrieve Repository Information
 
-> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) — 下記 snippet の `git-remote.sh` 呼び出しで使用する（未解決のまま実行すると git-remote.sh 経路が silent に失敗し、SSH host alias 環境で fallback の `gh repo view` も失敗する）。
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) — 下記 snippet の `git-remote.sh` 呼び出しで使用する。
+rationale: references/rationale.md#plugin-path-before-git-remote
 
 First classify the local repository before attempting GitHub resolution:
 
@@ -269,7 +270,8 @@ gh project create --owner {owner} --title "{repo-name}" --format json
 
 ### 3.3.5 Link Project to Repository (Both Paths)
 
-新規作成（3.3）・既存 Project 選択（3.2）のどちらのパスでも、Project 番号が確定したら必ず実行する。`gh project link` はリポジトリと Project を関連付け、Issue 作成 helper のフィールド取得 GraphQL クエリ（`repository(owner:, name:) { projectV2(number:) }` ルート、[../../references/graphql-helpers.md](../../references/graphql-helpers.md) 参照）を解決可能にする。link しないままだと初回 `/rite:issue-create` が `project_registration: "partial"` で失敗する。
+新規作成（3.3）・既存 Project 選択（3.2）のどちらのパスでも、Project 番号が確定したら必ず実行する。
+rationale: references/rationale.md#project-link
 
 ```bash
 # 冪等: 既にリンク済みでも成功する。失敗しても setup は続行する（non-blocking）
@@ -398,7 +400,7 @@ If the user selects "set up later", proceed to Phase 4 with `iteration.enabled: 
 
 ### 4.1 Generate rite-config.yml
 
-> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1. This resolved path is used by 1.4 (repository information retrieval — 通常は 1.4 到達時点で解決済み), 4.1.1 (template schema_version read), 4.1.2 (template-based generation), and 4.1.3 (upgrade).
+> **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing any steps in Phase 4.1（1.4 / 4.1.1 / 4.1.2 / 4.1.3。通常は 1.4 到達時点で解決済み）。
 
 #### 4.1.1 Check for Existing Configuration
 
@@ -460,11 +462,12 @@ Generate `rite-config.yml` from the template config file.
 
 **Step 4**: Write the result to `rite-config.yml` in the project root using the Write tool.
 
-> **Note on wiki section**: `templates/config/rite-config.yml` declares the `wiki:` section **above** the `# --- Advanced ---` boundary as an active (non-commented) block. Step 2 (extract content up to the Advanced boundary) therefore includes the active `wiki:` section automatically in the generated `rite-config.yml`. No additional append step is required for new-generation path. The Advanced boundary is the single source of truth for what gets emitted vs commented-out.
+> **Note on wiki section**: 新規生成は Advanced 境界より上を抽出するだけ。追加 append は不要。
+rationale: references/rationale.md#wiki-section-new-gen
 
 #### 4.1.3 Upgrade Existing Configuration
 
-> This phase is executed when `--upgrade` is specified. It upgrades an existing `rite-config.yml` to the latest schema version while preserving user-customized values.
+> `--upgrade` 指定時に実行。既存 `rite-config.yml` を最新 schema へ上げ、ユーザーカスタム値は保持する。
 
 **Step 1: Read current config and template**
 
@@ -481,16 +484,16 @@ Read both files with the Read tool:
 - Current: Read `schema_version` from existing file. If missing, treat as v1.
 - Latest: Read `schema_version` from template. If missing, treat as v1.
 
-**Branching** (Wiki follow-through を含む全 drift 追従): schema 同等であってもテンプレートはスキーマ版を bump せずに active セクション/サブキー（`multi_session`・新規セクション・Wiki 等）を獲得し得るため、`current >= latest` 経路でも config に欠落している drift を back-add して最新デフォルトへ追従させる必要がある。以下のとおり分岐する。**表の実行順序は左から右** (Step 番号順ではなく矢印順):
+**Branching** (全 drift 追従。**表の実行順序は左から右** — Step 番号順ではなく矢印順):
+rationale: references/rationale.md#upgrade-branching
 
 | Condition | Execution order (left → right) |
 |-----------|--------------------------------|
 | `current < latest` | (1) Step 3 Backup → (2) Step 4 Identify → (3) Step 5 Preview → (4) Step 6 Apply → (5) Step 7 Phase 4.7 |
 | `current >= latest` | (1) Step 3 Backup → (2) Step 4 Identify（drift のみ）→ (3) Step 6 Apply（multi_session/新規セクション/欠落サブキー/Wiki の back-add。User-customized 保全・冪等・preview なし）→ (4) Step 7 Phase 4.7 |
 
-両経路とも Step 6 が config を変更し得るため Step 3 Backup を必ず先に実行する (precondition)。`current >= latest` 経路は Step 5 Preview/confirm を挟まず、欠落している active セクション/サブキーのみを冪等に back-add する（テンプレート defaults への追従であり、User-customized 値（明示的な `enabled: false` を含む）は保全されるため無確認で適用する）。旧 Step 3.5 の Wiki 専用救済はこの一般化に吸収され、Wiki も他の active セクションと同様に Step 6 item 7 で back-add される（drift anchor SoT に一貫化）。
-
-`current >= latest` 経路で back-add 対象が皆無（全 active セクション/サブキーが既存）の場合、Step 6 は config を書き換えず `rite-config.yml は最新です (v{current})` を表示する。Phase 4.7 はそのまま実行され、Wiki 初期化済みなら Phase 4.7.2 が `wiki_status=already_initialized` を set して Skill 呼び出しは skip される (冪等)。
+両経路とも Step 3 Backup を必ず先に実行する (precondition)。`current >= latest` は Step 5 を挟まず、欠落 active セクション/サブキーのみを冪等に back-add する（User-customized 値と明示的な `enabled: false` は保全）。back-add 対象が皆無なら Step 6 は書き換えず `rite-config.yml は最新です (v{current})` を表示する。Phase 4.7 はそのまま実行（Wiki 初期化済みなら Skill は skip）。
+rationale: references/rationale.md#upgrade-branching
 
 **Step 3: Create backup**
 
@@ -515,11 +518,12 @@ Compare current config against the template and classify each key:
 | **`wiki:` section** | **Step 3/4 は扱わない**。wiki セクションの追加は **Phase 4.1.2 Step 2 (新規生成: template の Advanced 境界より上にある active block が自動コピーされる) および Phase 4.1.3 Step 6 item 7 (Upgrade path: 未存在時に active block として append。`current < latest` / `current >= latest` 両経路で実行) の専権**。template 側にはコメント形式の `# wiki:` ブロックは存在しない (active 位置に移動済み) ため、重複追加経路はない |
 | **Unknown key** (user-added keys not in template) | **Preserve with warning** — keep but display warning |
 
-**Unknown key 判定の scope**: Step 4 の "Unknown key" 判定 (user-added keys not in template) は、**template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。境界より下 (コメント形式の Advanced sections + 末尾コメント) は template 側で意図的に省略または注記のため存在する領域であり、ユーザー設定の classification 対象外。
+**Unknown key 判定の scope**: Step 4 の "Unknown key" 判定は **template の `# --- Advanced (below this line) ---` 境界より上の active section のみ**を参照する。
+rationale: references/rationale.md#unknown-key-scope
 
-**Active top-level sections covered on --upgrade** (drift anchor — the `init-upgrade-drift` test asserts this list ⊇ the template's active top-level keys above the `--- Advanced ---` marker): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `language`, `wiki`, `multi_session`, `tdd`, `safety`. Each is handled by Step 4/Step 6 above (User-customized values are preserved, missing sections/sub-keys are added). **When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
+**Active top-level sections covered on --upgrade** (drift anchor): `schema_version`, `github`, `iteration`, `branch`, `commands`, `verification`, `issue`, `review`, `language`, `wiki`, `multi_session`, `tdd`, `safety`. Step 4/6 が扱う。**When a new active top-level section is added to the template, add it to this list too** — otherwise the drift test fails and `--upgrade` would silently miss it.
 
-**Active sub-keys covered on --upgrade** (drift anchor — the `init-upgrade-drift` test T-12 asserts, per section, this list ⊇ each template active section's **direct** sub-keys above the `--- Advanced ---` marker; Step 6 item 4 adds any missing sub-key while preserving existing siblings). Sections whose value is a scalar (`schema_version`, `language`) have no sub-keys and are omitted:
+**Active sub-keys covered on --upgrade** (drift anchor。スカラー `schema_version` / `language` は省略):
 
 - `github`: `projects`
 - `iteration`: `enabled`, `field_name`, `auto_assign`, `show_in_list`
@@ -533,9 +537,9 @@ Compare current config against the template and classify each key:
 - `tdd`: `enabled`
 - `safety`: `max_implementation_rounds`, `max_review_cycles`, `time_budget_minutes`, `auto_stop_on_repeated_failure`, `repeated_failure_threshold`
 
-**When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it (the same guard as the top-level list, one level down).
+**When a new sub-key is added to an existing template section, add it to the matching row above too** — otherwise the T-12 sub-key drift test fails and `--upgrade` would silently miss it.
 
-**Step 5: Preview and confirm** (`current < latest` 経路のみ — `current >= latest` 短絡経路は Step 5 を挟まず Step 6 で欠落 drift を冪等に back-add する)
+**Step 5: Preview and confirm** (`current < latest` 経路のみ。`current >= latest` は Step 5 を挟まない)
 
 Display the changes to the user:
 
@@ -563,7 +567,8 @@ Ask with `AskUserQuestion`:
 
 **Step 6: Apply changes**
 
-**Path-dependent application**: On the `current < latest` path, apply all items below after the user confirms in Step 5. On the `current >= latest` short-circuit path (Step 5 skipped), apply **only items 3, 4, 6, 7** — the drift back-add (missing active sections / missing sub-keys / multi_session / wiki) — directly without confirmation. Items 1, 2, 5 (schema_version bump / deprecated-key removal / Advanced-section comments) are full-upgrade-only and are skipped on the short-circuit path (schema is already current, so item 1 would be a no-op anyway). Every back-add item (3, 4, 6, 7) is idempotent and preserves User-customized values (including an explicit `enabled: false`), so the short-circuit path applies unattended; when no item finds anything missing, the config is left unchanged and `rite-config.yml は最新です (v{current})` is displayed.
+**Path-dependent application**: On the `current < latest` path, apply all items below after the user confirms in Step 5. On the `current >= latest` short-circuit path (Step 5 skipped), apply **only items 3, 4, 6, 7** — the drift back-add (missing active sections / missing sub-keys / multi_session / wiki) — directly without confirmation. Items 1, 2, 5 は full-upgrade-only。back-add（3, 4, 6, 7）は冪等で User-customized（明示的な `enabled: false` を含む）を保全する。対象が皆無なら config は不変で `rite-config.yml は最新です (v{current})` を表示する。
+rationale: references/rationale.md#upgrade-apply-ssot
 
 Apply the following:
 
@@ -574,21 +579,24 @@ Apply the following:
 5. Add Advanced sections as comments (prefixed with `#`) using the Edit tool
 6. **If `multi_session:` section is absent**: append the active `multi_session:` block from the template (`enabled: true` + `worktree_base`) so `--upgrade`-ed projects get the same default-on session-worktree behavior as new generation.
 
-   **Block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the active `multi_session:` block (the `multi_session:` key line through its last sub-key, above the `# --- Advanced (below this line) ---` marker). Do not duplicate the literal here — any change to template defaults propagates to both new-install and `--upgrade`.
+   **Block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the active `multi_session:` block (the `multi_session:` key line through its last sub-key, above the `# --- Advanced (below this line) ---` marker)。本文にリテラルを複製しない。
+rationale: references/rationale.md#upgrade-apply-ssot
 
    **Idempotency guard**: Before inserting, Grep `^multi_session:` (excluding comment lines starting with `#`) in the project's `rite-config.yml`. If an active section already exists, skip the Edit entirely (no-op) — this preserves a user's existing block, **including an explicit `enabled: false`** (never overwrite `enabled`).
 
    **Anchor selection**: insert immediately before the `# --- Advanced (below this line) ---` marker line (`old_string` = marker line, `new_string` = multi_session block + `\n\n` + marker line). If the Advanced marker is absent (user-trimmed config), append after the last top-level active key. Display `rite-config.yml に multi_session セクションを追加しました（active, enabled: true）。` only when the Edit actually ran.
 7. **If `wiki:` section is absent**: append the active `wiki:` block from the template (single source of truth) so Phase 4.7 can auto-initialize Wiki.
 
-   **Wiki block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the block from `# Wiki settings` through the end of the `wiki:` section (the lines above the `# --- Advanced (below this line) ---` marker). This avoids literal duplication between `setup.md` and the template — any change to default values (e.g., `auto_ingest`, `branch_strategy`) in the template automatically propagates to both new-install and `--upgrade` paths.
+   **Wiki block source (SSOT)**: Read `{plugin_root}/templates/config/rite-config.yml` and extract the block from `# Wiki settings` through the end of the `wiki:` section (the lines above the `# --- Advanced (below this line) ---` marker)。本文にリテラルを複製しない。
+rationale: references/rationale.md#upgrade-apply-ssot
 
    **Idempotency guard**: Before inserting, Grep `^wiki:` (excluding comment lines starting with `#`) in the project's `rite-config.yml`. If an active section already exists, skip the Edit entirely (no-op).
 
    **Anchor selection**:
    - **Primary anchor**: the `language:` line in `rite-config.yml`. This is unique in the default template and provides a stable insertion point.
    - **Fallback anchor** (if `language:` line is absent due to user customization): the `# --- Advanced (below this line) ---` boundary marker line. Insert the wiki block **immediately before** this marker (`old_string` = marker line, `new_string` = wiki block + `\n\n` + marker line). If the Advanced marker is also absent, use the last top-level active key (line starting with `[a-z]` followed by `:`) before any comment-only tail region.
-   - **NOT tail-based**: do not anchor to the last non-empty line of the file — this can collide with the template's repeated `enabled: true` / `auto_query: true` lines in multi-section tails.
+   - **NOT tail-based**: do not anchor to the last non-empty line of the file。
+rationale: references/rationale.md#upgrade-apply-ssot
 
    **Edit action**:
    - `old_string` = the anchor line exactly as read (preserving trailing whitespace)
@@ -608,7 +616,8 @@ Step 7 has two sub-steps:
 
 Execute [Phase 4.7: Wiki Initialization](#phase-47-wiki-initialization-491) to bring existing users up to Wiki-initialized state. This is non-blocking; Phase 4.7 failure does not affect `--upgrade` success.
 
-Phase 4.7's internal "next step" instructions (e.g., "proceed to the next step: `--upgrade`: Phase 4.1.3 Step 7b status-line display and exit") mean **return to Step 7b here** (continuation after Phase 4.7 completes), not a recursive re-entry into Step 7a.
+Phase 4.7 内部の「次のステップ」は **Step 7b へ戻る**（7a への再入ではない）。
+rationale: references/rationale.md#upgrade-step7
 
 **Step 7b: Display status line and exit**
 
@@ -619,17 +628,12 @@ After Phase 4.7.1/4.7.2/4.7.4 returns control to Step 7, display a Wiki status l
 - Else if `wiki_status == "skipped_disabled"` → `Wiki: スキップ（無効）`
 - Else if `wiki_status == "failed"` → `Wiki: 失敗`
 
-Before exiting, execute [Phase 4.8: Sandbox Write-Allowlist 自動設定](#phase-48-sandbox-write-allowlist-自動設定multi_session-有効時1896--1942) and then [Phase 4.9: SSH Host Alias Remote の Sandbox 事前案内](#phase-49-ssh-host-alias-remote-の-sandbox-事前案内1907) (both non-blocking, each self-gated by its own check — safe to invoke unconditionally). Then display the status line and exit. (`--upgrade` skips Phases 1-3 and the Phase 5 full completion report, so only the Wiki status (and, when applicable, the Phase 4.8 / 4.9 guidance) is reported — there is no merge conflict with Phase 5 because `--upgrade` does not enter the new-install path.)
+Before exiting, execute [Phase 4.8: Sandbox Write-Allowlist 自動設定](#phase-48-sandbox-write-allowlist-自動設定multi_session-有効時1896--1942) and then [Phase 4.9: SSH Host Alias Remote の Sandbox 事前案内](#phase-49-ssh-host-alias-remote-の-sandbox-事前案内1907) (both non-blocking, each self-gated — invoke unconditionally). Then display the status line and exit.
+rationale: references/rationale.md#upgrade-step7
 
 If the user cancels: Display "アップグレードをキャンセルしました" and exit.
 
-**MUST requirements**:
-- `schema_version` 未設定の config は暗黙的に v1 として扱う
-- ユーザーカスタム値（project_number, owner, iteration, branch 等）を保持する
-- バックアップ (`rite-config.yml.bak.{timestamp}`) を作成する
-- 廃止キー (`project.name`, `commit.style`, `commit.enforce`, `commit.contextual`, `branch.release`, `branch.types`, `version`) を削除する
-- Advanced セクションはコメントアウトで追加する
-- テンプレートにないユーザー追加キーを削除しない（Unknown key → Preserve with warning）
+**MUST requirements**: Step 4 分類表が SoT。`schema_version` 欠落は v1。Backup 必須。Unknown key は削除しない。
 
 ### 4.2 Check Issue Templates
 
@@ -710,7 +714,7 @@ done
 fi
 ```
 
-Missing SoT files, directory creation failures, and copy failures are all non-blocking. Preserve each existing destination unchanged, display the emitted warning or status lines, and continue to Phase 4.5 regardless of the result.
+SoT 欠落・ディレクトリ作成失敗・copy 失敗はすべて non-blocking。既存 destination は不変のまま Phase 4.5 へ続行する。
 
 ---
 
@@ -718,11 +722,12 @@ Missing SoT files, directory creation failures, and copy failures are all non-bl
 
 > **Placeholder convention**: All `{hooks_dir}` occurrences in fenced code blocks within Phase 4.5 are **templates**, not literal commands. Replace `{hooks_dir}` with the absolute path resolved in Phase 4.5.0 before executing each command via the Bash tool.
 
-> **rite hook command の判定基準 (SoT)**: Phase 4.5 の各サブフェーズで hook command が「rite 自身の hook か」を判定する箇所では、command path 中で `rite` が **hooks ディレクトリ直上の完全な path segment** である場合のみ rite hook とみなす（その間に version segment を 1 個まで許容）。具体的には dev/relative の `…/rite/hooks/` と cache install の `…/rite-marketplace/rite/<version>/hooks/` がマッチし、`favorite/hooks/`・`prerite/hooks/`・`rite-something/hooks/` のように `rite` が別 segment の部分文字列にすぎない look-alike はマッチしない。これは helper の正規表現の**単一定義実体** `scripts/settings-local-rite-hook-cleanup.py` の `RITE_HOOK_RE`（正規表現 `(?:^|/)rite/(?:[^/]+/)?hooks/`）と同一基準であり、本ドキュメントで **「rite hook command」** と表記する箇所はすべてこの基準を指す。同名 `.sh` wrapper（python3 guard・atomic write を担う）も `session-start.sh` の settings.local.json 修復経路も、JSON 変換＝regex 適用をこの `.py` に委譲するため、正規表現の定義は `.py` 1 箇所のみに存在する（session-start.sh のインライン複製を解消）。素朴な substring `rite/hooks/` 一致は `favorite/hooks/` 等を over-match するため使わない。
+> **rite hook command の判定基準 (SoT)**: command path 中で `rite` が **hooks ディレクトリ直上の完全な path segment** である場合のみ（間に version segment を 1 個まで許容）。`…/rite/hooks/` と `…/rite-marketplace/rite/<version>/hooks/` がマッチ。`favorite/hooks/`・`prerite/hooks/`・`rite-something/hooks/` はマッチしない。正規表現の単一定義は `scripts/settings-local-rite-hook-cleanup.py` の `RITE_HOOK_RE`（`(?:^|/)rite/(?:[^/]+/)?hooks/`）。本ドキュメントの **「rite hook command」** はすべてこの基準。substring `rite/hooks/` 一致は使わない。
+rationale: references/rationale.md#rite-hook-command
 
 ### 4.5.0 Resolve Hook Script Directory
 
-Run the following bash command to detect the hook scripts directory. This command assumes CWD is the project root (Claude Code's Bash tool resets CWD to the project root on each invocation):
+次の bash で hook scripts ディレクトリを検出する。CWD はプロジェクト root（Bash tool は呼び出しごとに root へ戻す）:
 
 ```bash
 if [ -f "plugins/rite/hooks/pre-compact.sh" ]; then
@@ -758,7 +763,8 @@ fi
 ```
 
 - If `LOCAL:<path>` or `MARKETPLACE:<path>` → extract all text after the first `:` (the absolute path) and use it as `{hooks_dir}` for all subsequent phases. Also retain the source type (`LOCAL` or `MARKETPLACE`) for use in the Phase 5 completion report.
-- If `NOT_FOUND:NO_JQ` → display warning and **skip the rest of Phase 4.5**（jq のインストール案内は Phase 1.0 の依存検査で既出のため、ここでは繰り返さない — AC-3。NO_JQ 経路に入る時点で jq は必ず欠落しており Phase 1.0 が既に OS 別案内を表示済み）:
+rationale: references/rationale.md#plugin-path-mismatch
+- If `NOT_FOUND:NO_JQ` → display warning and **skip the rest of Phase 4.5**（jq 案内は Phase 1.0 で既出 — 繰り返さない）:
     ```
     ⚠️ Hook scripts not found. jq was not detected, so hook registration is skipped.
     (See the Phase 1.0 dependency check above for jq installation guidance.)
@@ -774,11 +780,10 @@ fi
 
 **Condition**: Execute only when Phase 4.5.0 returns `MARKETPLACE`.
 
-**Purpose**: Detect copy-type installations that don't receive automatic updates, compare versions with the latest release, and guide users to update if outdated.
+**Purpose**: copy 型インストール（自動更新なし）を検出し、最新リリースと版を比較して更新を案内する。
+rationale: references/rationale.md#copy-type-install
 
-> **Placeholder convention**: Step 1 derives `{marketplace_name}` and `{marketplace_dir}` from `{hooks_dir}`. Replace these placeholders in all subsequent bash blocks before execution, following the same convention as `{hooks_dir}` in Phase 4.5.
->
-> **Path note**: `~/.claude/plugins/marketplaces/{marketplace_name}/` is the directory where Claude Code clones marketplace source repositories during plugin installation. This is distinct from `~/.claude/plugins/cache/` (the extracted plugin files used at runtime).
+> **Placeholder convention**: Step 1 が `{hooks_dir}` から `{marketplace_name}` / `{marketplace_dir}` を導出する。以降の bash では Phase 4.5 の `{hooks_dir}` と同じく実行前に置換する。
 
 #### Step 1: Determine Install Type
 
@@ -800,7 +805,8 @@ else
 fi
 ```
 
-> **Path derivation**: `{hooks_dir}` has the format `.../cache/{marketplace_name}/{plugin_name}/{version}/hooks`. Removing the last component (`hooks`) gives the install root, then navigating two levels up yields a directory whose basename is the marketplace name. This name is used to construct the marketplace source directory path `$HOME/.claude/plugins/marketplaces/{marketplace_name}`.
+> **Path derivation**: `{hooks_dir}` = `.../cache/{marketplace_name}/{plugin_name}/{version}/hooks`。末尾 `hooks` を除き 2 階層上が marketplace 名。
+rationale: references/rationale.md#copy-type-install
 
 **Result handling**:
 - `SYMLINK` → Display "✅ Symlink インストールを検出（自動更新可能）" and **skip to Phase 4.5.0.2**.
@@ -910,7 +916,8 @@ Continue to Phase 4.5.0.1.
 
 Read `.claude/settings.json` (the project-level, non-local settings file) and check for hooks that may conflict with rite hooks.
 
-**Purpose**: Claude Code executes hooks from both `.claude/settings.json` and `.claude/settings.local.json`. If non-rite hooks exist in `settings.json` for the same events that rite registers (e.g., SessionStart, SessionEnd, PreCompact), they will be executed alongside rite hooks, causing duplicate execution. This check warns the user about such conflicts.
+**Purpose**: `settings.json` の非-rite hook と rite hook の二重実行を警告する（advisory only）。
+rationale: references/rationale.md#settings-json-conflict
 
 **Check procedure**:
 
@@ -934,11 +941,12 @@ settings.json の hooks は rite hooks と二重実行されます。
 
 **If no conflicting hooks are found**, no output is displayed.
 
-**Important**: This check is **advisory only**. Do not modify `.claude/settings.json` automatically. Do not block init execution regardless of the result. Continue to Phase 4.5.0.2 in all cases.
+**Important**: **advisory only**。`.claude/settings.json` は自動変更しない。結果に依らず init を止めず 4.5.0.2 へ進む。
 
 ### 4.5.0.2 Native Hook Management Check (hooks.json)
 
-**Purpose**: `hooks.json` が存在する場合、Claude Code はプラグインの hook をネイティブに管理する（`${CLAUDE_PLUGIN_ROOT}` を動的に解決）。この場合、`settings.local.json` への hook 登録は不要であり、バージョン更新時にパスが壊れる原因となる。
+**Purpose**: `hooks.json` があるときは `settings.local.json` への hook 登録をスキップする。
+rationale: references/rationale.md#native-hooks-json
 
 **Check procedure**:
 
@@ -953,7 +961,7 @@ fi
 [ -f "$_hooks_json" ] && echo "NATIVE" || echo "LEGACY"
 ```
 
-**Note**: `{hooks_dir}` は Phase 4.5.0 で解決された hooks ディレクトリの絶対パス。`hooks.json` は通常 `{hooks_dir}/hooks.json` に存在する。
+**Note**: `{hooks_dir}` は Phase 4.5.0 の絶対パス。`hooks.json` は通常 `{hooks_dir}/hooks.json`。
 
 **When `NATIVE` is returned** (hooks.json exists):
 
@@ -969,7 +977,8 @@ fi
    bash "{hooks_dir}/scripts/settings-local-rite-hook-cleanup.sh" ".claude/settings.local.json"
    ```
 
-   > **Helper contract**: `settings-local-rite-hook-cleanup.sh` は **rite hook を実際に除去したときのみ** `CLEANED` を返し、それ以外の安全側ケース (python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む) ではすべて `NO_RITE_HOOKS` を返す。ただし **mv 失敗** だけは「変換は成功したが swap-in できず stale な rite hook が残る」ケースであり真の silent skip ではないため、`NO_RITE_HOOKS` (+ exit 0 非ブロッキング) を保ったまま stderr に `[rite] WARNING: ... mv failed` を emit する。`*.py` を `*.sh` wrapper 経由で呼ぶ先例 `issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
+   > **Helper contract**: 実際に除去したときのみ `CLEANED`。それ以外の安全側は `NO_RITE_HOOKS`。**mv 失敗**は `NO_RITE_HOOKS` のまま stderr に `[rite] WARNING: ... mv failed`。
+rationale: references/rationale.md#cleanup-helper-contract
 
    - If `CLEANED` → display `ℹ️ settings.local.json からレガシー rite hook エントリを削除しました。`
    - If `NO_RITE_HOOKS` → no output (no rite hooks removed)
@@ -991,7 +1000,8 @@ Proceed to Phase 4.5.1 (existing flow — validate and register hooks in `settin
 
 Read `.claude/settings.local.json` and check for existing hooks section. If the file does not exist, it will be created.
 
-**⚠️ 重要: 4.5.1.1 と 4.5.1.2 は両方とも必ず実行すること。4.5.1.1 で全パスが正常でも 4.5.1.2 は必ず実行する。** 4.5.1.1 は既存フックのパス検証のみを行い、フックイベント自体の欠落は検出しない。4.5.1.2 が必須フックの存在チェックを担当する。
+**⚠️ 重要: 4.5.1.1 と 4.5.1.2 は両方とも必ず実行すること。4.5.1.1 で全パスが正常でも 4.5.1.2 は必ず実行する。**
+rationale: references/rationale.md#hook-path-absolute
 
 #### 4.5.1.1 Validate Existing Hook Paths
 
@@ -1002,7 +1012,8 @@ If the file already contains hooks, check each hook command for rite hook patter
 3. For each matching command, construct the expected full command string `bash {hooks_dir}/{script_name}` (where `{hooks_dir}` is the absolute path resolved in Phase 4.5.0 and `{script_name}` is the filename like `pre-tool-bash-guard.sh`). Compare the existing command string with the expected one
 4. If the existing command does NOT match the expected command, mark it as **needs update**
 
-**Note**: Phase 4.5.0 resolves `{hooks_dir}` as an absolute path (via `cd ... && pwd`). If existing hooks use relative paths (e.g., `bash plugins/rite/hooks/pre-tool-bash-guard.sh`), they will not match the absolute path and will be correctly marked for update. This is intentional — converting relative paths to absolute paths is one of the goals of this validation.
+**Note**: 既存 hook が相対パスなら絶対パスと一致せず更新対象になる（意図どおり）。
+rationale: references/rationale.md#hook-path-absolute
 
 **Display when outdated paths are detected** (where `{event}` is the hook event name such as PreCompact/PostCompact/SessionStart/SessionEnd/PreToolUse, and `{current_cmd}` is the existing command string):
 ```
@@ -1016,9 +1027,7 @@ If the file already contains hooks, check each hook command for rite hook patter
 
 #### 4.5.1.2 Check Required Hook Presence
 
-**⚠️ このサブフェーズは 4.5.1.1 の結果に関わらず必ず実行する。** 4.5.1.1 が「全パス正常」と判定しても、フックイベント自体が欠落している可能性がある（例: SessionEnd, PreToolUse が未登録）。
-
-After validating existing hook paths in 4.5.1.1, verify that **all** required rite hooks are registered. This check prevents the scenario where some hooks (e.g., PreCompact, SessionStart) are correctly configured but others (e.g., SessionEnd, PostCompact) are missing entirely.
+必須 rite hook がすべて登録されていることを確認する（4.5.1.1 の結果に関わらず実行）。
 
 **Required hooks**:
 
@@ -1038,7 +1047,7 @@ After validating existing hook paths in 4.5.1.1, verify that **all** required ri
 2. For each required hook event that **exists** in `.hooks`, check if any hook command is a **rite hook command** (per the 判定基準 above) ending in `{script_name}`. If no matching command is found, mark it as **missing**.
 3. Collect all **missing** hook events from steps 1 and 2.
 
-**Note**: If no required hooks are missing, no output is displayed from this sub-phase. The decision is deferred to the combined Decision logic below.
+**Note**: 欠落がなければ本サブフェーズは無出力。判定は下記 Decision logic。
 
 **Display when missing hooks are detected** (`{total_count}` = number of required hooks, currently 7):
 ```
@@ -1155,11 +1164,11 @@ Add the following hooks to `.claude/settings.local.json`:
 
 **Important**:
 - **Non-rite hooks**: If `.claude/settings.local.json` already has hooks whose command is NOT a **rite hook command** (per the 判定基準 above — this includes look-alikes such as `favorite/hooks/`), preserve them as-is. Do not overwrite or remove user-defined hooks.
-- **rite hooks (path update)**: If existing hooks are **rite hook commands** (per the 判定基準 above) but use an outdated path (detected in Phase 4.5.1.1), **replace** those hook entries with the updated `{hooks_dir}` path. This ensures re-running `/rite:setup` always corrects stale paths.
-- **Missing rite hooks**: If any of the required rite hooks (PreCompact, PostCompact, SessionStart, SessionEnd, PreToolUse, PostToolUse) are not present, add them. PostToolUse has two matchers (`Bash` and `Edit|Write|MultiEdit`) — both entries must coexist.
-- **Obsolete hooks**: If `post-compact-guard.sh` (PreToolUse) または `context-pressure.sh` (PostToolUse) exists, **remove** it. `post-compact-guard.sh` は `post-compact.sh` に置き換え済み。`context-pressure.sh` は廃止済み。
-- **Matcher rules**: `post-tool-wm-sync.sh` and `pre-tool-bash-guard.sh` use `"matcher": "Bash"` to fire only on Bash tool calls. `scripts/bang-backtick-edit-hook.sh` uses `"matcher": "Edit|Write|MultiEdit"` to fire only on file-edit tool calls. All other hooks use `"matcher": ""`.
-- **Permission for WM_SOURCE**: Add `"Bash(WM_SOURCE:*)"` to `.permissions.allow` if not already present. This allows the LLM to execute work memory update commands without prompting (defense-in-depth alongside the PostToolUse hook).
+- **rite hooks (path update)**: outdated **rite hook commands**（4.5.1.1）は `{hooks_dir}` パスへ **replace**。
+- **Missing rite hooks**: 必須 rite hook が無ければ追加。PostToolUse は 2 matcher（`Bash` と `Edit|Write|MultiEdit`）が共存必須。
+- **Obsolete hooks**: `post-compact-guard.sh` (PreToolUse) または `context-pressure.sh` (PostToolUse) があれば **remove**。
+- **Matcher rules**: `post-tool-wm-sync.sh` / `pre-tool-bash-guard.sh` は `"matcher": "Bash"`。`scripts/bang-backtick-edit-hook.sh` は `"matcher": "Edit|Write|MultiEdit"`。他は `"matcher": ""`。
+- **Permission for WM_SOURCE**: 未設定なら `.permissions.allow` へ `"Bash(WM_SOURCE:*)"` を追加。
 
 ### 4.5.3 Make Scripts Executable
 
@@ -1193,7 +1202,7 @@ Missing or non-executable scripts will be skipped at runtime.
 
 ### 4.5.5 Record Installed Version
 
-Write the current plugin version to a marker file for update detection by `session-start.sh`:
+現在の plugin 版を marker ファイルへ書く（`session-start.sh` の更新検出用）:
 
 ```bash
 PLUGIN_JSON="{hooks_dir}/../.claude-plugin/plugin.json"
@@ -1243,9 +1252,10 @@ Display: `✅ Work memory directory initialized (.rite-work-memory/)`
 
 ## Phase 4.7: Wiki Initialization
 
-Auto-initialize the Experience Wiki so the user does not need to run `/rite:wiki-init` manually. Executed after Phase 4.6 (new install) and after the Phase 4.1.3 Apply step (`--upgrade` path).
+Wiki を自動初期化する（手動 `/rite:wiki-init` 不要）。新規は Phase 4.6 の後、`--upgrade` は Phase 4.1.3 Apply の後。
 
-> **Non-blocking contract**: Phase 4.7 failure (including Skill invocation failure) MUST NOT abort `/rite:setup`. On failure, display a warning and continue to Phase 5. The flow always reports Wiki status via the completion report (Phase 5).
+> **Non-blocking contract**: Phase 4.7 failure (Skill 呼び出し失敗を含む) MUST NOT abort `/rite:setup`。失敗時は警告を出して Phase 5 へ。Wiki 状態は完了レポートで必ず報告する。
+rationale: references/rationale.md#wiki-init-contract
 
 > **Status enum** (consumed by Phase 5 — identifier-compatible values, no whitespace/parens):
 >
@@ -1256,15 +1266,13 @@ Auto-initialize the Experience Wiki so the user does not need to run `/rite:wiki
 > | `skipped_disabled` | `wiki.enabled: false` detected |
 > | `failed` | Post-check after Skill invocation found Wiki still uninitialized |
 
-**Retain `wiki_status` as LLM conversational state (NOT a shell variable)**. Claude Code's Bash tool invocations are independent subshells — shell variables do NOT persist across tool calls. Each status set point below instructs the LLM to **remember the value directly in conversation context** and carry it forward to Phase 5. Do NOT attempt `echo $wiki_status` in a subsequent Bash call.
-
-The enum values are identifier-compatible (snake_case, no whitespace or parentheses) so that Phase 5 / Step 7b can branch on `wiki_status` with an explicit if/else and select the matching literal directly. Do not construct the message dynamically from `wiki_status`.
+**Retain `wiki_status` as LLM conversational state (NOT a shell variable)**。後続 Bash で `echo $wiki_status` してはならない。Phase 5 / Step 7b は明示 if/else でリテラルを選ぶ。`wiki_status` から文面を動的組み立てしない。
+rationale: references/rationale.md#wiki-init-contract
 
 ### 4.7.1 Wiki Enabled Check
 
-Read `wiki.enabled` from `rite-config.yml`. Wiki is **opt-out**: missing section / missing key / unparseable value → treat as `true`. This mirrors `skills/wiki-init/SKILL.md` ステップ 1.1 logic, including the typo-detection WARNING path.
-
-> **sed range robustness note**: The `sed -n '/^wiki:/,/^[a-zA-Z]/p'` pattern terminates at the next line starting with any ASCII letter — which matches the next top-level YAML key. This relies on `rite-config.yml` following the standard shape produced by `/rite:setup` (wiki section followed by another top-level key or EOF). In pathological user-customized configs where the wiki section is the last top-level block and is followed only by comment lines, sed reads to EOF, which is still correct. The known limitation: if a user inserts comment lines **inside** the wiki section that start with a letter (e.g., `auto_query: true # note:`), the trailing `# note:` does not affect sed (it's part of the same line). Therefore this pattern is safe for configs conforming to the template shape. Drift in non-standard configs is tracked as a known limitation, not a blocker for the wiki section drift handling.
+Read `wiki.enabled` from `rite-config.yml`。Wiki は **opt-out**: セクション欠落 / キー欠落 / 解釈不能 → `true`。`wiki-init` ステップ 1.1 と同じ（typo 検出 WARNING を含む）。
+rationale: references/rationale.md#wiki-enabled-sed
 
 ```bash
 wiki_enabled=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null \
@@ -1345,11 +1353,13 @@ Display `rite:wiki-init を呼び出して Wiki を初期化します...`, then 
 skill: "rite:wiki-init"
 ```
 
-> **Rationale**: Claude Code's Skill tool does not surface a return value, so failure detection is done via post-check (4.7.4). Do NOT re-implement Wiki initialization logic here — always delegate to the Skill.
+Wiki 初期化ロジックをここへ再実装しない — 常に Skill へ委譲する。
+rationale: references/rationale.md#wiki-init-delegate
 
 ### 4.7.4 Post-check: Confirm Initialization
 
-After the Skill returns, re-run **only the detection portion** of 4.7.2 (the `if [ "$branch_strategy" = "separate_branch" ]; then ... fi` block) to confirm the Wiki was actually created. The `branch_strategy` / `wiki_branch` values from 4.7.2 are already known to the LLM and should be embedded as literals rather than re-parsing `rite-config.yml` — this avoids any drift if the Skill modified the config.
+Skill 復帰後、4.7.2 の **検出部分だけ**（`if [ "$branch_strategy" = "separate_branch" ]; then ... fi`）を再実行する。`branch_strategy` / `wiki_branch` は 4.7.2 の観測値を literal 埋め込みし、`rite-config.yml` を再パースしない。
+rationale: references/rationale.md#wiki-init-delegate
 
 **Detection-only re-run** (embed literal values from 4.7.2):
 
@@ -1392,17 +1402,19 @@ Then:
 
 ## Phase 4.8: Sandbox Write-Allowlist 自動設定（multi_session 有効時、#1896 / #1942）
 
-`multi_session.enabled: true`（Phase 4.1 で決定済み。新規生成・back-add いずれの経路でも既定 ON）**かつ** Claude 自身の Bash tool 定義（sandbox セクション）が filesystem write 制限を伴う sandbox で動作していることを示している場合のみ、以下を実行する。いずれか一方でも該当しない場合（`multi_session.enabled: false`、または sandbox 無効／write 制限なし）は本節を完全に silent skip する（案内・warning 共に一切出さない — AC-3）。
+`multi_session.enabled: true`（Phase 4.1 で決定済み。新規生成・back-add いずれでも既定 ON）**かつ** Claude 自身の Bash tool 定義（sandbox セクション）が filesystem write 制限付き sandbox で動作している場合のみ実行する。いずれか一方でも該当しない場合は本節を完全に silent skip する（案内・warning 共に一切出さない — AC-3）。
 
-判定は Claude 自身の実行コンテキスト（system prompt に記述された sandbox の write 許可リスト）を読んで行う。bash コマンドでは検出できない（sandbox の有無はセッションの起動設定であり、ファイルから読み取れる状態ではないため）。
+判定は実行コンテキスト（system prompt の sandbox write 許可リスト）を読む。bash では検出できない。
 
-該当する場合、まず main checkout root の絶対パスを取得する。`git rev-parse --show-toplevel` は現在の worktree の toplevel を返すため、setup がセッション worktree cwd から実行された場合（例: EnterWorktree 後の `/rite:setup --upgrade` 手動実行）に worktree パスを誤って返す（[`lib/worktree-git.sh`](../../hooks/scripts/lib/worktree-git.sh) が同じ理由でこのパターンを避けている）。代わりに `state-path-resolve.sh` で main checkout root を解決する:
+該当時は `state-path-resolve.sh` で main checkout root を解決する（`git rev-parse --show-toplevel` は使わない）:
+rationale: references/rationale.md#sandbox-allowlist
 
 ```bash
 bash {plugin_root}/hooks/state-path-resolve.sh
 ```
 
-その値を `{repo_root}` として、`.claude/settings.local.json`（コミットされる `.claude/settings.json` は書き換えない）の `sandbox.filesystem.allowWrite` へ idempotent に自動追記する。書込先はユーザーローカル設定として扱う意図のファイルだが、**リポジトリの `.gitignore` に明示エントリがなければコミット済み扱いになる**（開発者個人のグローバル gitignore に依存した除外は他の contributor 環境では効かない）ため、まず対象リポジトリの `.gitignore` に `.claude/settings.local.json` を保証してから書き込む（Phase 4.6 の gitignore 追記パターンと同形式）。方針転換の背景・(a)/(b)/(c) 比較検討は [git-worktree-patterns.md の Decision Log](../../references/git-worktree-patterns.md#sandbox-write-allowlist-設定の自動化decision-log) を参照（複製しない）:
+その値を `{repo_root}` として、`.claude/settings.local.json`（`.claude/settings.json` は書き換えない）の `sandbox.filesystem.allowWrite` へ idempotent に自動追記する。先に対象リポジトリの `.gitignore` へ `.claude/settings.local.json` を保証してから書く（Phase 4.6 と同形式）。詳細: [git-worktree-patterns.md の Decision Log](../../references/git-worktree-patterns.md#sandbox-write-allowlist-設定の自動化decision-log)。
+rationale: references/rationale.md#sandbox-allowlist
 
 ```bash
 # .gitignore に .claude/settings.local.json エントリを保証（未カバー時のみ追記）。
@@ -1437,7 +1449,8 @@ else
 fi
 ```
 
-**sandbox + multi_session 環境では、上記スクリプトが `added`/`already_present` を返さず初回から marker `failed` になるのが既定経路である**（例外ケースではない）。`jq ... > "$settings_file.tmp"` リダイレクトが単独で「読み込み専用ファイルシステムです」等のエラーを起こし、bash 全体としては正常終了（exit 0）したまま `else` 節に落ちて marker が直接 `failed` になる（bash ツール呼び出し自体はエラーにならない）。そのため **「コマンド自体が失敗したかどうか」を再試行の判定条件にしない** — marker が `failed` であれば理由を問わず、当該 bash ブロック全体を一度だけ `dangerouslyDisableSandbox: true` で再実行してよい（ユーザー確認は不要 — sandbox に拒否された main checkout 書き込みだけを再試行する既存ポリシーと同じ扱い。ブロック全体の再実行は `grep -qF` / `unique` により冪等なので、gitignore 追記側だけ再実行するより安全）。再実行後も `failed`（JSON 破損等、sandbox 起因でない失敗）の場合のみ、下記の手動案内メッセージにフォールバックする。
+**sandbox + multi_session では初回から marker `failed` になるのが既定経路**（例外ではない）。**「コマンド自体が失敗したか」を再試行条件にしない** — marker が `failed` なら理由を問わず、当該 bash ブロック全体を一度だけ `dangerouslyDisableSandbox: true` で再実行してよい（確認不要。ブロック全体は冪等）。再実行後も `failed` の場合のみ下記の手動案内へフォールバックする。
+rationale: references/rationale.md#sandbox-allowlist
 
 `SANDBOX_ALLOWLIST_AUTOWRITE` marker で分岐する:
 
@@ -1476,9 +1489,10 @@ fi
 
 ## Phase 4.9: SSH Host Alias Remote の Sandbox 事前案内（#1907）
 
-`origin` remote が SSH host alias 経由（例: `git@github.com-work:owner/repo.git`）で、かつ Claude 自身の Bash tool 定義（sandbox セクション）がネットワーク制限を伴う sandbox で動作していることを示している場合のみ、以下を表示する。いずれか一方でも該当しない場合（HTTPS remote / sandbox 無効）は本節を完全に silent skip する（案内・warning 共に一切出さない）。`multi_session` の有無には依存しない（Phase 4.8 と異なり、本問題は SSH alias remote + sandbox の組合せのみで発生するため独立した gate とする）。
+`origin` が SSH host alias 経由（例: `git@github.com-work:owner/repo.git`）**かつ** Claude 自身の Bash tool 定義がネットワーク制限付き sandbox のときのみ表示する。いずれか一方でも該当しない場合は本節を完全に silent skip する（案内・warning 共に一切出さない）。`multi_session` の有無には依存しない。
 
-SSH host alias remote かどうかは bash で判定できる（git config の読み取りであり検出可能。Phase 4.8 の sandbox 判定とは性質が異なる）:
+SSH host alias 判定は bash で行う:
+rationale: references/rationale.md#ssh-alias-sandbox
 
 ```bash
 origin_url=$(git remote get-url origin 2>/dev/null) || origin_url=""
@@ -1501,9 +1515,10 @@ else
 fi
 ```
 
-一方 sandbox の有効判定は Phase 4.8 と同じ理由（bash コマンドでは検出できない — sandbox の有無はセッションの起動設定であり、ファイルから読み取れる状態ではないため）により、Claude 自身の実行コンテキスト（system prompt に記述された sandbox のネットワーク許可リスト）を読んで行う。settings ファイルの `sandbox.enabled` を `jq` で読む経路は使わない（Phase 4.8 の判定方針と統一）。
+sandbox 有効判定は実行コンテキスト（system prompt のネットワーク許可リスト）を読む。settings の `sandbox.enabled` を `jq` で読まない。
 
-`SSH_ALIAS_REMOTE=yes` **かつ** sandbox 有効の両方が真のときのみ、以下を表示する（原因の因果連鎖や恒久対処の詳細本文は複製せず、要約 + [git-worktree-patterns.md](../../references/git-worktree-patterns.md#ssh-host-alias-経由の-git-pushfetch-が-sandbox-のネットワーク許可リストでブロックされる) への 1 行ポインタに留める）。以下のテンプレートをそのまま出力し、要約・言い換え（「〜旨を案内」等の間接話法を含む）をしないこと:
+`SSH_ALIAS_REMOTE=yes` **かつ** sandbox 有効のときのみ、以下を表示する。詳細は [git-worktree-patterns.md](../../references/git-worktree-patterns.md#ssh-host-alias-経由の-git-pushfetch-が-sandbox-のネットワーク許可リストでブロックされる)。テンプレートをそのまま出力し、要約・言い換え（「〜旨を案内」等の間接話法を含む）をしないこと:
+rationale: references/rationale.md#ssh-alias-sandbox
 
 ```
 ℹ️ sandbox 環境かつ origin remote が SSH host alias（{host}）経由です。sandbox 内からの
@@ -1517,7 +1532,7 @@ fi
 
 settings ファイルへの自動書き込みは行わない（案内のみ、MUST NOT）。
 
-**→ Proceed to Phase 5 (new-install) — this Phase is only reached via the new-install exit points in Phase 4.7 (§4.7.1/4.7.2/4.7.4) followed by Phase 4.8; `--upgrade` invokes this Phase directly after Phase 4.8 from Step 7b and then exits without a Phase 5 report.**
+**→ Proceed to Phase 5 (new-install)。`--upgrade` は Step 7b から Phase 4.8 の直後に本 Phase を呼び、Phase 5 なしで exit する。**
 
 ## Phase 5: Completion Report
 

--- a/plugins/rite/skills/setup/references/rationale.md
+++ b/plugins/rite/skills/setup/references/rationale.md
@@ -1,0 +1,202 @@
+# /rite:setup — 設計理由
+
+`skills/setup/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。
+
+## dep-check-nonblocking
+
+hook / スクリプトは bash 4+ / jq に依存し、flow-state のロックに flock を使う。導入時点で
+欠落を表面化しておかないと、macOS stock bash 3.2 のまま pr-review 系が不可解に失敗する。
+setup 自体は依存欠落でも止めない — 案内を出したうえで後続フェーズへ進む。全依存 OK のときは
+1 行サマリのみにし、ウィザードを邪魔しない。
+
+bash の判定基準は実行中シェルの `BASH_VERSION`（Decision D-01）。macOS の PATH 解決
+（Homebrew bash か `/bin/bash` 3.2 か）が環境依存で不確実なため、実行コンテキスト自身を測る。
+
+`[CONTEXT] DEP_CHECK` は data contract / observability として全ケースで emit するが、現状どの
+後続フェーズも機械 parse しない。jq 案内の重複排除は Phase 4.5.0 の NO_JQ メッセージが
+Phase 1.0 を文言で参照して達成しており、marker の消費には依存しない。
+
+## plugin-path-before-git-remote
+
+`{plugin_root}` を未解決のまま `git-remote.sh` を呼ぶと経路が silent に失敗し、SSH host alias
+環境では fallback の `gh repo view` も失敗する。
+
+## project-link
+
+`gh project link` はリポジトリと Project を関連付け、Issue 作成 helper のフィールド取得
+GraphQL（`repository(owner:, name:) { projectV2(number:) }` ルート）を解決可能にする。
+link しないままだと初回 `/rite:issue-create` が `project_registration: "partial"` で失敗する。
+
+## wiki-section-new-gen
+
+template は `wiki:` を `# --- Advanced ---` 境界より上の active block として宣言する。
+新規生成の抽出（境界より上）がそのまま `wiki:` を含むため、追加の append は不要。
+境界が「emit するかコメントアウトするか」の単一 SoT。
+
+## upgrade-branching
+
+schema 同等でもテンプレートは版を bump せずに active セクション / サブキー（`multi_session`・
+新規セクション・Wiki 等）を獲得し得る。`current >= latest` でも欠落 drift を back-add して
+最新デフォルトへ追従させる。
+
+両経路とも Step 6 が config を変更し得るため Backup を必ず先に置く。`current >= latest` は
+Preview/confirm を挟まない — 欠落している active セクション / サブキーのみの冪等 back-add で、
+User-customized 値（明示的な `enabled: false` を含む）は保全されるため無確認で適用する。
+旧 Wiki 専用救済（Wiki-only Step）はこの一般化に吸収され、Wiki も他の active セクションと
+同様に Step 6 item 7 で back-add される。
+
+`current >= latest` で back-add 対象が皆無なら Step 6 は書き換えず最新表示のみ。Phase 4.7 は
+そのまま実行され、Wiki 初期化済みなら Skill 呼び出しは skip される（冪等）。
+
+## unknown-key-scope
+
+Step 4 の Unknown key 判定は template の Advanced 境界より上の active section のみを参照する。
+境界より下（コメント形式の Advanced + 末尾コメント）は template 側で意図的に省略または注記の
+領域であり、ユーザー設定の classification 対象外。
+
+## upgrade-apply-ssot
+
+`multi_session:` / `wiki:` の挿入ブロックは template の active 区間から抽出する。本文に
+リテラルを複製しない — デフォルト変更が新規生成と `--upgrade` の両方へ伝播する。
+
+wiki の挿入位置をファイル末尾の非空行にしない。template の複数セクション末尾に繰り返される
+`enabled: true` / `auto_query: true` と衝突しうる。
+
+schema bump / 廃止キー削除 / Advanced コメント追加は full-upgrade（`current < latest`）専用。
+短絡経路では schema は既に現行のため、schema bump は no-op になる。
+
+## upgrade-step7
+
+Phase 4.7 内部の「次のステップ」案内は Step 7a への再入ではなく、完了後の 7b へ戻ることを
+指す。`--upgrade` は Phase 1–3 と Phase 5 の完了レポートをスキップするため、Wiki 状態行と
+（該当時）Phase 4.8 / 4.9 案内だけを報告する。新規インストール経路に入らないので Phase 5 と
+文面が衝突しない。
+
+## rite-hook-command
+
+「rite hook command」は command path 中で `rite` が hooks ディレクトリ直上の完全な path
+segment である場合だけ（間に version segment を 1 個まで許容）。dev/relative の
+`…/rite/hooks/` と cache install の `…/rite-marketplace/rite/<version>/hooks/` がマッチし、
+`favorite/hooks/`・`prerite/hooks/`・`rite-something/hooks/` のような部分文字列 look-alike
+はマッチしない。
+
+正規表現の単一定義実体は `scripts/settings-local-rite-hook-cleanup.py` の `RITE_HOOK_RE`
+（`(?:^|/)rite/(?:[^/]+/)?hooks/`）。同名 `.sh` wrapper も `session-start.sh` の
+settings.local.json 修復も JSON 変換＝regex 適用をこの `.py` に委譲する（session-start.sh
+のインライン複製を解消済み）。素朴な substring `rite/hooks/` は `favorite/hooks/` 等を
+over-match するため使わない。
+
+## plugin-path-mismatch
+
+4.5.0 の direct key lookup と、他スキル・hook が使う正準 one-liner（`rite@*` 先頭エントリ）
+は、`installed_plugins.json` に複数の `rite@*` があると異なるバージョンのパスを返し、
+1 セッション内で hooks と skills が別バージョンを参照する混在が silent に進行する。
+照合失敗・不一致は non-blocking。解決結果は従来どおり direct key を採用し、解決フロー自体は
+退行させない。
+
+## copy-type-install
+
+copy 型インストールは自動更新を受け取らない。マーケットプレースソース
+（`~/.claude/plugins/marketplaces/{name}/`）は runtime の cache
+（`~/.claude/plugins/cache/`）とは別ディレクトリ。`{hooks_dir}` は
+`.../cache/{marketplace_name}/{plugin_name}/{version}/hooks` なので、末尾 `hooks` を除き
+2 階層上が marketplace 名。
+
+## settings-json-conflict
+
+Claude Code は `.claude/settings.json` と `.claude/settings.local.json` の両方から hook を
+実行する。同一イベントに非-rite hook があると二重実行になる。チェックは advisory only —
+`settings.json` を自動変更せず、結果に依らず init を止めない。
+
+## native-hooks-json
+
+`hooks.json` があるとき Claude Code はプラグイン hook をネイティブ管理し
+`${CLAUDE_PLUGIN_ROOT}` を動的解決する。この場合 `settings.local.json` への登録は不要で、
+バージョン更新時にパスが壊れる原因になる。
+
+## cleanup-helper-contract
+
+`settings-local-rite-hook-cleanup.sh` は rite hook を実際に除去したときだけ `CLEANED` を返し、
+それ以外の安全側（python3 不在・file 不在・対象 hook 不在・不正 JSON・mktemp/mv 失敗を含む）
+はすべて `NO_RITE_HOOKS`。ただし **mv 失敗** だけは「変換は成功したが swap-in できず stale な
+rite hook が残る」ため、`NO_RITE_HOOKS`（exit 0 非ブロッキング）を保ったまま stderr に
+`[rite] WARNING: ... mv failed` を出す。`*.py` を `*.sh` wrapper 経由で呼ぶ先例
+`issue-comment-wm-update.py` / `issue-comment-wm-sync.sh` に準拠。
+
+## hook-path-absolute
+
+4.5.0 は `{hooks_dir}` を絶対パス（`cd ... && pwd`）で解決する。既存 hook が相対パス
+（例: `bash plugins/rite/hooks/pre-tool-bash-guard.sh`）なら一致せず更新対象になる。
+相対→絶対の変換はこの検証の目的の一つ。
+
+4.5.1.1 は既存フックのパス検証のみで、イベント自体の欠落は検出しない。必須フックの存在
+チェックは 4.5.1.2。片方だけ通すと「パスは正常だが SessionEnd / PreToolUse が未登録」を
+見逃す。
+
+## wiki-init-contract
+
+Phase 4.7 失敗（Skill 呼び出し失敗を含む）で `/rite:setup` を abort しない。Wiki 状態は
+完了レポート（Phase 5 / Step 7b）で必ず報告する。
+
+`wiki_status` は LLM 会話コンテキストに保持する。Bash tool は独立 subshell なのでシェル
+変数は呼び出しを跨がない。enum は identifier 互換（snake_case、空白・括弧なし）で、
+Phase 5 / Step 7b が明示 if/else でリテラルを選ぶ。`wiki_status` から文面を動的組み立て
+しない。
+
+## wiki-enabled-sed
+
+`wiki.enabled` の欠落 / キー欠落 / 解釈不能は `true`（opt-out）。`wiki-init` ステップ 1.1
+と同じで、typo 検出 WARNING 経路も含む。
+
+`sed -n '/^wiki:/,/^[a-zA-Z]/p'` は次の ASCII 英字始まり行（次のトップレベル YAML キー）で
+終わる。template 形状（wiki の次が別トップレベルキーまたは EOF）に依存する。wiki が末尾
+ブロックで後続がコメントのみなら EOF まで読むが、それでも正しい。既知の限界は wiki 節の
+**内部**に英字始まりコメント行を挿む非標準 config で、template 形状の drift は既知制限であり
+blocker ではない。
+
+## wiki-init-delegate
+
+Skill tool は戻り値を表面化しないため、失敗検出は post-check（4.7.4）。Wiki 初期化ロジックを
+ここへ再実装しない — 常に Skill へ委譲する。
+
+4.7.4 で `rite-config.yml` を再パースしないのは、Skill が config を変更した場合の drift を
+避けるため。4.7.2 で観測した値を literal 埋め込みする。
+
+## sandbox-allowlist
+
+`git rev-parse --show-toplevel` は現 worktree の toplevel を返す。セッション worktree cwd
+からの `/rite:setup --upgrade` では worktree パスを誤って返す（`lib/worktree-git.sh` が
+同じ理由でこのパターンを避ける）。main checkout root は `state-path-resolve.sh` で解決する。
+
+書込先はユーザーローカル意図のファイルだが、リポジトリ `.gitignore` に明示エントリがなければ
+コミット済み扱いになる。開発者個人のグローバル gitignore は他 contributor 環境では効かない。
+`.gitignore` を先に保証してから settings を書く。方針転換の (a)/(b)/(c) 比較は
+`git-worktree-patterns.md` の Decision Log。
+
+gitignore 追記が sandbox 等で失敗しても silent にしない。旧「案内のみ」フローでは settings に
+手動で path 追加済み・gitignore 未対応のユーザーが、gitignore 追記だけ失敗して未保護のまま
+放置される回帰があった。
+
+sandbox + multi_session では初回から marker `failed` になるのが既定経路。`jq` リダイレクトが
+「読み込み専用ファイルシステムです」等で失敗し、bash 全体は exit 0 のまま `else` に落ちる。
+「コマンド自体が失敗したか」を再試行条件にしない。marker `failed` なら理由を問わずブロック
+全体を一度だけ `dangerouslyDisableSandbox: true` で再実行する（確認不要。ブロック全体再実行は
+`grep -qF` / `unique` により冪等なので、gitignore 追記側だけ再実行するより安全）。
+
+`already_present` で無表示なのは `--upgrade` 再実行毎のノイズを出さないため。
+
+## ssh-alias-sandbox
+
+本問題は SSH alias remote + sandbox の組合せだけで起きる。`multi_session` の有無には依存
+しない（Phase 4.8 とは独立ゲート）。
+
+SSH alias 判定は git config の読み取りで bash 可能。sandbox 有効判定は Phase 4.8 と同じく
+bash では検出できない（セッション起動設定であり、ファイルから読めない）ため、実行コンテキスト
+のネットワーク許可リストを読む。settings の `sandbox.enabled` を `jq` で読む経路は使わない。
+
+settings への自動書き込みは行わない（案内のみ）。`sandbox.excludedCommands` が Linux/WSL2 では
+本問題を解消しない理由は `git-worktree-patterns.md` の SSH host alias 節。

--- a/plugins/rite/skills/wiki-ingest/SKILL.md
+++ b/plugins/rite/skills/wiki-ingest/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: ""
 
 # /rite:wiki-ingest
 
-Wiki Ingest エンジン。`.rite/wiki/raw/` の Raw Source を読解し、`.rite/wiki/pages/` に経験則として統合する。やることは以下のシーケンシャルなタスク列:
+Wiki Ingest エンジン。`.rite/wiki/raw/` の Raw Source を読解し、`.rite/wiki/pages/` に経験則として統合する。
 
 1. 事前チェック（Wiki 設定 / plugin root / worktree セットアップ）
 2. Raw Source の候補列挙と `ingested: false` 判定
@@ -24,7 +24,7 @@ Wiki Ingest エンジン。`.rite/wiki/raw/` の Raw Source を読解し、`.rit
 
 Raw Source の wiki branch 着地は `wiki-ingest-commit.sh` が `review` / `fix` / `issue-close` から直接呼ばれて完了している前提。本コマンドが扱うのは page 統合の LLM 責務のみ。
 
-`separate_branch` 戦略では `.rite/wiki-worktree/` worktree のツリーに対して Read/Write/Edit を行う。dev ブランチは ingest 実行中も常にそのまま。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md) で解決する。共通パターン (ディレクトリ構造 / ブランチ管理 / テンプレート展開) は [Wiki Patterns](../../references/wiki-patterns.md) を参照。Wiki が育たない / 動作しないときの診断手順 (raw が増えない / page が増えない / growth-check alarm の読み方) は [Wiki トラブルシューティング](./references/wiki-troubleshooting.md) を参照。
+`separate_branch` では `.rite/wiki-worktree/` に対して Read/Write/Edit する。dev ブランチは触らない。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md)。共通パターンは [Wiki Patterns](../../references/wiki-patterns.md)。診断は [Wiki トラブルシューティング](./references/wiki-troubleshooting.md)。
 
 ## Arguments
 
@@ -45,7 +45,8 @@ Raw Source の wiki branch 着地は `wiki-ingest-commit.sh` が `review` / `fix
 
 ### 1.1 Wiki 設定の読み取りとブランチ戦略判定
 
-`rite-config.yml` から `wiki_enabled` / `wiki_branch` / `branch_strategy` を**単一の bash ブロック**で取得する (本ブロックはプローブ用。helper 解決失敗のみ明示 fail-fast で扱い、値の欠落は `${var:-default}` で吸収するため `set -euo pipefail` は不要。strict mode はステップ 5.1 / 5.2 で明示宣言する):
+`rite-config.yml` から `wiki_enabled` / `wiki_branch` / `branch_strategy` を**単一の bash ブロック**で取得する:
+rationale: references/rationale.md#wiki-config-opt-out
 
 ```bash
 # YAML 読み取りは canonical helper (実ファイル) に委譲する。skill 本文の fenced bash に
@@ -71,9 +72,9 @@ branch_strategy="${branch_strategy:-separate_branch}"
 echo "wiki_enabled=$wiki_enabled branch_strategy=$branch_strategy wiki_branch=$wiki_branch"
 ```
 
-分散実装の完全一覧と設計差異は [Wiki 有効判定パターン §分散実装ファイル一覧](../../references/wiki-patterns.md#分散実装ファイル一覧-single-source-of-truth) を SoT として参照する。本ファイルは `lib/wiki-config.sh` の `parse_wiki_scalar` を直接呼ぶ lenient 2-arm 経路 (inject.sh と同型の lenient ファミリ、opt-out default)。trigger.sh は意図的に strict 3-arm fail-fast で別経路 — 詳細は SoT を参照。
+分散実装の一覧は [Wiki 有効判定パターン §分散実装ファイル一覧](../../references/wiki-patterns.md#分散実装ファイル一覧-single-source-of-truth) を SoT とする。
 
-**`[CONTEXT] WIKI_CONFIG_HELPER_UNAVAILABLE=1` (bash が rc=1 で終了) の場合**: 設定を判定できていないため無効扱いへ倒さず、そのまま中止してユーザーに案内する:
+**`[CONTEXT] WIKI_CONFIG_HELPER_UNAVAILABLE=1` (bash が rc=1 で終了) の場合**: 無効扱いへ倒さず中止し、ユーザーに案内する:
 
 ```
 Wiki 設定を読み取れませんでした（hooks/scripts/lib/wiki-config.sh を解決できません）。
@@ -89,7 +90,8 @@ Wiki 機能が無効です（wiki.enabled: false）。
 
 ### 1.2 Plugin Root の解決
 
-ステップ 1.3 の `wiki-worktree-setup.sh` 呼び出しが `$plugin_root` に依存するため、Wiki 初期化判定よりも前に解決する:
+Wiki 初期化判定より前に `plugin_root` を解決する:
+rationale: references/rationale.md#plugin-root-literal-embed
 
 ```bash
 plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
@@ -100,11 +102,11 @@ fi
 echo "plugin_root=$plugin_root"
 ```
 
-以降のすべての Bash ブロックでは `plugin_root` / `branch_strategy` / `wiki_branch`、および ステップ 1.3 で取得した `wiki_worktree_abs`（`WIKI_WORKTREE_ABS` の値）をリテラル値として埋め込んで使用する（Claude Code の Bash ツール間でシェル変数は保持されない）。
+以降のすべての Bash ブロックでは `plugin_root` / `branch_strategy` / `wiki_branch`、およびステップ 1.3 の `wiki_worktree_abs`（`WIKI_WORKTREE_ABS`）をリテラル埋め込みする。
 
 ### 1.3 Wiki 初期化判定と worktree セットアップ
 
-ステップ 1.1 で取得した `branch_strategy` / `wiki_branch` とステップ 1.2 の `plugin_root` を使い、wiki ブランチの存在と worktree の有効性を確認する。`separate_branch` 戦略では、ブランチがローカル/リモートのどちらかに存在することと worktree が有効に存在することを両方確認する:
+ステップ 1.1 の `branch_strategy` / `wiki_branch` とステップ 1.2 の `plugin_root` で、wiki ブランチの存在と worktree の有効性を確認する。`separate_branch` ではローカル/リモートいずれかのブランチ存在と有効な worktree の両方を確認する:
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -160,11 +162,13 @@ Wiki が初期化されていません ({reason})。先に /rite:wiki-init を�
 
 `reason=worktree_setup_failed` の場合は `wiki-worktree-setup.sh` のエラー出力を確認し、`git worktree prune` / `git fetch origin wiki:wiki` 等で復旧してから再実行する。
 
-`separate_branch` の場合、ステップ 1.3 が出力した絶対パス `WIKI_WORKTREE_ABS` を基点に（以降 `{wiki_worktree_abs}` として `plugin_root` と同様にリテラル埋め込みする）、すべての Wiki Read / Write / Edit と bash ブロックは `{wiki_worktree_abs}/.rite/wiki/...` で指す。これにより呼び出し時の cwd（セッション worktree でも main checkout でも）に依存せず、常に共有 root の wiki worktree 一箇所に解決される（multi-session design §9 / AC-5）。`{wiki_worktree_abs}` が空（旧バージョン互換のため未取得の場合）は `.rite/wiki-worktree` の相対パスに縮退してよい。
+`separate_branch` ではステップ 1.3 の絶対パス `WIKI_WORKTREE_ABS` を `{wiki_worktree_abs}` としてリテラル埋め込みし、すべての Wiki Read / Write / Edit と bash は `{wiki_worktree_abs}/.rite/wiki/...` で指す。空なら `.rite/wiki-worktree` に縮退してよい。
+rationale: references/rationale.md#cwd-independent-worktree
 
 ### 1.4 Ingest セッション lock の取得（並行 ingest の直列化）
 
-複数セッションが同時に ingest（cleanup → ingest 連鎖を含む）へ入っても安全になるよう、LLM の Write/Edit フェーズを直列化する。`flock` は複数 Bash 呼び出しに跨る ingest を守れないため、ingest 期間中保持する持続的 mkdir lock（`<共有root>/.rite/state/wiki-ingest-session.lockdir`）を取得する。stale 判定は保持セッションの flow-state liveness（`active=true` ∧ `updated_at` 2h 以内）を流用する（multi-session design §9）:
+Write/Edit フェーズを直列化する持続的 mkdir lock（`<共有root>/.rite/state/wiki-ingest-session.lockdir`）を取得する:
+rationale: references/rationale.md#session-lock-mkdir
 
 ```bash
 plugin_root="{plugin_root}"
@@ -174,7 +178,7 @@ bash "$plugin_root/hooks/scripts/wiki-ingest-lock.sh" acquire
 出力で分岐する:
 
 - `acquired` / `acquired_stale_reclaimed`（rc 0）: 取得成功。ステップ 2 以降へ進む。
-- `concurrent_ingest`（rc 11）: 他の live セッションが ingest 中。**以下を出力して即座に終了する**（pending raw は wiki branch に残り、次回 ingest が冪等に回収する — AC-4。新しい回収機構は作らない）:
+- `concurrent_ingest`（rc 11）: 他の live セッションが ingest 中。**以下を出力して即座に終了する**（pending raw は次回 ingest が冪等回収。新しい回収機構は作らない）:
 
   ```
   [CONTEXT] WIKI_INGEST_SKIPPED reason=concurrent_ingest
@@ -192,7 +196,7 @@ bash "$plugin_root/hooks/scripts/wiki-ingest-lock.sh" acquire
 
 引数 `<raw-file-path>` が指定されている場合は単一ファイルを Ingest 対象とし、省略時は `.rite/wiki/raw/` 配下から `ingested: false` を持つ Raw Source を全て列挙する。
 
-以下のカウンターを会話コンテキストに保持し、各ステップで incrementate する。値は ステップ 5 commit message と ステップ 9 完了レポートで literal substitute されるため、placeholder のまま使用してはならない:
+以下のカウンターを会話コンテキストに保持し、各ステップで incrementate する。ステップ 5 commit message とステップ 9 完了レポートで literal substitute する。placeholder のまま使用してはならない:
 
 | 変数 | 初期値 | 確定 / incrementate するタイミング |
 |------|:--:|---|
@@ -205,11 +209,13 @@ bash "$plugin_root/hooks/scripts/wiki-ingest-lock.sh" acquire
 | `n_dedup_removed` | 0 | ステップ 6 の各 helper 呼び出しが出力する `dedup_removed=` の値を加算 |
 | `n_contradictions` / `n_stale` / `n_orphans` / `n_missing_concept` / `n_unregistered_raw` / `n_broken_refs` | 0 | ステップ 8.3 step 2 (6 フィールド regex match) で Lint stdout から抽出 |
 
-`n_unregistered_raw` と `n_dedup_removed` は informational 指標で `n_warnings` には加算しない（意図的に経験則化しなかった件数、および index の自己修復として回収した重複行の件数は、いずれも警告ではない）。`auto_lint=false` 経路で ステップ 8.2-8.5 が skip された場合も、本ステップで 0 初期化されているためステップ 9 完了レポートの placeholder 残留は発生しない。
+`n_unregistered_raw` と `n_dedup_removed` は informational で `n_warnings` には加算しない。`auto_lint=false` で 8.2-8.5 が skip されても、本ステップの 0 初期化でステップ 9 の placeholder 残留は起きない。
+rationale: references/rationale.md#informational-counters
 
 ### 2.2 候補 Raw Source の列挙 (worktree ベース)
 
-`separate_branch` 戦略では Raw Source は wiki ブランチ上にあり、`{wiki_worktree_abs}/.rite/wiki/raw/` を直接 find する。dev ブランチ側 (`.rite/wiki/raw/`) は通常存在しないが、過去バージョンからのマイグレーション残骸を検出するために存在チェックして WARNING を出す:
+`separate_branch` では `{wiki_worktree_abs}/.rite/wiki/raw/` を直接 find する。dev 側 `.rite/wiki/raw/` が存在すれば WARNING を出す:
+rationale: references/rationale.md#dev-tree-drift
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -286,7 +292,7 @@ case "$ingested_norm" in
 esac
 ```
 
-候補は worktree (separate_branch) または dev ツリー (same_branch) を直接 Read / `cat` で読み取れる（`git show` / `git checkout` は不要）。読み取り失敗時は WARNING を出して次の候補へ:
+候補は worktree (separate_branch) または dev ツリー (same_branch) を Read / `cat` で読む（`git show` / `git checkout` は不要）。読み取り失敗時は WARNING を出して次の候補へ:
 
 ```bash
 # signal-specific trap (EXIT/INT/TERM/HUP) は反復ごとに再設定される (bash 仕様で idempotent)。
@@ -320,7 +326,7 @@ fi
 新しい経験則を蓄積するには /rite:pr-review や /rite:fix の完了後に再実行してください。
 ```
 
-**処理対象が確定したら**: ステップ 2.1 で初期化した `n_raw_sources` を件数に上書きする。各 Raw Source の完全な本文 (frontmatter + body) を Read ツールで取得し、会話コンテキストに保持する（ステップ 5 の Write/Edit phase で参照）。
+**処理対象が確定したら**: `n_raw_sources` を件数に上書きする。各 Raw Source の完全な本文 (frontmatter + body) を Read し、会話コンテキストに保持する。
 
 ---
 
@@ -355,8 +361,10 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 
 1. **読解**: Raw Source 本文から抽出可能な経験則を特定
 2. **ドメイン判定**: `patterns` / `heuristics` / `anti-patterns` に分類
-2.5. **昇格分類**: 本経験則が rite workflow 自体の挙動・スキル記述法に関するものなら、環境非依存性も判定する。環境非依存なら frontmatter に `promote: rite-plugin` を付け、環境固有なら一般化してから昇格するか、一般化できない domain 知見として Wiki に残す（マーケットプレイス配布先で Wiki 留置のままでは不活性になる知見の仕分け。CLAUDE.md「知見のルーティング」）。**機械検出可能（2.6）と両方に該当する場合は 2.6 が優先**し、ページを作らない（`promote` はページ作成時のみ）
-2.6. **検出器化候補の分類**: この経験則は grep / lint / lib 関数で機械的に強制できるか、を判定してフラグ付けするのみ（アクション決定は行わない）。できるなら `detector_candidate=true`、できないなら `false`。判断の正例: trap 順序の静的検査・mktemp 無音化の lint 化 → `true`。負例: ブランチ戦略の運用判断・ドメイン固有の文脈知識 → `false`（従来どおりページ化）
+2.5. **昇格分類**: 本経験則が rite workflow 自体の挙動・スキル記述法に関するものなら、環境非依存性も判定する。環境非依存なら frontmatter に `promote: rite-plugin` を付け、環境固有なら一般化してから昇格するか、一般化できない domain 知見として Wiki に残す。**機械検出可能（2.6）と両方に該当する場合は 2.6 が優先**し、ページを作らない（`promote` はページ作成時のみ）
+   rationale: references/rationale.md#knowledge-routing
+2.6. **検出器化候補の分類**: grep / lint / lib 関数で機械的に強制できるかフラグ付けするのみ（アクション決定はしない）。できるなら `detector_candidate=true`、できないなら `false`
+   rationale: references/rationale.md#detector-candidate
 3. **既存ページ照合**: `index.md` に同テーマの既存ページが存在するかを意味的に判定 (厳密一致ではなく、一行サマリーとタイトルから判断)
 4. **アクション決定**: 下表に**上から first-match**で 新規 / 更新 / スキップ を決定（2.6 のフラグとステップ 3 の照合結果を入力とする）
 5. **関連ページ特定**: ステップ 5.3 の `{related_page_title}` / `{related_page_path}` の値を決定 (詳細はステップ 4.3)
@@ -388,13 +396,16 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 
 - **追記**: 既存内容と矛盾せず補強する場合は「## 詳細」セクションに追記
 - **統合**: 一部矛盾するが新情報の方が確度が高い場合は該当箇所を書き換え（`updated` フィールド更新）
-- **`sources` 配列追記**: 新しい Raw Source への参照を必ず追加する。追加する各エントリは `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` の形式とし、**`ref` は必ず Raw Source のファイルパス形式 (`raw/{type}/{filename}`、wiki-root 起点)** にする。raw frontmatter の `source_ref` フィールド値（PR 識別子形式、例: `pr-1143`）を `ref` に転記してはならない（ステップ 5.3 `{source_ref}` 行の dual-use 警告と同一契約）
+- **`sources` 配列追記**: 新しい Raw Source への参照を必ず追加する。追加する各エントリは `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` の形式とし、**`ref` は必ず Raw Source のファイルパス形式 (`raw/{type}/{filename}`、wiki-root 起点)** にする。raw frontmatter の `source_ref` フィールド値（PR 識別子形式、例: `pr-1143`）を `ref` に転記してはならない
 - **`updated` 更新**: 現在の ISO 8601 タイムスタンプに更新
-- **`description` の新設・更新**: 本サイクルで概要が変わった場合は frontmatter `description` を更新する（未設定なら新設してよい）。値は上表の番号なし Why 要約をそのまま使い、独自の短縮・言い換えをしない。ステップ 6 の helper はこの値を index サマリー列へ渡すため、ここを更新しないと index のサマリーは既存値が保持され、同源テキストが drift する
+- **`description` の新設・更新**: 本サイクルで概要が変わった場合は frontmatter `description` を更新する（未設定なら新設してよい）。値は上表の番号なし Why 要約をそのまま使い、独自の短縮・言い換えをしない。ステップ 6 の helper はこの値を index サマリー列へ渡す
+rationale: references/rationale.md#source-ref-path-form
+rationale: references/rationale.md#summary-provenance
 
 ### 4.3 関連ページの特定
 
-新規ページ作成・既存ページ更新のいずれの場合も、ステップ 5.3 で展開する `{related_page_title}` / `{related_page_path}` placeholder の値を本ステップで決定する（本セクションが値決定手順の canonical source。ステップ 5.3 placeholder 表との矛盾発生時は本 4.3 を優先）。
+新規・更新のいずれも、ステップ 5.3 の `{related_page_title}` / `{related_page_path}` を本ステップで決定する（値決定の canonical source。5.3 表と矛盾したら本 4.3 を優先）。
+rationale: references/rationale.md#related-page-literal
 
 **実行タイミング**: ステップ 4.1 でタイトル/ドメイン決定後、ステップ 5 の Write/Edit に進む前。
 
@@ -406,7 +417,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 | 確信度 | LLM の判定として確信があるもの 1-3 件に絞る（量より質） |
 | index.md との照合 | ステップ 3 で読み込んだ `index_content` の一行サマリーとタイトルから判断する |
 
-**title 規約**: `{related_page_title}` は対象ページの frontmatter `title` フィールドと **literal 一致** させる。独自言い換えは禁止 (index.md ↔ link text の drift 防止)。`index.md` 登録行の link text は同じ値だが、ステップ 6 の 2 種の措置が適用されている場合がある — セル区切りエスケープ（`|` → `\|`）と、リンク構文の中和（`](` の `]` → `&#93;`。同定述語が読む先頭リンクを title が詐称できないようにするため）。**literal 一致の基準は frontmatter `title` の生値**であり、index 側のこれらは表記上の措置なので転記してはならない。
+**title 規約**: `{related_page_title}` は対象ページの frontmatter `title` フィールドと **literal 一致** させる。独自言い換えは禁止。**literal 一致の基準は frontmatter `title` の生値**であり、index 側のセル区切りエスケープとリンク構文中和は転記しない。
 
 **path 計算規約**: `{related_page_path}` には **page-dir 相対** の path を substitute する。新規 page 格納位置 `.rite/wiki/pages/{domain}/{slug}.md` の page-dir = `.rite/wiki/pages/{domain}/` を起点として相対 path を計算する:
 
@@ -415,9 +426,9 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 | 同ドメイン内 | `./other-page.md` (`./` prefix 付き推奨。page-dir 相対の意図を視覚的に表現する) |
 | 別ドメイン | `../{domain}/other-page.md` |
 
-`{source_ref}` (template 側で `../../` prefix を hardcode、wiki-root 起点) とは起点が異なるため、`{related_page_path}` には template リテラル側で prefix を付けず、placeholder 値そのものに page-dir 相対 path を入れる。
+`{source_ref}`（template 側で `../../` prefix、wiki-root 起点）とは起点が異なる。`{related_page_path}` には template 側 prefix を付けず、page-dir 相対 path を入れる。
 
-**該当ページなし時の処理**: 確信ある関連ページが特定できない場合、`## 関連ページ` セクション全体を Edit ツールで以下に置き換える（空 placeholder のままだと Markdown リンク `[]()` が破綻するため）:
+**該当ページなし時の処理**: 確信ある関連ページが特定できない場合、`## 関連ページ` セクション全体を Edit で以下に置き換える:
 
 ```
 ## 関連ページ
@@ -435,7 +446,7 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 
 ### 5.0 LLM が実行すべき具体的手順 (worktree ベース)
 
-`separate_branch` では `{wiki_worktree_abs}/` worktree のツリー（ステップ 1.3 で取得した絶対パス）に対して、`same_branch` では dev ツリーに対して直接 Write/Edit する。絶対パスを使うことで、ingest がセッション worktree 内から起動された場合でも共有 root の wiki worktree に正しく書き込まれる（§9 / AC-5）。LLM は以下を順に実施するだけ:
+`separate_branch` では `{wiki_worktree_abs}/`（ステップ 1.3 の絶対パス）、`same_branch` では dev ツリーに直接 Write/Edit する。順に実施する:
 
 1. **Raw Source 本文の確保**: ステップ 2.3 末尾で取得した本文を作業メモリに展開
 2. **Raw Source の `ingested: true` 化** (全戦略共通 — create / update / skip いずれでも実施):
@@ -447,15 +458,17 @@ LLM は Read ツールで `$wiki_index_path` を直接開き、既存ページ�
 
    `n_pages_created` を +1 する
 
-   > **複数 Raw Source からの作成**: page-template.md の `sources:` は単一スロット（`{source_type}`/`{source_ref}` 各 1 個）のみ。multi-cycle PR 等で複数の Raw Source を 1 ページに統合する場合は、Write 後に Edit で `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` エントリを追加する。**追加・置換するすべての `ref` は Raw Source のファイルパス形式 (`raw/{type}/{filename}`)** であり、raw frontmatter の `source_ref` フィールド値（PR 識別子形式）ではない（ステップ 5.3 `{source_ref}` 行の dual-use 警告と同一契約）。
+   > **複数 Raw Source からの作成**: page-template.md の `sources:` は単一スロット（`{source_type}`/`{source_ref}` 各 1 個）のみ。複数 Raw Source を 1 ページに統合する場合は、Write 後に Edit で `- type: "{type}"` / `  ref: "raw/{type}/{filename}"` を追加する。**すべての `ref` はファイルパス形式 (`raw/{type}/{filename}`)** であり、raw の `source_ref`（PR 識別子）ではない。
 4. **既存 Wiki ページの更新** (ステップ 4 で更新決定): 対象ページを Read で読み、Edit で `## 詳細` 追記・`updated` 更新・`sources` 配列追記。`n_pages_updated` を +1 する。**`sources` に追記する各 `ref` は必ず Raw Source のファイルパス形式 `raw/{type}/{filename}`**（PR 識別子形式 `pr-NNNN` 禁止。ステップ 4.2 / 5.3 と同一契約）
-5. **スキップ決定の処理** (ステップ 4 で skip 決定): step 2 と同じ手順で `ingested: true` 化し、**さらに当該 raw frontmatter に `ingest_status: skipped` と `skip_reason: "{理由}"` を Edit で追記する**（skip 状態の Source of Truth は raw frontmatter。lint の `wiki-lint-skipped-refs.sh` がこれを走査して `unregistered_raw` を判定する。）。**検出器化候補**（ステップ 4 表の `detector_candidate=true` かつ既存ページなし）の場合は `skip_reason: "detector-candidate: {one-line-summary}"` を使い、同じ要約をステップ 9 の `{detector_candidate_lines}` に列挙する。ステップ 7 の log.md には人間向けの Skip エントリ (OKF bullet) も追記する。`n_skipped` を +1 する
-6. **index.md の更新**: **手順 3 / 4 を実施した Raw Source についてのみ**、ステップ 6 の指示に従い `wiki-index-update.sh` helper を bash で呼び出す（LLM は Edit しない）。**skip 決定（手順 5）の Raw Source では実行しない** — helper が必須とする page metadata（title / domain / slug / updated / confidence）が存在せず、raw 由来の値で代用すると実在しないパスを指す登録行が新規追加されて孤児検出のシグナルを汚すため
+5. **スキップ決定の処理** (ステップ 4 で skip 決定): step 2 と同じ手順で `ingested: true` 化し、**さらに当該 raw frontmatter に `ingest_status: skipped` と `skip_reason: "{理由}"` を Edit で追記する**（skip 状態の SoT は raw frontmatter）。**検出器化候補**（ステップ 4 表の `detector_candidate=true` かつ既存ページなし）は `skip_reason: "detector-candidate: {one-line-summary}"` を使い、同じ要約をステップ 9 の `{detector_candidate_lines}` に列挙する。ステップ 7 の log.md に人間向け Skip エントリ (OKF bullet) を追記する。`n_skipped` を +1 する
+6. **index.md の更新**: **手順 3 / 4 を実施した Raw Source についてのみ**、ステップ 6 に従い `wiki-index-update.sh` を bash で呼ぶ（LLM は Edit しない）。**skip 決定（手順 5）では実行しない**
+   rationale: references/rationale.md#skip-no-index-update
 7. **log.md への追記**: ステップ 7 の指示に従い Edit で append-only 追加する
 
 ### 5.0.c canonical commit message 契約
 
-ステップ 5.1 (separate_branch) と ステップ 5.2 (same_branch) の両 bash block で使用する commit message は以下を **唯一の真実源** とする。両 phase は独立した bash block (Bash tool 呼び出し間でシェル状態が継承されない) のため、両サイトで以下と literal 一致する実装を保持する。drift 検出は将来 /rite:lint が本 section と ステップ 5.1 / 5.2 を grep で比較する予定。
+ステップ 5.1 と ステップ 5.2 の commit message は以下を **唯一の真実源** とする。両サイトで以下と literal 一致させる。
+rationale: references/rationale.md#commit-msg-three-sites
 
 **canonical template**:
 
@@ -479,7 +492,8 @@ esac
 
 ### 5.1 separate_branch 戦略 (worktree ベース)
 
-ステップ 5.0 手順 1-7 を Write/Edit ツールで実施した後、以下の bash ブロックを実行して worktree 内の変更を commit する。**push はここでは行わない**（#1941 wiki push batch/defer: 複数 raw source を処理するループの中で raw source ごとに push すると、SSH host alias 環境で毎回 sandbox バイパスが必要になり同一 push の短時間重複実行も起きていた。ステップ 8.6 で全 raw source 処理後にまとめて 1 回だけ push する）。commit 処理は `wiki-worktree-commit.sh --commit-only` に委譲されており、LLM が bash 契約を書く必要はない:
+ステップ 5.0 手順 1-7 を Write/Edit した後、以下で worktree 内の変更を commit する。**push はここでは行わない**。commit は `wiki-worktree-commit.sh --commit-only` に委譲する:
+rationale: references/rationale.md#push-defer-1941
 
 ```bash
 # ステップ 5.2 と対称に set -euo pipefail を宣言する (strict mode)
@@ -545,7 +559,7 @@ fi
 
 ### 5.2 same_branch 戦略
 
-`same_branch` では Raw Source / ページ / index.md / log.md はすべて dev ブランチのワークツリーに存在する。ステップ 5.0 手順 1-7 を Write/Edit で実施した後、以下の bash ブロックで一括 commit する (ブランチ切り替え不要、worktree も不要):
+`same_branch` では Raw Source / ページ / index.md / log.md はすべて dev ブランチ上。ステップ 5.0 手順 1-7 の後、以下で一括 commit する（ブランチ切り替え・worktree 不要）:
 
 ```bash
 set -euo pipefail
@@ -634,23 +648,25 @@ fi
 | `{related_page_title}` / `{related_page_path}` | ステップ 4.3 で決定した値。**該当ページがない場合は `## 関連ページ` セクション全体を `- （関連ページなし）` の平文 1 行に Edit で書き換える** (空 placeholder のままにすると Markdown link `[]()` が破綻) |
 | `{source_description}` | Raw Source の `title` フィールド (空なら `source_ref` を使用)。`## ソース` セクションのリンク表示テキストに使われ、URL には `{source_ref}` が使われることで両者を分離する |
 
-**confidence フィールド**: page-template.md の `confidence: medium` はリテラル値で、placeholder 走査の誤置換を避けるため上表とは別管理。Write 後に Edit で ステップ 4 の判定値 (`high` / `medium` / `low`) に置換する。
+**confidence フィールド**: page-template.md の `confidence: medium` はリテラル。Write 後に Edit でステップ 4 の判定値 (`high` / `medium` / `low`) に置換する。
+rationale: references/rationale.md#confidence-literal
 
 ---
 
 ## ステップ 6: index.md の更新
 
-`.rite/wiki/index.md` の `## ページ一覧` 5 列テーブル（列順: ページ / ドメイン / サマリー / 更新日 / 確信度）への登録行の追加/更新・重複行の回収・`## 統計` 3 行の同期を、`{plugin_root}/hooks/scripts/wiki-index-update.sh` の 1 回呼び出しで行う。同定述語・セル区切りエスケープ規約・重複時の中止条項・統計最小形・統計節不在スキップの確定仕様は **helper のヘッダ docstring が Source of Truth** であり、挙動は `hooks/tests/wiki-index-update.test.sh` の fixture が固定する。本ステップは入力の substitute と結果 marker の読み取りのみを担い、index.md への書き換えは helper が atomic に実施する（LLM が Read/Edit で index.md を直接操作してはならない）。
+`.rite/wiki/index.md` の `## ページ一覧` 5 列テーブル（列順: ページ / ドメイン / サマリー / 更新日 / 確信度）への登録行の追加/更新・重複行の回収・`## 統計` 3 行の同期を、`{plugin_root}/hooks/scripts/wiki-index-update.sh` の 1 回呼び出しで行う。同定述語・セル区切りエスケープ・重複中止・統計最小形・統計節不在スキップの確定仕様は **helper のヘッダ docstring が Source of Truth**。挙動は `hooks/tests/wiki-index-update.test.sh` の fixture が固定する。本ステップは substitute と結果 marker の読み取りのみ。index.md への書き換えは helper が atomic に行う（LLM が Read/Edit で index.md を直接操作してはならない）。
 
 **入力契約**: 対象ページの frontmatter 値とファイルパスを substitute する。
 
-- `{title}` / `{description}` / `{updated}` / `{confidence}` は page frontmatter の値から **YAML の引用符を外して**渡す（`title: "…"` の実体は引用符の内側）。**値の加工はそれだけ** — セル区切りエスケープとリンク構文の中和は helper 内で一元適用するので呼び出し側では行わず、言い換えも禁止（ステップ 4.3 の title 規約が frontmatter `title` の生値との literal 一致を要求する）
+- `{title}` / `{description}` / `{updated}` / `{confidence}` は page frontmatter の値から **YAML の引用符を外して**渡す（`title: "…"` の実体は引用符の内側）。**値の加工はそれだけ** — セル区切りエスケープとリンク構文の中和は helper 内で一元適用するので呼び出し側では行わず、言い換えも禁止
 - `{description}` は frontmatter に `description` が無ければ**空のまま**渡す（helper が既存行のサマリー列を保持する）。非空ならステップ 4.1 で作成した番号なし Why 要約と literal に同じ値を渡し、index 用の別要約を生成しない
-- `{domain}` / `{slug}` は対象ページの**ファイルパス** `pages/{domain}/{slug}.md` から取る（新規経路はステップ 4.1 で決めた値、更新経路はステップ 5.0 手順 4 で Read した既存ファイルの domain ディレクトリ名とファイル名 stem）。`title` からの再導出はしない — ステップ 4.2 は title の書き換えを許容するため、再導出すると既存ファイル名と異なる slug が渡り、実在しないパスを指す登録行が新規追加される（旧行は旧値のまま残る）
+- `{domain}` / `{slug}` は対象ページの**ファイルパス** `pages/{domain}/{slug}.md` から取る（新規経路はステップ 4.1 で決めた値、更新経路はステップ 5.0 手順 4 で Read した既存ファイルの domain ディレクトリ名とファイル名 stem）。`title` からの再導出はしない
 
-**substitute する 6 値はすべて quoted heredoc で受ける**（frontmatter は LLM 生成テキストで引用符・バックスラッシュ・`$(...)` を含みうる。double-quote されたシェル語へ直接置換すると値の `"` でクォートが閉じ、後続テキストがコマンドとして実行される — [`skills/fix/SKILL.md`](../fix/SKILL.md) の同旨規約と同じ理由。quoted heredoc は**終端子行と一致しない限り**シェル解釈を抑制する）。
+**substitute する 6 値はすべて quoted heredoc で受ける**。
+rationale: references/rationale.md#index-quoted-heredoc
 
-**実行前ゲート（必須）**: substitute する 6 値のいずれかが**複数行**、またはいずれかの**行が終端子 `WIU_EOF` と完全一致**する場合、**この bash を実行してはならない**。heredoc がその行で早期終了し、値の後続がシェルのコマンドとして実行される（quoted heredoc に残る唯一の脱出口で、6 つの heredoc が同じ終端子を共有するため後続の `wiu_*=$(cat <<'WIU_EOF'` が再度開いて構文が通り、helper 呼び出し行も正常に走るため **rc=0 + 3 marker 揃いの成功に見える**）。値は bash に渡る前の substitute 時点でしか検査できない（block 内のシェルは parse 済みで手遅れ）ため、本ゲートは LLM 側の責務である。該当した場合は当該ページの index 更新をスキップし、ステップ 9 の未完了事項に載せる（marker 表の exit 1 行と同じ扱い）。1 行値であることは helper 側の C0 検査でも担保されるが、それは**この bash を実行できた場合に限る**:
+**実行前ゲート（必須）**: substitute する 6 値のいずれかが**複数行**、またはいずれかの**行が終端子 `WIU_EOF` と完全一致**する場合、**この bash を実行してはならない**。該当したら当該ページの index 更新をスキップし、ステップ 9 の未完了事項に載せる（marker 表の exit 1 行と同じ扱い）:
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -691,7 +707,8 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
   --updated "$wiu_updated" --confidence "$wiu_confidence"
 ```
 
-**結果 marker**: helper は 1 回の呼び出しで `row_action=` / `dedup_removed=` / `stats_sync=` の 3 marker を**必ず同時に**出力する。**`row_action` 軸と `stats_sync` 軸は独立で、両軸の該当行をそれぞれ適用する**（ステップ 9 の `{wiki_push_line}` 表のような first-match ではない — 片方で打ち切ると同時に出ている他方の WARNING 表示指示に到達しない）。`dedup_removed=` は分岐を持たず、1 以上なら回収件数をステップ 9 の未完了事項へ載せる状態値である:
+**結果 marker**: helper は 1 回の呼び出しで `row_action=` / `dedup_removed=` / `stats_sync=` の 3 marker を**必ず同時に**出力する。**`row_action` 軸と `stats_sync` 軸は独立で、両軸の該当行をそれぞれ適用する**。`dedup_removed=` は分岐を持たず、1 以上なら回収件数をステップ 9 の未完了事項へ載せる:
+rationale: references/rationale.md#index-axes-independent
 
 | 結果 | アクション |
 |---|---|
@@ -705,15 +722,15 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
 | exit 1（ERROR 出力） | 環境・構造要因（index.md 不在・想定外構造）で再実行では解消しない。**部分適用は無い**（同上）。ERROR をそのまま表示して当該 Raw Source の index 更新をスキップし、ステップ 7 へ続行する。新規ページの未登録はステップ 8 の Lint が orphans として検出するが、**既存ページの更新失敗は登録行が旧値のまま残り Lint のどの観点にも載らない** — 表示した ERROR が唯一のシグナルなのでステップ 9 の未完了事項（`{ingest_outstanding_line}`）に必ず含める |
 | 上記以外の非ゼロ exit（helper パスを解決できない 127、signal 中断の 130 / 143 / 129 等。marker は 1 行も出力されない） | helper の出力（あれば）と exit code をそのまま表示し、当該 Raw Source の index 更新をスキップしてステップ 7 へ続行する。**部分適用は無い**（同上）。exit 1 と同様、表示した内容をステップ 9 の未完了事項に含める |
 
-**全 Raw Source が skip 決定だったサイクルでは本ステップが 1 度も走らない**（ステップ 5.0 手順 6 の条件）。その場合 helper の Procedure 3a（重複登録行の回収）も走らないため、既存の重複は次に page 作成/更新を伴うサイクルまで残る。docstring が 3a を「毎回実行」と規定しているのは**呼び出しごと**の意味であり、呼び出し自体の有無は本ステップの条件が決める。
-
-書き込みはステップ 5 と同じブランチコンテキスト (separate_branch なら worktree、same_branch なら dev ツリー) で行われる。パス解決の cwd 依存性は分岐で異なる — `separate_branch` かつ `{wiki_worktree_abs}` が非空なら絶対パス基点で cwd に依存しないが、`same_branch` および `{wiki_worktree_abs}` が空のときの縮退経路は相対パスなので、ステップ 3 の `wiki_index_path` 解決と同じく **dev ツリー root を cwd とする前提**で動く（前提が崩れると helper は index.md 不在の exit 1 で fail-loud に止まる）。
+**全 Raw Source が skip 決定だったサイクルでは本ステップが 1 度も走らない**（ステップ 5.0 手順 6 の条件）。書き込みはステップ 5 と同じブランチコンテキスト。`same_branch` および `{wiki_worktree_abs}` 空の縮退は **dev ツリー root を cwd とする前提**。
+rationale: references/rationale.md#skip-cycle-no-3a
 
 ---
 
 ## ステップ 7: log.md の追記
 
-`.rite/wiki/log.md` に OKF v0.1 予約構造（`## YYYY-MM-DD` 見出し + 散文 bullet、**新しい順** = 先頭が最新）で **append-only** に変更履歴を追記する。本ログは人間向けの変更履歴であり、skip 等の機械可読状態は raw frontmatter の `ingest_status`（ステップ 5）が Source of Truth で、本ログには保持しない。
+`.rite/wiki/log.md` に OKF v0.1 予約構造（`## YYYY-MM-DD` 見出し + 散文 bullet、**新しい順** = 先頭が最新）で **append-only** に変更履歴を追記する。skip 等の機械可読状態は raw frontmatter の `ingest_status`（ステップ 5）が SoT。
+rationale: references/rationale.md#log-human-only
 
 **追記ルール**:
 
@@ -724,8 +741,6 @@ bash "{plugin_root}/hooks/scripts/wiki-index-update.sh" \
   - **スキップ**: `* **Skip**: [{filename}](raw/{type}/{filename}) — {skip_reason}`（`{filename}` は当該 Raw Source のファイル名、`{type}` は Raw Source type）
 - 既存の日付見出し・bullet（過去エントリ）は改変しない
 
-log.md は append-only。既存エントリを変更してはいけない。
-
 ---
 
 ## ステップ 8: 自動 Lint
@@ -734,7 +749,8 @@ Ingest 直後、Wiki 全体の品質チェックを `/rite:wiki-lint --auto` と
 
 ### 8.1 auto_lint 設定の確認
 
-`rite-config.yml` の `wiki.auto_lint` を読み取る。**ステップ 1.1 とは別の inline lenient パーサ**を使う (1.1 は `lib/wiki-config.sh` の `parse_wiki_scalar` へ委譲済み。本ステップの awk は位置パラメータを参照しない bare regex 形のため Skill loader の展開を受けず、委譲しなくても壊れない — 検出は `hooks/scripts/dollar-zero-check.sh`)。**1.1 の旧形 (awk で行全体を参照する形) をここへ持ち込んではならない**:
+`rite-config.yml` の `wiki.auto_lint` を読み取る。**ステップ 1.1 とは別の inline lenient パーサ**を使う。**1.1 の旧形 (awk で行全体を参照する形) をここへ持ち込んではならない**:
+rationale: references/rationale.md#auto-lint-inline-parser
 
 ```bash
 wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || wiki_section=""
@@ -747,23 +763,22 @@ esac
 echo "auto_lint=$auto_lint"
 ```
 
-**`auto_lint=false` の場合**: ステップ 8.2-8.5 を skip する。**ステップ 8.6 (push の集約) はスキップしない** — ステップ 5.1 で `--commit-only` 積んだ raw source の commit を push するのは auto_lint の有無に関わらず必須のため、ステップ 8.6 を実行してからステップ 9 へ進む。Lint カウンタ 6 種はステップ 2.1 で 0 初期化済みのため placeholder 残留は発生しない。ステップ 9 完了レポートの「Wiki 品質警告」行は「スキップ (auto_lint disabled)」、「未登録 raw」行は `0` 件として表示する。
+**`auto_lint=false` の場合**: ステップ 8.2-8.5 を skip する。**ステップ 8.6 (push の集約) はスキップしない**。ステップ 8.6 を実行してからステップ 9 へ進む。Lint カウンタ 6 種はステップ 2.1 で 0 初期化済み。ステップ 9 の「Wiki 品質警告」行は「スキップ (auto_lint disabled)」、「未登録 raw」行は `0` 件。
 
 ### 8.2 Lint エンジンの呼び出し
 
 LLM は `skill: "rite:wiki-lint", args: "--auto"` 形式で `/rite:wiki-lint` を `--auto` モードで呼び出す。`--auto` モードの契約:
 
-- `Lint: contradictions={n}, stale={n}, orphans={n}, missing_concept={n}, unregistered_raw={n}, broken_refs={n}` 形式の 1 行 + `<!-- skill return signal: caller must continue next step -->` + `<!-- [lint:returned-to-caller:auto] -->` HTML コメント sentinel の 3 行を出力する (0 件でも必ず出力)。本 phase の parser (ステップ 8.3) は 1 行目の `^Lint: contradictions=` regex のみに依存するため、2 行目以降の disambiguator marker 追加 は互換性に影響しない
+- `Lint: contradictions={n}, stale={n}, orphans={n}, missing_concept={n}, unregistered_raw={n}, broken_refs={n}` 形式の 1 行 + `<!-- skill return signal: caller must continue next step -->` + `<!-- [lint:returned-to-caller:auto] -->` HTML コメント sentinel の 3 行を出力する (0 件でも必ず出力)
 - log.md への追記は lint.md 側がブランチ状態を判定し自律実行する
 - 常に exit 0 (非ブロッキング)
+rationale: references/rationale.md#lint-parser-first-line
 
-呼び出し時の CWD は常に dev ブランチ。lint.md ステップ 8.2 は `separate_branch` 戦略時に worktree 内で log.md 追記 → `wiki-worktree-commit.sh` 呼び出しを行う。
-
-Skill return 後、ステップ 8.3 (パース) → 8.4 (完了レポート統合) → 8.5 (n_warnings 加算) → ステップ 9 を順に実行する。
+呼び出し時の CWD は常に dev ブランチ。lint ステップ 8.2 は `separate_branch` 時に worktree 内で log.md 追記 → `wiki-worktree-commit.sh` を呼ぶ。Skill return 後、8.3 → 8.4 → 8.5 → ステップ 9 の順。
 
 ### 8.3 Lint 実行結果の取得とパース
 
-LLM は Skill 応答テキスト (= `lint.md` ステップ 9.2 の最終 stdout 出力) を会話コンテキストからパースする。Skill ツール呼び出しはシェル exit code を返さないため、**Skill 応答テキストの内容**で成否を判定する。以降の「stdout」はすべて Skill 応答テキストを指し、lint.md 内部の中間出力 (`pages_list=` 等) ではない。
+LLM は Skill 応答テキスト (= `lint.md` ステップ 9.2 の最終 stdout) を会話コンテキストからパースする。**Skill 応答テキストの内容**で成否を判定する。
 
 判定優先順位 (step 番号は **項目の論理的役割の名称** であり実行順とは異なる):
 
@@ -784,7 +799,7 @@ LLM は Skill 応答テキスト (= `lint.md` ステップ 9.2 の最終 stdout 
   └─ n_warnings += 1, n_lint_anomaly += 1, 6 変数を 0 fallback
 ```
 
-通常時は step 2 のみで完結する (lint.md ステップ 9.2 が必ず 6 フィールド 1 行を emit する契約のため)。
+通常時は step 2 のみで完結する。
 
 1. **ERROR 行の検出**: Skill 応答テキストに `ERROR:` で始まる任意行 (例: `ERROR: 未知の branch_strategy 値を検出しました`) が含まれるかを検査する。検出時:
 
@@ -813,9 +828,7 @@ LLM は Skill 応答テキスト (= `lint.md` ステップ 9.2 の最終 stdout 
    | `n_unregistered_raw` | group 5 |
    | `n_broken_refs` | group 6 |
 
-   全行 scan + 最初の match 採用とすることで、lint.md 側で preamble の echo / debug 出力が混入しても決定論的に `Lint:` 行を拾う (`set -x` debug / observability echo / informational banner 等の追加変更に対する resilience)。
-
-3. **stdout が空の場合**: **Lint 実行失敗として扱う** (lint.md の契約では regex-matchable な `Lint:` data 行を 0 件でも必ず 1 行出力するため、stdout 空は bash syntax error / 未捕捉 fatal error / SIGPIPE / OOM 等の異常経路。lint.md の総出力は disambiguator marker + sentinel を含めて 3 行だが、本 phase の parser が依存するのは regex `^Lint:` でマッチする 1 行目の data 行のみ):
+3. **stdout が空の場合**: **Lint 実行失敗として扱う**:
 
    - `n_warnings += 1` + `n_lint_anomaly += 1`
    - 6 変数を `0` に fallback
@@ -831,7 +844,7 @@ LLM は Skill 応答テキスト (= `lint.md` ステップ 9.2 の最終 stdout 
 
    - ステップ 8.4 では「Lint 結果: 実行失敗（stdout が空のため詳細取得不可）」と表示
 
-4. **stdout のどの行も regex にマッチしない場合**: Lint 側のフォーマット変更を検出した警告として扱う (silent に 0 件と誤認することを防ぐ):
+4. **stdout のどの行も regex にマッチしない場合**: フォーマット変更の警告として扱う:
 
    - `n_warnings += 1` + `n_lint_anomaly += 1` (format drift を Lint 異常経路として計上)
    - 6 変数を `0` に fallback
@@ -858,23 +871,21 @@ ERROR / stdout 空 / regex mismatch 経路では「Lint 結果: 実行失敗（{
 
 ### 8.5 `n_warnings` カウンタへの加算
 
-本ステップは **ステップ 8.3 step 2 (6 フィールド regex match 成功) 経路でのみ実行する**。step 1/3/4 経路ではステップ 8.3 内で既に `n_warnings += 1` と `n_lint_anomaly += 1` が加算済みのため skip する。
-
-ステップ 2.1 で初期化した `n_warnings` に、Lint の検出件数合計を加算する (step 2 経路のみ):
+**ステップ 8.3 step 2 (6 フィールド regex match 成功) 経路でのみ実行する**。step 1/3/4 は 8.3 内で加算済みのため skip。step 2 経路のみ `n_warnings` に Lint 検出件数合計を加算する:
 
 ```
 n_warnings += n_contradictions + n_stale + n_orphans + n_missing_concept + n_broken_refs
 ```
 
-**`n_unregistered_raw` は加算しない**: skip 済み raw (`ingest_status: skipped`) は意図的に経験則化しなかった件数 (skip 理由は raw frontmatter の `skip_reason` に記録済み) であり、警告として数えると skip 運用が膨らむほど警告カウンタが無意味に肥大する。informational 指標として完了レポートの内訳にのみ表示する。
+**`n_unregistered_raw` は加算しない**。informational 指標として完了レポートの内訳にのみ表示する。
+rationale: references/rationale.md#n-unregistered-not-warning
 
 **詳細な修正対応**: 検出結果の詳細確認は、Ingest 完了後に `/rite:wiki-lint`（`--auto` なし）で再実行して取得する。
 
 ### 8.6 Wiki push の集約（#1941 wiki push batch/defer）
 
-**`auto_lint` の値に関わらず必ず実行する**（ステップ 8.1 参照）。ステップ 5.1 (separate_branch) は raw source ごとに `--commit-only` で commit のみを行い、push を意図的に遅延させてきた。ステップ 8.2 の自動 Lint (`--auto` モード) も同様に `--commit-only` で log.md 追記を積む（[skills/wiki-lint/SKILL.md](../wiki-lint/SKILL.md) ステップ 8.3 参照）。ここで、蓄積されたローカル commit（0 件のこともある）をまとめて 1 回だけ push する（AC-1: 1 回の ingest フローで `git push origin {wiki_branch}` は最大 1 回）。
-
-`same_branch` では worktree を使わず push もこのフローの管轄外（PR ブランチの通常 push に含まれる）のため本ステップは no-op:
+**`auto_lint` の値に関わらず必ず実行する**（ステップ 8.1 参照）。蓄積されたローカル commit（0 件のこともある）をまとめて 1 回だけ push する。`same_branch` では本ステップは no-op:
+rationale: references/rationale.md#push-defer-1941
 
 ```bash
 branch_strategy="{branch_strategy}"
@@ -912,7 +923,7 @@ else
 fi
 ```
 
-`push_out` に含まれる `push=no-op` はそもそも push すべき commit が無かった（今回の全 raw source が skip 判定だった等）ことを示し、失敗ではない (`WIKI_INGEST_PUSH=ok` 扱いで問題ない)。`[CONTEXT] WIKI_INGEST_PUSH=` marker はステップ 9.0 完了レポートの push 状態表示、および `/rite:cleanup` ステップ 9 の push 失敗判定（stdout 中の `push=failed` 部分文字列を検出）に使う。
+`push_out` の `push=no-op` は失敗ではない（`WIKI_INGEST_PUSH=ok`）。`[CONTEXT] WIKI_INGEST_PUSH=` はステップ 9.0 の push 状態表示と `/rite:cleanup` ステップ 9 の push 失敗判定（stdout 中の `push=failed`）に使う。
 
 ---
 
@@ -920,7 +931,8 @@ fi
 
 ### 9.0 Ingest セッション lock の解放
 
-ステップ 5〜8 の Write/Edit/commit/lint がすべて完了したので、ステップ 1.4 で取得した ingest セッション lock を解放する（保持し続けると他セッションの ingest が `concurrent_ingest` で skip され続ける）。万一解放を逃しても次回 ingest が stale 判定で回収するため fail-safe だが、正常系では明示的に解放する:
+ステップ 1.4 で取得した ingest セッション lock を解放する:
+rationale: references/rationale.md#lock-release-failsafe
 
 ```bash
 bash "{plugin_root}/hooks/scripts/wiki-ingest-lock.sh" release
@@ -953,14 +965,14 @@ Wiki Ingest が完了しました。
 - 詳細な品質チェックは /rite:wiki-lint で確認してください（ステップ 8 で自動実行済み）
 ```
 
-`{detector_candidate_lines}` の展開規則（ステップ 4 の検出器化候補 routing。人間が Issue 化を判断する材料）:
+`{detector_candidate_lines}` の展開規則:
 
 | 条件 | 展開 |
 |------|------|
 | 1 件以上 | 各候補を `- [検出器化候補] {one-line-summary}（raw/{type}/{filename}）` の 1 行で列挙（1 経験則 1 行。`skip_reason: "detector-candidate: ..."` の要約と同一文にする） |
 | 0 件 | `- なし` |
 
-`{wiki_warnings_line}` の展開ルール (lint.md ステップ 9.1 と設計対称):
+`{wiki_warnings_line}` の展開ルール:
 
 | `auto_lint` | 「Wiki 品質警告:」行の展開 |
 |-------------|-----------------------|
@@ -969,9 +981,9 @@ Wiki Ingest が完了しました。
 
 「未登録 raw」行は `auto_lint=false` の場合も `0` 件として展開する (ステップ 2.1 で 0 初期化済みの値)。
 
-**等式**: `n_warnings = n_contradictions + n_stale + n_orphans + n_missing_concept + n_broken_refs + n_lint_anomaly`。step 2 成功時は `n_lint_anomaly=0` のため 5 カテゴリ合計が `n_warnings` と一致。step 1/3/4 anomaly 経路では 5 カテゴリは 0 fallback だが `n_lint_anomaly >= 1` のため `n_warnings >= 1` となる。
+**等式**: `n_warnings = n_contradictions + n_stale + n_orphans + n_missing_concept + n_broken_refs + n_lint_anomaly`。step 2 成功時は `n_lint_anomaly=0`。step 1/3/4 では 5 カテゴリは 0 fallback だが `n_lint_anomaly >= 1` のため `n_warnings >= 1`。
 
-`{wiki_push_line}` の展開ルール (ステップ 8.6 の `[CONTEXT] WIKI_INGEST_PUSH=` marker を上から評価し最初の一致を採用。#1941 AC-2: 未 push の wiki commit があれば回復コマンドを明示する):
+`{wiki_push_line}` の展開ルール (ステップ 8.6 の `[CONTEXT] WIKI_INGEST_PUSH=` を上から評価し最初の一致を採用):
 
 | `WIKI_INGEST_PUSH=` | 展開 |
 |---|---|
@@ -980,7 +992,8 @@ Wiki Ingest が完了しました。
 | `skipped; reason=same_branch` | `Wiki push: 対象外 (same_branch 戦略。通常の PR push に含まれる)` |
 | marker なし（ステップ 8.6 未到達などの想定外経路） | `⚠️ Wiki push: 実行結果が確認できませんでした。git -C {wiki_worktree_abs} status で確認してください` |
 
-`{ingest_outstanding_line}`（非ブロッキング失敗の集約欄。Wiki push については `{wiki_push_line}` と同じ `WIKI_INGEST_PUSH=` marker を再評価するだけで新しい記録先は持たない — local commit 自体が durable な記録であり、次回 ingest のステップ 8.6 が自動で flush を試みる）。**ステップ 6 の index 更新と Wiki push の 2 系統を評価し、該当するものをすべて列挙する**（index 更新の失敗・部分適用は Lint のどの観点にも載らず、ステップ 6 で表示した ERROR / WARNING が唯一のシグナルであるため、その場の表示に加えて本欄へ集約する）:
+`{ingest_outstanding_line}`（非ブロッキング失敗の集約欄。Wiki push については `{wiki_push_line}` と同じ `WIKI_INGEST_PUSH=` marker を再評価するだけで新しい記録先は持たない）。**ステップ 6 の index 更新と Wiki push の 2 系統を評価し、該当するものをすべて列挙する**:
+rationale: references/rationale.md#outstanding-no-new-store
 
 | 系統 | 条件 | 展開 |
 |---|---|---|
@@ -1000,9 +1013,8 @@ Wiki Ingest が完了しました。
 <!-- [ingest:returned-to-caller] -->
 ```
 
-sentinel は grep 可能 (`grep -F '[ingest:returned-to-caller]'`) で rendered view では不可視。bare bracket `[ingest:returned-to-caller]` は LLM turn-boundary heuristic 誤発火のため禁止、HTML コメント形式のみ許容する。
-
-> **Why `returned-to-caller` (not `completed`)**: 旧 `ingest:completed` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、caller skill (cleanup / open 等) の次 step を skip して turn が暗黙終了する事象が複数回再発した。`returned-to-caller` は「caller skill に return した = caller の次 step に進む」というネスト構造を semantic に内包し、terminal vocabulary を構造的に排除する。
+sentinel は grep 可能 (`grep -F '[ingest:returned-to-caller]'`) で rendered view では不可視。bare bracket `[ingest:returned-to-caller]` は禁止、HTML コメント形式のみ許容する。
+rationale: references/rationale.md#returned-to-caller
 
 ---
 

--- a/plugins/rite/skills/wiki-ingest/references/rationale.md
+++ b/plugins/rite/skills/wiki-ingest/references/rationale.md
@@ -1,0 +1,188 @@
+# /rite:wiki-ingest — 設計理由
+
+`skills/wiki-ingest/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。
+
+## wiki-config-opt-out
+
+ステップ 1.1 はプローブ用で、helper 解決失敗だけ fail-fast、値欠落は `${var:-default}` で吸収する。
+そのためここでは `set -euo pipefail` を付けない。strict mode は commit 経路（ステップ 5.1 / 5.2）
+で宣言する。
+
+本ファイルは `lib/wiki-config.sh` の `parse_wiki_scalar` を直接呼ぶ lenient 2-arm 経路（inject.sh
+と同型の opt-out default ファミリ）。trigger.sh は意図的に strict 3-arm fail-fast で別経路 —
+分散実装の完全一覧と設計差異は wiki-patterns の SoT 節。helper 不在で設定を判定できていないのに
+opt-out default で「Wiki 無効」と報告するのは、この Issue が潰した誤報告パターンの再演になる。
+
+## plugin-root-literal-embed
+
+ステップ 1.3 の `wiki-worktree-setup.sh` が `$plugin_root` に依存するため、Wiki 初期化判定より前に
+解決する。Claude Code の Bash ツール間でシェル変数は保持されないので、以降のブロックは
+`plugin_root` / `branch_strategy` / `wiki_branch` / `wiki_worktree_abs` をリテラル埋め込みする。
+
+## cwd-independent-worktree
+
+絶対パス基点にすると、セッション worktree から起動しても共有 root の wiki worktree 一箇所に
+解決される（multi-session design §9 / AC-5）。`{wiki_worktree_abs}` が空の縮退（旧バージョン互換）
+だけ相対パス `.rite/wiki-worktree` を許す。
+
+## session-lock-mkdir
+
+`flock` は複数 Bash 呼び出しに跨る ingest を守れない。持続的 mkdir lock の stale 判定は保持
+セッションの flow-state liveness（`active=true` ∧ `updated_at` 2h 以内）を流用する
+（multi-session design §9）。`concurrent_ingest` 時に新しい回収機構を作らないのは、pending raw
+が wiki branch に残り次回 ingest が冪等に回収する（AC-4）ため。
+
+## informational-counters
+
+`n_unregistered_raw` は意図的に経験則化しなかった件数、`n_dedup_removed` は index 自己修復で
+回収した重複行の件数であり、いずれも警告ではない。`auto_lint=false` で 8.2-8.5 が skip されても
+ステップ 2.1 で 0 初期化済みなら、ステップ 9 の placeholder 残留は起きない。
+
+## dev-tree-drift
+
+`separate_branch` では Raw Source は wiki ブランチ上にあり、dev 側 `.rite/wiki/raw/` は通常存在
+しない。存在チェックは旧 stash+checkout 経路のマイグレーション残骸を拾うためで、本 Ingest では
+処理しない。
+
+## knowledge-routing
+
+rite 挙動・スキル記述法の知見を Wiki に留置したままだと、マーケットプレイス配布先では不活性に
+なる（CLAUDE.md「知見のルーティング」）。環境非依存なら `promote: rite-plugin`、環境固有なら
+一般化してから昇格するか、一般化できなければ domain 知見として Wiki に残す。機械検出可能
+（2.6）と両方に該当する場合は 2.6 が優先し、ページを作らない — `promote` はページ作成時のみ。
+
+## detector-candidate
+
+2.6 はフラグ付けのみでアクション決定はしない。正例は trap 順序の静的検査・mktemp 無音化の
+lint 化、負例はブランチ戦略の運用判断・ドメイン固有の文脈知識。ステップ 9 の検出器化候補列挙は
+人間が Issue 化を判断する材料で、`promote: rite-plugin` タグと同型の役割。
+
+## summary-provenance
+
+Issue / PR 番号は出典の識別子であって概念の理由を説明しない。番号が担っていた観測事実・条件・
+因果は自己完結した散文にし、provenance は `sources` に分離する。`description` を更新しないと
+ステップ 6 helper が既存サマリー列を保持し、同源テキストが drift する。
+
+## source-ref-path-form
+
+raw frontmatter の `source_ref`（PR 識別子、例: `pr-1143`）を page の `sources[].ref` に転記する
+と、同名 placeholder と raw フィールドの dual-use で drift する。lint は `ref` をファイルパス
+形式で raw と突合するため、PR 識別子だと raw→page 追跡が切れ false `missing_concept` を量産する。
+概念は Wiki anti-pattern `placeholder-dual-use-resolution-drift`（wiki ブランチ上の経験則。
+develop ツリーには実体なし）。
+
+## related-page-literal
+
+4.3 を 5.3 表より優先するのは、矛盾時に値決定手順の SoT を一つに閉じるため。index 側のセル
+区切りエスケープとリンク構文中和（`](` の `]` → `&#93;`）は同定述語が読む先頭リンクを title
+が詐称できないようにする表記上の措置であり、転記すると frontmatter `title` との literal 一致
+が壊れる。空 placeholder のままにすると Markdown リンク `[]()` が破綻する。
+
+## skip-no-index-update
+
+skip 決定の Raw Source には helper が必須とする page metadata（title / domain / slug / updated /
+confidence）が無い。raw 由来の値で代用すると実在しないパスを指す登録行が新規追加され、孤児
+検出のシグナルを汚す。
+
+## commit-msg-three-sites
+
+5.1 と 5.2 は独立した bash block で、Bash ツール間にシェル状態は継承されない。両サイトで
+canonical と literal 一致させ、サイト識別子（`ステップ 5.{X}`）だけ置換する。template 変更時に
+3 箇所を同時更新しないと drift する。
+
+## push-defer-1941
+
+複数 raw source のループ内で raw ごとに push すると、SSH host alias 環境で毎回 sandbox バイパス
+が必要になり、同一 push の短時間重複実行も起きていた。ステップ 5.1 は `--commit-only`、Lint
+`--auto` も同様に commit のみ積み、ステップ 8.6 で全処理後に 1 回だけ push する（AC-1: 1 ingest
+フローで `git push origin {wiki_branch}` は最大 1 回）。`same_branch` の push は PR ブランチの
+通常 push に含まれ、このフローの管轄外。`push=no-op` は push すべき commit が無かっただけで
+失敗ではない。
+
+## confidence-literal
+
+page-template.md の `confidence: medium` はリテラル値。placeholder 走査の誤置換を避けるため
+展開表とは別管理し、Write 後に Edit で判定値へ置換する。
+
+## index-quoted-heredoc
+
+frontmatter は LLM 生成テキストで引用符・バックスラッシュ・`$(...)` を含みうる。double-quote
+されたシェル語へ直接置換すると値の `"` でクォートが閉じ、後続がコマンドとして実行される
+（fix スキルと同旨）。quoted heredoc は終端子行と一致しない限りシェル解釈を抑制するが、値が
+複数行、またはある行が終端子 `WIU_EOF` と完全一致すると heredoc が早期終了する。6 つの
+heredoc が同じ終端子を共有するため後続の `wiu_*=$(cat <<'WIU_EOF'` が再度開き、helper 呼び出し
+行も正常に走って rc=0 + 3 marker 揃いの成功に見える。block 内のシェルは parse 済みで手遅れ
+なので、ゲートは substitute 時点の LLM 責務。helper 側 C0 検査は「この bash を実行できた場合」
+にしか効かない。
+
+## index-axes-independent
+
+`row_action` と `stats_sync` を first-match で打ち切ると、同時に出ている他方の WARNING 表示
+指示に到達しない。`stats_sync=synced` の部分未同期は WARNING の有無だけでは判定できない —
+同じ呼び出しで重複中止 WARNING も stderr に出るため、完全同期を部分未同期と誤報告する。
+重複中止は `row_action=aborted_duplicate` 行が受け持つ。統計可視化の追加機構（専用 lint /
+marker attest / サイクル gating）は helper ヘッダが「実装しない」と明記している。
+
+既存ページの更新失敗は登録行が旧値のまま残り、Lint のどの観点にも載らない。表示した
+ERROR / WARNING が唯一のシグナルなのでステップ 9 の未完了事項へ集約する。
+
+## skip-cycle-no-3a
+
+全 Raw Source が skip のサイクルではステップ 6 が 1 度も走らず、helper Procedure 3a（重複回収）
+も走らない。docstring の「毎回実行」は呼び出しごとの意味で、呼び出し自体の有無はステップ
+5.0 手順 6 の条件が決める。`same_branch` および `{wiki_worktree_abs}` 空の縮退は相対パスなので、
+ステップ 3 と同じく dev ツリー root を cwd とする前提。前提が崩れると helper は index.md 不在
+の exit 1 で fail-loud に止まる。
+
+## log-human-only
+
+log.md は人間向けの変更履歴。skip 等の機械可読状態は raw frontmatter の `ingest_status` が
+SoT で、本ログには保持しない。
+
+## auto-lint-inline-parser
+
+ステップ 8.1 の awk は位置パラメータを参照しない bare regex 形のため、Skill loader の展開を
+受けず helper へ委譲しなくても壊れない（検出は `dollar-zero-check.sh`）。ステップ 1.1 は
+`parse_wiki_scalar` へ委譲済み。1.1 の旧形（awk で行全体を参照する形）をここへ持ち込むと
+恒偽化する。8.6 を skip しないのは、5.1 で `--commit-only` 積んだ commit の push が
+`auto_lint` の有無に依らず必須だから。
+
+## lint-parser-first-line
+
+ステップ 8.3 の parser は 1 行目の `^Lint: contradictions=` regex のみに依存する。2 行目以降の
+disambiguator 追加は互換性に影響しない。全行 scan + 最初の match は、lint 側の preamble /
+debug / banner 混入に対する resilience。stdout 空は lint 契約（0 件でも `Lint:` 1 行必須）に
+反する異常経路（syntax error / 未捕捉 fatal / SIGPIPE / OOM）。lint 総出力は 3 行でも、parser
+が依存するのは `^Lint:` の data 行だけ。format mismatch を silent に 0 件と誤認しないために
+anomaly 計上する。
+
+Skill ツール呼び出しはシェル exit code を返さない。以降の「stdout」は Skill 応答テキストを
+指し、lint 内部の中間出力（`pages_list=` 等）ではない。
+
+## n-unregistered-not-warning
+
+skip 済み raw を警告に数えると、skip 運用が膨らむほど `n_warnings` が無意味に肥大する。
+informational 指標として完了レポートの内訳にのみ表示する。
+
+## lock-release-failsafe
+
+lock を保持し続けると他セッションの ingest が `concurrent_ingest` で skip され続ける。万一
+解放を逃しても次回 ingest が stale 判定で回収する fail-safe はあるが、正常系では明示解放する。
+
+## outstanding-no-new-store
+
+Wiki push の未完了は `{wiki_push_line}` と同じ marker を再評価するだけで、新しい記録先は持た
+ない。local commit 自体が durable な記録であり、次回 ingest のステップ 8.6 が自動で flush を
+試みる。marker なしを「失敗なし」と断定しないのは、未確認と成功を混同しないため。
+
+## returned-to-caller
+
+旧 `ingest:completed` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、
+caller skill（cleanup / open 等）の次 step を skip して turn が暗黙終了する事象が複数回再発
+した。`returned-to-caller` は「caller に return した = caller の次 step に進む」というネスト
+構造を semantic に内包し、terminal vocabulary を構造的に排除する。bare bracket は同じ heuristic
+誤発火のため禁止で、HTML コメント形式のみ許容する。

--- a/plugins/rite/skills/wiki-lint/SKILL.md
+++ b/plugins/rite/skills/wiki-lint/SKILL.md
@@ -23,7 +23,8 @@ Wiki Lint エンジン。`.rite/wiki/pages/` の Wiki ページ、`.rite/wiki/ra
 8. log.md 追記 (`lint:clean` / `lint:warning`)
 9. 完了レポート (通常モード / `--auto` モード)
 
-機械判定可能な 3 カテゴリ (陳腐化 / 孤児 / 壊れた相互参照) は helper script に委譲する。helper が件数を marker block + `[CONTEXT]` sentinel で emit するため、LLM は数値を転記するだけになり「bash を実行せず 0 件と推測報告する」経路が構造的に存在しない (欠落概念の集合構築 helper `wiki-lint-skipped-refs.sh` / `wiki-lint-source-refs.sh` と同じ保証)。
+機械判定可能な 3 カテゴリ (陳腐化 / 孤児 / 壊れた相互参照) は helper に委譲する。件数は helper の marker block + `[CONTEXT]` を転記する（LLM 独自カウント禁止）。
+rationale: references/rationale.md#helper-delegation
 
 | 観点 | 検出対象 | ブロッキング |
 |------|---------|--------------|
@@ -35,9 +36,10 @@ Wiki Lint エンジン。`.rite/wiki/pages/` の Wiki ページ、`.rite/wiki/ra
 | **未登録 raw (unregistered_raw)** | `ingested: true` で `sources.ref` 未登録だが、raw frontmatter に `ingest_status: skipped` 記録がある raw。意図的に経験則化しなかった件数の informational 指標 | **No** (`n_warnings` 不加算) |
 | **説明的番号参照 (descriptive_number_ref)** | ページ本文と `index.md` のエントリサマリーに残った説明目的の Issue/PR 番号参照（裸の「PR #N は…」「Issue #N」、括弧付き「(refs #N)」、日本語の「#N で対応」「詳細は #N」）。Wiki は番号の受け皿ではなく Why 散文の場のため surface する。frontmatter の `sources:` ブロック・`## ソース` 節・コードフェンス / スパン・TODO/FIXME は除外。`log.md` / `raw/**` / `SCHEMA.md` は走査しない（意図的除外） | **No** (`n_warnings` 不加算、ステップ 7.5) |
 
-**設計契約**: lint は **読み取り専用** (`log.md` への追記を除く)。**原則 exit 0**で終了し、検出件数・事前チェック失敗 (下記 (c) を除く)・ブランチ読取失敗は非ブロッキングとして扱う。例外は (a) `branch_strategy` 未知値検出 (ステップ 2.2 / 4 / 5 / 6.0 / 6.2 / 7 / 7.5 / 8.2 / 8.3 で同型 fail-fast。うち 4 / 5 / 6.0 / 6.2 / 7 / 7.5 は helper 内で実行)、(b) `{mode}` / `{pages_list}` / `{log_entry}` / counter 等の Claude placeholder 残留検知 (各 site で同型 fail-fast)、(c) `lib/wiki-config.sh` の source 失敗 (ステップ 1.1)。いずれも設定ミス / 実装ミスを silent に通過させないための設計判断。
+**設計契約**: lint は **読み取り専用** (`log.md` への追記を除く)。**原則 exit 0**で終了し、検出件数・事前チェック失敗 (下記 (c) を除く)・ブランチ読取失敗は非ブロッキングとして扱う。例外は (a) `branch_strategy` 未知値検出 (ステップ 2.2 / 4 / 5 / 6.0 / 6.2 / 7 / 7.5 / 8.2 / 8.3 で同型 fail-fast。うち 4 / 5 / 6.0 / 6.2 / 7 / 7.5 は helper 内で実行)、(b) `{mode}` / `{pages_list}` / `{log_entry}` / counter 等の Claude placeholder 残留検知 (各 site で同型 fail-fast)、(c) `lib/wiki-config.sh` の source 失敗 (ステップ 1.1)。
+rationale: references/rationale.md#fail-loud-contract
 
-矛盾検出 (ステップ 3) と欠落概念検出 (ステップ 6) は LLM のセマンティック読解に依存する。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md) で解決する。共通パターン (ディレクトリ構造 / ブランチ管理 / テンプレート展開) は [Wiki Patterns](../../references/wiki-patterns.md) を参照。
+矛盾検出 (ステップ 3) と欠落概念検出 (ステップ 6) は LLM のセマンティック読解に依存する。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md) で解決する。共通パターンは [Wiki Patterns](../../references/wiki-patterns.md) を参照。
 
 ## Arguments
 
@@ -60,7 +62,7 @@ Wiki Lint エンジン。`.rite/wiki/pages/` の Wiki ページ、`.rite/wiki/ra
 
 ### 1.1 Wiki 設定の読み取りとブランチ戦略判定
 
-`rite-config.yml` から `wiki_enabled` / `wiki_branch` / `branch_strategy` を取得する。ingest.md ステップ 1.1 と同型の設定読み取り (`lib/wiki-config.sh` 委譲)。`branch_strategy` 未知値は fail-fast (silent default を撤廃):
+`rite-config.yml` から `wiki_enabled` / `wiki_branch` / `branch_strategy` を取得する。ingest ステップ 1.1 と同型の設定読み取り (`lib/wiki-config.sh` 委譲)。`branch_strategy` 未知値は fail-fast:
 
 ```bash
 # YAML 読み取りは canonical helper (実ファイル) に委譲する。skill 本文の fenced bash に
@@ -104,7 +106,8 @@ echo "branch_strategy=$branch_strategy"
 echo "wiki_branch=$wiki_branch"
 ```
 
-分散実装の完全一覧と設計差異は [Wiki 有効判定パターン §分散実装ファイル一覧](../../references/wiki-patterns.md#分散実装ファイル一覧-single-source-of-truth) を SoT として参照する。本ファイルは ingest.md と対称な `parse_wiki_scalar` 委譲の lenient 2-arm 経路 (#483 opt-out default)。`[CONTEXT] WIKI_CONFIG_HELPER_UNAVAILABLE=1` (bash rc=1) のときは設定を判定できていないため無効扱いへ倒さず中止し、plugin のインストール状態確認 / `/rite:setup` 再実行を案内する。
+分散実装の一覧は [Wiki 有効判定パターン §分散実装ファイル一覧](../../references/wiki-patterns.md#分散実装ファイル一覧-single-source-of-truth) を SoT とする。`[CONTEXT] WIKI_CONFIG_HELPER_UNAVAILABLE=1` (bash rc=1) のときは無効扱いへ倒さず中止し、plugin のインストール状態確認 / `/rite:setup` 再実行を案内する。
+rationale: references/rationale.md#wiki-config-opt-out
 
 **Wiki が無効の場合**: 早期 return (`--auto` モードでは ステップ 9.2 の 3 行出力契約を必ず守る):
 
@@ -270,7 +273,8 @@ echo "---"
 [ -n "$raw_list" ] && printf '%s\n' "$raw_list"
 ```
 
-LLM は stdout から `pages_list` と `raw_list` を会話コンテキストに保持する。両方空なら **ステップ 3-7 (7.5 を除く) を skip し、ステップ 7.5 → ステップ 9 に進む**。ステップ 7.5 だけは skip しない — `index.md` が単独で走査対象になりうるためで、skip すると wiki 初期化直後や `git ls-tree` 失敗時に index.md の指摘が無言で 0 件になる。
+LLM は stdout から `pages_list` と `raw_list` を会話コンテキストに保持する。両方空なら **ステップ 3-7 (7.5 を除く) を skip し、ステップ 7.5 → ステップ 9 に進む**。ステップ 7.5 だけは skip しない — `index.md` が単独で走査対象になりうる。
+rationale: references/rationale.md#empty-lists-keep-7-5
 
 `index.md` は ステップ 5 の `wiki-lint-orphans.sh` と ステップ 7.5 の `wiki-lint-descriptive-refs.sh` がそれぞれ自力で読み出すため、本ステップでの事前読出は不要。
 
@@ -326,11 +330,11 @@ LLM が `pages_list` の全ページペアを意味的に比較し、以下の�
 
 ## ステップ 4: 陳腐化検出
 
-検出本体は `wiki-lint-stale.sh` に委譲する。helper は全ページの frontmatter `updated` を cutoff (`now - stale_days`) と比較し、件数 + stale 集合を marker block で emit する。GNU date 事前検査 (macOS/BSD 非互換 skip) も helper が内包する。
+検出本体は `wiki-lint-stale.sh` に委譲する。helper は全ページの frontmatter `updated` を cutoff (`now - stale_days`) と比較し、件数 + stale 集合を marker block で emit する。GNU date 事前検査も helper が内包する。
 
-> **Reference**: canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-stale.sh`。helper は GNU date 検査・branch_strategy 別のページ読出 (`git show`(separate_branch) / `cat`(same_branch))・`updated` frontmatter 抽出・date パース失敗の WARNING skip・marker block / `stale_check_ok` enum / `[CONTEXT]` sentinel 出力をすべて内包する (旧 GNU date 事前検査 + 陳腐化検出 inline 実装を委譲)。placeholder residue gate も helper 内で実行される。state machine 契約 (marker block + enum) は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2 を参照。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-stale.sh`。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
-**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、ステップ 1.4 の `stale_days` は `--stale-days` arg に literal substitute する。`pages_list` は stdin (HEREDOC、single-quoted delimiter) で渡す (ステップ 6.2 の `wiki-lint-source-refs.sh` 呼び出しと同じ契約)。
+**Bash tool 呼び出し境界での state 伝達**: `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、`stale_days` は `--stale-days` arg に literal substitute する。`pages_list` は stdin (HEREDOC、single-quoted delimiter) で渡す (ステップ 6.2 と同じ契約)。
 
 **`{pages_list}` substitute 契約**: ステップ 2.2 stdout の **pages_list ブロックのみ** (separator `---` より前の `.rite/wiki/pages/...` 行のみ) を substitute する。空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate (`n_stale=0` が emit される)。
 
@@ -376,9 +380,9 @@ fi
 
 ## ステップ 5: 孤児ページ検出
 
-検出本体は `wiki-lint-orphans.sh` に委譲する。helper は index.md を branch_strategy 別に読み出し、カタログに登録されたページと `pages_list` の集合差分を marker block で emit する。登録ページの抽出は `](pages/...)` リンクの grep ベース（テーブルか箇条書きかに非依存）なので、箇条書き形式でもテーブル形式でも無改修で機能する（リンク先 `pages/{domain}/{slug}.md` を維持する条件）。
+検出本体は `wiki-lint-orphans.sh` に委譲する。helper は index.md を branch_strategy 別に読み出し、カタログ登録ページと `pages_list` の集合差分を marker block で emit する。登録抽出は `](pages/...)` リンクの grep ベース（テーブル / 箇条書き非依存。リンク先 `pages/{domain}/{slug}.md` を維持する条件）。
 
-> **Reference**: canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-orphans.sh`。helper は index.md 読出 (`git show`(separate_branch) / `cat`(same_branch))・登録ページ抽出 (`](pages/...)` リンクの `./pages/` / `../pages/` 形式対応の緩和 regex + `sort -u`、テーブル／箇条書き両形式で機能)・`.rite/wiki/` プレフィックス正規化・集合差分・読出失敗 / 抽出 0 件の skip 判定 (全ページ orphan 誤検出防止)・marker block / `orphan_check_ok` enum / `[CONTEXT]` sentinel 出力をすべて内包する (旧 index.md 事前読出 + 孤児検出 inline 実装を委譲)。placeholder residue gate も helper 内で実行される。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-orphans.sh`。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
 **Bash tool 呼び出し境界での state 伝達**: `branch_strategy` / `wiki_branch` は helper の arg、`pages_list` は stdin (HEREDOC) で渡す。substitute 契約はステップ 4 と同一 (pages_list ブロックのみ)。
 
@@ -426,11 +430,12 @@ fi
 
 ### 6.0 skip 済み raw source の集合構築
 
-ステップ 6.2 で参照する `skipped_refs` 集合の構築 (ステップ 6.2 の `all_source_refs` と対称な marker block + `log_read_ok` 4 値 enum) は `wiki-lint-skipped-refs.sh` に委譲する。 (Sub-3) で skip SoT が log.md から raw frontmatter (`ingest_status: skipped`) へ移行したため、helper は log.md ではなく **raw frontmatter を走査**する。
+ステップ 6.2 で参照する `skipped_refs` 集合の構築 (ステップ 6.2 の `all_source_refs` と対称な marker block + `log_read_ok` 4 値 enum) は `wiki-lint-skipped-refs.sh` に委譲する。helper は **raw frontmatter を走査**する。
+rationale: references/rationale.md#skip-sot-raw-frontmatter
 
-> **Reference**: 集合構築の canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh`。helper は `branch_strategy` 別の raw 走査 (`git ls-tree` + `git show`(separate_branch) / `find` + `cat`(same_branch)) で `.rite/wiki/raw/**/*.md` の frontmatter を読み、`ingest_status: skipped` を持つ raw を `raw/{type}/{filename}` 形式で抽出する・**legitimate absence** (raw ディレクトリ不在) と**真の IO error** (permission / 破損 / wiki_branch race) の `LC_ALL=C` 固定 stderr pattern 判別・`sort -u` 重複排除・列挙失敗時の io_error 降格・marker block / `log_read_ok` 4 値 enum 出力 (enum 名は stdout 契約のため据え置き、値は raw 走査状態を表す)・signal-specific trap cleanup をすべて内包する。`ingest_status` 欠落 raw は skipped でないものとして permissive に扱う (AC-6 後方互換)。placeholder residue gate も helper 内で実行される。state machine 契約 (marker block + 4 値 enum) は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2 を参照。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-skipped-refs.sh`。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
-**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は別 Bash tool 呼び出しで定義されているため、Claude は会話コンテキストから helper の `--branch-strategy` / `--wiki-branch` arg に literal substitute する (ステップ 6.2 の `wiki-lint-source-refs.sh` 呼び出しと同じ契約)。
+**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg に literal substitute する (ステップ 6.2 と同じ契約)。
 
 ```bash
 # plugin_root 解決 (ステップ 2.1 の inline one-liner。
@@ -455,7 +460,7 @@ else
 fi
 ```
 
-**`log_read_ok` 4 値 enum による状態伝達**: bash 変数は Bash tool 呼び出し境界を超えて失われるため、`log_read_ok` を stdout に `log_read_ok={value}` 形式で出力する。 (Sub-3) で skip SoT が log.md から raw frontmatter (`ingest_status: skipped`) へ移行したため、本 enum は **raw frontmatter 走査の状態**を表す (enum 名は lint.md の stdout 契約のため据え置き):
+**`log_read_ok` 4 値 enum による状態伝達**: bash 変数は Bash tool 呼び出し境界を超えて失われるため、`log_read_ok` を stdout に `log_read_ok={value}` 形式で出力する。本 enum は **raw frontmatter 走査の状態**を表す (enum 名は stdout 契約のため据え置き):
 
 | 値 | 意味 | ステップ 9.1 完了レポートでの扱い |
 |----|------|---------------------------------|
@@ -498,11 +503,12 @@ fi
 
 **`all_source_refs` の集合構築** (ステップ 6.0 の `skipped_refs` と対称な marker block + io_error 3 値 enum) は `wiki-lint-source-refs.sh` に委譲する。
 
-> **Reference**: 集合構築の canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-source-refs.sh`。helper は per-page の `git show`(separate_branch) / `cat`(same_branch) 読出・`sources[].ref` 抽出 (legacy 単行形式 `- ref:` と canonical multi-line 形式 ` ref:` の両対応)・legitimate absence と真の io_error の `LC_ALL=C` 固定 stderr pattern 判別・`sort -u` 重複排除・marker block / read_ok enum 出力・signal-specific trap cleanup をすべて内包する (旧 ~240 行 inline 実装を委譲)。placeholder residue gate / partial pollution gate も helper 内に移設済み。state machine 契約 (marker block + io_error 3 値 enum) は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2 を参照。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-source-refs.sh`。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
-**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` と ステップ 2.2 の `pages_list` は別 Bash tool 呼び出しで定義されているため、Claude は会話コンテキストから literal substitute する。`branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、`pages_list` は stdin (HEREDOC、single-quoted delimiter で shell expansion 抑制) で渡す。
+**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、ステップ 2.2 の `pages_list` は stdin (HEREDOC、single-quoted delimiter) で渡す。
 
-**`{pages_list}` substitute 契約**: ステップ 2.2 stdout は「pages_list 行 → '---' separator → raw_list 行」の 3 部構成。LLM は **pages_list ブロックのみ** (separator より前の `.rite/wiki/pages/...` 行のみ) を HEREDOC に substitute する。`.rite/wiki/raw/...` 行を含めると helper の partial pollution gate が fail-fast (exit 1) する (旧 silent missing_concept 誤分類の再発防止契約)。空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate。
+**`{pages_list}` substitute 契約**: ステップ 2.2 stdout は「pages_list 行 → '---' separator → raw_list 行」の 3 部構成。LLM は **pages_list ブロックのみ** (separator より前の `.rite/wiki/pages/...` 行のみ) を HEREDOC に substitute する。`.rite/wiki/raw/...` 行を含めると helper の partial pollution gate が fail-fast (exit 1) する。空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate。
+rationale: references/rationale.md#pages-list-pollution
 
 ```bash
 # plugin_root 解決 (ステップ 2.1 の inline one-liner。
@@ -532,7 +538,8 @@ fi
 
 **`skipped_refs` 集合の参照方法**: ステップ 6.0 の bash block 終了後、LLM は stdout から `---skipped_refs_begin---` と `---skipped_refs_end---` で囲まれた行を抽出して会話コンテキストに集合として保持する。ファイルパスの比較は両辺を `raw/{type}/{filename}` 形式に正規化してから完全一致で判定する。
 
-**marker block 未受信時の fallback** (silent false positive 防止): step 3 の 3 分岐は LLM が stdout の marker block を会話コンテキストに保持する契約に依存する。bash block が途中異常終了 (SIGPIPE / OOM / 構文 error / LLM context truncation) で marker block 自体を受信できなかった場合、当該集合を「空」と同視してはならない:
+**marker block 未受信時の fallback** (silent false positive 防止): bash block が途中異常終了で marker block 自体を受信できなかった場合、当該集合を「空」と同視してはならない:
+rationale: references/rationale.md#marker-unreceived-io-error
 
 - `---skipped_refs_begin---` / `---skipped_refs_end---` のいずれかが欠落 → `log_read_ok="io_error"` と同等扱い、ステップ 9.1 の false positive note を展開
 - `---all_source_refs_begin---` / `---all_source_refs_end---` のいずれかが欠落 → `all_source_refs_read_ok="io_error"` と同等扱い、ステップ 9.1 の false positive note を展開
@@ -571,7 +578,7 @@ fi
 
 検出本体は `wiki-lint-broken-refs.sh` に委譲する。helper は各ページ本文から Markdown リンクを抽出し、ページディレクトリ起点の `realpath -m -s` 解決で実在確認した結果を marker block で emit する。
 
-> **Reference**: canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-broken-refs.sh`。解決規約 (page_dir 起点 / `realpath -m -s` / 文字列マッチ禁止) と edge case は [Broken Reference Resolution](./references/broken-ref-resolution.md) を参照。helper は branch_strategy 別のページ読出・リンク抽出 (コードフェンス除去は awk による indent 不問の開閉トラッキングで、旧 `sed '/^```/,/^```/d'` の行頭限定の限界を解消。インライン code span 内の説明的リンク引用も除去)・画像リンク / 絶対パス / 外部 URL / アンカーのみの除外・`pages_list` / `raw_list` 突合・marker block / `broken_refs_read_ok` enum / `[CONTEXT]` sentinel 出力をすべて内包する (旧 7.1/7.2 inline 実装を委譲)。placeholder residue gate も helper 内で実行される。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-broken-refs.sh`。解決規約は [Broken Reference Resolution](./references/broken-ref-resolution.md)。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
 **Bash tool 呼び出し境界での state 伝達**: `branch_strategy` / `wiki_branch` は helper の arg。stdin には ステップ 2.2 stdout の **3 部構成をそのまま** (pages_list 行 → `---` separator → raw_list 行) substitute する (raw_list は `raw/...` 参照リンクの突合に使用するため、ステップ 4/5 と異なり separator 以降も含める)。
 
@@ -617,28 +624,32 @@ fi
 
 ## ステップ 7.5: 説明的番号参照検出 (informational)
 
-Wiki ページ本文と `index.md` のエントリサマリーに残った**説明目的の Issue/PR 番号参照**を検出する。Wiki は番号の受け皿ではなく経験則を Why 散文で残す場であり（Comment Best Practices SoT の[適用スコープ](../../skills/rite-workflow/references/comment-best-practices.md#適用スコープ)が Wiki ページを含む）、本文に「PR #N は…を統一した」「Issue #N 系譜の継続」「詳細は #N 参照」「(refs #N)」等が残っていれば finding として surface する。括弧やキーワードに包まれない裸の `PR #N` / `Issue #N` も対象で、これは SoT §C Detection Heuristics が reviewer 側 regex として既に宣言している範囲に機構を追随させたもの。[廃止判定ルール](../../skills/rite-workflow/references/comment-best-practices.md#廃止判定ルール-説明的参照-vs-前方ポインタ)に従い、TODO/FIXME 追跡番号は検出除外する。
+Wiki ページ本文と `index.md` のエントリサマリーに残った**説明目的の Issue/PR 番号参照**を検出する。本文に「PR #N は…」「Issue #N」「詳細は #N 参照」「(refs #N)」等が残っていれば finding として surface する。裸の `PR #N` / `Issue #N` も対象。[廃止判定ルール](../../skills/rite-workflow/references/comment-best-practices.md#廃止判定ルール-説明的参照-vs-前方ポインタ)に従い、TODO/FIXME 追跡番号は検出除外する。
+rationale: references/rationale.md#descriptive-refs-surface
 
 **検出対象と除外**:
 - 対象: ステップ 2 で収集した `pages_list` の各ページ全体（frontmatter の `sources:` ブロックを除く）と、`index.md` の**エントリごとのサマリーのみ**
-- 除外: frontmatter の `sources:` ブロック（`ref:` はファイルパスで番号規則に一致しないため防御的除外。`title:` / `description:` の散文は走査対象）、`## ソース` 節（provenance リンクラベル。維持対象）、コードフェンス / インラインコードスパン（literal 引用）、TODO/FIXME（前方追跡ポインタ）。除外規則は `index.md` にも適用するが、2 点だけ異なる。(1) **E5（TODO/FIXME）の適用単位** — ページは行単位で落とし、`index.md` はエントリのサマリー単位で判定する（コードスパンのマスク後に見るため、引用された TODO は無効化され hit として残る）。(2) **`index.md` 固有の除外** — 行頭 `<!--` で始まる HTML コメントブロックを行の分類より前に落とすため、コメント内の番号は数えない（ページ本文では数える）。箇条書きテンプレートが配布されていた期間に初期化された bundle の index.md 前文が記法例をコメントで保持しているためで（現行の配布テンプレートは記法例コメントを持たない）、落とさないと記法例が実エントリとして数えられ、それらの index.md では検出失敗ガードが恒久的に発火しなくなる。rationale: [references/descriptive-refs-rationale.md#index-summary-extraction](references/descriptive-refs-rationale.md#index-summary-extraction)
-- 走査しないファイル（意図的除外）: `log.md`（append-only の ingest / lint 台帳。番号の正しい受け皿）、`raw/**`（レビュー / fix の生ログ = provenance 資料）、`SCHEMA.md`（散文を持たない）。rationale: [references/descriptive-refs-rationale.md#scan-scope](references/descriptive-refs-rationale.md#scan-scope)
+- 除外: frontmatter の `sources:` ブロック（`title:` / `description:` の散文は走査対象）、`## ソース` 節、コードフェンス / インラインコードスパン、TODO/FIXME。除外規則は `index.md` にも適用するが、2 点だけ異なる。(1) **E5（TODO/FIXME）の適用単位** — ページは行単位、`index.md` はエントリのサマリー単位（コードスパンのマスク後）。(2) **`index.md` 固有の除外** — 行頭 `<!--` で始まる HTML コメントブロックを行の分類より前に落とす（ページ本文では数える）。
+rationale: references/descriptive-refs-rationale.md#index-summary-extraction
+- 走査しないファイル（意図的除外）: `log.md` / `raw/**` / `SCHEMA.md`
+rationale: references/descriptive-refs-rationale.md#scan-scope
 
 **本ステップは `pages_list` が空でも実行する** — `index.md` が単独で走査対象になりうるため（helper が自力で拾う）。ステップ 2.2 の「両方空なら skip」は ステップ 3-7 (7.5 を除く) が対象で、本ステップは含まない。helper の検出失敗ガードもこの契約に合わせて `pages_list` ではなく `index.md` 自身の内容で発火する。
-rationale: [references/descriptive-refs-rationale.md#entries-zero-guard](references/descriptive-refs-rationale.md#entries-zero-guard)
+rationale: references/descriptive-refs-rationale.md#entries-zero-guard
 
 **`index.md` の扱い**: helper が自力で読み出す（stdin に足す必要はない。渡した場合も完全一致で受理し重複計上しない）。**ステップ 2.2 の `pages_list` 構築は変更しない**。`index.md` が存在しない場合（Wiki 初期化直後）は静かに対象から落とし、`descriptive_refs_read_errors` にも走査母数にも数えない（存在するのに読めない場合のみ read error として計上する）。
-rationale: [references/descriptive-refs-rationale.md#pages-list-unchanged](references/descriptive-refs-rationale.md#pages-list-unchanged)
+rationale: references/descriptive-refs-rationale.md#pages-list-unchanged
 
-検出は 2 規則の**正規化**で表現する（表層形の列挙ではない）。R1 は「参照キーワードが番号の直前に来る」形で、括弧付き `(refs #N)` / `see PR #N` / 裸の `PR #N は…` はすべてこの 1 規則に畳まれる。R2 はキーワードを持たない日本語 2 構文（`#N で対応` / `詳細は #N`）。キーワードを伴わない裸の `#N` は正当な文脈が多すぎるため検出しない。語境界は `([^0-9]|$)` で表現する（gawk の `\b` はバックスペース扱いで never-match になるため使用禁止）。各除外の判断根拠と副作用（その範囲内では既知の再発が見えなくなる）は `references/descriptive-refs-rationale.md#exclusions` に記録している。
+検出は 2 規則の**正規化**で表現する。R1 は参照キーワードが番号の直前に来る形（`(refs #N)` / 裸の `PR #N は…` を含む）。R2 はキーワードを持たない日本語 2 構文（`#N で対応` / `詳細は #N`）。キーワードを伴わない裸の `#N` は検出しない。語境界は `([^0-9]|$)` で表現する（`\b` 使用禁止）。
+rationale: references/descriptive-refs-rationale.md#exclusions
 
 **検出ロジック**は `wiki-lint-descriptive-refs.sh` に委譲する（stdin `pages_list` はステップ 6.2 helper と同型 — ステップ 6.0 helper は入力を自前で列挙し stdin を読まない。marker block + read_ok enum は 6.0 / 6.2 の双方と同型）。
 
-> **Reference**: canonical 実装は `plugins/rite/hooks/scripts/wiki-lint-descriptive-refs.sh`。helper は per-page の `git show`(separate_branch) / `cat`(same_branch) 読出・`index.md` の存在プローブ付き読出とエントリ単位のサマリー抽出（テーブル / OKF 箇条書きを行単位で判別。テーブルのサマリー列位置と列数はヘッダー行から導出するため列数不問）・本文抽出フィルタ（frontmatter の `sources:` ブロック / `## ソース` 節 / コードフェンス / コードスパン / TODO・FIXME）・2 規則の検出・placeholder residue gate / partial pollution gate（`index.md` は完全一致で許容、`raw/` 行と `..` は従来どおり fail-fast）をすべて内包する。
+> **Reference**: `plugins/rite/hooks/scripts/wiki-lint-descriptive-refs.sh`。state machine 契約は `references/bash-cross-boundary-state-transfer.md` の Pattern 1/2。
 
-**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、ステップ 2.2 の `pages_list` は stdin (HEREDOC、single-quoted delimiter) で渡す（ステップ 6.2 の `wiki-lint-source-refs.sh` 呼び出しと同じ契約）。
+**Bash tool 呼び出し境界での state 伝達**: ステップ 1.1 の `branch_strategy` / `wiki_branch` は helper の `--branch-strategy` / `--wiki-branch` arg、ステップ 2.2 の `pages_list` は stdin (HEREDOC、single-quoted delimiter) で渡す（ステップ 6.2 と同じ契約）。
 
-`{pages_list}` の substitute 契約はステップ 4 / 5 / 6.2 と同一（separator より前の `.rite/wiki/pages/...` 行のみ）。`index.md` を足す必要はない — helper が自力で拾うため、substitute を忘れても走査から落ちない。`pages_list` が空の場合は HEREDOC 本文を空のまま substitute する（空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate。`(なし)` 等のリテラルを埋めると helper の partial pollution gate が exit 1 する）。本ステップは**両 list が空の経路でも実行される唯一のステップ**であるため、ステップ 4 / 5 / 6.2 / 7 が skip される状況でも空 HEREDOC を渡す（`pages_list` 空・`raw_list` 非空の経路では**ステップ 4 / 5 / 6.2** も実行され、同じく空 HEREDOC を受け取る — ステップ 4 / 6.2 の同旨の記述を参照。**ステップ 7 だけは別**で、HEREDOC が `pages_list` + separator + `raw_list` の 3 部構成のため `raw_list` が非空なら空にならない）。
+`{pages_list}` の substitute 契約はステップ 4 / 5 / 6.2 と同一（separator より前の `.rite/wiki/pages/...` 行のみ）。`index.md` を足す必要はない — helper が自力で拾う。`pages_list` が空の場合は HEREDOC 本文を空のまま substitute する（空 HEREDOC は Wiki 初期化直後 / 0 件で legitimate。`(なし)` 等のリテラルを埋めると helper の partial pollution gate が exit 1 する）。本ステップは**両 list が空の経路でも実行される唯一のステップ**であるため、ステップ 4 / 5 / 6.2 / 7 が skip される状況でも空 HEREDOC を渡す（`pages_list` 空・`raw_list` 非空の経路では**ステップ 4 / 5 / 6.2** も実行され、同じく空 HEREDOC を受け取る。**ステップ 7 だけは別**で、HEREDOC が `pages_list` + separator + `raw_list` の 3 部構成のため `raw_list` が非空なら空にならない）。
 
 ```bash
 # plugin_root 解決 (ステップ 2.1 の inline one-liner。
@@ -665,15 +676,17 @@ PAGES_LIST_EOF
 fi
 ```
 
-**`descriptive_refs_read_ok` enum**: `true`（対象 0 件、または 1 対象ファイル以上の**読出と検出**に成功 — **部分失敗も true のままで、欠損件数は `descriptive_refs_read_errors` が表す**）/ `io_error`（対象が 1 件以上あり全件失敗 — 0 件が実体を反映していない）/ `skipped_helper_missing`（上記 fallback）。marker block 未受信も `skipped_helper_missing` 同等に扱う（未受信を劣化値へ倒す点のみステップ 7 と同型。倒す先は異なる）。**`io_error` の発火条件は兄弟ステップ 7 と異なる**（7 は 1 件でも失敗すれば `io_error`、7.5 は全件失敗時のみ）ため、sibling の enum 説明をそのまま流用しないこと。`descriptive_refs_read_errors` は**読出または検出できなかった**対象ファイル数で、`read_ok=true` でも部分欠損があれば正の値を取る（`index.md` を読み出せてもエントリ形式を認識できない / `index.md` の HTML コメントブロック・コードフェンスが未閉鎖のまま EOF に達した場合は「検出失敗」として本カウンタに載る。frontmatter の `sources:` ブロックと `## ソース` 節は検査対象外）。`descriptive_refs_skipped_rows` は `index.md` 内でサマリーを抽出できなかった**行数**（ファイル単位ではない）。ステップ 9 完了レポートの note 展開はこの 3 値で決まる（展開表は同ステップの `{descriptive_refs_read_ok_note}` 展開ルールを参照）。
+**`descriptive_refs_read_ok` enum**: `true`（対象 0 件、または 1 対象ファイル以上の**読出と検出**に成功 — **部分失敗も true のままで、欠損件数は `descriptive_refs_read_errors` が表す**）/ `io_error`（対象が 1 件以上あり全件失敗 — 0 件が実体を反映していない）/ `skipped_helper_missing`（上記 fallback）。marker block 未受信も `skipped_helper_missing` 同等に扱う。**`io_error` の発火条件は兄弟ステップ 7 と異なる**（7 は 1 件でも失敗すれば `io_error`、7.5 は全件失敗時のみ）ため、sibling の enum 説明をそのまま流用しないこと。`descriptive_refs_read_errors` は**読出または検出できなかった**対象ファイル数で、`read_ok=true` でも部分欠損があれば正の値を取る（`index.md` を読み出せてもエントリ形式を認識できない / HTML コメントブロック・コードフェンスが未閉鎖のまま EOF に達した場合は「検出失敗」として本カウンタに載る。frontmatter の `sources:` ブロックと `## ソース` 節は検査対象外）。`descriptive_refs_skipped_rows` は `index.md` 内でサマリーを抽出できなかった**行数**（ファイル単位ではない）。ステップ 9 完了レポートの note 展開はこの 3 値で決まる（展開表は `{descriptive_refs_read_ok_note}` 展開ルール）。
 
-**検出結果の記録**: 本カテゴリは **informational 指標のため `issues[]` へは転記しない**（ステップ 9 完了レポートの専用行だけで surface する）。ステップ 1.4 カウンタ表の `issues[]` 行が定める generic 契約「helper 委譲カテゴリは marker block の行を転記する」の例外は**本ステップのみ**で、もう 1 つの informational 指標 `unregistered_raw` はステップ 6.3 で `issues[]` に記録されステップ 9.1 の `### 未登録 raw（skip 済）` グループとして出力される（対象外にしてはならない）。本ステップを転記すると 233 ページ分の検出詳細行（実測 736 hits）が `{issues_list_formatted}` を埋め、`n_warnings` に加算されない指標が warning 一覧を占有する。
+**検出結果の記録**: 本カテゴリは **informational 指標のため `issues[]` へは転記しない**（ステップ 9 完了レポートの専用行だけで surface する）。ステップ 1.4 カウンタ表の `issues[]` 行が定める generic 契約「helper 委譲カテゴリは marker block の行を転記する」の例外は**本ステップのみ**。`unregistered_raw` はステップ 6.3 で `issues[]` に記録する（対象外にしてはならない）。
+rationale: references/rationale.md#descriptive-refs-issues-exception
 
-marker block（`page=...; hits=...`）と `descriptive_refs_pages` は sibling helper（ステップ 6.0 / 6.2）との出力形状 parity のために出力しており、**件数**は本 SKILL.md 内に消費者を持たない（helper を直接実行したときの対象ファイル内訳がここでしか得られないため、出力自体は削らないこと）。対象ファイル内訳を人間が見たい場合は helper を直接実行する。
+marker block（`page=...; hits=...`）と `descriptive_refs_pages` は sibling helper（ステップ 6.0 / 6.2）との出力形状 parity のために出力しており、**件数**は本 SKILL.md 内に消費者を持たない（出力自体は削らないこと）。対象ファイル内訳を人間が見たい場合は helper を直接実行する。
 
-**扱い**: `n_descriptive_refs` は **informational 指標**（`unregistered_raw` と同様に `n_warnings` に加算しない）。canonical な `Lint: contradictions=...` summary 行（ステップ 9）の形式は **変更しない**（ingest 側の `^Lint: contradictions=...broken_refs=([0-9]+)$` parser 互換を維持するため）。検出結果はステップ 9 完了レポートの専用行で別途 surface する。
+**扱い**: `n_descriptive_refs` は **informational 指標**（`unregistered_raw` と同様に `n_warnings` に加算しない）。canonical な `Lint: contradictions=...` summary 行（ステップ 9）の形式は **変更しない**。検出結果はステップ 9 完了レポートの専用行で別途 surface する。
 
-> **検出機構との関係**: 同じ説明的参照は `/rite:lint` Phase 3.5（generic loop の `comment-journal-check.sh`、`.rite/wiki/**/*.md` をスコープに含む）でも検出される。ただし `comment-journal-check.sh` の `.rite/wiki` 走査が実体に届くのは `wiki.branch_strategy: same_branch` のときだけで、`separate_branch` では Wiki が wiki ブランチにあるため走査範囲外になる。本ステップは `git show` で wiki ブランチを直接読むため、`separate_branch` では Wiki ページの番号参照を見る唯一の経路である。
+> **検出機構との関係**: `/rite:lint` Phase 3.5 の `comment-journal-check.sh` は `same_branch` のときだけ `.rite/wiki` に届く。本ステップは `git show` で wiki ブランチを読むため、`separate_branch` では Wiki ページの番号参照を見る唯一の経路である。
+rationale: references/descriptive-refs-rationale.md#scan-scope
 
 ---
 
@@ -681,7 +694,8 @@ marker block（`page=...; hits=...`）と `descriptive_refs_pages` は sibling h
 
 ### 8.1 検出結果の log.md 記録
 
-Lint 完了後、`.rite/wiki/log.md` に OKF v0.1 予約構造（`## YYYY-MM-DD` 見出し + 散文 bullet、**新しい順** = 先頭が最新）で **append-only** にエントリを追記する。今日の日付見出し `## YYYY-MM-DD` が `# Directory Update Log` 直後（ログ先頭）に無ければ新規追加し、その見出し配下の **bullet 群末尾** に以下の 1 bullet を追加する（同日内の追記位置を ingest.md ステップ 7 と揃え、bullet 順序を実行者非依存にする。log.md は表形式より追記順を保ちやすい OKF 形式へ移行）:
+Lint 完了後、`.rite/wiki/log.md` に OKF v0.1 予約構造（`## YYYY-MM-DD` 見出し + 散文 bullet、**新しい順** = 先頭が最新）で **append-only** にエントリを追記する。今日の日付見出し `## YYYY-MM-DD` が `# Directory Update Log` 直後（ログ先頭）に無ければ新規追加し、その見出し配下の **bullet 群末尾** に以下の 1 bullet を追加する:
+rationale: references/rationale.md#okf-log-append
 
 ```
 * **{lint_action}** — contradictions={n}, stale={n}, orphans={n}, missing_concept={n}, unregistered_raw={n}, broken_refs={n}
@@ -694,7 +708,8 @@ Lint 完了後、`.rite/wiki/log.md` に OKF v0.1 予約構造（`## YYYY-MM-DD`
 - `lint:clean`: ブロッキングカテゴリ 5 種 (`n_contradictions`, `n_stale`, `n_orphans`, `n_missing_concept`, `n_broken_refs`) **すべてが 0** の場合。`n_unregistered_raw` の値に依存しない (`n_unregistered_raw > 0` でも他 5 カテゴリが全 0 なら `lint:clean`)
 - `lint:warning`: 上記 5 カテゴリのいずれか 1 つ以上が `> 0` の場合。`n_unregistered_raw` は判定から除外する
 
-**`lint_action` 自動判定** (Pattern 1: `[CONTEXT] key=value` stdout emit): 上記 prose 判定基準を LLM 解釈から切り離し、bash block で機械的に決定して stdout に emit する。ステップ 8.3 の `{log_entry}` 組み立てはこの emit 値を **single source of truth** として参照する:
+**`lint_action` 自動判定** (Pattern 1: `[CONTEXT] key=value` stdout emit): bash block で機械的に決定して stdout に emit する。ステップ 8.3 の `{log_entry}` 組み立てはこの emit 値を **single source of truth** として参照する:
+rationale: references/rationale.md#lint-action-machine
 
 ```bash
 # ステップ 8.1 canonical lint_action decision logic (ステップ 8.3 sibling sync 契約相手)
@@ -945,7 +960,8 @@ Wiki Lint が完了しました。
 
 **`{n_pages}` / `{n_raw}` 展開ルール**: LLM は ステップ 2.2 bash block stdout から `pages_list` / `raw_list` を会話コンテキストに保持している。各配列の要素数（空行と `---` separator を除いた非空行の数）を数えて展開する。両 list が空の場合は `0`。
 
-**`{n_descriptive_refs}` / `{descriptive_refs_read_ok_note}` 展開ルール**: LLM は ステップ 7.5 の helper stdout から `[CONTEXT] WIKI_DESCRIPTIVE_REFS=` を読み取り `{n_descriptive_refs}` に展開する。**`pages_list` が空でもステップ 7.5 は実行する** — `index.md` が単独で走査対象になりうるため（helper が自力で拾う）。note は兄弟 enum（`{stale_check_ok_note}` 等）と同じく件数の直後に置き、`descriptive_refs_read_ok` / `descriptive_refs_read_errors` / `descriptive_refs_skipped_rows` の 3 値から下表で決める — 読出失敗由来の `0` や部分欠損した集計を「解消済み」と読ませないため。**下表の条件は排他で、一致する行はちょうど 1 つ**（優先順位規約に依存しない）:
+**`{n_descriptive_refs}` / `{descriptive_refs_read_ok_note}` 展開ルール**: LLM は ステップ 7.5 の helper stdout から `[CONTEXT] WIKI_DESCRIPTIVE_REFS=` を読み取り `{n_descriptive_refs}` に展開する。**`pages_list` が空でもステップ 7.5 は実行する** — `index.md` が単独で走査対象になりうるため（helper が自力で拾う）。note は兄弟 enum（`{stale_check_ok_note}` 等）と同じく件数の直後に置き、`descriptive_refs_read_ok` / `descriptive_refs_read_errors` / `descriptive_refs_skipped_rows` の 3 値から下表で決める。**下表の条件は排他で、一致する行はちょうど 1 つ**（優先順位規約に依存しない）:
+rationale: references/rationale.md#descriptive-refs-note-unread
 
 | 条件 | note（件数の直後） |
 |------|------------------|
@@ -1015,7 +1031,7 @@ LLM は ステップ 6.0 stdout から `log_read_ok={value}`、ステップ 6.2 
 
 ### 9.2 `--auto` モードの出力
 
-Ingest 完了直後に呼ばれる場合、出力は最小化される。`--auto` モードの stdout は次の 3 行を **この順序で** 出力する:
+`--auto` モードの stdout は次の 3 行を **この順序で** 出力する:
 
 ```
 Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, missing_concept={n_missing_concept}, unregistered_raw={n_unregistered_raw}, broken_refs={n_broken_refs}
@@ -1028,21 +1044,21 @@ Lint: contradictions={n_contradictions}, stale={n_stale}, orphans={n_orphans}, m
 3. **HTML コメント sentinel** (`<!-- [lint:returned-to-caller:auto] -->`): 最終行に出力。rendered view では不可視で `grep -F '[lint:returned-to-caller:auto]'` で検出可能
 
 検出件数が全て 0 の場合も含めて常にこの 3 行を出力する。空 stdout は ingest 側で「lint 実行失敗」として扱われる。
-
-> **Why `returned-to-caller` (not `completed`)**: 旧 `lint:completed:auto` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、caller skill (ingest 等) の次 step を skip して turn が暗黙終了する事象が複数回再発した。`returned-to-caller` は「caller に return した = caller の次 step に進む」という semantic に置換することで、terminal vocabulary を構造的に排除する。
+rationale: references/rationale.md#returned-to-caller
 
 ### 9.3 exit code
 
 - **原則 exit 0**: 検出件数・事前チェック失敗 (下記 helper 解決失敗を除く)・ブランチ読取失敗のいずれも非ブロッキング
 - **例外 (`exit 1` fail-fast)**:
-  - `lib/wiki-config.sh` の source 失敗 (ステップ 1.1、`WIKI_CONFIG_HELPER_UNAVAILABLE`。設定を判定できないまま「Wiki 無効」へ倒す silent default の防止)
-  - `branch_strategy` 未知値 (ステップ 2.2 / 8.2 / 8.3 + helper 内 (4 / 5 / 6.0 / 6.2 / 7 / 7.5) で同型。設定ミスの silent 通過防止)
+  - `lib/wiki-config.sh` の source 失敗 (ステップ 1.1、`WIKI_CONFIG_HELPER_UNAVAILABLE`)
+  - `branch_strategy` 未知値 (ステップ 2.2 / 8.2 / 8.3 + helper 内 (4 / 5 / 6.0 / 6.2 / 7 / 7.5) で同型)
   - `{mode}` placeholder 残留 (ステップ 1.1 / 1.3 / 8.3)
-  - helper 委譲ステップ (4 / 5 / 6.0 / 6.2 / 7 / 7.5) の placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{stale_days}` / `{pages_list}` + 6.2 / 7.5 の partial pollution gate、LLM substitute 忘れによる silent 誤分類防止。各 helper 内で検知)
-  - ステップ 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数検知 (silent `lint:clean` 誤 emit 防止)
-  - ステップ 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種、literal 残留 commit landed 防止)
-  - GNU realpath (-m -s) 不在 (全 link silent broken 判定の防止、ステップ 7 helper 内)
+  - helper 委譲ステップ (4 / 5 / 6.0 / 6.2 / 7 / 7.5) の placeholder 残留 (`{branch_strategy}` / `{wiki_branch}` / `{stale_days}` / `{pages_list}` + 6.2 / 7.5 の partial pollution gate。各 helper 内で検知)
+  - ステップ 8.1 の counter placeholder (`n_*` 5 種) 残留 / 非整数検知
+  - ステップ 8.3 の placeholder 残留 (`{log_entry}` / `{branch_strategy}` の 2 種)
+  - GNU realpath (-m -s) 不在 (ステップ 7 helper 内)
 - 内部 bash 構文エラー等の unrecoverable error のみ非 0 exit となる可能性あり
+rationale: references/rationale.md#fail-loud-contract
 
 ---
 

--- a/plugins/rite/skills/wiki-lint/references/rationale.md
+++ b/plugins/rite/skills/wiki-lint/references/rationale.md
@@ -1,0 +1,83 @@
+# /rite:wiki-lint — 設計理由
+
+`skills/wiki-lint/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。説明的番号参照の検出設計（走査範囲・
+除外・正規化）は既存の `descriptive-refs-rationale.md` が SoT。
+
+## helper-delegation
+
+機械判定可能なカテゴリを helper に委譲し、件数を marker block + `[CONTEXT]` で emit するのは、
+LLM が bash を実行せず 0 件と推測報告する経路を構造的に消すため。欠落概念の集合構築 helper
+（`wiki-lint-skipped-refs.sh` / `wiki-lint-source-refs.sh`）と同じ保証。
+
+## fail-loud-contract
+
+原則 exit 0 の非ブロッキング契約と両立する fail-fast は、設定ミス / 実装ミスを silent に通過
+させないための設計判断。未知の `branch_strategy`・placeholder 残留・`lib/wiki-config.sh` の
+source 失敗が対象。
+
+## wiki-config-opt-out
+
+本ファイルは ingest と対称な `parse_wiki_scalar` 委譲の lenient 2-arm 経路（#483 opt-out
+default）。helper 不在で設定を判定できていないときに無効扱いへ倒すのは silent default そのもの。
+
+## empty-lists-keep-7-5
+
+両方空でステップ 7.5 まで skip すると、wiki 初期化直後や `git ls-tree` 失敗時に `index.md` の
+指摘が無言で 0 件になる。`index.md` は単独で走査対象になりうる。
+
+## skip-sot-raw-frontmatter
+
+(Sub-3) で skip SoT が `log.md` から raw frontmatter（`ingest_status: skipped`）へ移行した。
+enum 名 `log_read_ok` は stdout 契約のため据え置き、値は raw 走査状態を表す。
+
+## marker-unreceived-io-error
+
+helper 不在 / marker 未受信で当該集合を空と同視すると、skip 済み raw が `missing_concept` に
+誤計上される、あるいは真の欠落判定が false positive になる。`io_error` を明示してステップ 9.1
+の false positive note を展開する。
+
+## pages-list-pollution
+
+HEREDOC に `.rite/wiki/raw/...` 行を含めると helper の partial pollution gate が fail-fast する。
+旧 silent `missing_concept` 誤分類の再発防止契約。
+
+## descriptive-refs-surface
+
+Wiki は番号の受け皿ではなく経験則を Why 散文で残す場であり、Comment Best Practices SoT の適用
+スコープが Wiki ページを含む。括弧やキーワードに包まれない裸の `PR #N` / `Issue #N` も対象で、
+これは SoT §C Detection Heuristics が reviewer 側 regex として既に宣言している範囲に機構を
+追随させたもの。
+
+## descriptive-refs-issues-exception
+
+本ステップを `issues[]` に転記すると 233 ページ分の検出詳細行（実測 736 hits）が
+`{issues_list_formatted}` を埋め、`n_warnings` に加算されない指標が warning 一覧を占有する。
+もう 1 つの informational 指標 `unregistered_raw` はステップ 6.3 で `issues[]` に記録され
+ステップ 9.1 の `### 未登録 raw（skip 済）` グループとして出力される（対象外にしてはならない）。
+
+## descriptive-refs-note-unread
+
+note を兄弟 enum と同じく件数の直後に置くのは、読出失敗由来の `0` や部分欠損した集計を
+「解消済み」と読ませないため。
+
+## lint-action-machine
+
+`lint:clean` / `lint:warning` の判定を LLM 解釈から切り離し、bash で機械的に決定して stdout に
+emit する。ステップ 8.3 の `{log_entry}` 組み立てはこの emit 値を single source of truth として
+参照する。
+
+## okf-log-append
+
+同日内の追記位置を ingest ステップ 7 と揃え、bullet 順序を実行者非依存にする。log.md は表形式
+より追記順を保ちやすい OKF 形式へ移行した。
+
+## returned-to-caller
+
+旧 `lint:completed:auto` 形式は literal `completed` が LLM の turn-boundary heuristic と衝突し、
+caller skill（ingest 等）の次 step を skip して turn が暗黙終了する事象が複数回再発した。
+`returned-to-caller` は「caller に return した = caller の次 step に進む」という semantic に
+置換することで、terminal vocabulary を構造的に排除する。


### PR DESCRIPTION
## Summary

`skill-diet-method.md` を setup / cleanup / wiki-lint / wiki-ingest に適用した。散文（bytes_prose）だけを退避・圧縮し、機械レール（fenced block / 表行）は before/after で完全一致。設計理由は各スキル同梱 `references/rationale.md` へ移した。

## Related Issue

Closes #2288

## Changes

- `plugins/rite/skills/setup/SKILL.md` + `references/rationale.md` — bytes_prose 45305 → 35289（−22.1%）、bytes_rail 32187 一致
- `plugins/rite/skills/cleanup/SKILL.md` + `references/rationale.md` — bytes_prose 34150 → 30089（−11.9%）、bytes_rail 47771 一致
- `plugins/rite/skills/wiki-lint/SKILL.md` + `references/rationale.md` — bytes_prose 25110 → 20154（−19.7%）、bytes_rail 37568 一致
- `plugins/rite/skills/wiki-ingest/SKILL.md` + `references/rationale.md` — bytes_prose 22718 → 17322（−23.8%）、bytes_rail 29834 一致
- `docs/SPEC.md` — skills ツリーへ `references/rationale.md` 追記

## pin 棚卸し（AC-1）

| テスト | スキル | 分類 | 移送方針 |
|--------|--------|------|----------|
| `init-upgrade-drift.test.sh` | setup | 散文 pin | フレーズは SKILL.md に残置。変更不要 |
| `plugin-path-mismatch-warn.test.sh` | setup | パス pin | 変更不要 |
| `flow-state.test.sh` | setup | コメント参照 | 変更不要 |
| `base-update-classify.test.sh` | cleanup | bash 抽出 | 変更不要 |
| `remote-branch-delete-guard.test.sh` | cleanup | bash 抽出 + 見出し | 変更不要 |
| `cleanup-wm-source-select.test.sh` | cleanup | bash 抽出 | 変更不要 |
| `sandbox-ghost-dirty-integration.test.sh` | cleanup | bash 抽出 | 変更不要 |
| `review-results-archive-or-rm.test.sh` | cleanup | bash 抽出 | 変更不要 |
| `cleanup-wikichain-handoff-parity.test.sh` | cleanup / wiki-lint / wiki-ingest | sentinel / handoff | 変更不要 |
| `create-md-invocation-symmetry.test.sh` | cleanup | パス pin | 変更不要 |
| `cleanup-message-contract.test.sh` | cleanup | 契約 pin | 変更不要 |
| `outstanding-items-contract.test.sh` | cleanup / wiki-ingest | 契約 pin | 変更不要 |
| `sentinel-disambiguator-adjacency.test.sh` | 上記 3 | glob 走査 | 変更不要 |
| `documentation-fidelity-promotion-contract.test.sh` | cleanup | 散文 pin + count | フレーズ残置、`AskUserQuestion`=4 |
| `wiki-lint-descriptive-refs.test.sh` | wiki-lint | 散文 pin | フレーズ残置 |
| `wiki-lint-source-refs.test.sh` | wiki-lint | セクション pin | 変更不要 |
| `wiki-lint-ingest-contract-sync.test.sh` | wiki-lint / wiki-ingest | 散文 pin | 変更不要 |
| `wiki-push-batch-defer-static-pin.test.sh` | wiki-lint / wiki-ingest | 見出し + bash | 変更不要 |
| `wiki-lint-broken-refs.test.sh` | wiki-lint | bash 抽出 | 変更不要 |
| `wiki-summary-authoring-contract.test.sh` | wiki-ingest | 散文 pin | 変更不要 |
| `wiki-index-update.test.sh` | wiki-ingest | 見出し抽出 | 変更不要 |
| `distribution-boundary-promotion-contract.test.sh` | wiki-ingest | 散文 pin | フレーズ残置 |

散文 pin はすべて SKILL.md に残したため、pin テストの移送は発生していない。

## 計測（AC-2）

`skill-rail-diff-check.sh` は 4 本とも `machine rail identical`。hooks suite 138/138、scripts suite 全 green、`sentinel-contract-check.sh --all` findings 0。

## 未完了の Issue チェック項目

- [ ] epic #2276 へ計測還流コメント（PR 作成後に投稿）

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
