### PR TITLE
refactor(skills): SKILL 記述ダイエット第 2 波を中型 4 本へ適用

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -156,14 +156,14 @@ rite-workflow/
 │ ├── merge/ # /rite:merge (squash merge)
 │ ├── cleanup/ # /rite:cleanup (+ references/archive-procedures.md; + references/rationale.md)
 │ ├── batch-run/ # /rite:batch-run (複数 Issue 順次 open→iterate; --merge で ready→merge→cleanup まで)
-│ ├── pr-create/ # /rite:pr-create (draft PR 作成) — sub-skill
+│ ├── pr-create/ # /rite:pr-create (draft PR 作成; + references/rationale.md) — sub-skill
 │ # --- Issue 管理 ---
 │ ├── issue-create/ # /rite:issue-create (+ references/: complexity-gate / contract-section-mapping / slug-generation / body-fact-check / unknowns-boundary-rationale)
 │ ├── issue-list/ # /rite:issue-list
 │ ├── issue-update/ # /rite:issue-update
-│ ├── issue-close/ # /rite:issue-close
+│ ├── issue-close/ # /rite:issue-close (+ references/rationale.md)
 │ ├── issue-edit/ # /rite:issue-edit
-│ ├── issue-implement/ # /rite:issue-implement (sub-skill, /rite:open から呼出)
+│ ├── issue-implement/ # /rite:issue-implement (sub-skill, /rite:open から呼出; + references/rationale.md)
 │ # --- Wiki ---
 │ ├── wiki-init/ # /rite:wiki-init
 │ ├── wiki-query/ # /rite:wiki-query
@@ -176,7 +176,7 @@ rite-workflow/
 │ ├── unknowns/ # /rite:unknowns (実装前探索: ブラインドスポット/ブレスト/プロトタイプ/インタビュー; + references/feedback-mode.html)
 │ ├── investigate/ # /rite:investigate (構造化コード調査)
 │ ├── learn/ # /rite:learn (Socratic 理解度チェック)
-│ ├── lint/ # /rite:lint (品質チェック; orchestrator から呼ばれる sub-skill 兼用; + references/plugin-checks-rationale.md)
+│ ├── lint/ # /rite:lint (品質チェック; orchestrator から呼ばれる sub-skill 兼用; + references/plugin-checks-rationale.md; + references/rationale.md)
 │ ├── recover/ # /rite:recover (中断した作業の再開)
 │ ├── skill-suggest/ # /rite:skill-suggest
 │ ├── template-reset/ # /rite:template-reset

--- a/plugins/rite/skills/issue-close/SKILL.md
+++ b/plugins/rite/skills/issue-close/SKILL.md
@@ -25,7 +25,8 @@ Check the completion status of an Issue and guide necessary actions.
 
 ## Shared: Projects Status → Done (delegate pattern)
 
-Phase 1.3.2 / 4.2 / 4.6.3 はいずれも Projects Status を **Done** に更新する。直接の `gh api graphql` + `field-list` + `item-edit` インライン呼び出しは substep 間で LLM attention が失われ silent skip を生むため、共通スクリプト `projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と同一）。スクリプトは冪等で、API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update) を参照。
+Phase 1.3.2 / 4.2 / 4.6.3 は Projects Status を **Done** に更新する。`projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と同一）。冪等。API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update)。
+rationale: references/rationale.md#projects-status-delegate
 
 **委譲呼び出し**（`{issue}` は対象 Issue 番号、`auto_add false`・`non_blocking true`）:
 
@@ -85,7 +86,8 @@ Read tool で `rite-config.yml` の `github.projects.enabled` を確認。`false
 
 ### 1.3.2 Update Status
 
-[Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern) の委譲パターンを実行する（`{issue}` = `{issue_number}`、`auto_add false` の理由: 既に CLOSED の Issue を auto-add するのは config drift を masking するため）。結果分岐は共通テーブルに従い、いずれの場合も Phase 5 へ進む（non-blocking — Issue は既にクローズ済み）。
+[Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern) を実行する（`{issue}` = `{issue_number}`、`auto_add false`）。結果は共通テーブル。いずれも Phase 5（non-blocking）。
+rationale: references/rationale.md#auto-add-false-closed
 
 ---
 
@@ -205,7 +207,8 @@ gh issue close {issue_number} -R {owner_repo}
 
 ### 4.2 Update Projects Status
 
-`github.projects.enabled: false` ならスキップして Phase 4.3 へ。そうでなければ [Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern) の委譲パターンを実行する（`{issue}` = `{issue_number}`、`auto_add false` の理由: close 時点で `skills/open/SKILL.md` ステップ 2.4 が登録済み）。結果分岐は共通テーブルに従い、いずれの場合も Phase 4.3 へ（non-blocking — close は Phase 4.1 で実行済み）。
+`github.projects.enabled: false` なら Phase 4.3 へ。そうでなければ [Shared: Projects Status → Done](#shared-projects-status--done-delegate-pattern)（`{issue}` = `{issue_number}`、`auto_add false`）。いずれも Phase 4.3（non-blocking）。
+rationale: references/rationale.md#auto-add-false-closed
 
 ### 4.3 Update Local Work Memory
 
@@ -221,7 +224,7 @@ WM_SOURCE="close" \
   bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
-lock 失敗時は WARNING を出して続行（best-effort — Phase 5 でどのみち削除される）。Issue コメントへの backup sync は不要（最終的な archival record は `rite:cleanup` Phase 4.5 が更新する）。
+lock 失敗は WARNING して続行（best-effort）。Issue comment backup は不要（archival は `rite:cleanup` Phase 4.5）。
 
 ### 4.4 Completion Report
 
@@ -238,9 +241,10 @@ Status: Done
 
 ### 4.4.W Wiki Ingest Trigger (Conditional)
 
-> **Reference**: [Wiki Ingest](../wiki-ingest/SKILL.md) — `wiki-ingest-trigger.sh` API。本 Phase は raw source の **蓄積** を担う（page 統合は後続の `/rite:wiki-ingest` が冪等に行う）。raw 蓄積と page 統合を分離することで、page 統合が skip / 失敗しても raw source は失われない。
+> **Reference**: [Wiki Ingest](../wiki-ingest/SKILL.md) — `wiki-ingest-trigger.sh` API。本 Phase は raw の **蓄積**。page 統合は `/rite:wiki-ingest`。
+> rationale: references/rationale.md#wiki-raw-page-split
 
-> **⚠️ E2E Mandatory**: 本 Phase は出力最小化ルールで skip しない。orchestrator 経由 (例: `/rite:open` 後の parent close routing) でも実行する。唯一の正当な skip は Step 1 の config ベース skip（`WIKI_INGEST_SKIPPED=1` sentinel + WARNING を必ず emit）。
+> **⚠️ E2E Mandatory**: 出力最小化で skip しない。正当な skip は Step 1 の config のみ（`WIKI_INGEST_SKIPPED=1` + WARNING を必ず emit）。
 
 **Step 1**: Wiki 設定を確認する（`wiki.enabled` opt-out default true / `wiki.auto_ingest` default false）:
 
@@ -330,11 +334,13 @@ else
 fi
 ```
 
-**Non-blocking**: trigger 失敗・content write 失敗のいずれも workflow を止めない。LLM は `trigger_exit` を読み、非 0 なら Phase 4.4.W.2 をスキップする。`content_write_failed=1` (heredoc write 失敗) のときは trigger を起動せず、`WIKI_INGEST_FAILED reason=content_write_failed` を gate-visible に emit したうえで `trigger_exit=1` を設定して同じスキップ経路に合流する。これにより `/tmp` full 等での truncated retrospective の silent ingest を防ぐ (pr-review.md 6.5.W / fix.md 4.6.W と対称)。
+**Non-blocking**: trigger / content write 失敗で止めない。`trigger_exit` 非 0 なら Phase 4.4.W.2 を skip。`content_write_failed=1` は trigger 未起動のまま `WIKI_INGEST_FAILED reason=content_write_failed` を emit し `trigger_exit=1` で同じ skip へ合流する。
+rationale: references/rationale.md#content-write-fail-loud
 
 ### 4.4.W.2 Wiki Raw Commit
 
-> raw source の commit を単一スクリプト `wiki-ingest-commit.sh`（stash→checkout→add→commit→push→checkout-back→stash-pop を 1 プロセスで完結）に委譲する。LLM の multi-step orchestration に依存した旧 Skill 設計が E2E で fragile だったため。**本 block は raw source のみ commit**（page 統合は `/rite:wiki-ingest`）。
+> raw commit は `wiki-ingest-commit.sh` に委譲する。**本 block は raw のみ commit**（page 統合は `/rite:wiki-ingest`）。
+> rationale: references/rationale.md#commit-delegate-single-process
 
 **Condition**: `wiki_enabled=true` AND `auto_ingest=true` AND `trigger_exit=0` の場合のみ実行。満たさなければスキップして Phase 4.5 へ。
 
@@ -365,7 +371,8 @@ fi
 trap - EXIT INT TERM HUP
 ```
 
-`commit_rc=4` を観測した場合は、上の Bash block とは**別の Bash tool call**で次を 1 回だけ再試行する。`{wiki_push_attempt}` は直前の `WIKI_PUSH_ATTEMPT` marker の値へリテラル置換する。tool call には `dangerouslyDisableSandbox: true` を指定する（ユーザー確認不要。`/rite:open` ステップ 6.1 と同じ既知の SSH host-key / network sandbox 制約）。通常 sandbox のまま同じ push を繰り返してはならない。
+`commit_rc=4` を観測した場合は、上の Bash block とは**別の Bash tool call**で次を 1 回だけ再試行する。`{wiki_push_attempt}` は直前の `WIKI_PUSH_ATTEMPT` marker の値へリテラル置換する。tool call には `dangerouslyDisableSandbox: true` を指定する（ユーザー確認不要）。通常 sandbox のまま同じ push を繰り返してはならない。
+rationale: references/rationale.md#push-retry-sandbox
 
 ```bash
 if retry_out=$(bash {plugin_root}/hooks/scripts/wiki-ingest-commit.sh --push-only 2>&1); then
@@ -394,7 +401,8 @@ close の完了報告前に、**現在の `WIKI_PUSH_ATTEMPT` と同じ `attempt
 
 ### 4.5.1 Detect Parent Issue
 
-親 Issue を **3 method の OR 検出**で特定する。この 3-method 構造は [`projects-integration.md` §2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) と一致させる（method 順序・OR 意味・total-failure 時の `[DEBUG] parent not detected` emission に加え、**Method 3 の検証ループ本体**（自己マッチ除外 `cand != {issue_number}`・候補 body の tasklist 行再検証 regex・`--limit 10`）も両サイトで揃える。差異は `--state` のみ。method 順序・OR 意味・loop 本体のいずれかが乖離すると silent-skip / 誤検出回帰が再発する）。
+親 Issue を **3 method の OR 検出**で特定する。構造は [`projects-integration.md` §2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) と一致させる（順序・OR・`[DEBUG] parent not detected`・**Method 3 検証ループ**（自己マッチ除外 `cand != {issue_number}`・候補 body の tasklist 再検証・`--limit 10`）。差異は `--state` のみ）。
+rationale: references/rationale.md#three-method-parent
 
 **Method 1: `## 親 Issue` body meta（PRIMARY）** — `/rite:issue-create`（Decompose Path）が書く section:
 
@@ -419,7 +427,8 @@ echo "method2_parent=${parent_number:-none}"
 
 非空なら 4.5.2 へ。
 
-**Method 3: Tasklist search（last resort）** — 両 method が失敗した場合。GitHub code search の `[`/`]` は不安定（リテラルを無視しほぼ全 Issue を返す）なので最後の手段。複数候補を取得し、自己マッチ除外＋各候補 body に当該 tasklist 行が実在するか再検証してから採用する（根拠は [`projects-integration.md` §2.4.7.1](../../references/projects-integration.md#247-parent-issue-status-update-for-child-issues) の Note 参照）。`--state all`（closing Issue の親が既に closed の可能性）:
+**Method 3: Tasklist search（last resort）** — 両 method が失敗した場合。複数候補を取得し、自己マッチ除外＋各候補 body の tasklist 再検証してから採用する。`--state all`。
+rationale: references/rationale.md#three-method-parent
 
 ```bash
 # GitHub code search は `[`/`]` を無視する緩いマッチのため、複数候補を取得して検証する
@@ -438,7 +447,7 @@ done
 echo "method3_parent=${parent_number:-none}"
 ```
 
-**3 method すべて失敗（`parent_number` 空）の場合**は standalone として処理する（AC-4 — 正常動作。silent-skip 回帰検出のため debug log は残す）:
+**3 method すべて失敗（`parent_number` 空）**は standalone（AC-4。debug log は残す）:
 
 ```bash
 echo "[DEBUG] parent not detected for issue #{issue_number} — processing as standalone (methods tried: body_meta, sub_issues_api, tasklist_search)"
@@ -478,13 +487,15 @@ exit 0 で成功（`--diff-check` で変更不要時は skip）。非 0 なら�
 
 ## Phase 4.6: Parent Auto-Close (All Children Completed)
 
-検出した親のすべての子 Issue が closed になったら、親の auto-close を提案する（"child close → parent stays Open" の silent-skip hole を塞ぐ）。
+親の全子が closed なら auto-close を提案する。
 
-**実行条件**: Phase 4.5.1 で `{parent_number}` が検出された場合のみ。未検出なら Phase 4.6 全体をスキップして Phase 5 へ。**直接の親のみ処理**し、祖父母には再帰しない（three-level nesting は out of scope）。
+**実行条件**: Phase 4.5.1 で `{parent_number}` が検出された場合のみ。未検出なら Phase 4.6 全体をスキップして Phase 5 へ。**直接の親のみ処理**し、祖父母には再帰しない。
+rationale: references/rationale.md#parent-direct-only
 
 ### 4.6.0 + 4.6.1 Idempotency Check & Child Enumeration
 
-冪等性チェック（親が既 closed なら no-op）→ 子 Issue 列挙 → `all_closed` 判定を **単一 Bash block** で行う（block 間の shell state 喪失を回避）。stderr は tempfile に退避して surface する（`2>/dev/null` の silent-skip anti-pattern を避ける）。`set -uo pipefail`（`-e` は明示 `|| fallback` のため省略）。
+冪等性チェック（親が既 closed なら no-op）→ 子列挙 → `all_closed` を **単一 Bash block** で行う。stderr は tempfile に退避。`set -uo pipefail`（`-e` は明示 `|| fallback` のため省略）。
+rationale: references/rationale.md#single-block-p460
 
 ```bash
 set -uo pipefail
@@ -610,7 +621,8 @@ fi
 
 ### 4.6.3 Update Parent Status to Done & Close
 
-親の Projects Status → Done（[共通委譲パターン](#shared-projects-status--done-delegate-pattern)、`github.projects.enabled: false` ならスキップ）と `gh issue close` を **単一 block** で実行する。Step 3 の state-inconsistency summary を**必ず** emit し、片方成功/片方失敗の silent data corruption を可視化する。`{projects_enabled}` / `{project_number}` / `{owner}` / `{repo}` は `rite-config.yml` から、`{parent_number}` / `{issue_number}` は前 Phase から置換する。`{owner_repo}` は [Owner/Repo Resolution](../../references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe) で解決した実リポジトリの owner/repo（slash 形式）を literal substitute する（`{owner}` は Project owner 由来で repo owner と乖離しうるため、`-R` には使わない）。
+親の Projects Status → Done（[共通委譲パターン](#shared-projects-status--done-delegate-pattern)、`github.projects.enabled: false` ならスキップ）と `gh issue close` を **単一 block** で実行する。Step 3 の state-inconsistency summary を**必ず** emit する。`{projects_enabled}` / `{project_number}` / `{owner}` / `{repo}` は `rite-config.yml`、`{parent_number}` / `{issue_number}` は前 Phase。`{owner_repo}` は [Owner/Repo Resolution](../../references/gh-cli-patterns.md#ownerrepo-resolution-ssh-host-alias-safe) の slash 形式（`-R` に `{owner}` は使わない）。
+rationale: references/rationale.md#step3-inconsistency-summary
 
 ```bash
 set -uo pipefail
@@ -701,7 +713,7 @@ esac
 trap - EXIT INT TERM HUP
 ```
 
-いずれの結果でも Phase 5 へ（non-blocking — Step 3 summary が silent failure を不可能にする invariant）。
+いずれの結果でも Phase 5 へ（non-blocking）。
 
 ---
 
@@ -709,13 +721,13 @@ trap - EXIT INT TERM HUP
 
 **実行条件**: 既クローズ（Phase 1.2）/ 新規クローズ（Phase 4）を問わず最終 Phase として常に実行。`{issue_number}` のみ必要。
 
-指定 Issue のローカル作業メモリファイルと lockdir を削除する（close mode: 指定 Issue のファイルのみ削除。flow state reset や stale sweep はしない）。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) で解決:
+指定 Issue のローカル作業メモリと lockdir を削除する（close mode。flow-state reset / stale sweep はしない）。`{plugin_root}` は [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version):
 
 ```bash
 bash {plugin_root}/hooks/cleanup-work-memory.sh --issue {issue_number}
 ```
 
-`--issue` フラグは Issue 番号を直接渡し、スクリプトが内部でパスを構築する（LLM placeholder 置換をバイパス）。`.rite-work-memory/` ディレクトリ自体は削除しない（スクリプトが保持）。
+`--issue` は番号を直接渡す。`.rite-work-memory/` ディレクトリ自体は残す。
 
 **エラーハンドリング**（すべて non-blocking — 失敗時は警告して終了）:
 

--- a/plugins/rite/skills/issue-close/references/rationale.md
+++ b/plugins/rite/skills/issue-close/references/rationale.md
@@ -1,0 +1,73 @@
+# /rite:issue-close — 設計理由
+
+`skills/issue-close/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。
+
+## projects-status-delegate
+
+`gh api graphql` + `field-list` + `item-edit` を substep に分けて inline すると、LLM attention が
+途切れ Status 更新が silent skip する（open ステップ 2.4 / ready Phase 4 と同因）。共通
+スクリプトへ委譲する。
+
+## auto-add-false-closed
+
+既 CLOSED の Issue を auto-add すると、本来 open 時点で登録されているべき欠落を masking する。
+close 時点でも `skills/open/SKILL.md` ステップ 2.4 が登録済みという前提を崩さない。
+
+## wiki-raw-page-split
+
+本 Phase は raw の蓄積だけを担う。page 統合は後続 `/rite:wiki-ingest` が冪等に行う。分離しないと
+page 統合の skip / 失敗が raw ごと消す。E2E 出力最小化で本 Phase を skip すると、orchestrator
+経由の parent close で retrospective が永久に残らない。
+
+## content-write-fail-loud
+
+`/tmp` full / permission / inode 枯渇で heredoc が truncate されると、欠けた retrospective が
+silent に ingest される。write 失敗は trigger を起動せず、`WIKI_INGEST_FAILED
+reason=content_write_failed` を gate-visible に出す。W Phase の消費者は `WIKI_INGEST_*` だけを
+見るため、`WIKI_CONTENT_WRITE_FAILED` だけでは足りない。close は Step 2 と trigger が同一
+bash ブロックなので carry-forward は不要（pr-review / fix は別呼び出しのため必要 — 唯一の
+構造差）。
+
+## three-method-parent
+
+過去に `trackedIssues` だけ残す簡略化が、body meta / tasklist で繋がった親子の close を
+silent に壊した。3-method OR と Method 3 の検証ループ（自己マッチ除外・候補 body 再検証・
+`--limit 10`）を open / projects-integration と揃えないと、同じ回帰が再発する。GitHub code
+search は `[` / `]` を無視しほぼ全 Issue を返すので、先頭 1 件の盲目採用は standalone が自分
+自身や無関係 Issue を親にする。`--state all` は親が既 closed の可能性を拾う（open 側の
+`--state open` は着手対象を open に限る意図的差異）。3 method 失敗は standalone として正常
+（AC-4）。debug log を残すのは silent-skip 回帰を観測するため。
+
+## commit-delegate-single-process
+
+stash→checkout→add→commit→push→checkout-back→stash-pop を LLM の multi-step に任せた旧設計は
+E2E で fragile だった。`wiki-ingest-commit.sh` が 1 プロセスで完結する。本 block は raw のみ
+commit し、page 統合は `/rite:wiki-ingest`。
+
+## push-retry-sandbox
+
+exit 4 は local commit 済み・push 失敗。同じ sandbox で同じ push を繰り返しても、SSH host-key /
+network 許可リスト制約は解けない。別 Bash call + `dangerouslyDisableSandbox: true` を 1 回
+だけ試す（open ステップ 6.1 と同型）。完了報告の未完了行は **現在の `WIKI_PUSH_ATTEMPT` と同じ
+`attempt=`** にスコープする — 過去 attempt の失敗 marker が今回の成功を上書きしない。
+
+## parent-direct-only
+
+祖父母まで再帰すると three-level nesting の close 連鎖が本スキルのスコープを超える。直接の親
+だけ処理する。
+
+## single-block-p460
+
+冪等チェックと子列挙を別 bash に分けると、block 間で shell state が消え `parent_number` /
+`children_json` が空になる。`2>/dev/null` は silent-skip の温床なので stderr は tempfile へ
+退避して surface する。空配列は「子ゼロ = 全部終わった」ではなく判定不能。
+
+## step3-inconsistency-summary
+
+Status 更新と `gh issue close` を別 block にすると、片方成功・片方失敗が観測されず board と
+Issue state が食い違う。Step 3 summary を必ず emit するのが silent corruption を不可能にする
+invariant。

--- a/plugins/rite/skills/issue-implement/SKILL.md
+++ b/plugins/rite/skills/issue-implement/SKILL.md
@@ -10,11 +10,9 @@ user-invocable: false
 
 # Implementation Guidance
 
-This module handles the actual implementation work, commits, pushes, and checklist updates.
-
 ## 5.1 Implementation Work
 
-Perform actual implementation work following the implementation plan approved in `skills/open/SKILL.md` ステップ 3 (実装計画).
+`skills/open/SKILL.md` ステップ 3 で承認した計画に従って実装する。
 
 > **Reference**: Apply the Phase 5.1 checklist from [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md).
 > In particular, check `simplicity_enforcement`, `scope_discipline`, `dead_code_hygiene`, and `knowledge_routing` — route each finding to its durable medium (How → code, What → tests, Why → commit log, Why not → comments).
@@ -32,7 +30,8 @@ Perform actual implementation work following the implementation plan approved in
 
 ### 5.0.C Complexity Lane Determination (XS/S 軽量レーン)
 
-実装を始める前に、対象 Issue の**宣言 Complexity** からレーンを決める。同じ helper が 5.1.0.1 の並列実装ゲートと 5.1.0.8 の生産量制約の両方に供給する（Complexity の読み取りを 1 箇所に集約する）:
+対象 Issue の**宣言 Complexity** からレーンを決める。同じ helper が 5.1.0.1 と 5.1.0.8 の両方に供給する。
+rationale: references/rationale.md#complexity-read-once
 
 ```bash
 bash {plugin_root}/scripts/issue-complexity-lane.sh --issue {issue_number}
@@ -51,11 +50,9 @@ bash {plugin_root}/scripts/issue-complexity-lane.sh --issue {issue_number}
 
 > **Reference**: [Wiki Query](../wiki-query/SKILL.md) — `wiki-query-inject.sh` API
 
-Before starting implementation, inject relevant experiential knowledge from the Wiki to inform the implementation approach.
+**Condition**: `wiki.enabled: true` AND `wiki.auto_query: true`。それ以外は silent skip。
 
-**Condition**: Execute only when `wiki.enabled: true` AND `wiki.auto_query: true` in `rite-config.yml`. Skip silently otherwise.
-
-**Step 1**: Check Wiki configuration:
+**Step 1**: Wiki 設定:
 
 ```bash
 wiki_section=$(sed -n '/^wiki:/,/^[a-zA-Z]/p' rite-config.yml 2>/dev/null) || wiki_section=""
@@ -74,11 +71,9 @@ case "$auto_query" in true|yes|1) auto_query="true" ;; *) auto_query="false" ;; 
 echo "wiki_enabled=$wiki_enabled auto_query=$auto_query"
 ```
 
-If `wiki_enabled=false` or `auto_query=false`, skip this section and proceed to implementation.
+`wiki_enabled=false` または `auto_query=false` なら実装へ。
 
-**Step 2**: Generate keywords from the implementation plan and invoke the query:
-
-Keywords are derived from: implementation plan step descriptions, target file paths, and relevant domain terms from the plan.
+**Step 2**: 計画のステップ記述・対象パス・ドメイン用語から keywords を生成して query:
 
 ```bash
 # {plugin_root} はリテラル値で埋め込む
@@ -95,13 +90,13 @@ else
 fi
 ```
 
-**Step 3**: If `wiki_context` is non-empty, retain it in conversation context and reference it during implementation. The injected experiential knowledge may inform: common implementation patterns, known pitfalls, and effective approaches for similar changes.
+**Step 3**: `wiki_context` が非空なら会話 context に保持し、実装中に参照する。
 
 ### 5.0.T Canon TDD Cycle (Conditional)
 
 > **Reference**: Canon TDD (Kent Beck) — test list → pick one behavior → Red (write a failing test) → Green (minimal implementation) → Refactor → repeat until the list is empty. The `tdd:` config key is documented in [CONFIGURATION.md](../../../../docs/CONFIGURATION.md) (`### tdd`).
 
-When `tdd.enabled: true` (default, opt-out) in `rite-config.yml`, drive the implementation phase as a Canon TDD cycle instead of the conventional "implement, then verify" flow. The cycle applies to each behavior implemented in 5.1.
+`tdd.enabled: true`（既定、opt-out）なら 5.1 の各挙動を Canon TDD で進める。
 
 **Step T1: Configuration gate** (same sed/awk read pattern as 5.0.W):
 
@@ -143,20 +138,17 @@ echo "[CONTEXT] TDD_ENABLED=$tdd_enabled; TEST_CMD_SET=$([ -n "$test_cmd" ] && e
 5. **Refactor — only after Green**: improve structure with tests passing. **Refactoring on a Red / unverified state is prohibited** — if not Green (Full mode) or Green is unconfirmed (Degraded mode), do not refactor; return to step 4 or move to the next behavior.
 6. **Repeat** from step 2 until the test list is empty (every listed behavior implemented and, in Full mode, Green).
 
-**Relationship with 5.1.0 Parallel Implementation**: When TDD is active (Full / Degraded), the Canon TDD cycle takes precedence over parallel implementation for behavior implementation — the one-test-one-cycle sequencing must be preserved. Parallel implementation (5.1.0) is limited to independent Refactor-phase tasks (step 5) that do not share the cycle's Red/Green state.
+TDD 中の並列は Red/Green を共有しない Refactor（T2.5）に限る。per-behavior Green は 5.1.0.6 の実行手順だけ再利用し、フルゲート（rounds / 5.1 戻り）は pre-commit で 1 回。
+rationale: references/rationale.md#tdd-green-reuse
 
-**Green confirmation reuse (no duplication)**: 5.0.T does not implement its own test runner. The per-behavior Green check (T2.4) reuses 5.1.0.6's test-execution step (`commands.test` run + exit-code check); the full 5.1.0.6 Test Verification Gate then runs **once** at pre-commit time as the final verification (rounds budget / Phase-5.1-return semantics apply only to that final gate, not to each per-behavior Green check). 5.0.T only sequences *when* Red (before implementation) and Green (after implementation) are checked; the actual test run is owned by 5.1.0.6 / `commands.test`.
-
-**Disabled mode (`tdd.enabled: false`)**: 5.0.T is skipped entirely and the implementation phase behaves exactly as before this feature (conventional 5.1.0 / Basic implementation flow + the 5.1.0.6 pre-commit test gate). No behavioral change.
+**Disabled**（`tdd.enabled: false`）: 5.0.T を skip。従来の 5.1.0 / Basic + 5.1.0.6 と同一。
 
 **Basic implementation flow:**
 
-1. Check current file content with Read tool
-2. Apply changes with Edit tool
-3. After changes, verify behavior with Bash as needed (test execution, etc.)
-4. Repeat following plan order when there are multiple file changes
-
-**Tools used:**
+1. Read で現状確認
+2. Edit で変更
+3. 必要なら Bash で検証
+4. 計画順に繰り返す
 
 | Tool | Usage |
 |------|-------|
@@ -165,37 +157,18 @@ echo "[CONTEXT] TDD_ENABLED=$tdd_enabled; TEST_CMD_SET=$([ -n "$test_cmd" ] && e
 | Bash | Verify changes with `git status`, run tests |
 | Glob/Grep | Explore related files (when needed) |
 
-**When there is an implementation plan:**
-- Follow the plan's "Implementation steps (dependency graph)" — pick the next step whose `depends_on` prerequisites are all complete
-- After each step completion, re-evaluate remaining steps (see 5.1.0.5 Adaptive Re-evaluation)
-- Update work memory after each step completion as needed (described below)
-
-**When the implementation plan was skipped:**
-- Refer to the Issue's **What** (what to do) and **Where** (where to change) for work
-- Explore related files with Glob tool (file pattern search) or Grep tool (keyword search) as needed
-
-**Decisions during implementation:**
-- Record important design decisions in work memory
-- Pause and record the situation when unexpected problems occur
-
-**Work memory update (optional):**
-
-For large changes or work spanning multiple sessions, invoke `/rite:issue-update` via Skill tool to record progress:
+計画あり: `depends_on` が揃った次ステップを実行し、完了ごとに 5.1.0.5 で再評価。計画 skip: Issue の What / Where。判断は work memory に残す。大規模・複数セッションは `/rite:issue-update`（小変更は省略可）:
 
 ```
 Skill ツール呼び出し:
   skill: "rite:issue-update"
 ```
 
-**Note**: Can be omitted for small changes. Recommended at session end or interruption.
-
 ### 5.1.0 Parallel Implementation (Conditional)
 
-Execute parallel implementation when conditions are met if `parallel.enabled` is `true` (default) in `rite-config.yml`.
+`parallel.enabled` が `true`（既定）かつ下記 **all** のとき並列する。
 
 #### 5.1.0.1 Parallel Implementation Condition Check
-
-Execute parallel implementation when **all** of the following conditions are met:
 
 | Condition | Determination Method |
 |-----------|---------------------|
@@ -203,11 +176,12 @@ Execute parallel implementation when **all** of the following conditions are met
 | Complexity M or above | 5.0.C の marker が `COMPLEXITY_LANE=full` **かつ `complexity=` を伴う**（= 宣言値が M / L / XL）。**`COMPLEXITY_LANE_FALLBACK=1` を伴う fail-safe 経路は満たさない**（下記）。**helper が両記法（`**Complexity**: X` / `## 複雑度`）を受理するため、ここで body を再解析しない** — 2 箇所で別々に読むと片方だけが片方の記法に対応する drift が生まれる |
 | 2 or more independent tasks | Determined from implementation plan (see below) |
 
-> **fail-safe の向きは consumer ごとに違う**: レビュー側は `full` が「reviewer を減らさない」= 安全側だが、**本ゲートでは `full` が「並列 sub-agent を許可する」= 攻撃的な側**になる。したがって Complexity を読めなかった Issue（`COMPLEXITY_LANE_FALLBACK=1`）は `full` に含めず**順次実装へ倒す**。判定キーは `COMPLEXITY_LANE=full` 単独ではなく `complexity=` の存在（＝ `COMPLEXITY_LANE_FALLBACK` の不在）である。
+Complexity を読めなかった Issue（`COMPLEXITY_LANE_FALLBACK=1`）は `full` に含めず**順次実装へ倒す**。判定キーは `COMPLEXITY_LANE=full` 単独ではなく `complexity=` の存在。
+rationale: references/rationale.md#fail-safe-orientation
 
 **Independent task determination:**
 
-Analyze the "files to change" from the implementation plan (`skills/open/SKILL.md` ステップ 3) and determine independence using the following criteria:
+計画（`skills/open/SKILL.md` ステップ 3）の変更ファイルから独立性を判定:
 
 | Criterion | Determined as Independent | Determined as Dependent |
 |-----------|--------------------------|------------------------|
@@ -290,7 +264,7 @@ Task tool parameters:
   prompt: "{task_description}. Work ONLY in {worktree_path}. Use ABSOLUTE paths for all file operations (e.g., {worktree_path}/src/file.ts). Do NOT run any git commands (checkout, commit, push, branch, merge, stash). You may use Read, Edit, Write, Glob, Grep, and Bash (for non-git commands like test/lint) tools."
 ```
 
-**Critical**: Agent prompts must explicitly prohibit git operations (checkout, commit, push, branch, merge, stash). Only the orchestrator performs git operations.
+Agent prompt は git 操作（checkout, commit, push, branch, merge, stash）を明示禁止する。git は orchestrator だけ。
 
 **Step 4: Quality gate per worktree**
 
@@ -336,13 +310,10 @@ Use sequential implementation when: `parallel.enabled: false`, complexity S or b
 
 #### 5.1.0.5 Adaptive Re-evaluation Checkpoint
 
-After completing each implementation step, re-evaluate the remaining steps before proceeding to the next one. This follows the "tackle the next most obvious problem" strategy from autonomous agent patterns.
+各ステップ完了後、残ステップを再評価する。対象は `depends_on` 列のある計画（`skills/open/SKILL.md` ステップ 3.3）。計画 skip（ステップ 3.4）または `depends_on` 無しは skip。並列中は **batch 完了ごと**（個別タスクごとではない）。
 
-**When to execute**: After every step completion when the plan uses the dependency graph format (`skills/open/SKILL.md` ステップ 3.3 plan table with `depends_on` column). Skip if the plan was skipped at `skills/open/SKILL.md` ステップ 3.4 user confirmation, or if the plan lacks a `depends_on` column (pre-existing numbered list format).
-
-**Relationship with parallel implementation (5.1.0.1-5.1.0.4)**: When parallel implementation is active, execute the re-evaluation checkpoint **after each parallel batch completes** (not after each individual parallel task). The batch completion triggers dependency state update, and newly unblocked steps are candidates for the next parallel batch.
-
-**Re-evaluation purpose**（固定した手順表・チェック表・閾値は持たない — 列挙外の状況で判断が硬直するため。work memory への記録義務は維持する）:
+固定の手順表・チェック表・閾値は持たない。記録義務は維持する。
+rationale: references/rationale.md#adaptive-no-fixed-checklist
 
 各ステップ完了時に、次の 4 つを状況に応じて判断し、判断の痕跡を work memory に残す:
 
@@ -351,7 +322,7 @@ After completing each implementation step, re-evaluate the remaining steps befor
 3. **次ステップの選定**: `depends_on` が解けたステップの中から「次に最も明白な問題」を選ぶ。目安: 下流を最も多く解放するもの・リスクが高く早く失敗を表面化させたいもの・小さく完了して勢いを保てるもの — どれを優先するかは残りの計画全体を見て判断する
 4. **行き詰まりの検知**: このステップが計画時の粒度見積もりを明らかに超えて膨らんでいる（修正の往復が続く、変更ファイル・行数が想定と乖離した）と感じたら、[Bottleneck Detection Reference](../../references/bottleneck-detection.md) の Oracle discovery（既存の正しい実装を構造ガイドに使う）でステップをサブステップ `S{n}.1`, `S{n}.2`, ... に再分解し、work memory の「ボトルネック検出ログ」に記録する（記録は次回 bulk update = commit 時）。固定閾値は使わない — 膨らみの判断は計画粒度との乖離で行う。再分解後は最初のサブステップから実行を続ける
 
-**Mark step complete**: Output the display format below. This serves as the record in conversation context. For persistence across `/clear`, completed step IDs are reflected in the work memory's implementation plan `状態` column (bulk-updated from `⬜` to `✅` at commit time in 5.1.1.2, not after every step).
+完了表示を出す。永続化は commit 時 5.1.1.2 の一括更新（毎ステップではない）。
 
 **Display format** (after each step, normal path):
 
@@ -403,8 +374,8 @@ Read `rite-config.yml` and check:
 - `commands.test` is `null` or not set
 - `verification.run_tests_before_pr` is `false`
 
-When skipped, display the appropriate message:
-- `commands.test` not set: `テスト検証: スキップ（commands.test 未設定）`
+skip 時の表示:
+- `commands.test` 未設定: `テスト検証: スキップ（commands.test 未設定）`
 - `run_tests_before_pr: false`: `テスト検証: スキップ（verification.run_tests_before_pr: false）`
 
 ##### Test Execution
@@ -432,11 +403,11 @@ When skipped, display the appropriate message:
 実装を修正してテストを再実行してください。
 ```
 
-Return to Phase 5.1 (implementation). Do NOT proceed to commit.
+Phase 5.1 へ戻る。commit しない。
 
-**Re-execution limit**: Test re-execution follows the `safety.max_implementation_rounds` limit in `rite-config.yml`. When the limit is reached, display via `AskUserQuestion`: `テスト再実行の上限に達しました（{max_implementation_rounds}回）。続行しますか？ オプション: 継続する / 中断してユーザーに確認`
+再実行上限は `safety.max_implementation_rounds`。到達時は `AskUserQuestion`: `テスト再実行の上限に達しました（{max_implementation_rounds}回）。続行しますか？ オプション: 継続する / 中断してユーザーに確認`
 
-**Note**: When called from the `/rite:open` end-to-end flow, test results are retained in conversation context. The subsequent `/rite:lint` Phase 3.4 can skip duplicate test execution if tests were already run and passed in this phase.
+E2E では結果を context に残す（`/rite:lint` Phase 3.4 が再利用できる）。
 
 ##### 5.1.0.6.1 Acceptance Criteria Check (Conditional)
 
@@ -483,15 +454,14 @@ The section extends from the matched heading to the next `##` heading or end of 
 | All criteria satisfied | Proceed to 5.1.0.7 (documentation impact investigation) → 5.1.0.8 (XS/S production constraint) → 5.1.1 (commit) |
 | Some need attention | Display via `AskUserQuestion`: `受入条件の一部が未確認です。続行しますか？ オプション: コミットに進む / 実装に戻る` |
 
-**Note**: This check is advisory — it helps catch missed requirements but does not block the flow when the user chooses to proceed.
+advisory。ユーザーが続行を選べば止めない。
 
 #### 5.1.0.7 Documentation Impact Investigation
 
 > **Reference**: Apply `documentation_consistency` from [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md).
 
-Before committing, investigate whether the implementation introduces any user-facing specification change that requires updating related documentation (README, `docs/`, `CLAUDE.md`, `plugins/rite/**/*.md`, etc.). When stale documentation is detected, fix it immediately within the same branch — do NOT defer to a separate Issue, do NOT ask the user via `AskUserQuestion`.
-
-This step is the implementer's responsibility and complements (does not replace) the tech-writer reviewer at PR review time. Catching documentation drift before commit avoids a review round-trip.
+コミット前にユーザー可視の仕様変更がドキュメント更新を要するか調べ、stale なら同じブランチで即直す。別 Issue に回さない。`AskUserQuestion` しない。
+rationale: references/rationale.md#doc-impact-no-defer
 
 ##### Skip Conditions
 
@@ -507,14 +477,12 @@ The decision is made by the LLM based on the actual diff (`git diff --name-statu
 
 ##### Investigation Procedure
 
-（探し方の固定手順（必須 glob の列挙）は持たない — 台本ではなく「何を見つけて直すか」の目的で指示する。）
+固定 glob 列挙は持たない。実装が導入した**ユーザー可視の識別子**（コマンド名・config キー・ファイルパス・phase / workflow 名・hook / helper 名。ソースは work memory の「決定事項・メモ」と diff。内部限定は除く）ごとにリポジトリ全体を探し、食い違う記述を直す:
 
-実装が導入した**ユーザー可視の識別子**（コマンド名・config キー・ファイルパス・phase / workflow 名・hook / helper 名。work memory の「決定事項・メモ」と diff 自体がソース。明らかに内部限定のものは除く）ごとに、**リポジトリ全体**からその識別子に言及するドキュメントを探し、実装後の仕様と食い違う記述を見つけて直す:
-
-- 探索は Grep で行い、識別子の性質から言及がありそうな場所を判断して掃く。Markdown（`CLAUDE.md` / `docs/` / `plugins/**/*.md`）だけでなく、拡張子なし README や CHANGELOG のような `*.md` glob が取りこぼすファイルも対象に含める（「普段は *.md だから」と決め打ちすると silent drift になる）
-- 今回の変更ファイル集合（`git diff --name-only origin/{base_branch}...HEAD` — 通常は複数ファイル）は既に更新済みのため、調査対象から除外する
-- ヒットした各ファイルは Read で該当行の周辺を確認し、古い挙動・旧名称・削除済み機能を記述していれば Edit で即時修正する。周辺文脈がまだ正しいなら触らない。**迷ったら stale として更新する**（ドキュメントの過剰更新は drift の放置より安い）
-- 修正したドキュメントは実装と同じコミットにステージする。`AskUserQuestion` は使わない（下記 Constraints）
+- Grep。`*.md` 決め打ちしない（拡張子なし README / CHANGELOG も対象）
+- 今回の変更ファイル集合（`git diff --name-only origin/{base_branch}...HEAD`）は除外
+- ヒットは Read で周辺確認。古い挙動・旧名称・削除済みなら Edit。正しいなら触らない。**迷ったら stale として更新する**
+- 修正は実装と同じコミットにステージ。`AskUserQuestion` は使わない
 
 ##### Result Handling
 
@@ -535,7 +503,8 @@ The decision is made by the LLM based on the actual diff (`git diff --name-statu
 
 **Execution condition**: 5.0.C の `COMPLEXITY_LANE == light`。`full`（M / L / XL、および fail-safe 全 reason）のときは本サブセクション全体を skip し、挙動は本機能導入前と完全に同一。
 
-コミット前に、本レーンで**生産しすぎていないか**を確認する。過剰な生産物はそれ自体が次サイクルの churn の燃料になる（実測: 1 行の設定変更に対して implement が +250 行を生産し、その説明的散文が 2 サイクル分の指摘を生んだ）。該当したものはコミット前に**削る**（follow-up Issue へ回さない）:
+コミット前に、本レーンで**生産しすぎていないか**を確認する。該当したものはコミット前に**削る**（follow-up Issue へ回さない）:
+rationale: references/rationale.md#production-constraint-churn
 
 | 制約 | 適用 | 判定 |
 |---|---|---|
@@ -544,45 +513,25 @@ The decision is made by the LLM based on the actual diff (`git diff --name-statu
 
 **縮小しないもの**（本レーンでも M+ と同一）: 5.1.0.6 Test Verification Gate、5.1.0.6.1 Acceptance Criteria Check、5.1.0.7 Documentation Impact Investigation。5.1.0.7 が検出した stale ドキュメントの修正は「既存記述の同期」であり、XS でも**必ず実施する** — 本制約が禁じるのは新規の説明散文であって、既存記述を実装に合わせることではない。
 
-制約に抵触した生産物を削った場合は、その事実を work memory の「決定事項・メモ」に記録する（silent な削除は、後から「なぜこの説明が無いのか」を追えなくする）。
+削った事実は work memory の「決定事項・メモ」に記録する（silent 削除禁止）。
 
 > **Reference**: なぜ散文の新設禁止が XS 限定で、新規テストファイル抑制が XS/S 両方なのか: [complexity-lane.md](../pr-review/references/complexity-lane.md#レーン境界を二値にする理由)。
 
 ### 5.1.1 Commit and Push Changes
 
-After implementation is complete, push changes to remote:
-
 **Commit procedure:**
 
-1. Check changed files with `git status`
-2. Stage the changed files explicitly with `git add {changed_files}` (the paths edited/created in this implementation — **not** `git add .`: sandbox 有効環境では read-deny 対象の home dotfile が character-special device としてマスクされ untracked 表示されるため、`git add .` はそれらを拾って `can only add regular files, symbolic links or git-directories` で hard fail する —)
-3. Generate commit message in Conventional Commits format
-4. Commit with `git commit`
-5. Push to remote with `git push origin {branch_name}` (no `-u`: sandbox 環境での upstream tracking 書込拒否を避けるため)
+1. `git status` で変更ファイルを確認
+2. `git add {changed_files}` で明示 stage（**not** `git add .`）
+3. Conventional Commits でメッセージ生成
+4. `git commit`
+5. `git push origin {branch_name}`（`-u` なし）
+rationale: references/rationale.md#git-add-dot-sandbox
+rationale: references/rationale.md#push-no-upstream
 
-**Commit message generation:**
+> **⚠️ CRITICAL**: commit message の `description` は `language` 設定に従う。例の言語をコピーしない。
 
-> **⚠️ CRITICAL**: The `description` part of the commit message **MUST** follow the `language` setting in `rite-config.yml`. The examples below are for reference only — always generate the description in the language determined by the setting, not by copying the example language.
-
-Generated based on Issue title and implementation content:
-- Format: `{type}({scope}): {description}`
-- Examples:
-  - English: `feat(issue): add end-to-end workflow support`
-  - Japanese: `feat(issue): Issue一気通貫ワークフローを追加`
-
-**Commit message language:**
-
-Follow the `language` setting in `rite-config.yml` (`auto`: detect user input language, `ja`: Japanese, `en`: English). For `auto`, determine by presence of Japanese characters (hiragana, katakana, kanji). type/scope are always in English.
-
-**Commit body:**
-
-Use a free-form commit body. Include the reason for the change ("why") in the commit body.
-
-- Leave a blank line between the description line and the body
-- Write in free-form — no specific prefix or template required
-- Focus on "why" the change was needed, not "what" was changed (the description line already covers "what")
-- Follow the same language setting as the description line
-- Can be omitted for trivial changes (typo fixes, formatting, etc.)
+形式 `{type}({scope}): {description}`。言語は `rite-config.yml` の `language`（`auto` は日本語文字の有無）。type/scope は常に英語。body は why を自由形式。description との間に空行。trivial は省略可。
 
 ```bash
 git add {changed_files}
@@ -593,23 +542,18 @@ EOF
 git push origin {branch_name}
 ```
 
-`{changed_files}` は Claude が本フェーズで Edit/Write した実ファイルパスの明示列挙（`skills/fix/SKILL.md` ステップ 3.3 と同じ規約）。`git status`（手順 1）の出力を diff scope の確認に使ってよいが、`git add` の引数には常に把握済みの実装対象パスを渡す — カレントディレクトリ全体を無条件に stage する `git add .` / `git add -A` は使わない。
-
-**Note**: Commit and push must be completed before invoking `/rite:pr-create`.
+`{changed_files}` は本フェーズで Edit/Write した実パスの明示列挙（`skills/fix/SKILL.md` ステップ 3.3 と同規約）。`git add .` / `git add -A` は使わない。commit / push は `/rite:pr-create` より前に完了する。
 
 #### 5.1.1.1 Issue Body Checklist Update
 
-**Execution condition**: Execute only when Issue body checklist was extracted and retained at `skills/open/SKILL.md` ステップ 3.5 (Issue Body Checklist 更新).
+**Execution condition**: `skills/open/SKILL.md` ステップ 3.5 でチェックリストを保持しているときだけ。
 
-**Update as each task is completed**. Immediately update the Issue body checklist as implementation, test, and documentation tasks are completed.
+`git commit` 成功後と Phase 5.1 完了時に、変更ファイルとチェック項目の対応を見て `[ ]` → `[x]`。
 
-**Update trigger:** After `git commit` succeeds and at Phase 5.1 completion, Claude determines the relevance between changed files and checklist items, and updates `[ ]` to `[x]` for completed items.
+> **⚠️ 注意**: `--body "$var"` は禁止。`--body-file` + 一時ファイル。
+> rationale: references/rationale.md#body-file-not-var
 
-> **⚠️ 注意**: `--body "$var"` による直接更新は body 消失のリスクがあるため禁止。必ず `--body-file` + 一時ファイルパターンを使用すること。
-
-**Update procedure** (3-step safe update pattern):
-
-Execute in 3 stages (Bash → Read+Write → Bash). Shell variables do not persist across Bash tool calls, so the temp file paths output by Step 1 are passed to Step 3 as literals. On any validation failure, output a WARNING and skip remaining steps (do NOT `exit 1` — subsequent phase processing must continue).
+3 段（Bash → Read+Write → Bash）。temp パスは Step 1 出力を Step 3 へ literal 渡し。検証失敗は WARNING して残りを skip（`exit 1` しない）。
 
 **Step 1: Bash tool call — Fetch body and validate**
 
@@ -625,8 +569,7 @@ Outputs: `tmpfile_read=<path>`, `tmpfile_write=<path>`, `original_length=<n>`. I
 2. Create the full text with `[ ]` → `[x]` updates based on the read content
 3. Write the updated body to `$tmpfile_write` (path output in Step 1) using Claude Code's Write tool
 
-> Partial content causes the entire Issue body to be replaced with a fragment, losing all other sections (description, acceptance criteria, etc.).
-> **CRITICAL**: The Write tool output MUST contain the ENTIRE Issue body with only checkbox changes. Never output partial content or only the changed lines.
+> **CRITICAL**: Write はチェックボックス以外を変えない **全文**。部分出力禁止。
 
 **Step 3: Bash tool call — Validate and apply**
 
@@ -642,9 +585,7 @@ Also synchronize the "Issue checklist" section in the work memory.
 
 #### 5.1.1.2 Work Memory Progress Summary and Changed Files Update
 
-**Execution condition**: Execute after commit and push succeed, when on a work branch with an Issue number (`issue-{n}` pattern).
-
-**Purpose**: Update the progress summary table, implementation plan step statuses (`状態` column), and changed files section in the Issue work memory comment to reflect the actual implementation state. This ensures these sections are not left in their initial "⬜ 未着手" / "_まだ変更はありません_" state after implementation completes.
+**Execution condition**: commit / push 成功後、`issue-{n}` ブランチ。進捗表・計画 `状態`・変更ファイルを実装後の状態へ更新する。
 
 **Step 1: Determine progress summary statuses**
 
@@ -706,11 +647,8 @@ rm -f "$changed_files_tmp"
 
 #### 5.1.1.3 Local Work Memory Update
 
-**Execution condition**: Execute when on a work branch with an Issue number (`issue-{n}` pattern).
-
-After commit and push, update the local work memory file to record the phase transition to lint. Uses `mkdir` lock for concurrent access safety with pre-compact hook.
-
-Use the self-resolving wrapper. See [Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands) for details and marketplace install notes.
+**Execution condition**: `issue-{n}` ブランチ。commit / push 後に `phase=lint` へ。
+[Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands)
 
 ```bash
 WM_SOURCE="implement" \
@@ -722,11 +660,11 @@ WM_SOURCE="implement" \
   bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
-**On lock failure**: Log a warning (`rite: implement: local work memory lock failed`) and continue — local work memory update is best-effort. The flow state update (step 4a) is the primary state record.
+lock 失敗は WARNING（`rite: implement: local work memory lock failed`）して続行。主記録は 4a の flow-state。
 
 #### 5.1.2 Parent Issue Progress Update (only when working on child Issue)
 
-**Execution condition**: Execute only when `parent_issue_number` is non-zero. Read deterministically via `flow-state.sh` so per-session state is consulted instead of the legacy state file snapshot (also survives context compaction):
+**Execution condition**: `parent_issue_number` が非 0 のときだけ。`flow-state.sh` で読む:
 
 ```bash
 # `if ! var=$(cmd); then rc=$?` は bash 仕様上 `$?` が常に 0 になるため、capture と exit code を
@@ -760,9 +698,11 @@ Skip this section when `PARENT_ISSUE=none`.
 
 Update the relevant child Issue's `- [ ]` to `- [x]` in the `## Sub-Issues` section of the parent Issue body.
 
-> **⚠️ 注意**: `--body "$var"` による直接更新は body 消失のリスクがあるため禁止。必ず `--body-file` + 一時ファイルパターンを使用すること。
+> **⚠️ 注意**: `--body "$var"` は禁止。`--body-file` + 一時ファイル。
+> rationale: references/rationale.md#body-file-not-var
 
-Execute in 3 stages (Bash → Read+Write → Bash). On any validation failure, output a WARNING and skip remaining steps (do NOT `exit 1` — subsequent phase processing must continue).
+3 段（Bash → Read+Write → Bash）。検証失敗は WARNING して残りを skip（`exit 1` しない）。
+rationale: references/rationale.md#parent-step1-no-exit-trap
 
 **Step 1: Bash tool call — Fetch parent Issue body and validate**
 
@@ -840,12 +780,11 @@ Check the state of remaining child Issues with `trackedIssues` and calculate `re
 
 **After 5.1.1 commit/push completion:**
 
-1. Parent Issue progress update (only when working on child Issue, see 5.1.2)
-2. **Update work memory** (record phase info, changed files, next steps)
-3. **Update local work memory** (`.rite-work-memory/issue-{n}.md`) — see 5.1.1.3 above
-4. **CRITICAL: Initialize flow state and invoke lint** (atomic pair - MUST execute both):
-
-   > **Note**: All flow state writes use `flow-state.sh` which handles atomic write (PID-based temp file + `mv`) internally to prevent race conditions with concurrent hook shell processes (e.g. pre-compact, post-compact, session-start, session-end, post-tool-wm-sync, cleanup-work-memory).
+1. 親進捗（子 Issue のとき、5.1.2）
+2. **work memory 更新**
+3. **ローカル work memory 更新**（5.1.1.3）
+4. **CRITICAL: flow-state 初期化と lint invoke**（atomic pair — 両方必須）:
+rationale: references/rationale.md#lint-atomic-pair
 
    **4a**: Create state file:
 
@@ -856,17 +795,15 @@ Check the state of remaining child Issues with `trackedIssues` and calculate `re
      --next "After rite:lint returns: [lint:success/skipped]->/rite:open ステップ 6 (PR creation). [lint:error]->fix and re-invoke. [lint:aborted]->/rite:open 完了通知でユーザー判断. Do NOT stop."
    ```
 
-   **4b**: **Immediately** invoke `rite:lint` via Skill tool (following the flow continuation principle, stopping is prohibited)
+   **4b**: **Immediately** invoke `rite:lint` via Skill tool（停止禁止）
 
 ### Mandatory Action After Phase 5.1.1 Completion (Absolute Requirement)
 
-> **Warning**: Stopping without executing the following actions is prohibited.
->
-> 1. Confirm that commit and push succeeded
-> 2. **Immediately** invoke `rite:lint` via Skill tool
-> 3. Do NOT stop and guide the user with "Next steps"
+> 停止禁止。
+> 1. commit / push 成功を確認
+> 2. **Immediately** `rite:lint` を Skill で呼ぶ
+> 3. 「次のステップ」案内で止めない
 
-**Flow verification check (must confirm at Phase 5.1.1 completion):**
 - [ ] Commit complete
 - [ ] Push complete
 - [ ] **Next action**: Invoke `rite:lint` via Skill tool (**execute now**)

--- a/plugins/rite/skills/issue-implement/references/rationale.md
+++ b/plugins/rite/skills/issue-implement/references/rationale.md
@@ -1,0 +1,73 @@
+# /rite:issue-implement — 設計理由
+
+`skills/issue-implement/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。レーン境界の設計根拠は
+`skills/pr-review/references/complexity-lane.md` が SoT。
+
+## complexity-read-once
+
+Complexity を 5.1.0.1 と 5.1.0.8 で別々に body から読むと、片方だけが片方の記法
+（`**Complexity**: X` / `## 複雑度`）に対応する drift が起きる。5.0.C の helper 1 回が両ゲートへ
+供給する。
+
+## fail-safe-orientation
+
+レビュー側の `full` は「reviewer を減らさない」= 安全側。本ゲートの `full` は「並列
+sub-agent を許可する」= 攻撃側。Complexity を読めなかった Issue を `full` に含めると、不明な
+まま並列が走る。判定キーは `COMPLEXITY_LANE=full` 単独ではなく `complexity=` の存在。
+
+## tdd-green-reuse
+
+5.0.T が独自の test runner を持つと、`commands.test` の解釈と失敗時の戻り先が 5.1.0.6 と
+二重管理になる。per-behavior Green は実行手順だけ再利用し、rounds 予算と「失敗で 5.1 へ戻る」
+は pre-commit のフルゲートが 1 回だけ持つ。TDD 中の並列は Red/Green 状態を共有しない
+Refactor 作業に限る — 1 テスト 1 サイクルを崩さないため。
+
+## adaptive-no-fixed-checklist
+
+固定の手順表・閾値は、列挙外の状況で判断を硬直させる。記録義務だけ残し、膨らみの判断は計画
+粒度との乖離に置く。
+
+## doc-impact-no-defer
+
+ドキュメント drift を別 Issue に回すと `issue_accountability` に反し、tech-writer レビューが
+1 周余分に回る。AskUserQuestion も使わない — 実装と同じコミットで直すのが最安。迷ったら
+stale として更新する（過剰更新は drift 放置より安い）。`*.md` glob 決め打ちは拡張子なし
+README を取りこぼす。
+
+## production-constraint-churn
+
+過剰生産物は次サイクルの churn の燃料になる（実測: 1 行の設定変更に対して +250 行を生産し、
+説明的散文が 2 サイクル分の指摘を生んだ）。follow-up Issue へ回すと削られず残る。削除を
+silent にすると「なぜ説明が無いのか」を追えなくなる。
+
+## git-add-dot-sandbox
+
+sandbox 有効環境では read-deny 対象の home dotfile が character-special device としてマスクされ
+untracked 表示される。`git add .` はそれらを拾って
+`can only add regular files, symbolic links or git-directories` で hard fail する。明示パスだけ
+渡す。
+
+## push-no-upstream
+
+`-u` は sandbox 環境で upstream tracking の `.git/config` 書込が拒否される。
+
+## body-file-not-var
+
+`--body "$var"` は Issue body 全体を変数経由で送り、特殊文字・長さで消失・断片置換が起きる。
+`--body-file` + 一時ファイルの 3-step（fetch → Write 全文 → apply）が唯一の安全経路。Write が
+差分行だけだと他 section が消える。
+
+## parent-step1-no-exit-trap
+
+Step 1 は独立した Bash 呼び出しなので、そこで EXIT trap を掛けると Step 1 終了時に tempfile が
+消え、Step 2 の Read が空になる。cleanup は成功時 Step 3、失敗時はその場。
+
+## lint-atomic-pair
+
+commit/push のあと lint を呼ばずに止まると、open のステップ 5 が `[lint:*]` を観測できず
+フローが切れる。「次のステップ」案内でユーザーに戻すのは、本スキルが programmatic 専用である
+契約に反する。flow-state 書き込みと Skill invoke は対で、片方だけでは再開不能になる。

--- a/plugins/rite/skills/lint/SKILL.md
+++ b/plugins/rite/skills/lint/SKILL.md
@@ -18,8 +18,6 @@ argument-hint: ""
 
 ## E2E Output Minimization
 
-When called from the `/rite:open` end-to-end flow, minimize output to reduce context window consumption:
-
 | Phase | Standalone | E2E Flow |
 |-------|-----------|----------|
 | Phase 3 (Execution) | Full output | Full output (needed for error diagnosis) |
@@ -28,41 +26,29 @@ When called from the `/rite:open` end-to-end flow, minimize output to reduce con
 | Phase 4.3 (Summary) | Full table | **Skip entirely** |
 | Phase 4.4 (Work Memory) | Full update | Full update (no change) |
 
-> **⚠️ "Skip entirely" は出力の話**: Phase 4.3 の "Skip entirely" は **人間向けサマリー表示を省く** ことを意味するのみで、Phase 3 の lint 実行や Phase 4.4 の work memory 更新など処理本体は常に実行する。時間・context を理由にした lint 処理そのものの省略は禁止。Identity: [workflow-identity.md](../../skills/rite-workflow/references/workflow-identity.md)。
+> **⚠️ "Skip entirely" は出力の話**: Phase 4.3 は **人間向けサマリー表示を省く** だけ。Phase 3 の実行と Phase 4.4 の work memory 更新は常に行う。Identity: [workflow-identity.md](../../skills/rite-workflow/references/workflow-identity.md)。
+> rationale: references/rationale.md#skip-entirely-display-only
 
-**Detection**: See [Caller Context and End-to-End Flow](#caller-context-and-end-to-end-flow) determination method below.
-
----
-
-Execute the following phases in order when this command is invoked.
+判定は下記 Caller Context 表。
 
 ## Caller Context and End-to-End Flow
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing bash hook commands in this file.
-
-This command has two invocation cases: standalone execution and being called from the `/rite:open` end-to-end flow.
 
 | Caller | Output Pattern | Subsequent Action |
 |-----------|-------------|---------------|
 | `/rite:open` (end-to-end flow) | Output (required) | `/rite:open` calls `rite:pr-create` at ステップ 6 after consuming the lint result at ステップ 5.1 |
 | Standalone execution | Output (required) | Display "next steps" guidance |
 
-**Determination method**: Claude determines the caller from conversation context:
-
 | Condition | Result |
 |------|---------|
 | `rite:lint` was called via the `Skill` tool immediately prior within the same session | Within end-to-end flow |
 | Otherwise (user directly typed `/rite:lint`) | Standalone execution |
 
-**Note**: `skills/fix/SKILL.md` also uses conversation context for determination in the same manner.
+必須パターン: `[lint:success]` / `[lint:skipped]` / `[lint:error]` / `[lint:aborted]`
 
-**Output patterns (required regardless of caller):**
-- `[lint:success]` - lint completed successfully
-- `[lint:skipped]` - lint skipped
-- `[lint:error]` - lint errors detected
-- `[lint:aborted]` - user aborted
-
-> **Important (flow continuation responsibility)**: When executed within the end-to-end flow, **this command does NOT directly call `rite:pr-create`; it returns control to the caller `/rite:open`**. `/rite:open` calls `rite:pr-create` at ステップ 6 after consuming the lint result at ステップ 5.1 (checklist completion confirmation happens earlier at ステップ 4.4).
+E2E では **`rite:pr-create` を直接呼ばない**。sentinel を出して `/rite:open` に返す。
+rationale: references/rationale.md#no-direct-pr-create
 
 ---
 
@@ -76,11 +62,7 @@ This command has two invocation cases: standalone execution and being called fro
 
 ## Phase 0: Load Work Memory (End-to-End Flow)
 
-When executed within the end-to-end flow, load necessary information from work memory (shared memory).
-
 ### 0.1 End-to-End Flow Determination
-
-Determine the caller from conversation context:
 
 | Condition | Result | Action |
 |------|---------|------|
@@ -88,8 +70,6 @@ Determine the caller from conversation context:
 | `/rite:lint` was executed standalone | Standalone execution | Can identify Issue from branch name |
 
 ### 0.2 Load Work Memory
-
-Extract the Issue number from the current branch and retrieve work memory:
 
 ```bash
 # ブランチ名から Issue 番号を抽出
@@ -112,8 +92,6 @@ gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
 
 ### 0.3 Information to Retrieve
 
-Extract the following information from work memory and retain in context:
-
 | Field | Extraction Pattern | Purpose |
 |-----------|-------------|------|
 | Issue number | `issue-(\d+)` from branch name | Phase 4.4 work memory update |
@@ -121,11 +99,7 @@ Extract the following information from work memory and retain in context:
 | Phase | `- **フェーズ**: (.+)` | Flow position confirmation |
 | Next steps | `### 次のステップ` section | Expected operation confirmation |
 
-**If work memory is not found:**
-
-If the Issue number cannot be obtained or the work memory comment does not exist:
-- Display a warning and skip
-- Continue with normal lint execution (proceed to Phase 1)
+Issue 番号または work memory が無ければ警告して skip し、Phase 1 へ。
 
 ---
 
@@ -133,25 +107,21 @@ If the Issue number cannot be obtained or the work memory comment does not exist
 
 ### 1.1 Check Explicit Configuration
 
-Retrieve the lint command from `rite-config.yml`:
+`rite-config.yml` から lint コマンドを取る:
 
 ```yaml
 commands:
   lint: "npm run lint"  # 明示的に設定されている場合
 ```
 
-Read the configuration file:
-
 ```bash
 # rite-config.yml を読み取り
 cat rite-config.yml
 ```
 
-If `commands.lint` has a configured value, use it.
+`commands.lint` があればそれを使う。
 
 ### 1.2 Auto-Detection (When No Configuration Exists)
-
-Detect project files and determine the lint command:
 
 | File | Detection Condition | Lint Command |
 |----------|----------|---------------|
@@ -179,9 +149,7 @@ ls package.json pyproject.toml Cargo.toml go.mod Makefile 2>/dev/null
 
 ### 1.3 When Command Cannot Be Detected
 
-If the lint command cannot be detected, use the `AskUserQuestion` tool to interactively confirm.
-
-**Note**: `AskUserQuestion` is a standard Claude Code tool that presents choices to the user and retrieves their response.
+検出できなければ `AskUserQuestion`:
 
 ```
 lint コマンドを検出できませんでした
@@ -198,17 +166,13 @@ lint コマンドを検出できませんでした
 - 中断: 処理を中断します
 ```
 
-**Subsequent processing for each choice:**
-
 | Choice | Subsequent Processing |
 |--------|----------|
 | **Skip and continue** | Record "lint skipped" in conversation context, skip Phase 2 onward, and complete normally. If called from `/rite:open`, proceed to the next step (PR creation) |
 | **Specify command** | Follow up with `AskUserQuestion` to prompt for command input (see below), then execute Phase 2 onward with the entered command |
 | **Abort** | Abort processing and display guidance to "configure lint and run again" |
 
-**Output and recording when skipped:**
-
-When lint is skipped, output the completion message in the following format:
+スキップ時:
 
 **Standalone execution:**
 ```
@@ -230,30 +194,17 @@ lint をスキップしました。
 🔄 **フロー継続**: 呼び出し元の `/rite:open` が ステップ 6（PR 作成）を実行
 ```
 
-> If `/rite:lint` continues to PR creation directly, it bypasses the checklist confirmation in the caller, potentially creating a PR with incomplete tasks.
-> **CRITICAL**: When called from `/rite:open`, `/rite:lint` outputs the above message and **terminates**. The call to `rite:pr-create` is made by `/rite:open` at ステップ 6 after the lint result is consumed at ステップ 5.1.
+> **CRITICAL**: `/rite:open` から呼ばれたときは上記を出して **終了**する。`rite:pr-create` は `/rite:open` ステップ 5.1 が sentinel を消費したあと ステップ 6 が呼ぶ。
+> rationale: references/rationale.md#no-direct-pr-create
 
-**Meaning of output patterns:**
-- `[lint:skipped]`: Used by `/rite:open` ステップ 5.1 to detect this pattern and decide to proceed to ステップ 6 (PR creation)
-- `[lint:success]`: When lint completed successfully (output in Phase 4.1)
-- `[lint:error]`: When lint detected errors (output in Phase 4.2)
-- `[lint:aborted]`: When the user selected "Abort"
-
-**Clarification of responsibilities:**
-
-Reflecting the lint skip in the PR body is the responsibility of `/rite:open` ステップ 5:
-1. `/rite:lint` only outputs the above output patterns
-2. When `/rite:open` detects `[lint:skipped]`, it prepares the PR body template before calling `/rite:pr-create`
-3. The "Known Issues" section of the PR body includes the following:
+`[lint:skipped]` の PR 本文反映は `/rite:open` ステップ 5 の責務:
 
 ```markdown
 ## Known Issues
 - lint 未実行（lint コマンドが検出されませんでした）
 ```
 
-**Processing when command is specified:**
-
-When "Specify command" is selected, use `AskUserQuestion` to prompt for command input:
+「コマンドを指定」なら:
 
 ```
 使用する lint コマンドを入力してください（例: npm run lint, ruff check .）
@@ -264,13 +215,7 @@ When "Specify command" is selected, use `AskUserQuestion` to prompt for command 
 - 他のコマンドを入力（Other を選択）
 ```
 
-**Note**: Present representative commands as choices in `AskUserQuestion` `options`. The user can also select "Other" to enter a custom command.
-
-When the user enters/selects a command:
-
-1. Execute Phase 2 onward using the entered command
-2. Do not save to `rite-config.yml` (temporary use only)
-3. If saving to configuration is needed, guide the user to `/rite:setup` or manual editing
+代表コマンドを選択肢に出し、Other で任意入力可。入力後は Phase 2 以降をそのコマンドで実行する。`rite-config.yml` には書かない。永続化は `/rite:setup` または手動編集。
 
 ---
 
@@ -296,34 +241,16 @@ If the path does not exist:
 
 ### 2.2 When Arguments Are Omitted
 
-Detect changed files (in priority order):
-
 #### 2.2.1 Get Base Branch
-
-Read `rite-config.yml` from the project root using the Read tool, and retrieve the `branch.base` value:
 
 ```
 Read: rite-config.yml
 ```
 
-**Retrieval logic:**
-1. If `rite-config.yml` exists and `branch.base` is set -> Use that value as `{base_branch}`
-2. If `rite-config.yml` does not exist (Read tool returns an error), or `branch.base` is not set -> Use `main` as the default
-
-**Definition of "not set":**
-- `branch.base` key does not exist
-- `branch.base` key value is `null` or empty string
-- `branch` section itself does not exist
-
-**Placeholder interpretation:**
-
-`{base_branch}` in this document is replaced with the actual branch name obtained by the above logic. For example, if `branch.base: "develop"` is configured, the subsequent bash command `git diff --name-only origin/{base_branch}...HEAD` is executed as `git diff --name-only origin/develop...HEAD`.
+1. `branch.base` があれば `{base_branch}`
+2. ファイル不在 / キー不在 / `null` / 空文字 / `branch` 節不在 → `main`
 
 #### 2.2.2 Detect Changed Files
-
-Use the `{base_branch}` value obtained above to detect diffs. Follow the fallback logic below, trying each in sequence:
-
-**Fallback logic (sequential attempts):**
 
 | Priority | Condition | Command to Execute |
 |--------|------|-------------|
@@ -354,7 +281,8 @@ git diff --name-only {base_branch}...HEAD
 3. git fetch origin でリモート情報を更新
 ```
 
-Terminate processing. Do not silently fall back to `HEAD` diff or targeting the entire project — this would change the lint scope without the user's knowledge.
+処理を中止する。`HEAD` 差分やプロジェクト全体へ黙って倒さない。
+rationale: references/rationale.md#no-silent-head-fallback
 
 **When there are no changed files:**
 
@@ -365,7 +293,7 @@ Terminate processing. Do not silently fall back to `HEAD` diff or targeting the 
 特定のパスに限定するには /rite:lint <path> を指定してください。
 ```
 
-Target the entire project (current directory) with a visible warning that the scope has expanded.
+スコープ拡大を警告したうえでプロジェクト全体を対象にする。
 
 ---
 
@@ -387,35 +315,20 @@ Target the entire project (current directory) with a visible warning that the sc
 {lint_command} {target_files}
 ```
 
-**Notes:**
-- The method for specifying target files varies by command
-- `npm run lint` follows the project configuration
-- `ruff check` accepts paths as arguments
-- Display output even if there are errors (determine by exit code)
+対象ファイルの指定方法はコマンド依存。エラー時も出力を表示し、判定は exit code。
 
 ### 3.3 Capture Execution Results
 
-Record the command's exit code and output:
-- Exit code 0: No issues
-- Exit code 1+: Errors or warnings present
+exit 0 = 問題なし。exit 1+ = エラーまたは警告。
 
 ### 3.4 Test Execution (Conditional)
 
-Execute test commands as part of quality check when configured.
+**Condition**: `commands.test` が non-null かつ `verification.run_tests_before_pr` が `true`（既定 `true`）。`verification` 節不在は既定 enabled。`commands.test` は必須。
 
-**Condition**: `commands.test` is set (non-null) in `rite-config.yml` AND `verification.run_tests_before_pr` is `true` (default: `true`).
+**Skip**（いずれか → Phase 4）: `commands.test` が `null` / 未設定、または `run_tests_before_pr: false`。
 
-**Skip conditions** (any match → skip to Phase 4):
-- `commands.test` is `null` or not set
-- `verification.run_tests_before_pr` is `false`
-
-**Note**: When the `verification` section does not exist in `rite-config.yml`, treat defaults as enabled (`run_tests_before_pr: true`). The test execution condition still requires `commands.test` to be set.
-
-**Duplicate execution avoidance**: When called from the `/rite:open` end-to-end flow and tests were already run and passed in `implement.md` Phase 5.1.0.6 (Test Verification Gate — implement.md retains its own internal phase numbering; test results available in conversation context), skip duplicate test execution and reuse previous results.
-
-When skipped, no output needed (silent skip).
-
-**Execution:**
+E2E で implement.md Phase 5.1.0.6 が既に成功していれば再実行せず結果を再利用する。skip 時は無出力。
+rationale: references/rationale.md#no-duplicate-test-in-e2e
 
 ```
 テストを実行しています...
@@ -435,14 +348,12 @@ When skipped, no output needed (silent skip).
 | 0 | Tests passed — record success, continue to Phase 4 |
 | Non-zero | Tests failed — record as error, include in Phase 4 report |
 
-**Record test results** alongside lint results for Phase 4 reporting:
-- `test_status`: `success` / `error` / `skipped`
-- `test_error_count`: Number of failed tests (0 if success)
-- `test_output`: Test command output (truncated if >500 lines)
+Phase 4 用: `test_status`（`success` / `error` / `skipped`）、`test_error_count`、`test_output`（500 行超は truncate）。
 
 ### 3.5 Plugin-specific Checks (Generic Loop)
 
-Before the informational checks, run the descriptive-number diff gate. Unlike the generic checks below, a finding or an unreadable diff is blocking: record it in `lint_output`, increment `error_count`, and route to Phase 4.2 (`[lint:error]`). The gate resolves `branch.base` with the same origin-first fallback used in Phase 2.2 and scans only added lines under `plugins/rite/`; `tests/` remains excluded.
+情報系チェックの前に descriptive-number diff gate を実行する。finding または読めない diff は blocking: `lint_output` に記録し `error_count` を増やし Phase 4.2（`[lint:error]`）。`branch.base` は Phase 2.2 と同じ origin-first。走査は `plugins/rite/` の追加行のみ。`tests/` は除外。
+rationale: references/rationale.md#descriptive-number-blocking
 
 ```bash
 descriptive_number_diff_output=$(bash {plugin_root}/hooks/scripts/descriptive-number-diff-gate.sh 2>&1)
@@ -460,9 +371,9 @@ case "$descriptive_number_diff_rc" in
 esac
 ```
 
-Run every rite-workflow internal quality check listed in the check table below through one generic execution loop. These checks are **independent of `commands.lint` configuration** (they lint the rite workflow definition itself, not the user's code). Per-check background (incident origin), detection patterns, and exclusion rules live in [references/plugin-checks-rationale.md](references/plugin-checks-rationale.md); each script's header comment is the SoT for its exact regex literals and algorithm.
+下記表の rite 内部チェックを 1 つの generic loop で回す。`commands.lint` 非依存。根拠は [plugin-checks-rationale.md](references/plugin-checks-rationale.md)。regex / アルゴリズムは各 script header が SoT。
 
-**Check table** (SoT for what runs and how — the loop, the Phase 4.1 appendix, and the Phase 4.3 summary rows all iterate over this table in order):
+**Check table**（loop / 4.1 appendix / 4.3 行の SoT。表順）:
 
 | # | Check (label) | Invocation (relative to `{plugin_root}/`) | Vars prefix | Count line (regex) |
 |---|---------------|-------------------------------------------|-------------|---------------------|
@@ -506,33 +417,32 @@ fi
 | 2 | `error` | Invocation error — record as warning, display error message |
 | -1 | `skipped` | Script not found (e.g., marketplace install without the script directory) — **skip silently** |
 
-- **Findings are warnings, not errors**: no check result changes the overall lint result pattern — `[lint:success]` remains `[lint:success]` regardless of findings. Do NOT promote a warning to an error. These checks surface awareness for progressive cleanup; they do not gate CI.
-- **Recording** (for Phase 4 reporting, 3 variables per check): `{prefix}_status` (per the table above) / `{prefix}_finding_count` (extract from `{prefix}_output` by matching the Count line regex in the check table; if no match found, default to 0) / `{prefix}_output` (script output, truncated if >50 lines). Example: the `bang_backtick` prefix records `bang_backtick_status` / `bang_backtick_finding_count` / `bang_backtick_output`.
-- **Out-of-contract exit codes** (anything other than 0/1/2/-1): treat as `error` — record as warning and continue.
+- **Findings are warnings, not errors**: どのチェックも結果パターンを変えない。`[lint:success]` は findings があっても `[lint:success]`。warning を error に昇格しない。
+- **Recording**（チェックごと 3 変数）: `{prefix}_status` / `{prefix}_finding_count`（Count line regex。無マッチは 0）/ `{prefix}_output`（50 行超は truncate）。例: `bang_backtick` → `bang_backtick_status` / `bang_backtick_finding_count` / `bang_backtick_output`。
+- **Out-of-contract exit codes**（0/1/2/-1 以外）: `error` として warning 記録し続行。
+rationale: references/rationale.md#findings-are-warnings
 
-**Per-check notes** (differences the table cannot express):
+**Per-check notes**: Number reference — 走査面（CHANGELOG en/ja と本ファイル）へ Issue/PR 番号参照を戻さない。面を広げるなら script の `DEFAULT_TARGETS` へ追加。
 
-- **Number reference check**: operational rule — do not reintroduce Issue/PR number references into the scanned surface (CHANGELOG en/ja and this file); cite the rationale in prose instead. To widen the surface, append paths to `DEFAULT_TARGETS` in the script.
-
-**Adding a new check**: add one row to the check table (script path + label + vars prefix + count-line regex), make the script follow the exit code contract above (0 = pass / 1 = findings / 2 = invocation error) and emit a count line, then add its background to [references/plugin-checks-rationale.md](references/plugin-checks-rationale.md). No new Phase section, appendix, or summary row is needed — the generic loop, appendix, and summary iterate over the table.
+**Adding a new check**: 表に 1 行（path / label / prefix / count regex）、exit 契約（0/1/2）と count line、根拠を [plugin-checks-rationale.md](references/plugin-checks-rationale.md) へ。新 Phase / appendix / summary 行は不要。
 
 <!-- Heading numbers 3.8 / 3.9 / 3.15 / 3.18 below are pinned: header comments in hooks/scripts (Non-Target files) structurally reference these lint.md Phase numbers, and sh-cross-ref-check verifies those references against this file's heading numbers. Do not renumber or remove these supplement headings without updating the referencing scripts. -->
 
 ### 3.8 Wiki Growth Check supplement (internal no-op contract)
 
-Warns when the wiki branch has gone unchanged for `wiki.growth_check.threshold_prs` consecutive merged PRs (evidence that the wiki-update phases in pr-review / fix / issue-close are being silently skipped). Wiki disabled / wiki branch absent / `gh` CLI missing / `rite-config.yml` absent are all handled inside the script → exit 0 with `findings: 0`, and the Phase 4.3 summary row simply shows `success (0 findings)` for these legitimate no-op states.
+wiki 無効 / wiki branch 不在 / `gh` 不在 / config 不在は script 内で exit 0・`findings: 0`。4.3 は `success (0 findings)`。
 
 ### 3.9 Gitignore Health Check supplement (internal no-op contract)
 
-Detects regression of the `.rite/wiki/` exclusion rule in `.gitignore` (the last line of defense against wiki-ingest silent leaks). Wiki disabled / config absent are handled inside the script → exit 0 with `findings: 0`.
+wiki 無効 / config 不在は script 内で exit 0・`findings: 0`。
 
 ### 3.15 Orphan Reference Check supplement (detection inputs)
 
-Flags a file as orphan only when inbound references (searched in `plugins/rite/`, `docs/`, `.github/`, excluding self-references) AND test pins (searched in `plugins/rite/hooks/tests/` and `plugins/rite/scripts/tests/`) are both zero. Well-known static assets (`.gitkeep`, `__init__.py`, `LICENSE`, `CHANGELOG.md`) are skipped.
+orphan は inbound（`plugins/rite/` / `docs/` / `.github/`、自己参照除く）AND test pin（`hooks/tests/` / `scripts/tests/`）が両方 0 のときだけ。静的資産（`.gitkeep` / `__init__.py` / `LICENSE` / `CHANGELOG.md`）は skip。
 
 ### 3.18 Projects Board Drift Check supplement (detect-and-enumerate only)
 
-Lint does NOT auto-reconcile — the `Done` transition stays the responsibility of `/rite:cleanup` / `/rite:issue-close`; on-demand reconciliation is available via the script's `--reconcile` flag. Its no-op contract (projects disabled / config absent → exit 0 inside the script) matches the 3.8 / 3.9 supplements.
+lint は auto-reconcile しない。`Done` 遷移は `/rite:cleanup` / `/rite:issue-close`。on-demand は `--reconcile`。no-op（projects 無効 / config 不在 → exit 0）は 3.8 / 3.9 と同じ。
 
 ---
 
@@ -540,11 +450,8 @@ Lint does NOT auto-reconcile — the `Done` transition stays the responsibility 
 
 ### 4.0 Defense-in-Depth: State Update Before Output (End-to-End Flow)
 
-Before outputting any result pattern (`[lint:success]`, `[lint:skipped]`, `[lint:error]`, `[lint:aborted]`), update flow state to reflect the post-lint phase (defense-in-depth). This prevents intermittent flow interruptions when the fork context returns to the caller — even if the LLM churns after fork return and the system forcibly terminates the turn (bypassing the Stop hook), the state file will already contain the correct `next_action` for resumption.
-
-**Condition**: Execute only when flow state file exists (indicating e2e flow). Skip if the file does not exist (standalone execution).
-
-**State update by result**:
+結果パターンを出す**前に** flow-state を更新する。flow-state ファイルがあるときだけ（standalone は skip）。
+rationale: references/rationale.md#defense-in-depth-state
 
 | Result | Phase | Phase Detail | Next Action |
 |--------|-------|-------------|-------------|
@@ -560,13 +467,10 @@ bash {plugin_root}/hooks/flow-state.sh set \
   --if-exists
 ```
 
-Replace `{phase_value}` and `{next_action_value}` with the values from the table above based on the lint result.
+`{phase_value}` / `{next_action_value}` は上表。`error_count` は set のたびに 0（`--preserve-error-count` 以外）。
+rationale: references/rationale.md#defense-in-depth-state
 
-**Note on `error_count`**: `flow-state.sh set` resets `error_count` to 0 by default on every phase transition, and preserves the existing value only when `--preserve-error-count` is passed. `error_count` is currently a reserved/legacy schema slot with no production reader; resetting on transition keeps the slot well-defined for future re-introduction without carrying stale counts.
-
-**Also sync to local work memory** (`.rite-work-memory/issue-{n}.md`) when flow state file exists:
-
-Use the self-resolving wrapper. See [Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands) for details and marketplace install notes.
+flow-state があるときはローカル work memory も同期。[Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands)
 
 ```bash
 WM_SOURCE="lint" \
@@ -580,9 +484,7 @@ WM_SOURCE="lint" \
   bash {plugin_root}/hooks/local-wm-update.sh 2>/dev/null || true
 ```
 
-Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flow state update above. Claude substitutes these with the actual values based on the lint result before executing.
-
-**On lock failure**: Log a warning and continue — local work memory update is best-effort.
+placeholder は上表の実値。lock 失敗は WARNING して続行（best-effort）。
 
 ### 4.1 When No Issues Found
 
@@ -602,18 +504,15 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 [lint:success] — lint passed ({target_file_count} files)
 ```
 
-**Plugin-specific check appendix** (both standalone and E2E): for each check in the Phase 3.5 check table (in table order), when `{prefix}_status` is `warning` **or `error`**, append the following after the lint result output. Both statuses use the same appendix so that invocation failures (exit code 2) are never silently dropped — for `warning` the `{prefix}_output` carries the findings, for `error` it carries the failure diagnostic. These appendices do NOT change the result pattern — `[lint:success]` remains the pattern regardless of how many checks report warnings or invocation errors:
+**Plugin-specific check appendix**（standalone / E2E）: Phase 3.5 表の順で `{prefix}_status` が `warning` **または `error`** なら追記。exit 2 を黙って落とさない。appendix は結果パターンを変えない:
 
 ```
 ⚠️ {check label}: {finding_count} findings detected ({status}, non-blocking)
 {output}
 ```
 
-> **Context savings**: Omit target description, command details, and flow continuation text. The caller already knows the context.
-
-> **CRITICAL**: When called from `/rite:open`, `/rite:lint` outputs the above message and **terminates**. The call to `rite:pr-create` is made by `/rite:open` at ステップ 6 after the lint result is consumed at ステップ 5.1.
-
-**Note**: `[lint:success]` is an output pattern used by `/rite:open` ステップ 5.1 to determine the lint result.
+> E2E では対象・コマンド・継続文を省く。出力して **終了**。`rite:pr-create` は呼ばない。
+> rationale: references/rationale.md#no-direct-pr-create
 
 ### 4.2 When Issues Found
 
@@ -623,7 +522,7 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 {first 10 lines of lint_output}
 ```
 
-> **Context savings**: In e2e flow, omit fix suggestions (the caller returns to ステップ 4 implementation for fixes). Only include first 10 lines of lint output to identify the issue category.
+> E2E では修正提案を省き、lint 出力は先頭 10 行。
 
 **Standalone execution:**
 ```
@@ -639,11 +538,7 @@ Where `{phase_value}`, `{phase_detail}`, and `{next_action_value}` match the flo
 修正案:
 ```
 
-**Note**: `[lint:error]` is an output pattern used by `/rite:open` ステップ 5.1 to determine the lint result.
-
-**Presenting fix suggestions:**
-
-Analyze the error content and present fix suggestions when possible:
+**Presenting fix suggestions**（standalone）:
 
 1. **When auto-fix is available:**
    ```
@@ -689,29 +584,25 @@ Analyze the error content and present fix suggestions when possible:
 > **注**: `/rite:open` の一気通貫フローから呼び出された場合、この「次のステップ」案内は**スキップ**されます。呼び出し元が出力パターン（`[lint:success]` 等）を検出し、自動的に次のアクション（PR 作成）に進みます。**この案内は単独実行時のみ参照してください**。
 ```
 
-**Note**: The `テスト` row is only shown when `commands.test` is configured. When tests were skipped, omit the row entirely. Plugin-specific check rows follow one shared rule: one row per check in the Phase 3.5 check table (table order), omit the row when `{prefix}_status` is `skipped`, and display it for `success` / `warning` / `error` (`success` = no findings or a legitimate internal no-op; `warning` = findings detected; `error` = invocation failure — displayed so the failure is surfaced rather than silently dropped).
+`テスト` 行は `commands.test` があるときだけ。skip なら省略。プラグイン行は Phase 3.5 表順、1 チェック 1 行。`skipped` は省略。`success` / `warning` / `error` は表示（`error` = 起動失敗を落とさない）。
 
 ### 4.4 Automatic Work Memory Update (Conditional)
 
 > **WARNING**: Work memory is published as Issue comments. In public repositories, it is visible to third parties. Do not record confidential information (credentials, personal information, internal URLs, etc.) in work memory.
 
-Record the quality check results in work memory.
-
-**Execution condition**: Automatically executed only when on a work branch linked to an Issue (branch containing the `issue-{number}` pattern). Not executed on main/master branches or branches that do not contain an Issue number.
+`issue-{number}` ブランチのときだけ。main/master や Issue 番号無しは実行しない。
 
 #### 4.4.1 Identify Related Issue
 
-Extract the Issue number from the branch name:
+ブランチ名から Issue 番号:
 
 ```bash
 issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
 ```
 
-If no Issue number is found, skip the work memory update.
+番号が無ければ skip。
 
 #### 4.4.2 Retrieve and Update Work Memory Comment
-
-Write the lint result content (from 4.4.3 template) to a temp file, then append to the work memory comment:
 
 ```bash
 lint_result_tmp=$(mktemp)
@@ -733,7 +624,7 @@ rm -f "$lint_result_tmp"
 
 #### 4.4.3 Update Content
 
-Automatically append the following to work memory:
+追記テンプレート:
 
 ```markdown
 ### 品質チェック履歴
@@ -745,16 +636,11 @@ Automatically append the following to work memory:
 - **対象**: {target}
 ```
 
-**Notes**:
-- If the work memory comment is not found, skip the update
-- If on the main/master branch, skip the update
-- This update is performed automatically and does not require user confirmation
+comment 不在 / main・master なら skip。確認不要。
 
 #### 4.4.4 Record "Next Steps"
 
-After the quality check is complete, record "next steps" in work memory.
-
-**Content to append (on lint success):**
+**success:**
 
 ```markdown
 ### 次のステップ
@@ -763,7 +649,7 @@ After the quality check is complete, record "next steps" in work memory.
 - **備考**: lint 完了、PR 作成準備完了
 ```
 
-**Content to append (on lint skip):**
+**skip:**
 
 ```markdown
 ### 次のステップ
@@ -772,7 +658,7 @@ After the quality check is complete, record "next steps" in work memory.
 - **備考**: lint スキップ（コマンド未検出）、PR 作成準備完了
 ```
 
-**Content to append (on lint error):**
+**error:**
 
 ```markdown
 ### 次のステップ
@@ -781,16 +667,7 @@ After the quality check is complete, record "next steps" in work memory.
 - **備考**: lint エラー修正後、再度 lint を実行
 ```
 
-**Notes**:
-- If an existing `### 次のステップ` section exists, replace its content
-- If the section does not exist, append to the end of work memory
-
-**Specific replacement procedure:**
-
-1. Retrieve the existing work memory body
-2. Detect from `### 次のステップ` to the next `###` or EOF
-3. Replace that section with the new "next steps" section
-4. If the section is not found, append to the end of the body
+既存 `### 次のステップ` は置換、無ければ末尾追記。
 
 ```bash
 # lint 結果に応じて次のステップの内容を選択し、一時ファイルに書き出す
@@ -885,8 +762,6 @@ go vet {files}
 
 ### 5.1 Flow Continuation Decision
 
-Continue the end-to-end flow based on the output pattern from Phase 4.
-
 | Output Pattern | Action in End-to-End Flow |
 |-------------|---------------------------|
 | `[lint:success]` | `/rite:lint` execution completes, and the caller `/rite:open` consumes the sentinel at ステップ 5.1 then proceeds to ステップ 6 (PR creation) |
@@ -894,23 +769,13 @@ Continue the end-to-end flow based on the output pattern from Phase 4.
 | `[lint:error]` | After fixing errors, run lint again (return to Phase 3) |
 | `[lint:aborted]` | Flow ends (execution of `/rite:open` also ends) |
 
-**Note**: During standalone execution (when the user directly executes `/rite:lint`), the ステップ 5.1 sentinel consumption and ステップ 6 PR creation are **not executed**. Lint sentinel consumption and PR creation are features only executed within the `/rite:open` end-to-end flow; standalone lint execution ends without flow continuation.
+standalone では ステップ 5.1 の sentinel 消費も ステップ 6 の PR 作成も **実行しない**。
 
 ### 5.2 Processing After `/rite:lint` Completion
 
-When `[lint:success]` or `[lint:skipped]` is output:
-
-**`/rite:lint` execution completes**, and Claude returns to `/rite:open` ステップ 5.1 to consume the lint sentinel, then proceeds to ステップ 6 to call `rite:pr-create`.
-
-**Important**:
-- `/rite:lint` does **NOT directly call** `rite:pr-create`
-- The caller `/rite:open` consumes the lint sentinel at ステップ 5.1 and proceeds to ステップ 6 (PR creation)
-- After all checklist items are complete, `/rite:open` calls `rite:pr-create`
-
-**Design intent**:
-- Guard function to prevent proceeding to PR creation until all Issue checklist items are complete
-- If there are incomplete items, return to ステップ 4 (implementation) to continue implementation
+`[lint:success]` / `[lint:skipped]` なら実行完了。`/rite:open` ステップ 5.1 が sentinel を消費し ステップ 6 で `rite:pr-create` を呼ぶ。本スキルは **`rite:pr-create` を直接呼ばない**。
+rationale: references/rationale.md#checklist-guard
 
 ### 5.3 Standalone Execution Behavior
 
-During standalone execution, Phase 5 is not executed; display the "next steps" guidance from Phase 4 and terminate.
+Phase 5 は実行しない。Phase 4 の案内を出して終了する。

--- a/plugins/rite/skills/lint/references/rationale.md
+++ b/plugins/rite/skills/lint/references/rationale.md
@@ -1,0 +1,55 @@
+# /rite:lint — 設計理由
+
+`skills/lint/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。チェックごとの検出根拠は
+[plugin-checks-rationale.md](plugin-checks-rationale.md) が SoT。
+
+## skip-entirely-display-only
+
+E2E の "Skip entirely" は人間向けサマリー表示だけを省く。lint 実行や work memory 更新まで省くと、
+時間・context を理由にした品質スキップになる。出力最小化と処理省略を同一視しない。
+
+## no-direct-pr-create
+
+本スキルが `rite:pr-create` を直接呼ぶと、caller のチェックリスト確認（open ステップ 4.4 /
+sentinel 消費 5.1）を迂回し、未完了タスクのまま PR が作られる。sentinel を出して caller に
+返すのが唯一の継続契約。
+
+## no-silent-head-fallback
+
+`HEAD` 差分やプロジェクト全体へ黙って倒すと、lint スコープがユーザーの知らない範囲に広がる。
+ベースブランチ不在はエラーで止める。差分ゼロの全体チェックは警告を出してから行う。
+
+## no-duplicate-test-in-e2e
+
+open → implement の Test Verification Gate が既に通っているのに lint が再実行すると、同じ
+`commands.test` を二重に燃やす。会話 context に成功結果があるときだけ再利用する。
+
+## descriptive-number-blocking
+
+generic loop の findings は warning のまま `[lint:success]` を保つ（progressive cleanup）。
+説明的番号の **新規追加** だけは blocking — 番号を本文に戻す退行を「後で直す」と残すと、
+number-free 面がすぐに崩れる。diff が読めない（rc=2）も「見ていないのに success」になるため
+同じ error 経路へ倒す。
+
+## findings-are-warnings
+
+プラグイン自己検査は CI ゲートではない。warning を error に昇格すると、marketplace 利用者の
+通常フローが内部 cleanup で止まる。appendix が `warning` と `error`（起動失敗）を同じ形で出す
+のは、exit 2 を黙って落とさないため。
+
+## defense-in-depth-state
+
+結果パターンを出す前に flow-state を書くのは、fork 復帰後に LLM が空転して Stop hook を
+迂回したターン強制終了でも、再開用の `next_action` が残るようにするため。
+
+`error_count` は現状 reader の無い予約スロット。毎回 0 に戻すのは、stale 件数を次 phase へ
+持ち越さないため。
+
+## checklist-guard
+
+open ステップ 5 が `[lint:*]` を消費してから ステップ 6 で PR を作る。lint 側に PR 作成を
+持たせないのは、チェックリスト未完のまま提出する抜け穴を構造的に閉じるため。

--- a/plugins/rite/skills/pr-create/SKILL.md
+++ b/plugins/rite/skills/pr-create/SKILL.md
@@ -20,38 +20,28 @@ user-invocable: false
 
 ## E2E Output Minimization
 
-When called from an orchestrator's end-to-end flow (e.g. `/rite:open` ステップ 6), minimize output to reduce context window consumption:
-
 | Phase | Standalone | E2E Flow |
 |-------|-----------|----------|
 | Phase 3 (PR Creation) | Full output | `[pr:created:{number}]` + PR URL only |
 | Phase 4 (Completion) | Full report | **Skip** (pattern already output) |
 
-**Detection**: Reuse Caller Context determination in the "Caller Context and End-to-End Flow" section below.
-
----
-
-Execute the following phases in order when this command is invoked.
+判定は下記 Caller Context 表。
 
 ## Caller Context and End-to-End Flow
 
 > **Plugin Path**: Resolve `{plugin_root}` per [Plugin Path Resolution](../../references/plugin-path-resolution.md#resolution-script-full-version) before executing bash hook commands in this file.
-
-This command can be invoked in two ways: standalone execution or from an orchestrator's end-to-end flow (e.g. `/rite:open` ステップ 6).
 
 | Caller | Subsequent Action |
 |-----------|---------------|
 | End-to-end flow (via any orchestrator's Skill tool invocation, e.g. `/rite:open` ステップ 6) | **Output pattern and return control to caller** |
 | Standalone execution | Display "next steps" guidance |
 
-**Determination method**: Claude determines the caller from conversation context:
-
 | Condition | Determination |
 |------|---------|
 | Invoked via `Skill` tool from any orchestrator within the same session (caller-name agnostic — e.g. `/rite:open`) | Within end-to-end flow |
 | All other cases (user directly typed `/rite:pr-create`) | Standalone execution |
 
-> **Important (responsibility for flow continuation)**: When executed within the end-to-end flow, this Skill outputs a machine-readable output pattern (`[pr:created:{number}]` or `[pr-create-failed]`) and **returns control to the caller** (orchestrator). The caller determines the next action based on this output pattern.
+E2E では `[pr:created:{number}]` / `[pr-create-failed]` を出して **caller に制御を返す**。次アクションは caller が決める。
 
 ---
 
@@ -65,11 +55,7 @@ This command can be invoked in two ways: standalone execution or from an orchest
 
 ## Phase 0: Load Work Memory (During End-to-End Flow)
 
-When executed within the end-to-end flow, load necessary information from work memory (shared memory).
-
 ### 0.1 Determine End-to-End Flow Status
-
-Determine the caller from conversation context:
 
 | Condition | Determination | Action |
 |------|---------|------|
@@ -78,16 +64,14 @@ Determine the caller from conversation context:
 
 ### 0.2 Load Work Memory
 
-Extract Issue number from the current branch and retrieve work memory from local file (SoT):
+ブランチ名から Issue 番号を取り、ローカル work memory（SoT）を読む:
 
 ```bash
 # ブランチ名から Issue 番号を抽出
 issue_number=$(git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
 ```
 
-**Local work memory (SoT)**: Read `.rite-work-memory/issue-{issue_number}.md` with the Read tool. This local file is the Source of Truth.
-
-**Fallback (local file missing/corrupt)**: If the local file does not exist or is corrupt, fall back to the Issue comment API:
+Read `.rite-work-memory/issue-{issue_number}.md`（SoT）。欠落 / 破損時は Issue comment API:
 
 ```bash
 # SSH host alias 対応: git-remote.sh 優先 + gh repo view fallback
@@ -106,8 +90,6 @@ gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
 
 ### 0.3 Information to Retrieve
 
-Extract the following information from work memory and retain in context:
-
 | Field | Extraction Pattern | Purpose |
 |-----------|-------------|------|
 | Issue number | `issue-(\d+)` from branch name | Generate `Closes #XX` in PR body |
@@ -115,9 +97,7 @@ Extract the following information from work memory and retain in context:
 | Phase | `- **フェーズ**: (.+)` | Confirm flow position |
 | lint results | `### 品質チェック履歴` section | Reflect in PR body |
 
-**If work memory is not found:**
-
-If Issue number cannot be retrieved, delegate to Phase 1.4 fallback processing.
+Issue 番号が取れなければ Phase 1.4。
 
 ---
 
@@ -125,13 +105,12 @@ If Issue number cannot be retrieved, delegate to Phase 1.4 fallback processing.
 
 ### 1.0 Bang-Backtick Adjacency Pre-Check (Pre-PR Gate)
 
-> **Reference**: Pre-submission hard gate for the parser-trigger pattern (backtick + bang adjacency in inline code spans of `plugins/rite/{commands,skills,agents,references}/**/*.md`). The underlying static check is `plugins/rite/hooks/scripts/bang-backtick-check.sh`.
+> **DRIFT-CHECK ANCHOR (MUST)**: `skills/pr-create/SKILL.md` §1.0 と `skills/ready/SKILL.md` §1.0 の bash は同期する。片方の変更は必ず他方へ複製する。
 >
-> **DRIFT-CHECK ANCHOR (MUST)**: This bash block is intentionally synchronized between `skills/pr-create/SKILL.md` §1.0 and `skills/ready/SKILL.md` §1.0. Any modification to either side MUST be replicated to the other. Wiki 経験則「Asymmetric Fix Transcription (対称位置への伝播漏れ)」の dominant failure mode を構造的に予防する。
->
-> **Independent of the `/rite:lint` Phase 3.5 bang-backtick check**: lint records bang-backtick findings as warnings (`[lint:success]` is preserved). This gate, in contrast, **blocks** PR mutation when the same pattern is present — lint is the early heads-up, this is the final hard gate before submission.
+> lint Phase 3.5 は warning（`[lint:success]` は保つ）。本ゲートは同じパターンが残っていれば **PR mutation を止める**。
+> rationale: references/rationale.md#bang-backtick-gate
 
-Resolve plugin_root with the inline one-liner (per [Plugin Path Resolution](../../references/plugin-path-resolution.md#inline-one-liner-for-command-files)) and run the check:
+`{plugin_root}` は [inline one-liner](../../references/plugin-path-resolution.md#inline-one-liner-for-command-files) で解決して実行する:
 
 ```bash
 plugin_root=$(cat .rite-plugin-root 2>/dev/null || bash -c 'if [ -d "plugins/rite" ]; then cd plugins/rite && pwd; elif command -v jq &>/dev/null && [ -f "$HOME/.claude/plugins/installed_plugins.json" ]; then jq -r "limit(1; .plugins | to_entries[] | select(.key | startswith(\"rite@\"))) | .value[0].installPath // empty" "$HOME/.claude/plugins/installed_plugins.json"; fi')
@@ -169,7 +148,8 @@ case "$bang_rc" in
 esac
 ```
 
-> **On exit 1 from this bash block**: The bash block exits before any `skills/pr-create/SKILL.md` result pattern (`[pr:created:{N}]` / `[pr-create-failed]`) is emitted, so the orchestrator treats this as a missing-result-pattern Skill invocation — default 経路は `WARNING` を stderr に出力し、AskUserQuestion で「手動作成 / 再試行 / 中止」を提示する — **NOT** a `[pr-create-failed]` pattern. The `BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` retention flag is a stderr-only diagnostic; operators must triage the retained flag manually for invocation-side failures (script missing / rc=2). For finding detection (rc=1 — a normal "fix the code" feedback path), no flag is set at all (the failure is expected and the user fixes the code).
+> exit 1 のとき結果パターンは出ない。orchestrator は missing-result-pattern として扱う（**NOT** `[pr-create-failed]`）。default は stderr `WARNING` + AskUserQuestion「手動作成 / 再試行 / 中止」。`BANG_BACKTICK_CHECK_INVOCATION_FAILED=1` は script 不在 / rc=2 のみ（rc=1 の検出はフラグなし）。
+> rationale: references/rationale.md#bang-backtick-gate
 
 ### 1.1 Retrieve Base Branch
 
@@ -179,18 +159,8 @@ Read `rite-config.yml` at the project root using the Read tool, and get the `bra
 Read: rite-config.yml
 ```
 
-**Retrieval logic:**
-1. If `rite-config.yml` exists and `branch.base` is set -> Use that value as `{base_branch}`
-2. If `rite-config.yml` does not exist (Read tool returns an error), or `branch.base` is not set -> Use `main` as default
-
-**Definition of "not set":**
-- `branch.base` key does not exist
-- `branch.base` key value is `null` or empty string
-- `branch` section itself does not exist
-
-**Placeholder interpretation:**
-
-`{base_branch}` in this document is replaced with the actual branch name obtained by the logic above. For example, if `branch.base: "develop"` is configured, the subsequent bash command `git diff --stat origin/{base_branch}...HEAD` is executed as `git diff --stat origin/develop...HEAD`.
+1. `rite-config.yml` に `branch.base` があればその値を `{base_branch}` にする
+2. ファイル不在 / キー不在 / `null` / 空文字 / `branch` 節不在 → `main`
 
 ### 1.2 Branch Verification
 
@@ -232,7 +202,8 @@ git log --oneline origin/{base_branch}...HEAD
 3. 手動で差分を確認: git diff <base_branch>...HEAD
 ```
 
-Terminate processing. Do not fall back to `HEAD` diff — this would produce an inaccurate change summary.
+処理を中止する。`HEAD` 差分へ倒さない。
+rationale: references/rationale.md#no-head-diff-fallback
 
 **If no commits exist:**
 
@@ -293,10 +264,7 @@ Retrieve work memory from Issue comments:
 gh api repos/{owner}/{repo}/issues/{issue_number}/comments --jq '.[] | select(.body | contains("rite 作業メモリ"))'
 ```
 
-If work memory is found, extract the following information:
-- Progress status
-- Changed files
-- Decisions and notes
+見つかれば進捗・変更ファイル・決定事項を抽出する。
 
 ---
 
@@ -304,7 +272,7 @@ If work memory is found, extract the following information:
 
 ### 2.1 Verify Auto-Detected Commands
 
-Retrieve build/lint commands from `rite-config.yml`:
+`rite-config.yml` から build/lint コマンドを取る:
 
 ```yaml
 commands:
@@ -312,14 +280,11 @@ commands:
   lint: null   # 自動検出
 ```
 
-Auto-detection logic:
-1. Detect from `scripts` in `package.json`
-2. Detect from targets in `Makefile`
-3. Language-specific default commands
+自動検出: `package.json` の `scripts` → `Makefile` の target → 言語既定。
 
 ### 2.2 Confirm Quality Check Execution
 
-Confirm execution with `AskUserQuestion`:
+`AskUserQuestion`:
 
 ```
 PR 作成前に品質チェックを実行しますか？
@@ -335,8 +300,6 @@ PR 作成前に品質チェックを実行しますか？
 ```
 
 ### 2.3 Execute Checks
-
-Execute the selected checks:
 
 ```bash
 # lint 実行例
@@ -358,11 +321,11 @@ npm run lint
 
 ### 2.4 Verify Issue Body Checklist
 
-If the Issue body contains a checklist, check for incomplete items and display a warning.
+Issue 本文にチェックリストがあれば未完了を警告する。
 
 #### 2.4.1 Extract Checklist
 
-Extract checklist from the Issue body obtained in Phase 1.5:
+Phase 1.5 の本文から抽出:
 
 ```bash
 # Issue 本文を取得（既に Phase 1.5 で取得済みの場合は再利用）
@@ -377,7 +340,7 @@ gh issue view {issue_number} -R {owner_repo} --json body --jq '.body'
 
 **Exclusion pattern:**
 
-Exclude Tasklists containing Issue references (used for parent-child Issue management):
+親子管理の Issue 参照 Tasklist は除外:
 
 ```
 パターン: /^- \[[ xX]\] #\d+/gm
@@ -385,13 +348,7 @@ Exclude Tasklists containing Issue references (used for parent-child Issue manag
 
 #### 2.4.2 Detect Incomplete Check Items
 
-Detect incomplete items (`- [ ]`) from the extracted checklist.
-
-**If no incomplete items (all checklist items completed):**
-
-If a checklist exists and all items are completed (`- [x]`), proceed to Phase 2.5.
-
-**If incomplete items exist:**
+未完了は `- [ ]`。全完了（`- [x]`）またはチェックリスト無しなら Phase 2.5。未完了があれば:
 
 ```
 警告: Issue 本文に未完了のチェック項目があります
@@ -417,7 +374,7 @@ If a checklist exists and all items are completed (`- [x]`), proceed to Phase 2.
 
 #### 2.4.3 Record Incomplete Items in PR Body
 
-If "Create PR with incomplete items" is selected, add the following section to the PR body:
+「未完了のまま PR 作成」なら PR 本文へ:
 
 ```markdown
 ## 未完了の Issue チェック項目
@@ -433,17 +390,13 @@ If "Create PR with incomplete items" is selected, add the following section to t
 
 #### 2.4.4 If No Checklist Exists
 
-If the Issue body does not contain a checklist, skip this section and proceed to Phase 2.5.
+チェックリストが無ければ Phase 2.5。
 
 ### 2.5 Verify Unresolved Issues (issue_accountability)
 
-> **Reference**: [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md) - `issue_accountability` (Sincere response to identified issues)
-
-Before creating the PR, verify that there are no unresolved issues or findings.
+> **Reference**: [AI Coding Principles](../../skills/rite-workflow/references/coding-principles.md) - `issue_accountability`
 
 #### 2.5.1 Verification Targets
-
-Detect unresolved issues from the following sources:
 
 | Source | What to Verify |
 |--------|----------|
@@ -451,15 +404,11 @@ Detect unresolved issues from the following sources:
 | Conversation history | Warnings/errors detected by lint/test |
 | Review results in conversation history | Findings judged as "out of scope" or "not applicable" (including self-review results)[^1] |
 
-[^1]: If self-review results do not exist in the same session (e.g., when `/rite:pr-create` is executed standalone), this source is skipped.
+[^1]: 同一セッションに self-review が無い（standalone 起動など）ならこの source は skip。
 
 #### 2.5.2 Verify Work Memory
 
-Parse the "要確認事項" section of work memory.
-
-**Note**: If work memory was already retrieved in Phase 0.2, reuse that content without making another API call. For standalone execution, use values (`{owner}`, `{repo}`, `{issue_number}`) already retrieved in Phase 1.6.
-
-**Determination method**: If work memory has already been retrieved within this session (API call made in Phase 0.2 or Phase 1.6), the result is retained in context, so the command below is not executed; instead, the retained content is referenced.
+Phase 0.2 / 1.6 で取得済みなら再利用。未取得のときだけ:
 
 ```bash
 # 作業メモリから要確認事項を抽出（Phase 0.2 または Phase 1.6 で未取得の場合のみ実行）
@@ -467,21 +416,18 @@ gh api repos/{owner}/{repo}/issues/{issue_number}/comments \
   --jq '.[] | select(.body | contains("📜 rite 作業メモリ")) | .body'
 ```
 
-Claude extracts the "### 要確認事項" section from the retrieved work memory body and detects unchecked items (`- [ ]` format).
+`### 要確認事項` の `- [ ]` を検出する。bash の `grep -A` 等は使わない。
+rationale: references/rationale.md#no-bash-grep-wm
 
-**Note**: Do not use bash text processing (`grep -A`, etc.); Claude analyzes the entire body to identify the section. This avoids line count limitation issues.
-
-If unchecked items exist, display a warning.
+未チェックがあれば警告。
 
 #### 2.5.3 Detection from Conversation History
 
-Claude **reviews conversations within its own context window** and checks whether there are statements matching the following **specific patterns**.
-
-Detect the following from conversation context: "out of scope"/"not applicable" judgments, "pre-existing issue" judgments, unresolved lint/test warnings, newly added TODO/FIXME comments (detected via `git diff origin/{base_branch}...HEAD | grep -E "^\+.*(TODO:|FIXME:|XXX:)"`). Resolved determination: if any of the following exists in conversation history, consider it resolved: fix (Edit/Write), Issue creation (`gh issue create`), or explanation/reply.
+会話 context から検出: 「対象外」/「該当せず」/「既存問題」、未解決の lint/test 警告、新規 TODO/FIXME（`git diff origin/{base_branch}...HEAD | grep -E "^\+.*(TODO:|FIXME:|XXX:)"`）。解決済み: 修正（Edit/Write）、Issue 作成（`gh issue create`）、説明/返信のいずれかがあれば解決。
 
 #### 2.5.4 Processing When Unresolved Issues Exist
 
-If unresolved issues are detected, confirm with `AskUserQuestion`:
+`AskUserQuestion`:
 
 ```
 警告: 未対応の問題・指摘があります
@@ -501,9 +447,7 @@ If unresolved issues are detected, confirm with `AskUserQuestion`:
 - PR 作成を中止する: 問題を確認してから再実行します
 ```
 
-**Note**: `{problem_summary}` and `{detection_source}` are the same placeholders defined in Phase 2.5.5.
-
-**Subsequent processing for each option:**
+`{problem_summary}` / `{detection_source}` は 2.5.5 と同じ。
 
 | Option | Subsequent Processing |
 |--------|----------|
@@ -511,11 +455,8 @@ If unresolved issues are detected, confirm with `AskUserQuestion`:
 | **問題を今すぐ修正する** | Display guidance to fix unresolved issues and re-run `/rite:pr-create`, then terminate processing |
 | **PR 作成を中止する** | Terminate processing |
 
-**When there are many issues (5 or more):**
-
-**Note**: This threshold (5) is a fixed value and cannot be changed in `rite-config.yml`. It is set to optimize user experience by recommending batch processing.
-
-If 5 or more unresolved issues are detected, recommend batch processing:
+5 件以上は一括を推奨（閾値は固定）。
+rationale: references/rationale.md#issue-accountability-never-skip
 
 ```
 警告: 未対応の問題・指摘が {count} 件あります（5件以上）
@@ -536,19 +477,13 @@ If 5 or more unresolved issues are detected, recommend batch processing:
 
 #### 2.5.5 Auto-Create Issues
 
-If "Create separate Issues and continue with PR creation" is selected, create an Issue for each unresolved problem:
+「別 Issue を作成して続行」なら未対応ごとに 1 Issue。
 
 > **Reference**: [Issue Creation with Projects Integration](../../references/issue-create-with-projects.md)
 
-**Note**: The heredoc below contains `{placeholder}` markers. Claude substitutes these with actual values **before** generating the bash script — they are not shell variables.
+heredoc の `{placeholder}` はスクリプト生成前に実値へ置換（シェル変数ではない）。ブロック全体を **単一 Bash 呼び出し**で実行する。Priority 既定 → Medium。Complexity: XS = 1 行/1 箇所、S = 1–2 ファイルの複数行。
 
-**Important**: The entire script block must be executed in a **single Bash tool invocation**.
-
-**Priority mapping**: Default → Medium
-
-**Complexity mapping**: XS: single-line/single-location fix. S: multi-line change within 1-2 files
-
-**Placeholder value sources** (Claude はスクリプト生成前に必ず以下のソースから値を取得し、プレースホルダーを置換すること):
+プレースホルダーはスクリプト生成前に置換する:
 
 | Placeholder | Source | Example |
 |-------------|--------|---------|
@@ -634,11 +569,7 @@ printf '%s' "$result" | jq -r '.warnings[]' 2>/dev/null | while read -r w; do ec
 | Script returns `issue_url: ""` | Display warning with error details. If remaining candidates exist, continue creating others |
 | `project_registration: "partial"` or `"failed"` | Display warnings from result. Issue creation itself succeeded |
 
-Apply the `tech-debt` label only if it exists (skip if not). On Issue creation failure, choose retry/skip/abort (max 2 retries).
-
-After creation, append to the "Related Issues" section of the PR body:
-
-**Sequential suffix naming convention**: When creating multiple Issues, assign sequential suffixes `_1`, `_2`, ... in creation order. For example, if 3 Issues are created, they become `{created_issue_1}`, `{created_issue_2}`, `{created_issue_3}`.
+`tech-debt` ラベルは存在するときだけ。作成失敗は retry/skip/abort（最大 2 回）。作成後、PR 本文の「関連 Issue」へ追記。複数時は作成順に `_1`, `_2`, ...。
 
 ```markdown
 ## 関連 Issue
@@ -653,17 +584,13 @@ Closes #{original_issue_number}
 
 #### 2.5.6 If No Issues Found
 
-If no unresolved issues are detected:
-
 ```
 未対応の問題は検出されませんでした。Phase 3 へ進みます。
 ```
 
-Proceed to Phase 3.
+Phase 3 へ。
 
 #### 2.5.7 Behavior During End-to-End Flow
-
-Behavior when invoked from an orchestrator (e.g. `/rite:open` ステップ 6):
 
 | Situation | Behavior |
 |------|------|
@@ -671,7 +598,8 @@ Behavior when invoked from an orchestrator (e.g. `/rite:open` ステップ 6):
 | Unresolved issues (fewer than 5) | Proceed to Phase 3 after individual confirmation |
 | Unresolved issues (5 or more) | Proceed to Phase 3 after batch confirmation |
 
-**Important**: Even within the end-to-end flow, verification of unresolved issues is **never skipped**. This is the core of the `issue_accountability` principle and is mandatory to prevent suppression of issues.
+E2E でも未対応問題の検証は **skip しない**。
+rationale: references/rationale.md#issue-accountability-never-skip
 
 ---
 
@@ -679,11 +607,7 @@ Behavior when invoked from an orchestrator (e.g. `/rite:open` ステップ 6):
 
 ### 3.1 Generate PR Title
 
-Generate the title in Conventional Commits format:
-
-**Language determination rules:**
-
-Determine the PR title language according to the `language` setting in `rite-config.yml`:
+Conventional Commits。言語は `rite-config.yml` の `language`:
 
 | Setting | Behavior |
 |--------|------|
@@ -691,14 +615,9 @@ Determine the PR title language according to the `language` setting in `rite-con
 | `ja` | Generate title in Japanese |
 | `en` | Generate title in English |
 
-**Note**: If the Issue title is in a different language from the configured language, translate to the configured language when generating the title.
+Issue タイトルが設定言語と違うときは翻訳する。type はブランチ名、scope / description は Issue タイトル。
 
-**Title generation rules:**
-1. Use the type from the branch name
-2. Extract scope and description from the Issue title
-3. Generate the title in the determined language
-
-> **⚠️ CRITICAL**: The `description` part of the PR title **MUST** follow the `language` setting in `rite-config.yml`. The examples below are for reference only — always generate the description in the language determined by the setting, not by copying the example language.
+> **⚠️ CRITICAL**: PR title の `description` は `language` 設定に従う。例の言語をコピーしない。
 
 ```
 Pattern: {type}({scope}): {description}
@@ -721,9 +640,7 @@ Example (Japanese): feat(pr): /rite:pr-create コマンドを実装
 
 Template file: `templates/pr/generic.md`
 
-**Language consistency rules:**
-
-Generate the PR body in **the same language determined in Phase 3.1**:
+本文言語は **Phase 3.1 と同じ**。
 
 | Element | Subject to Language Unification |
 |------|---------------|
@@ -731,44 +648,40 @@ Generate the PR body in **the same language determined in Phase 3.1**:
 | Boilerplate text | Description for `Closes #XX`, etc. |
 | Checklist items | `- [ ] Tests added` / `- [ ] テスト追加`, etc. |
 
-Information to include in the PR body: summary, related Issue (`Closes #{number}`), changes (from work memory or git diff), checklist, Implementation Notes summary (§3.2.2, when applicable). Generate all in the language determined in Phase 3.1.
+含める: 概要、関連 Issue（`Closes #{number}`）、変更（work memory または git diff）、チェックリスト、Implementation Notes（§3.2.2、該当時）。
 
 #### 3.2.1 Context Optimization During End-to-End Flow
 
-When executed via an orchestrator's end-to-end flow (e.g. `/rite:open` ステップ 6), apply the following optimizations to reduce context usage.
-
-**Optimization conditions (OR evaluation):** During end-to-end flow execution / 20 or more changed files / Over 30 tool invocations. 30 invocations is lightweight optimization for PR creation alone; 50 invocations (see `skills/open/SKILL.md` 等の上位 orchestrator) is full-scale mitigation.
-
-**Optimization content:** Changes -> file list and summary only (show top 3 files), Work memory -> progress summary only, Checklist -> mandatory items only, Implementation Notes -> capped per §3.2.2's E2E optimization cap rule. Applied automatically without user confirmation.
+OR: E2E 実行中 / 変更ファイル 20 以上 / ツール呼び出し 30 超。確認なしで適用。変更は上位 3 ファイルの一覧と要約、work memory は進捗要約、チェックリストは必須項目のみ、Implementation Notes は §3.2.2 の cap。
+rationale: references/rationale.md#impl-notes-for-reviewers
 
 #### 3.2.2 Implementation Notes Summary (Plan Deviation / Decision Log)
 
-Before finalizing the PR body, gather two additional sources so reviewers start with the same unknowns the implementer had (rather than re-deriving them from the diff alone):
+1. **Work memory Plan Deviation Log**（`### 計画逸脱ログ` — [Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#plan-deviation-log-section)）。ローカル SoT、無ければ Issue comment。`_計画逸脱はありません_` / 節不在は 0 件（error にしない）。
+2. **Issue body Section 9 Decision Log**（`## 9. Decision Log` — [Issue Template Structure](../../templates/issue/template-structure.md)）。context の本文。`D-xx:` 無しは 0 件。
 
-1. **Work memory Plan Deviation Log** (`### 計画逸脱ログ` table — see [Work Memory Format](../../skills/rite-workflow/references/work-memory-format.md#plan-deviation-log-section)). Read the local work memory file or, if absent, the Issue comment sync. If the table shows only `_計画逸脱はありません_` (or the section/file is absent), treat this source as 0 items — do not error.
-2. **Issue body Section 9 Decision Log** (`## 9. Decision Log` — see [Issue Template Structure](../../templates/issue/template-structure.md)). Read the Issue body already retained in conversation context. If the section is absent or contains no `D-xx:` entries, treat this source as 0 items — do not error.
+各項目 1 行: `{種別}: {1 行要約} — {理由}`。`種別` は Phase 3.1 の言語（`en`: Deviation / Decision、`ja`: 逸脱 / 判断）。1 文。ポインタであり全文転記ではない。
 
-**Summarization rule**: For each item found, generate one line: `{種別}: {1 行要約} — {理由}`, where `種別` is `Deviation` / `逸脱` (from the Plan Deviation Log) or `Decision` / `判断` (from the Decision Log), following the language determined in Phase 3.1 — use the English label in `en` mode and the Japanese label in `ja` mode, matching the heading's language switch below. Keep each line to a single sentence — this is a pointer for the reviewer, not a full transcript.
+**Zero-item rule (MUST)**: 両ソース 0 件なら節ごと省略（見出し含む）。空見出し・空リストは出さない。
 
-**Zero-item rule (MUST)**: If both sources yield 0 items, omit the entire section — heading included. Never emit an empty heading or an empty bullet list.
+見出し: `## Implementation Notes`（en）/ `## 実装中の判断・計画逸脱`（ja）。位置は `## Changes` と `## Checklist` の間（`templates/pr/generic.md`）。
 
-**Section heading**: Follow the language determined in Phase 3.1 — `## Implementation Notes` (English) or `## 実装中の判断・計画逸脱` (Japanese). Place the section between `## Changes` and `## Checklist` (see `templates/pr/generic.md`).
-
-**E2E optimization cap**: When Phase 3.2.1's optimization conditions are met, cap the summary to the top 3 items — Plan Deviation items first, then Decision Log items, both in source order — and append a note stating how many were omitted (e.g. `(他 N 件省略)` / `(N more omitted)`).
+E2E 最適化時は上位 3 件（逸脱 → 判断、ソース順）、省略数を注記（`(他 N 件省略)` / `(N more omitted)`）。
+rationale: references/rationale.md#impl-notes-for-reviewers
 
 ### 3.3 Push to Remote
-
-Push the local branch to remote:
 
 ```bash
 git push origin {branch_name}
 ```
 
-> `-u`（upstream 設定）は付けない。sandbox 有効環境で upstream tracking の `.git/config` 書込が拒否されるため。3.4 の `gh pr create` は `--head` で明示的にブランチを指定するため upstream に依存しない。
+> `-u` は付けない。3.4 の `gh pr create` は `--head` でブランチを指定する。
+> rationale: references/rationale.md#push-no-upstream
 
 ### 3.4 Create Draft PR
 
-> **3 段プロトコル**: PR title / body をインライン heredoc・インライン `--title` で bash ブロックに埋め込むと、特殊文字（全角記号・`≠`・括弧・コロン等）を含む長文で Claude のツールコール解析が malform し、エラーなく無言でターンが終了する。これを構造的に避けるため、LLM は (A) workdir を `mktemp -d` で確保 → (B) **Write tool** で title / body を raw ファイル化（heredoc を使わない）→ (C) bash は変数 / `--body-file` 経由で `gh pr create` を実行、の 3 段で行う。title 特殊文字を bash ブロックに一切インライン展開しないのがこの設計の要点。
+> **3 段プロトコル**: (A) workdir を `mktemp -d` で確保 → (B) **Write tool** で title / body を raw ファイル化（heredoc を使わない）→ (C) bash は変数 / `--body-file` 経由で `gh pr create` を実行。title を bash ブロックにインライン展開しない。
+> rationale: references/rationale.md#three-stage-protocol
 
 **(A) workdir 確保**
 
@@ -786,9 +699,8 @@ echo "[CONTEXT] PR_CREATE_WORKDIR=$pr_workdir"
 
 **(C) gh pr create（単一 bash block）**
 
-> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換する（`mktemp -d` 生成パスのため特殊文字を含まない）。冒頭で literal を shell 変数 `pr_workdir` に束縛し、以降の cat / `--body-file` / cleanup すべてで `$pr_workdir` を参照する（literal placeholder 置換漏れ時の `rm -rf "{...}"` 誤動作を防ぐ）。title は変数（ファイル読込）経由のため bash ブロックに inline しない。workdir の cleanup は inline `rm -rf` ではなく **signal-specific trap** で行い、空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP のすべての exit 経路で確実に削除する（同一ファイル他ブロック・`coding-principles.md` Rule 5・[bash-trap-patterns.md](../../references/bash-trap-patterns.md#signal-specific-trap-template) の canonical 形に準拠）。空 body / 空 title チェックは title / body が動的生成のため必須（body と title は対称にガードする）。
->
-> **既知の trade-off (Cause A)**: 3 段プロトコルは workdir を (A)/(B Write)/(C) の **別プロセス**に跨がせるため、malformed tool-call で (A) 確保後・(C) 到達前に無言終了した場合（Cause A: harness/transport 側ゆらぎ、rite では除去不能）、`mktemp -d` した空 workdir が orphan として残る。本 trap は (C) 自身の中断のみカバーし、この cross-process orphan は救えない（OS の `/tmp` reaping と `/rite:recover` 再開で実害は限定的）。この `rite-pr-create-*` 孤児 workdir の能動的 GC は `pr-cycle-cleanup.sh` Step 3 で実装済み — review/fix/cleanup の各サイクルで `${TMPDIR:-/tmp}/rite-pr-create-*` のうち age 超過 (mtime > 24h) のものを回収する。age ガードにより in-flight workdir は誤回収されない。
+> `{PR_CREATE_WORKDIR}` は (A) の CONTEXT marker から literal 置換し、冒頭で `pr_workdir` に束縛する。以降は `$pr_workdir` のみ。title は変数経由（bash に inline しない）。cleanup は **signal-specific trap**（空 body / 空 title / `gh` 失敗 / SIGINT/TERM/HUP）。空 title / 空 body は対称にガードする。[bash-trap-patterns.md](../../references/bash-trap-patterns.md#signal-specific-trap-template)
+> rationale: references/rationale.md#three-stage-protocol
 
 ```bash
 pr_workdir="{PR_CREATE_WORKDIR}"
@@ -816,13 +728,12 @@ gh pr create -R {owner_repo} --draft --base "{base_branch}" --head "{branch_name
 
 ### 3.5 Update Work Memory Phase
 
-After PR creation, update the local work memory (SoT) and sync to Issue comment (backup).
-
-**Note**: Phase 3.5 performs immediate phase transition (`pr`) right after PR creation. Phase 4.1.2 later adds detailed information (progress summary, changed files, PR metadata). The `update-progress` in Phase 4.1.2 also updates the timestamp, effectively superseding Phase 3.5's timestamp. This two-step approach ensures the phase transition is recorded even if Phase 4 fails.
+ローカル SoT を更新し、Issue comment へ backup sync。3.5 は `phase=pr` の即時遷移、4.1.2 が詳細を足す。
+rationale: references/rationale.md#wm-two-step
 
 **Step 1: Update local work memory**
 
-Use the self-resolving wrapper. See [Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands) for details.
+[Work Memory Format - Usage in Commands](../../skills/rite-workflow/references/work-memory-format.md#usage-in-commands)
 
 ```bash
 WM_SOURCE="create" \
@@ -855,11 +766,7 @@ bash {plugin_root}/hooks/issue-comment-wm-sync.sh update \
 
 > **Warning**: Work memory is published as Issue comments. In public repositories, it is viewable by third parties. Do not record confidential information (credentials, personal information, internal URLs, etc.) in work memory.
 
-Automatically update the Issue's work memory comment.
-
 #### 4.1.1 Collect Update Information
-
-Automatically collect the following information during PR creation:
 
 ```bash
 # 変更ファイルの取得
@@ -871,7 +778,7 @@ git log --oneline origin/{base_branch}...HEAD
 
 #### 4.1.2 Retrieve and Update Work Memory Comment
 
-The update has two parts: (A) **update progress and changed files**, and (B) **append PR-specific sections**. Both use `issue-comment-wm-sync.sh` for deterministic execution.
+(A) 進捗と変更ファイル、(B) PR 固有節の追記。どちらも `issue-comment-wm-sync.sh`。
 
 ```bash
 # Part (A): 進捗サマリー + 変更ファイル更新
@@ -930,9 +837,7 @@ rm -f "$pr_info_tmp"
 
 #### 4.1.3 Update Content Reference
 
-The 4.1.2 bash block performs the following updates:
-
-**(A) Update existing sections** (via Python inline script):
+4.1.2 の更新内容:
 
 | Section | Update |
 |---------|--------|
@@ -941,22 +846,16 @@ The 4.1.2 bash block performs the following updates:
 | `次のステップ` section | Set to `/rite:pr-review #{pr_number}` |
 | `最終更新` timestamp | Replace with current timestamp |
 
-**(B) Append new sections** (via heredoc):
+`{pr_number}` は実番号。placeholder のまま残さない。
 
-**Note**: `{pr_number}` is replaced with the actual PR number when recording. It must not be recorded as a placeholder.
-
-**Changed files format** (for `changed_files_md`):
-
-Generate from `git diff --name-status origin/{base_branch}...HEAD`:
+`changed_files_md` は `git diff --name-status origin/{base_branch}...HEAD` から:
 
 ```markdown
 - `path/to/file1.ts` - 変更
 - `path/to/file2.ts` - 追加
 ```
 
-Status mapping: `A` → 追加, `M` → 変更, `D` → 削除, `R` → 名前変更.
-
-**Note**: If the work memory comment is not found, skip the update and display a warning.
+`A` → 追加, `M` → 変更, `D` → 削除, `R` → 名前変更。work memory comment が無ければ警告して skip。
 
 ### 4.2 Completion Report
 
@@ -995,19 +894,15 @@ Follow `language` in `rite-config.yml` (`auto`: detect input language, `ja`: Jap
 
 ### 5.1 Output Pattern (Return Control to Caller)
 
-Output the following pattern based on PR creation result:
-
 | State | Output Pattern |
 |-------|---------------|
 | PR creation succeeded | `[pr:created:{pr_number}]` |
 | PR creation failed | `[pr-create-failed]` |
 
-**Important**:
-- Do **NOT** invoke `rite:pr-review` via the Skill tool
-- Return control to the caller (orchestrator — caller-name agnostic, e.g. `/rite:open`)
-- The caller determines the next action based on this output pattern
+`rite:pr-review` を Skill で **呼ばない**。caller（orchestrator）に制御を返す。
 
-> **Missing-sentinel recovery contract**: Phase 3.4 で `gh pr create` が malformed tool-call により sentinel を 1 つも emit せず無言でターンが終了する（Cause A: harness/transport 側のゆらぎ。rite では除去不能）ことがある。この場合 caller（orchestrator）は `[pr:created:{N}]` / `[pr-create-failed]` のいずれも context に観測できないため **missing-sentinel** として扱う。本 Skill は flow-state を所有せず caller が `phase` を保持するため、caller 側の missing-sentinel 検出 → `/rite:recover` 再開で PR 作成ステップを安全にやり直せる（重複 draft PR の検出・再構成は orchestrator の resume 経路が担う。`skills/open/SKILL.md` ステップ 0 phase=pr / ステップ 6 参照）。Phase 3.4 の Write tool 委譲はこの Cause A 自体を消すものではなく、Cause B（インライン heredoc / 特殊文字 title による malform 増幅）を除去して発生確率を下げる対策である。
+> **Missing-sentinel recovery contract**: Phase 3.4 が sentinel 無しで無言終了したら、caller は `[pr:created:{N}]` / `[pr-create-failed]` を観測できず **missing-sentinel** として扱う。再開は caller の `/rite:recover`（`skills/open/SKILL.md` ステップ 0 phase=pr / ステップ 6）。
+> rationale: references/rationale.md#missing-sentinel-recovery
 
 **Example output:**
 ```
@@ -1018,4 +913,4 @@ PR #{pr_number} をドラフトとして作成しました。
 
 ### 5.2 Behavior During Standalone Execution
 
-For standalone execution, skip Phase 5 entirely and display the Phase 4.2 completion report (see the blockquote at the beginning of Phase 5 for details).
+standalone は Phase 5 を skip し、Phase 4.2 の完了報告を出して終了する。

--- a/plugins/rite/skills/pr-create/references/rationale.md
+++ b/plugins/rite/skills/pr-create/references/rationale.md
@@ -1,0 +1,77 @@
+# /rite:pr-create — 設計理由
+
+`skills/pr-create/SKILL.md` から退避した rationale（設計理由・背景・過去の障害）。本体は各該当箇所に
+`rationale: references/rationale.md#<anchor>` の 1 行ポインタだけを残す。
+
+ここにあるのは **why** のみ。分岐表・sentinel 一覧・bash ブロックといった実行時に必要な機械
+インターフェースは本体が SoT であり、本ファイルへ複製しない。
+
+## bang-backtick-gate
+
+lint Phase 3.5 は同一パターンを warning として記録するだけで `[lint:success]` を保つ。本ゲートは
+提出直前の hard gate で、同じパターンが残っていると PR 変異を止める。早期の heads-up と最終
+block を分離しないと、warning を見たまま提出してしまう。
+
+bash 本体は `skills/ready/SKILL.md` §1.0 と同期する。片方だけ直すと Wiki 経験則
+「Asymmetric Fix Transcription（対称位置への伝播漏れ）」が再発する。
+
+exit 1 のあと本スキルの結果パターンは出ない。orchestrator は missing-result-pattern として扱い、
+`[pr-create-failed]` には倒さない。検出（rc=1）は「コードを直す」通常経路なので
+`BANG_BACKTICK_CHECK_INVOCATION_FAILED` を立てない。立てるのは script 不在 / 起動失敗（rc=2）
+だけで、運用者が手動 triage する。
+
+## no-head-diff-fallback
+
+`HEAD` 差分へ黙って倒すと、ベースブランチとの差分ではない要約が PR 本文に入る。取得不能は
+エラーで止める。
+
+## issue-accountability-never-skip
+
+E2E でも未対応問題の検証を省くと、`issue_accountability` が「確認は standalone だけ」に縮退する。
+対象外 / 既存問題は対応しない理由にならない。5 件以上の一括は UX 用の固定閾値で、config 化は
+しない（実需が出てから）。
+
+## no-bash-grep-wm
+
+`grep -A` 等の行数制限つき抽出は、要確認事項セクションが長いと途中で切れる。本文全体を読んで
+節を特定する。
+
+## impl-notes-for-reviewers
+
+Plan Deviation Log と Decision Log を PR 本文へ要約するのは、レビュアーが diff だけから
+unknowns を再導出しなくてよいようにするため。両ソース 0 件なら節ごと省略する — 空見出しは
+「判断が無かった」ではなく「書き忘れた」に見える。
+
+E2E の 30 呼び出しは PR 作成単体の軽量最適化、orchestrator 側 50 はフル緩和。閾値を混ぜると
+単独作成でも本文が削られすぎる。
+
+## push-no-upstream
+
+`-u` は sandbox 有効環境で upstream tracking の `.git/config` 書込が拒否される。`gh pr create`
+は `--head` でブランチを明示するため tracking に依存しない。
+
+## three-stage-protocol
+
+title / body をインライン heredoc・インライン `--title` で bash に埋め込むと、特殊文字を含む
+長文でツールコール解析が malform し、エラーなく無言でターンが終わる。workdir 確保 → Write
+tool で raw ファイル化 → 変数 / `--body-file` 経由、の 3 段は title 特殊文字を bash ブロックに
+一切インライン展開しないため、この Cause B を構造的に除く。
+
+signal-specific trap は (C) 自身の中断だけをカバーする。3 段は別プロセスに跨るため、
+malformed tool-call で (A) 確保後・(C) 到達前に無言終了した orphan（Cause A: harness /
+transport 側ゆらぎ、rite では除去不能）は trap では救えない。能動的 GC は
+`pr-cycle-cleanup.sh` Step 3 の 24h age ガード。空 title / 空 body は動的生成なので対称に
+ガードする。`{PR_CREATE_WORKDIR}` を冒頭で shell 変数へ束縛するのは、placeholder 置換漏れ時の
+`rm -rf "{...}"` 誤動作を防ぐため。
+
+## wm-two-step
+
+Phase 3.5 は PR 作成直後に `phase=pr` だけを先に書く。4.1.2 の詳細更新が失敗しても、相転移は
+残る。4.1.2 の timestamp が 3.5 を上書きするのは意図どおり。
+
+## missing-sentinel-recovery
+
+Cause A（harness / transport のゆらぎ）は rite 側では消せない。本スキルは flow-state を持たず
+caller が `phase` を保持するため、missing-sentinel 検出と `/rite:recover` 再開は orchestrator
+の責務。3 段プロトコルは Cause B（インライン heredoc / 特殊文字 title）の発生確率を下げる
+だけで、Cause A 自体は残る。


### PR DESCRIPTION
## Summary

`skill-diet-method.md` を pr-create / lint / issue-implement / issue-close に適用した。散文（bytes_prose）だけを退避・圧縮し、機械レール（fenced block / 表行）は before/after で完全一致。設計理由は各スキル同梱 `references/rationale.md` へ移した。

## Related Issue

Closes #2289

## Changes

- `plugins/rite/skills/pr-create/SKILL.md` + `references/rationale.md` — bytes_prose 20406 → 9081（−55.5%）、bytes_rail 16117 一致
- `plugins/rite/skills/lint/SKILL.md` + `references/rationale.md` — bytes_prose 20294 → 8315（−59.0%）、bytes_rail 14738 一致
- `plugins/rite/skills/issue-implement/SKILL.md` + `references/rationale.md` — bytes_prose 29921 → 20317（−32.1%）、bytes_rail 15951 一致
- `plugins/rite/skills/issue-close/SKILL.md` + `references/rationale.md` — bytes_prose 9046 → 7850（−13.2%）、bytes_rail 22783 一致
- `docs/SPEC.md` — skills ツリーへ `references/rationale.md` 追記

## pin 棚卸し（AC-1）

| テスト | スキル | 分類 | 移送方針 |
|--------|--------|------|----------|
| `work-memory-update.test.sh` | pr-create | パス pin | 変更不要 |
| `bang-backtick-pr-create-pre-check.test.sh` | pr-create / lint | bash 抽出 + フレーズ | フレーズ残置 |
| `create-md-invocation-symmetry.test.sh` | pr-create | bash 抽出 | 変更不要 |
| `pr-create-promotion-contract.test.sh` | pr-create | 散文 pin | `3 段プロトコル` / Write tool / `pr_title=$(cat` 残置 |
| `descriptive-number-diff-gate.test.sh` | lint | 散文 pin | フレーズ残置 |
| `complexity-lane-contract.test.sh` | issue-implement | 散文 pin（他ファイル中心） | 変更不要 |
| `wiki-push-sandbox-retry-contract.test.sh` | issue-close | 見出し + フレーズ | `4.4.W.2` / `commit_rc=4` 残置 |
| `parent-child-sync-static.test.sh` | issue-close | 散文 pin | `## 親 Issue` / trackedIssues / P460 残置 |
| `sh-cross-ref-check.test.sh` | 上記 | 合成 fixture | 変更不要 |
| glob 走査 / sentinel-contract | 上記 | glob | 実行で green |

散文 pin は SKILL.md に残したため、pin テストの移送は発生していない。

## 計測（AC-2）

`skill-rail-diff-check.sh` は 4 本とも `machine rail identical`。hooks suite 138/138、scripts suite 20/20、`sentinel-contract-check.sh --all` findings 0。

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
