### PR TITLE
docs(claude-md): スキル行数原則を diet 世代基準へ改訂する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,11 @@ rite-config.yml        # プロジェクト固有設定（ブランチ戦略、P
 
 **コンポーネント間の関係**: スキル（`skills/`）が**エントリポイントかつ実行手順書**（v0.7 で旧 `commands/` を全廃しスキルへ統合）。orchestrator スキル（open / iterate / run 等）が sub-skill（pr-review / fix / pr-create / issue-implement 等）を Skill ツール経由で呼び出し、各スキルは `agents/`（Task で spawn）や `references/`（自スキル内 `references/` + plugin-root `references/` の共有分）を参照する。hooks/ は Claude Code のライフサイクルから独立に発火し、orchestrator とコンテキスト注入・sentinel emit で連携する。ディレクトリ・ファイルの完全な一覧は `docs/SPEC.md` の Plugin Structure 節を参照。
 
-**スキル行数原則**: 入口スキルの SKILL.md は 500 行未満に保つ。実行手順書スキル（pr-review / fix / lint / setup など bash 実行ブロックを本体に持つもの）は 4,000 行以内を上限とし、rationale（設計理由・背景解説）は SKILL.md 本体に書かず同梱 references/ へ退避して該当箇所に 1 行ポインタ（`rationale: references/<file>.md#<anchor>`）を残す。実行時に必要な情報（分岐表・sentinel 表・エラー処理指示・reason 表）は本体に維持する。
+**スキル行数原則**: 短いほど良い。増える変更は理由を要する。行数上限までの余白を埋めてはならない。
+
+- **主指標は散文バイト**（`bytes_prose`）。総行数は副次。実測: open パイロット 約 −36%（`plugins/rite/references/skill-diet-method.md` §3.1）、第 1 波 iterate −33.3% / fix −32.3% / pr-review −25.5%。4,000 行上限を「書いてよい量」としては使わない。
+- **構成**: outcome + 検証条件 + 機械ステップ。rationale（設計理由・背景解説）は SKILL.md 本体に書かず同梱 `references/` へ退避し、該当箇所に 1 行ポインタ（`rationale: references/<file>.md#<anchor>`）を残す。機械レール（分岐表・sentinel 表・fenced bash・エラー処理指示）は本体に維持する。
+- **入口スキル**は薄い SKILL.md を保つ（500 行は薄さの目安であり上限ではない）。新規作成・追記は `plugins/rite/references/skill-diet-method.md` に従う。
 
 ## 開発ルール
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -317,7 +317,11 @@ Plugin metadata file format:
 
 rite の全機能はスキル (`skills/<name>/SKILL.md`) として実装される（旧 `commands/` は v0.7 で全廃）。各スキルは薄い SKILL.md + 同梱 `references/` で構成し、`/rite:<name>` で起動する。
 
-**スキル行数原則**: 入口スキルの SKILL.md は 500 行未満に保つ。実行手順書スキル（pr-review / fix / lint / setup など bash 実行ブロックを本体に持つもの）は 4,000 行以内を上限とし、rationale（設計理由・背景解説）は SKILL.md 本体に書かず同梱 references/ へ退避して該当箇所に 1 行ポインタ（`rationale: references/<file>.md#<anchor>`）を残す。実行時に必要な情報（分岐表・sentinel 表・エラー処理指示・reason 表）は本体に維持する。
+**スキル行数原則**: 短いほど良い。増える変更は理由を要する。行数上限までの余白を埋めてはならない。
+
+- **主指標は散文バイト**（`bytes_prose`）。総行数は副次。実測: open パイロット 約 −36%（`plugins/rite/references/skill-diet-method.md` §3.1）、第 1 波 iterate −33.3% / fix −32.3% / pr-review −25.5%。4,000 行上限を「書いてよい量」としては使わない。
+- **構成**: outcome + 検証条件 + 機械ステップ。rationale（設計理由・背景解説）は SKILL.md 本体に書かず同梱 `references/` へ退避し、該当箇所に 1 行ポインタ（`rationale: references/<file>.md#<anchor>`）を残す。機械レール（分岐表・sentinel 表・fenced bash・エラー処理指示）は本体に維持する。
+- **入口スキル**は薄い SKILL.md を保つ（500 行は薄さの目安であり上限ではない）。新規作成・追記は `plugins/rite/references/skill-diet-method.md` に従う。
 
 SKILL.md は YAML frontmatter を持つ:
 


### PR DESCRIPTION
## Summary

CLAUDE.md のスキル行数原則を diet 世代の基準へ改訂した。4,000 行上限を「書いてよい量」とする上限内合戦を廃し、散文バイト最小・機械レール明確・outcome + 検証 + 機械ステップ構成へ転換する。手法 SoT は `plugins/rite/references/skill-diet-method.md`。根拠は open パイロット約 −36% と第 1 波 iterate −33.3% / fix −32.3% / pr-review −25.5%。`docs/SPEC.md` の同原則を同期した。スキル本文は変更していない。

## Related Issue

Closes #2291

## Changes

- `CLAUDE.md`: スキル行数原則をバイト基準・構成基準・手法配線へ改訂
- `docs/SPEC.md`: 同原則を同期

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)

<!-- rite:nbr:comment-id:5275625731 -->
