### PR TITLE
fix(batch-run): --merge 完了文の「failed 扱いを除き」を failed 空のとき出さない

### DIFF
--- a/plugins/rite/skills/batch-run/SKILL.md
+++ b/plugins/rite/skills/batch-run/SKILL.md
@@ -418,7 +418,7 @@ echo "[CONTEXT] RUN_DONE; processed=$processed; failed=$failed; outstanding=$out
 ## /rite:batch-run 完了
 
 処理した Issue: {processed_issues}
-全 Issue を処理しました（failed 扱いを除き open→iterate→ready→merge→cleanup を完走）。
+全 Issue を処理しました（open→iterate→ready→merge→cleanup を完走）。
 （`failed=` が非空のときのみ）サーキットブレーカーで非収束（failed）となり merge/cleanup をスキップした Issue: {failed_issues} — draft/open PR をレビュー待ちで残しています。`/rite:iterate <pr>` で再開できます。
 未完了事項: （`outstanding=` が空のとき）なし（全 Issue） / （非空のとき）{outstanding_issues} の cleanup で非ブロッキング失敗が残っています — 各 Issue の cleanup 完了報告（本セッションのログ）を参照するか、`/rite:recover <issue>` で確認してください。
 


### PR DESCRIPTION
## 概要

`--merge` 完了通知の常時行から「failed 扱いを除き」を除き、括弧内をパイプライン名だけにした。`failed=[]` のとき除外対象があるように読めないようにする。非空のときは従来どおり専用行で列挙する。

## 関連 Issue

Closes #2299

## 変更内容

- `plugins/rite/skills/batch-run/SKILL.md`: ステップ 7 `--merge` 常時行の文言

## チェックリスト

- [x] コードはプロジェクトの規約に従っている
- [x] テストは通過している（該当する場合）
- [x] ドキュメントは更新されている（該当する場合）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
