### PR TITLE
fix(projects): 既 CLOSED 親でも Status を Done に同期する

### DIFF
--- a/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
+++ b/plugins/rite/hooks/tests/parent-child-sync-static.test.sh
@@ -20,8 +20,9 @@ PLUGIN_ROOT="$(_helpers_resolve_plugin_root "$SCRIPT_DIR")"
 CLOSE_MD="$PLUGIN_ROOT/skills/issue-close/SKILL.md"
 PR_OPEN_MD="$PLUGIN_ROOT/skills/open/SKILL.md"
 PROJECTS_REF="$PLUGIN_ROOT/references/projects-integration.md"
+ARCHIVE_MD="$PLUGIN_ROOT/skills/cleanup/references/archive-procedures.md"
 
-for f in "$CLOSE_MD" "$PR_OPEN_MD" "$PROJECTS_REF"; do
+for f in "$CLOSE_MD" "$PR_OPEN_MD" "$PROJECTS_REF" "$ARCHIVE_MD"; do
   [ -f "$f" ] || { echo "ERROR: required file not found: $f" >&2; exit 1; }
 done
 
@@ -50,5 +51,13 @@ echo "=== Phase 4: projects-integration.md retains 3-method documentation ==="
 assert_grep "projects-integration.md §2.4.7 retains Method 1 (## 親 Issue body meta)" "$PROJECTS_REF" "## 親 Issue"
 assert_grep "projects-integration.md §2.4.7 retains Method 2 (sub_issues GraphQL feature)" "$PROJECTS_REF" "sub_issues"
 assert_grep "projects-integration.md §2.4.7 retains Method 3 (tasklist / in:body search)" "$PROJECTS_REF" "in:body|tasklist"
+
+echo "=== Phase 5: already-closed parent still syncs Status → Done ==="
+# close 冪等 skip と board 同期が同一 skip に畳まれると AC-1 が壊れる。
+assert_grep "close.md skip_already_closed continues for Status → Done" "$CLOSE_MD" "continue for Status"
+assert_grep "close.md skip_already_closed + all-closed runs Shared Status on parent" "$CLOSE_MD" "skip_already_closed.*Shared: Status|Shared: Status → Done（\\{issue\\} = \\{parent_number\\}）"
+assert_not_grep "close.md skip_already_closed no longer exits Phase 4.6 before enumeration" "$CLOSE_MD" "skipping Phase 4.6 \\(close-side idempotency\\)"
+assert_grep "archive-procedures already-CLOSED parent runs 3.7.2.1 only" "$ARCHIVE_MD" "parent is already CLOSED.*3\\.7\\.2\\.1"
+assert_grep "archive-procedures 3.7.2.2 skipped when parent already CLOSED" "$ARCHIVE_MD" "Skip this substep if the parent Issue is already CLOSED"
 
 print_summary "$(basename "$0")" "If you remove any of the 3 parent-detection methods (body meta / GraphQL trackedIssues / tasklist) from close.md or pr/open.md ステップ 1.2, regression risk reopens. Re-confirm cross-references before removing methods."

--- a/plugins/rite/skills/cleanup/references/archive-procedures.md
+++ b/plugins/rite/skills/cleanup/references/archive-procedures.md
@@ -362,13 +362,13 @@ query($owner: String!, $repo: String!, $number: Int!) {
 
 | Condition | Processing |
 |-----------|-----------|
-| Parent Issue is already CLOSED | Skip (no message) |
-| All child Issues are CLOSED | Proceed to Phase 3.7.2 (auto-close parent Issue) |
-| Some child Issues are OPEN | Proceed to Phase 3.7.3 (notify about remaining child Issues) |
+| Some child Issues are OPEN | Proceed to Phase 3.7.3 (notify about remaining child Issues). Do not update parent Status to Done. Do not close |
+| All child Issues are CLOSED and parent is OPEN | Proceed to Phase 3.7.2 (Status → Done then close) |
+| All child Issues are CLOSED and parent is already CLOSED | Proceed to 3.7.2.1 (Status → Done) only. Skip 3.7.2.2 (do not run `gh issue close`) |
 
 #### 3.7.2 Auto-Close Parent Issue
 
-If all child Issues are complete, auto-close the parent Issue without user confirmation.
+If all child Issues are complete, auto-close the parent Issue without user confirmation. If the parent is already CLOSED, skip 3.7.2.2 (close) but still run 3.7.2.1 (Status → Done).
 
 ##### 3.7.2.1 Update Parent Issue's Projects Status to "Done"
 
@@ -418,6 +418,8 @@ Inspect the script's stdout JSON:
 
 ##### 3.7.2.2 Close the Parent Issue
 
+Skip this substep if the parent Issue is already CLOSED. Do not execute `gh issue close`.
+
 Close with a detailed comment and short close reason (2-step pattern per `gh-cli-patterns.md` policy):
 
 **Note**: The following code block is a template. `cat <<'BODY_EOF'` is a **single-quoted HEREDOC**, so bash variable expansion does not occur. Claude should replace placeholders as an LLM and then construct the command.
@@ -462,6 +464,14 @@ Generated from `trackedIssues.nodes` retrieved in Phase 3.7.1:
 ```
 
 ##### 3.7.2.3 Close Completion Message
+
+親が既 CLOSED で 3.7.2.2 を skip した場合:
+
+```
+親 Issue #{parent_issue_number} は既に CLOSED です。Projects Status を Done に同期しました
+```
+
+それ以外（3.7.2.2 で close した場合）:
 
 ```
 親 Issue #{parent_issue_number} を自動クローズしました

--- a/plugins/rite/skills/issue-close/SKILL.md
+++ b/plugins/rite/skills/issue-close/SKILL.md
@@ -25,7 +25,7 @@ Check the completion status of an Issue and guide necessary actions.
 
 ## Shared: Projects Status → Done (delegate pattern)
 
-Phase 1.3.2 / 4.2 / 4.6.3 は Projects Status を **Done** に更新する。`projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と同一）。冪等。API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update)。
+Phase 1.3.2 / 4.2 / 4.6.3 / `skip_already_closed`（全子 CLOSED）は Projects Status を **Done** に更新する。`projects-status-update.sh` に委譲する（`skills/open/SKILL.md` ステップ 2.4 / `skills/ready/SKILL.md` Phase 4 と同一）。冪等。API 詳細は [projects-integration.md §2.4](../../references/projects-integration.md#24-github-projects-status-update)。
 rationale: references/rationale.md#projects-status-delegate
 
 **委譲呼び出し**（`{issue}` は対象 Issue 番号、`auto_add false`・`non_blocking true`）:
@@ -494,7 +494,7 @@ rationale: references/rationale.md#parent-direct-only
 
 ### 4.6.0 + 4.6.1 Idempotency Check & Child Enumeration
 
-冪等性チェック（親が既 closed なら no-op）→ 子列挙 → `all_closed` を **単一 Bash block** で行う。stderr は tempfile に退避。`set -uo pipefail`（`-e` は明示 `|| fallback` のため省略）。
+冪等性チェック（親が既 closed なら close は no-op。Status → Done は 4.6.1 の後）→ 子列挙 → `all_closed` を **単一 Bash block** で行う。stderr は tempfile に退避。`set -uo pipefail`（`-e` は明示 `|| fallback` のため省略）。
 rationale: references/rationale.md#single-block-p460
 
 ```bash
@@ -519,7 +519,7 @@ p46_err=""
 trap 'rm -f "${p46_err:-}"' EXIT INT TERM HUP
 p46_err=$(mktemp 2>/dev/null) || p46_err=""
 
-# --- 4.6.0: Idempotency — 親が既に CLOSED なら no-op (close-side idempotency, extends AC-6 principle) ---
+# --- 4.6.0: Idempotency — 親が既に CLOSED なら close は no-op。Status → Done は 4.6.1 の後 ---
 parent_state=""
 if parent_state=$(gh issue view "$parent_number" -R "$owner_repo_slash" --json state --jq '.state' 2>"${p46_err:-/dev/null}"); then
   echo "parent_state=$parent_state"
@@ -534,11 +534,11 @@ if [ -z "$parent_state" ]; then
   echo "[CONTEXT] P460_DECISION=skip_retrieval_failed"
   exit 0
 elif [ "$parent_state" = "CLOSED" ]; then
-  echo "[DEBUG] parent #${parent_number} already closed — skipping Phase 4.6 (close-side idempotency)"
+  echo "[DEBUG] parent #${parent_number} already closed — skip close; continue for Status → Done"
   echo "[CONTEXT] P460_DECISION=skip_already_closed"
-  exit 0
+else
+  echo "[CONTEXT] P460_DECISION=proceed_to_enumeration"
 fi
-echo "[CONTEXT] P460_DECISION=proceed_to_enumeration"
 
 # --- 4.6.1: Enumerate children (Method A: trackedIssues / Tasklists API → Method B: body parse) ---
 # trackedIssues は Tasklists 機能 (body `- [ ] #N` parser)。GitHub Sub-Issues API (subIssues) とは別物。
@@ -600,10 +600,12 @@ fi
 |----|-------------|
 | `P460_DECISION=skip_routing_bug` | routing bug（empty/literal/非数値）。Phase 4.6 を抜けて Phase 5 へ |
 | `P460_DECISION=skip_retrieval_failed` | 親 state 取得失敗。Phase 4.6 を抜けて Phase 5 へ（non-blocking） |
-| `P460_DECISION=skip_already_closed` | 親が既 closed の no-op。Phase 4.6 を抜けて Phase 5 へ |
-| `P461_DECISION=skip_empty_children` | 子一覧取得不可。`親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。自動クローズをスキップします。` を表示し Phase 5 へ |
-| `P461_DECISION=skip_open_children; open_count=N` | `親 Issue #{parent_number} にはまだ N 件の未完了子 Issue があります。自動クローズはスキップします。` を表示し Phase 5 へ |
-| `P461_DECISION=proceed_to_confirmation` | 4.6.2 へ |
+| `P460_DECISION=skip_already_closed` + `P461_DECISION=proceed_to_confirmation` | close は skip。Shared: Status → Done（`{issue}` = `{parent_number}`）。4.6.2 / 4.6.3 は実行しない。Phase 5 へ |
+| `P460_DECISION=skip_already_closed` + `P461_DECISION=skip_open_children` | Phase 5 へ（Status も Done にしない） |
+| `P460_DECISION=skip_already_closed` + `P461_DECISION=skip_empty_children` | 子一覧取得不可。`親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。自動クローズをスキップします。` を表示し Phase 5 へ |
+| `P461_DECISION=skip_empty_children`（`P460=proceed_to_enumeration`） | 子一覧取得不可。`親 Issue #{parent_number} の子 Issue 一覧が取得できませんでした。自動クローズをスキップします。` を表示し Phase 5 へ |
+| `P461_DECISION=skip_open_children; open_count=N`（`P460=proceed_to_enumeration`） | `親 Issue #{parent_number} にはまだ N 件の未完了子 Issue があります。自動クローズはスキップします。` を表示し Phase 5 へ |
+| `P461_DECISION=proceed_to_confirmation`（`P460=proceed_to_enumeration`） | 4.6.2 へ |
 
 ### 4.6.2 User Confirmation
 


### PR DESCRIPTION
## 概要

親 Issue が既に CLOSED のとき、子の `/rite:cleanup` / `/rite:issue-close` が Projects Status → Done まで飛ばさないようにする。close の冪等 skip と board 同期を分離する。

## 関連 Issue

Closes #2301

## 変更内容

- `issue-close` Phase 4.6.0: 親 CLOSED でも列挙へ進み、全子 CLOSED なら Shared Status → Done。`gh issue close` は実行しない
- `archive-procedures` 3.7.1 / 3.7.2: 親 already CLOSED + 全子 CLOSED は 3.7.2.1 のみ。3.7.2.2 は skip
- 静的テストに skip 分岐が Status 同期を残す契約を pin

## チェックリスト

- [x] プロジェクトの規約に従っている
- [x] テストが通る（該当する場合）
- [x] ドキュメントを更新した（該当する場合）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)

<!-- rite:nbr:comment-id:5276918962 -->
