### PR TITLE
docs(intro-video): HyperFrames 版 PROVENANCE の冒頭宣言を README 差し替え後の実態へ合わせる

### DIFF
--- a/media/intro-video-en/PROVENANCE.md
+++ b/media/intro-video-en/PROVENANCE.md
@@ -1,6 +1,6 @@
 # intro-video-en — Provenance and handling
 
-HyperFrames source for the **English** intro video (~125s) referenced in the "Demo" section of `README.md`.
+HyperFrames source for the former Demo (replaced in v0.11.0 by the v2 full cut under `media/intro-video-v2`).
 
 ## Provenance
 

--- a/media/intro-video/PROVENANCE.md
+++ b/media/intro-video/PROVENANCE.md
@@ -1,6 +1,6 @@
 # intro-video — 来歴と取り扱い
 
-README.ja.md の「Demo」節で参照している**日本語字幕版**紹介動画（約125秒）の HyperFrames ソース。
+旧 Demo（v0.11.0 で `media/intro-video-v2` の v2 フルカットへ差し替え済み）の HyperFrames ソース。
 
 ## 来歴
 


### PR DESCRIPTION
## 概要

README Demo は v2 フルカットへ差し替え済みのため、旧 HyperFrames 版 `PROVENANCE.md` の冒頭宣言が「README で参照している」と主張していた記述を改める。再レンダ・削除は行わない。

## 関連 Issue

Closes #2307

## 変更内容

- `media/intro-video/PROVENANCE.md` — 冒頭宣言を旧 Demo である旨へ改訂
- `media/intro-video-en/PROVENANCE.md` — 同上（英語）

## チェックリスト

- [x] コードはプロジェクトの規約に従っている
- [x] テストは通過している（該当する場合）
- [x] ドキュメントを更新した（該当する場合）

---
🤖 Generated with [rite workflow](https://github.com/B16B1RD/cc-rite-workflow)
