### PR TITLE
chore: v0.11.0 バージョンバンプ + CHANGELOG 更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rite",
       "source": "./plugins/rite",
       "description": "Universal Issue-driven development workflow for Claude Code",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "author": { "name": "B16B1RD" },
       "license": "MIT"
     }

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -39,7 +39,7 @@ Fixed/Changed/Removed エントリは修正対象の旧挙動を述べてよい�
 - **`/rite:cleanup` / `/rite:issue-close` が、親 Issue が既に CLOSED でも Projects Status を Done に同期する** — close の冪等 skip と board 同期を分離し、全子 CLOSED の already-closed 親も Done に到達する。(#2301)
 - **reviewer の spawn spread 計測を orchestrator の spawn 時刻から取る** — レポート執筆時刻に寄ると長時間の並列レビューが直列化と誤判定されていた。同一メッセージの reviewer は同じ値を共有する。(#2281)
 - **`/rite:batch-run --merge` の完了文が、`failed=[]` のとき「failed 扱いを除き」を出さない** — 非空のときは専用行で列挙する。(#2299)
-- **`/rite:release` が develop→main 昇格を安全に完走できるようになった** — リリース準備 PR に `/rite:iterate` を組み込み、昇格コミットは既マージ PR 経由であること（`release-promotion-verify.sh`）を検証し、検証済み head SHA を `--match-head-commit` で固定する。Phase 2.5 の staging は更新対象 7 ファイルに限定（sandbox 安全）。`multi_session.enabled` 時は準備ブランチを issue session worktree に置き、Phase 3 は `main` を触る前にその worktree から退出する（`action: keep`）。(#2269, #2268, #2270, #2271)
+- **プロジェクトローカルの `/release` スキルが develop→main 昇格を安全に完走できるようになった** — リリース準備 PR に `/rite:iterate` を組み込み、昇格コミットは既マージ PR 経由であること（`release-promotion-verify.sh`）を検証し、検証済み head SHA を `--match-head-commit` で固定する。Phase 2.5 の staging は更新対象 7 ファイルに限定（sandbox 安全）。`multi_session.enabled` 時は準備ブランチを issue session worktree に置き、Phase 3 は `main` を触る前にその worktree から退出する（`action: keep`）。(#2269, #2268, #2270, #2271)
 
 ## [0.10.0] - 2026-08-12
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -25,6 +25,22 @@ Fixed/Changed/Removed エントリは修正対象の旧挙動を述べてよい�
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-13
+
+### 変更
+
+- **SKILL 記述ダイエット: outcome + 検証 + 機械ステップへ再構成し、rationale を同梱 references へ退避** — 散文（`bytes_prose`）だけを圧縮・退避し、機械レール（fenced bash・分岐表・sentinel）はバイト一致のまま残す。手法は `plugins/rite/references/skill-diet-method.md`（線引きチェックリスト・pin 移送手順・測定テンプレート）に記録し、`open` パイロットで約 −36% を確認した (#2278)。第 1 波は `iterate`（−33.3%）/ `fix`（−32.3%）/ `pr-review`（−25.5%）(#2285, #2286, #2287)。第 2 波は残り全数: 大型 4 本（`setup` / `cleanup` / `wiki-lint` / `wiki-ingest`）(#2292)、中型 4 本（`pr-create` / `lint` / `issue-implement` / `issue-close`）(#2293)、小型残り 19 本 (#2294)。CLAUDE.md のスキル行数原則も diet 世代基準へ改訂し、主指標を `bytes_prose` とし、4,000 行上限を「書いてよい量」としては使わない (#2295)。
+- **README Demo が v0.11.0 日英 v2 紹介動画を指すようになった**（`media/intro-video-v2` の約 55 秒フルカット）。退役した HyperFrames 版 `PROVENANCE.md` の冒頭宣言も、README が今もそのカットを参照しているという主張を外すよう更新した。(#2297, #2307)
+- **自律実行前文が、コンテキスト制限を理由にした停止を禁じ、報告を outcome / 次の一手に限る** — 枯渇時の再開は既存の compact / recovery 経路のまま。(#2279)
+
+### 修正
+
+- **`iterate` が、cycle 境界で前 cycle の review-result JSON が無いとき修復ゲートへ昇格する** — コンテキストに結果が残っていれば既存 save helper で即時保存し、残っていなければ cycle counter を進めず（`INC=held`）再レビューする。LOST 注記とトレンド計算は変えない。(#2305)
+- **`/rite:cleanup` / `/rite:issue-close` が、親 Issue が既に CLOSED でも Projects Status を Done に同期する** — close の冪等 skip と board 同期を分離し、全子 CLOSED の already-closed 親も Done に到達する。(#2301)
+- **reviewer の spawn spread 計測を orchestrator の spawn 時刻から取る** — レポート執筆時刻に寄ると長時間の並列レビューが直列化と誤判定されていた。同一メッセージの reviewer は同じ値を共有する。(#2281)
+- **`/rite:batch-run --merge` の完了文が、`failed=[]` のとき「failed 扱いを除き」を出さない** — 非空のときは専用行で列挙する。(#2299)
+- **`/rite:release` が develop→main 昇格を安全に完走できるようになった** — リリース準備 PR に `/rite:iterate` を組み込み、昇格コミットは既マージ PR 経由であること（`release-promotion-verify.sh`）を検証し、検証済み head SHA を `--match-head-commit` で固定する。Phase 2.5 の staging は更新対象 7 ファイルに限定（sandbox 安全）。`multi_session.enabled` 時は準備ブランチを issue session worktree に置き、Phase 3 は `main` を触る前にその worktree から退出する（`action: keep`）。(#2269, #2268, #2270, #2271)
+
 ## [0.10.0] - 2026-08-12
 
 ### 追加
@@ -867,6 +883,7 @@ v0.4.0 では値は silent に無視されます。機能的な代替はあり�
 - TDD Light モード
 - git worktree による並列実装サポート
 
+[0.11.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.0...v0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ that aid upgraders are kept verbatim.
 - **`/rite:cleanup` / `/rite:issue-close` still sync a parent Issue's Projects Status to Done when the parent is already CLOSED** — close-idempotency skip and board sync are separated, so an already-closed parent with all children closed still reaches Done. (#2301)
 - **Reviewer spawn-spread is measured from the orchestrator's spawn timestamp**, not from the time the report is written, so a long parallel review is no longer misclassified as serialized. Reviewers in the same message share one value. (#2281)
 - **`/rite:batch-run --merge` completion text no longer says "excluding failed" when `failed=[]`.** A non-empty failed list is still listed on its own line. (#2299)
-- **`/rite:release` can complete a develop→main promotion safely** — the prep PR now runs `/rite:iterate`; promotion commits must already have arrived via merged PRs (`release-promotion-verify.sh`); the verified head SHA is pinned with `--match-head-commit`; Phase 2.5 stages only the seven release files (sandbox-safe); with `multi_session.enabled` the prep branch is placed in the issue session worktree; Phase 3 exits that worktree (`action: keep`) before touching `main`. (#2269, #2268, #2270, #2271)
+- **The project-local `/release` skill can complete a develop→main promotion safely** — the prep PR now runs `/rite:iterate`; promotion commits must already have arrived via merged PRs (`release-promotion-verify.sh`); the verified head SHA is pinned with `--match-head-commit`; Phase 2.5 stages only the seven release files (sandbox-safe); with `multi_session.enabled` the prep branch is placed in the issue session worktree; Phase 3 exits that worktree (`action: keep`) before touching `main`. (#2269, #2268, #2270, #2271)
 
 ## [0.10.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ that aid upgraders are kept verbatim.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-13
+
+### Changed
+
+- **SKILL description diet: outcome + verification + mechanical steps, with rationale exiled to bundled references** — prose (`bytes_prose`) is compressed and moved to per-skill `references/`, while mechanical rails (fenced bash, branch tables, sentinels) stay byte-identical. The method is recorded in `plugins/rite/references/skill-diet-method.md` (line-drawing checklist, pin-transfer procedure, measurement template) and piloted on `open` (~−36%) (#2278). Wave 1 applied it to `iterate` (−33.3%) / `fix` (−32.3%) / `pr-review` (−25.5%) (#2285, #2286, #2287). Wave 2 covered the remaining skills: the large four (`setup` / `cleanup` / `wiki-lint` / `wiki-ingest`) (#2292), the medium four (`pr-create` / `lint` / `issue-implement` / `issue-close`) (#2293), and the remaining 19 small skills (#2294). CLAUDE.md's skill line-count principle is rewritten around the diet generation: `bytes_prose` is the primary metric, and the 4,000-line cap is no longer treated as a writing budget (#2295).
+- **README Demo points at the v0.11.0 English/Japanese v2 intro videos** (~55s full cuts from `media/intro-video-v2`). The retired HyperFrames `PROVENANCE.md` opening claim is updated so it no longer says the README still references that cut. (#2297, #2307)
+- **Autonomous-execution preamble forbids stopping for a context-budget reason and limits reports to outcome / next action.** Resume after exhaustion stays with the existing compact/recovery path. (#2279)
+
+### Fixed
+
+- **`iterate` promotes a missing review-result JSON at the cycle boundary to a repair gate** — if the previous cycle's result is still in context it is saved immediately through the existing helper; otherwise the cycle counter is held (`INC=held`) and the review is re-run. LOST annotation and trend calculation stay unchanged. (#2305)
+- **`/rite:cleanup` / `/rite:issue-close` still sync a parent Issue's Projects Status to Done when the parent is already CLOSED** — close-idempotency skip and board sync are separated, so an already-closed parent with all children closed still reaches Done. (#2301)
+- **Reviewer spawn-spread is measured from the orchestrator's spawn timestamp**, not from the time the report is written, so a long parallel review is no longer misclassified as serialized. Reviewers in the same message share one value. (#2281)
+- **`/rite:batch-run --merge` completion text no longer says "excluding failed" when `failed=[]`.** A non-empty failed list is still listed on its own line. (#2299)
+- **`/rite:release` can complete a develop→main promotion safely** — the prep PR now runs `/rite:iterate`; promotion commits must already have arrived via merged PRs (`release-promotion-verify.sh`); the verified head SHA is pinned with `--match-head-commit`; Phase 2.5 stages only the seven release files (sandbox-safe); with `multi_session.enabled` the prep branch is placed in the issue session worktree; Phase 3 exits that worktree (`action: keep`) before touching `main`. (#2269, #2268, #2270, #2271)
+
 ## [0.10.0] - 2026-08-12
 
 ### Added
@@ -870,6 +886,7 @@ If you previously relied on `max_review_fix_loops` hitting a hard limit to escap
 - TDD Light mode
 - Parallel implementation with git worktree support
 
+[0.11.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/B16B1RD/cc-rite-workflow/compare/v0.9.0...v0.9.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 > Claude Code のための汎用 Issue ドリブン開発ワークフロー
 
-[![Version](https://img.shields.io/badge/version-0.10.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.10.0)
+[![Version](https://img.shields.io/badge/version-0.11.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.11.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [English](README.md) | **日本語**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Universal Issue-Driven Development Workflow for Claude Code
 
-[![Version](https://img.shields.io/badge/version-0.10.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.10.0)
+[![Version](https://img.shields.io/badge/version-0.11.0-blue.svg)](https://github.com/B16B1RD/cc-rite-workflow/releases/tag/v0.11.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **English** | [日本語](README.ja.md)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -298,7 +298,7 @@ Plugin metadata file format:
 ```json
 {
  "name": "rite",
- "version": "0.10.0",
+ "version": "0.11.0",
  "description": "Universal Issue-driven development workflow for Claude Code",
  "author": { "name": "B16B1RD" },
  "license": "MIT"

--- a/plugins/rite/.claude-plugin/plugin.json
+++ b/plugins/rite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rite",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Universal Issue-driven development workflow for Claude Code",
   "author": { "name": "B16B1RD" },
   "license": "MIT"


### PR DESCRIPTION
Closes #2309

## Summary

- バージョンを 0.10.0 → 0.11.0 へ更新（marketplace.json / plugin.json / README バッジ / SPEC 例）
- CHANGELOG.md / CHANGELOG.ja.md に 0.11.0 セクションと比較リンクを追加

## Test plan

- [x] 5 ファイルに 0.10.0 が残っていないこと
- [x] staging が更新対象 7 ファイルと一致すること

<!-- rite:nbr:comment-id:5279505545 -->
